### PR TITLE
ENH: prototype for centralized URL handler

### DIFF
--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -51,9 +51,9 @@ from .. import cfg
 from ..consts import CRAWLER_META_DIR, HANDLE_META_DIR, CRAWLER_META_CONFIG_PATH
 from ..consts import CRAWLER_META_CONFIG_FILENAME
 from ..utils import updated
-from ..utils import parse_url_opts
 from ..dochelpers import exc_str
 from ..support.gitrepo import GitRepo
+from ..support.network import parse_url_opts
 from ..support.stats import ActivityStats
 from ..support.configparserinc import SafeConfigParserWithIncludes
 

--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -42,6 +42,12 @@ no verification is done and things can go utterly wrong.  So nodes must be robus
 provide informative logging.
 """
 
+__dev_doc__ = """
+Somewhat similar loose/flexible pipelining in Python approaches
+
+- https://github.com/freeman-lab/pipeit
+"""
+
 import sys
 from glob import glob
 from os.path import dirname, join as opj, isabs, exists, curdir, basename

--- a/datalad/crawler/pipelines/crcns.py
+++ b/datalad/crawler/pipelines/crcns.py
@@ -38,7 +38,7 @@ def collection_pipeline():
         # .reset() for nodes with state so we could first get through the pipe elements and reset
         # them all
         a_href_match("(?P<url>.*/data-sets/(?P<dataset_category>[^/#]+)/(?P<dataset>[^_/#]+))$"),
-        # https://openfmri.org/dataset/ds000001/
+        # http://crcns.org/data-sets/vc/pvc-1
         assign({'handle_name': '%(dataset)s'}, interpolate=True),
         annex.initiate_handle(
             template="crcns",

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -13,7 +13,7 @@ __docformat__ = 'restructuredtext'
 import os
 import re
 from os.path import exists, join as opj, basename, abspath
-
+from collections import OrderedDict
 from six.moves.urllib.parse import quote as urlquote, unquote as urlunquote
 
 import logging
@@ -22,7 +22,6 @@ lgr.log(5, "Importing datalad.customremotes.archive")
 
 from ..cmd import link_file_load
 from ..support.archives import ArchivesCache
-from ..support.network import parse_url_opts
 from ..support.network import URL
 from ..utils import getpwd
 from .base import AnnexCustomRemote
@@ -81,11 +80,11 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 raise ValueError("Provide archive_file or archive_key - not both")
             archive_key = self.repo.get_file_key(archive_file)
         assert(archive_key is not None)
-        attrs = {}  # looking forward for more
-        if size is not None:
-            attrs['size'] = size
+        attrs = OrderedDict()  # looking forward for more
         if file:
             attrs['path'] = file.lstrip('/')
+        if size is not None:
+            attrs['size'] = size
         return str(URL(scheme=self.URL_SCHEME, path=archive_key, fragment=attrs))
 
     @property

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -23,6 +23,7 @@ lgr.log(5, "Importing datalad.customremotes.archive")
 from ..cmd import link_file_load
 from ..support.archives import ArchivesCache
 from ..support.network import parse_url_opts
+from ..support.network import URL
 from ..utils import getpwd
 from .base import AnnexCustomRemote
 from .base import URI_PREFIX
@@ -39,7 +40,8 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
     CUSTOM_REMOTE_NAME = "archive"
     SUPPORTED_SCHEMES = (AnnexCustomRemote._get_custom_scheme(CUSTOM_REMOTE_NAME),)
     # Since we support only 1 scheme here
-    URL_PREFIX = SUPPORTED_SCHEMES[0] + ":"
+    URL_SCHEME = SUPPORTED_SCHEMES[0]
+    URL_PREFIX = URL_SCHEME + ":"
 
     AVAILABILITY = "local"
 
@@ -63,9 +65,9 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         Examples:
         ---------
 
-        dl+archive:SHA256E-s176--69...3e.tar.gz/1/d2/2d#size=123
+        dl+archive:SHA256E-s176--69...3e.tar.gz#path=1/d2/2d&size=123
             when size of file within archive was known to be 123
-        dl+archive:SHA256E-s176--69...3e.tar.gz/1/d2/2d
+        dl+archive:SHA256E-s176--69...3e.tar.gz#path=1/d2/2d
             when size of file within archive was not provided
 
         Parameters
@@ -79,12 +81,12 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 raise ValueError("Provide archive_file or archive_key - not both")
             archive_key = self.repo.get_file_key(archive_file)
         assert(archive_key is not None)
-        file_quoted = urlquote(file)
         attrs = {}  # looking forward for more
         if size is not None:
             attrs['size'] = size
-        sattrs = '#%s' % ('&'.join("%s=%s" % x for x in attrs.items())) if attrs else ''
-        return '%s%s/%s%s' % (self.URL_PREFIX, archive_key, file_quoted.lstrip('/'), sattrs)
+        if file:
+            attrs['path'] = file.lstrip('/')
+        return str(URL(scheme=self.URL_SCHEME, path=archive_key, fragment=attrs))
 
     @property
     def cache(self):
@@ -93,11 +95,18 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
     def _parse_url(self, url):
         """Parse url and return archive key, file within archive and additional attributes (such as size)
         """
-        url_prefix = self.URL_PREFIX
-        assert(url[:len(url_prefix)] == url_prefix)
-        key, file_attrs = url[len(url_prefix):].split('/', 1)
-        file_, attrs = parse_url_opts(file_attrs)
-        return key, file_, attrs
+        url = URL(url)
+        assert(url.scheme == self.URL_SCHEME)
+        fdict = url.fragment_dict
+        if 'path' not in fdict:
+            # must be old-style key/path#size=
+            assert '/' in url.path, "must be of key/path format"
+            key, path = url.path.split('/', 1)
+        else:
+            key, path = url.path, fdict.pop('path')
+        if 'size' in fdict:
+            fdict['size'] = int(fdict['size'])
+        return key, path, fdict
 
     #
     # Helper methods

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -22,8 +22,8 @@ lgr = logging.getLogger('datalad.customremotes.archive')
 from ..cmd import link_file_load, Runner
 from ..support.exceptions import CommandError
 from ..support.archives import ArchivesCache
+from ..support.network import parse_url_opts
 from ..utils import getpwd
-from ..utils import parse_url_opts
 from .base import AnnexCustomRemote
 from .base import URI_PREFIX
 

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -49,11 +49,16 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     annexcr = ArchiveAnnexCustomRemote(path=d)
     # few quick tests for get_file_url
 
-    eq_(annexcr.get_file_url(archive_key="xyz", file="a.dat"), "dl+archive:xyz/a.dat")
-    eq_(annexcr.get_file_url(archive_key="xyz", file="a.dat", size=999), "dl+archive:xyz/a.dat#size=999")
+    eq_(annexcr.get_file_url(archive_key="xyz", file="a.dat"), "dl+archive:xyz#path=a.dat")
+    eq_(annexcr.get_file_url(archive_key="xyz", file="a.dat", size=999), "dl+archive:xyz#path=a.dat&size=999")
 
+    # see https://github.com/datalad/datalad/issues/441#issuecomment-223376906
+    # old style
     eq_(annexcr._parse_url("dl+archive:xyz/a.dat#size=999"), ("xyz", "a.dat", {'size': 999}))
     eq_(annexcr._parse_url("dl+archive:xyz/a.dat"), ("xyz", "a.dat", {}))  # old format without size
+    # new style
+    eq_(annexcr._parse_url("dl+archive:xyz#path=a.dat&size=999"), ("xyz", "a.dat", {'size': 999}))
+    eq_(annexcr._parse_url("dl+archive:xyz#path=a.dat"), ("xyz", "a.dat", {}))  # old format without size
 
     file_url = annexcr.get_file_url(
         archive_file=fn_archive,

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -30,8 +30,8 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.gitrepo import GitRepo, GitCommandError
 from datalad.support.param import Parameter
 from datalad.utils import expandpath, knows_annex, assure_dir, \
-    is_explicit_path, on_windows, swallow_logs, get_local_path_from_url, \
-    is_url
+    is_explicit_path, on_windows, swallow_logs, get_local_path_from_url
+from datalad.support.network import is_url
 
 lgr = logging.getLogger('datalad.distribution.install')
 

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -30,7 +30,8 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.gitrepo import GitRepo, GitCommandError
 from datalad.support.param import Parameter
 from datalad.utils import expandpath, knows_annex, assure_dir, \
-    is_explicit_path, on_windows, swallow_logs, get_local_path_from_url
+    is_explicit_path, on_windows, swallow_logs
+from datalad.support.network import get_local_path_from_url
 from datalad.support.network import is_url
 
 lgr = logging.getLogger('datalad.distribution.install')

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -30,9 +30,8 @@ from datalad.tests.utils import assure_dict_from_str, assure_list_from_str
 from datalad.tests.utils import ok_generator
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_raises
-from datalad.tests.utils import ok_startswith
-from datalad.tests.utils import skip_if_no_module, skip_ssh
-from datalad.tests.utils import ok_clean_git, on_windows, get_local_file_url
+from datalad.tests.utils import skip_ssh
+from datalad.utils import on_windows
 
 
 @skip_ssh

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -7,7 +7,17 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Interface information about credentials
+
+Provides minimalistic interface to deal (query, request, store) with most common
+types of credentials.  To be used by Authenticators
 """
