### PR TITLE
ENH: upgrade .debug to .info for install API cmd to depict what is going on

### DIFF
--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -379,7 +379,7 @@ class Install(Interface):
 
         assert(ds is not None)
 
-        lgr.debug("Resolved target dataset for installation: {0}".format(ds))
+        lgr.info("Installing {0}".format(ds))
 
         vcs = ds.repo
         if vcs is None:


### PR DESCRIPTION
I could swear I have had this change as a part of another PR but currently can't locate it... I guess I dreamed it up.  Anyways -- when installing, especially with --recursive, it would be nice if at least at INFO level we would have got some feedback about ongoing activities. 