### PR TITLE
ENH: run tests under condition of absent scrapy (Closes #583)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     # must operate nicely with those env variables set
     - http_proxy=
     - https_proxy=
+  - python: 2.7
+    env:
+    - PYTHONPATH=$PWD/tools/testing/bad_internals/_scrapy/
   - python: 3.3
   - python: 3.4
   # Those aren't yet ready since lxml Ibelieve fails to install

--- a/datalad/crawler/nodes/matches.py
+++ b/datalad/crawler/nodes/matches.py
@@ -21,13 +21,14 @@ from ...support.network import dlurljoin
 from logging import getLogger
 lgr = getLogger('datalad.crawler')
 
-from scrapy.http import Response
 try:
+    from scrapy.http import Response
     from scrapy.selector import Selector
 except ImportError:
     lgr.debug("Failed to import Selector from scrapy, so matches would not be functional")
     class Selector(object):
         xpath = css = None
+    Response = None
 
 
 # for now heavily based on scrapy but we might make the backend

--- a/tools/testing/bad_internals/_scrapy/scrapy.py
+++ b/tools/testing/bad_internals/_scrapy/scrapy.py
@@ -1,0 +1,1 @@
+raise ImportError("Scrapy import is ruined for testing")


### PR DESCRIPTION
I think all our cases are covered and #583 actually does not demonstrate
some tests failing due to absent scrapy - it skips them but with this PR
we would be able to assure that.  scrapy is just an optional dependency
needed for some scraping pipelines