### PR TITLE
BF: do not cd under docs while running doctests etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,10 +72,8 @@ script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Verify that we can render manpages
   - make manpages
-  # Generate documentation
-  - cd docs; PYTHONPATH=$PWD/.. make html
-  # Run the doctests in the documentation
-  - PYTHONPATH=$PWD/.. make doctest
+  # Generate documentation and run doctests
+  - PYTHONPATH=$PWD/.. make -C docs html doctest
 
 after_success:
   - coveralls


### PR DESCRIPTION
That prevent coverage report tools to report back since they ended up
running from under docs/

@bpoldrack so it was my bad