### PR TITLE
OPT minimize initial import times and starttime of various cmdline entry points

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -9,22 +9,29 @@
 """DataLad aims to expose (scientific) data available online as a unified data
 distribution with the convenience of git-annex repositories as a backend."""
 
-from .version import __version__
+import atexit
 
-from datalad.log import lgr
-lgr.debug("Importing the rest of datalad.__init__")
+from .version import __version__
+from .log import lgr
+
+# Other imports are interspersed with lgr.debug to ease troubleshooting startup
+# delays etc.
+lgr.debug("Instantiating config")
 from .config import ConfigManager
 cfg = ConfigManager()
 
-from datalad.support.sshconnector import SSHManager
+lgr.debug("Instantiating ssh manager")
+from .support.sshconnector import SSHManager
 ssh_manager = SSHManager()
-import atexit
 atexit.register(ssh_manager.close)
 
 
-# be friendly on systems with ancient numpy -- no tests, but at least
-# importable
 def test(package='datalad', **kwargs):
+    """A helper to run datalad's tests.  Requires numpy and nose
+
+    See numpy.testing.Tester -- **kwargs are passed into the
+    Tester().test call
+    """
     try:
         from numpy.testing import Tester
         Tester(package=package).test(**kwargs)

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -64,6 +64,9 @@ def setup_package():
 
 
 def teardown_package():
+    import os
+    if os.environ.get('DATALAD_TESTS_NOTEARDOWN'):
+        return
     from datalad.tests import _TEMP_PATHS_GENERATED
     from datalad.tests.utils import rmtemp
     if len(_TEMP_PATHS_GENERATED):

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -21,20 +21,22 @@ ssh_manager = SSHManager()
 import atexit
 atexit.register(ssh_manager.close)
 
+
 # be friendly on systems with ancient numpy -- no tests, but at least
 # importable
-try:
-    from numpy.testing import Tester
-    test = Tester().test
-    bench = Tester().bench
-    del Tester
-except ImportError:
-    def test(*args, **kwargs):
-        lgr.warning('Need numpy >= 1.2 for datalad.tests().  Nothing is done')
-    test.__test__ = False
+def test(package='datalad', **kwargs):
+    try:
+        from numpy.testing import Tester
+        Tester(package=package).test(**kwargs)
+        # we don't have any benchmarks atm
+        # bench = Tester().bench
+    except ImportError:
+        raise RuntimeError('Need numpy >= 1.2 for datalad.tests().  Nothing is done')
+test.__test__ = False
 
 # Following fixtures are necessary at the top level __init__ for fixtures which
 # would cover all **/tests and not just datalad/tests/
+
 
 def setup_package():
     import os
@@ -52,6 +54,7 @@ def setup_package():
         if ev in os.environ and not (os.environ[ev]):
             lgr.debug("Removing %s from the environment since it is empty", ev)
             os.environ.pop(ev)
+
 
 def teardown_package():
     from datalad.tests import _TEMP_PATHS_GENERATED

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -16,11 +16,11 @@ from .log import lgr
 
 # Other imports are interspersed with lgr.debug to ease troubleshooting startup
 # delays etc.
-lgr.debug("Instantiating config")
+lgr.log(5, "Instantiating config")
 from .config import ConfigManager
 cfg = ConfigManager()
 
-lgr.debug("Instantiating ssh manager")
+lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager
 ssh_manager = SSHManager()
 atexit.register(ssh_manager.close)
@@ -73,3 +73,5 @@ def teardown_package():
     lgr.debug("Teardown tests. " + msg)
     for path in _TEMP_PATHS_GENERATED:
         rmtemp(path, ignore_errors=True)
+
+lgr.log(5, "Done importing main __init__")

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -18,9 +18,9 @@ from six.moves.urllib.parse import quote as urlquote, unquote as urlunquote
 
 import logging
 lgr = logging.getLogger('datalad.customremotes.archive')
+lgr.log(5, "Importing datalad.customremotes.archive")
 
-from ..cmd import link_file_load, Runner
-from ..support.exceptions import CommandError
+from ..cmd import link_file_load
 from ..support.archives import ArchivesCache
 from ..utils import getpwd
 from ..utils import parse_url_opts
@@ -301,3 +301,5 @@ from .main import main as super_main
 def main():
     """cmdline entry point"""
     super_main(backend="archive")
+
+lgr.log(5, "Done importing datalad.customremotes.archive")

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -15,22 +15,18 @@ import os
 import sys
 
 from os.path import exists, join as opj, realpath, dirname, lexists
-from traceback import format_exc
 
 from six.moves import range
 from six.moves.urllib.parse import urlparse, urlunparse
 
