### PR TITLE
RF:  ironing repo classes Part I

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_install:
   # The ultimate one-liner setup for NeuroDebian repository
   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
   - travis_retry sudo apt-get update -qq
-  - sudo tools/ci/prep-travis-forssh.sh
 
 install:
   # Install standalone build of git-annex for the recent enough version
@@ -60,7 +59,7 @@ install:
 
 script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
-  - DATALAD_TESTS_SSH=1 DATALAD_LOGLEVEL=INFO $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --with-cov --cover-package datalad --logging-level=INFO
+  - DATALAD_LOGLEVEL=INFO $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --with-cov --cover-package datalad --logging-level=INFO
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Verify that we can render manpages
   - make manpages

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -162,7 +162,7 @@ class AutomagicIO(object):
         # either it has content
         if (under_annex or under_annex is None) and not annex.file_has_content(filepath):
             lgr.info("File %s has no content -- retrieving", filepath)
-            annex.annex_get(filepath, log_online=self._log_online)
+            annex.get(filepath, log_online=self._log_online)
 
     def activate(self):
         # Some beasts (e.g. tornado used by IPython) override outputs, and

--- a/datalad/crawler/dbs/base.py
+++ b/datalad/crawler/dbs/base.py
@@ -21,6 +21,8 @@ from os.path import isabs
 from ...utils import auto_repr
 from ...utils import find_files
 from ...consts import HANDLE_META_DIR
+from ...support.annexrepo import AnnexRepo
+from ...support.gitrepo import GitRepo
 
 import logging
 lgr = logging.getLogger('datalad.crawler.dbs')
@@ -85,7 +87,15 @@ class JsonBaseDB(object):
         lgr.debug("Writing %s to %s" % (self.__class__.__name__, self._filepath))
         with open(self._filepath, 'w') as f:
             json.dump(db, f, indent=2, sort_keys=True, separators=(',', ': '))
-        self.repo.git_add(self._filepath)  # stage to be committed
+
+        # stage to be committed:
+        if isinstance(self.repo, AnnexRepo):
+            self.repo.add(self._filepath, git=True)
+        elif isinstance(self.repo, GitRepo):
+            self.repo.add(self._filepath)
+        else:
+            raise ValueError("Unknown repo: %s" % self.repo)
+
 
     @property
     def db_version(self):

--- a/datalad/crawler/dbs/base.py
+++ b/datalad/crawler/dbs/base.py
@@ -50,8 +50,8 @@ class JsonBaseDB(object):
         if self._filepath is not None:
             return
         self._filepath = opj(realpath(self.repo.path),
-                     self.__class__.__crawler_subdir__,
-                     (self.name or self.repo.git_get_active_branch())+'.json')
+                             self.__class__.__crawler_subdir__,
+                             (self.name or self.repo.get_active_branch()) + '.json')
         if lexists(self._filepath):
             self.load()
             self._loaded = True

--- a/datalad/crawler/dbs/base.py
+++ b/datalad/crawler/dbs/base.py
@@ -89,13 +89,7 @@ class JsonBaseDB(object):
             json.dump(db, f, indent=2, sort_keys=True, separators=(',', ': '))
 
         # stage to be committed:
-        if isinstance(self.repo, AnnexRepo):
-            self.repo.add(self._filepath, git=True)
-        elif isinstance(self.repo, GitRepo):
-            self.repo.add(self._filepath)
-        else:
-            raise ValueError("Unknown repo: %s" % self.repo)
-
+        self.repo.add(self._filepath, git=True)
 
     @property
     def db_version(self):

--- a/datalad/crawler/dbs/files.py
+++ b/datalad/crawler/dbs/files.py
@@ -54,7 +54,7 @@ class PhysicalFileStatusesDB(FileStatusesBaseDB):
         filestat = os.lstat(filepath)
         try:
             with swallow_logs():
-                info = self.annex.annex_info(filepath, batch=True)
+                info = self.annex.info(filepath, batch=True)
             size = info['size']
         except (CommandError, TypeError) as exc:
             # must be under git or a plain file

--- a/datalad/crawler/dbs/tests/test_files.py
+++ b/datalad/crawler/dbs/tests/test_files.py
@@ -66,7 +66,7 @@ def _test_AnnexDB(cls, path):
     # we should be able to get status of files out and inside of git
     set_db_status_from_file('2git')
     status_git1 = db.get('2git')
-    annex.git_add('2git')
+    annex.add('2git', git=True)
     annex.git_commit("added 2git")
     assert_equal(db.get('2git'), status_git1)
 

--- a/datalad/crawler/dbs/tests/test_files.py
+++ b/datalad/crawler/dbs/tests/test_files.py
@@ -32,7 +32,7 @@ def _test_AnnexDB(cls, path):
     annex = AnnexRepo(path, create=True)
     # PhysicalFileStatusesDB relies on information in annex so files
     # must be committed first
-    annex.annex_add('file1.txt')
+    annex.add('file1.txt')
     annex.git_commit("initial commit")
     db = cls(annex=annex)
 

--- a/datalad/crawler/dbs/tests/test_files.py
+++ b/datalad/crawler/dbs/tests/test_files.py
@@ -33,7 +33,7 @@ def _test_AnnexDB(cls, path):
     # PhysicalFileStatusesDB relies on information in annex so files
     # must be committed first
     annex.add('file1.txt')
-    annex.git_commit("initial commit")
+    annex.commit("initial commit")
     db = cls(annex=annex)
 
     def set_db_status_from_file(fpath):
@@ -67,7 +67,7 @@ def _test_AnnexDB(cls, path):
     set_db_status_from_file('2git')
     status_git1 = db.get('2git')
     annex.add('2git', git=True)
-    annex.git_commit("added 2git")
+    annex.commit("added 2git")
     assert_equal(db.get('2git'), status_git1)
 
     # we should be able to get status of files with relative path to top dir and abs path

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -718,7 +718,7 @@ class Annexificator(object):
         self.repo._git_custom_command(fpaths, ["git", "reset"])
 
     def _stage(self, fpaths):
-        self.repo.git_add(fpaths)
+        self.repo.add(fpaths, git=True)
         # self.repo.cmd_call_wrapper.run(["git", "add"] + fpaths)
 
     def _get_status(self):

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -366,8 +366,8 @@ class Annexificator(object):
             # So we have only filename
             assert(fpath)
             # Just add into git directly for now
-            # TODO: tune  annex_add so we could use its json output, and may be even batch it
-            out_json = _call(self.repo.annex_add, fpath, options=self.options)
+            # TODO: tune  add so we could use its json output, and may be even batch it
+            out_json = _call(self.repo.add, fpath, options=self.options)
         # elif self.mode == 'full':
         #     # Since addurl ignores annex.largefiles we need first to download that file and then
         #     # annex add it
@@ -377,7 +377,7 @@ class Annexificator(object):
         #         # Just to feed into _call for dry-run
         #         filepath_downloaded = downloader.download(url, filepath, overwrite=True, stats=stats)
         #         assert(filepath_downloaded == filepath)
-        #         self.repo.annex_add(fpath, options=self.options)
+        #         self.repo.add(fpath, options=self.options)
         #         # and if the file ended up under annex, and not directly under git -- addurl
         #         # TODO: better function which explicitly checks if file is under annex or either under git
         #         if self.repo.file_has_content(fpath):
@@ -668,7 +668,7 @@ class Annexificator(object):
                 elif strategy == 'theirs':
                     self.repo.merge(to_merge, options=["-s", "ours", "--no-commit"], expect_stderr=True)
                     self.repo._git_custom_command([], "git read-tree -m -u %s" % to_merge)
-                    self.repo.annex_add('.', options=self.options)  # so everything is staged to be committed
+                    self.repo.add('.', options=self.options)  # so everything is staged to be committed
                 else:
                     raise NotImplementedError(strategy)
 
@@ -991,7 +991,7 @@ class Annexificator(object):
             stats = data.get('datalad_stats', None)
             if self.repo.dirty:  # or self.tracker.dirty # for dry run
                 lgr.info("Repository found dirty -- adding and committing")
-                _call(self.repo.annex_add, '.', options=self.options)  # so everything is committed
+                _call(self.repo.add, '.', options=self.options)  # so everything is committed
 
                 stats_str = ('\n\n' + stats.as_str(mode='full')) if stats else ''
                 _call(self._commit, "%s%s" % (', '.join(self._states), stats_str), options=["-a"])

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -244,7 +244,7 @@ class Annexificator(object):
         if special_remotes:
             for remote in special_remotes:
                 if remote not in git_remotes:
