### PR TITLE
BF: bring back our custom tempfiles prefix and do not swallow exception

### DIFF
--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -107,7 +107,7 @@ def test_with_tempfile_default_prefix(d1):
            'datalad.tests.test_tests_utils.test_with_tempfile_default_prefix'
     if on_windows:
         ok_startswith(d, short)
-        ok_startswith(d, full)
+        nok_startswith(d, full)
     else:
         ok_startswith(d, full)
 

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -17,7 +17,7 @@ from .utils import eq_, ok_, ok_startswith, nok_startswith, assert_false, \
     with_tempfile, with_testrepos, with_tree, \
     rmtemp, OBSCURE_FILENAMES, get_most_obscure_supported_name, \
     swallow_outputs, swallow_logs, \
-    on_windows
+    on_windows, assert_raises
 
 #
 # Test with_tempfile, especially nested invocations
@@ -168,3 +168,18 @@ def test_swallow_logs():
         eq_(cm.out, 'debug1\n') # not even visible at level 9
         lgr.info("info")
         eq_(cm.out, 'debug1\ninfo\n') # not even visible at level 9
+
+def test_ok_startswith():
+    ok_startswith('abc', 'abc')
+    ok_startswith('abc', 'a')
+    ok_startswith('abc', '')
+    ok_startswith(' abc', ' ')
+    ok_startswith('abc\r\n', 'a') # no effect from \r\n etc
+    assert_raises(AssertionError, ok_startswith, 'abc', 'b')
+    assert_raises(AssertionError, ok_startswith, 'abc', 'abcd')
+
+def test_nok_startswith():
+    nok_startswith('abc', 'bc')
+    nok_startswith('abc', 'c')
+    assert_raises(AssertionError, nok_startswith, 'abc', 'a')
+    assert_raises(AssertionError, nok_startswith, 'abc', 'abc')

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -99,26 +99,23 @@ def test_with_tempfile_mkdir():
         ok_(not os.path.exists(dnames[0])) # got removed
 
 
-def test_with_tempfile_prefix():
+@with_tempfile()
+def test_with_tempfile_default_prefix(d1):
+    d = basename(d1)
+    short = 'datalad_temp_'
+    full = short + \
+           'datalad.tests.test_tests_utils.test_with_tempfile_default_prefix'
+    if on_windows:
+        ok_startswith(d, short)
+        ok_startswith(d, full)
+    else:
+        ok_startswith(d, full)
 
-    @with_tempfile()
-    def check_default_prefix(d1):
-        d = basename(d1)
-        short = 'datalad_temp_'
-        full = short + 'datalad.tests.test_tests_utils.check_default_prefix'
-        if on_windows:
-            ok_startswith(d, short)
-            ok_startswith(d, full)
-        else:
-            ok_startswith(d, full)
 
-    @with_tempfile(prefix="nodatalad_")
-    def check_specified_prefix(d1):
-        ok_startswith(basename(d1), 'nodatalad_')
-        ok_('datalad.tests.test_tests_utils.check_default_prefix' not in d1)
-
-    yield check_default_prefix
-    yield check_specified_prefix
+@with_tempfile(prefix="nodatalad_")
+def test_with_tempfile_specified_prefix(d1):
+    ok_startswith(basename(d1), 'nodatalad_')
+    ok_('datalad.tests.test_tests_utils.test_with_tempfile_specified_prefix' not in d1)
 
 
 def test_get_most_obscure_supported_name():

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -9,7 +9,7 @@
 
 import os, platform, sys
 
-from os.path import exists, join as opj
+from os.path import exists, join as opj, basename
 from glob import glob
 from mock import patch
 
@@ -95,6 +95,21 @@ def test_with_tempfile_mkdir():
     check_mkdir()
     if not os.environ.get('DATALAD_TESTS_KEEPTEMP'):
         ok_(not os.path.exists(dnames[0])) # got removed
+
+
+def test_with_tempfile_prefix():
+
+    @with_tempfile()
+    def check_default_prefix(d1):
+        ok_(basename(d1).startswith('datalad_temp_'))
+
+    @with_tempfile(prefix="nodatalad_")
+    def check_specified_prefix(d1):
+        ok_(basename(d1).startswith('nodatalad_'))
+
+    check_default_prefix()
+    check_specified_prefix()
+
 
 def test_get_most_obscure_supported_name():
     n = get_most_obscure_supported_name()

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -228,12 +228,8 @@ def with_tempfile(t, *targs, **tkwargs):
         tkwargs_ = tkwargs.copy()
 
         if len(targs)<2 and not 'prefix' in tkwargs_:
-            try:
-                tkwargs_['prefix'] = 'datalad_temp_%s.%s' \
-                                    % (func.__module__, func.func_name)
-            except:
-                # well -- if something wrong just proceed with defaults
-                pass
+            tkwargs_['prefix'] = 'datalad_temp_%s.%s' \
+                                % (t.__module__, t.func_name)
 
         # if DATALAD_TESTS_TEMPDIR is set, use that as directory,
         # let mktemp handle it otherwise. However, an explicitly provided

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -15,7 +15,7 @@ from functools import wraps
 from os.path import exists, join as opj
 
 from nose.tools import \
-    assert_equal, assert_raises, assert_greater, assert_false, \
+    assert_equal, assert_raises, assert_greater, assert_true, assert_false, \
     assert_in, assert_in as in_, \
     raises, ok_, eq_, make_decorator
 from nose import SkipTest
@@ -108,6 +108,15 @@ def ok_file_under_git(path, filename, annexed=False):
     repo = AnnexRepo(path)
     assert(filename in repo.get_indexed_files()) # file is known to Git
     assert(annexed == os.path.islink(opj(path, filename)))
+
+
+def ok_startswith(s, prefix):
+    ok_(s.startswith(prefix),
+        msg="String %r doesn't start with %r" % (s, prefix))
+
+def nok_startswith(s, prefix):
+    assert_false(s.startswith(prefix),
+        msg="String %r starts with %r" % (s, prefix))
 
 
 #
@@ -228,8 +237,10 @@ def with_tempfile(t, *targs, **tkwargs):
         tkwargs_ = tkwargs.copy()
 
         if len(targs)<2 and not 'prefix' in tkwargs_:
-            tkwargs_['prefix'] = 'datalad_temp_%s.%s' \
-                                % (t.__module__, t.func_name)
+            tkwargs_['prefix'] = \
+                'datalad_temp_' + \
+                ('' if on_windows \
+                    else '%s.%s' % (t.__module__, t.func_name))
 
         # if DATALAD_TESTS_TEMPDIR is set, use that as directory,
         # let mktemp handle it otherwise. However, an explicitly provided


### PR DESCRIPTION
we lost our custom tempfiles prefix a while back without noticing
and in part because of some obnoxious swallow -- I dont really see a reason for it, thus removed try/except

also introduced two new checkers

Q: should we adopt having "nok_" prefix for negated asserts? or may be some other?