-from ..cmd import Runner
-from ..support.exceptions import CommandError
+import logging
+lgr = logging.getLogger('datalad.customremotes')
+lgr.log(5, "Importing datalad.customremotes.main")
+
 from ..support.protocol import ProtocolInterface
-from ..support.annexrepo import AnnexRepo
 from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 
-import logging
-
-
-lgr = logging.getLogger('datalad.customremotes')
 
 URI_PREFIX = "dl"
 SUPPORTED_PROTOCOL = 1
@@ -190,6 +186,9 @@ class AnnexCustomRemote(object):
         """
         # TODO: probably we shouldn't have runner here but rather delegate
         # to AnnexRepo's functionality
+        from ..support.annexrepo import AnnexRepo
+        from ..cmd import Runner
+        
         self.runner = Runner()
 
         # Custom remotes correspond to annex via stdin/stdout
@@ -377,6 +376,7 @@ class AnnexCustomRemote(object):
             except Exception as e:
                 self.error("Problem processing %r with parameters %r: %r"
                            % (req, req_load, e))
+                from traceback import format_exc
                 lgr.error("Caught exception detail: %s" % format_exc())
 
     def req_INITREMOTE(self, *args):
@@ -556,3 +556,5 @@ class AnnexCustomRemote(object):
     # TODO: test on annex'es generated with those new options e.g.-c annex.tune.objecthash1=true
     #def get_GETCONFIG SETCONFIG  SETCREDS  GETCREDS  GETUUID  GETGITDIR  SETWANTED  GETWANTED
     #SETSTATE GETSTATE SETURLPRESENT  SETURLMISSING
+
+lgr.log(5, "Done importing datalad.customremotes.main")

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -21,7 +21,6 @@ from ..cmdline import helpers
 from ..cmdline.main import _license_info
 
 from ..utils import setup_exceptionhook
-from ..utils import use_cassette
 from ..ui import ui
 
 backends = ['archive']
@@ -100,6 +99,7 @@ def _main(args, backend=None):
         # If no command - run the special remote
         if 'DATALAD_USECASSETTE' in os.environ:
             # optionally feeding it a cassette, used by tests
+            from ..support.vcr_ import use_cassette
             with use_cassette(os.environ['DATALAD_USECASSETTE']):
                 remote.main()
         else:

--- a/datalad/support/tests/test_vcr_.py
+++ b/datalad/support/tests/test_vcr_.py
@@ -1,0 +1,35 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for vcr adapter"""
+
+from ..vcr_ import use_cassette
+from ...tests.utils import SkipTest
+from ...tests.utils import eq_
+
+
+def test_use_cassette_if_no_vcr():
+    # just test that our do nothing decorator does the right thing if vcr is not present
+    skip = False
+    try:
+        import vcr
+        skip = True
+    except ImportError:
+        pass
+    except:
+        # if anything else goes wrong with importing vcr, we still should be able to
+        # run use_cassette
+        pass
+    if skip:
+        raise SkipTest("vcr is present, can't test behavior with vcr presence ATM")
+
+    @use_cassette("some_path")
+    def checker(x):
+        return x + 1
+
+    eq_(checker(1), 2)

