### PR TITLE
ENH: uninstall

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -164,7 +164,7 @@ class Dataset(object):
 
         repo = self.repo
         if repo is None:
-            return
+            return []
 
         # check whether we have anything in the repo. if not go home early
         if not repo.repo.head.is_valid():

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -169,7 +169,7 @@ def test_subdatasets(path):
     # from scratch
     ds = Dataset(path)
     assert_false(ds.is_installed())
-    eq_(ds.get_subdatasets(), None)
+    eq_(ds.get_subdatasets(), [])
     ds = ds.create()
     assert_true(ds.is_installed())
     eq_(ds.get_subdatasets(), [])

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -1,0 +1,32 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test uninstall action
+
+"""
+
+from datalad.tests.utils import SkipTest
+
+
+def test_uninstall_annex_file():
+    raise SkipTest("TODO")
+
+
+def test_uninstall_git_file():
+    raise SkipTest("TODO")
+
+
+def test_uninstall_dataset():
+    raise SkipTest("TODO")
+
+
+def test_uninstall_subdataset():
+    raise SkipTest("TODO")
+
+
+def test_uninstall_invalid():
+    raise SkipTest("TODO")

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,15 +9,78 @@
 
 """
 
+from os.path import join as opj
+from os.path import exists
+
+from datalad.api import uninstall
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.tests.utils import ok_
+from datalad.tests.utils import eq_
+from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import SkipTest
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import ok_file_under_git
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import assert_in
+
+from ..dataset import Dataset
 
 
-def test_uninstall_annex_file():
-    raise SkipTest("TODO")
+@with_testrepos('.*basic.*', flavors=['local'])
+def test_uninstall_invalid(path):
+
+    assert_raises(InsufficientArgumentsError, uninstall)
+
+    res = uninstall(dataset=Dataset(path), path='not_existent')
+    ok_(res is None)
+
+    with assert_raises(ValueError) as cme:
+        uninstall(dataset=Dataset(path))
+        eq_("No dataset found to uninstall %s from." % path, str(cme))
 
 
-def test_uninstall_git_file():
-    raise SkipTest("TODO")
+@with_testrepos('basic_annex', flavors=['clone'])
+def test_uninstall_annex_file(path):
+    ds = Dataset(path)
+    ok_(ds.is_installed())
+    ok_file_under_git(path, 'test-annex.dat', annexed=True)
+    ds.repo.get('test-annex.dat')
+    ok_(ds.repo.file_has_content('test-annex.dat'))
+
+    # remove file's content:
+    res = ds.uninstall(path='test-annex.dat', data_only=True)
+    # test it happened:
+    ok_(not ds.repo.file_has_content('test-annex.dat'))
+    ok_file_under_git(path, 'test-annex.dat', annexed=True)
+    # test result:
+    eq_(res, ['test-annex.dat'])
+
+    ds.repo.get('test-annex.dat')
+
+    # remove file:
+    ds.uninstall(path='test-annex.dat')
+    assert_raises(AssertionError, ok_file_under_git, path, 'test-annex.dat',
+                  annexed=True)
+    assert_raises(AssertionError, ok_file_under_git, path, 'test-annex.dat',
+                  annexed=False)
+    ok_(not exists(opj(path, 'test-annex.dat')))
+
+
+@with_testrepos('.*basic.*', flavors=['clone'])
+def test_uninstall_git_file(path):
+    ds = Dataset(path)
+    ok_(ds.is_installed())
+    ok_(exists(opj(path, 'INFO.txt')))
+    ok_file_under_git(path, 'INFO.txt')
+
+    # uninstalling data only doesn't make sense:
+    assert_raises(ValueError, ds.uninstall, path='INFO.txt', data_only=True)
+
+    # uninstall removes the file:
+    res = ds.uninstall(path='INFO.txt')
+    assert_raises(AssertionError, ok_file_under_git, path, 'INFO.txt')
+    ok_(not exists(opj(path, 'INFO.txt')))
+    eq_(res, ['INFO.txt'])
 
 
 def test_uninstall_dataset():
@@ -28,5 +91,6 @@ def test_uninstall_subdataset():
     raise SkipTest("TODO")
 
 
-def test_uninstall_invalid():
+def test_uninstall_recursive():
     raise SkipTest("TODO")
+

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -167,10 +167,15 @@ class Uninstall(Interface):
             return
 
         if relativepath in ds.get_subdatasets(recursive=True):