+
+__dev_doc__ = """
+Possibly useful in the future 3rd part developments
+
+https://github.com/omab/python-social-auth  social authentication/registration mechanism with support for several frameworks and auth providers
+"""
+
 from collections import OrderedDict
 
 from ..dochelpers import exc_str

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -323,7 +323,7 @@ class URL(object):
 
     __slots__ = _FIELDS + ('_fields', '_str')
 
-    def __init__(self, url=None, **kwargs):
+    def __init__(self, url=None, implicit=None, **kwargs):
         """
 
         Parameters
@@ -345,6 +345,7 @@ class URL(object):
         # Not provided seems to be exactly as empty string, so Ok (stdlib
         # guys knew what they were doing ;)
         self._fields = self._get_blank_fields()
+        self._implicit = None
         if url:
             self._set_from_str(url)
         else:
@@ -353,10 +354,6 @@ class URL(object):
     @classmethod
     def _get_blank_fields(cls, **kwargs):
         return OrderedDict(((f, kwargs.get(f, '')) for f in cls._FIELDS))
-
-    @property
-    def is_implicit(self):
-        return self._fields['scheme'].endswith(':implicit')
 
     @property
     def fields(self):
@@ -414,7 +411,7 @@ class URL(object):
     def _as_str(self):
         """Re-evaluate string repsentation"""
 
-        if not self.is_implicit:
+        if not self.implicit:
             return urlunparse(self.to_pr())
         else:
             base_scheme = self.scheme.split(':', 1)[0]
@@ -688,7 +685,7 @@ def is_url(s):
         url = URL(s)
     except:
         return False
-    implicit = url.is_implicit
+    implicit = url.implicit
     scheme = url.scheme
     return scheme in {'ssh:implicit'} or (not implicit and bool(url))
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -341,8 +341,8 @@ class URL(object):
             self._set_from_fields(**kwargs)
 
     @classmethod
-    def _get_blank_fields(cls):
-        return OrderedDict(((f, '') for f in cls._FIELDS))
+    def _get_blank_fields(cls, **kwargs):
+        return OrderedDict(((f, kwargs.get(f, '')) for f in cls._FIELDS))
 
     @property
     def is_implicit(self):
@@ -542,14 +542,16 @@ class URL(object):
                     " -- it failed matching regex. Dunno how to handle. Contact developers"
                     % (url,)
                 )
-            fields = self._get_blank_fields()  # reset them all
+            fields = self._get_blank_fields(scheme='ssh:implicit')  # reset them all
             fields.update({k: v for k, v in iteritems(ssh_re.groupdict()) if v})
-            fields['scheme'] = 'ssh:implicit'
             if fields['path'] and fields['path'].startswith('//'):
                 # Let's normalize for now to avoid multiple leading slashes
                 fields['path'] = '/' + fields['path'].lstrip('/')
             # escape path so we have direct representation of the path to work with
             fields['path'] = unescape_ssh_path(fields['path'])
+        elif fields['scheme'] == 'file:implicit':
+            fields = self._get_blank_fields(scheme='file:implicit')  # reset them all
+            fields['path'] = url
         elif not fields['scheme'].endswith(':implicit'):
             # So regular URL -- entries should have been quoted, we need to unquote
             # we need to unquote some.

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -372,7 +372,17 @@ class URL(object):
         for f in {'query', 'fragment'}:
             v = kwargs.get(f)
             if isinstance(v, dict):
-                kwargs[f] = urlencode(v)
+
+                ev = urlencode(v)
+                # / is reserved char within query
+                if f == 'fragment' and '%2F' not in str(v):
+                    # but seems to be ok'ish within the fragment which is
+                    # the last element of URI and anyways used only by the
+                    # client (i.e. by us here if used to compose the URL)
+                    # so let's return / back for clarity if there were no
+                    # awkward %2F to startwith
+                    ev = ev.replace('%2F', '/')
+                kwargs[f] = ev
 
         # set them to provided values
         for f in self._FIELDS:

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -347,7 +347,7 @@ class RI(object):
             # RI class was used as a factory
             cls = _guess_ri_cls(ri)
 
-        ri_obj = super(RI, cls).__new__(cls, ri=ri, **kwargs)
+        ri_obj = super(RI, cls).__new__(cls)
         # Store internally original str
         ri_obj._str = ri
         return ri_obj

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -302,7 +302,7 @@ class URL(object):
             self.__class__.__name__,
             ", ".join(["%s=%r" % (k, v) for k, v in sorted(fields.items()) if v]))
 
-
+    # Some custom __str__s for :implicit URLs
     def __str_ssh__(self):
         """Custom str for ssh:implicit"""
         url = urlunparse(self._to_pr())
@@ -344,8 +344,19 @@ class URL(object):
                                  % base_scheme)
             return __str__()
 
+    #
+    # If any field is specified, URL is not considered 'False', i.e.
+    # non-existing, although may be we could/shout omit having only
+    # scheme or port specified since it doesn't point to any useful
+    # location
+    #
+
     def __nonzero__(self):
         return any(getattr(self, f) for f in self._FIELDS)
+
+    #
+    # Helpers to deal with internal structures and conversions
+    #
 
     def _set_from_fields(self, **kwargs):
         unknown_fields = set(kwargs).difference(self._FIELDS)
@@ -455,6 +466,10 @@ class URL(object):
         if url != url_rec:
             lgr.warning("Parsed version of url %r differs from original %r",
                         url_rec, url)
+
+    #
+    # Quick comparators
+    #
 
     def __eq__(self, other):
         if not isinstance(other, URL):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -235,3 +235,17 @@ class SimpleURLStamper(object):
             return dict(mtime=r_stamp['mtime'], size=r_stamp['size'], url=url)
         finally:
             r.close()
+
+
+def parse_url_opts(url):
+    """Given a string with url-style query, split into content before # and options as dict"""
+    if '?' in url:
+        url_, attrs_str = url.split('?', 1)
+        opts = dict(x.split('=', 1) for x in attrs_str.split('&'))
+        if 'size' in opts:
+            opts['size'] = int(opts['size'])
+    else:
+        url_, opts = url, {}
+    return url_, opts
+
+

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -645,7 +645,7 @@ class DataLadURL(URLBase, RegexBasedURLMixin):
     )
 
     # For now or forever we don't deal with any fragments or other special stuff
