### PR TITLE
RF: normalize_paths to return a single output if a single input filename is provided

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -96,8 +96,6 @@ class AnnexRepo(GitRepo):
         """
         super(AnnexRepo, self).__init__(path, url, runner=runner)
 
-
-
         # Check whether an annex already exists at destination
         if not exists(opj(self.path, '.git', 'annex')):
             lgr.debug('No annex found in %s.'

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -276,7 +276,7 @@ class AnnexRepo(GitRepo):
         Parameters:
         -----------
         files: list, str
-            file to look up
+            file(s) to look up
 
         Returns:
         --------
@@ -313,7 +313,7 @@ class AnnexRepo(GitRepo):
                 # Not sure, whether or not this can actually happen
                 raise e
 
-        return output[0].split(linesep)[0]
+        return output[0].rstrip(linesep).split(linesep)
 
 
     @normalize_paths
@@ -341,7 +341,7 @@ class AnnexRepo(GitRepo):
                               "'find' operation per each file")
                     # we need to go file by file since one of them is non
                     # existent and annex pukes on it
-                    return [self.file_has_content(file_)[0] for file_ in files]
+                    return [self.file_has_content(file_) for file_ in files]
                 return [False]
             else:
                 raise
@@ -467,7 +467,7 @@ class AnnexRepo(GitRepo):
 
         self._run_annex_command('drop', annex_options=files)
 
-    @normalize_paths
+    @normalize_paths(match_return_type=False)
     def annex_whereis(self, files):
         """Lists repositories that have actual content of file(s).
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -22,7 +22,7 @@ from functools import wraps
 
 from ConfigParser import NoOptionError
 
-from gitrepo import GitRepo, normalize_paths
+from gitrepo import GitRepo, normalize_path, normalize_paths
 from exceptions import CommandNotAvailableError, CommandError, \
     FileNotInAnnexError, FileInGitError
 
@@ -212,7 +212,7 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: list
+        files: [str], str
             list of paths to get
 
         kwargs: options for the git annex get command.
@@ -232,7 +232,7 @@ class AnnexRepo(GitRepo):
 
         Parameters
         ----------
-        files: list
+        files: [str], str
             list of paths to add to the annex
         """
 
@@ -275,13 +275,13 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: list, str
+        files: [str], str
             file(s) to look up
 
         Returns:
         --------
-        str
-            key used by git-annex for `path`
+        [str]
+            keys used by git-annex for each of the files
         """
 
         if len(files) > 1:
@@ -322,8 +322,8 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: list
-            file_(s) to check for being actually present.
+        files: [str], str
+            file(s) to check for being actually present.
 
         Returns:
         --------
@@ -361,7 +361,7 @@ class AnnexRepo(GitRepo):
 
         Parameters
         ----------
-        files: list
+        files: [str], str
             list of paths to add to git
         """
 
@@ -395,8 +395,8 @@ class AnnexRepo(GitRepo):
 
         self._run_annex_command('enableremote', annex_options=[name])
 
-    @normalize_paths
-    def annex_addurl_to_file(self, file, url, options=[]):
+    @normalize_path
+    def annex_addurl_to_file(self, file_, url, options=[]):
         """Add file from url to the annex.
 
         Downloads `file` from `url` and add it to the annex.
@@ -405,7 +405,7 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        file: str
+        file_: str
             technically it's a list, but conversion is done by the decorator
             and only a single string will work here.
             TODO: figure out, how to document this behaviour
@@ -417,7 +417,7 @@ class AnnexRepo(GitRepo):
             options to the annex command
         """
 
-        annex_options = ['--file=%s' % file[0]] + options + [url]
+        annex_options = ['--file=%s' % file_] + options + [url]
         self._run_annex_command('addurl', annex_options=annex_options,
                                 log_online=True, log_stderr=False)
         # Don't capture stderr, since download progress provided by wget uses
@@ -439,18 +439,18 @@ class AnnexRepo(GitRepo):
         # Don't capture stderr, since download progress provided by wget uses
         # stderr.
 
-    @normalize_paths
-    def annex_rmurl(self, file, url):
+    @normalize_path
+    def annex_rmurl(self, file_, url):
         """Record that the file is no longer available at the url.
 
         Parameters:
         -----------
