### PR TITLE
ENH: Make argument-less `datalad ls` work

### DIFF
--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -39,13 +39,14 @@ class Ls(Interface):
     --------
 
       $ datalad ls s3://openfmri/tarballs/ds202  # to list S3 bucket
-      $ datalad ls .                             # to list current dataset
+      $ datalad ls                               # to list current dataset
     """
 
     _params_ = dict(
         loc=Parameter(
-            doc="URL to list, e.g. s3:// url",
-            nargs="+",
+            doc="URL or path to list, e.g. s3://...",
+            metavar='PATH/URL',
+            nargs="*",
             constraints=EnsureStr() | EnsureNone(),
         ),
         recursive=Parameter(
@@ -80,6 +81,9 @@ class Ls(Interface):
 
     @staticmethod
     def __call__(loc, recursive=False, fast=False, all=False, config_file=None, list_content=False):
+        if isinstance(loc, list) and not len(loc):
+            # nothing given, CWD assumed -- just like regular ls
+            loc = '.'
 
         kw = dict(fast=fast, recursive=recursive, all=all)
         if isinstance(loc, list):

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -17,7 +17,7 @@ from glob import glob
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from ...api import ls
-from ...utils import swallow_outputs
+from ...utils import swallow_outputs, chpwd
 from ...tests.utils import assert_equal, assert_in
 from ...tests.utils import use_cassette
 from ...tests.utils import with_tempfile
@@ -56,3 +56,17 @@ def test_ls_repos(toppath):
                 assert_in('master', cmo.out)
                 if "bogus" in args:
                     assert_in('unknown', cmo.out)
+
+
+@with_tempfile
+def test_ls_noarg(toppath):
+    # smoke test pretty much
+    AnnexRepo(toppath, create=True)
+
+    # this test is pointless for now and until ls() actually returns
+    # something
+    with swallow_outputs():
+        ls_out = ls(toppath)
+        with chpwd(toppath):
+            assert_equal(ls_out, ls([]))
+            assert_equal(ls_out, ls('.'))


### PR DESCRIPTION
Implementation of `ls` should be adjusted to return something meaningful
in Python world too, and print via a renderer.