### PR TITLE
Apparently master is broken due to some docs failures -- fixing up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   - DATALAD_LOGLEVEL=INFO $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --with-cov --cover-package datalad --logging-level=INFO
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests
-  - PYTHONPATH=$PWD/.. make -C docs html doctest
+  - PYTHONPATH=$PWD make -C docs html doctest
 
 after_success:
   - coveralls

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -186,6 +186,7 @@ def get_repo_instance(path=curdir, class_=None):
     Check whether a certain path is inside a known type of repository and
     returns an instance representing it. May also check for a certain type
     instead of detecting the type of repository.
+
     Parameters
     ----------
     path: str
@@ -193,6 +194,7 @@ def get_repo_instance(path=curdir, class_=None):
     class_: class
       if given, check whether path is inside a repository, that can be
       represented as an instance of the passed class.
+
     Raises
     ------
     RuntimeError, in case cwd is not inside a known repository.

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -65,7 +65,18 @@ def extract_readme(data):
 
 
 def pipeline(dataset, versioned_urls=True, topurl=TOPURL):
-    """Pipeline to crawl/annex an openfmri dataset"""
+    """Pipeline to crawl/annex an openfmri dataset
+
+    Parameters
+    ----------
+    dataset: str
+      Id of the OpenfMRI dataset (e.g. ds000001)
+    versioned_urls: bool, optional
+      Request versioned URLs.  OpenfMRI bucket is versioned, but if
+      original data resides elsewhere, set to False
+    topurl: str, optional
+      Top level URL to the datasets.
+    """
 
     dataset_url = '%s%s' % (topurl, dataset)
     lgr.info("Creating a pipeline for the openfmri dataset %s" % dataset)


### PR DESCRIPTION
Locally for me fails anyways with

```
Warning, treated as error:
/home/yoh/proj/datalad/datalad/docs/source/usecases/index.rst:5: WARNING: toctree contains reference to nonexisting document u'generated/examples/3rdparty_analysis_workflow'
```
but I am not sure yet who/when should've generated those