### PR TITLE
BF: annex from subdir

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -23,12 +23,13 @@ import functools
 
 from six import PY3, PY2
 from six import string_types, binary_type
+from os.path import abspath, isabs
 
 from .dochelpers import exc_str
 from .support.exceptions import CommandError
 from .support.protocol import NullProtocol, DryRunProtocol, \
     ExecutionTimeProtocol, ExecutionTimeExternalsProtocol
-from .utils import on_windows, chpwd
+from .utils import on_windows
 from . import cfg
 
 lgr = logging.getLogger('datalad.cmd')
@@ -355,108 +356,32 @@ class Runner(object):
 
 class GitRunner(Runner):
     """
-    Overloads the runner class to check update GIT_DIR and GIT_WORK_TREE environment variables set to the correct path
+    Runner to be used to run git and git annex commands
+
+    Overloads the runner class to check & update GIT_DIR and
+    GIT_WORK_TREE environment variables set to the absolute path
+    if is defined and is relative path
     """
 
-    def run(self, cmd, log_stdout=True, log_stderr=True, log_online=False,
-            expect_stderr=False, expect_fail=False,
-            cwd=None, env=None, shell=None):
+    @staticmethod
+    def get_git_environ_adjusted(env=None):
+        """
+        Replaces GIT_DIR and GIT_WORK_TREE with absolute paths if relative path and defined
+        """
+        git_env = env.copy() if env else os.environ.copy()         # if env set copy else get os environment
 
-        # assert_true(cwd, None)
-        # assert_false(self.cwd, None)
-        env = {"GIT_DIR": self.cwd+"/.git", "GIT_WORK_TREE": self.cwd+"/"}  # set environment variables, rm chdir error
+        for varstring in ['GIT_DIR', 'GIT_WORK_TREE']:
+            var = git_env.get(varstring)
+            if var:                                                # if env variable set
+                if not isabs(var):                                 # and it's a relative path
+                    git_env[varstring] = abspath(var)              # convert it to absolute path
+                    lgr.debug("Updated %s to %s" % (varstring, git_env[varstring]))
 
-        cwd = os.getcwd()   # store current working directory
-        # lgr.error("INFO: set environment to %s based on git_root @ %s, cwd @ %s" % (env, self.cwd, os.getcwd()))
+        return git_env
 
-        # chpwd(self.cwd)     # move to git-root
-        # lgr.error("INFO: moved to git_root @ %s" % (os.getcwd()))
-
-        outputstream = subprocess.PIPE if log_stdout else sys.stdout
-        errstream = subprocess.PIPE if log_stderr else sys.stderr
-
-        self.log("Running: %s" % (cmd,))
-
-        if self.protocol.do_execute_ext_commands:
-
-            if shell is None:
-                shell = isinstance(cmd, string_types)
-
-            if self.protocol.records_ext_commands:
-                prot_exc = None
-                prot_id = self.protocol.start_section(
-                    shlex.split(cmd, posix=not on_windows)
-                    if isinstance(cmd, string_types)
-                    else cmd)
-
-            try:
-                proc = subprocess.Popen(cmd, stdout=outputstream,
-                                        stderr=errstream,
-                                        shell=shell,
-                                        cwd=cwd or self.cwd,
-                                        env=env or self.env)
-
-            except Exception as e:
-                prot_exc = e
-                lgr.error("Failed to start %r%r: %s" %
-                          (cmd, " under %r" % cwd if cwd else '', exc_str(e)))
-                raise
-
-            finally:
-                if self.protocol.records_ext_commands:
-                    self.protocol.end_section(prot_id, prot_exc)
-
-                # move back to current working directory
-                if os.path.isdir(cwd):
-                    chpwd(cwd)
-
-            if log_online:
-                out = self._get_output_online(proc, log_stdout, log_stderr,
-                                              expect_stderr=expect_stderr,
-                                              expect_fail=expect_fail)
-            else:
-                out = proc.communicate()
-
-            if PY3:
-                # Decoding was delayed to this point
-                def decode_if_not_None(x):
-                    return "" if x is None else binary_type.decode(x)
-                # TODO: check if we can avoid PY3 specific here
-                out = tuple(map(decode_if_not_None, out))
-
-            status = proc.poll()
-
-            # needs to be done after we know status
-            if not log_online:
-                self._log_out(out[0])
-                if status not in [0, None]:
-                    self._log_err(out[1], expected=expect_fail)
-                else:
-                    # as directed
-                    self._log_err(out[1], expected=expect_stderr)
-
-            if status not in [0, None]:
-                msg = "Failed to run %r%s. Exit code=%d. out=%s err=%s" \
-                    % (cmd, " under %r" % (cwd or self.cwd), status, out[0], out[1])
-                (lgr.debug if expect_fail else lgr.error)(msg)
-                raise CommandError(str(cmd), msg, status, out[0], out[1])
-            else:
-                self.log("Finished running %r with status %s" % (cmd, status),
-                         level=8)
-
-        else:
-            if self.protocol.records_ext_commands:
-                self.protocol.add_section(shlex.split(cmd,
-                                                      posix=not on_windows)
-                                          if isinstance(cmd, string_types)
-                                          else cmd, None)
-            out = ("DRY", "DRY")
-
-        # move back to current working directory
-        if os.path.isdir(cwd):
-            chpwd(cwd)
-
-        return out
+    def run(self, cmd, env=None, *args, **kwargs):
+        return super(GitRunner, self).run(
+            cmd, env=self.get_git_environ_adjusted(), *args, **kwargs)
 
 # ####
 # Preserve from previous version

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -187,9 +187,9 @@ class AnnexCustomRemote(object):
         # TODO: probably we shouldn't have runner here but rather delegate
         # to AnnexRepo's functionality
         from ..support.annexrepo import AnnexRepo
