### PR TITLE
No static interface imports anymore (closes: gh-408)

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -8,37 +8,43 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Python DataLad API exposing user-oriented commands (also available via CLI)"""
 
+from importlib import import_module as _impmod
+
 from .interface.base import update_docstring_with_parameters as _update_docstring
 from .interface.base import get_interface_groups as _get_interface_groups
 from .interface.base import dedent_docstring as _dedent_docstring
-# TODO:  make those lazy!  ATM importing api requires importing nearly everything
-# Ideally all the bindings/docstrings should be generated upon the first
-# access to them from within api module
-from . import interface as _interfaces
 from .distribution.dataset import Dataset
 
 # auto detect all available interfaces and generate a function-based
 # API from them
 
 for _grp_name, _grp_descr, _interfaces in _get_interface_groups():
-    for _intfcls in _interfaces:
-        _intf = _intfcls
+    for _intfspec in _interfaces:
+        # turn the interface spec into an instance
+        _mod = _impmod(_intfspec[0], package='datalad')
+        _intf = getattr(_mod, _intfspec[1])
         _spec = getattr(_intf, '_params_', dict())
 
         # FIXME no longer using an interface class instance
         # convert the parameter SPEC into a docstring for the function
         _update_docstring(_intf.__call__, _spec,
-                          prefix=_dedent_docstring(_intfcls.__doc__),
-                          suffix=_dedent_docstring(_intfcls.__call__.__doc__))
+                          prefix=_dedent_docstring(_intf.__doc__),
+                          suffix=_dedent_docstring(_intf.__call__.__doc__))
         # register the function in the namespace, using the name of the
         # module it is defined in
-        globals()[_intf.__module__.split('.')[-1]] = _intf.__call__
+        if len(_intfspec) > 3:
+            api_name = _intfspec[3]
+        else:
+            api_name = _intf.__module__.split('.')[-1]
+        globals()[api_name] = _intf.__call__
         # cleanup namespace
+        del _mod
+        del _intfspec
         del _intf
-        del _intfcls
 
 # be nice and clean up the namespace properly
 del _interfaces
+del _impmod
 del _get_interface_groups
 del _grp_name
 del _grp_descr

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -16,6 +16,7 @@ import logging
 import sys
 import os
 import textwrap
+from importlib import import_module
 
 import datalad
 from datalad.log import lgr
@@ -109,10 +110,14 @@ def setup_parser():
         # for all subcommand modules it can find
         cmd_short_descriptions = []
 
-        for _intfcls in _interfaces:
-            _intf = _intfcls
-
-            cmd_name = _intf.__module__.split('.')[-1].replace('_', '-')
+        for _intfspec in _interfaces:
+            # turn the interface spec into an instance
+            _mod = import_module(_intfspec[0], package='datalad')
+            _intf = getattr(_mod, _intfspec[1])
+            if len(_intfspec) > 2:
+                cmd_name = _intfspec[2]
+            else:
+                cmd_name = _intf.__module__.split('.')[-1].replace('_', '-')
             # deal with optional parser args
             if hasattr(_intf, 'parser_args'):
                 parser_args = _intf.parser_args

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -12,57 +12,41 @@
 
 __docformat__ = 'restructuredtext'
 
-# the following should be series of imports of interface implementations
-# the shall be exposed in the Python API and the cmdline interface
-#from .sparql_query import SPARQLQuery
-from datalad.distribution.modify_subhandle_urls import ModifySubhandleURLs
-from datalad.distribution.move import Move
-from datalad.distribution.uninstall import Uninstall
-from datalad.distribution.update import Update
-from .add_archive_content import AddArchiveContent
-from .clean import Clean
-from .crawl import Crawl
-from .download_url import DownloadURL
-from .ls import Ls
-from .pull import Pull
-from .push import Push
-from .test import Test
-from ..distribution.add_sibling import AddSibling
-from ..distribution.create_publication_target_sshwebserver import \
-    CreatePublicationTargetSSHWebserver
-from ..distribution.install import Install
-from ..distribution.publish import Publish
 
-# very optional ones
-from ..distribution.tests.create_test_dataset import CreateTestDataset
-
+# the following should be series of import definitions for interface implementations
+# that shall be exposed in the Python API and the cmdline interface
 # all interfaces should be associated with (at least) one of the groups below
 _group_dataset = (
     'Commands for dataset operations',
     [
-        Install,
-        Publish,
-        Uninstall,
-        Move,
-        Update,
-        CreatePublicationTargetSSHWebserver,
-        AddSibling,
-        ModifySubhandleURLs,
+        # source module, source object[, dest. cmdline name[, dest python name]]
+        # src module can be relative, but has to be relative to the main 'datalad' package
+        ('datalad.distribution.install', 'Install'),
+        ('datalad.distribution.publish', 'Publish'),
+        ('datalad.distribution.uninstall', 'Uninstall'),
+        ('datalad.distribution.move', 'Move'),
+        ('datalad.distribution.update', 'Update'),
+        ('datalad.distribution.create_publication_target_sshwebserver',
+         'CreatePublicationTargetSSHWebserver',
+         'create-publication-target-sshwebserver'),
+        ('datalad.distribution.add_sibling', 'AddSibling', 'add-sibling'),
+        ('datalad.distribution.modify_subhandle_urls', 'ModifySubhandleURLs',
+         'modify-subhandle-urls'),
     ])
 
 _group_misc = (
     'Miscellaneous commands',
     [
-        Test,
-        Crawl,
-        #SPARQLQuery,
-        #Describe,
-        Pull,
-        Push,
-        #ImportMetadata,
-        AddArchiveContent,
-        DownloadURL,
-        Ls,
-        Clean,
-        CreateTestDataset,
+        ('datalad.interface.test', 'Test'),
+        ('datalad.interface.crawl', 'Crawl'),
+        ('datalad.interface.pull', 'Pull'),
+        ('datalad.interface.push', 'Push'),
+        ('datalad.interface.ls', 'Ls'),
+        ('datalad.interface.clean', 'Clean'),
+        ('datalad.interface.add_archive_content', 'AddArchiveContent',
+         'add-archive-content'),
+        ('datalad.interface.download_url', 'DownloadURL', 'download-url'),
+        # very optional ones
+        ('datalad.distribution.tests.create_test_dataset', 'CreateTestDataset',
+         'create-test-dataset'),
     ])


### PR DESCRIPTION
This doesn't implement a clever lazy-importing scheme, but it
nevertheless removes all static interface imports. In a nutshell:

Static imports are replaced with definitions of what needs importing,
plus an optional definition of target names for Python API and cmdline
interface.

This moves us into a position to make import more clever/leaner/lazier
if needed in the future.

Closes #408 