### PR TITLE
NF: Introduce always_commit option

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -156,10 +156,8 @@ class AnnexRepo(GitRepo):
         debug = ['--debug'] if lgr.getEffectiveLevel() <= logging.DEBUG else []
         backend = ['--backend=%s' % backend] if backend else []
 
-        if git_options is None:
-            git_options = []
-        if annex_options is None:
-            annex_options = []
+        git_options = git_options[:] if git_options else []
+        annex_options = annex_options[:] if annex_options else []
 
         if not self.always_commit:
             git_options += ['-c', 'annex.alwayscommit=false']
@@ -269,8 +267,7 @@ class AnnexRepo(GitRepo):
             For example `from='myremote'` translates to
             annex option "--from=myremote".
         """
-        if options is None:
-            options = []
+        options = options[:] if options else []
 
         # don't capture stderr, since it provides progress display
         self._run_annex_command('get', annex_options=options + files,
@@ -286,8 +283,7 @@ class AnnexRepo(GitRepo):
         files: list of str
             list of paths to add to the annex
         """
-        if options is None:
-            options = []
+        options = options[:] if options else []
 
         self._run_annex_command('add', annex_options=options + files,
                                 backend=backend)
@@ -464,8 +460,7 @@ class AnnexRepo(GitRepo):
         options: list
             options to the annex command
         """
-        if options is None:
-            options = []
+        options = options[:] if options else []
 
         annex_options = ['--file=%s' % file_] + options + [url]
         self._run_annex_command('addurl', annex_options=annex_options,
@@ -484,8 +479,7 @@ class AnnexRepo(GitRepo):
         options: list
             options to the annex command
         """
-        if options is None:
-            options = []
+        options = options[:] if options else []
 
         self._run_annex_command('addurl', annex_options=options + urls,
                                 backend=backend, log_online=True,
@@ -517,8 +511,7 @@ class AnnexRepo(GitRepo):
         -----------
         files: list of str
         """
-        if options is None:
-            options = []
+        options = options[:] if options else []
 
         self._run_annex_command('drop', annex_options=files + options)
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -66,8 +66,10 @@ class AnnexRepo(GitRepo):
     accepted either way.
     """
 
+    __slots__ = GitRepo.__slots__ + ['always_commit']
+
     def __init__(self, path, url=None, runner=None,
-                 direct=False, backend=None):
+                 direct=False, backend=None, always_commit=True):
         """Creates representation of git-annex repository at `path`.
 
         AnnexRepo is initialized by giving a path to the annex.
@@ -98,6 +100,8 @@ class AnnexRepo(GitRepo):
             that are 'getted' afterwards.
         """
         super(AnnexRepo, self).__init__(path, url, runner=runner)
+
+        self.always_commit = always_commit
 
         # Check whether an annex already exists at destination
         if not exists(opj(self.path, '.git', 'annex')):
@@ -151,6 +155,9 @@ class AnnexRepo(GitRepo):
 
         debug = ['--debug'] if lgr.getEffectiveLevel() <= logging.DEBUG else []
         backend = ['--backend=%s' % backend] if backend else []
+
+        if not self.always_commit:
+            git_options.extend(['-c', 'annex.alwayscommit=false'])
 
         if git_options:
             cmd_list = ['git'] + git_options + ['annex']
@@ -244,7 +251,6 @@ class AnnexRepo(GitRepo):
         # TODO: When to expect stderr?
         # on crippled filesystem for example (think so)?
 
-    @kwargs_to_options
     @normalize_paths
     def annex_get(self, files, options=[]):
         """Get the actual content of files

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -119,7 +119,7 @@ class AnnexRepo(GitRepo):
         if backend:
             self.repo.config_writer().set_value("annex", "backends", backend)
 
-    def _run_annex_command(self, annex_cmd, git_options=[], annex_options=[],
+    def _run_annex_command(self, annex_cmd, git_options=None, annex_options=None,
                            log_stdout=True, log_stderr=True, log_online=False,
                            expect_stderr=False, expect_fail=False,
                            backend=None):
@@ -156,8 +156,13 @@ class AnnexRepo(GitRepo):
         debug = ['--debug'] if lgr.getEffectiveLevel() <= logging.DEBUG else []
         backend = ['--backend=%s' % backend] if backend else []
 
+        if git_options is None:
+            git_options = []
+        if annex_options is None:
+            annex_options = []
+
         if not self.always_commit:
-            git_options.extend(['-c', 'annex.alwayscommit=false'])
+            git_options += ['-c', 'annex.alwayscommit=false']
 
         if git_options:
             cmd_list = ['git'] + git_options + ['annex']
@@ -252,7 +257,7 @@ class AnnexRepo(GitRepo):
         # on crippled filesystem for example (think so)?
 
     @normalize_paths
-    def annex_get(self, files, options=[]):
+    def annex_get(self, files, options=None):
         """Get the actual content of files
 
         Parameters:
@@ -264,6 +269,8 @@ class AnnexRepo(GitRepo):
             For example `from='myremote'` translates to
             annex option "--from=myremote".
         """
+        if options is None:
+            options = []
 
         # don't capture stderr, since it provides progress display
         self._run_annex_command('get', annex_options=options + files,
@@ -271,7 +278,7 @@ class AnnexRepo(GitRepo):
                                 log_online=True, expect_stderr=True)
 
     @normalize_paths
-    def annex_add(self, files, backend=None, options=[]):
+    def annex_add(self, files, backend=None, options=None):
         """Add file(s) to the annex.
 
         Parameters
@@ -279,6 +286,8 @@ class AnnexRepo(GitRepo):
         files: list of str
             list of paths to add to the annex
         """
+        if options is None:
+            options = []
 
         self._run_annex_command('add', annex_options=options + files,
                                 backend=backend)
@@ -439,7 +448,7 @@ class AnnexRepo(GitRepo):
         self._run_annex_command('enableremote', annex_options=[name])
 
     @normalize_path
-    def annex_addurl_to_file(self, file_, url, options=[], backend=None):
+    def annex_addurl_to_file(self, file_, url, options=None, backend=None):
         """Add file from url to the annex.
 
         Downloads `file` from `url` and add it to the annex.
@@ -455,6 +464,8 @@ class AnnexRepo(GitRepo):
         options: list
             options to the annex command
         """
+        if options is None:
+            options = []
 
         annex_options = ['--file=%s' % file_] + options + [url]
         self._run_annex_command('addurl', annex_options=annex_options,
@@ -463,7 +474,7 @@ class AnnexRepo(GitRepo):
         # Don't capture stderr, since download progress provided by wget uses
         # stderr.
 
-    def annex_addurls(self, urls, options=[], backend=None):
+    def annex_addurls(self, urls, options=None, backend=None):
         """Downloads each url to its own file, which is added to the annex.
 
         Parameters:
@@ -473,6 +484,8 @@ class AnnexRepo(GitRepo):
         options: list
             options to the annex command
         """
+        if options is None:
+            options = []
 
         self._run_annex_command('addurl', annex_options=options + urls,
                                 backend=backend, log_online=True,
@@ -494,7 +507,7 @@ class AnnexRepo(GitRepo):
         self._run_annex_command('rmurl', annex_options=[file_] + [url])
 
     @normalize_paths
-    def annex_drop(self, files, options=[]):
+    def annex_drop(self, files, options=None):
         """Drops the content of annexed files from this repository.
 
         Drops only if possible with respect to required minimal number of
@@ -504,6 +517,8 @@ class AnnexRepo(GitRepo):
         -----------
         files: list of str
         """
+        if options is None:
+            options = []
 
         self._run_annex_command('drop', annex_options=files + options)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -165,15 +165,15 @@ def _remove_empty_items(list_):
 
     Parameter:
     ----------
-    files: list of str
+    list_: list of str
 
     Returns:
     list of str
     """
     if not isinstance(list_, list):
         lgr.warning(
-            "_remove_empty_items() called with non-list type: %s" % type(files))
-        return files
+            "_remove_empty_items() called with non-list type: %s" % type(list_))
+        return list_
     return [file_ for file_ in list_ if file_]
 
 

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -396,7 +396,7 @@ def test_AnnexRepo_always_commit(path):
     num_commits = len([commit
                        for commit in out.rstrip(os.linesep).split(os.linesep)
                        if commit.startswith('commit')])
-    assert_equal(num_commits, 3)
+    assert_equal(num_commits, 3, "catched output:\n%s" % out.rstrip(os.linesep).split(os.linesep))
 
     repo.always_commit = False
     repo.annex_add(file2)

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -379,7 +379,7 @@ def test_AnnexRepo_always_commit(path):
     with open(opj(path, file2), 'w') as f:
         f.write("Second file.")
 
-    repo.always_commit = True
+    # always_commit == True is expected to be default
     repo.annex_add(file1)
 
     # Now git-annex log should show the addition:
@@ -393,16 +393,16 @@ def test_AnnexRepo_always_commit(path):
 
     repo.always_commit = True
 
-    # Still one commit only in log:
+    # Still one commit only in log,
+    # but 'git annex log' was called when always_commit was true again,
+    # so it should commit the addition at the end. Calling it again should then
+    # show two commits.
     out, err = repo._run_annex_command('log')
     out_list = out.rstrip(os.linesep).split(os.linesep)
     assert_equal(len(out_list), 2, "Output:\n%s" % out_list)
     assert_in(file1, out_list[0])
     assert_in("recording state in git", out_list[1])
 
