### PR TITLE
git remove -- should not match_return_type

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -148,8 +148,7 @@ def normalize_paths(func, match_return_type=True):
     def newfunc(self, files, *args, **kwargs):
         if isinstance(files, string_types) or not files:
             files_new = [_normalize_path(self.path, files)]
-            file_path = opj(self.path, files_new[0])
-            single_file = exists(file_path) and not(isdir(file_path))
+            single_file = True
         elif isinstance(files, list):
             files_new = [_normalize_path(self.path, path) for path in files]
             single_file = False
@@ -320,7 +319,7 @@ class GitRepo(object):
         else:
             lgr.warning("git_add was called with empty file list.")
 
-    @normalize_paths
+    @normalize_paths(match_return_type=False)
     def git_remove(self, files, **kwargs):
         """Remove files.
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -148,7 +148,8 @@ def normalize_paths(func, match_return_type=True):
     def newfunc(self, files, *args, **kwargs):
         if isinstance(files, string_types) or not files:
             files_new = [_normalize_path(self.path, files)]
-            single_file = not(isdir(opj(self.path, files_new[0])))
+            file_path = opj(self.path, files_new[0])
+            single_file = exists(file_path) and not(isdir(file_path))
         elif isinstance(files, list):
             files_new = [_normalize_path(self.path, path) for path in files]
             single_file = False

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -13,7 +13,7 @@ For further information on GitPython see http://gitpython.readthedocs.org/
 """
 
 from os import linesep
-from os.path import join as opj, exists, normpath, isabs, commonprefix, relpath, realpath
+from os.path import join as opj, exists, normpath, isabs, commonprefix, relpath, realpath, isdir
 from os.path import dirname, basename
 import logging
 import shlex
@@ -148,7 +148,7 @@ def normalize_paths(func, match_return_type=True):
     def newfunc(self, files, *args, **kwargs):
         if isinstance(files, string_types) or not files:
             files_new = [_normalize_path(self.path, files)]
-            single_file = True
+            single_file = not(isdir(opj(self.path, files_new[0])))
         elif isinstance(files, list):
             files_new = [_normalize_path(self.path, path) for path in files]
             single_file = False

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -112,6 +112,22 @@ def test_GitRepo_add(src, path):
 
 
 @assert_cwd_unchanged
+@with_tree(tree={
+    'd': {'f1': 'content1',
+          'f2': 'content2'},
+    'file': 'content3'
+    })
+def test_GitRepo_remove(path):
+
+    gr = GitRepo(path, create=True)
+    gr.git_add('*')
+    gr.git_commit("committing all the files")
+
+    eq_(gr.git_remove('file'), 'file')
+    eq_(set(gr.git_remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
+
+
+@assert_cwd_unchanged
 @with_tempfile
 def test_GitRepo_commit(path):
 

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -127,7 +127,7 @@ def test_GitRepo_remove(path):
     gr.git_add('*')
     gr.git_commit("committing all the files")
 
-    eq_(gr.git_remove('file'), 'file')
+    eq_(gr.git_remove('file'), ['file'])
     eq_(set(gr.git_remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
 
     eq_(set(gr.git_remove('*', r=True, f=True)), {'file2', 'd2/f1', 'd2/f2'})
@@ -223,6 +223,8 @@ def test_GitRepo_files_decorator():
         def __init__(self):
             self.path = opj('some', 'where')
 
+        # TODO
+        # yoh:  logic is alien to me below why to have two since both look identical!
         @normalize_paths
         def decorated_many(self, files):
             return files
@@ -236,7 +238,8 @@ def test_GitRepo_files_decorator():
     # When a single file passed -- single path returned
     obscure_filename = get_most_obscure_supported_name()
     file_to_test = opj(test_instance.path, 'deep', obscure_filename)
-    eq_(test_instance.decorated_many(file_to_test),
+    # file doesn't exist
+    eq_(test_instance.decorated_one(file_to_test),
                  _normalize_path(test_instance.path, file_to_test))
     eq_(test_instance.decorated_one(file_to_test),
                  _normalize_path(test_instance.path, file_to_test))

--- a/datalad/tests/test_gitrepo.py
+++ b/datalad/tests/test_gitrepo.py
@@ -115,7 +115,11 @@ def test_GitRepo_add(src, path):
 @with_tree(tree={
     'd': {'f1': 'content1',
           'f2': 'content2'},
-    'file': 'content3'
+    'file': 'content3',
+    'd2': {'f1': 'content1',
+          'f2': 'content2'},
+    'file2': 'content3'
+
     })
 def test_GitRepo_remove(path):
 
@@ -126,6 +130,7 @@ def test_GitRepo_remove(path):
     eq_(gr.git_remove('file'), 'file')
     eq_(set(gr.git_remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
 
+    eq_(set(gr.git_remove('*', r=True, f=True)), {'file2', 'd2/f1', 'd2/f2'})
 
 @assert_cwd_unchanged
 @with_tempfile


### PR DESCRIPTION
I left original commits where I have tried to add more magic to the magical normalize_paths in the history.  IMHO we should review all the other functions and probably disable matching in many if not all of them.  
What if some glob which git understands is given?