### PR TITLE
ENH: if running from under git __version__ will be based on git-describe

### DIFF
--- a/datalad/version.py
+++ b/datalad/version.py
@@ -9,4 +9,23 @@
 """Defines version to be imported in the module and obtained from setup.py
 """
 
+from os.path import lexists, dirname, join as opj
+
+# Hard coded version, to be done by release process
 __version__ = '0.1.dev0'
+
+if lexists(opj(dirname(dirname(__file__)), '.git')):
+    # If under git -- attempt to deduce a better "dynamic" version following git
+    try:
+        import sys
+        from subprocess import Popen, PIPE
+        git = Popen(['git', 'describe', '--abbrev=4', '--dirty', '--match', '[0-9]*\.*'],
+                    stdout=PIPE, stderr=sys.stderr)
+        if git.wait() != 0:
+            raise OSError
+        line = git.stdout.readlines()[0]
+        # Just take describe and replace initial '-' with .dev to be more "pythonish"
+        __version__ = line.strip().decode('ascii').replace('-', '.dev', 1)
+    except:
+        __version__ += ".giterror"
+

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -21,11 +21,14 @@ if lexists(opj(dirname(dirname(__file__)), '.git')):
     try:
         import sys
         from subprocess import Popen, PIPE
+        from os.path import dirname
         git = Popen(['git', 'describe', '--abbrev=4', '--dirty', '--match', '[0-9]*\.*'],
-                    stdout=PIPE, stderr=sys.stderr)
+                    stdout=PIPE, stderr=PIPE,
+                    cwd=dirname(dirname(__file__)))
         if git.wait() != 0:
             raise OSError
         line = git.stdout.readlines()[0]
+        _ = git.stderr.readlines()
         # Just take describe and replace initial '-' with .dev to be more "pythonish"
         __version__ = line.strip().decode('ascii').replace('-', '.dev', 1)
     except:

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -14,6 +14,8 @@ from os.path import lexists, dirname, join as opj
 # Hard coded version, to be done by release process
 __version__ = '0.1.dev0'
 
+# NOTE: might cause problems with "python setup.py develop" deployments
+#  so I have even changed buildbot to use  pip install -e .
 if lexists(opj(dirname(dirname(__file__)), '.git')):
     # If under git -- attempt to deduce a better "dynamic" version following git
     try:


### PR DESCRIPTION
So we could easily include in our troubleshooting reports, e.g.:

```
$> datalad --version 2>&1 | head -1 
datalad 0.1.dev629-g75a6d
```

`-dirty` suffix would be added if there are uncommitted changes 