### PR TITLE
ENH: Make 'make test' work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,14 @@ all: clean test
 
 clean:
 	$(PYTHON) setup.py clean
-	rm -rf dist
+	rm -rf dist build bin
 
+bin:
+	mkdir -p $@
+	PYTHONPATH=bin:$(PYTHONPATH) python setup.py develop --install-dir $@
 
-test-code:
-	$(NOSETESTS) -s -v $(MODULE)
+test-code: bin
+	PATH=bin:$(PATH) PYTHONPATH=bin:$(PYTHONPATH) $(NOSETESTS) -s -v $(MODULE)
 
 test-coverage:
 	rm -rf coverage .coverage


### PR DESCRIPTION
Due to popular demand: a `make test` that doesn't need pip or other fancy Python foo to run the tests on a mortal's machine.