### PR TITLE
ENH/RF: Allow for incremental publishing by --force -> --existing=skip

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -124,7 +124,7 @@ class Publish(Interface):
         if path is not None:
             path = resolve_path(path, ds)
 
-        lgr.debug("Resolved component to be published: {0}".format(path))
+        lgr.info("Publishing {0}".format(path))
 
         # if we have no dataset given, figure out which one we need to operate
         # on, based on the resolved location (that is now guaranteed to

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -74,7 +74,7 @@ def test_target_ssh_simple(origin, src_path, target_path):
                                                target="local_target",
                                                sshurl="ssh://localhost" +
                                                       opj(target_path, "basic"),
-                                               force=True)
+                                               existing='replace')
         eq_("ssh://localhost" + opj(target_path, "basic"),
             source.repo.git_get_remote_url("local_target"))
         eq_("ssh://localhost" + opj(target_path, "basic"),
@@ -91,7 +91,7 @@ def test_target_ssh_simple(origin, src_path, target_path):
                                                               "basic"),
                                                target_pushurl="ssh://localhost" +
                                                       opj(target_path, "basic"),
-                                               force=True)
+                                               existing='replace')
         eq_(opj(target_path, "basic"),
             source.repo.git_get_remote_url("local_target"))
         eq_("ssh://localhost" + opj(target_path, "basic"),


### PR DESCRIPTION
partially addresses #464 (at least can reinvoke the same command again to create new needed target directories on the remote server)

also upgraded one log msg to .info since generally we want to see what is going on at least at the highest level