-    _REGEX = re.compile(r'//(?P<remote>\S*?)?/(?P<path>.*)?$')
+    _REGEX = re.compile(r'//(?P<remote>[^\s/]*)/(?P<path>.*)$')
 
     # do they need to be normalized??? loosing track ...
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -211,9 +211,10 @@ def dlurljoin(u_path, url):
         # independent full url, so just return it
         return url
     if u_path.endswith('/'):  # should here be also a scheme use?
-        if url.startswith('/'): # jump to the root
+        if url.startswith('/'):  # jump to the root
             u_path_rec = urlparse(u_path)
-            return urljoin(urlunparse((u_path_rec.scheme, u_path_rec.netloc, '','','','')), url)
+            return urljoin(urlunparse(
+                (u_path_rec.scheme, u_path_rec.netloc, '', '', '', '')), url)
         else:
             return os.path.join(u_path, url)
     # TODO: recall where all this dirname came from and bring into the test
@@ -323,6 +324,15 @@ class URL(object):
     __slots__ = _FIELDS + ('_fields', '_str')
 
     def __init__(self, url=None, **kwargs):
+        """
+
+        Parameters
+        ----------
+        url: str
+          String representation of the url
+        **kwargs: dict
+          The values for the fields defined in _FIELDS class variable.
+        """
         if url and (bool(url) == bool(kwargs)):
             raise ValueError(
                 "Specify either url or breakdown from the fields, not both. "

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -113,6 +113,7 @@ def _check_url(url, **fields):
     """just a helper to carry out few checks on urls"""
     url_ = URL(**fields)
     eq_(URL(url), url_)
+    eq_(str(URL(url)), url)
     eq_(url, url_)  # just in case ;)  above should fail first if smth is wrong
     eq_(url, str(url_))  # that we can reconstruct it EXACTLY on our examples
     # and that we have access to all those fields
@@ -201,9 +202,19 @@ def test_url_samples():
                scheme="ssh:implicit", hostname="host", path="user/proj", username='git')
 
     _check_url('weired:/', scheme='ssh:implicit', hostname='weired', path='/')
