### PR TITLE
NF+RF: os.{chdir,getcwd} -> utils.{chpwd,getpwd}

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -22,7 +22,7 @@ from datalad.log import lgr
 
 from datalad.cmdline import helpers
 from ..interface.base import dedent_docstring, get_interface_groups
-from ..utils import setup_exceptionhook
+from ..utils import setup_exceptionhook, chpwd
 
 
 def _license_info():
@@ -191,7 +191,7 @@ def main(cmdlineargs=None):
     cmdlineargs = parser.parse_args(cmdlineargs)
     if not cmdlineargs.change_path is None:
         for path in cmdlineargs.change_path:
-            os.chdir(path)
+            chpwd(path)
     # run the function associated with the selected command
     if cmdlineargs.common_debug:
         # So we could see/stop clearly at the point of failure

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -17,15 +17,15 @@ from nose.tools import assert_raises, assert_is_instance, assert_true, \
     assert_equal, assert_in, assert_false
 from git.exc import GitCommandError, NoSuchPathError, InvalidGitRepositoryError
 
-from datalad.support.gitrepo import GitRepo, normalize_paths, _normalize_path
-from datalad.tests.utils import with_tempfile, with_testrepos, \
+from ..support.gitrepo import GitRepo, normalize_paths, _normalize_path
+from ..support.exceptions import FileNotInRepositoryError
+from ..cmd import Runner
+from ..utils import getpwd, chpwd
+
+from .utils import with_tempfile, with_testrepos, \
     assert_cwd_unchanged, on_windows, with_tree, \
     get_most_obscure_supported_name, ok_clean_git
-from datalad.support.exceptions import FileNotInRepositoryError
-from datalad.cmd import Runner
-
 from .utils import swallow_logs
-
 from .utils import local_testrepo_flavors
 from .utils import skip_if_no_network
 from .utils import assert_re_in
@@ -139,7 +139,7 @@ def test_GitRepo_get_indexed_files(src, path):
 @assert_cwd_unchanged(ok_to_chdir=True)
 def test_normalize_path(git_path):
 
-    cwd = os.getcwd()
+    pwd = getpwd()
     gr = GitRepo(git_path)
 
     # cwd is currently outside the repo, so any relative path
@@ -165,7 +165,7 @@ def test_normalize_path(git_path):
 
     # now we are inside, so relative paths are relative to cwd and have
     # to be converted to be relative to annex_path:
-    os.chdir(opj(git_path, 'd1', 'd2'))
+    chpwd(opj(git_path, 'd1', 'd2'))
 
     result = _normalize_path(gr.path, "testfile")
     assert_equal(result, opj('d1', 'd2', 'testfile'), "_normalize_path() returned %s" % result)
@@ -178,7 +178,7 @@ def test_normalize_path(git_path):
     result = _normalize_path(gr.path, opj(git_path, 'd1', 'testfile'))
     assert_equal(result, opj('d1', 'testfile'), "_normalize_path() returned %s" % result)
 
-    os.chdir(cwd)
+    chpwd(pwd)
 
 
 def test_GitRepo_files_decorator():

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -17,15 +17,16 @@ import logging
 from mock import patch
 from six import PY3
 
-from os.path import join as opj
+from os.path import join as opj, isabs, abspath
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
 from ..utils import get_local_file_url
+from ..utils import getpwd, chpwd
 from ..support.annexrepo import AnnexRepo
 
 from nose.tools import ok_, eq_, assert_false, assert_raises, assert_equal
 from .utils import with_tempfile, assert_in, with_tree
 from .utils import SkipTest
-
+from .utils import assert_cwd_unchanged, skip_if_on_windows
 
 @with_tempfile(mkdir=True)
 def test_rotree(d):
@@ -138,3 +139,25 @@ def test_get_local_file_url_linux():
 
 def test_get_local_file_url_windows():
     raise SkipTest("TODO")
+
+@assert_cwd_unchanged
+def test_getpwd_basic():
+    pwd = getpwd()
+    ok_(isabs(pwd))
+    eq_(os.getcwd(), abspath(pwd))
+
+
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@assert_cwd_unchanged
+def test_getpwd_symlink(tdir):
+    sdir = opj(tdir, 's1')
+    pwd_orig = getpwd()
+    os.symlink('.', sdir)
+    try:
+        chpwd(sdir)
+        pwd = getpwd()
+        eq_(pwd, sdir)
+    finally:
+        chpwd(pwd_orig)
+

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -158,6 +158,12 @@ def test_getpwd_symlink(tdir):
         chpwd(sdir)
         pwd = getpwd()
         eq_(pwd, sdir)
+        chpwd('s1')
+        eq_(getpwd(), opj(sdir, 's1'))
+        chpwd('.')
+        eq_(getpwd(), opj(sdir, 's1'))
+        chpwd('..')
+        eq_(getpwd(), sdir)
     finally:
         chpwd(pwd_orig)
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -89,6 +89,7 @@ import git
 import os
 from os.path import exists, join
 from datalad.support.annexrepo import AnnexRepo, FileNotInAnnexError
