### PR TITLE
ENH: improve catching versions (in openfmri in particular default to have 1.0.0 version)

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -693,6 +693,12 @@ class Annexificator(object):
                         rename=False,
                         **kwargs):
         """Generate multiple commits if multiple versions were staged
+
+        Parameters
+        ----------
+        TODO
+        **kwargs: dict, optional
+          Passed to get_versions
         """
         def _commit_versions(data):
             self._precommit()  # so that all batched annexes stop

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -92,7 +92,7 @@ def pipeline(dataset, versioned_urls=True, topurl="https://openfmri.org/dataset/
             ],
             # TODO: describe_handle
             # Now some true magic -- possibly multiple commits, 1 per each detected new version!
-            annex.commit_versions('_R(?P<version>\d+[\.\d]*)(?=[\._])'),
+            annex.commit_versions('_R(?P<version>\d+[\.\d]*)(?=[\._])', unversioned='default', default='1.0.0'),
         ],
         annex.remove_obsolete(),  # should be called while still within incoming but only once
         # TODO: since it is a very common pattern -- consider absorbing into e.g. add_archive_content?

--- a/datalad/support/tests/test_versions.py
+++ b/datalad/support/tests/test_versions.py
@@ -10,6 +10,7 @@
 from ..versions import get_versions
 from ...tests.utils import assert_equal, assert_false
 from ...tests.utils import assert_raises
+from ...support.status import FileStatus
 from nose.tools import assert_not_equal
 from collections import OrderedDict as od
 
@@ -20,7 +21,7 @@ def test_get_versions_regex():
     # no versioneer, so version is left as the full match
     assert_equal(get_versions([fn], '_r\d+[.\d]*_'), od([('_r1.0_', {'fbuga': fn})]))
     # use versioneer to tune it up
-    assert_equal(get_versions([fn], '_r\d+[.\d]*_', versioneer=lambda x: x.strip('_r')), od([('1.0', {'fbuga': fn})]))
+    assert_equal(get_versions([fn], '_r\d+[.\d]*_', versioneer=lambda f, v, *args: v.strip('_r')), od([('1.0', {'fbuga': fn})]))
     # use group
     assert_equal(get_versions([fn], '_r(\d+[.\d]*)_'), od([('1.0', {'fbuga': fn})]))
     # and now non memorizing lookup for the trailing _ which then would leave it for the fpath
@@ -54,3 +55,23 @@ def test_get_versions():
     assert_equal(get_versions([('f1', None)], '\d+'), od([('1', {'f': ('f1', None)})]))
     assert_equal(get_versions(['un', ('d1/f1', None), 'd1/f2', 'd2/f2'], '(?<=f)\d+'),
                  od([(None, {'un': 'un'}), ('1', {'d1/f': ('d1/f1', None)}), ('2', {'d1/f': 'd1/f2', 'd2/f': 'd2/f2'})]))
+
+
+def test_get_versions_default_version():
+    # by default we raise exception if conflict was detected
+    assert_raises(ValueError, get_versions, ['f1', 'f'], '\d+')
+    # but for default default_version we would need mtime, so raising another one again
+    assert_raises(ValueError, get_versions, ['f1', 'f'], '\d+', unversioned='default')
+    fstatus = FileStatus(mtime=1456538387)
+    assert_equal(get_versions(['f1', ('f', fstatus)], '\d+', unversioned='default'),
+                 od([('0.0.20160226', {'f': ('f', fstatus)}), ('1', {'f': 'f1'})]))
+    assert_equal(get_versions(['f1', ('f', fstatus)], '\d+', unversioned='default', default='1.0.0'),
+                 od([('1', {'f': 'f1'}), ('1.0.0', {'f': ('f', fstatus)})]))
+    # and we should be able to assign default one which has no % in its default
+    # even without mtime
+    assert_equal(get_versions(['f1', 'f'], '\d+', unversioned='default', default='0.0.1'),
+                 od([('0.0.1', {'f': 'f'}), ('1', {'f': 'f1'})]))
+
+    # if default is specified but not unversioned -- the same
+    assert_equal(get_versions(['f1', 'f'], '\d+', default='0.0.1'),
+             od([('0.0.1', {'f': 'f'}), ('1', {'f': 'f1'})]))

--- a/datalad/support/tests/test_versions.py
+++ b/datalad/support/tests/test_versions.py
@@ -62,7 +62,7 @@ def test_get_versions_default_version():
     assert_raises(ValueError, get_versions, ['f1', 'f'], '\d+')
     # but for default default_version we would need mtime, so raising another one again
     assert_raises(ValueError, get_versions, ['f1', 'f'], '\d+', unversioned='default')