-    # FAIL?!!!  since schema is not allowing some symbols so we need to add additional
-    # check
-    #_check_url('weired_url:/', scheme='ssh:implicit', hostname='weired_url', path='/')
+    # since schema is not allowing some symbols so we need to add additional check
+    _check_url('weired_url:/', scheme='ssh:implicit', hostname='weired_url', path='/')
+    _check_url('example.com:/', scheme='ssh:implicit', hostname='example.com', path='/')
+    _check_url('example.com:path/sp1', scheme='ssh:implicit', hostname='example.com', path='path/sp1')
+    _check_url('example.com/path/sp1\:fname',
+               scheme='file:implicit', path='example.com/path/sp1\:fname')
+    # ssh is as stupid as us, so we will stay "Consistently" dumb
+    """
+    $> ssh example.com/path/sp1:fname
+    ssh: Could not resolve hostname example.com/path/sp1:fname: Name or service not known
+    """
+    _check_url('example.com/path/sp1:fname',
+               scheme='ssh:implicit', hostname='example.com/path/sp1', path='fname')
 
     # check that we are getting a warning logged when url can't be reconstructed
     # precisely

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -23,7 +23,8 @@ from ..support.network import parse_url_opts
 from ..support.network import URL
 from ..support.network import _split_colon
 from ..support.network import is_url
-
+from ..support.network import get_local_file_url
+from ..support.network import get_local_path_from_url
 
 def test_same_website():
     ok_(same_website("http://a.b", "http://a.b/2014/01/xxx/"))
@@ -244,4 +245,23 @@ def test_is_url():
     nok_(is_url('like@sshlogin'))
     nok_(is_url(''))
     nok_(is_url(' '))
