### PR TITLE
RF: call git-annex directly (not git annex) where possible

### DIFF
--- a/datalad/customremotes/archive.py
+++ b/datalad/customremotes/archive.py
@@ -314,7 +314,7 @@ class AnnexArchiveCustomRemote(AnnexCustomRemote):
             # Command could have fail to run if key was not present locally yet
             # Thus retrieve the key using annex
             try:
-                self.runner(["git", "annex", "get", "--key", akey],
+                self.runner(["git-annex", "get", "--key", akey],
                             cwd=self.path)
                 akey_path = self._get_key_path(akey)
                 assert(exists(akey_path))

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -451,7 +451,7 @@ class AnnexCustomRemote(object):
         """
         # TODO: should actually be implemented by AnnexRepo
         (out, err) = \
-            self.runner(['git', 'annex', 'lookupkey', file], cwd=self.path)
+            self.runner(['git-annex', 'lookupkey', file], cwd=self.path)
         return out.rstrip(os.linesep)
 
     def _get_key_path(self, key):
@@ -460,7 +460,7 @@ class AnnexCustomRemote(object):
         # TODO: should actually be implemented by AnnexRepo
         #       Command is available in annex >= 20140410
         (out, err) = \
-            self.runner(['git', 'annex', 'contentlocation', key], cwd=self.path)
+            self.runner(['git-annex', 'contentlocation', key], cwd=self.path)
         # TODO: it would exit with non-0 if key is not present locally.
         # we need to catch and throw our exception
         return opj(self.path, out.rstrip(os.linesep))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -151,10 +151,13 @@ class AnnexRepo(GitRepo):
 
         debug = ['--debug'] if lgr.getEffectiveLevel() <= logging.DEBUG else []
         backend = ['--backend=%s' % backend] if backend else []
-        cmd_list = ['git'] + git_options +\
-                   ['annex', annex_cmd] +\
-                   backend + debug +\
-                   annex_options
+
+        if git_options:
+            cmd_list = ['git'] + git_options + ['annex']
+        else:
+            cmd_list = ['git-annex']
+        cmd_list += [annex_cmd] + backend + debug + annex_options
+
         try:
             return self.cmd_call_wrapper.run(cmd_list,
                                              log_stdout=log_stdout,

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -235,7 +235,7 @@ def test_link_file_load(tempfile):
 def test_runner_failure(dir):
 
     runner = Runner()
-    failing_cmd = ['git', 'annex', 'add', 'notexistent.dat']
+    failing_cmd = ['git-annex', 'add', 'notexistent.dat']
     assert_raises(CommandError, runner.run, failing_cmd, cwd=dir)
 
     try:


### PR DESCRIPTION
Testing this solution to see if it helps to reduce number
of zombie git processes on buildbot dockers