-        file: str
+        file_: str
 
         url: str
         """
 
-        self._run_annex_command('rmurl', annex_options=[file[0]] + [url])
+        self._run_annex_command('rmurl', annex_options=[file_] + [url])
 
     @normalize_paths
     def annex_drop(self, files):
@@ -461,7 +461,7 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: list
+        files: [str]
         """
         # TODO: options needed
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -212,7 +212,7 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: [str], str
+        files: list of str
             list of paths to get
 
         kwargs: options for the git annex get command.
@@ -232,7 +232,7 @@ class AnnexRepo(GitRepo):
 
         Parameters
         ----------
-        files: [str], str
+        files: list of str
             list of paths to add to the annex
         """
 
@@ -275,12 +275,12 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: [str], str
+        files: list of str
             file(s) to look up
 
         Returns:
         --------
-        [str]
+        list of str
             keys used by git-annex for each of the files
         """
 
@@ -322,12 +322,12 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: [str], str
+        files: list of str
             file(s) to check for being actually present.
 
         Returns:
         --------
-        [bool]
+        list of bool
             Per each input file states either file has content locally
         """
         # TODO: Also provide option to look for key instead of path
@@ -361,7 +361,7 @@ class AnnexRepo(GitRepo):
 
         Parameters
         ----------
-        files: [str], str
+        files: list of str
             list of paths to add to git
         """
 
@@ -461,7 +461,7 @@ class AnnexRepo(GitRepo):
 
         Parameters:
         -----------
-        files: [str]
+        files: list of str
         """
         # TODO: options needed
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -21,8 +21,9 @@ from functools import wraps
 from git import Repo
 from git.exc import GitCommandError
 
-from datalad.support.exceptions import FileNotInRepositoryError
-from datalad.cmd import Runner
+from ..support.exceptions import FileNotInRepositoryError
+from ..cmd import Runner
+from ..utils import optional_args
 
 lgr = logging.getLogger('datalad.gitrepo')
 
@@ -79,7 +80,8 @@ def _normalize_path(base_dir, path):
     return relpath(path, start=base_dir)
 
 
-def normalize_paths(func):
+@optional_args
+def normalize_paths(func, match_return_type=True):
     """Decorator to provide unified path conversions.
 
     Note
@@ -92,19 +94,41 @@ def normalize_paths(func):
     is a member of, is expected to have an attribute 'path'.
 
     Accepts either a list of paths or a single path in a str. Passes a list
-    to decorated function either way!
+    to decorated function either way, but would return based on the value of
+    match_return_type and possibly input argument
+
+    Parameters
+    ----------
+    match_return_type : bool, optional
+      If True, and a single string was passed in, it would return the first
+      element of the output (after verifying that it is a list of length 1).
+      It makes easier to work with single files input.
     """
 
     @wraps(func)
     def newfunc(self, files, *args, **kwargs):
         if isinstance(files, basestring):
             files_new = [_normalize_path(self.path, files)]
+            single_file = True
         elif isinstance(files, list):
             files_new = [_normalize_path(self.path, path) for path in files]
+            single_file = False
         else:
             raise ValueError("_files_decorator: Don't know how to handle instance of %s." %
                              type(files))
-        return func(self, files_new, *args, **kwargs)
+
+        result = func(self, files_new, *args, **kwargs)
+
+        if (result is None) or not match_return_type or not single_file:
+            # If function doesn't return anything or no denormalization
+            # was requested or it was not a single file
+            return result
+        elif single_file:
+            assert(len(result) == 1)
+            return result[0]
+        else:
+            return RuntimeError("should have not got here... check logic")
+
     return newfunc
 
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -81,6 +81,31 @@ def _normalize_path(base_dir, path):
 
 
 @optional_args
+def normalize_path(func):
+    """Decorator to provide unified path conversion for a single file
+
+    Unlike normalize_paths, intended to be used for functions dealing with a
+    single filename at a time
+
+    Note
+    ----
+    This is intended to be used within the repository classes and therefore
+    returns a class method!
+
+    The decorated function is expected to take a path at
+    first positional argument (after 'self'). Additionally the class `func`
+    is a member of, is expected to have an attribute 'path'.
+    """
+
+    @wraps(func)
+    def newfunc(self, file_, *args, **kwargs):
+        file_new = _normalize_path(self.path, file_)
+        return func(self, file_new, *args, **kwargs)
+
+    return newfunc
+
+
+@optional_args
 def normalize_paths(func, match_return_type=True):
     """Decorator to provide unified path conversions.
 

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -77,9 +77,9 @@ def test_AnnexRepo_get(src, dst):
     assert_is_instance(ar, AnnexRepo, "AnnexRepo was not created.")
     testfile = 'test-annex.dat'
     testfile_abs = os.path.join(dst, testfile)