-    fstatus = FileStatus(mtime=1456538387)
+    fstatus = FileStatus(mtime=1456495187)
     assert_equal(get_versions(['f1', ('f', fstatus)], '\d+', unversioned='default'),
                  od([('0.0.20160226', {'f': ('f', fstatus)}), ('1', {'f': 'f1'})]))
     assert_equal(get_versions(['f1', ('f', fstatus)], '\d+', unversioned='default', default='1.0.0'),

--- a/datalad/support/tests/test_versions.py
+++ b/datalad/support/tests/test_versions.py
@@ -75,3 +75,15 @@ def test_get_versions_default_version():
     # if default is specified but not unversioned -- the same
     assert_equal(get_versions(['f1', 'f'], '\d+', default='0.0.1'),
              od([('0.0.1', {'f': 'f'}), ('1', {'f': 'f1'})]))
+
+    # and what about always versioned and some which do not have to be versioned?
+    # test run without forcing
+    assert_equal(get_versions(['README', 'f1', 'f', ('ds', fstatus)], '\d+', default='%Y'),
+                 od([(None, {'README': 'README', 'ds': ('ds', fstatus)}),
+                     ('1', {'f': 'f1'}),
+                     ('2016', {'f': 'f'})]))
+    assert_equal(get_versions(['README', 'f1', 'f', ('ds', fstatus)], '\d+', default='%Y', always_versioned='^ds.*'),
+             od([(None, {'README': 'README'}),
+                 ('1', {'f': 'f1'}),
+                 ('2016', {'f': 'f', 'ds': ('ds', fstatus)})]))
+

--- a/datalad/support/versions.py
+++ b/datalad/support/versions.py
@@ -28,7 +28,8 @@ lgr = getLogger('datalad.support.versions')
 
 
 def get_versions(vfpath_statuses, regex, overlay=True,
-                 unversioned=None, default=None, versioneer=None):
+                 unversioned=None, default=None, always_versioned=None,
+                 versioneer=None):
     """Return an ordered dict of versions with entries being vfpath_statuses
 
     ATM doesn't care about statuses but it might in the future so we could
@@ -54,6 +55,8 @@ def get_versions(vfpath_statuses, regex, overlay=True,
       If no '%' found in `default`, its value is used as is and no status is needed.
       If `unversioned` is None and `default` is specified -- assume 'default', and
       'fail' otherwise.
+    always_versioned: str, optional
+      Regular expression to force versioning of file names matching the regex.
     default: str, optional
       Default version to use in case of unversioned is 'default'
     versioneer: callable, optional
@@ -95,20 +98,10 @@ def get_versions(vfpath_statuses, regex, overlay=True,
             # unversioned
             nunversioned += 1
             fpath = vfpath
-            if unversioned == 'fail':
-                # just will be checked later if there is no conflicts
-                version = None
-            elif unversioned == 'default':
-                if '%' in default:  # so we seek strftime formatting
-                    if status is None:
-                        raise ValueError(
-                            "No status was provided within %r entry. "
-                            "No mtime could be figured out for this unversioned file" % entry)
-                    version = time.strftime(default, time.localtime(status.mtime))
-                else:  # just the default
-                    version = default
+            if always_versioned and re.match(always_versioned, basename(vfpath)):
+                version = _get_default_version(entry, default, status)
             else:
-                raise ValueError("Do not know how to handle %r" % (unversioned,))
+                version = None
         else:
             nversioned += 1
             fpath = vfpath[:res.start()] + vfpath[res.end():]  # unversioned one
@@ -135,25 +128,46 @@ def get_versions(vfpath_statuses, regex, overlay=True,
             len(all_versions),
             all_versions if nversioned + nunversioned < 100 else "too many to list")
 
-    # sort all the versions and place into an ordered dictionary
+    if None in all_versions:
+        # check if for each one of them there is no unversioned one
+        # we will be augmenting all_versions, thus go through those keys we have so far
+        for version in list(all_versions):
+            fpaths = all_versions[version]
+            if version is None:
+                continue
+            for fpath in fpaths:
+                if fpath in all_versions[None]:
+                    # So we had versioned AND unversioned
+                    if unversioned == 'fail':
+                        raise ValueError(
+                            "There is an unversioned file %r whenever also following "
+                            "version for it was found: %s" % (fpath, version))
+                    elif unversioned == 'default':
+                        version = _get_default_version(entry, default, status)
+                        all_versions[version][fpath] = all_versions[None].pop(fpath)
+                    else:
+                        raise ValueError("Do not know how to handle %r" % (unversioned,))
+        if not all_versions[None]:
+            # may be no unversioned left
+            all_versions.pop(None)
+
+    # sort all the versions and place into an ordered dictionary, but strip None first
     had_None = None in all_versions
     versions_sorted = list(map(str, sorted((LooseVersion(v) for v in all_versions if v is not None))))
     if had_None:
         versions_sorted = [None] + versions_sorted
 
-    versions = OrderedDict(((v, all_versions[v]) for v in versions_sorted))
+    return OrderedDict(((v, all_versions[v]) for v in versions_sorted))
 
-    if unversioned == 'fail':
-        if None in versions:
-            # check if for each one of them there is no unversioned one
-            for version, fpaths in iteritems(versions):
-                if version is None:
-                    continue
-                for fpath in fpaths:
-                    if fpath in versions[None]:
-                        raise ValueError(
-                            "There is an unversioned file %r whenever also following "
-                            "version for it was found: %s" % (fpath, version))
-    return versions
+
+def _get_default_version(entry, default, status):
+    if '%' in default:  # so we seek strftime formatting
+        if status is None:
+            raise ValueError(
+                "No status was provided within %r entry. "
+                "No mtime could be figured out for this unversioned file" % entry)
+        return time.strftime(default, time.localtime(status.mtime))
+    else:  # just the default
+        return default
 
 


### PR DESCRIPTION
to make it work again due to recent changes upload to openfmri