+
+
+def test_get_local_file_url_linux():
+    eq_(get_local_file_url('/a'), 'file:///a')
+    eq_(get_local_file_url('/a/b/c'), 'file:///a/b/c')
+    eq_(get_local_file_url('/a~'), 'file:///a%7E')
+    eq_(get_local_file_url('/a b/'), 'file:///a%20b/')
+
+
+def test_get_local_path_from_url():
+    assert_raises(ValueError, get_local_path_from_url, 'http://some')
+    assert_raises(ValueError, get_local_path_from_url, 'file://elsewhere/some')
+    # invalid URL -- is it?  just that 'hostname' is some and no path
+    assert_raises(ValueError, get_local_path_from_url, 'file://some')
+    eq_(get_local_path_from_url('file:///some'), '/some')
+    eq_(get_local_path_from_url('file://localhost/some'), '/some')
+    eq_(get_local_path_from_url('file://::1/some'), '/some')
+    eq_(get_local_path_from_url('file://127.3.4.155/some'), '/some')
+
 

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -13,6 +13,7 @@ from ..support.network import same_website, dlurljoin
 from ..support.network import get_tld
 from ..support.network import get_url_straight_filename
 from ..support.network import get_response_disposition_filename
+from ..support.network import parse_url_opts
 
 
 def test_same_website():
@@ -67,3 +68,19 @@ def test_rfc2822_to_epoch():
 def test_get_response_disposition_filename():
     eq_(get_response_disposition_filename('attachment;filename="Part1-Subjects1-99.tar"'), "Part1-Subjects1-99.tar")
     eq_(get_response_disposition_filename('attachment'), None)
+
+
+def test_parse_url_opts():
+    url = 'http://map.org/api/download/?id=157'
+    output = parse_url_opts(url)
+    eq_(output, ('http://map.org/api/download/', {'id': '157'}))
+
+    url = 's3://bucket/save/?key=891'
+    output = parse_url_opts(url)
+    eq_(output, ('s3://bucket/save/', {'key': '891'}))
+
+    url = 'http://map.org/api/download/?id=98&code=13'
+    output = parse_url_opts(url)
+    eq_(output, ('http://map.org/api/download/', {'id': '98', 'code': '13'}))
+
+

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -201,6 +201,10 @@ def test_url_samples():
                scheme="ssh:implicit", hostname="host", path="user/proj", username='git')
 
     _check_url('weired:/', scheme='ssh:implicit', hostname='weired', path='/')
+    # FAIL?!!!  since schema is not allowing some symbols so we need to add additional
+    # check
+    #_check_url('weired_url:/', scheme='ssh:implicit', hostname='weired_url', path='/')
+
     # check that we are getting a warning logged when url can't be reconstructed
     # precisely
     # actually failed to come up with one -- becomes late here
@@ -209,9 +213,14 @@ def test_url_samples():
     # actually this one is good enough to trigger a warning and I still don't know
     # what it should exactly be!?
     with swallow_logs(new_level=logging.WARNING) as cml:
-        repr(URL('weired://'))
+        weired_str = 'weired://'
+        weired_url = URL(weired_str)
+        repr(weired_url)
         assert_re_in('Parsed version of url .weired. differs from original .weired://.',
                      cml.out)
+        # but we store original str
+        eq_(str(weired_url), weired_str)
+        neq_(weired_url._as_str(), weired_str)
 
 
 def test_url_compose_archive_one():

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -9,6 +9,8 @@
 
 import logging
 
+from collections import OrderedDict
+
 from .utils import eq_, neq_, ok_, nok_, assert_raises
 from .utils import skip_if_on_windows
 from .utils import swallow_logs
@@ -199,7 +201,8 @@ def test_url():
 
 
 def test_url_compose_archive_one():
-    url = URL(scheme='dl+archive', path='KEY', fragment={'path': 'f/p/ s+', 'size': 30})
+    url = URL(scheme='dl+archive', path='KEY',
+              fragment=OrderedDict((('path', 'f/p/ s+'), ('size', 30))))
     # funny - space is encoded as + but + is %2B
     eq_(str(url), 'dl+archive:KEY#path=f/p/+s%2B&size=30')
     eq_(url.fragment_dict, {'path': 'f/p/ s+', 'size': '30'})
@@ -223,6 +226,7 @@ def test_url_fragments_and_query():
 
 def test_url_dicts():
     eq_(URL("http://host").query_dict, {})
+
 
 @skip_if_on_windows
 def test_get_url_path_on_fileurls():

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -198,8 +198,10 @@ def test_url():
 
 
 def test_url_compose_archive_one():
-    eq_(str(URL(scheme='dl+archive', path='KEY', fragment={'path': 'f/p', 'size': 30})),
-        'dl+archive:KEY#path=f%2Fp&size=30')
+    url = URL(scheme='dl+archive', path='KEY', fragment={'path': 'f/p/ s+', 'size': 30})
+    # funny - space is encoded as + but + is %2B
+    eq_(str(url), 'dl+archive:KEY#path=f/p/+s%2B&size=30')
+    eq_(url.fragment_dict, {'path': 'f/p/ s+', 'size': '30'})
 
 
 def test_url_fragments_and_query():