-    assert_false(ar.file_has_content("test-annex.dat")[0][1])
+    assert_false(ar.file_has_content("test-annex.dat")[0])
     ar.annex_get(testfile)
-    assert_true(ar.file_has_content("test-annex.dat")[0][1])
+    assert_true(ar.file_has_content("test-annex.dat")[0])
 
     f = open(testfile_abs, 'r')
     assert_equal(f.readlines(), ['123\n'],
@@ -202,11 +202,16 @@ def test_AnnexRepo_file_has_content(src, annex_path):
 
     ar = AnnexRepo(annex_path, src)
     testfiles = ["test-annex.dat", "test.dat"]
-    assert_equal(ar.file_has_content(testfiles),
-                 [("test-annex.dat", False), ("test.dat", False)])
+    assert_equal(ar.file_has_content(testfiles), [False, False])
+
     ar.annex_get("test-annex.dat")
-    assert_equal(ar.file_has_content(testfiles),
-                 [("test-annex.dat", True), ("test.dat", False)])
+    assert_equal(ar.file_has_content(testfiles), [True, False])
+
+    assert_equal(ar.file_has_content(testfiles + ["bogus.txt"]),
+                 [True, False, False])
+
+    assert_equal(ar.file_has_content(["bogus.txt"]),
+                 [False])
 
 
 def test_AnnexRepo_options_decorator():
@@ -250,7 +255,7 @@ def test_AnnexRepo_web_remote(src, dst):
     l = ar.annex_whereis(testfile)
     assert_in('web', l[testfile])
     assert_equal(len(l[testfile]), 2)
-    assert_in((testfile, True), ar.file_has_content(testfile))
+    assert_equal(ar.file_has_content(testfile), [True])
 
     # remove the remote
     ar.annex_rmurl(testfile, testurl)
@@ -269,19 +274,19 @@ def test_AnnexRepo_web_remote(src, dst):
 
     assert_true(failed)
 
-    # readd the url using different method
+    # read the url using different method
     ar.annex_addurl_to_file(testfile, testurl)
     l = ar.annex_whereis(testfile)
     assert_in('web', l[testfile])
     assert_equal(len(l[testfile]), 2)
-    assert_in((testfile, True), ar.file_has_content(testfile))
+    assert_equal(ar.file_has_content(testfile), [True])
 
     # 2 known copies now; drop should succeed
     ar.annex_drop(testfile)
     l = ar.annex_whereis(testfile)
     assert_in('web', l[testfile])
     assert_equal(len(l[testfile]), 1)
-    assert_in((testfile, False), ar.file_has_content(testfile))
+    assert_equal(ar.file_has_content(testfile), [False])
 
 # TODO:
 #def annex_initremote(self, name, options):

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -77,9 +77,9 @@ def test_AnnexRepo_get(src, dst):
     assert_is_instance(ar, AnnexRepo, "AnnexRepo was not created.")
     testfile = 'test-annex.dat'
     testfile_abs = os.path.join(dst, testfile)
-    assert_false(ar.file_has_content("test-annex.dat")[0])
+    assert_false(ar.file_has_content("test-annex.dat"))
     ar.annex_get(testfile)
-    assert_true(ar.file_has_content("test-annex.dat")[0])
+    assert_true(ar.file_has_content("test-annex.dat"))
 
     f = open(testfile_abs, 'r')
     assert_equal(f.readlines(), ['123\n'],
@@ -206,12 +206,13 @@ def test_AnnexRepo_file_has_content(src, annex_path):
 
     ar.annex_get("test-annex.dat")
     assert_equal(ar.file_has_content(testfiles), [True, False])
+    assert_equal(ar.file_has_content(testfiles[:1]), [True])
 
     assert_equal(ar.file_has_content(testfiles + ["bogus.txt"]),
                  [True, False, False])
 
-    assert_equal(ar.file_has_content(["bogus.txt"]),
-                 [False])
+    assert_false(ar.file_has_content("bogus.txt"))
+    assert_true(ar.file_has_content("test-annex.dat"))
 
 
 def test_AnnexRepo_options_decorator():
@@ -255,7 +256,7 @@ def test_AnnexRepo_web_remote(src, dst):
     l = ar.annex_whereis(testfile)
     assert_in('web', l[testfile])
     assert_equal(len(l[testfile]), 2)
-    assert_equal(ar.file_has_content(testfile), [True])
+    assert_true(ar.file_has_content(testfile))
 
     # remove the remote
     ar.annex_rmurl(testfile, testurl)
@@ -279,14 +280,14 @@ def test_AnnexRepo_web_remote(src, dst):
     l = ar.annex_whereis(testfile)
     assert_in('web', l[testfile])
     assert_equal(len(l[testfile]), 2)
-    assert_equal(ar.file_has_content(testfile), [True])
+    assert_true(ar.file_has_content(testfile))
 
     # 2 known copies now; drop should succeed
     ar.annex_drop(testfile)
     l = ar.annex_whereis(testfile)
     assert_in('web', l[testfile])
     assert_equal(len(l[testfile]), 1)
-    assert_equal(ar.file_has_content(testfile), [False])
+    assert_false(ar.file_has_content(testfile))
 
 # TODO:
 #def annex_initremote(self, name, options):

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -13,6 +13,8 @@
 import os
 import os.path
 
+from os.path import join as opj
+
 from nose.tools import assert_raises, assert_is_instance, assert_true, assert_equal, assert_in
 from git.exc import GitCommandError
 
@@ -35,7 +37,7 @@ def test_GitRepo_instance_from_clone(src, dst):
 
     gr = GitRepo(dst, src)
     assert_is_instance(gr, GitRepo, "GitRepo was not created.")
-    assert_true(os.path.exists(os.path.join(dst, '.git')))
+    assert_true(os.path.exists(opj(dst, '.git')))
 
     # do it again should raise GitCommandError since git will notice there's already a git-repo at that path
     # and therefore can't clone to `dst`
@@ -48,7 +50,7 @@ def test_GitRepo_instance_from_existing(path):
 
     gr = GitRepo(path)
     assert_is_instance(gr, GitRepo, "GitRepo was not created.")
-    assert_true(os.path.exists(os.path.join(path, '.git')))
+    assert_true(os.path.exists(opj(path, '.git')))
 
 
 @assert_cwd_unchanged
@@ -57,7 +59,7 @@ def test_GitRepo_instance_brand_new(path):
 
     gr = GitRepo(path)
     assert_is_instance(gr, GitRepo, "GitRepo was not created.")
-    assert_true(os.path.exists(os.path.join(path, '.git')))
+    assert_true(os.path.exists(opj(path, '.git')))
 
 
 @assert_cwd_unchanged
@@ -67,7 +69,7 @@ def test_GitRepo_add(src, path):
 
     gr = GitRepo(path, src)
     filename = get_most_obscure_supported_name()
-    with open(os.path.join(path, filename), 'w') as f:
+    with open(opj(path, filename), 'w') as f:
         f.write("File to add to git")
     gr.git_add(filename)
 
@@ -80,7 +82,7 @@ def test_GitRepo_commit(path):
 
     gr = GitRepo(path)
     filename = get_most_obscure_supported_name()
-    with open(os.path.join(path, filename), 'w') as f:
+    with open(opj(path, filename), 'w') as f:
         f.write("File to add to git")
 
     gr.git_add(filename)
@@ -127,34 +129,34 @@ def test_normalize_path(git_path):
     result = _normalize_path(gr.path, "testfile")
     assert_equal(result, "testfile", "_normalize_path() returned %s" % result)
 
-    # result = _normalize_path(gr.path, os.path.join('.', 'testfile'))
+    # result = _normalize_path(gr.path, opj('.', 'testfile'))
     # assert_equal(result, "testfile", "_normalize_path() returned %s" % result)
     #
-    # result = _normalize_path(gr.path, os.path.join('testdir', '..', 'testfile'))
+    # result = _normalize_path(gr.path, opj('testdir', '..', 'testfile'))
     # assert_equal(result, "testfile", "_normalize_path() returned %s" % result)
     # Note: By now, normpath within normalize_paths() is disabled, therefore
     # disable these tests.
 
-    result = _normalize_path(gr.path, os.path.join('testdir', 'testfile'))
-    assert_equal(result, os.path.join("testdir", "testfile"), "_normalize_path() returned %s" % result)
+    result = _normalize_path(gr.path, opj('testdir', 'testfile'))
+    assert_equal(result, opj("testdir", "testfile"), "_normalize_path() returned %s" % result)
 
-    result = _normalize_path(gr.path, os.path.join(git_path, "testfile"))
+    result = _normalize_path(gr.path, opj(git_path, "testfile"))
     assert_equal(result, "testfile", "_normalize_path() returned %s" % result)
 
     # now we are inside, so relative paths are relative to cwd and have
     # to be converted to be relative to annex_path:
-    os.chdir(os.path.join(git_path, 'd1', 'd2'))
+    os.chdir(opj(git_path, 'd1', 'd2'))
 
     result = _normalize_path(gr.path, "testfile")
-    assert_equal(result, os.path.join('d1', 'd2', 'testfile'), "_normalize_path() returned %s" % result)
+    assert_equal(result, opj('d1', 'd2', 'testfile'), "_normalize_path() returned %s" % result)
 
-    result = _normalize_path(gr.path, os.path.join('..', 'testfile'))
-    assert_equal(result, os.path.join('d1', 'testfile'), "_normalize_path() returned %s" % result)
+    result = _normalize_path(gr.path, opj('..', 'testfile'))
+    assert_equal(result, opj('d1', 'testfile'), "_normalize_path() returned %s" % result)
 
-    assert_raises(FileNotInRepositoryError, _normalize_path, gr.path, os.path.join(git_path, '..', 'outside'))
+    assert_raises(FileNotInRepositoryError, _normalize_path, gr.path, opj(git_path, '..', 'outside'))
 
-    result = _normalize_path(gr.path, os.path.join(git_path, 'd1', 'testfile'))
-    assert_equal(result, os.path.join('d1', 'testfile'), "_normalize_path() returned %s" % result)
+    result = _normalize_path(gr.path, opj(git_path, 'd1', 'testfile'))
+    assert_equal(result, opj('d1', 'testfile'), "_normalize_path() returned %s" % result)
 
     os.chdir(cwd)
 
@@ -163,7 +165,7 @@ def test_GitRepo_files_decorator():
 
     class testclass(object):
         def __init__(self):
-            self.path = os.path.join('some', 'where')
+            self.path = opj('some', 'where')
 
         @normalize_paths
         def decorated(self, files):
@@ -171,22 +173,26 @@ def test_GitRepo_files_decorator():
 
     test_instance = testclass()
 
-    files_to_test = os.path.join(test_instance.path, 'deep', get_most_obscure_supported_name())
-    assert_equal(test_instance.decorated(files_to_test),
-                 [_normalize_path(test_instance.path, files_to_test)])
+    # When a single file passed -- single path returned
+    obscure_filename = get_most_obscure_supported_name()
+    file_to_test = opj(test_instance.path, 'deep', obscure_filename)
+    assert_equal(test_instance.decorated(file_to_test),
+                 _normalize_path(test_instance.path, file_to_test))
 
-    files_to_test = get_most_obscure_supported_name()
-    assert_equal(test_instance.decorated(files_to_test),
-                 [_normalize_path(test_instance.path, files_to_test)])
+    file_to_test = obscure_filename
+    assert_equal(test_instance.decorated(file_to_test),
+                 _normalize_path(test_instance.path, file_to_test))
 
-    files_to_test = os.path.join(get_most_obscure_supported_name(), 'beyond', 'obscure')
-    assert_equal(test_instance.decorated(files_to_test),
-                 [_normalize_path(test_instance.path, files_to_test)])
+    file_to_test = opj(obscure_filename, 'beyond', 'obscure')
+    assert_equal(test_instance.decorated(file_to_test),
+                 _normalize_path(test_instance.path, file_to_test))
 
-    files_to_test = os.path.join(os.getcwd(), 'somewhere', 'else', get_most_obscure_supported_name())
-    assert_raises(FileNotInRepositoryError, test_instance.decorated, files_to_test)
+    file_to_test = opj(os.getcwd(), 'somewhere', 'else', obscure_filename)
+    assert_raises(FileNotInRepositoryError, test_instance.decorated,
+                  file_to_test)
 
-    files_to_test = ['now', os.path.join('a list', 'of'), 'paths']
+    # If a list passed -- list returned
+    files_to_test = ['now', opj('a list', 'of'), 'paths']
     expect = []
     for item in files_to_test:
         expect.append(_normalize_path(test_instance.path, item))

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -24,6 +24,8 @@ from datalad.tests.utils import with_tempfile, with_testrepos, assert_cwd_unchan
 from datalad.support.exceptions import FileNotInRepositoryError
 from datalad.cmd import Runner
 
+from .utils import swallow_logs
+
 # For now (at least) we would need to clone from the network
 # since there are troubles with submodules on Windows.
 # See: https://github.com/datalad/datalad/issues/44
@@ -41,7 +43,8 @@ def test_GitRepo_instance_from_clone(src, dst):
 
     # do it again should raise GitCommandError since git will notice there's already a git-repo at that path
     # and therefore can't clone to `dst`
-    assert_raises(GitCommandError, GitRepo, dst, src)
+    with swallow_logs() as logs:
+        assert_raises(GitCommandError, GitRepo, dst, src)
 
 
 @assert_cwd_unchanged
@@ -168,27 +171,37 @@ def test_GitRepo_files_decorator():
             self.path = opj('some', 'where')
 
         @normalize_paths
-        def decorated(self, files):
+        def decorated_many(self, files):
             return files
+
+        @normalize_paths
+        def decorated_one(self, file_):
+            return file_
+
 
     test_instance = testclass()
 
     # When a single file passed -- single path returned
     obscure_filename = get_most_obscure_supported_name()
     file_to_test = opj(test_instance.path, 'deep', obscure_filename)
-    assert_equal(test_instance.decorated(file_to_test),
+    assert_equal(test_instance.decorated_many(file_to_test),
+                 _normalize_path(test_instance.path, file_to_test))
+    assert_equal(test_instance.decorated_one(file_to_test),
                  _normalize_path(test_instance.path, file_to_test))
 
     file_to_test = obscure_filename
-    assert_equal(test_instance.decorated(file_to_test),
+    assert_equal(test_instance.decorated_many(file_to_test),
+                 _normalize_path(test_instance.path, file_to_test))
+    assert_equal(test_instance.decorated_one(file_to_test),
                  _normalize_path(test_instance.path, file_to_test))
 
+
     file_to_test = opj(obscure_filename, 'beyond', 'obscure')
-    assert_equal(test_instance.decorated(file_to_test),
+    assert_equal(test_instance.decorated_many(file_to_test),
                  _normalize_path(test_instance.path, file_to_test))
 
     file_to_test = opj(os.getcwd(), 'somewhere', 'else', obscure_filename)
-    assert_raises(FileNotInRepositoryError, test_instance.decorated,
+    assert_raises(FileNotInRepositoryError, test_instance.decorated_many,
                   file_to_test)
 
     # If a list passed -- list returned
@@ -196,6 +209,6 @@ def test_GitRepo_files_decorator():
     expect = []
     for item in files_to_test:
         expect.append(_normalize_path(test_instance.path, item))
-    assert_equal(test_instance.decorated(files_to_test), expect)
+    assert_equal(test_instance.decorated_many(files_to_test), expect)
 
-    assert_raises(ValueError, test_instance.decorated, 1)
+    assert_raises(ValueError, test_instance.decorated_many, 1)

--- a/datalad/tests/test_handle.py
+++ b/datalad/tests/test_handle.py
@@ -82,9 +82,9 @@ def test_Handle_get(src, dst):
     assert_is_instance(ds, Handle, "AnnexRepo was not created.")
     testfile = 'test-annex.dat'
     testfile_abs = os.path.join(dst, testfile)
-    assert_false(ds.file_has_content("test-annex.dat")[0][1])
+    assert_false(ds.file_has_content("test-annex.dat"))
     ds.get(testfile)
-    assert_true(ds.file_has_content("test-annex.dat")[0][1])
+    assert_true(ds.file_has_content("test-annex.dat"))
     f = open(testfile_abs, 'r')
     assert_equal(f.readlines(), ['123\n'], "test-annex.dat's content doesn't match.")
 


### PR DESCRIPTION
`+` refactor file_has_content to work for a single or multiple files reliably.

This way coding becomes easier and more "logical", since you don't get lists back even if you ask about a single file.  I still fill though that we might simply need additional option for this normalize_paths for cases if function can't operate on multiple files -- then we shouldn't may be even wrap into a list -- just provide normalization.

As for `file_has_content`, and `get_file_key` - they are outcasted in the API where everything else starts with `annex_` so we might want to unify