### PR TITLE
BF: skip the tests which rely on newer scrapy so we build on 14.04

### DIFF
--- a/datalad/crawler/nodes/matches.py
+++ b/datalad/crawler/nodes/matches.py
@@ -15,14 +15,19 @@ import types
 
 from six import PY3
 
-from scrapy.selector import Selector
-from scrapy.http import Response
-
 from ...utils import updated
 from ...support.network import dlurljoin
 
 from logging import getLogger
 lgr = getLogger('datalad.crawler')
+
+from scrapy.http import Response
+try:
+    from scrapy.selector import Selector
+except ImportError:
+    lgr.debug("Failed to import Selector from scrapy, so matches would not be functional")
+    class Selector(object):
+        xpath = css = None
 
 
 # for now heavily based on scrapy but we might make the backend

--- a/datalad/crawler/nodes/tests/test_crawl_url.py
+++ b/datalad/crawler/nodes/tests/test_crawl_url.py
@@ -12,6 +12,10 @@ from glob import glob
 from os.path import exists, join as opj
 from datalad.tests.utils import eq_, ok_
 from datalad.tests.utils import serve_path_via_http, with_tree
+
+from datalad.tests.utils import skip_if_scrapy_without_selector
+skip_if_scrapy_without_selector()
+
 from ..crawl_url import crawl_url
 from ..crawl_url import parse_checksums
 from ..matches import a_href_match

--- a/datalad/crawler/nodes/tests/test_matches.py
+++ b/datalad/crawler/nodes/tests/test_matches.py
@@ -9,8 +9,10 @@
 
 import inspect
 from nose import SkipTest
-from ..matches import *
 from datalad.tests.utils import ok_, eq_, assert_raises
+from datalad.tests.utils import skip_if_scrapy_without_selector
+skip_if_scrapy_without_selector()
+from ..matches import *
 
 try:
     import scrapy

--- a/datalad/crawler/pipelines/tests/__init__.py
+++ b/datalad/crawler/pipelines/tests/__init__.py
@@ -1,2 +1,5 @@
 from datalad.tests.utils import skip_if_no_module
 skip_if_no_module('scrapy')
+
+from datalad.tests.utils import skip_if_scrapy_without_selector
+skip_if_scrapy_without_selector()

--- a/datalad/crawler/tests/__init__.py
+++ b/datalad/crawler/tests/__init__.py
@@ -9,3 +9,5 @@
 
 from datalad.tests.utils import skip_if_no_module
 skip_if_no_module('scrapy')
+from datalad.tests.utils import skip_if_scrapy_without_selector
+skip_if_scrapy_without_selector()

--- a/datalad/crawler/tests/test_pipeline.py
+++ b/datalad/crawler/tests/test_pipeline.py
@@ -9,6 +9,9 @@
 
 from os.path import join as opj
 
+from datalad.tests.utils import skip_if_scrapy_without_selector
+skip_if_scrapy_without_selector()
+
 from ..nodes.crawl_url import crawl_url
 from ..nodes.matches import *
 from ..pipeline import run_pipeline, FinishPipeline

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -66,6 +66,18 @@ def skip_if_no_module(module):
         raise SkipTest("Module %s fails to load: %s" % (module, exc_str(exc)))
 
 
+def skip_if_scrapy_without_selector():
+    """A little helper to skip some tests which require recent scrapy"""
+    try:
+        import scrapy
+        from scrapy.selector import Selector
+    except ImportError:
+        from nose import SkipTest
+        raise SkipTest(
+            "scrapy misses Selector (too old? version: %s)"
+            % getattr(scrapy, '__version__'))
+
+
 def create_tree_archive(path, name, load, overwrite=False, archives_leading_dir=True):
     """Given an archive `name`, create under `path` with specified `load` tree
     """


### PR DESCRIPTION
So we could still build packages on 14.04 although the scraping wouldn't really be functional since available "installable" scrapy is too old

Should help to address #533 