### PR TITLE
ENH: make global --help fit some screens + misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 
 install:
   # Install standalone build of git-annex for the recent enough version
-  - sudo apt-get install git-annex-standalone zip
+  - sudo apt-get install git-annex-standalone zip help2man
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
   - git submodule update --init --recursive
@@ -48,6 +48,8 @@ script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   - DATALAD_LOGLEVEL=INFO $NOSE_WRAPPER `which nosetests` -v --with-doctest --with-cov --cover-package datalad --logging-level=INFO --failed
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
+  # Verify that we can render manpages
+  - make manpages
 
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,19 @@ trailing-spaces:
 code-analysis:
 	flake8 $(MODULE) | grep -v __init__ | grep -v external
 	pylint -E -i y $(MODULE)/ # -d E1103,E0611,E1101
+
+manpages: bin
+	mkdir -p build/man
+	# main manpage
+	PYTHONPATH=. help2man --no-discard-stderr \
+		--help-option="--help-np" -N -n "data managment and sharing tool" \
+			"bin/datalad" > build/man/datalad.1 ; \
+	# figure out all relevant interface files, fuck yeah Python
+	for api in $$(PYTHONPATH=. python -c "from datalad.interface.base import get_interface_groups; print(' '.join([' '.join([j.__module__.split('.')[-1] for j in i[2]]) for i in get_interface_groups()]))"); do \
+		cmd="$$(echo "$$api" | tr '_' '-')" ; \
+		summary="$$(grep -A 1 'class.*(.*Interface.*)' datalad/interface/$${api}.py | grep -v ':' | grep -v '^--' | sed -e 's/"//g' -e 's/^[ \t]*//;s/[ \t.]*$$//' | tr 'A-Z' 'a-z')" ; \
+		PYTHONPATH=. help2man --no-discard-stderr \
+			--help-option="--help-np" -N -n "$$summary" \
+				"bin/datalad $${cmd}" > build/man/datalad-$${cmd}.1 ; \
+	done
+

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ code-analysis:
 manpages: bin
 	mkdir -p build/man
 	# main manpage
-	PYTHONPATH=. help2man --no-discard-stderr \
-		--help-option="--help-np" -N -n "data managment and sharing tool" \
+	DATALAD_HELP2MAN=1 PYTHONPATH=. help2man --no-discard-stderr \
+		--help-option="--help-np" -N -n "data management and sharing tool" \
 			"bin/datalad" > build/man/datalad.1 ; \
 	# figure out all relevant interface files, fuck yeah Python
 	for api in $$(PYTHONPATH=. python -c "from datalad.interface.base import get_interface_groups; print(' '.join([' '.join([j.__module__.split('.')[-1] for j in i[2]]) for i in get_interface_groups()]))"); do \
 		cmd="$$(echo "$$api" | tr '_' '-')" ; \
 		summary="$$(grep -A 1 'class.*(.*Interface.*)' datalad/interface/$${api}.py | grep -v ':' | grep -v '^--' | sed -e 's/"//g' -e 's/^[ \t]*//;s/[ \t.]*$$//' | tr 'A-Z' 'a-z')" ; \
-		PYTHONPATH=. help2man --no-discard-stderr \
+		DATALAD_HELP2MAN=1 PYTHONPATH=. help2man --no-discard-stderr \
 			--help-option="--help-np" -N -n "$$summary" \
 				"bin/datalad $${cmd}" > build/man/datalad-$${cmd}.1 ; \
 	done

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -12,6 +12,7 @@
 __docformat__ = 'restructuredtext'
 
 import argparse
+import os
 import re
 import sys
 
@@ -20,8 +21,6 @@ from ..log import is_interactive
 
 class HelpAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-#        import pydb; pydb.debugger()
-
         if is_interactive() and option_string == '--help':
             # lets use the manpage on mature systems ...
             try:
@@ -67,15 +66,18 @@ class HelpAction(argparse.Action):
         # usage is on the same line
         helpstr = re.sub(r'^usage:', 'Usage:', helpstr)
         if option_string == '--help-np':
-            # Convert 1-line command descriptions to remove leading -
-            helpstr = re.sub('\n\s*-\s*([-a-z0-9]*):\s*?([^\n]*)', r"\n'\1':\n  \2\n", helpstr)
             usagestr = re.split(r'\n\n[A-Z]+', helpstr, maxsplit=1)[0]
             usage_length = len(usagestr)
             usagestr = re.subn(r'\s+', ' ', usagestr.replace('\n', ' '))[0]
             helpstr = '%s\n%s' % (usagestr, helpstr[usage_length:])
