### PR TITLE
BF+TST: "user-friendly" early error messages + rudimentary functionality test for install-handle Closes #223

### DIFF
--- a/datalad/interface/tests/test_install_handle.py
+++ b/datalad/interface/tests/test_install_handle.py
@@ -1,0 +1,57 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for get command
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import re
+from mock import patch
+
+from os.path import join as opj, exists
+from ...utils import swallow_logs
+from ...api import install_handle
+
+from ...support.annexrepo import AnnexRepo
+from ...tests.utils import ok_, eq_
+from ...tests.utils import assert_raises
+from ...tests.utils import with_testrepos
+from ...tests.utils import with_tempfile
+
+#@assert_cwd_unchanged
+@with_testrepos('basic', flavors=['clone'])
+@with_tempfile()
+@with_tempfile(mkdir=True)
+def test_install_handle_basic(handle_url, path, lcpath):
+    ok_(not exists(opj(lcpath, "localcollection")))
+    # TODO: make it saner see https://github.com/datalad/datalad/issues/234
+    # apparently can't mock a property
+    #with patch('datalad.interface.install_handle.dirs.user_data_dir', lcpath):
+
+    class mocked_dirs:
+        user_data_dir = lcpath
+
+    with patch('datalad.interface.install_handle.dirs', mocked_dirs), \
+        swallow_logs() as cml:
+        install_handle(handle_url, path)
+        # TODO: verify output value, see https://github.com/datalad/datalad/issues/236
+        ok_(exists(opj(lcpath, "localcollection")))
+
+        # we should be able to install handle again to the same location
+        install_handle(handle_url, path)
+
+        with assert_raises(ValueError) as cm:
+            install_handle(handle_url, path, name="some different name")
+        ok_(re.match('Different handle .* is already installed under %s' % path, cm.exception.message))
+
+        # We have no check for orin
+        with assert_raises(RuntimeError) as cm:
+            install_handle(handle_url, lcpath)
+        eq_(cm.exception.message, '%s already exists, and is not a handle' % lcpath)

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -49,8 +49,35 @@ def get_url_deposition_filename(url):
     finally:
         r.close()
 
-def get_url_straight_filename(url):
-    return os.path.basename(urlunquote(urlsplit(url).path))
+def get_url_straight_filename(url, strip=[], allowdir=False):
+    """Get file/dir name of the last path component of the URL
+
+    Parameters
+    ----------
+    strip: list, optional
+      If provided, listed names will not be considered and their
+      parent directory will be selected
+    allowdir: bool, optional
+      If url points to a "directory" (ends with /), empty string
+      would be returned unless allowdir is True, in which case the
+      name of the directory would be returned
+    """
+    path = urlunquote(urlsplit(url).path)
+    path_parts = path.split('/')
+
+    if allowdir:
+        # strip empty ones
+        while len(path_parts) > 1 and not path_parts[-1]:
+            path_parts = path_parts[:-1]
+
+    if strip:
+        while path_parts and path_parts[-1] in strip:
+            path_parts = path_parts[:-1]
+
+    if path_parts:
+        return path_parts[-1]
+    else:
+        return None
 
 def get_url_response_stamp(url, response_info):
     size, mtime = None, None

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -10,6 +10,7 @@
 from .utils import eq_, ok_
 
 from ..support.network import same_website, dgurljoin
+from ..support.network import get_url_straight_filename
 
 
 def test_same_website():
@@ -23,3 +24,22 @@ def test_dgurljoin():
     eq_(dgurljoin('http://a.b/page', 'f'), 'http://a.b/f')
     eq_(dgurljoin('http://a.b/dir/', 'f'), 'http://a.b/dir/f')
     eq_(dgurljoin('http://a.b/dir/', 'http://url'), 'http://url')
+
+def _test_get_url_straight_filename(suf):
+    eq_(get_url_straight_filename('http://a.b/' + suf), '')
+    eq_(get_url_straight_filename('http://a.b/p1' + suf), 'p1')
+    eq_(get_url_straight_filename('http://a.b/p1/' + suf), '')
+    #eq_(get_url_straight_filename('http://a.b/p1/' + suf, allowdir=True), 'p1')
+    eq_(get_url_straight_filename('http://a.b/p1/p2' + suf), 'p2')
+    eq_(get_url_straight_filename('http://a.b/p1/p2/' + suf), '')
+    eq_(get_url_straight_filename('http://a.b/p1/p2/' + suf, allowdir=True), 'p2')
+    eq_(get_url_straight_filename('http://a.b/p1/p2/' + suf, allowdir=True, strip=('p2', 'xxx')), 'p1')
+    eq_(get_url_straight_filename('http://a.b/p1/p2/' + suf, strip=('p2', 'xxx')), '')
+
+def test_get_url_straight_filename():
+    yield _test_get_url_straight_filename, ''
+    yield _test_get_url_straight_filename, '#'
+    yield _test_get_url_straight_filename, '#tag'
+    yield _test_get_url_straight_filename, '#tag/obscure'
+    yield _test_get_url_straight_filename, '?param=1'
+    yield _test_get_url_straight_filename, '?param=1&another=/'

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -19,7 +19,7 @@ from six import PY3
 
 from os.path import join as opj, isabs, abspath
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
-from ..utils import get_local_file_url
+from ..utils import get_local_file_url, get_url_path
 from ..utils import getpwd, chpwd
 from ..support.annexrepo import AnnexRepo
 
@@ -136,6 +136,14 @@ def test_get_local_file_url_linux():
     assert_equal(get_local_file_url('/a/b/c'), 'file:///a/b/c')
     assert_equal(get_local_file_url('/a~'), 'file:///a%7E')
     assert_equal(get_local_file_url('/a b/'), 'file:///a%20b/')
+
+@skip_if_on_windows
+def test_get_url_path_on_fileurls():
+    assert_equal(get_url_path('file:///a'), '/a')
+    assert_equal(get_url_path('file:///a/b'), '/a/b')
+    assert_equal(get_url_path('file:///a/b#id'), '/a/b')
+    assert_equal(get_url_path('file:///a/b?whatever'), '/a/b')
+
 
 def test_get_local_file_url_windows():
     raise SkipTest("TODO")

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -9,8 +9,9 @@
 
 import collections
 import six.moves.builtins as __builtin__
-from six.moves.urllib.parse import quote as urlquote
+from six.moves.urllib.parse import quote as urlquote, unquote as urlunquote, urlsplit
 
+import re
 import logging
 import shutil, stat, os, sys
 import tempfile
@@ -76,6 +77,10 @@ def get_local_file_url(fname):
         furl = "file://%s" % urlquote(fname)
     return furl
 
+def get_url_path(url):
+    """Given a file:// url, return the path itself"""
+
+    return urlunquote(urlsplit(url).path)
 
 def rotree(path, ro=True, chmod_files=True):
     """To make tree read-only or writable


### PR DESCRIPTION
Not sure if all of those checks/functionality should be within interface or the corresponding handle.

This PR also includes some utility additions/changes

whenever decided/acted upon #236, tests should be extended
whenever #234 is addressed, test should mock less, and we might even make a dedicated fixture e.g. @with_fake_localcollection