+from ..utils import chpwd, getpwd
 
 
 def ok_clean_git_annex_proxy(path):
@@ -97,15 +98,15 @@ def ok_clean_git_annex_proxy(path):
     # TODO: May be let's make a method of AnnexRepo for this purpose
 
     ar = AnnexRepo(path)
-    cwd = os.getcwd()
-    os.chdir(path)
+    cwd = getpwd()
+    chpwd(path)
 
     try:
         out = ar.annex_proxy("git status")
     except CommandNotAvailableError as e:
         raise SkipTest
     finally:
-        os.chdir(cwd)
+        chpwd(cwd)
 
     assert_in("nothing to commit, working directory clean", out[0], "git-status output via proxy not plausible: %s" % out[0])
 
@@ -243,7 +244,7 @@ class SilentHTTPHandler(SimpleHTTPRequestHandler):
 
 
 def _multiproc_serve_path_via_http(hostname, path_to_serve_from, queue): # pragma: no cover
-    os.chdir(path_to_serve_from)
+    chpwd(path_to_serve_from)
     httpd = HTTPServer((hostname, 0), SilentHTTPHandler)
     queue.put(httpd.server_port)
     httpd.serve_forever()
@@ -501,6 +502,18 @@ def skip_if_no_network(func):
         return func(*args, **kwargs)
     return newfunc
 
+
+def skip_if_on_windows(func):
+    """Skip test completely under Windows
+    """
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        if on_windows:
+            raise SkipTest("Skipping on Windows")
+        return func(*args, **kwargs)
+    return newfunc
+
+
 @optional_args
 def assert_cwd_unchanged(func, ok_to_chdir=False):
     """Decorator to test whether the current working directory remains unchanged
@@ -509,20 +522,25 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
     @wraps(func)
     def newfunc(*args, **kwargs):
         cwd_before = os.getcwd()
+        pwd_before = getpwd()
         exc_info = None
         try:
             func(*args, **kwargs)
         except:
             exc_info = sys.exc_info()
         finally:
-            cwd_after = os.getcwd()
+            try:
+                cwd_after = os.getcwd()
+            except OSError as e:
+                lgr.warning("Failed to getcwd: %s" % e)
+                cwd_after = None
 
         if cwd_after != cwd_before:
-            os.chdir(cwd_before)
+            chpwd(pwd_before)
             if not ok_to_chdir:
                 lgr.warning(
                     "%s changed cwd to %s. Mitigating and changing back to %s"
-                    % (func, cwd_after, cwd_before))
+                    % (func, cwd_after, pwd_before))
                 # If there was already exception raised, we better re-raise
                 # that one since it must be more important, so not masking it
                 # here with our assertion
@@ -532,6 +550,32 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
 
         if exc_info is not None:
             raise exc_info[0](exc_info[1], exc_info[2])
+
+    return newfunc
+
+@optional_args
+def run_under_dir(func, newdir='.'):
+    """Decorator to run tests under another directory
+
+    It is somewhat ugly since we can't really chdir
+    back to a directory which had a symlink in its path.
+    So using this decorator has potential to move entire
+    testing run under the dereferenced directory name -- sideeffect.
+
+    The only way would be to instruct testing framework (i.e. nose
+    in our case ATM) to run a test by creating a new process with
+    a new cwd
+    """
+
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        pwd_before = getpwd()
+        try:
+            chpwd(newdir)
+            func(*args, **kwargs)
+        finally:
+            chpwd(pwd_before)
+
 
     return newfunc
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -18,7 +18,7 @@ import platform
 import gc
 
 from functools import wraps
-from os.path import exists, join as opj
+from os.path import exists, join as opj, isabs, normpath
 from time import sleep
 
 lgr = logging.getLogger("datalad.utils")
@@ -404,6 +404,8 @@ def chpwd(path):
     and we have no ability to assess directory path without dereferencing
     symlinks
     """
+    if not isabs(path):
+        path = normpath(opj(getpwd(), path))
     os.chdir(path)  # for grep people -- ok, to chdir here!
     os.environ['PWD'] = path
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -397,3 +397,22 @@ def assure_dir(*args):
         os.makedirs(dirname)
     return dirname
 
+def chpwd(path):
+    """Wrapper around os.chdir which also adjusts environ['PWD']
+
+    The reason is that otherwise PWD is simply inherited from the shell
+    and we have no ability to assess directory path without dereferencing
+    symlinks
+    """
+    os.chdir(path)  # for grep people -- ok, to chdir here!
+    os.environ['PWD'] = path
+
+def getpwd():
+    """Try to return a CWD without dereferencing possible symlinks
+
+    If no PWD found in the env, output of getcwd() is returned
+    """
+    try:
+        return os.environ['PWD']
+    except KeyError:
+        return os.getcwd()


### PR DESCRIPTION
The reason is that there is no bloody way to return
to original directory if original directory had
symlinked directories in its path.  The only way is to
cd PWD as in the environment.  BUT that one is set by the shell
and not but os.chdir.  So -- those functions become PWD
aware and adjust it upon chdir

This will be needed for carrying out unittests which would
need to change CWD/PWD to a specific directory