### PR TITLE
BF: Fully honor DATALAD_TESTS_NONETWORK

### DIFF
--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -16,6 +16,7 @@ from six import PY3
 
 from nose.tools import assert_raises, assert_is_instance, assert_true, \
     assert_equal, assert_false, assert_in, assert_not_in
+from nose import SkipTest
 
 from ..support.annexrepo import AnnexRepo, kwargs_to_options, GitRepo
 from ..support.exceptions import CommandNotAvailableError, \
@@ -242,6 +243,8 @@ def test_AnnexRepo_annex_add_to_git(src, dst):
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile
 def test_AnnexRepo_web_remote(src, dst):
+    if os.environ.get('DATALAD_TESTS_NONETWORK'):
+        raise SkipTest
 
     ar = AnnexRepo(dst, src)
 

--- a/datalad/tests/test_basic_functionality.py
+++ b/datalad/tests/test_basic_functionality.py
@@ -48,7 +48,8 @@ def test_local_master(m_path):
 
 @with_tempfile
 def test_register_collection(m_path):
-
+    if os.environ.get('DATALAD_TESTS_NONETWORK'):
+        raise SkipTest
     test_url = "https://github.com/bpoldrack/ExampleCollection.git"
     test_name = test_url.split('/')[-1].rstrip('.git')
     assert_equal(test_name, 'ExampleCollection')
@@ -190,6 +191,8 @@ def test_install_handle(m_path, c_path, h_path, install_path):
 
 @with_tempfile
 def test_unregister_collection(m_path):
+    if os.environ.get('DATALAD_TESTS_NONETWORK'):
+        raise SkipTest
 
     # setup:
     m_path = opj(m_path, 'localcollection')

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -15,6 +15,7 @@ from os.path import join as opj, exists
 
 from nose.tools import assert_raises, assert_is_instance, assert_true, \
     assert_equal, assert_in, assert_false
+from nose import SkipTest
 from git.exc import GitCommandError, NoSuchPathError, InvalidGitRepositoryError
 
 from datalad.support.gitrepo import GitRepo, normalize_paths, _normalize_path
@@ -245,6 +246,9 @@ def test_GitRepo_remote_add(orig_path, path):
     assert_in('origin', out)
     assert_in('github', out)
     assert_equal(len(out), 2)
+    # until here is actually doesn't need network access
+    if os.environ.get('DATALAD_TESTS_NONETWORK'):
+        raise SkipTest
     out = gr.git_remote_show('github')
     assert_in('  Fetch URL: git://github.com/datalad/testrepo--basic--r1', out)
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -469,7 +469,12 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False):
         flavors_ = _get_resolved_flavors(flavors)
 
         testrepos_uris = _get_testrepos_uris(regex, flavors_)
-        assert(testrepos_uris)
+        # MIH: I don't think we can assert that there always is a testrepo
+        # for network test when NONETWORK is given, this list will be empty
+        # will change it to skipping the test. Remove on ACK.
+        #assert(testrepos_uris)
+        if not len(testrepos_uris):
+            raise SkipTest
 
         for uri in testrepos_uris:
             if __debug__:


### PR DESCRIPTION
With this change the tests actually pass on a machine that is
"air-gapped". tests/utils.py has a change that needs a closer look.