### PR TITLE
ENH: a rudimentary stub for a 'datalad test' command

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -10,3 +10,13 @@
 from .version import __version__
 
 import datalad.log
+
+# be friendly on systems with ancient numpy -- no tests, but at least
+# importable
+try:
+    from numpy.testing import Tester
+    test = Tester().test
+    bench = Tester().bench
+    del Tester
+except ImportError:
+    def test(*args, **kwargs): raise RuntimeError('Need numpy >= 1.2 for tests')

--- a/datalad/cmdline/cmd_test.py
+++ b/datalad/cmdline/cmd_test.py
@@ -6,11 +6,22 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-"""
+"""Run internal DataLad (unit)tests to verify correct operation on the system"""
+
 
 __docformat__ = 'restructuredtext'
 
-import cmd_crawl
-import cmd_install
-import cmd_test
+# magic line for manpage summary
+# man: -*- % get a dataset from a remote repository
+
+from .helpers import parser_add_common_args
+
+import nose
+
+def setup_parser(parser):
+    # TODO -- pass options such as verbosity etc
+    pass
+    
+def run(args):
+    import datalad
+    datalad.test()


### PR DESCRIPTION
Needs
- probably drop using numpy's shim but just run nose tests using
  directly nose
- needs to pass at least some nosetests cmdline  options (e.g. -s -v)
- it seems that fails tests if ran as if installed
- also, in installed form we would lack the testrepo submodules.
  Default operation of with_repos now is to raise and expection (instead 
  of Skip) if no repositories were found -- may be we should rethink that

But in general we should aim to provide such a functionality