### PR TITLE
ENH: use short_description for constraints repr

### DIFF
--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -41,6 +41,10 @@ class Constraint(object):
 
     # TODO: __str__ and/or __repr__ for every one of them
 
+    def __repr__(self):
+        """Rudimentary repr to avoid default scary to the user Python repr"""
+        return "constraint:%s" % self.short_description()
+
     def __and__(self, other):
         return Constraints(self, other)
 

--- a/datalad/tests/test_interface.py
+++ b/datalad/tests/test_interface.py
@@ -88,7 +88,7 @@ def test_interface():
     with swallow_outputs() as cmo:
         assert_raises(SystemExit, parser.parse_args, ['--demoarg', 'abc'])
         # that is what we dump upon folks atm. TODO: improve reporting of illspecified options
-        assert_re_in(".*invalid <datalad.support.constraints.EnsureInt object at .*> value:.*",
+        assert_re_in(".*invalid constraint:int value:.*",
                      cmo.err, re.DOTALL)
 
     # missing argument to option


### PR DESCRIPTION
Should make error messages by argparse for misspecified arguments
a bit more user-friendly and informative.

Relates to #445 discussion on --recursive