-    # but 'git annex log' was called when always_commit was true again,
-    # so it committed the addition at the end. Calling it again should show
-    # two commits now:
     out, err = repo._run_annex_command('log')
     out_list = out.rstrip(os.linesep).split(os.linesep)
     assert_equal(len(out_list), 2, "Output:\n%s" % out_list)

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -404,7 +404,7 @@ def test_AnnexRepo_always_commit(path):
     # No additional git commit:
     out, err = runner.run(['git', 'log', 'git-annex'])
     num_commits = len([commit
-                       for commit in out.rstrip(os.linesep).split(os.linesep)
+                       for commit in out.rstrip(os.linesep).split('\n')
                        if commit.startswith('commit')])
     assert_equal(num_commits, 3)
 
@@ -429,7 +429,7 @@ def test_AnnexRepo_always_commit(path):
     # Now git knows as well:
     out, err = runner.run(['git', 'log', 'git-annex'])
     num_commits = len([commit
-                       for commit in out.rstrip(os.linesep).split(os.linesep)
+                       for commit in out.rstrip(os.linesep).split('\n')
                        if commit.startswith('commit')])
     assert_equal(num_commits, 4)
 

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -394,9 +394,9 @@ def test_AnnexRepo_always_commit(path):
     # update (by annex log)
     out, err = runner.run(['git', 'log', 'git-annex'])
     num_commits = len([commit
-                       for commit in out.rstrip(os.linesep).split(os.linesep)
+                       for commit in out.rstrip(os.linesep).split('\n')
                        if commit.startswith('commit')])
-    assert_equal(num_commits, 3, "catched output:\n%s" % out.rstrip(os.linesep).split(os.linesep))
+    assert_equal(num_commits, 3)
 
     repo.always_commit = False
     repo.annex_add(file2)

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -367,6 +367,49 @@ def test_AnnexRepo_get_file_backend(src, dst):
         assert_raises(CommandNotAvailableError, ar.migrate_backend,
                       'test-annex.dat', backend='SHA1')
 
+
+@with_tempfile
+def test_AnnexRepo_always_commit(path):
+
+    repo = AnnexRepo(path)
+    file1 = get_most_obscure_supported_name() + "_1"
+    file2 = get_most_obscure_supported_name() + "_2"
+    with open(opj(path, file1), 'w') as f:
+        f.write("First file.")
+    with open(opj(path, file2), 'w') as f:
+        f.write("Second file.")
+
+    repo.always_commit = True
+    repo.annex_add(file1)
+
+    # Now git-annex log should show the addition:
+    out, err = repo._run_annex_command('log')
+    out_list = out.rstrip(os.linesep).split(os.linesep)
+    assert_equal(len(out_list), 1)
+    assert_in(file1, out_list[0])
+
+    repo.always_commit = False
+    repo.annex_add(file2)
+
+    repo.always_commit = True
+
+    # Still one commit only in log:
+    out, err = repo._run_annex_command('log')
+    out_list = out.rstrip(os.linesep).split(os.linesep)
+    assert_equal(len(out_list), 2, "Output:\n%s" % out_list)
+    assert_in(file1, out_list[0])
+    assert_in("recording state in git", out_list[1])
+
+    # but 'git annex log' was called when always_commit was true again,
+    # so it committed the addition at the end. Calling it again should show
+    # two commits now:
+    out, err = repo._run_annex_command('log')
+    out_list = out.rstrip(os.linesep).split(os.linesep)
+    assert_equal(len(out_list), 2, "Output:\n%s" % out_list)
+    assert_in(file1, out_list[0])
+    assert_in(file2, out_list[1])
+
+
 # TODO:
 #def annex_initremote(self, name, options):
 #def annex_enableremote(self, name):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -243,8 +243,12 @@ def swallow_outputs():
         def cleanup(self):
             self._out.close()
             self._err.close()
-            rmtemp(self._out.name)
-            rmtemp(self._err.name)
+            out_name = self._out.name
+            err_name = self._err.name
+            del self._out
+            del self._err
+            rmtemp(out_name)
+            rmtemp(err_name)
 
 
 
@@ -318,7 +322,9 @@ def swallow_logs(new_level=None):
 
         def cleanup(self):
             self._out.close()
-            rmtemp(self._out.name)
+            out_name = self._out.name
+            del self._out
+            rmtemp(out_name)
 
     adapter = StringIOAdapter()
     lgr.handlers = [logging.StreamHandler(adapter.handle)]


### PR DESCRIPTION
As proposed herein, always_commit works as a mode of operation. Set to false to not instantly commit changes by git-annex calls.

Note: windows fails due to issue #147 