+
+        if os.environ.get('DATALAD_HELP2MAN'):
+            # Convert 1-line command descriptions to remove leading -
+            helpstr = re.sub('\n\s*-\s*([-a-z0-9]*):\s*?([^\n]*)', r"\n'\1':\n  \2\n", helpstr)
         else:
-            # Those do not contribute to readability in regular text mode
+            # Those *s intended for man formatting do not contribute to readability in regular text mode
             helpstr = helpstr.replace('*', '')
+
         print(helpstr)
         sys.exit(0)
 

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -40,9 +40,8 @@ class HelpAction(argparse.Action):
         else:
             helpstr = parser.format_help()
         # better for help2man
-        helpstr = re.sub(r'optional arguments:', 'options:', helpstr)
-        # yoh: TODO for datalad + help2man
-        #helpstr = re.sub(r'positional arguments:\n.*\n', '', helpstr)
+        helpstr = re.sub(r'optional arguments:', '*Options*', helpstr)
+        helpstr = re.sub(r'positional arguments:', '*Arguments*', helpstr)
         # convert all heading to have the first character uppercase
         headpat = re.compile(r'^([a-z])(.*):$',  re.MULTILINE)
         helpstr = re.subn(

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -53,15 +53,14 @@ def setup_parser():
     # main parser
     parser = argparse.ArgumentParser(
         fromfile_prefix_chars='@',
+        # Default usage is too heavy
+        usage="datalad [global-opts] command [command-opts]",
         # usage="%(prog)s ...",
         description=dedent_docstring("""\
-    DataLad aims to expose (scientific) data available online as a unified data
-    distribution with the convenience of git-annex repositories as a backend.
-
-    datalad command line tool facilitates initial construction and update of
-    harvested online datasets.  It supports following commands
-    """),
-        epilog='"Control Your Data"',
+            DataLad provides a unified data distribution with the convenience of git-annex
+            repositories as a backend.  datalad command line tool allows to manipulate
+            (obtain, create, update, publish, etc.) datasets and their collections."""),
+        epilog='DataLad v%s "Control Your Data"' % datalad.__version__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         add_help=False)
     # common options
@@ -91,7 +90,7 @@ def setup_parser():
     #                         only warnings and errors are printed.""")
 
     # subparsers
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(title="Commands summary")
 
     # auto detect all available interfaces and generate a function-based
     # API from them
@@ -143,20 +142,20 @@ def setup_parser():
 
         cmd_summary.append('\n%s\n' % (grp_descr,))
         for cd in grp_cmds:
-            cmd_summary.append('  %s\n%s\n\n'
+            cmd_summary.append('  - %s:  %s'
                                % (cd[0],
                                   textwrap.fill(
-                                      cd[1],
+                                      cd[1].rstrip(' .'),
                                       75,
-                                      initial_indent=' ' * 4,
-                                      subsequent_indent=' ' * 4)))
+                                      #initial_indent=' ' * 4,
+                                      subsequent_indent=' ' * 8)))
     parser.description = '%s\n%s\n\n%s' \
         % (parser.description,
            '\n'.join(cmd_summary),
            textwrap.fill(dedent_docstring("""\
     Detailed usage information for individual commands is
-    available via command-specific help options, i.e.:
-    %s <command> --help""") % sys.argv[0],
+    available via command-specific --help, i.e.:
+    datalad <command> --help"""),
                          75, initial_indent='', subsequent_indent=''))
     return parser
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -53,14 +53,12 @@ def setup_parser():
     # main parser
     parser = argparse.ArgumentParser(
         fromfile_prefix_chars='@',
-        # Default usage is too heavy
-        usage="datalad [global-opts] command [command-opts]",
         # usage="%(prog)s ...",
         description=dedent_docstring("""\
             DataLad provides a unified data distribution with the convenience of git-annex
             repositories as a backend.  datalad command line tool allows to manipulate
             (obtain, create, update, publish, etc.) datasets and their collections."""),
-        epilog='DataLad v%s "Control Your Data"' % datalad.__version__,
+        epilog='"Control Your Data"',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         add_help=False)
     # common options

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -90,7 +90,7 @@ def setup_parser():
     #                         only warnings and errors are printed.""")
 
     # subparsers
-    subparsers = parser.add_subparsers(title="Commands summary")
+    subparsers = parser.add_subparsers()
 
     # auto detect all available interfaces and generate a function-based
     # API from them
@@ -140,7 +140,7 @@ def setup_parser():
         grp_descr = grp[1]
         grp_cmds = grp_short_descriptions[i]
 
-        cmd_summary.append('\n%s\n' % (grp_descr,))
+        cmd_summary.append('\n*%s*\n' % (grp_descr,))
         for cd in grp_cmds:
             cmd_summary.append('  - %s:  %s'
                                % (cd[0],
@@ -149,6 +149,9 @@ def setup_parser():
                                       75,
                                       #initial_indent=' ' * 4,
                                       subsequent_indent=' ' * 8)))
