### PR TITLE
ENH: make  install  understand DataLadRI

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -24,3 +24,5 @@ ARCHIVES_SPECIAL_REMOTE = 'datalad-archives'
 DATALAD_SPECIAL_REMOTE = 'datalad'
 
 ARCHIVES_TEMP_DIR = join('.git', 'datalad', 'tmp', 'archives')
+
+DATASETS_TOPURL = "http://datasets.datalad.org/"

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -27,7 +27,7 @@ lgr = logging.getLogger('datalad.dataset')
 def resolve_path(path, ds=None):
     """Resolve a path specification (against a Dataset location)
 
-    Any explicit path (absolute or relative) is return as an absolute path.
+    Any explicit path (absolute or relative) is returned as an absolute path.
     In case of an explicit relative path, the current working directory is
     used as a reference. Any non-explicit relative path is resolved against
     as dataset location, i.e. considered relative to the location of the

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -32,6 +32,7 @@ from datalad.support.param import Parameter
 from datalad.utils import expandpath, knows_annex, assure_dir, \
     is_explicit_path, on_windows, swallow_logs
 from datalad.support.network import RI
+from datalad.support.network import DataLadRI
 from datalad.support.network import is_url, is_datalad_compat_ri
 from datalad.utils import rmtree
 
@@ -43,7 +44,19 @@ def _with_sep(path):
     return path + sep if not path.endswith(sep) else path
 
 
-def _installationpath_from_url(url):
+def _get_git_url_from_source(source):
+    """Return URL for cloning associated with a source specification
+
+    For now just resolves DataLadRIs
+    """
+    source_ri = RI(source)
+    if isinstance(source_ri, DataLadRI):
+        # we have got our DataLadRI as the source, so expand it
+        source = source_ri.as_git_url()
+    return source
+
+
+def _get_installationpath_from_url(url):
     """Returns a relative path derived from the trailing end of a URL
 
     This can be used to determine an installation path of a Dataset
@@ -312,7 +325,7 @@ class Install(Interface):
         # on, based on the resolved target location (that is now guaranteed to
         # be specified, but only if path isn't a URL (anymore) -> special case,
         # handles below
-        if ds is None and path is not None and not is_url(path):
+        if ds is None and path is not None and not is_datalad_compat_ri(path):
             # try to find a dataset at or above the installation target
             dspath = GitRepo.get_toppath(abspath(path))
             if dspath is None:
@@ -324,7 +337,7 @@ class Install(Interface):
             # no dataset, no source
             # this could be a shortcut install call, where the first
             # arg identifies the source
-            if is_url(path) or os.path.exists(path):
+            if is_datalad_compat_ri(path) or os.path.exists(path):
                 # we have an actual URL -> this should be the source
                 # OR
                 # it is not a URL, but it exists locally
@@ -336,15 +349,18 @@ class Install(Interface):
 
         lgr.debug("Resolved installation target: {0}".format(path))
 
-        if ds is None and path is None and source is not None:
+        # Possibly do conversion from source into a git-friendly url
+        source_url = _get_git_url_from_source(source)
+
+        if ds is None and path is None and source_url is not None:
             # we got nothing but a source. do something similar to git clone
-            # and derive the path from the source and continue
+            # and derive the path from the source_url and continue
             lgr.debug(
                 "Neither dataset not target installation path provided. "
                 "Assuming installation of a remote dataset. "
                 "Deriving destination path from given source {0}".format(
-                    source))
-            ds = Dataset(_installationpath_from_url(source))
+                    source_url))
+            ds = Dataset(_get_installationpath_from_url(source_url))
 
         if not path and ds is None:
             # no dataset, no target location, nothing to do
@@ -354,7 +370,10 @@ class Install(Interface):
 
         assert(ds is not None)
 
-        lgr.info("Installing {0}".format(path if path else ds))
+        lgr.info("Installing {0}{1}".format(
+            path if path else ds,
+            " from %s" % source_url if source_url else ""
+        ))
 
         vcs = ds.repo
         if vcs is None:
@@ -363,25 +382,25 @@ class Install(Interface):
             existed = ds.path and exists(ds.path)
 
             # We possibly need to consider /.git URL
