### PR TITLE
RF testrepos -- generate testrepos locally (but only once per run) + allow for use of network "clone"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "datalad/tests/testrepos"]
-	path = datalad/tests/testrepos
-	url = git://github.com/datalad/testrepos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,6 @@ Files organization
       the `cmd_*.py` files here for an example
     - `crawler/` functionality relevant for `crawl`ing operation of DataLad
     - `tests/` all unit- and regression- tests
-        - `testrepos/` a git submodule pointing to the
-          [datalad/testrepos repository][gh-datalad]
-          intended to collate repositories used for testing
         - `utils.py` provides convenience helpers used by unit-tests such as
           `@with_tree`, `@serve_path_via_http` and other decorators
 - `tools/` contains helper utilities used during development, testing, and
@@ -35,10 +32,7 @@ we outline the workflow used by the developers:
 0. Have a clone of our main [project repository][gh-datalad] as `origin`
    remote in your git:
 
-          git clone --recursive git://github.com/datalad/datalad
-
-    `--recursive` is used to initialize any needed git submodules.  If you have 
-    cloned without it already, just run `git submodule update --init --recursive`
+          git clone git://github.com/datalad/datalad
 
 1. Fork the [project repository][gh-datalad]: click on the 'Fork'
    button near the top of the page.  This creates a copy of the code