@@ -208,10 +210,10 @@ def test_url_fragments_and_query():
     eq_(url.query, 'a=x%2Fb&b=y')
     eq_(url.query_dict, {'a': 'x/b', 'b': 'y'})
 
-    url = URL(hostname="host", fragment={'a': 'x', 'b': 'y'})
-    eq_(str(url), '//host#a=x&b=y')
-    eq_(url.fragment, 'a=x&b=y')
-    eq_(url.fragment_dict, {'a': 'x', 'b': 'y'})
+    url = URL(hostname="host", fragment={'a': 'x/b', 'b': 'y'})
+    eq_(str(url), '//host#a=x/b&b=y')
+    eq_(url.fragment, 'a=x/b&b=y')
+    eq_(url.fragment_dict, {'a': 'x/b', 'b': 'y'})
 
     fname = get_most_obscure_supported_name()
     url = URL(hostname="host", fragment={'a': fname})

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -255,25 +255,27 @@ def test_url_samples():
 
 def _test_url_quote_path(scheme, target_url):
     path = '/ "\';a&b&cd `| '
-    url = URL(scheme=scheme, hostname="example.com", path=path)
+    hostname = 'example.com' if scheme not in ('file:implicit',) else ''
+    url = URL(scheme=scheme, hostname=hostname, path=path)
     eq_(url.path, path)
-    eq_(url.hostname, 'example.com')
+    eq_(url.hostname, hostname)
     # all nasty symbols should be quoted
     url_str = str(url)
     eq_(url_str, target_url)
     # no side-effects:
     eq_(url.path, path)
-    eq_(url.hostname, 'example.com')
+    eq_(url.hostname, hostname)
 
     # and unquoted
     url_ = URL(url_str)
     eq_(url_.path, path)
-    eq_(url.hostname, 'example.com')
+    eq_(url.hostname, hostname)
 
 
 def test_url_quote_path():
     yield _test_url_quote_path, "ssh:implicit", r'example.com:/\ \"' + r"\'\;a\&b\&cd\ \`\|\ "
     yield _test_url_quote_path, "http", 'http://example.com/%20%22%27%3Ba%26b%26cd%20%60%7C%20'
+    yield _test_url_quote_path, "file:implicit", r'/ "' + r"';a&b&cd `| "  # nothing is done to file:implicit
 
 
 def test_url_compose_archive_one():

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -136,7 +136,7 @@ def test_url_base():
     eq_(url.scheme, 'http')
     eq_(url.port, '')  # not specified -- empty strings
     eq_(url.username, '')  # not specified -- empty strings
-    nok_(url.is_implicit)
+    nok_(url.implicit)
     eq_(repr(url), "URL(hostname='example.com', scheme='http')")
     eq_(url, "http://example.com")  # automagic coercion in __eq__
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -55,9 +55,17 @@ from .utils import skip_if_no_module
 
 
 def test_parse_url_opts():
-    url = 'http://human.brain-map.org/api/v2/well_known_file_download/?id=157722290'
+    url = 'http://map.org/api/download/?id=157'
     output = parse_url_opts(url)
-    eq_(output, ('http://human.brain-map.org/api/v2/well_known_file_download/', {'id': '157722290'}))
+    eq_(output, ('http://map.org/api/download/', {'id': '157'}))
+
+    url = 's3://bucket/save/?key=891'
+    output = parse_url_opts(url)
+    eq_(output, ('s3://bucket/save/', {'key': '891'}))
+
+    url = 'http://map.org/api/download/?id=98&code=12'
+    output = parse_url_opts(url)
+    eq_(output, ('http://map.org/api/download/', {'id': '98', 'code': '12'}))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -23,10 +23,8 @@ from collections import OrderedDict
 
 from ..dochelpers import exc_str
 from ..utils import updated
-from ..utils import get_local_file_url
 from os.path import join as opj, abspath, exists
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
-from ..utils import get_local_path_from_url
 from ..utils import getpwd, chpwd
 from ..utils import auto_repr
 from ..utils import find_files
@@ -169,22 +167,6 @@ def test_updated():
     d_ = updated(d, {0: 1})
     ok_(isinstance(d_, OrderedDict))
     eq_(d_, OrderedDict(((99, 0), ('z', 0), ('a', 0), (0, 1))))
-
-def test_get_local_file_url_linux():
-    assert_equal(get_local_file_url('/a'), 'file:///a')
-    assert_equal(get_local_file_url('/a/b/c'), 'file:///a/b/c')
-    assert_equal(get_local_file_url('/a~'), 'file:///a%7E')
-    assert_equal(get_local_file_url('/a b/'), 'file:///a%20b/')
-
-def test_get_local_path_from_url():
-    assert_raises(ValueError, get_local_path_from_url, 'http://some')
-    assert_raises(ValueError, get_local_path_from_url, 'file://elsewhere/some')
-    # invalid URL -- is it?  just that 'hostname' is some and no path
-    assert_raises(ValueError, get_local_path_from_url, 'file://some')
-    assert_equal(get_local_path_from_url('file:///some'), '/some')
-    assert_equal(get_local_path_from_url('file://localhost/some'), '/some')
-    assert_equal(get_local_path_from_url('file://::1/some'), '/some')
-    assert_equal(get_local_path_from_url('file://127.3.4.155/some'), '/some')
 
 
 def test_get_local_file_url_windows():

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -63,9 +63,9 @@ def test_parse_url_opts():
     output = parse_url_opts(url)
     eq_(output, ('s3://bucket/save/', {'key': '891'}))
 