-            # it's a submodule
-            # --recursive required or implied?
-            raise NotImplementedError("TODO: uninstall submodule %s from "
-                                      "dataset %s" % (relativepath, ds.path))
+            # TODO: recursive?
+            #       => deinit has no recursive option itself.
+
+            if data_only:
+                # git submodule deinit
+                raise NotImplementedError("TODO: git submodule deinit %s" % relativepath)
+            else:
+                # git rm
+                raise NotImplementedError("TODO git rm %s" % relativepath)
 
         if isdir(path):
             if data_only:

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -196,7 +196,7 @@ class Uninstall(Interface):
                 # TODO: Do we want to just rm -rf instead of raising?
                 #       Or do it with --force or sth?
                 raise ValueError("No dataset found to uninstall %s from." %
-                                 path)
+                                 ds.path)
             return Uninstall.__call__(dataset=Dataset(dspath),
                                       path=relpath(ds.path, start=dspath),
                                       data_only=data_only,
@@ -350,7 +350,8 @@ class Uninstall(Interface):
                 raise ValueError("%s is not a file handle. Removing its "
                                  "data only doesn't make sense." % path)
             else:
-                return ds.repo.remove([relativepath])
+                ds.repo.remove([relativepath])
+                return [relativepath]
 
         elif _untracked_or_within_submodule:
             subds = get_containing_subdataset(ds, relativepath)

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -13,6 +13,8 @@
 __docformat__ = 'restructuredtext'
 
 import logging
+import glob
+
 from os.path import join as opj, abspath, exists, isabs, relpath, pardir, isdir
 from os.path import islink
 from datalad.support.gitrepo import GitRepo
@@ -231,7 +233,7 @@ class Uninstall(Interface):
             if data_only or not fast:
                 # uninstall data of subds
                 if isinstance(subds.repo, AnnexRepo):
-                    results.extend(ds.repo.drop(relativepath))
+                    results.extend(subds.repo.drop(glob.glob1(subds.path, '*')))
                     if data_only and not recursive:
                         # all done
                         return results

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -280,4 +280,18 @@ class Uninstall(Interface):
             # it wasn't installed, so we cannot uninstall it
             raise ValueError("Cannot uninstall %s" % path)
 
-
+    @staticmethod
+    def result_renderer_cmdline(res):
+        from datalad.ui import ui
+        if not res:
+            ui.message("Nothing was uninstalled")
+            return
+        msg = "{n} {obj} uninstalled:\n".format(
+            obj='items were' if len(res) > 1 else 'item was',
+            n=len(res))
+        for item in res:
+            if isinstance(item, Dataset):
+                msg += "Dataset: %s\n" % item.path
+            else:
+                msg += "File: %s\n" % item
+        ui.message(msg)

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -231,9 +231,7 @@ class Uninstall(Interface):
             if data_only or not fast:
                 # uninstall data of subds
                 if isinstance(subds.repo, AnnexRepo):
-                    # todo: correct return values
-                    ds.repo.drop(relativepath)
-                    results.append(relativepath)
+                    results.extend(ds.repo.drop(relativepath))
                     if data_only and not recursive:
                         # all done
                         return results
@@ -301,7 +299,6 @@ class Uninstall(Interface):
         if isdir(path):
             if data_only:
                 if isinstance(ds.repo, AnnexRepo):
-                    # TODO: Return value for ANnexRepo.drop()!
                     return ds.repo.drop(relativepath)
                 else:
                     raise ValueError("%s is not in annex. Removing its "
@@ -321,8 +318,7 @@ class Uninstall(Interface):
                     # it's an annexed file
                     if data_only:
                         # drop content
-                        ds.repo.drop([relativepath])
-                        return path
+                        return ds.repo.drop([relativepath])
                     else:
                         # remove from repo
                         ds.repo.remove(relativepath)

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -176,6 +176,8 @@ class Uninstall(Interface):
             # don't know what to do yet
             # in git vs. untracked?
             # recursive?
+            # => git rm -r
+            # => data-only?
             raise NotImplementedError("TODO: uninstall directory %s from "
                                       "dataset %s" % (path, ds.path))
 
@@ -185,12 +187,14 @@ class Uninstall(Interface):
                 if ds.repo.get_file_key(relativepath):
                     # it's an annexed file
                     if data_only:
+                        # drop content
                         ds.repo.drop([relativepath])
                         return path
                     else:
-                        raise NotImplementedError("TODO: fully uninstall file %s "
-                                          "(annex) from dataset %s" %
-                                          (path, ds.path))
+                        # remove from repo
+                        ds.repo.remove(relativepath)
+                        return path
+
             except FileInGitError:
                 # file directly in git
                 _file_in_git = True

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import logging
 from os.path import join as opj, abspath, exists, isabs, relpath, pardir, isdir
+from os.path import islink
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo, FileInGitError, \
     FileNotInAnnexError
@@ -79,7 +80,7 @@ class Uninstall(Interface):
 
     @staticmethod
     @datasetmethod(name='uninstall')
-    def __call__(dataset=None, path=None, data_only=True, recursive=False):
+    def __call__(dataset=None, path=None, data_only=False, recursive=False):
 
         # Note: copy logic from install to resolve dataset and path:
         # shortcut
@@ -160,7 +161,7 @@ class Uninstall(Interface):
                 ds, relativepath))
 
         # figure out, what path actually is pointing to:
