### PR TITLE
BF/ENH: test helper decorators should pass new arguments as "additional" ones

### DIFF
--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -57,8 +57,8 @@ def test_AnnexRepo_instance_brand_new(path):
 
 
 @ignore_nose_capturing_stdout
-@with_tempfile
 @with_testrepos(flavors=['network'])
+@with_tempfile
 def test_AnnexRepo_get(src, dst):
 
     ar = AnnexRepo(dst, src)

--- a/datalad/tests/test_dataset.py
+++ b/datalad/tests/test_dataset.py
@@ -56,8 +56,8 @@ def test_Dataset_instance_brand_new(path):
 
 
 @ignore_nose_capturing_stdout
-@with_tempfile
 @with_testrepos(flavors=['network'])
+@with_tempfile
 def test_Dataset_get(src, dst):
 
     ds = Dataset(dst, src)

--- a/datalad/tests/test_main.py
+++ b/datalad/tests/test_main.py
@@ -67,7 +67,7 @@ def verify_nothing_was_done(stats):
 
 @with_tree(**tree1args)
 @serve_path_via_http()
-def check_page2annex_same_incoming_and_public(url, mode, path):
+def check_page2annex_same_incoming_and_public(mode, path, url):
     dout = tempfile.mkdtemp()
     cfg = EnhancedConfigParser.get_default(dict(
         DEFAULT=dict(
@@ -133,7 +133,7 @@ def test_page2annex_same_incoming_and_public():
 
 @with_tree(**tree1args)
 @serve_path_via_http()
-def check_page2annex_separate_public(url, separate, mode, incoming_destiny, path):
+def check_page2annex_separate_public(separate, mode, incoming_destiny, path, url):
     fast_mode = mode in ['fast', 'relaxed']
     din = tempfile.mkdtemp()
     dout = tempfile.mkdtemp() if separate else din
@@ -361,7 +361,7 @@ tree2args = dict(
 
 @with_tree(**tree2args)
 @serve_path_via_http()
-def test_page2annex_recurse(url, path):
+def test_page2annex_recurse(path, url):
 
     din = tempfile.mkdtemp()
     dout = tempfile.mkdtemp()

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -1,0 +1,43 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import os
+
+from .utils import eq_, ok_, with_tempfile, with_testrepos, with_tree
+
+#
+# Test with_tempfile, especially nested invocations
+#
+@with_tempfile
+@with_tempfile
+def test_nested_with_tempfile_basic(f1, f2):
+    ok_(f1 != f2)
+    ok_(not os.path.exists(f1))
+    ok_(not os.path.exists(f2))
+
+# And the most obscure case to test.  Generator for the test is
+# used as well to verify that every one of those functions adds new argument
+# to the end of incoming arguments.
+@with_tempfile(prefix="TEST", suffix='big')
+@with_tree((('f1.txt', 'load'),))
+@with_tempfile(suffix='.cfg')
+@with_tempfile(suffix='.cfg.old')
+@with_testrepos(flavors=['local'])
+def check_nested_with_tempfile_parametrized_surrounded(param, f0, tree, f1, f2, repo):
+    eq_(param, "param1")
+    ok_(f0.endswith('big'), msg="got %s" % f0)
+    ok_(os.path.basename(f0).startswith('TEST'), msg="got %s" % f0)
+    ok_(os.path.exists(os.path.join(tree, 'f1.txt')))
+    ok_(f1 != f2)
+    ok_(f1.endswith('.cfg'), msg="got %s" % f1)
+    ok_(f2.endswith('.cfg.old'), msg="got %s" % f2)
+    ok_('testrepos' in repo)
+
+def test_nested_with_tempfile_parametrized_surrounded():
+    yield check_nested_with_tempfile_parametrized_surrounded, "param1"


### PR DESCRIPTION
This way we can more easily chain decorators without getting lost which then
argument gets embedded into the test function list of arguments.  Before this,
some were pre-pending, or using **kwarg, making it all messy and inconsistent.
Additional tests now very correct operation and double-decoration with e.g.
with_tempfile.  Closes #60