### PR TITLE
RF: by default do not delete original archives durin Annexificator.add_archive_content

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -979,7 +979,7 @@ class Annexificator(object):
             # TODO: may be adjust annex_options
             annex = add_archive_content(
                 archive, annex=self.repo,
-                delete=True, key=False, commit=commit, allow_dirty=True,
+                key=False, commit=commit, allow_dirty=True,
                 annex_options=self.options,
                 stats=stats,
                 **aac_kwargs

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -187,6 +187,7 @@ def _test_add_archive_content_tar(direct, repo_path):
     output_addarchive = list(
         annex.add_archive_content(
             existing='archive-suffix',
+            delete=True,
             strip_leading_dirs=True,)(output_add[0]))
     assert_equal(output_addarchive,
                  [{'datalad_stats': ActivityStats(add_annex=1, add_git=1, files=3, renamed=2),
@@ -204,6 +205,7 @@ def _test_add_archive_content_tar(direct, repo_path):
 def test_add_archive_content_tar():
     for direct in (True, False):
         yield _test_add_archive_content_tar, direct
+
 
 @assert_cwd_unchanged()
 @with_tempfile(mkdir=True)

--- a/datalad/crawler/pipelines/crcns.py
+++ b/datalad/crawler/pipelines/crcns.py
@@ -117,6 +117,7 @@ def pipeline(dataset, dataset_category, versioned_urls=False):
                     existing='archive-suffix',
                     # Since inconsistent and seems in many cases no leading dirs to strip, keep them as provided
                     strip_leading_dirs=True,
+                    delete=True,
                     leading_dirs_consider=['crcns.*', dataset],
                     leading_dirs_depth=2,
                     exclude='.*__MACOSX.*',  # some junk penetrates

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -150,6 +150,7 @@ def pipeline(dataset, versioned_urls=True, topurl=TOPURL):
                     existing='archive-suffix',
                     strip_leading_dirs=True,
                     leading_dirs_depth=1,
+                    delete=True,
                     exclude=['(^|%s)\._' % os.path.sep],  # some files like '._whatever'
                     # overwrite=True,
                     # TODO: we might need a safeguard for cases when multiple subdirectories within a single tarball


### PR DESCRIPTION
Minor RF which I will merge if tests pass

To stay uniform with default behavior of add_archive_content itself