@@ -153,17 +147,6 @@ then to later deactivate the virtualenv just simply enter
 deactivate
 ```
 
-Remember, some tests use testing repositories which are available as submodules
-under the `datalad/tests/testrepos` submodule (two tier- to not pollute
-top repository submodules namespace).  To enable those tests do:
-
-```sh
-git submodule update --init --recursive
-```
-
-or do the original repository clone described above with the `--recursive` 
-option.
-
 Alternatively, or complimentary to that, you can use `tox` -- there is a `tox.ini`
 file which sets up a few virtual environments for testing locally, which you can 
 later reuse like any other regular virtualenv for troubleshooting.
@@ -210,24 +193,6 @@ provides built-in PEP8 checker and handy tools such as smart
 splits/joins making it easier to maintain code following the PEP8
 recommendations.  NeuroDebian provides `pycharm-community-sloppy`
 package to ease pycharm installation even further.
-
-
-### Test repositories
-
-`datalad/tests/testrepos/` is a submodule containing git/git-annex repositories
-(again as submodules), which are then used by various unit tests under
-`datalad/tests/`.  Creation of (some of) those test repositories is scripted in
-`tools/testing/make_test_repo`, and "protocoled" in
-`tools/testing/make_test_repos`.  Test repositories are organized under
-`testrepos/` in two-levels `flavor/sample`, e.g. `basic/r1` was created by
-running `make_test_repo basic r1`.  We could generate e.g. `r2` similarly on a
-different system.  Generated `info.txt` file provides information about
-git/git-annex versions used to generate the repository.
-
-Since those are linked to mainline the `datalad` repository as submodules of the
-`datalad/tests/testrepos` submodule, it requires committing/pushing at all 3
-levels. `make_test_repo` script, on example of `basic` flavor provides steps to
-achieve that.
 
 
 Easy Issues

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -68,6 +68,7 @@ class AnnexRepo(GitRepo):
 
     __slots__ = GitRepo.__slots__ + ['always_commit']
 
+    # TODO: pass description
     def __init__(self, path, url=None, runner=None,
                  direct=False, backend=None, always_commit=True):
         """Creates representation of git-annex repository at `path`.

--- a/datalad/tests/__init__.py
+++ b/datalad/tests/__init__.py
@@ -8,7 +8,22 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import os
+import shutil
 import tempfile
+from logging import getLogger
+
+lgr = getLogger("datalad.tests")
+
+# We will delay generation of some test files/directories until they are
+# actually used but then would remove them here
+_TEMP_PATHS_GENERATED = []
+def teardown_module():
+    from datalad.tests.utils import rmtemp
+    lgr.debug("Teardown tests. " +
+              (("Removing dirs/files: %s" % ', '.join(_TEMP_PATHS_GENERATED))
+                if _TEMP_PATHS_GENERATED else "Nothing to remove"))
+    for path in _TEMP_PATHS_GENERATED:
+        rmtemp(path)
 
 # Give a custom template so we could hunt them down easily
 tempfile.template = os.path.join(tempfile.gettempdir(),

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -14,7 +14,7 @@ from .utils import eq_, ok_, with_testrepos, with_tempfile
 from datalad.cmd import Runner
 from .utils import local_testrepo_flavors
 
-@with_testrepos(flavors=local_testrepo_flavors)
+@with_testrepos(flavors=['clone'])
 def test_having_annex(path):
     ok_(os.path.exists(os.path.join(path, '.git')))
     repo = git.Repo(path)

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -90,7 +90,7 @@ def test_with_testrepos():
 
     check_with_testrepos()
 
-    eq_(len(repos), 3)  # local, local-url, clone
+    eq_(len(repos), 2 if on_windows else 3)  # local, local-url, clone
 
     for repo in repos:
         if not (repo.startswith('git://') or repo.startswith('http')):

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -90,7 +90,7 @@ def test_with_testrepos():
 
     check_with_testrepos()
 
-    eq_(len(repos), 4 if exists(opj(os.path.dirname(__file__), 'testrepos')) else 2)
+    eq_(len(repos), 3)  # local, local-url, clone
 
     for repo in repos:
         if not (repo.startswith('git://') or repo.startswith('http')):

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -15,7 +15,11 @@ from .utils_testrepos import BasicTestRepo
 from .utils import with_tempfile, assert_true, ok_clean_git
 from .utils import ok_file_under_git, ok_broken_symlink, ok_good_symlink
 from .utils import swallow_outputs
+from .utils import on_windows
+from .utils import SkipTest
 
+if on_windows:
+    raise SkipTest("experiencing issues on windows -- disabled for now")
 
 def _test_BasicTestRepo(repodir):
     trepo = BasicTestRepo(repodir)

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -1,0 +1,31 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for test repositories
+
+"""
+from os.path import join as pathjoin
+
+from .utils_testrepos import BasicTestRepo
+from .utils import with_tempfile, assert_true, ok_clean_git
+from .utils import ok_file_under_git, ok_broken_symlink, ok_good_symlink
+from .utils import swallow_outputs
+
+
+@with_tempfile()
+def test_BasicTestRepo(repodir):
+    trepo = BasicTestRepo(repodir)
+    ok_clean_git(repodir)
+    ok_file_under_git(repodir, 'test.dat')
+    ok_file_under_git(repodir, 'test-annex.dat', annexed=True)
+    if not trepo.repo.is_crippled_fs():
+        ok_broken_symlink(pathjoin(repodir, 'test-annex.dat'))
+    with swallow_outputs():
+        trepo.repo.annex_get('test-annex.dat')
+    if not trepo.repo.is_crippled_fs():
+        ok_good_symlink(pathjoin(repodir, 'test-annex.dat'))

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -17,15 +17,24 @@ from .utils import ok_file_under_git, ok_broken_symlink, ok_good_symlink
 from .utils import swallow_outputs
 
 
-@with_tempfile()
-def test_BasicTestRepo(repodir):
+def _test_BasicTestRepo(repodir):
     trepo = BasicTestRepo(repodir)
-    ok_clean_git(repodir)
-    ok_file_under_git(repodir, 'test.dat')
-    ok_file_under_git(repodir, 'test-annex.dat', annexed=True)
+    trepo.create()
+    ok_clean_git(trepo.path)
+    ok_file_under_git(trepo.path, 'test.dat')
+    ok_file_under_git(trepo.path, 'test-annex.dat', annexed=True)
     if not trepo.repo.is_crippled_fs():
-        ok_broken_symlink(pathjoin(repodir, 'test-annex.dat'))
+        ok_broken_symlink(pathjoin(trepo.path, 'test-annex.dat'))
     with swallow_outputs():
         trepo.repo.annex_get('test-annex.dat')
     if not trepo.repo.is_crippled_fs():
-        ok_good_symlink(pathjoin(repodir, 'test-annex.dat'))
+        ok_good_symlink(pathjoin(trepo.path, 'test-annex.dat'))
+
+# Use of @with_tempfile() apparently is not friendly to test generators yet
+# so generating two tests manually
+def test_BasicTestRepo_random_location_generated():
+    _test_BasicTestRepo(None)  # without explicit path -- must be generated
+
+@with_tempfile()
+def test_BasicTestRepo(path):
+    yield _test_BasicTestRepo, path

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -12,6 +12,7 @@ import glob
 import shutil
 import stat
 import os
+import re
 import tempfile
 import platform
 import multiprocessing
@@ -351,10 +352,8 @@ def with_tempfile(t, *targs, **tkwargs):
     return newfunc
 
 
-_TESTREPOS = {'basic/r1': 'git://github.com/datalad/testrepo--basic--r1'}
-
 def _get_resolved_flavors(flavors):
-    flavors_ = ['local', 'network', 'clone', 'network-clone'] if flavors=='auto' else flavors
+    flavors_ = ['local', 'local-url', 'clone'] if flavors == 'auto' else flavors
 
     if not isinstance(flavors_, list):
         flavors_ = [flavors_]
@@ -392,41 +391,38 @@ def clone_url(url):
     return tdir
 
 
-def _extend_globs(path, flavors):
-    globs = glob.glob(path)
 
-    globs_extended = []
-    if 'local' in flavors:
-        globs_extended += globs
+local_testrepo_flavors = ['local'] # 'local-url'
 
-    if 'network' in flavors:
-        globs_extended += [_get_repo_url(repo) for repo in globs]
+from .utils_testrepos import BasicTestRepo, TestRepo
+_basic_test_repo = BasicTestRepo()
+_TESTREPOS = {'basic':
+                  {'network': 'git://github.com/datalad/testrepo--basic--r1',
+                   'local': _basic_test_repo.path,
+                   'local-url': _basic_test_repo.url}}
 
-    if 'clone' in flavors:
-        globs_extended += [clone_url(repo) for repo in globs]
+def _get_testrepos_uris(regex, flavors):
+    uris = []
+    # assure that now we do have those test repos created -- delayed
+    # their creation until actually used
+    _basic_test_repo.create()
+    for name, spec in iteritems(_TESTREPOS):
+        if not re.match(regex, name):
+            continue
+        uris += [spec[x] for x in set(spec.keys()).intersection(flavors)]
 
-    if 'network-clone' in flavors:
-        globs_extended += [clone_url(_get_repo_url(repo)) for repo in globs]
+        # additional flavors which might have not been
+        if 'clone' in flavors and 'clone' not in spec:
+            uris.append(clone_url(spec['local']))
 
-    return globs_extended
+        if 'network-clone' in flavors and 'network-clone' not in spec:
+            uris.append(clone_url(spec['network']))
 
-def get_testrepos_dir():
-    return opj(os.path.dirname(__file__), 'testrepos')
+    return uris
 
-def has_testrepos_dir():
-    return exists(get_testrepos_dir())
-
-# For now (at least) we would need to clone from the network
-# since there are troubles with submodules on Windows.
-# See: https://github.com/datalad/datalad/issues/44
-# TODO: redo  tools/testing/make_test_repo  as a python module which
-# could be reused here and test repos could be initialized in temp location if not present
-local_testrepo_flavors = ['network-clone'
-                 if (on_windows or not has_testrepos_dir())
-                 else 'local']
 
 @optional_args
-def with_testrepos(t, paths='*/*', toppath=None, flavors='auto', skip=False):
+def with_testrepos(t, regex='.*', flavors='auto', skip=False):
     """Decorator to provide a test repository available locally and/or over the Internet
 
     All tests under datalad/tests/testrepos are stored in two-level hierarchy,
@@ -436,26 +432,20 @@ def with_testrepos(t, paths='*/*', toppath=None, flavors='auto', skip=False):
 
     Parameters
     ----------
-    paths : string, optional
-      Glob paths to consider
-    toppath : string, optional
-      Path to the test repositories top directory.  If not provided,
-      `datalad/tests/testrepos` within datalad is used.
-    flavors : {'auto', 'local', 'clone', 'network', 'network-clone'} or list of thereof, optional
-      What URIs to provide.  E.g. 'local' would just provide path to that
-      submodule, while 'network' would provide url of the origin remote where
-      that submodule was originally fetched from.  'clone' would clone repository
+    regex : string, optional
+      Regex to select which test repos to use
+    flavors : {'auto', 'local', 'local-url', 'clone', 'network', 'network-clone'} or list of thereof, optional
+      What URIs to provide.  E.g. 'local' would just provide path to the
+      repository, while 'network' would provide url of the remote location
+      available on Internet containing the test repository.  'clone' would clone repository
       first to a temporary location. 'network-clone' would first clone from the network
       location. 'auto' would include the list of appropriate
       ones (e.g., no 'network*' flavors if network tests are "forbidden").
-    skip : bool, optional
-      Allow to skip if no repositories were found. Otherwise would raise
-      AssertionError
 
     Examples
     --------
 
-        @with_testrepos('basic/*')
+        @with_testrepos('basic')
         def test_write(repo):
             assert(os.path.exists(os.path.join(repo, '.git', 'annex')))
 
@@ -465,46 +455,20 @@ def with_testrepos(t, paths='*/*', toppath=None, flavors='auto', skip=False):
     def newfunc(*arg, **kw):
         # TODO: would need to either avoid this "decorator" approach for
         # parametric tests or again aggregate failures like sweepargs does
-        toppath_ = get_testrepos_dir() \
-            if toppath is None else toppath
-
         flavors_ = _get_resolved_flavors(flavors)
 
-        globs_extended = _extend_globs(opj(toppath_, paths), flavors_)
-        under_git = os.path.exists(realpath(
-            opj(toppath_, pardir, pardir, pardir, '.git')))
+        testrepos_uris = _get_testrepos_uris(regex, flavors_)
+        assert(testrepos_uris)
 
-        if not len(globs_extended):
-            network_flavors = list(filter(lambda x: x.startswith('network'), flavors_))
-
-            if network_flavors:
-                # Let's just get through those which we know and
-                lgr.debug("No local test repositories were found.  Just cloning ones from the web")
-
-                urls = [u for p, u in iteritems(_TESTREPOS) if fnmatch(p, paths)]
-                if 'network' in network_flavors:
-                    globs_extended += urls
-                if 'network-clone' in network_flavors:
-                    globs_extended += [clone_url(url) for url in urls]
-
-            else:
-                raise (SkipTest if skip else AssertionError)(
-                    "Found no test repositories under %s, nor network* ones were requested."
-                    % opj(toppath_, paths) +
-                    (" Run git submodule update --init --recursive "
-                     if (toppath is None and under_git) else ""))
-
-        # print globs_extended
-        for d in globs_extended:
-            repo = d
+        for uri in testrepos_uris:
             if __debug__:
-                lgr.debug('Running %s on %s' % (t.__name__, repo))
+                lgr.debug('Running %s on %s' % (t.__name__, uri))
             try:
-                t(*(arg + (repo,)), **kw)
+                t(*(arg + (uri,)), **kw)
             finally:
                 # ad-hoc but works
-                if exists(repo) and exists(opj(repo, ".git", "remove-me")):
-                    rmtemp(repo)
+                if exists(uri) and exists(opj(uri, ".git", "remove-me")):
+                    rmtemp(uri)
                 pass  # might need to provide additional handling so, handle
     return newfunc
 with_testrepos.__test__ = False

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -353,7 +353,10 @@ def with_tempfile(t, *targs, **tkwargs):
 
 
 def _get_resolved_flavors(flavors):
-    flavors_ = ['local', 'local-url', 'clone'] if flavors == 'auto' else flavors
+    #flavors_ = (['local', 'clone'] + (['local-url'] if not on_windows else [])) \
+    #           if flavors == 'auto' else flavors
+    flavors_ = (['local', 'clone', 'local-url'] if not on_windows else ['network', 'network-clone']) \
+               if flavors == 'auto' else flavors
 
     if not isinstance(flavors_, list):
         flavors_ = [flavors_]
@@ -391,8 +394,10 @@ def clone_url(url):
     return tdir
 
 
-
-local_testrepo_flavors = ['local'] # 'local-url'
+if not on_windows:
+    local_testrepo_flavors = ['local'] # 'local-url'
+else:
+    local_testrepo_flavors = ['network-clone']
 
 from .utils_testrepos import BasicTestRepo, TestRepo
 _basic_test_repo = BasicTestRepo()
@@ -405,7 +410,8 @@ def _get_testrepos_uris(regex, flavors):
     uris = []
     # assure that now we do have those test repos created -- delayed
     # their creation until actually used
-    _basic_test_repo.create()
+    if not on_windows:
+        _basic_test_repo.create()
     for name, spec in iteritems(_TESTREPOS):
         if not re.match(regex, name):
             continue

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -75,9 +75,12 @@ class BasicTestRepo(TestRepo):
         self.create_info_file()
         self.create_file('test.dat', '123\n', annex=False)
         self.repo.git_commit("Adding a basic INFO file and rudimentary load file for annex testing")
-        self.repo.annex_addurl_to_file(
-            "test-annex.dat",
-            get_local_file_url(realpath(pathjoin(self.path, 'test.dat'))))
+        # even this doesn't work on bloody Windows
+        from .utils import on_windows
+        fileurl = get_local_file_url(realpath(pathjoin(self.path, 'test.dat'))) \
+                  if not on_windows \
+                  else "https://raw.githubusercontent.com/datalad/testrepo--basic--r1/master/test.dat"
+        self.repo.annex_addurl_to_file("test-annex.dat", fileurl)
         self.repo.git_commit("Adding a rudimentary git-annex load file")
         self.repo.annex_drop("test-annex.dat")  # since available from URL
 

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -14,27 +14,7 @@ from ..support.annexrepo import AnnexRepo
 from ..cmd import Runner
 from ..utils import get_local_file_url
 from ..utils import swallow_outputs
-
-#GH_ORG=datalad
-#GH_PREFIX=testrepo--
-
-topdir = pathjoin(dirname(__file__), pardir, pardir)
-reposdir = pathjoin(dirname(__file__), 'testrepos')
-
-#flavor="$1"
-#name="$2"
-
-# Repo specific variables
-#descr="datalad test repo $flavor/$name"
-#repodir=$reposdir/$flavor/$name
-#ghrepo=${GH_ORG}/${GH_PREFIX}$flavor--$name
-
-# Information about the system
-#git_version = $(git --version | sed -e 's,.* \([0-9]\),\1,g')
-#annex_version = $(dpkg -l git-annex | awk '/^ii/{print $3;}')
-
-git_version = "X"
-annex_version = "Y"
+from ..version import __version__
 
 class TestRepo(object):
 
@@ -58,91 +38,30 @@ class TestRepo(object):
         (self.repo.annex_add if annex else self.repo.git_add)(name)
 
     def create_info_file(self):
-        self.create_file('INFO.txt', """\
-    git: %s
-    annex: %s
-""" % (git_version, annex_version), annex=False)
+        runner = Runner()
+        annex_version = runner.run("git annex version")[0].split()[2]
+        git_version = runner.run("git --version")[0].split()[2]
+        self.create_file('INFO.txt',
+                         "git: %s\n"
+                         "annex: %s\n"
+                         "datalad: %s\n"
+                         % (git_version, annex_version, __version__),
+                         annex=False)
 
     @abstractmethod
     def create(self):
         raise NotImplementedError("Should be implemented in ")
 
-    """rm_repo() {
-    _info "removing $repodir"
-    chmod +w -R $repodir/.git  # inefficient but for us sufficient
-    rm -rf $repodir
-}"""
-
-    """create_github_repo() {
-    _info "creating github repo"
-    cd $repodir
-    # it wouldn't delete or complain in exit code if exists already
-    hub create -d "$descr (otherwise userless)" $ghrepo
-    git remote | grep -q '^origin' || git remote add origin git://github.com/$ghrepo
-    git push --set-upstream --all -f origin
-}"""
 
 class BasicTestRepo(TestRepo):
+    """Creates a basic test repository"""
     def create(self):
         self.create_info_file()
         self.create_file('test.dat', '123', annex=False)
         with swallow_outputs() as cmo: # we don't need those outputs at this point
             self.repo.git_commit("Adding a basic INFO file and rudimentary load file for annex testing")
-            # create_github_repo
-            #	cp test.dat test-annex.dat
-            #	git annex add test-annex.dat
-            # git annex addurl --file=test-annex.dat https://raw.githubusercontent.com/$ghrepo/master/test.dat
-            # TODO: windows etc??
             self.repo.annex_addurl_to_file(
                 "test-annex.dat",
                 get_local_file_url(realpath(pathjoin(self.path, 'test.dat'))))
             self.repo.git_commit("Adding a rudimentary git-annex load file")
             self.repo.annex_drop("test-annex.dat") # since available from URL
-        #  git push --all origin # and push again
-
-"""
-initremote_archive() {
-    git annex initremote annexed-archives \
-        encryption=none type=external externaltype=dl+archive
-}
-
-flavor_archive() {
-    create_repo
-    initremote_archive
-    create_info_file
-    mkdir -p d; echo "123" > d/test.dat; tar -czf d.tar.gz d;
-    mv d/test.dat test2.dat; rm -rf d;
-    git annex add d.tar.gz
-    git commit -m "Added tarball"
-    key=$(git annex lookupkey d.tar.gz)
-    git annex add test2.dat
-    git commit -m "Added the load file"
-    git annex addurl --file test2.dat dl+archive:$key/d/test.dat
-    _info "Added the dl+archive URL, committing"
-    #git commit -m "Added a url for the file"
-    git annex drop --force test2.dat # TODO -- should work without force
-    git annex get test2.dat
-}
-
-if [ -e $repodir ]; then
-    # TODO -- ask
-    rm_repo
-fi
-
-register_repo_submodule() {
-    cd $reposdir
-    _info "registering git submodule"
-    # TODO: verify if not registered already
-    #git submodule ...
-    git submodule add --force git://github.com/$ghrepo ./$flavor/$name && \
-        git commit -m "Added test $flavor/$name" -a && \
-        git push origin
-}
-
-# cd datalad/tests/testrepos
-# hub create -d "Super-submodule collating test repositories for datalad" datalad/testrepos
-
-eval flavor_$flavor
-
-#register_repo_submodule
-"""

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -1,0 +1,148 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from abc import ABCMeta, abstractmethod
+from os.path import dirname, join as pathjoin, exists, pardir, realpath
+
+from ..support.annexrepo import AnnexRepo
+from ..cmd import Runner
+from ..utils import get_local_file_url
+from ..utils import swallow_outputs
+
+#GH_ORG=datalad
+#GH_PREFIX=testrepo--
+
+topdir = pathjoin(dirname(__file__), pardir, pardir)
+reposdir = pathjoin(dirname(__file__), 'testrepos')
+
+#flavor="$1"
+#name="$2"
+
+# Repo specific variables
+#descr="datalad test repo $flavor/$name"
+#repodir=$reposdir/$flavor/$name
+#ghrepo=${GH_ORG}/${GH_PREFIX}$flavor--$name
+
+# Information about the system
+#git_version = $(git --version | sed -e 's,.* \([0-9]\),\1,g')
+#annex_version = $(dpkg -l git-annex | awk '/^ii/{print $3;}')
+
+git_version = "X"
+annex_version = "Y"
+
+class TestRepo(object):
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, path, puke_if_exists=True):
+        if puke_if_exists and exists(path):
+            raise RuntimeError("Directory %s for test repo already exist" % path)
+        self.repo = AnnexRepo(path)
+        self.runner = Runner(cwd=self.repo.path)
+        self.create()
+
+    @property
+    def path(self):
+        return self.repo.path
+
+    def create_file(self, name, content, annex=False):
+        filename = pathjoin(self.path, name)
+        with open(filename, 'wb') as f:
+            f.write(content.encode())
+        (self.repo.annex_add if annex else self.repo.git_add)(name)
+
+    def create_info_file(self):
+        self.create_file('INFO.txt', """\
+    git: %s
+    annex: %s
+""" % (git_version, annex_version), annex=False)
+
+    @abstractmethod
+    def create(self):
+        raise NotImplementedError("Should be implemented in ")
+
+    """rm_repo() {
+    _info "removing $repodir"
+    chmod +w -R $repodir/.git  # inefficient but for us sufficient
+    rm -rf $repodir
+}"""
+
+    """create_github_repo() {
+    _info "creating github repo"
+    cd $repodir
+    # it wouldn't delete or complain in exit code if exists already
+    hub create -d "$descr (otherwise userless)" $ghrepo
+    git remote | grep -q '^origin' || git remote add origin git://github.com/$ghrepo
+    git push --set-upstream --all -f origin
+}"""
+
+class BasicTestRepo(TestRepo):
+    def create(self):
+        self.create_info_file()
+        self.create_file('test.dat', '123', annex=False)
+        with swallow_outputs() as cmo: # we don't need those outputs at this point
+            self.repo.git_commit("Adding a basic INFO file and rudimentary load file for annex testing")
+            # create_github_repo
+            #	cp test.dat test-annex.dat
+            #	git annex add test-annex.dat
+            # git annex addurl --file=test-annex.dat https://raw.githubusercontent.com/$ghrepo/master/test.dat
+            # TODO: windows etc??
+            self.repo.annex_addurl_to_file(
+                "test-annex.dat",
+                get_local_file_url(realpath(pathjoin(self.path, 'test.dat'))))
+            self.repo.git_commit("Adding a rudimentary git-annex load file")
+            self.repo.annex_drop("test-annex.dat") # since available from URL
+        #  git push --all origin # and push again
+
+"""
+initremote_archive() {
+    git annex initremote annexed-archives \
+        encryption=none type=external externaltype=dl+archive
+}
+
+flavor_archive() {
+    create_repo
+    initremote_archive
+    create_info_file
+    mkdir -p d; echo "123" > d/test.dat; tar -czf d.tar.gz d;
+    mv d/test.dat test2.dat; rm -rf d;
+    git annex add d.tar.gz
+    git commit -m "Added tarball"
+    key=$(git annex lookupkey d.tar.gz)
+    git annex add test2.dat
+    git commit -m "Added the load file"
+    git annex addurl --file test2.dat dl+archive:$key/d/test.dat
+    _info "Added the dl+archive URL, committing"
+    #git commit -m "Added a url for the file"
+    git annex drop --force test2.dat # TODO -- should work without force
+    git annex get test2.dat
+}
+
+if [ -e $repodir ]; then
+    # TODO -- ask
+    rm_repo
+fi
+
+register_repo_submodule() {
+    cd $reposdir
+    _info "registering git submodule"
+    # TODO: verify if not registered already
+    #git submodule ...
+    git submodule add --force git://github.com/$ghrepo ./$flavor/$name && \
+        git commit -m "Added test $flavor/$name" -a && \
+        git push origin
+}
+
+# cd datalad/tests/testrepos
+# hub create -d "Super-submodule collating test repositories for datalad" datalad/testrepos
+
+eval flavor_$flavor
+
+#register_repo_submodule
+"""

--- a/tools/testing/make_test_repo
+++ b/tools/testing/make_test_repo
@@ -7,7 +7,9 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-
+#
+# DEPRECATED!!!!!  Kept for references
+#
 set -e
 #set -x
 set -u


### PR DESCRIPTION
So, testrepo should be generated whenever with_testrepos is used.