-        from ..cmd import Runner
-        
-        self.runner = Runner()
+        from ..cmd import GitRunner
+
+        self.runner = GitRunner()
 
         # Custom remotes correspond to annex via stdin/stdout
         self.fin = sys.stdin

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -12,6 +12,7 @@ from ..archives import ArchiveAnnexCustomRemote
 from ...support.annexrepo import AnnexRepo
 from ...consts import ARCHIVES_SPECIAL_REMOTE
 from ...tests.utils import *
+from ...cmd import Runner
 
 from . import _get_custom_runner
 
@@ -28,7 +29,7 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 # TODO: with_tree ATM for archives creates this nested top directory
 # matching archive name, so it will be a/d/test.dat ... we don't want that probably
 @with_tree(
-    tree=(('a.tar.gz', (('d', ((fn_inarchive_obscure, '123'),)),)),
+    tree=(('a.tar.gz', {'d': {fn_inarchive_obscure: '123'}}),
           ('simple.txt', '123'),
           (fn_archive_obscure, (('d', ((fn_inarchive_obscure, '123'),)),)),
           (fn_extracted_obscure, '123')))
@@ -96,6 +97,19 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     # verify that we can drop if original archive gets dropped but available online:
     #  -- done as part of the test_add_archive_content.py
     # verify that we can't drop a file if archive key was dropped and online archive was removed or changed size! ;)
+
+
+@with_tree(
+    tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
+)
+def test_annex_get_from_subdir(topdir):
+    from datalad.api import add_archive_content
+    annex = AnnexRepo(topdir, init=True)
+    annex.add('a.tar.gz', commit=True)
+    add_archive_content('a.tar.gz', annex=annex, delete=True)
+    with chpwd(opj(topdir, 'a', 'd')):
+        runner = Runner()
+        runner(['git', 'annex', 'drop', fn_inarchive_obscure])
 
 
 def test_basic_scenario():

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -113,6 +113,23 @@ def test_annex_get_from_subdir(topdir):
         runner(['git', 'annex', 'drop', fn_inarchive_obscure])
 
 
+def test_get_git_environ_adjusted():
+    gitrunner = GitRunner()
+    env = {"GIT_DIR": "../../.git", "GIT_WORK_TREE": "../../", "TEST_VAR": "Exists"}
+
+    # test conversion of relevant env vars from relative_path to correct absolute_path
+    adj_env = gitrunner.get_git_environ_adjusted(env)
+    assert_equal(adj_env["GIT_DIR"], abspath(env["GIT_DIR"]))
+    assert_equal(adj_env["GIT_WORK_TREE"], abspath(env["GIT_WORK_TREE"]))
+
+    # test if other environment variables passed to function returned unaltered
+    assert_equal(adj_env["TEST_VAR"], env["TEST_VAR"])
+
+    # test import of sys_env if no environment passed to function
+    sys_env = gitrunner.get_git_environ_adjusted()
+    assert_equal(sys_env["PWD"], os.environ.get("PWD"))
+
+
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
     if not on_windows:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -12,7 +12,7 @@ from ..archives import ArchiveAnnexCustomRemote
 from ...support.annexrepo import AnnexRepo
 from ...consts import ARCHIVES_SPECIAL_REMOTE
 from ...tests.utils import *
-from ...cmd import Runner
+from ...cmd import Runner, GitRunner
 
 from . import _get_custom_runner
 
@@ -107,9 +107,14 @@ def test_annex_get_from_subdir(topdir):
     annex = AnnexRepo(topdir, init=True)
     annex.add('a.tar.gz', commit=True)
     add_archive_content('a.tar.gz', annex=annex, delete=True)
+
     with chpwd(opj(topdir, 'a', 'd')):
-        runner = Runner()
-        runner(['git', 'annex', 'drop', fn_inarchive_obscure])
+        runner = GitRunner(cwd=topdir)               # pass git-root to GitRunner
+        assert_true(os.path.exists(topdir+"/.git"))  # does .git exist in top-directory/git-root
+        assert_true(os.path.exists(fn_inarchive_obscure))    # does data.txt exist in current directory
+        # import pdb; pdb.set_trace()
+        runner(['git', 'annex', 'drop', fn_inarchive_obscure])  # run git annex drop through git runner
+        # git annex contentlocation
 
 
 def test_basic_scenario():

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -107,10 +107,14 @@ def test_annex_get_from_subdir(topdir):
     annex = AnnexRepo(topdir, init=True)
     annex.add('a.tar.gz', commit=True)
     add_archive_content('a.tar.gz', annex=annex, delete=True)
+    fpath = opj(topdir, 'a', 'd', fn_inarchive_obscure)
 
     with chpwd(opj(topdir, 'a', 'd')):
         runner = Runner()
-        runner(['git', 'annex', 'drop', fn_inarchive_obscure])
+        runner(['git', 'annex', 'drop', fn_inarchive_obscure])  # run git annex drop
+        assert_false(annex.file_has_content(fpath))             # and verify if file deleted from directory
+        runner(['git', 'annex', 'get', fn_inarchive_obscure])   # run git annex get
+        assert_true(annex.file_has_content(fpath))              # and verify if file got into directory
 
 
 def test_get_git_environ_adjusted():

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -109,12 +109,8 @@ def test_annex_get_from_subdir(topdir):
     add_archive_content('a.tar.gz', annex=annex, delete=True)
 
     with chpwd(opj(topdir, 'a', 'd')):
-        runner = GitRunner(cwd=topdir)               # pass git-root to GitRunner
-        assert_true(os.path.exists(topdir+"/.git"))  # does .git exist in top-directory/git-root
-        assert_true(os.path.exists(fn_inarchive_obscure))    # does data.txt exist in current directory
-        # import pdb; pdb.set_trace()
-        runner(['git', 'annex', 'drop', fn_inarchive_obscure])  # run git annex drop through git runner
-        # git annex contentlocation
+        runner = Runner()
+        runner(['git', 'annex', 'drop', fn_inarchive_obscure])
 
 
 def test_basic_scenario():

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1055,10 +1055,11 @@ class AnnexRepo(GitRepo):
         cmd = shlex.split(cmd_str + " " + " ".join(files), posix=not on_windows) \
             if isinstance(cmd_str, string_types) \
             else cmd_str + files
-        return self.cmd_call_wrapper.run(cmd, log_stderr=log_stderr,
-                                  log_stdout=log_stdout, log_online=log_online,
-                                  expect_stderr=expect_stderr, cwd=cwd,
-                                  env=env, shell=shell, expect_fail=expect_fail)
+        return self.cmd_call_wrapper.run(
+            cmd,
+            log_stderr=log_stderr, log_stdout=log_stdout, log_online=log_online,
+            expect_stderr=expect_stderr,
+            cwd=cwd, env=env, shell=shell, expect_fail=expect_fail)
 
     @normalize_paths
     def migrate_backend(self, files, backend=None):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -34,6 +34,7 @@ from datalad import ssh_manager
 from datalad.dochelpers import exc_str
 from datalad.utils import auto_repr
 from datalad.utils import on_windows
+from datalad.cmd import GitRunner
 
 # imports from same module:
 from .gitrepo import GitRepo
@@ -1212,6 +1213,7 @@ class BatchedAnnex(object):
         # kwargs = dict(bufsize=1, universal_newlines=True) if PY3 else {}
         self._process = Popen(cmd, stdin=PIPE, stdout=PIPE
                               # , stderr=PIPE
+                              , env=GitRunner.get_git_environ_adjusted()
                               , cwd=self.path
                               , bufsize=1
                               , universal_newlines=True #**kwargs

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -38,7 +38,7 @@ from git.exc import InvalidGitRepositoryError
 from git.objects.blob import Blob
 
 from datalad import ssh_manager
-from datalad.cmd import Runner
+from datalad.cmd import Runner, GitRunner
 from datalad.utils import optional_args
 from datalad.utils import on_windows
 from datalad.utils import getpwd
@@ -342,7 +342,7 @@ class GitRepo(object):
         """
 
         self.path = abspath(normpath(path))
-        self.cmd_call_wrapper = runner or Runner(cwd=self.path)
+        self.cmd_call_wrapper = runner or GitRunner(cwd=self.path)
         # TODO: Concept of when to set to "dry".
         #       Includes: What to do in gitrepo class?
         #       Now: setting "dry" means to give a dry-runner to constructor.


### PR DESCRIPTION
Created a GitRunner subclass that inherits from Runner class in datalad/cmd.py. sets the required environment variables to point to git_root before running git annex based commands.

The chdir error seems to be gone after setting environment variable GIT_WORK_TREE and GIT_DIR. 

Still can't git annex drop from subdirectory.
git annex drop doesn't let you remove as it can't find other instances of the file to be dropped.