+    # we need one last formal section to not have the trailed be
+    # confused with the last command group
+    cmd_summary.append('\n*General information*\n')
     parser.description = '%s\n%s\n\n%s' \
         % (parser.description,
            '\n'.join(cmd_summary),

--- a/datalad/interface/add_handle.py
+++ b/datalad/interface/add_handle.py
@@ -28,7 +28,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class AddHandle(Interface):
-    """Adds a handle to a collection."""
+    """Add a handle to a collection."""
     _params_ = dict(
         handle=Parameter(
             doc="path to or name of the handle",

--- a/datalad/interface/crawl.py
+++ b/datalad/interface/crawl.py
@@ -19,7 +19,7 @@ class Crawl(Interface):
 
     Examples:
 
-    $ datalad crawl cfgs/openfmri.cfg
+      $ datalad crawl cfgs/openfmri.cfg
     """
     _params_ = dict(
         configs=Parameter(

--- a/datalad/interface/create_collection.py
+++ b/datalad/interface/create_collection.py
@@ -25,7 +25,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class CreateCollection(Interface):
-    """Creates a new collection."""
+    """Create a new collection."""
     _params_ = dict(
         path=Parameter(
             args=('path',),

--- a/datalad/interface/create_handle.py
+++ b/datalad/interface/create_handle.py
@@ -26,7 +26,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class CreateHandle(Interface):
-    """Creates a new handle."""
+    """Create a new handle."""
     _params_ = dict(
         path=Parameter(
             args=('path',),

--- a/datalad/interface/get.py
+++ b/datalad/interface/get.py
@@ -25,7 +25,7 @@ class Get(Interface):
 
     Examples:
 
-    $ datalad get foo/*
+      $ datalad get foo/*
     """
 
     _params_ = dict(

--- a/datalad/interface/install_handle.py
+++ b/datalad/interface/install_handle.py
@@ -27,8 +27,9 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class InstallHandle(Interface):
-    """Installs a handle.
-        Examples:
+    """Install a handle.
+
+    Examples:
 
     $ datalad install-handle http://psydata.ovgu.de/forrest_gump/.git /foo/bar
     $ datalad install-handle MyCoolCollection/EvenCoolerHandle /foo/bar

--- a/datalad/interface/install_handle.py
+++ b/datalad/interface/install_handle.py
@@ -31,8 +31,8 @@ class InstallHandle(Interface):
 
     Examples:
 
-    $ datalad install-handle http://psydata.ovgu.de/forrest_gump/.git /foo/bar
-    $ datalad install-handle MyCoolCollection/EvenCoolerHandle /foo/bar
+      $ datalad install-handle http://psydata.ovgu.de/forrest_gump/.git /foo/bar
+      $ datalad install-handle MyCoolCollection/EvenCoolerHandle /foo/bar
     """
     _params_ = dict(
         handle=Parameter(

--- a/datalad/interface/list_collections.py
+++ b/datalad/interface/list_collections.py
@@ -25,7 +25,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class ListCollection(Interface):
-    """list all colections known to datalad."""
+    """List all collections known to datalad."""
 
     def __call__(self):
 

--- a/datalad/interface/list_handles.py
+++ b/datalad/interface/list_handles.py
@@ -25,7 +25,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class ListHandles(Interface):
-    """list all locally installed handles."""
+    """List all locally installed handles."""
 
     def __call__(self):
 

--- a/datalad/interface/publish_handle.py
+++ b/datalad/interface/publish_handle.py
@@ -30,7 +30,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class PublishHandle(Interface):
-    """publish a handle.
+    """Publish a handle.
 
     This is basic implementation for testing purposes
     """

--- a/datalad/interface/pull.py
+++ b/datalad/interface/pull.py
@@ -25,8 +25,8 @@ class Pull(Interface):
 
     Examples:
 
-    ~/MyRepository $ datalad pull
-    ~/MyRepository $ datalad pull MyRemote
+      ~/MyRepository $ datalad pull
+      ~/MyRepository $ datalad pull MyRemote
     """
 
     _params_ = dict(

--- a/datalad/interface/pull.py
+++ b/datalad/interface/pull.py
@@ -21,7 +21,7 @@ from ..log import lgr
 
 
 class Pull(Interface):
-    """Get changes froma remote repository.
+    """Get changes from a remote repository.
 
     Examples:
 

--- a/datalad/interface/push.py
+++ b/datalad/interface/push.py
@@ -25,8 +25,8 @@ class Push(Interface):
 
     Examples:
 
-    ~/MyRepository $ datalad push
-    ~/MyRepository $ datalad push MyRemote
+      ~/MyRepository $ datalad push
+      ~/MyRepository $ datalad push MyRemote
     """
 
     _params_ = dict(

--- a/datalad/interface/push.py
+++ b/datalad/interface/push.py
@@ -21,7 +21,7 @@ from ..log import lgr
 
 
 class Push(Interface):
-    """Get changes froma remote repository.
+    """Push changes to a remote repository.
 
     Examples:
 

--- a/datalad/interface/search_collection.py
+++ b/datalad/interface/search_collection.py
@@ -29,7 +29,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class SearchCollection(Interface):
-    """search for a collection.
+    """Search for a collection.
     """
     # TODO: A lot of doc ;)
 

--- a/datalad/interface/search_handle.py
+++ b/datalad/interface/search_handle.py
@@ -29,7 +29,7 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class SearchHandle(Interface):
-    """search for a handle.
+    """Search for a handle.
     """
     # TODO: A lot of doc ;)
 

--- a/datalad/interface/sparql_query.py
+++ b/datalad/interface/sparql_query.py
@@ -27,7 +27,8 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class SPARQLQuery(Interface):
-    """Querying metadata by a SPARQL query string."""
+    """Query metadata by a SPARQL query string."""
+
     _params_ = dict(
         query=Parameter(
             doc="string containing the SPARQL query",

--- a/datalad/interface/uninstall_handle.py
+++ b/datalad/interface/uninstall_handle.py
@@ -29,8 +29,9 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 class UninstallHandle(Interface):
-    """Uninstalls a handle.
-        Examples:
+    """Uninstall a handle.
+
+    Examples:
 
     $ datalad uninstall-handle MyCoolHandle
     """

--- a/datalad/interface/uninstall_handle.py
+++ b/datalad/interface/uninstall_handle.py
@@ -33,7 +33,7 @@ class UninstallHandle(Interface):
 
     Examples:
 
-    $ datalad uninstall-handle MyCoolHandle
+      $ datalad uninstall-handle MyCoolHandle
     """
     _params_ = dict(
         handle=Parameter(

--- a/datalad/interface/update.py
+++ b/datalad/interface/update.py
@@ -32,18 +32,18 @@ class Update(Interface):
 
     Examples:
 
-    Updating registered collections:
-    $ datalad update
+    Updating registered collections
+      $ datalad update
 
-    Updating a local handle:
-    ~/MyHandle/$ datalad update
+    Updating a local handle
+      ~/MyHandle/$ datalad update
     or
-    $ datalad update MyHandle
+      $ datalad update MyHandle
 
-    Updating a local collection:
-    ~/MyCollection/$ datalad update
+    Updating a local collection
+      ~/MyCollection/$ datalad update
     or
-    $ datalad update MyCollection
+      $ datalad update MyCollection
     """
     _params_ = dict(
         key=Parameter(

--- a/datalad/tests/test_cmdline_main.py
+++ b/datalad/tests/test_cmdline_main.py
@@ -65,10 +65,17 @@ def test_version():
     in_("Permission is hereby granted", out)
 
 
-def test_help():
-    stdout, stderr = run_main(['--help'])
+def test_help_np():
+    stdout, stderr = run_main(['--help-np'])
 
     # Let's extract section titles:
-    sections = list(filter(re.compile('[a-zA-Z ]{4,50}:').match, stdout.split('\n')))
-    ok_(sections[0].startswith('Usage:'))  # == Usage: nosetests [-h] if running using nose
-    assert_equal(sections[1:], ['Positional arguments:', 'Options:'])
+    # enough of bin/datalad and .tox/py27/bin/datalad -- guarantee consistency! ;)
+    ok_(stdout.startswith('Usage: datalad'))
+    # Sections start/end with * in --help-np mode
+    sections = [l[1:-1] for l in filter(re.compile('^\*.*\*$').match, stdout.split('\n'))]
+    assert_equal(sections,
+                 ['Commands for collection handling',
+                  'Commands for handle operations',
+                  'Miscellaneous commands',
+                  'General information',
+                  'Global options'])

--- a/datalad/tests/test_cmdline_main.py
+++ b/datalad/tests/test_cmdline_main.py
@@ -66,16 +66,20 @@ def test_version():
 
 
 def test_help_np():
-    stdout, stderr = run_main(['--help-np'])
+    with patch.dict('os.environ', {'DATALAD_HELP2MAN': '1'}):
+        stdout, stderr = run_main(['--help-np'])
 
     # Let's extract section titles:
     # enough of bin/datalad and .tox/py27/bin/datalad -- guarantee consistency! ;)
     ok_(stdout.startswith('Usage: datalad'))
-    # Sections start/end with * in --help-np mode
+    # Sections start/end with * if ran under DATALAD_HELP2MAN mode
     sections = [l[1:-1] for l in filter(re.compile('^\*.*\*$').match, stdout.split('\n'))]
-    assert_equal(sections,
-                 ['Commands for collection handling',
+    # but order is still not guaranteed (dict somewhere)! TODO
+    # see https://travis-ci.org/datalad/datalad/jobs/80519004
+    # thus testing sets
+    assert_equal(set(sections),
+                 {'Commands for collection handling',
                   'Commands for handle operations',
                   'Miscellaneous commands',
                   'General information',
-                  'Global options'])
+                  'Global options'})


### PR DESCRIPTION
misc:
    - spit out version in the bottom
    - custom short usage
    - "Command summary" instead of "Positional arguments"

now --help looks like

```
Usage: datalad [global-opts] command [command-opts]

DataLad provides a unified data distribution with the convenience of git-annex
repositories as a backend.  datalad command line tool allows to manipulate
(obtain, create, update, publish, etc.) datasets and their collections.

Commands for collection handling

  - create-collection:  Create a new collection
  - register-collection:  Register a collection with datalad
  - unregister-collection:  Unregister a collection with datalad
  - list-collections:  List all collections known to datalad

Commands for handle operations

  - create-handle:  Create a new handle
  - add-handle:  Add a handle to a collection
  - install-handle:  Install a handle
  - uninstall-handle:  Uninstall a handle
  - list-handles:  List all locally installed handles
  - get:  Get dataset's content from a remote repository
  - upgrade-handle:  Upgrade a handle
  - publish-handle:  Publish a handle

Miscellaneous commands

  - test:  Run internal DataLad (unit)tests
  - crawl:  Crawl online resource to create or update a handle
  - sparql-query:  Query metadata by a SPARQL query string
  - search-handle:  Search for a handle
  - search-collection:  Search for a collection
  - update:  Update information from a remote repository
  - whereis:  Find a handle or collection by its name
  - describe:  Add metadata to the repository in cwd
  - pull:  Get changes from a remote repository
  - push:  Push changes to a remote repository

Detailed usage information for individual commands is available via
command-specific --help, i.e.: datalad <command> --help

Options:
  -h, --help, --help-np
                        show this help message and exit. --help-np forcefully
                        disables the use of a pager for displaying the help.
  -l {critical,error,warning,info,debug,1,2,3,4,5,6,7,8,9}, --log-level {critical,error,warning,info,debug,1,2,3,4,5,6,7,8,9}
                        level of verbosity. Integers provide even more
                        debugging information
  --version             show program's version and license information and
                        exit
  --dbg                 do not catch exceptions and show exception traceback

Commands summary:
  {create-collection,register-collection,unregister-collection,list-collections,create-handle,add-handle,install-handle,uninstall-handle,list-handles,get,upgrade-handle,publish-handle,test,crawl,sparql-query,search-handle,search-collection,update,whereis,describe,pull,push}

DataLad v0.0.3.dev0 "Control Your Data"
```