### PR TITLE
BF: do not list datalad under py_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
   - git submodule update --init --recursive
   - cd ..; pip install -q coveralls; cd -
   - pip install -r requirements.txt
+  # Verify that setup.py build doesn't puke
+  - python setup.py build
   - pip install -e .
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     author_email="team@datalad.org",
     version=datalad.version.__version__,
     description="data distribution geared toward scientific datasets",
-    py_modules=['datalad'],
     packages=datalad_pkgs,
     install_requires=[
         "GitPython",  # 'git://github.com/gitpython-developers/GitPython'


### PR DESCRIPTION
It is listed under datalad_pkgs, and with listed in modules
in current sid then setup.py build fails while looking for
some obnoxious reason for datalad.py

Sending this minor one as a PR to get tests ran