### PR TITLE
BF+RF AnnexRepo

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -112,7 +112,9 @@ class AnnexRepo(GitRepo):
         self.always_commit = always_commit
 
         # Check whether an annex already exists at destination
-        if not exists(opj(self.path, '.git', 'annex')):
+        if not (
+            exists(opj(self.path, '.git', 'annex')) or
+            any((b.endswith('/git-annex') for b in self.git_get_remote_branches()))):
             if create:
                 lgr.debug('No annex found at %s.'
                           ' Creating a new one ...' % self.path)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -14,6 +14,7 @@ For further information on GitPython see http://gitpython.readthedocs.org/
 
 from os import getcwd, linesep
 from os.path import join as opj, exists, normpath, isabs, commonprefix, relpath, realpath
+from os.path import dirname, basename
 import logging
 import shlex
 from six import string_types
@@ -69,7 +70,10 @@ def _normalize_path(base_dir, path):
     # But we don't want to realpath relative paths, in case cwd isn't the correct base.
 
     if isabs(path):
-        path = realpath(path)
+        # path might already be a symlink pointing to annex etc,
+        # so realpath only its directory, to get "inline" with realpath(base_dir)
+        # above
+        path = opj(realpath(dirname(path)), basename(path))
         if commonprefix([path, base_dir]) != base_dir:
             raise FileNotInRepositoryError(msg="Path outside repository: %s"
                                                % path, filename=path)

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -445,7 +445,7 @@ def test_AnnexRepo_always_commit(path):
 @with_testrepos('basic', flavors=['clone'])
 def test_AnnexRepo_on_uninited_annex(path):
     assert_false(exists(opj(path, '.git', 'annex'))) # must not be there for this test to be valid
-    annex = AnnexRepo(path, create=False)  # so we can initialize without
+    annex = AnnexRepo(path, create=False, init=False)  # so we can initialize without
     # and still can get our things
     assert_false(annex.file_has_content('test-annex.dat'))
     with swallow_outputs():

--- a/datalad/tests/test_annexrepo.py
+++ b/datalad/tests/test_annexrepo.py
@@ -11,6 +11,7 @@
 """
 
 import gc
+from os.path import exists
 from git.exc import GitCommandError
 from six import PY3
 from six.moves.urllib.parse import urljoin, urlsplit
@@ -441,6 +442,15 @@ def test_AnnexRepo_always_commit(path):
                        if commit.startswith('commit')])
     assert_equal(num_commits, 4)
 
+@with_testrepos('basic', flavors=['clone'])
+def test_AnnexRepo_on_uninited_annex(path):
+    assert_false(exists(opj(path, '.git', 'annex'))) # must not be there for this test to be valid
+    annex = AnnexRepo(path, create=False)  # so we can initialize without
+    # and still can get our things
+    assert_false(annex.file_has_content('test-annex.dat'))
+    with swallow_outputs():
+        annex.annex_get('test-annex.dat')
+        assert_true(annex.file_has_content('test-annex.dat'))
 
 # TODO:
 #def annex_initremote(self, name, options):


### PR DESCRIPTION
Extracted from #205 to ease review etc.  Main goal here is to "sense" existing repositories without anyhow causing any changes in them.  It is not only about create or not create, but also about init or not init.

*whining:* I think part of the problem is actually due to decision to allow *Repo constructors to create repositories (i.e. having `create`).  E.g. now "constructor" might not only create and intialize a repository but also modify existing one (e.g. set backend, switch mode) etc, even if create is False.  But should it?  IMHO such actions should be done explicitly only when repository is explicitly created, or explicitly requested via corresponding methods. And imho ideally there should be a classmethod  `create` which would take that role while constructor at most would do 'init' (optionally) on top of an annex repository.  This should make code possibly longer but clearer to understand -- at any given point are we creating a repo or just loading existing one?  are we doing any action on that repository while merely creating a Python "view" of it?  Now with default `create=True` we don't have those guarantees