### PR TITLE
ENH: Enabling codecov support in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
   - git submodule update --init --recursive
-  - cd ..; pip install -q coveralls; cd -
+  - cd ..; pip install -q coveralls codecov; cd -
   - pip install -r requirements.txt
   # Verify that setup.py build doesn't puke
   - python setup.py build
@@ -58,6 +58,7 @@ script:
 
 after_success:
   - coveralls
+  - codecov
 
 # makes it only more difficult to comprehend the failing output.  Enable only when necessary
 # for a particular debugging

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ internals and/or contributing to the project.
 
 * [![Coverage Status](https://coveralls.io/repos/datalad/datalad/badge.png?branch=master)](https://coveralls.io/r/datalad/datalad)
 
+* [![codecov.io](https://codecov.io/github/datalad/datalad/coverage.svg?branch=master)](https://codecov.io/github/datalad/datalad?branch=master)
+
 * [![Documentation](https://readthedocs.org/projects/datalad/badge/?version=latest)](http://datalad.rtfd.org)
 
 # Dependencies


### PR DESCRIPTION
That service provides browser extension to display coverage right while browsing github -- real handy