-    url = 'http://map.org/api/download/?id=98&code=12'
+    url = 'http://map.org/api/download/?id=98&code=13'
     output = parse_url_opts(url)
-    eq_(output, ('http://map.org/api/download/', {'id': '98', 'code': '12'}))
+    eq_(output, ('http://map.org/api/download/', {'id': '98', 'code': '13'}))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -26,13 +26,10 @@ from ..utils import updated
 from ..utils import get_local_file_url
 from os.path import join as opj, abspath, exists
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
-from ..utils import get_url_path
-from ..utils import is_url
 from ..utils import get_local_path_from_url
 from ..utils import getpwd, chpwd
 from ..utils import auto_repr
 from ..utils import find_files
-from ..utils import parse_url_opts
 from ..utils import line_profile
 from ..utils import not_supported_on_windows
 from ..utils import file_basename
@@ -179,28 +176,10 @@ def test_get_local_file_url_linux():
     assert_equal(get_local_file_url('/a~'), 'file:///a%7E')
     assert_equal(get_local_file_url('/a b/'), 'file:///a%20b/')
 
-@skip_if_on_windows
-def test_get_url_path_on_fileurls():
-    assert_equal(get_url_path('file:///a'), '/a')
-    assert_equal(get_url_path('file:///a/b'), '/a/b')
-    assert_equal(get_url_path('file:///a/b#id'), '/a/b')
-    assert_equal(get_url_path('file:///a/b?whatever'), '/a/b')
-
-def test_is_url():
-    assert_true(is_url('file://localhost/some'))
-    assert_true(is_url('http://localhost'))
-    assert_true(is_url('ssh://me@localhost'))
-    assert_true(is_url('weired://'))
-    assert_false(is_url('relative'))
-    assert_false(is_url('/absolute'))
-    assert_false(is_url('like@sshlogin'))
-    assert_false(is_url(''))
-
-
 def test_get_local_path_from_url():
     assert_raises(ValueError, get_local_path_from_url, 'http://some')
     assert_raises(ValueError, get_local_path_from_url, 'file://elsewhere/some')
-    # invalid URL
+    # invalid URL -- is it?  just that 'hostname' is some and no path
     assert_raises(ValueError, get_local_path_from_url, 'file://some')
     assert_equal(get_local_path_from_url('file:///some'), '/some')
     assert_equal(get_local_path_from_url('file://localhost/some'), '/some')

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -54,20 +54,6 @@ from .utils import ok_startswith
 from .utils import skip_if_no_module
 
 
-def test_parse_url_opts():
-    url = 'http://map.org/api/download/?id=157'
-    output = parse_url_opts(url)
-    eq_(output, ('http://map.org/api/download/', {'id': '157'}))
-
-    url = 's3://bucket/save/?key=891'
-    output = parse_url_opts(url)
-    eq_(output, ('s3://bucket/save/', {'key': '891'}))
-
-    url = 'http://map.org/api/download/?id=98&code=13'
-    output = parse_url_opts(url)
-    eq_(output, ('http://map.org/api/download/', {'id': '98', 'code': '13'}))
-
-
 @with_tempfile(mkdir=True)
 def test_rotree(d):
     d2 = opj(d, 'd1', 'd2')  # deep nested directory

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -32,6 +32,7 @@ from ..utils import get_local_path_from_url
 from ..utils import getpwd, chpwd
 from ..utils import auto_repr
 from ..utils import find_files
+from ..utils import parse_url_opts
 from ..utils import line_profile
 from ..utils import not_supported_on_windows
 from ..utils import file_basename
@@ -51,6 +52,12 @@ from .utils import assert_not_in
 from .utils import assert_raises
 from .utils import ok_startswith
 from .utils import skip_if_no_module
+
+
+def test_parse_url_opts():
+    url = 'http://human.brain-map.org/api/v2/well_known_file_download/?id=157722290'
+    output = parse_url_opts(url)
+    eq_(output, ('http://human.brain-map.org/api/v2/well_known_file_download/', {'id': '157722290'}))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -54,6 +54,9 @@ from . import _TEMP_PATHS_GENERATED
 _TEMP_PATHS_CLONES = set()
 
 
+# additional shortcuts
+neq_ = assert_not_equal
+
 def skip_if_no_module(module):
     try:
         imp = __import__(module)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -56,6 +56,7 @@ _TEMP_PATHS_CLONES = set()
 
 # additional shortcuts
 neq_ = assert_not_equal