-        if not exists(path):
+        if not exists(path) and not islink(path):
             # nothing there, nothing to uninstall
             lgr.info("Nothing found to uninstall at %s" % path)
             return

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -173,13 +173,20 @@ class Uninstall(Interface):
                                       "dataset %s" % (relativepath, ds.path))
 
         if isdir(path):
-            # don't know what to do yet
-            # in git vs. untracked?
-            # recursive?
-            # => git rm -r
-            # => data-only?
-            raise NotImplementedError("TODO: uninstall directory %s from "
-                                      "dataset %s" % (path, ds.path))
+            if data_only:
+                if isinstance(ds.repo, AnnexRepo):
+                    # TODO: Return value for ANnexRepo.drop()!
+                    return ds.repo.drop(relativepath)
+                else:
+                    raise ValueError("%s is not in annex. Removing its "
+                                 "data only doesn't make sense." % path)
+            else:
+                # git rm -r
+                # TODO: Move to GitRepo and integrate with remove()
+                std_out, std_err = ds.repo._git_custom_command(
+                    relativepath, ['git', 'rm', '-r'])
+                return [line.split()[1][1:-1] for line in std_out.splitlines()
+                        if line.startswith('rm')]
 
         # we know, it's an existing file
         if isinstance(ds.repo, AnnexRepo):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -983,7 +983,9 @@ class AnnexRepo(GitRepo):
         """
         # TODO: Review!
 
-        out, err = self._run_annex_command('find')
+        out, err = self._run_annex_command('find',
+                                           annex_options=['--include', "*"])
+        # TODO: JSON
         return out.splitlines()
 
     def precommit(self):
@@ -1017,8 +1019,12 @@ class AnnexRepo(GitRepo):
         """
         self.precommit()  # since might interfere
         if self.is_direct_mode():
-            self.proxy('git rm ' + ('--force ' if force else '') +
-                       ' '.join(files))
+            stdout, stderr = self.proxy('git rm ' +
+                                        ('--force ' if force else '') +
+                                        ' '.join(files))
+            # output per removed file is expected to be "rm 'PATH'":
+            r_list = [line.strip()[4:-1] for line in stdout.splitlines()]
+
             # yoh gives up -- for some reason sometimes it remains,
             # so if we force -- we mean it!
             if force:
@@ -1026,9 +1032,12 @@ class AnnexRepo(GitRepo):
                     filepath = opj(self.path, f)
                     if lexists(filepath):
                         unlink(filepath)
+                        r_list.append(f)
+            return r_list
         else:
-            super(AnnexRepo, self).remove(files, force=force,
-                                          normalize_paths=False, **kwargs)
+            return super(AnnexRepo, self).remove(files, force=force,
+                                                 normalize_paths=False,
+                                                 **kwargs)
 
     def get_contentlocation(self, key, batch=False):
         """Get location of the key content

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -246,7 +246,6 @@ class AnnexRepo(GitRepo):
                              " -S %s" % c.ctrl_path)
             writer.release()
 
-
     def __repr__(self):
         return "<AnnexRepo path=%s (%s)>" % (self.path, type(self))
 
@@ -781,14 +780,23 @@ class AnnexRepo(GitRepo):
         """
         options = options[:] if options else []
 
+        output_lines = []
         if key:
             # we can't drop multiple in 1 line, and there is no --batch yet, so
             # one at a time
             options = options + ['--key']
             for k in files:
-                self._run_annex_command('drop', annex_options=options + [k])
+                std_out, std_err = \
+                    self._run_annex_command('drop', annex_options=options + [k])
+                output_lines.extend(std_out.splitlines())
         else:
-            self._run_annex_command('drop', annex_options=options + files)
+            std_out, std_err = \
+                self._run_annex_command('drop', annex_options=options + files)
+            output_lines.extend(std_out.splitlines())
+
+        return [line.split()[1] for line in output_lines
+                if line.startswith('drop') and line.endswith('ok')]
+
 
     def drop_key(self, keys, options=None, batch=False):
         """Drops the content of annexed files from this repository referenced by keys

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -494,7 +494,6 @@ class GitRepo(object):
                 msg = self._get_added_files_commit_msg(files)
             self.commit(msg=msg)
 
-    # TODO: like add melt in
     @normalize_paths(match_return_type=False)
     def remove(self, files, **kwargs):
         """Remove files.
@@ -503,6 +502,8 @@ class GitRepo(object):
         ----------
         files: str
           list of paths to remove
+        kwargs:
+          see `__init__`
 
         Returns
         -------
@@ -511,6 +512,26 @@ class GitRepo(object):
         """
 
         files = _remove_empty_items(files)
+
+        # todo: we are able to remove objects, not necessarily specified by a
+        #       path (see below). We may want to make this available at some
+        #       point.
+        # Multiple types of items are supported which may be be freely mixed.
+        #
+        #     - path string
+        #         Remove the given path at all stages. If it is a directory, you must
+        #         specify the r=True keyword argument to remove all file entries
+        #         below it. If absolute paths are given, they will be converted
+        #         to a path relative to the git repository directory containing
+        #         the working tree
+        #
+        #         The path string may include globs, such as *.c.
+        #
+        #     - Blob Object
+        #         Only the path portion is used in this case.
+        #
+        #     - BaseIndexEntry or compatible type
+        #         The only relevant information here Yis the path. The stage is ignored.
 
         return self.repo.index.remove(files, working_tree=True, **kwargs)
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -955,3 +955,29 @@ def test_annex_copy_to(origin, clone):
     eq_(repo.copy_to("test-annex.dat", "target"), ["test-annex.dat"])
     eq_(repo.copy_to(["INFO.txt", "test-annex.dat"], "target"), ["test-annex.dat"])
 
+
+@with_testrepos('.*annex.*', flavors=['local', 'network'])
+@with_tempfile
+def test_annex_drop(src, dst):
+    ar = AnnexRepo(dst, src)
+    testfile = 'test-annex.dat'
+    assert_false(ar.file_has_content(testfile))
+    ar.get(testfile)
+    ok_(ar.file_has_content(testfile))
+
+    # drop file by name:
+    result = ar.drop([testfile])
+    assert_false(ar.file_has_content(testfile))
+    ok_(isinstance(result, list))
+    eq_(result[0], testfile)
+    eq_(len(result), 1)
+
+    ar.get(testfile)
+
+    # drop file by key:
+    testkey = ar.get_file_key(testfile)
+    result = ar.drop([testkey], key=True)
+    assert_false(ar.file_has_content(testfile))
+    ok_(isinstance(result, list))
+    eq_(result[0], testkey)
+    eq_(len(result), 1)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -982,6 +982,13 @@ def test_annex_drop(src, dst):
     eq_(result[0], testkey)
     eq_(len(result), 1)
 
+    # insufficient arguments:
+    assert_raises(TypeError, ar.drop)
+    assert_raises(InsufficientArgumentsError, ar.drop, [], options=["--jobs=5"])
+    assert_raises(InsufficientArgumentsError, ar.drop, [])
+
+    # too much arguments:
+    assert_raises(CommandError, ar.drop, ['.'], options=['--all'])
 
 @with_testrepos('basic_annex', flavors=['clone'])
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
Even though `uninstall` is neither well defined yet nor fully functional, I'd vote for merge.
There is a (drafted) `uninstall` in master already and this one is nonetheless an improvement to it.
Until further discussion during OHBM I'd like to stop working on that and focus on ironing the lower level things.

It currently should work for uninstalling files and subdatasets. `recursive` probably is not ready yet and uninstalling a dataset, that is not part of a superdatasets is not implemented yet. But from my point of view, core functionality is available and everything else is up to getting to an agreement on what it should behave like.