-                    self.repo.annex_initremote(
+                    self.repo.init_remote(
                             remote,
                             ['encryption=none', 'type=external', 'autoenable=true',
                              'externaltype=%s' % remote])
@@ -266,7 +266,7 @@ class Annexificator(object):
 
     # def add(self, filename, url=None):
     #     # TODO: modes
-    #     self.repo.annex_addurl_to_file(filename, url, batch=True #, TODO  backend
+    #     self.repo.add_url_to_file(filename, url, batch=True #, TODO  backend
     #                                    )
     #     raise NotImplementedError()
     #
@@ -382,7 +382,7 @@ class Annexificator(object):
         #         # TODO: better function which explicitly checks if file is under annex or either under git
         #         if self.repo.file_has_content(fpath):
         #             stats.add_annex += 1
-        #             self.repo.annex_addurl_to_file(fpath, url, batch=True)
+        #             self.repo.add_url_to_file(fpath, url, batch=True)
         #         else:
         #             stats.add_git += 1
         #     _call(_download_and_git_annex_add, url, fpath)
@@ -414,7 +414,7 @@ class Annexificator(object):
             if self.mode == 'full' and remote_status and remote_status.size:  # > 1024**2:
                 lgr.info("Need to download %s from %s. No progress indication will be reported"
                          % (naturalsize(remote_status.size), url))
-            out_json = _call(self.repo.annex_addurl_to_file, fpath, url, options=annex_options, batch=True)
+            out_json = _call(self.repo.add_url_to_file, fpath, url, options=annex_options, batch=True)
             added_to_annex = 'key' in out_json
 
             if self.mode == 'full' or not added_to_annex:
@@ -453,7 +453,7 @@ class Annexificator(object):
         # db_filename = self.db.get_filename(url)
         # if filename is not None and filename != db_filename:
         #     # need to download new
-        #     self.repo.annex_addurls
+        #     self.repo.add_urls
         #     # remove old
         #     self.repo.git_remove([db_filename])
         #     self.db.set_filename(url, filename)

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -455,7 +455,7 @@ class Annexificator(object):
         #     # need to download new
         #     self.repo.add_urls
         #     # remove old
-        #     self.repo.git_remove([db_filename])
+        #     self.repo.remove([db_filename])
         #     self.db.set_filename(url, filename)
         # # figure out if we need to download it
         # #if self.mode in ('relaxed', 'fast'):
@@ -581,7 +581,7 @@ class Annexificator(object):
                     lgr.info("Checking out a new detached branch %s" % (branch))
                     self.repo.checkout(branch, options="--orphan")
                     if self.repo.dirty:
-                        self.repo.git_remove('.', r=True, f=True)  # TODO: might be insufficient if directories etc  TEST/fix
+                        self.repo.remove('.', r=True, f=True)  # TODO: might be insufficient if directories etc  TEST/fix
                 else:
                     if parent not in existing_branches:
                         raise RuntimeError("Parent branch %s does not exist" % parent)
@@ -1062,7 +1062,7 @@ class Annexificator(object):
                     files_str = ": " + ', '.join(obsolete) if len(obsolete) < 10 else ""
                     lgr.info('Removing %d obsolete files%s' % (len(obsolete), files_str))
                     stats = data.get('datalad_stats', None)
-                    _call(self.repo.git_remove, obsolete)
+                    _call(self.repo.remove, obsolete)
                     if stats:
                         _call(stats.increment, 'removed', len(obsolete))
                     for filepath in obsolete:
@@ -1082,7 +1082,7 @@ class Annexificator(object):
         # TODO: not sure if we should may be check if exists, and skip/just complain if not
         if stats:
             _call(stats.increment, 'removed')
-        _call(self.repo.git_remove, filename)
+        _call(self.repo.remove, filename)
         yield data
 
     def initiate_handle(self, *args, **kwargs):

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -86,7 +86,7 @@ def _test_annex_file(mode, topdir, topurl, outdir):
         # in fast or relaxed mode there must not be any content
         assert_raises(AssertionError, ok_file_has_content, tfile, '1.dat load')
 
-    whereis = annex.repo.annex_whereis(tfile)
+    whereis = annex.repo.whereis(tfile)
     assert_in(annex.repo.WEB_UUID, whereis)  # url must have been added
     assert_equal(len(whereis), 1 + int(mode == 'full'))
     # TODO: check the url

--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -338,7 +338,7 @@ def initiate_pipeline_config(template, path=curdir, kwargs=None, commit=False):
         repo = GitRepo(path)
         repo.add(crawl_config_repo_path)
         if repo.dirty:
-            repo.git_commit("Initialized crawling configuration to use template %s" % template)
+            repo.commit("Initialized crawling configuration to use template %s" % template)
         else:
             lgr.debug("Repository is not dirty -- not committing")
 

--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -336,7 +336,7 @@ def initiate_pipeline_config(template, path=curdir, kwargs=None, commit=False):
 
     if commit:
         repo = GitRepo(path)
-        repo.git_add(crawl_config_repo_path)
+        repo.add(crawl_config_repo_path)
         if repo.dirty:
             repo.git_commit("Initialized crawling configuration to use template %s" % template)
         else:

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -58,7 +58,7 @@ def check_dropall_get(repo):
     clean(annex=repo)  # remove possible extracted archives
     with assert_raises(AssertionError):
         ok_file_has_content(t1w_fpath, "mighty load 2.0.0")
-    repo.annex_get('.')
+    repo.get('.')
     ok_file_has_content(t1w_fpath, "mighty load 2.0.0")
 
 

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -204,20 +204,20 @@ def test_openfmri_pipeline1(ind, topurl, outd):
     repo = AnnexRepo(outd, create=False)  # to be used in the checks
     # Inspect the tree -- that we have all the branches
     branches = {'master', 'incoming', 'incoming-processed', 'git-annex'}
-    eq_(set(repo.git_get_branches()), branches)
+    eq_(set(repo.get_branches()), branches)
     # We do not have custom changes in master yet, so it just follows incoming-processed atm
-    # eq_(repo.git_get_hexsha('master'), repo.git_get_hexsha('incoming-processed'))
+    # eq_(repo.get_hexsha('master'), repo.get_hexsha('incoming-processed'))
     # Since we did initiate_handle -- now we have separate master!
-    assert_not_equal(repo.git_get_hexsha('master'), repo.git_get_hexsha('incoming-processed'))
+    assert_not_equal(repo.get_hexsha('master'), repo.get_hexsha('incoming-processed'))
     # and that one is different from incoming
-    assert_not_equal(repo.git_get_hexsha('incoming'), repo.git_get_hexsha('incoming-processed'))
+    assert_not_equal(repo.get_hexsha('incoming'), repo.get_hexsha('incoming-processed'))
 
     # actually the tree should look quite neat with 1.0.0 tag having 1 parent in incoming
     # 1.0.1 having 1.0.0 and the 2nd commit in incoming as parents
 
-    commits = {b: list(repo.git_get_branch_commits(b)) for b in branches}
-    commits_hexsha = {b: list(repo.git_get_branch_commits(b, value='hexsha')) for b in branches}
-    commits_l = {b: list(repo.git_get_branch_commits(b, limit='left-only')) for b in branches}
+    commits = {b: list(repo.get_branch_commits(b)) for b in branches}
+    commits_hexsha = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_l = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
     eq_(len(commits['incoming']), 2)
     eq_(len(commits_l['incoming']), 2)
     eq_(len(commits['incoming-processed']), 4)
@@ -272,15 +272,15 @@ def test_openfmri_pipeline1(ind, topurl, outd):
     eq_(set(all_files), target_files)
 
     # check that -beh was committed in 2nd commit in incoming, not the first one
-    assert_not_in('ds666-beh_R1.0.1.tar.gz', repo.git_get_files(commits_l['incoming'][-1]))
-    assert_in('ds666-beh_R1.0.1.tar.gz', repo.git_get_files(commits_l['incoming'][0]))
+    assert_not_in('ds666-beh_R1.0.1.tar.gz', repo.get_files(commits_l['incoming'][-1]))
+    assert_in('ds666-beh_R1.0.1.tar.gz', repo.get_files(commits_l['incoming'][0]))
 
     # rerun pipeline -- make sure we are on the same in all branches!
     with chpwd(outd):
         out = run_pipeline(pipeline)
     eq_(len(out), 1)
 
-    commits_hexsha_ = {b: list(repo.git_get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_hexsha_ = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
     eq_(commits_hexsha, commits_hexsha_)  # i.e. nothing new
     # actually we do manage to add_git 1 (README) since it is generated committed directly to git
     # Nothing was committed so stats leaked all the way up
@@ -304,9 +304,9 @@ def test_openfmri_pipeline1(ind, topurl, outd):
 
     # new instance so it re-reads git stuff etc
     # repo = AnnexRepo(outd, create=False)  # to be used in the checks
-    commits_ = {b: list(repo.git_get_branch_commits(b)) for b in branches}
-    commits_hexsha_ = {b: list(repo.git_get_branch_commits(b, value='hexsha')) for b in branches}
-    commits_l_ = {b: list(repo.git_get_branch_commits(b, limit='left-only')) for b in branches}
+    commits_ = {b: list(repo.get_branch_commits(b)) for b in branches}
+    commits_hexsha_ = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_l_ = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
 
     assert_not_equal(commits_hexsha, commits_hexsha_)
     eq_(out[0]['datalad_stats'], ActivityStats())  # commit happened so stats were consumed
@@ -332,10 +332,10 @@ def test_openfmri_pipeline1(ind, topurl, outd):
             # They shouldn't have any difference but still should be new commits
             assert_in("There is already a tag 2.0.0 in the repository", cml.out)
     eq_(len(out), 1)
-    incoming_files = repo.git_get_files('incoming')
+    incoming_files = repo.get_files('incoming')
     target_incoming_files.remove('ds666_R1.0.0.tar.gz')
     eq_(set(incoming_files), target_incoming_files)
-    commits_hexsha_removed = {b: list(repo.git_get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_hexsha_removed = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
     # our 'statuses' database should have recorded the change thus got a diff
     # which propagated through all branches
     for b in 'master', 'incoming-processed':
@@ -388,20 +388,20 @@ def test_openfmri_pipeline2(ind, topurl, outd):
     repo = AnnexRepo(outd, create=False)  # to be used in the checks
     # Inspect the tree -- that we have all the branches
     branches = {'master', 'incoming', 'incoming-processed', 'git-annex'}
-    eq_(set(repo.git_get_branches()), branches)
+    eq_(set(repo.get_branches()), branches)
     # We do not have custom changes in master yet, so it just follows incoming-processed atm
-    # eq_(repo.git_get_hexsha('master'), repo.git_get_hexsha('incoming-processed'))
+    # eq_(repo.get_hexsha('master'), repo.get_hexsha('incoming-processed'))
     # Since we did initiate_handle -- now we have separate master!
-    assert_not_equal(repo.git_get_hexsha('master'), repo.git_get_hexsha('incoming-processed'))
+    assert_not_equal(repo.get_hexsha('master'), repo.get_hexsha('incoming-processed'))
     # and that one is different from incoming
-    assert_not_equal(repo.git_get_hexsha('incoming'), repo.git_get_hexsha('incoming-processed'))
+    assert_not_equal(repo.get_hexsha('incoming'), repo.get_hexsha('incoming-processed'))
 
     # actually the tree should look quite neat with 1.0.0 tag having 1 parent in incoming
     # 1.0.1 having 1.0.0 and the 2nd commit in incoming as parents
 
-    commits = {b: list(repo.git_get_branch_commits(b)) for b in branches}
-    commits_hexsha = {b: list(repo.git_get_branch_commits(b, value='hexsha')) for b in branches}
-    commits_l = {b: list(repo.git_get_branch_commits(b, limit='left-only')) for b in branches}
+    commits = {b: list(repo.get_branch_commits(b)) for b in branches}
+    commits_hexsha = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_l = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
     eq_(len(commits['incoming']), 1)
     eq_(len(commits_l['incoming']), 1)
     eq_(len(commits['incoming-processed']), 2)
@@ -414,7 +414,7 @@ def test_openfmri_pipeline2(ind, topurl, outd):
         out = run_pipeline(pipeline)
     eq_(len(out), 1)
 
-    commits_hexsha_ = {b: list(repo.git_get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_hexsha_ = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
     eq_(commits_hexsha, commits_hexsha_)  # i.e. nothing new
     eq_(out[0]['datalad_stats'], ActivityStats(files=3, skipped=2, urls=2, add_git=1))
     eq_(out[0]['datalad_stats'], out[0]['datalad_stats'].get_total())

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -42,8 +42,8 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
          ])
     # We want two maximally obscure names, which are also different
     assert(fn_extracted != fn_inarchive_obscure)
-    annex.add_to_annex(fn_archive, "Added tarball")
-    annex.add_to_annex(fn_extracted, "Added the load file")
+    annex.add(fn_archive, commit=True, msg="Added tarball")
+    annex.add(fn_extracted, commit=True, msg="Added the load file")
 
     # Operations with archive remote URL
     annexcr = ArchiveAnnexCustomRemote(path=d)

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -35,7 +35,7 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 @with_tempfile()
 def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
-    annex.annex_initremote(
+    annex.init_remote(
         ARCHIVES_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % ARCHIVES_SPECIAL_REMOTE,
          'autoenable=true'
@@ -59,32 +59,32 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
         archive_file=fn_archive,
         file=fn_archive.replace('.tar.gz', '') + '/d/'+fn_inarchive_obscure)
 
-    annex.annex_addurl_to_file(fn_extracted, file_url, ['--relaxed'])
-    annex.annex_drop(fn_extracted)
+    annex.add_url_to_file(fn_extracted, file_url, ['--relaxed'])
+    annex.drop(fn_extracted)
 
-    list_of_remotes = annex.annex_whereis(fn_extracted, output='descriptions')
+    list_of_remotes = annex.whereis(fn_extracted, output='descriptions')
     in_('[%s]' % ARCHIVES_SPECIAL_REMOTE, list_of_remotes)
 
     assert_false(annex.file_has_content(fn_extracted))
     annex.get(fn_extracted)
     assert_true(annex.file_has_content(fn_extracted))
 
-    annex.annex_rmurl(fn_extracted, file_url)
+    annex.rm_url(fn_extracted, file_url)
     with swallow_logs() as cm:
-        assert_raises(RuntimeError, annex.annex_drop, fn_extracted)
+        assert_raises(RuntimeError, annex.drop, fn_extracted)
         in_("git-annex: drop: 1 failed", cm.out)
 
-    annex.annex_addurl_to_file(fn_extracted, file_url)
-    annex.annex_drop(fn_extracted)
+    annex.add_url_to_file(fn_extracted, file_url)
+    annex.drop(fn_extracted)
     annex.get(fn_extracted)
-    annex.annex_drop(fn_extracted)  # so we don't get from this one next
+    annex.drop(fn_extracted)  # so we don't get from this one next
 
     # Let's create a clone and verify chain of getting file through the tarball
     cloned_annex = AnnexRepo(d2, d,
                            runner=_get_custom_runner(d2),
                            direct=direct)
     # we still need to enable manually atm that special remote for archives
-    # cloned_annex.annex_enableremote('annexed-archives')
+    # cloned_annex.enable_remote('annexed-archives')
 
     assert_false(cloned_annex.file_has_content(fn_archive))
     assert_false(cloned_annex.file_has_content(fn_extracted))

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -21,7 +21,7 @@ from ...downloaders.tests.utils import get_test_providers
 @skip_if_no_network
 def check_basic_scenario(direct, d):
     annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
-    annex.annex_initremote(
+    annex.init_remote(
         DATALAD_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % DATALAD_SPECIAL_REMOTE,
          'autoenable=true'])
@@ -31,7 +31,7 @@ def check_basic_scenario(direct, d):
 
     # Let's try to add some file which we should have access to
     with swallow_outputs() as cmo:
-        annex.annex_addurls(['s3://datalad-test0-versioned/3versions-allversioned.txt'])
+        annex.add_urls(['s3://datalad-test0-versioned/3versions-allversioned.txt'])
         if PY2:
             assert_in('100%', cmo.err)  # we do provide our progress indicator
         else:
@@ -40,7 +40,7 @@ def check_basic_scenario(direct, d):
     # if we provide some bogus address which we can't access, we shouldn't pollute output
     with swallow_outputs() as cmo, swallow_logs() as cml:
         with assert_raises(CommandError) as cme:
-            annex.annex_addurls(['s3://datalad-test0-versioned/3versions-allversioned.txt_bogus'])
+            annex.add_urls(['s3://datalad-test0-versioned/3versions-allversioned.txt_bogus'])
         # assert_equal(cml.out, '')
         err, out = cmo.err, cmo.out
     assert_equal(out, '')

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -153,14 +153,14 @@ class AddSibling(Interface):
         already_existing = list()
         conflicting = list()
         for repo in repos:
-            if name in repos[repo]['repo'].git_get_remotes():
+            if name in repos[repo]['repo'].get_remotes():
                 already_existing.append(repo)
                 lgr.debug("""Remote '{0}' already exists
                           in '{1}'.""".format(name, repo))
 
-                existing_url = repos[repo]['repo'].git_get_remote_url(name)
+                existing_url = repos[repo]['repo'].get_remote_url(name)
                 existing_pushurl = \
-                    repos[repo]['repo'].git_get_remote_url(name, push=True)
+                    repos[repo]['repo'].get_remote_url(name, push=True)
 
                 if repos[repo]['url'].rstrip('/') != existing_url.rstrip('/') \
                         or (pushurl and existing_pushurl and

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -89,7 +89,7 @@ class Dataset(object):
         elif not isinstance(self._repo, AnnexRepo):
             # repo was initially set to be self._repo but might become AnnexRepo
             # at a later moment, so check if it didn't happen
-            if 'git-annex' in self._repo.git_get_branches():
+            if 'git-annex' in self._repo.get_branches():
                 # we acquired git-annex branch
                 self._repo = AnnexRepo(self._repo.path, create=False)
         return self._repo
@@ -118,7 +118,7 @@ class Dataset(object):
         if verify is not None:
             raise NotImplementedError("TODO: verify not implemented yet")
 
-        if name not in repo.git_get_remotes():
+        if name not in repo.get_remotes():
             # Add remote
             repo.add_remote(name, url)
             if publish_url is not None:
@@ -253,7 +253,7 @@ class Dataset(object):
         if not self.is_installed():
             raise RuntimeError(
                 "cannot remember a state when a dataset is not yet installed")
-        self.repo.git_checkout(whereto)
+        self.repo.checkout(whereto)
 
     def is_installed(self):
         """Returns whether a dataset is installed.

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -236,7 +236,7 @@ class Dataset(object):
                 "cannot remember a state when a dataset is not yet installed")
         repo = self.repo
         if auto_add_changes:
-            repo.annex_add('.')
+            repo.add('.')
         repo.commit(message)
         if version:
             repo._git_custom_command('', 'git tag "{0}"'.format(version))

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -120,7 +120,7 @@ class Dataset(object):
 
         if name not in repo.git_get_remotes():
             # Add remote
-            repo.git_remote_add(name, url)
+            repo.add_remote(name, url)
             if publish_url is not None:
                 # set push url:
                 repo._git_custom_command('', ["git", "remote",

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -460,7 +460,7 @@ class Install(Interface):
                 # this is an annex'ed file -> get it
                 # TODO implement `copy --from` using `source`
                 # TODO fail if `source` is something strange
-                vcs.annex_get(relativepath)
+                vcs.get(relativepath)
                 # return the absolute path to the installed file
                 return path
 
@@ -649,7 +649,7 @@ class Install(Interface):
             except CommandError:
                 # FLOW GUIDE EXIT POINT
                 # apaarently not a repo, assume it is a file url
-                vcs.annex_addurl_to_file(relativepath, source)
+                vcs.add_url_to_file(relativepath, source)
                 return path
 
     @staticmethod

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -557,7 +557,7 @@ class Install(Interface):
                 added_files = resolve_path(relativepath, ds)
             else:
                 # do a blunt `annex add`
-                added_files = vcs.annex_add(relativepath)
+                added_files = vcs.add(relativepath)
                 # return just the paths of the installed components
                 if isinstance(added_files, list):
                     added_files = [resolve_path(i['file'], ds) for i in added_files]

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -553,7 +553,13 @@ class Install(Interface):
 
             # switch `add` procedure between Git and Git-annex according to flag
             if add_data_to_git:
-                vcs.git_add(relativepath)
+                if isinstance(vcs, AnnexRepo):
+                    vcs.add(relativepath, git=True)
+                elif isinstance(vcs, GitRepo):
+                    vcs.add(relativepath)
+                else:
+                    # unknown vcs
+                    raise ValueError("Unknown VCS ({0})".format(vcs))
                 added_files = resolve_path(relativepath, ds)
             else:
                 # do a blunt `annex add`

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -520,13 +520,7 @@ class Install(Interface):
 
             # switch `add` procedure between Git and Git-annex according to flag
             if add_data_to_git:
-                if isinstance(vcs, AnnexRepo):
-                    vcs.add(relativepath, git=True)
-                elif isinstance(vcs, GitRepo):
-                    vcs.add(relativepath)
-                else:
-                    # unknown vcs
-                    raise ValueError("Unknown VCS ({0})".format(vcs))
+                vcs.add(relativepath, git=True)
                 added_files = resolve_path(relativepath, ds)
             else:
                 # do a blunt `annex add`

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -111,7 +111,7 @@ def _install_subds_from_flexible_source(ds, sm_path, sm_url, recursive):
     if tracking_branch:
         # name of the default remote for the active branch
         remote_name = repo.active_branch.tracking_branch().remote_name
-        remote_url = vcs.git_get_remote_url(remote_name, push=False)
+        remote_url = vcs.get_remote_url(remote_name, push=False)
         if remote_url.rstrip('/').endswith('/.git'):
             url_suffix = '/.git'
             remote_url = remote_url[:-5]

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -231,7 +231,7 @@ class Publish(Interface):
             # #       - or: We need a different approach on the templates
             #
             # # Add the remote
-            # ds.repo.git_remote_add(dest_resolved, remote_url)
+            # ds.repo.add_remote(dest_resolved, remote_url)
             # if dest_pushurl:
             #     # Fill in template:
             #     remote_url_push = \

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -179,7 +179,7 @@ class Publish(Interface):
             try:
                 std_out, std_err = \
                     ds.repo._git_custom_command('',
-                                                ["git", "config", "--get", "branch.{active_branch}.remote".format(active_branch=ds.repo.git_get_active_branch())],
+                                                ["git", "config", "--get", "branch.{active_branch}.remote".format(active_branch=ds.repo.get_active_branch())],
                                                 expect_fail=True)
             except CommandError as e:
                 if e.code == 1 and e.stdout == "":
@@ -202,7 +202,7 @@ class Publish(Interface):
             std_out, std_err = \
                 ds.repo._git_custom_command('',
                                             ["git", "config", "--get",
-                                             "branch.{active_branch}.merge".format(active_branch=ds.repo.git_get_active_branch())],
+                                             "branch.{active_branch}.merge".format(active_branch=ds.repo.get_active_branch())],
                                             expect_fail=True)
         except CommandError as e:
             if e.code == 1 and e.stdout == "":
@@ -212,7 +212,7 @@ class Publish(Interface):
                 raise
 
         # is `dest` an already known remote?
-        if dest_resolved not in ds.repo.git_get_remotes():
+        if dest_resolved not in ds.repo.get_remotes():
             # unknown remote
             raise ValueError("No sibling '%s' found." % dest_resolved)
 
@@ -266,7 +266,7 @@ class Publish(Interface):
             # => publish the dataset itself
             # push local state:
             ds.repo.push(remote=dest_resolved,
-                         refspec=ds.repo.git_get_active_branch(),
+                         refspec=ds.repo.get_active_branch(),
                          set_upstream=set_upstream)
             # push annex branch:
             if isinstance(ds.repo, AnnexRepo):

--- a/datalad/distribution/tests/create_test_dataset.py
+++ b/datalad/distribution/tests/create_test_dataset.py
@@ -78,7 +78,11 @@ def _makeds(path, levels, ds=None):
     fn = opj(path, "file%d.dat" % random.randint(1, 1000))
     with open(fn, 'w') as f:
         f.write(fn)
-    repo.git_add(fn)
+    if isinstance(repo, AnnexRepo):
+        repo.add(fn, git=True)
+    else:
+        # GitRepo (see line 74)
+        repo.add(fn)
     repo.git_commit("Added %s" % fn)
     if ds:
         rpath = os.path.relpath(path, ds.path)

--- a/datalad/distribution/tests/create_test_dataset.py
+++ b/datalad/distribution/tests/create_test_dataset.py
@@ -78,12 +78,7 @@ def _makeds(path, levels, ds=None):
     fn = opj(path, "file%d.dat" % random.randint(1, 1000))
     with open(fn, 'w') as f:
         f.write(fn)
-    if isinstance(repo, AnnexRepo):
-        repo.add(fn, git=True)
-    else:
-        # GitRepo (see line 74)
-        repo.add(fn)
-    repo.commit("Added %s" % fn)
+    repo.add(fn, git=True, commit=True, msg="Added %s" % fn)
     if ds:
         rpath = os.path.relpath(path, ds.path)
         out = install(

--- a/datalad/distribution/tests/create_test_dataset.py
+++ b/datalad/distribution/tests/create_test_dataset.py
@@ -83,7 +83,7 @@ def _makeds(path, levels, ds=None):
     else:
         # GitRepo (see line 74)
         repo.add(fn)
-    repo.git_commit("Added %s" % fn)
+    repo.commit("Added %s" % fn)
     if ds:
         rpath = os.path.relpath(path, ds.path)
         out = install(
@@ -95,7 +95,7 @@ def _makeds(path, levels, ds=None):
         if isinstance(ds.repo, AnnexRepo):
             ds.repo.commit("subdataset %s installed." % rpath)
         else:
-            ds.repo.git_commit("subdataset %s installed." % rpath)
+            ds.repo.commit("subdataset %s installed." % rpath)
 
     if not levels:
         return

--- a/datalad/distribution/tests/test_add_sibling.py
+++ b/datalad/distribution/tests/test_add_sibling.py
@@ -42,22 +42,22 @@ def test_add_sibling(origin, repo_path):
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
         AnnexRepo(opj(repo_path, subds), init=True,
-                  create=True).git_checkout("master")
+                  create=True).checkout("master")
 
     res = add_sibling(dataset=source, name="test-remote",
                       url="http://some.remo.te/location")
     eq_(res, [basename(source.path)])
-    assert_in("test-remote", source.repo.git_get_remotes())
+    assert_in("test-remote", source.repo.get_remotes())
     eq_("http://some.remo.te/location",
-        source.repo.git_get_remote_url("test-remote"))
+        source.repo.get_remote_url("test-remote"))
 
     # doing it again doesn't do anything
     res = add_sibling(dataset=source, name="test-remote",
                       url="http://some.remo.te/location")
     eq_(res, [])
-    assert_in("test-remote", source.repo.git_get_remotes())
+    assert_in("test-remote", source.repo.get_remotes())
     eq_("http://some.remo.te/location",
-        source.repo.git_get_remote_url("test-remote"))
+        source.repo.get_remote_url("test-remote"))
 
     # fail with conflicting url:
     with assert_raises(RuntimeError) as cm:
@@ -71,7 +71,7 @@ def test_add_sibling(origin, repo_path):
                       url="http://some.remo.te/location/elsewhere", force=True)
     eq_(res, [basename(source.path)])
     eq_("http://some.remo.te/location/elsewhere",
-        source.repo.git_get_remote_url("test-remote"))
+        source.repo.get_remote_url("test-remote"))
 
     # add a push url without force fails, since in a way the fetch url is the
     # configured push url, too, in that case:
@@ -88,9 +88,9 @@ def test_add_sibling(origin, repo_path):
                       pushurl="ssh://push.it", force=True)
     eq_(res, [basename(source.path)])
     eq_("http://some.remo.te/location/elsewhere",
-        source.repo.git_get_remote_url("test-remote"))
+        source.repo.get_remote_url("test-remote"))
     eq_("ssh://push.it",
-        source.repo.git_get_remote_url("test-remote", push=True))
+        source.repo.get_remote_url("test-remote", push=True))
 
     # recursively:
     res = add_sibling(dataset=source, name="test-remote",
@@ -104,9 +104,9 @@ def test_add_sibling(origin, repo_path):
     for repo in [source.repo,
                  GitRepo(opj(source.path, "sub1")),
                  GitRepo(opj(source.path, "sub2"))]:
-        assert_in("test-remote", repo.git_get_remotes())
-        url = repo.git_get_remote_url("test-remote")
-        pushurl = repo.git_get_remote_url("test-remote", push=True)
+        assert_in("test-remote", repo.get_remotes())
+        url = repo.get_remote_url("test-remote")
+        pushurl = repo.get_remote_url("test-remote", push=True)
         ok_(url.startswith("http://some.remo.te/location/" + basename(source.path)))
         ok_(url.endswith(basename(repo.path)))
         ok_(pushurl.startswith("ssh://push.it/" + basename(source.path)))
@@ -125,9 +125,9 @@ def test_add_sibling(origin, repo_path):
     for repo in [source.repo,
                  GitRepo(opj(source.path, "sub1")),
                  GitRepo(opj(source.path, "sub2"))]:
-        assert_in("test-remote-2", repo.git_get_remotes())
-        url = repo.git_get_remote_url("test-remote-2")
-        pushurl = repo.git_get_remote_url("test-remote-2", push=True)
+        assert_in("test-remote-2", repo.get_remotes())
+        url = repo.get_remote_url("test-remote-2")
+        pushurl = repo.get_remote_url("test-remote-2", push=True)
         ok_(url.startswith("http://some.remo.te/location"))
         ok_(pushurl.startswith("ssh://push.it/"))
         if repo != source.repo:

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -82,14 +82,14 @@ def test_register_sibling(remote, path):
     AnnexRepo(path)
     ds = Dataset(path)
     ds.register_sibling('my_sibling', remote)
-    assert_in('my_sibling', ds.repo.git_get_remotes())
-    eq_(ds.repo.git_get_remote_url('my_sibling'), remote)
+    assert_in('my_sibling', ds.repo.get_remotes())
+    eq_(ds.repo.get_remote_url('my_sibling'), remote)
 
 
     ds.register_sibling('my_other_sibling', remote,
                         publish_url='http://fake.pushurl.com')
-    assert_in('my_other_sibling', ds.repo.git_get_remotes())
-    eq_(ds.repo.git_get_remote_url('my_other_sibling'), remote)
+    assert_in('my_other_sibling', ds.repo.get_remotes())
+    eq_(ds.repo.get_remote_url('my_other_sibling'), remote)
     # TODO: GitRepo method for push-url!
 
     # TODO: Validation!

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -129,7 +129,7 @@ def test_install_plain_git(src, path):
     # make plain git repo
     gr = GitRepo(src, create=True)
     gr.add('test.txt')
-    gr.git_commit('demo')
+    gr.commit('demo')
     # now install it somewhere else
     ds = install(path=path, source=src)
     # stays plain Git repo

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -128,7 +128,7 @@ def test_create(path):
 def test_install_plain_git(src, path):
     # make plain git repo
     gr = GitRepo(src, create=True)
-    gr.git_add('test.txt')
+    gr.add('test.txt')
     gr.git_commit('demo')
     # now install it somewhere else
     ds = install(path=path, source=src)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -42,14 +42,14 @@ def test_publish_simple(origin, src_path, dst_path):
     # TODO: For now, circumnavigate the detached head issue.
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
-        AnnexRepo(opj(src_path, subds), init=True, create=True).git_checkout("master")
+        AnnexRepo(opj(src_path, subds), init=True, create=True).checkout("master")
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
-    source.repo.git_remote_remove("origin")
+    source.repo.remove_remote("origin")
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
-    target.git_checkout("TMP", "-b")
+    target.checkout("TMP", "-b")
     source.repo.add_remote("target", dst_path)
 
     res = publish(dataset=source, dest="target")
@@ -57,8 +57,8 @@ def test_publish_simple(origin, src_path, dst_path):
 
     ok_clean_git(src_path, annex=False)
     ok_clean_git(dst_path, annex=False)
-    eq_(list(target.git_get_branch_commits("master")),
-        list(source.repo.git_get_branch_commits("master")))
+    eq_(list(target.get_branch_commits("master")),
+        list(source.repo.get_branch_commits("master")))
 
     # don't fail when doing it again
     res = publish(dataset=source, dest="target")
@@ -66,10 +66,10 @@ def test_publish_simple(origin, src_path, dst_path):
 
     ok_clean_git(src_path, annex=False)
     ok_clean_git(dst_path, annex=False)
-    eq_(list(target.git_get_branch_commits("master")),
-        list(source.repo.git_get_branch_commits("master")))
-    eq_(list(target.git_get_branch_commits("git-annex")),
-        list(source.repo.git_get_branch_commits("git-annex")))
+    eq_(list(target.get_branch_commits("master")),
+        list(source.repo.get_branch_commits("master")))
+    eq_(list(target.get_branch_commits("git-annex")),
+        list(source.repo.get_branch_commits("git-annex")))
 
     # 'target/master' should be tracking branch at this point, so
     # try publishing without `dest`:
@@ -85,10 +85,10 @@ def test_publish_simple(origin, src_path, dst_path):
     eq_(res, source)
 
     ok_clean_git(dst_path, annex=False)
-    eq_(list(target.git_get_branch_commits("master")),
-        list(source.repo.git_get_branch_commits("master")))
-    eq_(list(target.git_get_branch_commits("git-annex")),
-        list(source.repo.git_get_branch_commits("git-annex")))
+    eq_(list(target.get_branch_commits("master")),
+        list(source.repo.get_branch_commits("master")))
+    eq_(list(target.get_branch_commits("git-annex")),
+        list(source.repo.get_branch_commits("git-annex")))
 
 
 @with_testrepos('submodule_annex', flavors=['local'])
@@ -103,11 +103,11 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     # TODO: For now, circumnavigate the detached head issue.
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
-        AnnexRepo(opj(src_path, subds), init=True, create=True).git_checkout("master")
+        AnnexRepo(opj(src_path, subds), init=True, create=True).checkout("master")
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
-    target.git_checkout("TMP", "-b")
+    target.checkout("TMP", "-b")
     source.repo.add_remote("target", dst_path)
 
     # subdatasets have no remote yet, so recursive publishing should fail:
@@ -117,9 +117,9 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # now, set up targets for the submodules:
     sub1_target = GitRepo(sub1_pub, create=True)
-    sub1_target.git_checkout("TMP", "-b")
+    sub1_target.checkout("TMP", "-b")
     sub2_target = GitRepo(sub2_pub, create=True)
-    sub2_target.git_checkout("TMP", "-b")
+    sub2_target.checkout("TMP", "-b")
     sub1 = GitRepo(opj(src_path, 'sub1'), create=False)
     sub2 = GitRepo(opj(src_path, 'sub2'), create=False)
     sub1.add_remote("target", sub1_pub)
@@ -137,18 +137,18 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     eq_(res[1].path, sub1.path)
     eq_(res[2].path, sub2.path)
 
-    eq_(list(target.git_get_branch_commits("master")),
-        list(source.repo.git_get_branch_commits("master")))
-    eq_(list(target.git_get_branch_commits("git-annex")),
-        list(source.repo.git_get_branch_commits("git-annex")))
-    eq_(list(sub1_target.git_get_branch_commits("master")),
-        list(sub1.git_get_branch_commits("master")))
-    eq_(list(sub1_target.git_get_branch_commits("git-annex")),
-        list(sub1.git_get_branch_commits("git-annex")))
-    eq_(list(sub2_target.git_get_branch_commits("master")),
-        list(sub2.git_get_branch_commits("master")))
-    eq_(list(sub2_target.git_get_branch_commits("git-annex")),
-        list(sub2.git_get_branch_commits("git-annex")))
+    eq_(list(target.get_branch_commits("master")),
+        list(source.repo.get_branch_commits("master")))
+    eq_(list(target.get_branch_commits("git-annex")),
+        list(source.repo.get_branch_commits("git-annex")))
+    eq_(list(sub1_target.get_branch_commits("master")),
+        list(sub1.get_branch_commits("master")))
+    eq_(list(sub1_target.get_branch_commits("git-annex")),
+        list(sub1.get_branch_commits("git-annex")))
+    eq_(list(sub2_target.get_branch_commits("master")),
+        list(sub2.get_branch_commits("master")))
+    eq_(list(sub2_target.get_branch_commits("git-annex")),
+        list(sub2.get_branch_commits("git-annex")))
 
 
 @with_testrepos('submodule_annex', flavors=['clone'])
@@ -161,36 +161,36 @@ def test_publish_submodule(origin, src_path, target_1, target_2):
     # TODO: For now, circumnavigate the detached head issue.
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
-        AnnexRepo(opj(src_path, subds), init=True, create=True).git_checkout("master")
+        AnnexRepo(opj(src_path, subds), init=True, create=True).checkout("master")
 
     # first, try publishing from super dataset using `path`
     source_super = source
     source_sub = Dataset(opj(src_path, 'sub1'))
     target = GitRepo(target_1, create=True)
-    target.git_checkout("TMP", "-b")
+    target.checkout("TMP", "-b")
     source_sub.repo.add_remote("target", target_1)
 
     res = publish(dataset=source_super, dest="target", path="sub1")
     assert_is_instance(res, Dataset)
     eq_(res.path, source_sub.path)
 
-    eq_(list(GitRepo(target_1, create=False).git_get_branch_commits("master")),
-        list(source_sub.repo.git_get_branch_commits("master")))
-    eq_(list(GitRepo(target_1, create=False).git_get_branch_commits("git-annex")),
-        list(source_sub.repo.git_get_branch_commits("git-annex")))
+    eq_(list(GitRepo(target_1, create=False).get_branch_commits("master")),
+        list(source_sub.repo.get_branch_commits("master")))
+    eq_(list(GitRepo(target_1, create=False).get_branch_commits("git-annex")),
+        list(source_sub.repo.get_branch_commits("git-annex")))
 
     # now, publish directly from within submodule:
     target = GitRepo(target_2, create=True)
-    target.git_checkout("TMP", "-b")
+    target.checkout("TMP", "-b")
     source_sub.repo.add_remote("target2", target_2)
 
     res = publish(dataset=source_sub, dest="target2")
     eq_(res, source_sub)
 
-    eq_(list(GitRepo(target_2, create=False).git_get_branch_commits("master")),
-        list(source_sub.repo.git_get_branch_commits("master")))
-    eq_(list(GitRepo(target_2, create=False).git_get_branch_commits("git-annex")),
-        list(source_sub.repo.git_get_branch_commits("git-annex")))
+    eq_(list(GitRepo(target_2, create=False).get_branch_commits("master")),
+        list(source_sub.repo.get_branch_commits("master")))
+    eq_(list(GitRepo(target_2, create=False).get_branch_commits("git-annex")),
+        list(source_sub.repo.get_branch_commits("git-annex")))
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
@@ -203,26 +203,26 @@ def test_publish_with_data(origin, src_path, dst_path):
     # TODO: For now, circumnavigate the detached head issue.
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
-        AnnexRepo(opj(src_path, subds), init=True, create=True).git_checkout("master")
+        AnnexRepo(opj(src_path, subds), init=True, create=True).checkout("master")
     source.repo.get('test-annex.dat')
 
     # create plain git at target:
     target = AnnexRepo(dst_path, create=True)
-    target.git_checkout("TMP", "-b")
+    target.checkout("TMP", "-b")
     source.repo.add_remote("target", dst_path)
 
     res = publish(dataset=source, dest="target", with_data=['test-annex.dat'])
     eq_(res, source)
 
-    eq_(list(target.git_get_branch_commits("master")),
-        list(source.repo.git_get_branch_commits("master")))
+    eq_(list(target.get_branch_commits("master")),
+        list(source.repo.get_branch_commits("master")))
     # TODO: last commit in git-annex branch differs. Probably fine,
     # but figure out, when exactly to expect this for proper testing:
-    eq_(list(target.git_get_branch_commits("git-annex"))[1:],
-        list(source.repo.git_get_branch_commits("git-annex"))[1:])
+    eq_(list(target.get_branch_commits("git-annex"))[1:],
+        list(source.repo.get_branch_commits("git-annex"))[1:])
 
     # we need compare target/master:
-    target.git_checkout("master")
+    target.checkout("master")
     eq_(target.file_has_content(['test-annex.dat']), [True])
 
 
@@ -236,14 +236,14 @@ def test_publish_file_handle(origin, src_path, dst_path):
     # TODO: For now, circumnavigate the detached head issue.
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
-        AnnexRepo(opj(src_path, subds), init=True, create=True).git_checkout("master")
+        AnnexRepo(opj(src_path, subds), init=True, create=True).checkout("master")
     source.repo.get('test-annex.dat')
 
     # create plain git at target:
     target = AnnexRepo(dst_path, create=True)
     # actually not needed for this test, but provide same setup as
     # everywhere else:
-    target.git_checkout("TMP", "-b")
+    target.checkout("TMP", "-b")
     source.repo.add_remote("target", dst_path)
 
     # directly publish a file handle, not the dataset itself:
@@ -251,9 +251,9 @@ def test_publish_file_handle(origin, src_path, dst_path):
     eq_(res, opj(source.path, 'test-annex.dat'))
 
     # only file was published, not the dataset itself:
-    assert_not_in("master", target.git_get_branches())
+    assert_not_in("master", target.get_branches())
     eq_(Dataset(dst_path).get_dataset_handles(), [])
-    assert_not_in("test.dat", target.git_get_files())
+    assert_not_in("test.dat", target.get_files())
 
     # content is now available from 'target':
     assert_in("target",
@@ -283,7 +283,7 @@ def test_publish_file_handle(origin, src_path, dst_path):
 #     # TODO: For now, circumnavigate the detached head issue.
 #     # Figure out, what to do.
 #     for subds in source.get_dataset_handles(recursive=True):
-#         AnnexRepo(opj(src_path, subds), init=True, create=True).git_checkout("master")
+#         AnnexRepo(opj(src_path, subds), init=True, create=True).checkout("master")
 #     sub1 = GitRepo(opj(src_path, 'sub1'))
 #     sub2 = GitRepo(opj(src_path, 'sub2'))
 #
@@ -294,11 +294,11 @@ def test_publish_file_handle(origin, src_path, dst_path):
 #     pub_path_sub1 = opj(dst_path, basename(src_path) + '-sub1')
 #     pub_path_sub2 = opj(dst_path, basename(src_path) + '-sub2')
 #     super_target = GitRepo(pub_path_super, create=True)
-#     super_target.git_checkout("TMP", "-b")
+#     super_target.checkout("TMP", "-b")
 #     sub1_target = GitRepo(pub_path_sub1, create=True)
-#     sub1_target.git_checkout("TMP", "-b")
+#     sub1_target.checkout("TMP", "-b")
 #     sub2_target = GitRepo(pub_path_sub2, create=True)
-#     sub2_target.git_checkout("TMP", "-b")
+#     sub2_target.checkout("TMP", "-b")
 #
 #     url_template = dst_path + os.path.sep + '%NAME'
 #
@@ -316,17 +316,17 @@ def test_publish_file_handle(origin, src_path, dst_path):
 #     eq_(res[2].path, sub2.path)
 #
 #
-#     eq_(list(super_target.git_get_branch_commits("master")),
-#         list(source.repo.git_get_branch_commits("master")))
-#     eq_(list(super_target.git_get_branch_commits("git-annex")),
-#         list(source.repo.git_get_branch_commits("git-annex")))
+#     eq_(list(super_target.get_branch_commits("master")),
+#         list(source.repo.get_branch_commits("master")))
+#     eq_(list(super_target.get_branch_commits("git-annex")),
+#         list(source.repo.get_branch_commits("git-annex")))
 #
-#     eq_(list(sub1_target.git_get_branch_commits("master")),
-#         list(sub1.git_get_branch_commits("master")))
-#     eq_(list(sub1_target.git_get_branch_commits("git-annex")),
-#         list(sub1.git_get_branch_commits("git-annex")))
+#     eq_(list(sub1_target.get_branch_commits("master")),
+#         list(sub1.get_branch_commits("master")))
+#     eq_(list(sub1_target.get_branch_commits("git-annex")),
+#         list(sub1.get_branch_commits("git-annex")))
 #
-#     eq_(list(sub2_target.git_get_branch_commits("master")),
-#         list(sub2.git_get_branch_commits("master")))
-#     eq_(list(sub2_target.git_get_branch_commits("git-annex")),
-#         list(sub2.git_get_branch_commits("git-annex")))
+#     eq_(list(sub2_target.get_branch_commits("master")),
+#         list(sub2.get_branch_commits("master")))
+#     eq_(list(sub2_target.get_branch_commits("git-annex")),
+#         list(sub2.get_branch_commits("git-annex")))

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -77,7 +77,12 @@ def test_publish_simple(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.repo.git_add(opj(src_path, 'test_mod_file'))
+    if isinstance(source.repo, AnnexRepo):
+        source.repo.add(opj(src_path, 'test_mod_file'), git=True)
+    elif isinstance(source.repo, GitRepo):
+        source.repo.add(opj(src_path, 'test_mod_file'))
+    else:
+        raise ValueError("Unknown repo: %s" % source.repo)
     source.repo.git_commit("Modified.")
     ok_clean_git(src_path, annex=False)
 

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -50,7 +50,7 @@ def test_publish_simple(origin, src_path, dst_path):
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
     target.git_checkout("TMP", "-b")
-    source.repo.git_remote_add("target", dst_path)
+    source.repo.add_remote("target", dst_path)
 
     res = publish(dataset=source, dest="target")
     eq_(res, source)
@@ -108,7 +108,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
     target.git_checkout("TMP", "-b")
-    source.repo.git_remote_add("target", dst_path)
+    source.repo.add_remote("target", dst_path)
 
     # subdatasets have no remote yet, so recursive publishing should fail:
     with assert_raises(ValueError) as cm:
@@ -122,8 +122,8 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     sub2_target.git_checkout("TMP", "-b")
     sub1 = GitRepo(opj(src_path, 'sub1'), create=False)
     sub2 = GitRepo(opj(src_path, 'sub2'), create=False)
-    sub1.git_remote_add("target", sub1_pub)
-    sub2.git_remote_add("target", sub2_pub)
+    sub1.add_remote("target", sub1_pub)
+    sub2.add_remote("target", sub2_pub)
 
     # publish recursively
     res = publish(dataset=source, dest="target", recursive=True)
@@ -168,7 +168,7 @@ def test_publish_submodule(origin, src_path, target_1, target_2):
     source_sub = Dataset(opj(src_path, 'sub1'))
     target = GitRepo(target_1, create=True)
     target.git_checkout("TMP", "-b")
-    source_sub.repo.git_remote_add("target", target_1)
+    source_sub.repo.add_remote("target", target_1)
 
     res = publish(dataset=source_super, dest="target", path="sub1")
     assert_is_instance(res, Dataset)
@@ -182,7 +182,7 @@ def test_publish_submodule(origin, src_path, target_1, target_2):
     # now, publish directly from within submodule:
     target = GitRepo(target_2, create=True)
     target.git_checkout("TMP", "-b")
-    source_sub.repo.git_remote_add("target2", target_2)
+    source_sub.repo.add_remote("target2", target_2)
 
     res = publish(dataset=source_sub, dest="target2")
     eq_(res, source_sub)
@@ -209,7 +209,7 @@ def test_publish_with_data(origin, src_path, dst_path):
     # create plain git at target:
     target = AnnexRepo(dst_path, create=True)
     target.git_checkout("TMP", "-b")
-    source.repo.git_remote_add("target", dst_path)
+    source.repo.add_remote("target", dst_path)
 
     res = publish(dataset=source, dest="target", with_data=['test-annex.dat'])
     eq_(res, source)
@@ -244,7 +244,7 @@ def test_publish_file_handle(origin, src_path, dst_path):
     # actually not needed for this test, but provide same setup as
     # everywhere else:
     target.git_checkout("TMP", "-b")
-    source.repo.git_remote_add("target", dst_path)
+    source.repo.add_remote("target", dst_path)
 
     # directly publish a file handle, not the dataset itself:
     res = publish(dataset=source, dest="target", path="test-annex.dat")
@@ -257,9 +257,9 @@ def test_publish_file_handle(origin, src_path, dst_path):
 
     # content is now available from 'target':
     assert_in("target",
-              source.repo.annex_whereis('test-annex.dat',
-                                        output="descriptions"))
-    source.repo.annex_drop('test-annex.dat')
+              source.repo.whereis('test-annex.dat',
+                                  output="descriptions"))
+    source.repo.drop('test-annex.dat')
     eq_(source.repo.file_has_content(['test-annex.dat']), [False])
     source.repo._run_annex_command('get', annex_options=['test-annex.dat',
                                                          '--from=target'])

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -77,13 +77,8 @@ def test_publish_simple(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    if isinstance(source.repo, AnnexRepo):
-        source.repo.add(opj(src_path, 'test_mod_file'), git=True)
-    elif isinstance(source.repo, GitRepo):
-        source.repo.add(opj(src_path, 'test_mod_file'))
-    else:
-        raise ValueError("Unknown repo: %s" % source.repo)
-    source.repo.commit("Modified.")
+    source.repo.add(opj(src_path, 'test_mod_file'), git=True,
+                    commit=True, msg="Modified.")
     ok_clean_git(src_path, annex=False)
 
     res = publish(dataset=source)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -83,7 +83,7 @@ def test_publish_simple(origin, src_path, dst_path):
         source.repo.add(opj(src_path, 'test_mod_file'))
     else:
         raise ValueError("Unknown repo: %s" % source.repo)
-    source.repo.git_commit("Modified.")
+    source.repo.commit("Modified.")
     ok_clean_git(src_path, annex=False)
 
     res = publish(dataset=source)

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -50,8 +50,8 @@ def test_target_ssh_simple(origin, src_path, target_path):
                                            target_dir=opj(target_path, "basic"))
 
     GitRepo(opj(target_path, "basic"), create=False) # raises if not a git repo
-    assert_in("local_target", source.repo.git_get_remotes())
-    eq_("ssh://localhost", source.repo.git_get_remote_url("local_target"))
+    assert_in("local_target", source.repo.get_remotes())
+    eq_("ssh://localhost", source.repo.get_remote_url("local_target"))
     # should NOT be able to push now, since url isn't correct:
     assert_raises(GitCommandError, publish, dataset=source, dest="local_target")
 
@@ -76,9 +76,9 @@ def test_target_ssh_simple(origin, src_path, target_path):
                                                       opj(target_path, "basic"),
                                                existing='replace')
         eq_("ssh://localhost" + opj(target_path, "basic"),
-            source.repo.git_get_remote_url("local_target"))
+            source.repo.get_remote_url("local_target"))
         eq_("ssh://localhost" + opj(target_path, "basic"),
-            source.repo.git_get_remote_url("local_target", push=True))
+            source.repo.get_remote_url("local_target", push=True))
 
         # again, by explicitly passing urls. Since we are on localhost, the
         # local path should work:
@@ -93,9 +93,9 @@ def test_target_ssh_simple(origin, src_path, target_path):
                                                       opj(target_path, "basic"),
                                                existing='replace')
         eq_(opj(target_path, "basic"),
-            source.repo.git_get_remote_url("local_target"))
+            source.repo.get_remote_url("local_target"))
         eq_("ssh://localhost" + opj(target_path, "basic"),
-            source.repo.git_get_remote_url("local_target", push=True))
+            source.repo.get_remote_url("local_target", push=True))
 
         # now, push should work:
         publish(dataset=source, dest="local_target")
@@ -113,7 +113,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
         AnnexRepo(opj(src_path, subds), init=True,
-                  create=False).git_checkout("master")
+                  create=False).checkout("master")
 
     sub1 = Dataset(opj(src_path, "sub1"))
     sub2 = Dataset(opj(src_path, "sub2"))
@@ -131,5 +131,5 @@ def test_target_ssh_recursive(origin, src_path, target_path):
                      create=False)
 
     for repo in [source.repo, sub1.repo, sub2.repo]:
-        assert_not_in("local_target", repo.git_get_remotes())
+        assert_not_in("local_target", repo.get_remotes())
 

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -113,8 +113,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
     with open(opj(remote_2, "second.txt"), "w") as f:
         f.write("different file load")
-    rmt2.git_add("second.txt")
-    rmt2.git_commit("Add file to git.")
+    rmt2.add("second.txt", git=True, commit=True, msg="Add file to git.")
 
     # fetch all remotes
     ds.update(fetch_all=True)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -108,7 +108,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
     # modify the remotes:
     with open(opj(remote_1, "first.txt"), "w") as f:
         f.write("some file load")
-    rmt1.add_to_annex("first.txt")
+    rmt1.add("first.txt", commit=True)
     # TODO: Modify an already present file!
 
     with open(opj(remote_2, "second.txt"), "w") as f:

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -43,10 +43,10 @@ def test_update_simple(origin, src_path, dst_path):
     # Figure out, what to do.
     for subds in source.get_dataset_handles(recursive=True):
         AnnexRepo(opj(src_path, subds), init=True,
-                  create=True).git_checkout("master")
+                  create=True).checkout("master")
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
-    source.repo.git_remote_remove("origin")
+    source.repo.remove_remote("origin")
 
     # get a clone to update later on:
     dest = install(path=dst_path, source=src_path, recursive=True)
@@ -54,7 +54,7 @@ def test_update_simple(origin, src_path, dst_path):
     # Figure out, what to do.
     for subds in dest.get_dataset_handles(recursive=True):
         AnnexRepo(opj(dst_path, subds), init=True,
-                  create=True).git_checkout("master")
+                  create=True).checkout("master")
     # test setup done;
     # assert all fine
     ok_clean_git(dst_path)
@@ -76,15 +76,15 @@ def test_update_simple(origin, src_path, dst_path):
     dest.update()
     # modification is not known to active branch:
     assert_not_in("update.txt",
-                  dest.repo.git_get_files(dest.repo.git_get_active_branch()))
+                  dest.repo.get_files(dest.repo.get_active_branch()))
     # modification is known to branch origin/master
-    assert_in("update.txt", dest.repo.git_get_files("origin/master"))
+    assert_in("update.txt", dest.repo.get_files("origin/master"))
 
     # merge:
     dest.update(merge=True)
     # modification is now known to active branch:
     assert_in("update.txt",
-              dest.repo.git_get_files(dest.repo.git_get_active_branch()))
+              dest.repo.get_files(dest.repo.get_active_branch()))
     # it's known to annex, but has no content yet:
     dest.repo.get_file_key("update.txt")  # raises if unknown
     eq_([False], dest.repo.file_has_content(["update.txt"]))
@@ -121,12 +121,12 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
     # no merge, so changes are not in active branch:
     assert_not_in("first.txt",
-                  ds.repo.git_get_files(ds.repo.git_get_active_branch()))
+                  ds.repo.get_files(ds.repo.get_active_branch()))
     assert_not_in("second.txt",
-                  ds.repo.git_get_files(ds.repo.git_get_active_branch()))
+                  ds.repo.get_files(ds.repo.get_active_branch()))
     # but we know the changes in remote branches:
-    assert_in("first.txt", ds.repo.git_get_files("sibling_1/master"))
-    assert_in("second.txt", ds.repo.git_get_files("sibling_2/master"))
+    assert_in("first.txt", ds.repo.get_files("sibling_1/master"))
+    assert_in("second.txt", ds.repo.get_files("sibling_2/master"))
 
     # no merge strategy for multiple remotes yet:
     assert_raises(NotImplementedError, ds.update, merge=True, fetch_all=True)
@@ -136,10 +136,10 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
     # changes from sibling_2 still not present:
     assert_not_in("second.txt",
-                  ds.repo.git_get_files(ds.repo.git_get_active_branch()))
+                  ds.repo.get_files(ds.repo.get_active_branch()))
     # changes from sibling_1 merged:
     assert_in("first.txt",
-              ds.repo.git_get_files(ds.repo.git_get_active_branch()))
+              ds.repo.get_files(ds.repo.get_active_branch()))
     # it's known to annex, but has no content yet:
     ds.repo.get_file_key("first.txt")  # raises if unknown
     eq_([False], ds.repo.file_has_content(["first.txt"]))

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -190,7 +190,7 @@ class Uninstall(Interface):
 
             # it's an annexed file
             if data_only:
-                ds.repo.annex_drop([path])
+                ds.repo.drop([path])
                 return path
             else:
                 raise NotImplementedError("TODO: fully uninstall file %s "

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -213,7 +213,7 @@ class Uninstall(Interface):
                 raise ValueError("%s is not a file handle. Removing its "
                                  "data only doesn't make sense." % path)
             else:
-                return ds.repo.git_remove([relativepath])
+                return ds.repo.remove([relativepath])
 
         elif _untracked_or_within_submodule:
             subds = get_containing_subdataset(ds, relativepath)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -106,7 +106,7 @@ class Update(Interface):
 
         for repo in repos_to_update:
             # get all remotes:
-            remotes = repo.git_get_remotes()
+            remotes = repo.get_remotes()
             if name and name not in remotes:
                 lgr.warning("'%s' not known to dataset %s.\nSkipping" %
                             (name, repo.path))
@@ -138,9 +138,9 @@ class Update(Interface):
                 try:
                     std_out, std_err = \
                         repo._git_custom_command('',
-                        ["git", "config", "--get",
+                                                 ["git", "config", "--get",
                          "branch.{active_branch}.remote".format(
-                             active_branch=repo.git_get_active_branch())])
+                             active_branch=repo.get_active_branch())])
                 except CommandError as e:
                     if e.code == 1 and e.stdout == "":
                         std_out = None
@@ -163,7 +163,7 @@ class Update(Interface):
                     # => TODO: allow for passing a branch
                     # (or more general refspec?)
                     # For now, just use the same name
-                    cmd_list.append(repo.git_get_active_branch())
+                    cmd_list.append(repo.get_active_branch())
 
                 out, err = repo._git_custom_command('', cmd_list)
                 lgr.info(out)

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -248,7 +248,7 @@ class AddArchiveContent(Interface):
         # TODO: check if may be it was already added
         if ARCHIVES_SPECIAL_REMOTE not in annex.git_get_remotes():
             lgr.debug("Adding new special remote {}".format(ARCHIVES_SPECIAL_REMOTE))
-            annex.annex_initremote(
+            annex.init_remote(
                 ARCHIVES_SPECIAL_REMOTE,
                 ['encryption=none', 'type=external', 'externaltype=%s' % ARCHIVES_SPECIAL_REMOTE,
                  'autoenable=true'])
@@ -372,7 +372,7 @@ class AddArchiveContent(Interface):
                           target_file, url, annex_options)
 
                 target_file_gitpath = opj(extract_relpath, target_file) if extract_relpath else target_file
-                out_json = annex.annex_addurl_to_file(
+                out_json = annex.add_url_to_file(
                     target_file_gitpath,
                     url, options=annex_options,
                     batch=True)
@@ -397,7 +397,7 @@ class AddArchiveContent(Interface):
                 # # above action might add to git or to annex
                 # if annex.file_has_content(target_path):
                 #     # if not --  it was added to git, if in annex, it is present and output is True
-                #     annex.annex_addurl_to_file(target_file, url, options=['--relaxed'], batch=True)
+                #     annex.add_url_to_file(target_file, url, options=['--relaxed'], batch=True)
                 #     stats.add_annex += 1
                 # else:
                 #     lgr.debug("File {} was added to git, not adding url".format(target_file))
@@ -435,7 +435,7 @@ class AddArchiveContent(Interface):
             if keys_to_drop:
                 # since we know that keys should be retrievable, we --force since no batching
                 # atm and it would be expensive
-                annex.annex_drop(keys_to_drop, options=['--force'], key=True)
+                annex.drop(keys_to_drop, options=['--force'], key=True)
                 stats.dropped += len(keys_to_drop)
                 annex.precommit()  # might need clean up etc again
 

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -246,7 +246,7 @@ class AddArchiveContent(Interface):
         earchive = annexarchive.cache[key_path]
 
         # TODO: check if may be it was already added
-        if ARCHIVES_SPECIAL_REMOTE not in annex.git_get_remotes():
+        if ARCHIVES_SPECIAL_REMOTE not in annex.get_remotes():
             lgr.debug("Adding new special remote {}".format(ARCHIVES_SPECIAL_REMOTE))
             annex.init_remote(
                 ARCHIVES_SPECIAL_REMOTE,

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -393,7 +393,7 @@ class AddArchiveContent(Interface):
                     stats.removed += 1
 
                 # # chaining 3 annex commands, 2 of which not batched -- less efficient but more bullet proof etc
-                # annex.annex_add(target_path, options=annex_options)
+                # annex.add(target_path, options=annex_options)
                 # # above action might add to git or to annex
                 # if annex.file_has_content(target_path):
                 #     # if not --  it was added to git, if in annex, it is present and output is True

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -149,7 +149,7 @@ class DsModel(object):
         """Date of the last commit
         """
         try:
-            commit = next(self.ds.repo.git_get_branch_commits(self.branch))
+            commit = next(self.ds.repo.get_branch_commits(self.branch))
         except:
             return None
         return commit.committed_date
@@ -162,7 +162,7 @@ class DsModel(object):
     def branch(self):
         if self._branch is None:
             try:
-                self._branch = self.repo.git_get_active_branch()
+                self._branch = self.repo.get_active_branch()
             except:
                 return None
         return self._branch

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -176,7 +176,7 @@ class DsModel(object):
     @property
     def info(self):
         if self._info is None and isinstance(self.repo, AnnexRepo):
-            self._info = self.repo.annex_repo_info()
+            self._info = self.repo.repo_info()
         return self._info
 
     @property

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -87,7 +87,7 @@ def test_add_archive_content(path_orig, url, repo_path):
         repo.add_urls([opj(url, '1.tar.gz')], options=["--pathdepth", "-1"])
         for s in range(1, 5):
             repo.add_urls([opj(url, '%du/1.tar.gz' % s)], options=["--pathdepth", "-2"])
-    repo.git_commit("added 1.tar.gz")
+    repo.commit("added 1.tar.gz")
 
     key_1tar = repo.get_file_key('1.tar.gz')  # will be used in the test later
 
@@ -148,7 +148,7 @@ def test_add_archive_content(path_orig, url, repo_path):
         with swallow_outputs():
             repo.add_urls([opj(url, 'd1', '1.tar.gz')], options=["--pathdepth", "-1"],
                           cwd=getpwd())  # invoke under current subdir
-        repo.git_commit("added 1.tar.gz in d1")
+        repo.commit("added 1.tar.gz in d1")
 
         def d2_basic_checks():
             ok_(exists('1'))
@@ -202,7 +202,7 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
     # Let's add first archive to the repo so we could test
     with swallow_outputs():
         repo.add_urls([opj(url, '1.tar.gz')], options=["--pathdepth", "-1"])
-    repo.git_commit("added 1.tar.gz")
+    repo.commit("added 1.tar.gz")
 
     add_archive_content('1.tar.gz', strip_leading_dirs=True)
     ok_(not exists('1'))

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -227,7 +227,7 @@ class TestAddArchiveOptions():
         direct = False  # TODO: test on undirect, but too long ATM
         self.annex = annex = AnnexRepo(repo_path, create=True, direct=direct)
         # Let's add first archive to the annex so we could test
-        annex.annex_add('1.tar')
+        annex.add('1.tar')
         annex.commit(msg="added 1.tar")
 
     def teardown(self):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -955,7 +955,7 @@ class AnnexRepo(GitRepo):
         if self.is_direct_mode():
             self.proxy('git commit -m "%s"' % msg, expect_stderr=True)
         else:
-            super(AnnexRepo, self).git_commit(msg)
+            super(AnnexRepo, self).commit(msg)
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, force=False):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -151,9 +151,9 @@ class AnnexRepo(GitRepo):
         # - request SSHConnection instance and write config even if no
         #   connection needed (but: connection is not actually created/opened)
         # - no solution for a ssh url of a file (annex addurl)
-        for r in self.git_get_remotes():
-            for url in [self.git_get_remote_url(r),
-                        self.git_get_remote_url(r, push=True)]:
+        for r in self.get_remotes():
+            for url in [self.get_remote_url(r),
+                        self.get_remote_url(r, push=True)]:
                 if url is not None and url.startswith('ssh:'):
                     c = ssh_manager.get_connection(url)
 
@@ -172,8 +172,8 @@ class AnnexRepo(GitRepo):
         if not exists(opj(self.path, '.git', 'annex')):
             # so either it is not annex at all or just was not yet initialized
             # TODO: unify/reuse code somewhere else on detecting being annex
-            if any((b.endswith('/git-annex') for b in self.git_get_remote_branches())) or \
-                any((b == 'git-annex' for b in self.git_get_branches())):
+            if any((b.endswith('/git-annex') for b in self.get_remote_branches())) or \
+                any((b == 'git-annex' for b in self.get_branches())):
                 # it is an annex repository which was not initialized yet
                 if create or init:
                     lgr.debug('Annex repository was not yet initialized at %s.'

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -387,16 +387,19 @@ class AnnexRepo(GitRepo):
             msg=None):
         """Add file(s) to the repository.
 
-
         Parameters
         ----------
         files: list of str
           list of paths to add to the annex
-        git
-        commit
-        msg
-        backend
-        options
+        git: bool
+          if True, add to git instead of annex.
+        commit: bool
+          whether or not to directly commit
+        msg: str
+          commit message in case `commit=True`. A default message, containing
+          the list of files that were added, is created by default.
+        backend:
+        options:
 
         Returns
         -------

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -958,7 +958,7 @@ class AnnexRepo(GitRepo):
             super(AnnexRepo, self).commit(msg)
 
     @normalize_paths(match_return_type=False)
-    def remove(self, files, force=False):
+    def remove(self, files, force=False, **kwargs):
         """Remove files from git/annex (works in direct mode as well)
 
         Parameters
@@ -966,17 +966,20 @@ class AnnexRepo(GitRepo):
         files
         force: bool, optional
         """
-        self.precommit()  # since might interfer
+        self.precommit()  # since might interfere
         if self.is_direct_mode():
-            self.proxy('git rm ' + ('--force ' if force else '') + ' '.join(files))
-            # yoh gives up -- for some reason sometimes it remains, so if we force -- we mean it!
+            self.proxy('git rm ' + ('--force ' if force else '') +
+                       ' '.join(files))
+            # yoh gives up -- for some reason sometimes it remains,
+            # so if we force -- we mean it!
             if force:
                 for f in files:
                     filepath = opj(self.path, f)
                     if lexists(filepath):
                         os.unlink(filepath)
         else:
-            self.git_remove(files, force=force, normalize_paths=False)
+            super(AnnexRepo, self).remove(files, force=force,
+                                          normalize_paths=False, **kwargs)
 
     def get_contentlocation(self, key, batch=False):
         """Get location of the key content

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -14,29 +14,37 @@ For further information on git-annex see https://git-annex.branchable.com/.
 
 import json
 import logging
-import os
 import re
 import shlex
 from os import linesep
-from os.path import join as opj, exists, islink, realpath, lexists
+from os import unlink
+from os.path import join as opj
+from os.path import exists
+from os.path import islink
+from os.path import realpath
+from os.path import lexists
 from subprocess import Popen, PIPE
-
-#import pexpect
-
 from functools import wraps
 
 from six import string_types
 from six.moves import filter
 from six.moves.configparser import NoOptionError
 
-from ..dochelpers import exc_str
-from ..utils import auto_repr
-from datalad.support.gitrepo import GitRepo, normalize_path, normalize_paths, GitCommandError
-from .exceptions import CommandNotAvailableError, CommandError, \
-    FileNotInAnnexError, FileInGitError
-from .exceptions import AnnexBatchCommandError
-from ..utils import on_windows
 from datalad import ssh_manager
+from datalad.dochelpers import exc_str
+from datalad.utils import auto_repr
+from datalad.utils import on_windows
+
+# imports from same module:
+from .gitrepo import GitRepo
+from .gitrepo import normalize_path
+from .gitrepo import normalize_paths
+from .gitrepo import GitCommandError
+from .exceptions import CommandNotAvailableError
+from .exceptions import CommandError
+from .exceptions import FileNotInAnnexError
+from .exceptions import FileInGitError
+from .exceptions import AnnexBatchCommandError
 
 lgr = logging.getLogger('datalad.annex')
 
@@ -983,7 +991,7 @@ class AnnexRepo(GitRepo):
                 for f in files:
                     filepath = opj(self.path, f)
                     if lexists(filepath):
-                        os.unlink(filepath)
+                        unlink(filepath)
         else:
             super(AnnexRepo, self).remove(files, force=force,
                                           normalize_paths=False, **kwargs)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -413,7 +413,7 @@ class AnnexRepo(GitRepo):
                 return_list = {u'file': '', u'success': True}
             else:
                 # TODO: Make sure return value from GitRepo is consistent
-                return_list = super(AnnexRepo, self).git_add(files)
+                return_list = super(AnnexRepo, self).add(files)
         else:
             options = options[:] if options else []
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -408,12 +408,14 @@ class AnnexRepo(GitRepo):
                 cmd_list = ['git', '-c', 'core.bare=false', 'add'] + files
                 self.cmd_call_wrapper.run(cmd_list, expect_stderr=True)
                 # TODO: use options with git_add instead!
-                # => return value
-                # to be replaced:
-                return_list = {u'file': '', u'success': True}
             else:
-                # TODO: Make sure return value from GitRepo is consistent
-                return_list = super(AnnexRepo, self).add(files)
+                super(AnnexRepo, self).add(files)
+
+            # TODO: Make sure return value from GitRepo is consistent
+            # currently simulating return value, assuming success
+            # for all files:
+            return_list = [{u'file': f, u'success': True} for f in files]
+
         else:
             options = options[:] if options else []
 
@@ -429,8 +431,8 @@ class AnnexRepo(GitRepo):
                     file_list = [return_list['file']] \
                         if return_list['success'] else []
                 else:
-                    # don't know how to deal with
-                    file_list = []
+                    raise ValueError("Unexpected return type: %s" %
+                                     type(return_list))
                 msg = "Added file(s):" + '\n'.join(file_list)
             self.commit(msg)  # TODO: For consisteny: Also json return value (success)?
         return return_list

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -643,7 +643,7 @@ class GitRepo(object):
 
 # TODO: --------------------------------------------------------------------
 
-    def git_remote_add(self, name, url, options=''):
+    def add_remote(self, name, url, options=''):
         """
         """
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -382,7 +382,7 @@ class GitRepo(object):
 
     # TODO: see AnnexRepo.add_to_git/annex
     @normalize_paths
-    def git_add(self, files):
+    def add(self, files):
         """Adds file(s) to the repository.
 
         Parameters

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -418,7 +418,7 @@ class GitRepo(object):
 
     # TODO: like add melt in
     @normalize_paths(match_return_type=False)
-    def git_remove(self, files, **kwargs):
+    def remove(self, files, **kwargs):
         """Remove files.
 
         Parameters

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -414,7 +414,7 @@ class GitRepo(object):
         if commit:
             if msg is None:
                 msg = "Added file(s):" + '\n'.join(files)
-            self.git_commit(msg=msg)
+            self.commit(msg=msg)
 
     # TODO: like add melt in
     @normalize_paths(match_return_type=False)
@@ -441,8 +441,7 @@ class GitRepo(object):
         """
         self.repo.index.write()  # flush possibly cached in GitPython changes to index
 
-    # TODO: Before renaming, change calls => super().git_commit
-    def git_commit(self, msg=None, options=None):
+    def commit(self, msg=None, options=None):
         """Commit changes to git.
 
         Parameters

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -12,32 +12,46 @@ For further information on GitPython see http://gitpython.readthedocs.org/
 
 """
 
+import logging
+import shlex
 from os import linesep
-from os.path import join as opj, exists, normpath, isabs, commonprefix, relpath, realpath, isdir, abspath
-from os.path import dirname, basename
-from os.path import curdir, pardir, sep
+from os.path import join as opj
+from os.path import exists
+from os.path import normpath
+from os.path import isabs
+from os.path import commonprefix
+from os.path import relpath
+from os.path import realpath
+from os.path import abspath
+from os.path import dirname
+from os.path import basename
+from os.path import curdir
+from os.path import pardir
+from os.path import sep
+
+from six import string_types
+from functools import wraps
+import git as gitpy
+from git.exc import GitCommandError
+from git.exc import NoSuchPathError
+from git.exc import InvalidGitRepositoryError
+from git.objects.blob import Blob
+
+from datalad import ssh_manager
+from datalad.cmd import Runner
+from datalad.utils import optional_args
+from datalad.utils import on_windows
+from datalad.utils import getpwd
+from datalad.utils import swallow_logs
+
+# imports from same module:
+from .exceptions import CommandError
+from .exceptions import FileNotInRepositoryError
+
 # shortcuts
 _curdirsep = curdir + sep
 _pardirsep = pardir + sep
 
-import logging
-import shlex
-from six import string_types
-
-from functools import wraps
-
-import git as gitpy
-from git.exc import GitCommandError, NoSuchPathError, \
-    InvalidGitRepositoryError, BadName
-from git.objects.blob import Blob
-
-from datalad import ssh_manager
-from datalad.support.exceptions import CommandError
-from datalad.support.exceptions import FileNotInRepositoryError
-from datalad.cmd import Runner
-from datalad.utils import optional_args, on_windows, getpwd
-from datalad.utils import swallow_logs
-from datalad.utils import swallow_outputs
 
 lgr = logging.getLogger('datalad.gitrepo')
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -380,26 +380,29 @@ class GitRepo(object):
         except OSError:
             return GitRepo.get_toppath(dirname(path))
 
-    # TODO: see AnnexRepo.add_to_git/annex
     @normalize_paths
-    def add(self, files):
+    def add(self, files, commit=False, msg=None):
         """Adds file(s) to the repository.
 
         Parameters
         ----------
         files: list
             list of paths to add
+        commit: bool
+        msg: str
         """
 
         files = _remove_empty_items(files)
         if files:
             try:
                 self.cmd_call_wrapper(self.repo.index.add, files, write=True)
-                # TODO: May be make use of 'fprogress'-option to indicate progress
+                # TODO: May be make use of 'fprogress'-option to indicate
+                # progress
                 # But then, we don't have it for git-annex add, anyway.
                 #
                 # TODO: Is write=True a reasonable way to do it?
-                # May be should not write until success of operation is confirmed?
+                # May be should not write until success of operation is
+                # confirmed?
                 # What's best in case of a list of files?
             except OSError as e:
                 lgr.error("git_add: %s" % e)
@@ -407,6 +410,11 @@ class GitRepo(object):
 
         else:
             lgr.warning("git_add was called with empty file list.")
+
+        if commit:
+            if msg is None:
+                msg = "Added file(s):" + '\n'.join(files)
+            self.git_commit(msg=msg)
 
     # TODO: like add melt in
     @normalize_paths(match_return_type=False)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -69,8 +69,7 @@ class SSHConnection(object):
         # TODO: Do we need to check for the connection to be open or just rely
         # on possible ssh failing?
 
-        ssh_cmd = self.cmd_prefix
-        ssh_cmd += cmd if isinstance(cmd, list) \
+        ssh_cmd = self.cmd_prefix + cmd if isinstance(cmd, list) \
             else sh_split(cmd, posix=not on_windows)
             # windows check currently not needed, but keep it as a reminder
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,21 +10,15 @@
 
 """
 
-import gc
-from os.path import exists, islink
-from git.exc import GitCommandError
-from six import PY3
-from six.moves.urllib.parse import urljoin, urlsplit
+from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urlsplit
 from shutil import copyfile
+from nose.tools import assert_is_instance
 
-from nose.tools import assert_raises, assert_is_instance, assert_true, \
-    assert_equal, assert_false, assert_in, assert_not_in
+from datalad.tests.utils import *
 
-from ..annexrepo import AnnexRepo, kwargs_to_options, GitRepo
-from ..exceptions import CommandNotAvailableError, \
-    FileInGitError, FileNotInAnnexError, CommandError, AnnexBatchCommandError
-from ...cmd import Runner
-from ...tests.utils import *
+# imports from same module:
+from ..annexrepo import *
 
 
 @ignore_nose_capturing_stdout
@@ -43,7 +37,6 @@ def test_AnnexRepo_instance_from_clone(src, dst):
         assert_raises(GitCommandError, AnnexRepo, dst, src)
         if git.__version__ != "1.0.2" and git.__version__ != "2.0.5":
             assert("already exists" in cm.out)
-
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -780,11 +780,11 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
         ar2.add_url_to_file(filename, testurl, batch=True)
         assert_equal(len(ar2._batched), 1)  # we added one more with batch_size=1
     ar2.commit("added new file")  # would do nothing ATM, but also doesn't fail
-    assert_in(filename, ar2.git_get_files())
+    assert_in(filename, ar2.get_files())
     assert_in(ar.WEB_UUID, ar2.whereis(filename))
 
     ar.commit("actually committing new files")
-    assert_in(filename, ar.git_get_files())
+    assert_in(filename, ar.get_files())
     assert_in(ar.WEB_UUID, ar.whereis(filename))
     # this poor bugger still wasn't added since we used default batch_size=0 on him
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -10,29 +10,17 @@
 
 """
 
-import os
-from os.path import join as opj, exists, realpath, curdir, pardir, abspath
+from nose.tools import assert_is_instance
 
-from git.exc import GitCommandError, NoSuchPathError, InvalidGitRepositoryError
-from nose.tools import assert_raises, assert_is_instance, assert_true, \
-    eq_, assert_in, assert_false, assert_not_equal, assert_not_in
+from datalad.tests.utils import *
+from datalad.tests.utils_testrepos import BasicAnnexTestRepo
+from datalad.utils import getpwd, chpwd
 
-from datalad.support.gitrepo import GitRepo, normalize_paths, _normalize_path, \
-    split_remote_branch
-from ...tests.utils import SkipTest
-from ...tests.utils import assert_re_in
-from ...tests.utils import local_testrepo_flavors
-from ...tests.utils import ok_
-from ...tests.utils import skip_if_no_network
-from ...tests.utils import swallow_logs
-from ...tests.utils import with_tempfile, with_testrepos, \
-    assert_cwd_unchanged, with_tree, \
-    get_most_obscure_supported_name, ok_clean_git
-from ...tests.utils import skip_ssh
-from ...tests.utils_testrepos import BasicAnnexTestRepo
-from ...cmd import Runner
-from ...support.exceptions import FileNotInRepositoryError
-from ...utils import getpwd, chpwd
+# imports from same module:
+# we want to test everything in gitrepo:
+from ..gitrepo import *
+from ..gitrepo import _normalize_path
+from ..exceptions import FileNotInRepositoryError
 
 
 @assert_cwd_unchanged
@@ -44,8 +32,8 @@ def test_GitRepo_instance_from_clone(src, dst):
     assert_is_instance(gr, GitRepo, "GitRepo was not created.")
     assert_true(exists(opj(dst, '.git')))
 
-    # do it again should raise GitCommandError since git will notice there's already a git-repo at that path
-    # and therefore can't clone to `dst`
+    # do it again should raise GitCommandError since git will notice there's
+    # already a git-repo at that path and therefore can't clone to `dst`
     with swallow_logs() as logs:
         assert_raises(GitCommandError, GitRepo, dst, src)
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -30,6 +30,8 @@ def test_GitRepo_instance_from_clone(src, dst):
 
     gr = GitRepo(dst, src)
     assert_is_instance(gr, GitRepo, "GitRepo was not created.")
+    assert_is_instance(gr.repo, gitpy.Repo,
+                       "Failed to instantiate GitPython Repo object.")
     assert_true(exists(opj(dst, '.git')))
 
     # do it again should raise GitCommandError since git will notice there's

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -107,7 +107,7 @@ def test_GitRepo_add(src, path):
     filename = get_most_obscure_supported_name()
     with open(opj(path, filename), 'w') as f:
         f.write("File to add to git")
-    gr.git_add(filename)
+    gr.add(filename)
 
     assert_in(filename, gr.get_indexed_files(), "%s not successfully added to %s" % (filename, path))
 
@@ -125,7 +125,7 @@ def test_GitRepo_add(src, path):
 def test_GitRepo_remove(path):
 
     gr = GitRepo(path, create=True)
-    gr.git_add('*')
+    gr.add('*')
     gr.git_commit("committing all the files")
 
     eq_(gr.git_remove('file'), ['file'])
@@ -142,7 +142,7 @@ def test_GitRepo_commit(path):
     with open(opj(path, filename), 'w') as f:
         f.write("File to add to git")
 
-    gr.git_add(filename)
+    gr.add(filename)
     gr.git_commit("Testing GitRepo.git_commit().")
     ok_clean_git(path, annex=False, untracked=[])
 
@@ -351,7 +351,7 @@ def test_GitRepo_pull(test_path, orig_path, clone_path):
 
     with open(opj(orig_path, filename), 'w') as f:
         f.write("New file.")
-    origin.git_add(filename)
+    origin.add(filename)
     origin.git_commit("new file added.")
     clone.pull()
     assert_true(exists(opj(clone_path, filename)))
@@ -369,7 +369,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     origin.checkout("new_branch", "-b")
     with open(opj(orig_path, filename), 'w') as f:
         f.write("New file.")
-    origin.git_add(filename)
+    origin.add(filename)
     origin.git_commit("new file added.")
 
     clone.fetch(remote='origin')
@@ -423,7 +423,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     remote_repo.checkout("ssh-test", "-b")
     with open(opj(remote_repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
-    remote_repo.git_add("ssh_testfile.dat")
+    remote_repo.add("ssh_testfile.dat")
     remote_repo.git_commit("ssh_testfile.dat added.")
 
     # file is not locally known yet:
@@ -458,7 +458,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     repo.checkout("ssh-test", "-b")
     with open(opj(repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
-    repo.git_add("ssh_testfile.dat")
+    repo.add("ssh_testfile.dat")
     repo.git_commit("ssh_testfile.dat added.")
 
     # file is not known to the remote yet:
@@ -487,7 +487,7 @@ def test_GitRepo_push_n_checkout(orig_path, clone_path):
 
     with open(opj(clone_path, filename), 'w') as f:
         f.write("New file.")
-    clone.git_add(filename)
+    clone.add(filename)
     clone.git_commit("new file added.")
     # TODO: need checkout first:
     clone.push('origin', '+master:new-branch')
@@ -510,23 +510,23 @@ def test_GitRepo_remote_update(path1, path2, path3):
     # Setting up remote 'git2'
     with open(opj(path2, 'masterfile'), 'w') as f:
         f.write("git2 in master")
-    git2.git_add('masterfile')
+    git2.add('masterfile')
     git2.git_commit("Add something to master.")
     git2.checkout('branch2', '-b')
     with open(opj(path2, 'branch2file'), 'w') as f:
         f.write("git2 in branch2")
-    git2.git_add('branch2file')
+    git2.add('branch2file')
     git2.git_commit("Add something to branch2.")
 
     # Setting up remote 'git3'
     with open(opj(path3, 'masterfile'), 'w') as f:
         f.write("git3 in master")
-    git3.git_add('masterfile')
+    git3.add('masterfile')
     git3.git_commit("Add something to master.")
     git3.checkout('branch3', '-b')
     with open(opj(path3, 'branch3file'), 'w') as f:
         f.write("git3 in branch3")
-    git3.git_add('branch3file')
+    git3.add('branch3file')
     git3.git_commit("Add something to branch3.")
 
     git1.update_remote()
@@ -569,7 +569,7 @@ def test_GitRepo_get_files(url, path):
     filename = 'another_file.dat'
     with open(opj(path, filename), 'w') as f:
         f.write("something")
-    gr.git_add(filename)
+    gr.add(filename)
     gr.git_commit("Added.")
 
     # now get the files again:
@@ -641,7 +641,7 @@ def test_GitRepo_get_merge_base(src):
     repo = GitRepo(src, create=True)
     with open(opj(src, 'file.txt'), 'w') as f:
         f.write('load')
-    repo.git_add('*')
+    repo.add('*')
     repo.git_commit('committing')
 
     assert_raises(ValueError, repo.get_merge_base, [])
@@ -656,7 +656,7 @@ def test_GitRepo_get_merge_base(src):
     # it will have all the files
     # Must not do:  https://github.com/gitpython-developers/GitPython/issues/375
     # repo.git_add('.')
-    repo.git_add('*')
+    repo.add('*')
     # NOTE: fun part is that we should have at least a different commit message
     # so it results in a different checksum ;)
     repo.git_commit("committing again")
@@ -678,7 +678,7 @@ def test_GitRepo_git_get_branch_commits(src):
     repo = GitRepo(src, create=True)
     with open(opj(src, 'file.txt'), 'w') as f:
         f.write('load')
-    repo.git_add('*')
+    repo.add('*')
     repo.git_commit('committing')
 
     commits = list(repo.get_branch_commits('master'))

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -290,7 +290,7 @@ def test_GitRepo_remote_add(orig_path, path):
     out = gr.git_remote_show()
     assert_in('origin', out)
     eq_(len(out), 1)
-    gr.git_remote_add('github', 'git://github.com/datalad/testrepo--basic--r1')
+    gr.add_remote('github', 'git://github.com/datalad/testrepo--basic--r1')
     out = gr.git_remote_show()
     assert_in('origin', out)
     assert_in('github', out)
@@ -304,7 +304,7 @@ def test_GitRepo_remote_add(orig_path, path):
 def test_GitRepo_remote_remove(orig_path, path):
 
     gr = GitRepo(path, orig_path)
-    gr.git_remote_add('github', 'git://github.com/datalad/testrepo--basic--r1')
+    gr.add_remote('github', 'git://github.com/datalad/testrepo--basic--r1')
     gr.git_remote_remove('github')
     out = gr.git_remote_show()
     eq_(len(out), 1)
@@ -316,7 +316,7 @@ def test_GitRepo_remote_remove(orig_path, path):
 def test_GitRepo_remote_show(orig_path, path):
 
     gr = GitRepo(path, orig_path)
-    gr.git_remote_add('github', 'git://github.com/datalad/testrepo--basic--r1')
+    gr.add_remote('github', 'git://github.com/datalad/testrepo--basic--r1')
     out = gr.git_remote_show(verbose=True)
     eq_(len(out), 4)
     assert_in('origin\t%s (fetch)' % orig_path, out)
@@ -334,7 +334,7 @@ def test_GitRepo_remote_show(orig_path, path):
 def test_GitRepo_get_remote_url(orig_path, path):
 
     gr = GitRepo(path, orig_path)
-    gr.git_remote_add('github', 'git://github.com/datalad/testrepo--basic--r1')
+    gr.add_remote('github', 'git://github.com/datalad/testrepo--basic--r1')
     eq_(gr.git_get_remote_url('origin'), orig_path)
     eq_(gr.git_get_remote_url('github'),
                  'git://github.com/datalad/testrepo--basic--r1')
@@ -390,7 +390,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     url = "ssh://localhost" + abspath(remote_path)
     socket_path = opj(ssh_manager.socket_dir, 'localhost')
     repo = GitRepo(repo_path, create=True)
-    repo.git_remote_add("ssh-remote", url)
+    repo.add_remote("ssh-remote", url)
 
     # we don't know any branches of the remote:
     eq_([], repo.git_get_remote_branches())
@@ -417,7 +417,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     url = "ssh://localhost" + abspath(remote_path)
     socket_path = opj(ssh_manager.socket_dir, 'localhost')
     repo = GitRepo(repo_path, create=True)
-    repo.git_remote_add("ssh-remote", url)
+    repo.add_remote("ssh-remote", url)
 
     # modify remote:
     remote_repo.git_checkout("ssh-test", "-b")
@@ -452,7 +452,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     url = "ssh://localhost" + abspath(remote_path)
     socket_path = opj(ssh_manager.socket_dir, 'localhost')
     repo = GitRepo(repo_path, create=True)
-    repo.git_remote_add("ssh-remote", url)
+    repo.add_remote("ssh-remote", url)
 
     # modify local repo:
     repo.git_checkout("ssh-test", "-b")
@@ -504,8 +504,8 @@ def test_GitRepo_remote_update(path1, path2, path3):
     git2 = GitRepo(path2)
     git3 = GitRepo(path3)
 
-    git1.git_remote_add('git2', path2)
-    git1.git_remote_add('git3', path3)
+    git1.add_remote('git2', path2)
+    git1.add_remote('git3', path3)
 
     # Setting up remote 'git2'
     with open(opj(path2, 'masterfile'), 'w') as f:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -128,10 +128,10 @@ def test_GitRepo_remove(path):
     gr.add('*')
     gr.commit("committing all the files")
 
-    eq_(gr.git_remove('file'), ['file'])
-    eq_(set(gr.git_remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
+    eq_(gr.remove('file'), ['file'])
+    eq_(set(gr.remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
 
-    eq_(set(gr.git_remove('*', r=True, f=True)), {'file2', 'd2/f1', 'd2/f2'})
+    eq_(set(gr.remove('*', r=True, f=True)), {'file2', 'd2/f1', 'd2/f2'})
 
 @assert_cwd_unchanged
 @with_tempfile

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -126,7 +126,7 @@ def test_GitRepo_remove(path):
 
     gr = GitRepo(path, create=True)
     gr.add('*')
-    gr.git_commit("committing all the files")
+    gr.commit("committing all the files")
 
     eq_(gr.git_remove('file'), ['file'])
     eq_(set(gr.git_remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
@@ -143,7 +143,7 @@ def test_GitRepo_commit(path):
         f.write("File to add to git")
 
     gr.add(filename)
-    gr.git_commit("Testing GitRepo.git_commit().")
+    gr.commit("Testing GitRepo.commit().")
     ok_clean_git(path, annex=False, untracked=[])
 
 
@@ -352,7 +352,7 @@ def test_GitRepo_pull(test_path, orig_path, clone_path):
     with open(opj(orig_path, filename), 'w') as f:
         f.write("New file.")
     origin.add(filename)
-    origin.git_commit("new file added.")
+    origin.commit("new file added.")
     clone.pull()
     assert_true(exists(opj(clone_path, filename)))
 
@@ -370,7 +370,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     with open(opj(orig_path, filename), 'w') as f:
         f.write("New file.")
     origin.add(filename)
-    origin.git_commit("new file added.")
+    origin.commit("new file added.")
 
     clone.fetch(remote='origin')
 
@@ -424,7 +424,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     with open(opj(remote_repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
     remote_repo.add("ssh_testfile.dat")
-    remote_repo.git_commit("ssh_testfile.dat added.")
+    remote_repo.commit("ssh_testfile.dat added.")
 
     # file is not locally known yet:
     assert_not_in("ssh_testfile.dat", repo.get_indexed_files())
@@ -459,7 +459,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     with open(opj(repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
     repo.add("ssh_testfile.dat")
-    repo.git_commit("ssh_testfile.dat added.")
+    repo.commit("ssh_testfile.dat added.")
 
     # file is not known to the remote yet:
     assert_not_in("ssh_testfile.dat", remote_repo.get_indexed_files())
@@ -488,7 +488,7 @@ def test_GitRepo_push_n_checkout(orig_path, clone_path):
     with open(opj(clone_path, filename), 'w') as f:
         f.write("New file.")
     clone.add(filename)
-    clone.git_commit("new file added.")
+    clone.commit("new file added.")
     # TODO: need checkout first:
     clone.push('origin', '+master:new-branch')
     origin.checkout('new-branch')
@@ -511,23 +511,23 @@ def test_GitRepo_remote_update(path1, path2, path3):
     with open(opj(path2, 'masterfile'), 'w') as f:
         f.write("git2 in master")
     git2.add('masterfile')
-    git2.git_commit("Add something to master.")
+    git2.commit("Add something to master.")
     git2.checkout('branch2', '-b')
     with open(opj(path2, 'branch2file'), 'w') as f:
         f.write("git2 in branch2")
     git2.add('branch2file')
-    git2.git_commit("Add something to branch2.")
+    git2.commit("Add something to branch2.")
 
     # Setting up remote 'git3'
     with open(opj(path3, 'masterfile'), 'w') as f:
         f.write("git3 in master")
     git3.add('masterfile')
-    git3.git_commit("Add something to master.")
+    git3.commit("Add something to master.")
     git3.checkout('branch3', '-b')
     with open(opj(path3, 'branch3file'), 'w') as f:
         f.write("git3 in branch3")
     git3.add('branch3file')
-    git3.git_commit("Add something to branch3.")
+    git3.commit("Add something to branch3.")
 
     git1.update_remote()
 
@@ -570,7 +570,7 @@ def test_GitRepo_get_files(url, path):
     with open(opj(path, filename), 'w') as f:
         f.write("something")
     gr.add(filename)
-    gr.git_commit("Added.")
+    gr.commit("Added.")
 
     # now get the files again:
     local_files = set(gr.get_files())
@@ -610,7 +610,7 @@ def test_GitRepo_dirty():
     # new file added to index
     trepo.create_file('newfiletest.dat', '123\n', annex=False)
     assert_true(repo.dirty)
-    repo.git_commit("just a commit")
+    repo.commit("just a commit")
     assert_false(repo.dirty)
 
     # file modified to be the same
@@ -620,7 +620,7 @@ def test_GitRepo_dirty():
     # file modified
     trepo.create_file('newfiletest.dat', '12\n', annex=False)
     assert_true(repo.dirty)
-    repo.git_commit("just a commit")
+    repo.commit("just a commit")
     assert_false(repo.dirty)
 
     # new file not added to index
@@ -632,7 +632,7 @@ def test_GitRepo_dirty():
     # new annexed file
     trepo.create_file('newfiletest2.dat', '123\n', annex=True)
     assert_true(repo.dirty)
-    repo.git_commit("just a commit")
+    repo.commit("just a commit")
     assert_false(repo.dirty)
 
 
@@ -642,7 +642,7 @@ def test_GitRepo_get_merge_base(src):
     with open(opj(src, 'file.txt'), 'w') as f:
         f.write('load')
     repo.add('*')
-    repo.git_commit('committing')
+    repo.commit('committing')
 
     assert_raises(ValueError, repo.get_merge_base, [])
     branch1 = repo.get_active_branch()
@@ -659,7 +659,7 @@ def test_GitRepo_get_merge_base(src):
     repo.add('*')
     # NOTE: fun part is that we should have at least a different commit message
     # so it results in a different checksum ;)
-    repo.git_commit("committing again")
+    repo.commit("committing again")
     assert(repo.get_indexed_files())  # we did commit
     assert(repo.get_merge_base(branch1) is None)
     assert(repo.get_merge_base([branch2, branch1]) is None)
@@ -679,7 +679,7 @@ def test_GitRepo_git_get_branch_commits(src):
     with open(opj(src, 'file.txt'), 'w') as f:
         f.write('load')
     repo.add('*')
-    repo.git_commit('committing')
+    repo.commit('committing')
 
     commits = list(repo.get_branch_commits('master'))
     eq_(len(commits), 1)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -110,7 +110,23 @@ def test_GitRepo_add(src, path):
         f.write("File to add to git")
     gr.add(filename)
 
-    assert_in(filename, gr.get_indexed_files(), "%s not successfully added to %s" % (filename, path))
+    assert_in(filename, gr.get_indexed_files(),
+              "%s not successfully added to %s" % (filename, path))
+    # uncommitted:
+    ok_(gr.repo.is_dirty())
+
+    filename = "another.txt"
+    with open(opj(path, filename), 'w') as f:
+        f.write("Another file to add to git")
+    assert_raises(AssertionError, gr.add, filename, git=False)
+    assert_raises(AssertionError, gr.add, filename, git=None)
+
+    # include committing:
+    gr.add(filename, commit=True, msg="Add two files.")
+
+    assert_in(filename, gr.get_indexed_files(),
+              "%s not successfully added to %s" % (filename, path))
+    ok_clean_git(path, annex=False)
 
 
 @assert_cwd_unchanged

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -60,7 +60,7 @@ def test_proxying_open_testrepobased(repo):
     os.makedirs(dirname(fpath2))
     with open(fpath2, 'w') as f:
         f.write(content)
-    annex.annex_add(fpath2)
+    annex.add(fpath2)
     annex.drop(fpath2)
     annex.git_commit("added and dropped")
     assert_raises(IOError, open, fpath2)
@@ -85,7 +85,7 @@ def _test_proxying_open(generate_load, verify_load, repo):
     generate_load(fpath1)
     os.makedirs(dirname(fpath2))
     generate_load(fpath2)
-    annex.annex_add([fpath1, fpath2])
+    annex.add([fpath1, fpath2])
     verify_load(fpath1)
     verify_load(fpath2)
     annex.git_commit("Added some files")

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -62,7 +62,7 @@ def test_proxying_open_testrepobased(repo):
         f.write(content)
     annex.add(fpath2)
     annex.drop(fpath2)
-    annex.git_commit("added and dropped")
+    annex.commit("added and dropped")
     assert_raises(IOError, open, fpath2)
 
     # Let's use context manager form
@@ -88,7 +88,7 @@ def _test_proxying_open(generate_load, verify_load, repo):
     annex.add([fpath1, fpath2])
     verify_load(fpath1)
     verify_load(fpath2)
-    annex.git_commit("Added some files")
+    annex.commit("Added some files")
 
     # clone to another repo
     repo2 = repo + "_2"

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -61,7 +61,7 @@ def test_proxying_open_testrepobased(repo):
     with open(fpath2, 'w') as f:
         f.write(content)
     annex.annex_add(fpath2)
-    annex.annex_drop(fpath2)
+    annex.drop(fpath2)
     annex.git_commit("added and dropped")
     assert_raises(IOError, open, fpath2)
 
@@ -101,7 +101,7 @@ def _test_proxying_open(generate_load, verify_load, repo):
 
     with AutomagicIO():
         # verify that it doesn't even try to get files which do not exist
-        with patch('datalad.support.annexrepo.AnnexRepo.annex_get') as gricm:
+        with patch('datalad.support.annexrepo.AnnexRepo.get') as gricm:
             # if we request absent file
             assert_raises(IOError, open, fpath1_2+"_", 'r')
             # no get should be called
@@ -109,7 +109,7 @@ def _test_proxying_open(generate_load, verify_load, repo):
         verify_load(fpath1_2)
         verify_load(fpath2_2)
         # and even if we drop it -- we still can get it no problem
-        annex2.annex_drop(fpath2_2)
+        annex2.drop(fpath2_2)
         assert_false(annex2.file_has_content(fpath2_2))
         verify_load(fpath2_2)
         assert_true(annex2.file_has_content(fpath2_2))
@@ -117,7 +117,7 @@ def _test_proxying_open(generate_load, verify_load, repo):
     # if we override stdout with something not supporting fileno, like tornado
     # does which ruins using get under IPython
     # TODO: we might need to refuse any online logging in other places like that
-    annex2.annex_drop(fpath2_2)
+    annex2.drop(fpath2_2)
     class StringIOfileno(StringIO):
         def fileno(self):
             raise Exception("I have no clue how to do fileno")

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -36,7 +36,7 @@ def _test_BasicAnnexTestRepo(repodir):
     if not trepo.repo.is_crippled_fs():
         ok_broken_symlink(pathjoin(trepo.path, 'test-annex.dat'))
     with swallow_outputs():
-        trepo.repo.annex_get('test-annex.dat')
+        trepo.repo.get('test-annex.dat')
     if not trepo.repo.is_crippled_fs():
         ok_good_symlink(pathjoin(trepo.path, 'test-annex.dat'))
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -196,7 +196,7 @@ def put_file_under_git(path, filename=None, content=None, annexed=False):
     if annexed:
         if not isinstance(repo, AnnexRepo):
             repo = AnnexRepo(repo.path)
-        repo.add_to_annex(file_repo_path)
+        repo.add(file_repo_path, commit=True)
     else:
         repo.git_add(file_repo_path)
     ok_file_under_git(repo.path, file_repo_path, annexed)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -131,7 +131,7 @@ def ok_clean_git_annex_proxy(path):
     chpwd(path)
 
     try:
-        out = ar.annex_proxy("git status")
+        out = ar.proxy("git status")
     except CommandNotAvailableError as e:
         raise SkipTest
     finally:
@@ -276,14 +276,14 @@ def ok_git_config_not_empty(ar):
 
 
 def ok_annex_get(ar, files, network=True):
-    """Helper to run .annex_get decorated checking for correct operation
+    """Helper to run .get decorated checking for correct operation
 
-    annex_get passes through stderr from the ar to the user, which pollutes
+    get passes through stderr from the ar to the user, which pollutes
     screen while running tests
     """
     ok_git_config_not_empty(ar) # we should be working in already inited repo etc
     with swallow_outputs() as cmo:
-        ar.annex_get(files)
+        ar.get(files)
         if network:
             # wget or curl - just verify that annex spits out expected progress bar
             ok_('100%' in cmo.err or '100.0%' in cmo.err or '100,0%' in cmo.err)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -198,7 +198,12 @@ def put_file_under_git(path, filename=None, content=None, annexed=False):
             repo = AnnexRepo(repo.path)
         repo.add(file_repo_path, commit=True)
     else:
-        repo.git_add(file_repo_path)
+        if isinstance(repo, AnnexRepo):
+            repo.add(file_repo_path, git=True)
+        elif isinstance(repo, GitRepo):
+            repo.add(file_repo_path)
+        else:
+            raise ValueError("Unknown repo: %s" % repo)
     ok_file_under_git(repo.path, file_repo_path, annexed)
     return repo
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -184,6 +184,7 @@ def ok_file_under_git(path, filename=None, annexed=False):
 
     assert(annexed == in_annex)
 
+
 def put_file_under_git(path, filename=None, content=None, annexed=False):
     """Place file under git/annex and return used Repo
     """
@@ -198,14 +199,10 @@ def put_file_under_git(path, filename=None, content=None, annexed=False):
             repo = AnnexRepo(repo.path)
         repo.add(file_repo_path, commit=True)
     else:
-        if isinstance(repo, AnnexRepo):
-            repo.add(file_repo_path, git=True)
-        elif isinstance(repo, GitRepo):
-            repo.add(file_repo_path)
-        else:
-            raise ValueError("Unknown repo: %s" % repo)
+        repo.add(file_repo_path, git=True)
     ok_file_under_git(repo.path, file_repo_path, annexed)
     return repo
+
 
 def _prep_file_under_git(path, filename):
     """Get instance of the repository for the given filename

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -56,7 +56,7 @@ class TestRepo(object):
         with open(filename, 'wb') as f:
             f.write(content.encode())
         if add:
-            (self.repo.annex_add if annex else self.repo.git_add)(name)
+            (self.repo.add if annex else self.repo.git_add)(name)
 
     def create(self):
         if self._created:

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -85,9 +85,9 @@ class BasicAnnexTestRepo(TestRepo):
         fileurl = get_local_file_url(realpath(opj(self.path, 'test.dat'))) \
                   if not on_windows \
                   else "https://raw.githubusercontent.com/datalad/testrepo--basic--r1/master/test.dat"
-        self.repo.annex_addurl_to_file("test-annex.dat", fileurl)
+        self.repo.add_url_to_file("test-annex.dat", fileurl)
         self.repo.git_commit("Adding a rudimentary git-annex load file")
-        self.repo.annex_drop("test-annex.dat")  # since available from URL
+        self.repo.drop("test-annex.dat")  # since available from URL
 
     def create_info_file(self):
         runner = Runner()

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -90,14 +90,14 @@ class BasicAnnexTestRepo(TestRepo):
     def populate(self):
         self.create_info_file()
         self.create_file('test.dat', '123\n', annex=False)
-        self.repo.git_commit("Adding a basic INFO file and rudimentary load file for annex testing")
+        self.repo.commit("Adding a basic INFO file and rudimentary load file for annex testing")
         # even this doesn't work on bloody Windows
         from .utils import on_windows
         fileurl = get_local_file_url(realpath(opj(self.path, 'test.dat'))) \
                   if not on_windows \
                   else "https://raw.githubusercontent.com/datalad/testrepo--basic--r1/master/test.dat"
         self.repo.add_url_to_file("test-annex.dat", fileurl)
-        self.repo.git_commit("Adding a rudimentary git-annex load file")
+        self.repo.commit("Adding a rudimentary git-annex load file")
         self.repo.drop("test-annex.dat")  # since available from URL
 
     def create_info_file(self):
@@ -120,7 +120,7 @@ class BasicGitTestRepo(TestRepo):
     def populate(self):
         self.create_info_file()
         self.create_file('test.dat', '123\n', annex=False)
-        self.repo.git_commit("Adding a basic INFO file and rudimentary "
+        self.repo.commit("Adding a basic INFO file and rudimentary "
                              "load file.")
 
     def create_info_file(self):

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -56,7 +56,18 @@ class TestRepo(object):
         with open(filename, 'wb') as f:
             f.write(content.encode())
         if add:
-            (self.repo.add if annex else self.repo.git_add)(name)
+            if annex:
+                if isinstance(self.repo, AnnexRepo):
+                    self.repo.add(name)
+                else:
+                    raise ValueError("Can't annex add to a non-annex repo.")
+            else:
+                if isinstance(self.repo, AnnexRepo):
+                    self.repo.add(name, git=True)
+                elif isinstance(self.repo, GitRepo):
+                    self.repo.add(name)
+                else:
+                    raise ValueError("Unknown repo: %s" % self.repo)
 
     def create(self):
         if self._created:

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -62,12 +62,7 @@ class TestRepo(object):
                 else:
                     raise ValueError("Can't annex add to a non-annex repo.")
             else:
-                if isinstance(self.repo, AnnexRepo):
-                    self.repo.add(name, git=True)
-                elif isinstance(self.repo, GitRepo):
-                    self.repo.add(name)
-                else:
-                    raise ValueError("Unknown repo: %s" % self.repo)
+                self.repo.add(name, git=True)
 
     def create(self):
         if self._created:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -830,5 +830,5 @@ def knows_annex(path):
         return False
     from datalad.support.gitrepo import GitRepo
     repo = GitRepo(path, create=False)
-    return "origin/git-annex" in repo.git_get_remote_branches() \
-           or "git-annex" in repo.git_get_branches()
+    return "origin/git-annex" in repo.get_remote_branches() \
+           or "git-annex" in repo.get_branches()


### PR DESCRIPTION
Part I is restricted to all the required renaming, in order to merge ASAP, since this stuff is spread out through the entire code base.
(But still wait for "WiP" marker to be gone ;) )

Note: This PR is based on PR #435 already

Closes #434 