### PR TITLE
BF,TST: return back to original cwd if test brings us somewhere else (Closes #96)

### DIFF
--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -13,9 +13,11 @@ from os.path import exists, join as opj
 from glob import glob
 from mock import patch
 
-from .utils import eq_, ok_, with_tempfile, with_testrepos, with_tree, rmtemp, \
-                   OBSCURE_FILENAMES, get_most_obscure_supported_name, \
-                   swallow_outputs, swallow_logs, assert_false
+from .utils import eq_, ok_, assert_false, \
+    with_tempfile, with_testrepos, with_tree, \
+    rmtemp, OBSCURE_FILENAMES, get_most_obscure_supported_name, \
+    swallow_outputs, swallow_logs, \
+    on_windows, assert_raises, assert_equal, assert_cwd_unchanged
 
 #
 # Test with_tempfile, especially nested invocations
@@ -146,3 +148,15 @@ def test_swallow_logs():
         eq_(cm.out, 'debug1\n') # not even visible at level 9
         lgr.info("info")
         eq_(cm.out, 'debug1\ninfo\n') # not even visible at level 9
+
+
+def test_assert_cwd_unchanged():
+
+    @assert_cwd_unchanged
+    def do_chdir():
+        os.chdir(os.pardir)
+
+    orig_dir = os.getcwd()
+    assert_raises(AssertionError, do_chdir)
+    eq_(orig_dir, os.getcwd(),
+        "assert_cwd_unchanged didn't return us back to %s" % orig_dir)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -391,7 +391,13 @@ def assert_cwd_unchanged(func):
         cwd_before = os.getcwd()
         func(*args, **kwargs)
         cwd_after = os.getcwd()
-        assert_equal(cwd_before, cwd_after ,"CWD changed from %s to %s" % (cwd_before, cwd_after))
+        if cwd_after != cwd_before:
+            lgr.warning(
+                "%s changed cwd to %s. Mitigating and changing back to %s"
+                % (func, cwd_after, cwd_before))
+            os.chdir(cwd_before)
+            assert_equal(cwd_before, cwd_after,
+                         "CWD changed from %s to %s" % (cwd_before, cwd_after))
 
     return newfunc
 


### PR DESCRIPTION
Conflicts:
	datalad/tests/test_tests_utils.py -- I was picking up from another branch.
     Took the state of other branch and removed imports which are not present
     here