+nok_ = assert_false
 
 def skip_if_no_module(module):
     try:

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -15,7 +15,7 @@ from os.path import dirname, join as opj, exists, pardir, realpath
 from ..support.gitrepo import GitRepo
 from ..support.annexrepo import AnnexRepo
 from ..cmd import Runner
-from ..utils import get_local_file_url
+from ..support.network import get_local_file_url
 from ..utils import swallow_outputs
 from ..utils import swallow_logs
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -100,6 +100,10 @@ def __auto_repr__(obj):
         if attr.startswith('_'):
             continue
         value = getattr(obj, attr)
+        # TODO:  should we add this feature to minimize some talktative reprs
+        # such as of URL?
+        #if value is None:
+        #    continue
         items.append("%s=%s" % (attr, shortened_repr(value)))
 
     return "%s(%s)" % (obj.__class__.__name__, ', '.join(items))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -173,43 +173,6 @@ def find_files(regex, topdir=curdir, exclude=None, exclude_vcs=True, dirs=False)
             yield path
 
 
-#### windows workaround ###
-# TODO: There should be a better way
-def get_local_file_url(fname):
-    """Return OS specific URL pointing to a local file
-
-    Parameters
-    ----------
-    fname : string
-        Full filename
-    """
-    if on_windows:
-        fname_rep = fname.replace('\\', '/')
-        furl = "file:///%s" % urlquote(fname_rep)
-        lgr.debug("Replaced '\\' in file\'s url: %s" % furl)
-    else:
-        furl = "file://%s" % urlquote(fname)
-    return furl
-
-
-def get_local_path_from_url(url):
-    """If given a file:// URL, returns a local path, if possible.
-
-    Raises `ValueError` if not possible, for example, if the URL
-    scheme is different, or if the `host` isn't empty or 'localhost'
-
-    The returned path is always absolute.
-    """
-    urlparts = urlsplit(url)
-    if not urlparts.scheme == 'file':
-        raise ValueError(
-            "Non 'file://' URL cannot be resolved to a local path")
-    if not (urlparts.netloc in ('', 'localhost', '::1') \
-            or urlparts.netloc.startswith('127.')):
-        raise ValueError("file:// URL does not point to 'localhost'")
-    return urlunquote(urlparts.path)
-
-
 def expandpath(path, force_absolute=True):
     """Expand all variables and user handles in a path.
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -189,12 +189,6 @@ def get_local_file_url(fname):
     return furl
 
 
-def get_url_path(url):
-    """Given a url, return the path component"""
-
-    return urlunquote(urlsplit(url).path)
-
-
 def get_local_path_from_url(url):
     """If given a file:// URL, returns a local path, if possible.
 
@@ -211,14 +205,6 @@ def get_local_path_from_url(url):
             or urlparts.netloc.startswith('127.')):
         raise ValueError("file:// URL does not point to 'localhost'")
     return urlunquote(urlparts.path)
-
-
-def is_url(s):
-    """Returns whether a string looks like a URL.
-
-    Test implementation uses the presence of a URL scheme as criterion.
-    """
-    return bool(urlsplit(s).scheme)
 
 
 def expandpath(path, force_absolute=True):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -211,8 +211,8 @@ def get_local_path_from_url(url):
 
 def parse_url_opts(url):
     """Given a string with url-style options, split into content before # and options as dict"""
-    if '#' in url:
-        url_, attrs_str = url.split('#', 1)
+    if '?' in url:
+        url_, attrs_str = url.split('?', 1)
         opts = dict(x.split('=', 1) for x in attrs_str.split('&'))
         if 'size' in opts:
             opts['size'] = int(opts['size'])

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -209,18 +209,6 @@ def get_local_path_from_url(url):
     return urlunquote(urlparts.path)
 
 
-def parse_url_opts(url):
-    """Given a string with url-style options, split into content before # and options as dict"""
-    if '?' in url:
-        url_, attrs_str = url.split('?', 1)
-        opts = dict(x.split('=', 1) for x in attrs_str.split('&'))
-        if 'size' in opts:
-            opts['size'] = int(opts['size'])
-    else:
-        url_, opts = url, {}
-    return url_, opts
-
-
 def is_url(s):
     """Returns whether a string looks like a URL.
 


### PR DESCRIPTION
Whatever I thought would be a quick thing, ended up a monster which needs RFing, but I wanted first to run by you the idea.of having a URL class, which would expose pretty much all attributes which named tuple ParseResults return, but which

- supports ssh "urls", or possibly other "implicit"ly defined schemes (e.g. host:: for rsync?)
- supports our ad-hoc perspective '//[remote]/[dataset]' urls

`is_url` now should report ssh urls as urls as well

please look at `test_url` functions either you would agree with such behavior... or may be ':implicit' suffix should just migrate into 'implicit' attribute of URL?

Aims to close #440, #493, #441 

TODO:

- [x] address #440 -- should be just defer to `str(URL(scheme='file', path=abspath(path)))`
- [x] address #441 while providing compatibility so we could still work with already generated datasets with archives