### PR TITLE
BF: ok_annex_get always assumed a download was needed.

### DIFF
--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -363,6 +363,9 @@ def test_AnnexRepo_get_file_backend(src, dst):
         ok_annex_get(ar, 'test-annex.dat')
         ar.migrate_backend('test-annex.dat', backend='SHA1')
         assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA1')
+    else:
+        assert_raises(CommandNotAvailableError, ar.migrate_backend,
+                      'test-annex.dat', backend='SHA1')
 
 # TODO:
 #def annex_initremote(self, name, options):

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -360,7 +360,7 @@ def test_AnnexRepo_get_file_backend(src, dst):
     assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA256E')
     if not ar.is_direct_mode():
         # no migration in direct mode
-        ok_annex_get(ar, 'test-annex.dat')
+        ok_annex_get(ar, 'test-annex.dat', network=False)
         ar.migrate_backend('test-annex.dat', backend='SHA1')
         assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA1')
     else:

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -162,7 +162,7 @@ def nok_startswith(s, prefix):
         msg="String %r starts with %r" % (s, prefix))
 
 
-def ok_annex_get(ar, files):
+def ok_annex_get(ar, files, network=True):
     """Helper to run .annex_get decorated checking for correct operation
 
     annex_get passes through stderr from the ar to the user, which pollutes
@@ -170,8 +170,9 @@ def ok_annex_get(ar, files):
     """
     with swallow_outputs() as cmo:
         ar.annex_get(files)
-        # wget or curl - just verify that annex spits out expected progress bar
-        ok_('100%' in cmo.err or '100.0%' in cmo.err)
+        if network:
+            # wget or curl - just verify that annex spits out expected progress bar
+            ok_('100%' in cmo.err or '100.0%' in cmo.err)
     # verify that load was fetched
     has_content = ar.file_has_content(files)
     if isinstance(has_content, bool):


### PR DESCRIPTION
test helper ok_annex_get used to always check the output of wget/curl. In case retrieving a file's content doesn't involve a remote clone but a locally available one, this test failed.