-            candidate_sources = [source]
-            if source and not source.rstrip('/').endswith('/.git'):
-                candidate_sources.append('{0}/.git'.format(source.rstrip('/')))
+            candidate_source_urls = [source_url]
+            if source_url and not source_url.rstrip('/').endswith('/.git'):
+                candidate_source_urls.append('{0}/.git'.format(source_url.rstrip('/')))
 
-            for source_ in candidate_sources:
+            for source_url_ in candidate_source_urls:
                 try:
-                    lgr.debug("Retrieving a dataset from URL: {0}".format(source_))
+                    lgr.debug("Retrieving a dataset from URL: {0}".format(source_url_))
                     with swallow_logs():
-                        vcs = Install._get_new_vcs(ds, source_)
+                        vcs = Install._get_new_vcs(ds, source_url_)
                     break  # do not bother with other sources if succeeded
                 except GitCommandError:
-                    lgr.debug("Failed to retrieve from URL: {0}".format(source_))
+                    lgr.debug("Failed to retrieve from URL: {0}".format(source_url_))
                     if not existed and ds.path and exists(ds.path):
                         lgr.debug("Wiping out unsuccessful clone attempt at {}".format(ds.path))
                         rmtree(ds.path)
-                    if source_ == candidate_sources[-1]:
+                    if source_url_ == candidate_source_urls[-1]:
                         # Re-raise if failed even with the last candidate
                         lgr.debug("Unable to establish repository instance at {0} from {1}"
-                                  "".format(ds.path, candidate_sources))
+                                  "".format(ds.path, candidate_source_urls))
                         raise
 
         assert(ds.repo)  # is automagically re-evaluated in the .repo property

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -32,7 +32,6 @@ from datalad.support.param import Parameter
 from datalad.utils import expandpath, knows_annex, assure_dir, \
     is_explicit_path, on_windows, swallow_logs
 from datalad.support.network import RI
-from datalad.support.network import get_local_path_from_ri
 from datalad.support.network import is_url, is_datalad_compat_ri
 from datalad.utils import rmtree
 
@@ -296,18 +295,15 @@ class Install(Interface):
 
         # resolve the target location (if local) against the provided dataset
         if path is not None:
+            # Should work out just fine for regular paths, so no additional
+            # conditioning is necessary
             path_ri = RI(path)
-            # make sure it is not a URL, `resolve_path` cannot handle that
-            if is_datalad_compat_ri(path_ri):
-                try:
-                    # Wouldn't work for SSHRI ATM, see TODO within SSHRI
-                    path = get_local_path_from_ri(path_ri)
-                    path = resolve_path(path, ds)
-                except ValueError:
-                    # URL doesn't point to a local something
-                    pass
-            else:
-                path = resolve_path(path, ds)
+            try:
+                # Wouldn't work for SSHRI ATM, see TODO within SSHRI
+                path = resolve_path(path_ri.localpath, ds)
+            except ValueError:
+                # URL doesn't point to a local something
+                pass
 
         # any `path` argument that point to something local now resolved and
         # is no longer a URL

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -15,11 +15,15 @@ from os.path import join as opj, abspath, isdir
 from os.path import exists
 from os.path import realpath
 
+from mock import patch
+
 from ..dataset import Dataset
 from datalad.api import create
 from datalad.api import install
+from datalad.consts import DATASETS_TOPURL
 from datalad.distribution.install import get_containing_subdataset
-from datalad.distribution.install import _installationpath_from_url
+from datalad.distribution.install import _get_installationpath_from_url
+from datalad.distribution.install import _get_git_url_from_source
 from datalad.utils import chpwd
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import FileInGitError
@@ -37,6 +41,7 @@ from datalad.tests.utils import SkipTest
 from datalad.tests.utils import assert_cwd_unchanged, skip_if_on_windows
 from datalad.tests.utils import assure_dict_from_str, assure_list_from_str
 from datalad.tests.utils import ok_generator
+from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import ok_startswith
@@ -60,7 +65,13 @@ def test_installationpath_from_url():
               'http://example.com/lastbit',
               'http://example.com/lastbit.git',
               ):
-        assert_equal(_installationpath_from_url(p), 'lastbit')
+        assert_equal(_get_installationpath_from_url(p), 'lastbit')
+
+
+def test_get_git_url_from_source():
+    eq_(_get_git_url_from_source('///subds'), DATASETS_TOPURL + 'subds')
+    eq_(_get_git_url_from_source('http://example.com'), 'http://example.com')
+    assert_raises(NotImplementedError, _get_git_url_from_source, '//custom/subds')
 
 
 @with_tree(tree={'test.txt': 'whatever'})
