### PR TITLE
BF remove stale tempdirs which started to appear again

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -24,3 +24,28 @@ except ImportError:
     def test(*args, **kwargs):
         lgr.warning('Need numpy >= 1.2 for datalad.tests().  Nothing is done')
     test.__test__ = False
+
+# Following fixtures are necessary at the top level __init__ for fixtures which
+# would cover all **/tests and not just datalad/tests/
+
+def setup_package():
+    import os
+    # To overcome pybuild by default defining http{,s}_proxy we would need
+    # to define them to e.g. empty value so it wouldn't bother touching them.
+    # But then haskell libraries do not digest empty value nicely, so we just
+    # pop them out from the environment
+    for ev in ('http_proxy', 'https_proxy'):
+        if ev in os.environ and not (os.environ[ev]):
+            lgr.debug("Removing %s from the environment since it is empty", ev)
+            os.environ.pop(ev)
+
+def teardown_package():
+    from datalad.tests import _TEMP_PATHS_GENERATED
+    from datalad.tests.utils import rmtemp
+    if len(_TEMP_PATHS_GENERATED):
+        msg = "Removing %d dirs/files: %s" % (len(_TEMP_PATHS_GENERATED), ', '.join(_TEMP_PATHS_GENERATED))
+    else:
+        msg = "Nothing to remove"
+    lgr.debug("Teardown tests. " + msg)
+    for path in _TEMP_PATHS_GENERATED:
+        rmtemp(path, ignore_errors=True)

--- a/datalad/tests/__init__.py
+++ b/datalad/tests/__init__.py
@@ -14,26 +14,9 @@ from logging import getLogger
 
 lgr = getLogger("datalad.tests")
 
-def setup_module():
-    # To overcome pybuild by default defining http{,s}_proxy we would need
-    # to define them to e.g. empty value so it wouldn't bother touching them.
-    # But then haskell libraries do not digest empty value nicely, so we just
-    # pop them out from the environment
-    for ev in ('http_proxy', 'https_proxy'):
-        if ev in os.environ and not (os.environ[ev]):
-            lgr.debug("Removing %s from the environment since it is empty", ev)
-            os.environ.pop(ev)
-
 # We will delay generation of some test files/directories until they are
 # actually used but then would remove them here
 _TEMP_PATHS_GENERATED = []
-def teardown_module():
-    from datalad.tests.utils import rmtemp
-    lgr.debug("Teardown tests. " +
-              (("Removing dirs/files: %s" % ', '.join(_TEMP_PATHS_GENERATED))
-                if _TEMP_PATHS_GENERATED else "Nothing to remove"))
-    for path in _TEMP_PATHS_GENERATED:
-        rmtemp(path)
 
 # Give a custom template so we could hunt them down easily
 tempfile.template = os.path.join(tempfile.gettempdir(),

--- a/datalad/tests/test_main.py
+++ b/datalad/tests/test_main.py
@@ -11,9 +11,10 @@ import os, tempfile, time, platform
 from os.path import join, exists, lexists, isdir
 
 from .utils import eq_, ok_, assert_greater, \
-     with_tree, serve_path_via_http, sorted_files, rmtree, create_tree_archive, \
+     with_tree, serve_path_via_http, sorted_files, create_tree_archive, \
      md5sum, ok_clean_git, ok_file_under_git, get_most_obscure_supported_name, \
      on_windows, on_osx
+from ..utils import rmtemp
 from nose.exc import SkipTest
 
 from ..config import EnhancedConfigParser
@@ -124,7 +125,7 @@ def check_page2annex_same_incoming_and_public(mode, path, url):
     verify_nothing_was_done(stats2_dry)
     ok_clean_git(dout)
 
-    rmtree(dout, True)
+    rmtemp(dout)
 
 def test_page2annex_same_incoming_and_public():
     for mode in ('download',
@@ -327,8 +328,8 @@ def check_page2annex_separate_public(separate, mode, incoming_destiny, path, url
 
     # TODO: "removal" mode, when files get removed"
 
-    rmtree(dout, True)
-    rmtree(din, True)
+    rmtemp(dout)
+    rmtemp(din)
 
 def test_page2annex_separate_public():
     # separate lines for easy selection for debugging of a particular
@@ -396,5 +397,5 @@ def test_page2annex_recurse(path, url):
         [obscure, '1/1 f.txt', '1/d/1d',     #u'2/юнякод.txt',
                                     '2/d/1d', '2/f/1d', 'test.txt'])
 
-    #rmtree(dout, True)
-    #rmtree(din, True)
+    rmtemp(dout)
+    rmtemp(din)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -412,7 +412,7 @@ from .utils_testrepos import BasicAnnexTestRepo, BasicHandleTestRepo, \
     BasicGitTestRepo, MetadataPTHandleTestRepo, BasicCollectionTestRepo
 
 _TESTREPOS = None
-
+from . import _TEMP_PATHS_GENERATED
 
 def _get_testrepos_uris(regex, flavors):
     global _TESTREPOS

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -43,6 +43,10 @@ from ..utils import *
 from ..support.exceptions import CommandNotAvailableError
 from ..support.archives import compress_files
 
+from . import _TEMP_PATHS_GENERATED
+
+# temp paths used by clones
+_TEMP_PATHS_CLONES = set()
 
 def create_tree_archive(path, name, load, overwrite=False):
     """Given an archive `name`, create under `path` with specified `load` tree
@@ -399,7 +403,7 @@ def clone_url(url):
     runner = Runner()
     tdir = tempfile.mkdtemp(**get_tempfile_kwargs({}, prefix='clone_url'))
     _ = runner(["git", "clone", url, tdir], expect_stderr=True)
-    open(opj(tdir, ".git", "remove-me"), "w").write("Please")  # signal for it to be removed after
+    _TEMP_PATHS_CLONES.add(tdir)
     return tdir
 
 
@@ -412,7 +416,6 @@ from .utils_testrepos import BasicAnnexTestRepo, BasicHandleTestRepo, \
     BasicGitTestRepo, MetadataPTHandleTestRepo, BasicCollectionTestRepo
 
 _TESTREPOS = None
-from . import _TEMP_PATHS_GENERATED
 
 def _get_testrepos_uris(regex, flavors):
     global _TESTREPOS
@@ -515,8 +518,8 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False):
             try:
                 t(*(arg + (uri,)), **kw)
             finally:
-                # ad-hoc but works
-                if exists(uri) and exists(opj(uri, ".git", "remove-me")):
+                if uri in _TEMP_PATHS_CLONES:
+                    _TEMP_PATHS_CLONES.discard(uri)
                     rmtemp(uri)
                 pass  # might need to provide additional handling so, handle
     return newfunc

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -138,6 +138,9 @@ def rmtemp(f, *args, **kwargs):
     environment variable is defined
     """
     if not os.environ.get('DATALAD_TESTS_KEEPTEMP'):
+        if not os.path.lexists(f):
+            lgr.debug("Path %s does not exist, so can't be removed" % f)
+            return
         lgr.log(5, "Removing temp file: %s" % f)
         # Can also be a directory
         if os.path.isdir(f):
@@ -148,7 +151,7 @@ def rmtemp(f, *args, **kwargs):
                     os.unlink(f)
                 except OSError as e:
                     if i < 9:
-                        sleep(0.5)
+                        sleep(0.1)
                         continue
                     else:
                         raise


### PR DESCRIPTION
it required moving test fixtures all the way to `datalad/__init__.py` which is kinda not nice, but I guess that is the only way