--- a/datalad/support/vcr_.py
+++ b/datalad/support/vcr_.py
@@ -1,0 +1,87 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Adapters and decorators for vcr
+"""
+
+import logging
+
+from functools import wraps
+from os.path import isabs
+from os.path import realpath
+from contextlib import contextmanager
+
+from datalad.dochelpers import exc_str
+
+lgr = logging.getLogger("datalad.support.vcr")
+
+
+def _get_cassette_path(path):
+    """Return a path to the cassette within our unified 'storage'"""
+    if not isabs(path):  # so it was given as a name
+        return "fixtures/vcr_cassettes/%s.yaml" % path
+    return path
+
+try:
+    # TEMP: Just to overcome problem with testing on jessie with older requests
+    # https://github.com/kevin1024/vcrpy/issues/215
+    import vcr.patch as _vcrp
+    import requests as _
+    try:
+        from requests.packages.urllib3.connectionpool import HTTPConnection as _a, VerifiedHTTPSConnection as _b
+    except ImportError:
+        def returnnothing(*args, **kwargs):
+            return()
+        _vcrp.CassettePatcherBuilder._requests = returnnothing
+
+    from vcr import use_cassette as _use_cassette, VCR as _VCR
+
+    def use_cassette(path, return_body=None, **kwargs):
+        """Adapter so we could create/use custom use_cassette with custom parameters
+
+        Parameters
+        ----------
+        path : str
+          If not absolute path, treated as a name for a cassette under fixtures/vcr_cassettes/
+        """
+        path = _get_cassette_path(path)
+        lgr.debug("Using cassette %s" % path)
+        if return_body is not None:
+            my_vcr = _VCR(
+                before_record_response=lambda r: dict(r, body={'string': return_body.encode()}))
+            return my_vcr.use_cassette(path, **kwargs)  # with a custom response
+        else:
+            return _use_cassette(path, **kwargs)  # just a straight one
+
+except Exception as exc:
+    if not isinstance(exc, ImportError):
+        # something else went hairy (e.g. vcr failed to import boto due to some syntax error)
+        lgr.warning("Failed to import vcr, no cassettes will be available: %s",
+                    exc_str(exc, limit=10))
+    # If there is no vcr.py -- provide a do nothing decorator for use_cassette
+    def use_cassette(*args, **kwargs):
+        def do_nothing_decorator(t):
+            @wraps(t)
+            def wrapper(*args, **kwargs):
+                lgr.debug("Not using vcr cassette")
+                return t(*args, **kwargs)
+            return wrapper
+        return do_nothing_decorator
+
+
+@contextmanager
+def externals_use_cassette(name):
+    """Helper to pass instruction via env variables to use specified cassette
+
+    For instance whenever we are testing custom special remotes invoked by the annex
+    but want to minimize their network traffic by using vcr.py
+    """
+    from mock import patch
+    with patch.dict('os.environ', {'DATALAD_USECASSETTE': realpath(_get_cassette_path(name))}):
+        yield
+

--- a/datalad/tests/test_misc.py
+++ b/datalad/tests/test_misc.py
@@ -7,11 +7,15 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from os.path import join
+from distutils.version import LooseVersion
 
 from .utils import *
 
-from ..support.network import get_url_response_stamp, is_url_quoted
+
+import datalad
+from datalad.support.network import get_url_response_stamp, is_url_quoted
+from datalad.utils import swallow_outputs
+
 
 def test_is_url_quoted():
     ok_(is_url_quoted('%22%27%3ba&b&cd|'))
@@ -25,3 +29,13 @@ def test_get_response_stamp():
     eq_(r['size'], 101)
     eq_(r['mtime'], 1367377320)
     eq_(r['url'], "http://www.example.com/1.dat")
+
+
+def test_test():
+    try:
+        import numpy
+        assert LooseVersion(numpy.__version__) >= '1.2'
+    except:
+        raise SkipTest("Need numpy 1.2")
+    # we can't swallow outputs due to all the nosetests dances etc
+    datalad.test('datalad.support.tests.test_status', verbose=0)

--- a/datalad/tests/test_misc.py
+++ b/datalad/tests/test_misc.py
@@ -37,5 +37,8 @@ def test_test():
         assert LooseVersion(numpy.__version__) >= '1.2'
     except:
         raise SkipTest("Need numpy 1.2")
-    # we can't swallow outputs due to all the nosetests dances etc
-    datalad.test('datalad.support.tests.test_status', verbose=0)
+
+    # we need to avoid running global teardown
+    with patch.dict('os.environ', {'DATALAD_TESTS_NOTEARDOWN': '1'}):
+        # we can't swallow outputs due to all the nosetests dances etc
+        datalad.test('datalad.support.tests.test_status', verbose=0)

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -44,7 +44,6 @@ from .utils import assert_re_in
 from .utils import local_testrepo_flavors
 from .utils import skip_if_no_network
 from .utils import run_under_dir
-from .utils import use_cassette
 from .utils import skip_if
 from .utils import ok_file_has_content
 from .utils import without_http_proxy
@@ -506,24 +505,3 @@ def test_run_under_dir(d):
     assert_raises(AssertionError, f, 1, 3)
     eq_(getpwd(), orig_pwd)
     eq_(os.getcwd(), orig_cwd)
-
-
-def test_use_cassette_if_no_vcr():
-    # just test that our do nothing decorator does the right thing if vcr is not present
-    skip = False
-    try:
-        import vcr
-        skip = True
-    except ImportError:
-        pass
-    except:
-        # if anything else goes wrong with importing vcr, we still should be able to
-        # run use_cassette
-        pass
-    if skip:
-        raise SkipTest("vcr is present, can't test behavior with vcr presence ATM")
-    @use_cassette("some_path")
-    def checker(x):
-        return x + 1
-
-    eq_(checker(1), 2)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -947,6 +947,8 @@ def with_testsui(t, responses=None):
             ui.set_backend(old_backend)
 
     return newfunc
+with_testsui.__test__ = False
+
 #
 # Context Managers
 #

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -45,6 +45,7 @@ from ..cmd import Runner
 from ..utils import *
 from ..support.exceptions import CommandNotAvailableError
 from ..support.archives import compress_files
+from ..support.vcr_ import *
 from ..dochelpers import exc_str
 from ..cmdline.helpers import get_repo_instance
 from ..consts import ARCHIVES_TEMP_DIR

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -30,16 +30,19 @@ from time import sleep
 
 lgr = logging.getLogger("datalad.utils")
 
+lgr.log(5, "Importing datalad.utils")
 #
 # Some useful variables
 #
-on_windows = platform.system() == 'Windows'
-on_osx = platform.system() == 'Darwin'
-on_linux = platform.system() == 'Linux'
+_platform_system = platform.system().lower()
+on_windows = _platform_system == 'windows'
+on_osx = _platform_system == 'darwin'
+on_linux = _platform_system == 'linux'
 try:
-    on_debian_wheezy = platform.system() == 'Linux' \
-                and platform.linux_distribution()[0] == 'debian' \
-                and platform.linux_distribution()[1].startswith('7.')
+    linux_distribution = platform.linux_distribution()
+    on_debian_wheezy = on_linux \
+                       and linux_distribution[0] == 'debian' \
+                       and linux_distribution[1].startswith('7.')
 except:  # pragma: no cover
     on_debian_wheezy = False
 
@@ -770,3 +773,5 @@ def knows_annex(path):
     repo = GitRepo(path, create=False)
     return "origin/git-annex" in repo.git_get_remote_branches() \
            or "git-annex" in repo.git_get_branches()
+
+lgr.log(5, "Done importing datalad.utils")

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -660,68 +660,6 @@ def swallow_logs(new_level=None):
         adapter.cleanup()
 
 
-def _get_cassette_path(path):
-    if not isabs(path):  # so it was given as a name
-        return "fixtures/vcr_cassettes/%s.yaml" % path
-    return path
-
-try:
-    # TEMP: Just to overcome problem with testing on jessie with older requests
-    # https://github.com/kevin1024/vcrpy/issues/215
-    import vcr.patch as _vcrp
-    import requests as _
-    try:
-        from requests.packages.urllib3.connectionpool import HTTPConnection as _a, VerifiedHTTPSConnection as _b
-    except ImportError:
-        def returnnothing(*args, **kwargs):
-            return()
-        _vcrp.CassettePatcherBuilder._requests = returnnothing
-
-    from vcr import use_cassette as _use_cassette, VCR as _VCR
-
-    def use_cassette(path, return_body=None, **kwargs):
-        """Adapter so we could create/use custom use_cassette with custom parameters
-
-        Parameters
-        ----------
-        path : str
-          If not absolute path, treated as a name for a cassette under fixtures/vcr_cassettes/
-        """
-        path = _get_cassette_path(path)
-        lgr.debug("Using cassette %s" % path)
-        if return_body is not None:
-            my_vcr = _VCR(before_record_response=lambda r: dict(r, body={'string': return_body.encode()}))
-            return my_vcr.use_cassette(path, **kwargs)  # with a custom response
-        else:
-            return _use_cassette(path, **kwargs)  # just a straight one
-
-except Exception as exc:
-    if not isinstance(exc, ImportError):
-        # something else went hairy (e.g. vcr failed to import boto due to some syntax error)
-        lgr.warning("Failed to import vcr, no cassettes will be available: %s", exc_str(exc, limit=10))
-    # If there is no vcr.py -- provide a do nothing decorator for use_cassette
-    def use_cassette(*args, **kwargs):
-        def do_nothing_decorator(t):
-            @wraps(t)
-            def wrapper(*args, **kwargs):
-                lgr.debug("Not using vcr cassette")
-                return t(*args, **kwargs)
-            return wrapper
-        return do_nothing_decorator
-
-
-@contextmanager
-def externals_use_cassette(name):
-    """Helper to pass instruction via env variables to use specified cassette
-
-    For instance whenever we are testing custom special remotes invoked by the annex
-    but want to minimize their network traffic by using vcr.py
-    """
-    from mock import patch
-    with patch.dict('os.environ', {'DATALAD_USECASSETTE': realpath(_get_cassette_path(name))}):
-        yield
-
-
 #
 # Additional handlers
 #


### PR DESCRIPTION
Inspired by whining against adding import of sshmanager into the top init -- apparently it wasn't the "worst" of our sins ;)

Primarily OPT was done through identifying heavy imports in few spots which we import from all around (e.g. vcr in utils).
It seems to shave off seconds from total run time of some tests (e.g. of customremotes)

I wonder how we could add some tests to somewhat 'establish' baseline import / execution times?
I though that may be (with all those added tracing imports debug lines) we could at least verify that some imports do not happen when we e.g. just execute 'datalad --help' etc.  what do you think?

BTW -- everyone is optimizing imports today !!! ;)  see e.g. https://github.com/tqdm/tqdm/pull/179