@@ -281,6 +292,27 @@ def test_install_subdataset(src, path):
     # we shouldn't be able silently ignore attempt to provide source while
     # "installing" file under git
     assert_raises(FileInGitError, ds.install, opj('sub2', 'INFO.txt'), source="http://bogusbogus")
+
+
+@with_tree(tree={
+    'ds': {'test.txt': 'some'},
+    })
+@serve_path_via_http
+@with_tempfile(mkdir=True)
+def test_install_dataladri(src, topurl, path):
+    # make plain git repo
+    ds_path = opj(src, 'ds')
+    gr = GitRepo(ds_path, create=True)
+    gr.add('test.txt')
+    gr.commit('demo')
+    Runner(cwd=gr.path)(['git', 'update-server-info'])
+    # now install it somewhere else
+    with patch('datalad.support.network.DATASETS_TOPURL', topurl), \
+        swallow_logs():
+        ds = install(path=path, source='///ds')
+    eq_(ds.path, path)
+    ok_clean_git(path, annex=False)
+    ok_file_has_content(opj(path, 'test.txt'), 'some')
 
 
 def test_install_list():

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -28,7 +28,7 @@ from six.moves.urllib.parse import urlencode
 from six.moves.urllib.error import URLError
 
 from datalad.utils import on_windows
-from datalad.dochelpers import exc_str
+from datalad.consts import DATASETS_TOPURL
 
 from datalad.utils import auto_repr
 # TODO not sure what needs to use `six` here yet
@@ -713,6 +713,18 @@ class DataLadRI(RI, RegexBasedURLMixin):
 
     def as_str(self):
         return "//{remote}/{path}".format(**self._fields)
+
+    def as_git_url(self):
+        """Dereference /// into original URLs which could be used by git for cloning
+
+        Returns
+        -------
+        str
+          URL string to reference the DataLadRI from its /// form
+        """
+        if self.remote:
+            raise NotImplementedError("not supported ATM to reference additional remotes")
+        return "{}{}".format(DATASETS_TOPURL, self.path)
 
 
 def _split_colon(s, maxsplit=1):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -701,15 +701,21 @@ def parse_url_opts(url):
 
 # TODO: should we just define URL.good_for_git or smth like that? ;)
 # although git also understands regular paths
-def is_url(s):
-    """Returns whether a string looks like something what datalad should treat as a URL
+def is_url(ri):
+    """Returns whether argument looks like something what datalad should treat as a URL
 
     This includes ssh "urls" which git understands.
+
+    Parameters
+    ----------
+    ri : str or RI
+      The resource identifier (as a string or RI) to "analyze"
     """
-    try:
-        ri = RI(s)
-    except:
-        return False
+    if not isinstance(ri, RI):
+        try:
+            ri = RI(ri)
+        except:
+            return False
     return isinstance(ri, (URL, SSHRI))
 
 

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -366,6 +366,7 @@ def test_is_url():
     ok_(is_url('like@sshlogin'))  # actually we do allow ssh:implicit urls ATM
     nok_(is_url(''))
     nok_(is_url(' '))
+    nok_(is_url(123))  # stuff of other types wouldn't be considered a URL
 
     # we can pass RI instance directly
     ok_(is_url(RI('file://localhost/some')))
@@ -378,6 +379,7 @@ def test_is_datalad_compat_ri():
     ok_(is_datalad_compat_ri('///localhost/some'))
     nok_(is_datalad_compat_ri('relative'))
     nok_(is_datalad_compat_ri('.///localhost/some'))
+    nok_(is_datalad_compat_ri(123))
 
 
 def test_get_local_file_url_linux():

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -343,6 +343,10 @@ def test_is_url():
     nok_(is_url(''))
     nok_(is_url(' '))
 
+    # we can pass RI instance directly
+    ok_(is_url(RI('file://localhost/some')))
+    nok_(is_url(RI('relative')))
+
 
 def test_get_local_file_url_linux():
     eq_(get_local_file_url('/a'), 'file:///a')


### PR DESCRIPTION
So we could do something like
```shell
datalad install ///openfmri/ds000001
```
no support of specifying the siblings name yet since we don't have discussed how we will 'register' them really yet