### PR TITLE
RF: Implement new API (create)

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -84,16 +84,15 @@ class Create(Interface):
         force=Parameter(
             args=("-f", "--force",),
             doc="""enforce creation of a dataset in a non-empty directory""",
-            action='store_false'),
+            action='store_true'),
         description=dataset_description,
         add_to_super=add_to_superdataset,
         name=Parameter(
-            args=("name",),
+            args=("--name",),
             metavar='NAME',
             doc="""name of the dataset within the namespace of it's superdataset.
             By default its path relative to the superdataset is used. Used only
             together with `add_to_super`.""",
-            nargs='?',
             constraints=EnsureStr() | EnsureNone()),
         no_annex=Parameter(
             args=("--no-annex",),

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -93,6 +93,7 @@ class Create(Interface):
             doc="""name of the dataset within the namespace of it's superdataset.
             By default its path relative to the superdataset is used. Used only
             together with `add_to_super`.""",
+            nargs='?',
             constraints=EnsureStr() | EnsureNone()),
         no_annex=Parameter(
             args=("--no-annex",),

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -82,6 +82,13 @@ class Create(Interface):
             constraints=EnsureStr() | EnsureDataset() | EnsureNone()),
         description=dataset_description,
         add_to_super=add_to_superdataset,
+        name=Parameter(
+            args=("name",),
+            metavar='NAME',
+            doc="""name of the dataset within the namespace of it's superdataset.
+            By default its path relative to the superdataset is used. Used only
+            together with `add_to_super`.""",
+            constraints=EnsureStr() | EnsureNone()),
         no_annex=Parameter(
             args=("--no-annex",),
             doc="""if set, a plain Git repository will be created without any
@@ -115,13 +122,13 @@ class Create(Interface):
             path=None,
             description=None,
             add_to_super=False,
+            name=None,
             no_annex=False,
             annex_version=None,
             annex_backend='MD5E',
             git_opts=None,
             annex_opts=None,
             annex_init_opts=None):
-            # TODO: name? (technically not equal to path)
 
         if path:
             if isinstance(path, Dataset):
@@ -138,6 +145,7 @@ class Create(Interface):
 
             return Dataset(sds_path).create_subdataset(
                 ds.path,
+                name=name,
                 description=description,
                 no_annex=no_annex,
                 annex_version=annex_version,

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -10,18 +10,31 @@
 
 """
 
-__docformat__ = 'restructuredtext'
-
 import logging
 import os
-from datalad.distribution.dataset import Dataset, datasetmethod, EnsureDataset
+
+from os.path import join as opj
+
 from datalad.interface.base import Interface
-from datalad.support.constraints import EnsureStr, EnsureNone, EnsureDType
+from datalad.interface.common_opts import git_opts
+from datalad.interface.common_opts import annex_opts
+from datalad.interface.common_opts import annex_init_opts
+from datalad.interface.common_opts import dataset_description
+from datalad.interface.common_opts import add_to_superdataset
+from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureDType
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
-from datalad.interface.common_opts import git_opts, annex_opts, \
-    annex_init_opts, dataset_description, add_to_superdataset
+from datalad.utils import getpwd
+
+from .dataset import Dataset
+from .dataset import datasetmethod
+from .dataset import EnsureDataset
+
+
+__docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.distribution.create')
 
@@ -107,25 +120,66 @@ class Create(Interface):
             git_opts=None,
             annex_opts=None,
             annex_init_opts=None):
-        # if add_to_super:
-        #   find parent ds and call its create_subdataset() which calls this
-        #   function again, with add_to_super=False and afterwards added the
-        #   new subdataset to itself
+            # TODO: name? (technically not equal to path)
 
-        if description and no_annex:
-            raise ValueError("Incompatible arguments: cannot specify description for "
-                             "annex repo and declaring no annex repo.")
-        if loc is None:
-            loc = os.curdir
-        elif isinstance(loc, Dataset):
-            loc = loc.path
-        if no_annex:
-            lgr.info("Creating a new git repo at %s", loc)
-            vcs = GitRepo(loc, url=None, create=True)
+        if path:
+            if isinstance(path, Dataset):
+                ds = path
+            else:
+                ds = Dataset(path)  # TODO: Is there a need to resolve path?
         else:
-            # always come with annex when created from scratch
-            lgr.info("Creating a new annex repo at %s", loc)
-            vcs = AnnexRepo(
-                loc, url=None, create=True, backend=annex_backend,
-                version=annex_version, description=description)
-        return Dataset(loc)
+            ds = Dataset(getpwd())
+
+        if add_to_super:
+            sds_path = GitRepo.get_toppath(opj(ds.path, os.pardir))
+            if sds_path is None:
+                raise ValueError("No super dataset found for dataset %s" % ds)
+
+            return Dataset(sds_path).create_subdataset(
+                ds.path,
+                description=description,
+                no_annex=no_annex,
+                annex_version=annex_version,
+                annex_backend=annex_backend,
+                git_opts=git_opts,
+                annex_opts=annex_opts,
+                annex_init_opts=annex_init_opts)
+
+        else:
+            if no_annex:
+                if description:
+                    raise ValueError("Incompatible arguments: cannot specify "
+                                     "description for annex repo and declaring "
+                                     "no annex repo.")
+                if annex_opts:
+                    raise ValueError("Incompatible arguments: cannot specify "
+                                     "options for annex and declaring no "
+                                     "annex repo.")
+                if annex_init_opts:
+                    raise ValueError("Incompatible arguments: cannot specify "
+                                     "options for annex init and declaring no "
+                                     "annex repo.")
+
+                lgr.info("Creating a new git repo at %s", ds.path)
+                vcs = GitRepo(ds.path, url=None, create=True,
+                              git_opts=git_opts)
+            else:
+                # always come with annex when created from scratch
+                lgr.info("Creating a new annex repo at %s", ds.path)
+                vcs = AnnexRepo(ds.path, url=None, create=True,
+                                backend=annex_backend,
+                                version=annex_version,
+                                description=description,
+                                git_opts=git_opts,
+                                annex_opts=annex_opts,
+                                annex_init_opts=annex_init_opts)
+
+            return ds
+
+    @staticmethod
+    def result_renderer_cmdline(res):
+        from datalad.ui import ui
+        if res is None:
+            ui.message("Nothing was created")
+        elif isinstance(res, Dataset):
+            ui.message("Created dataset at %s." % res.path)

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -140,7 +140,12 @@ class Create(Interface):
             if isinstance(path, Dataset):
                 ds = path
             else:
-                ds = Dataset(path)  # TODO: Is there a need to resolve path?
+                # this means we are not bound to a Dataset instance.
+                # Therefore there is no difference between a relative path and
+                # an "explicit" path. Both are based on CWD, since there is no
+                # repo or dataset it is passed to. Hence `path` doesn't need to
+                # be resolved.
+                ds = Dataset(path)
         else:
             ds = Dataset(getpwd())
 

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -11,9 +11,6 @@
 """
 
 import logging
-import os
-
-from os.path import join as opj
 
 from datalad.interface.base import Interface
 from datalad.interface.common_opts import git_opts
@@ -139,11 +136,11 @@ class Create(Interface):
             ds = Dataset(getpwd())
 
         if add_to_super:
-            sds_path = GitRepo.get_toppath(opj(ds.path, os.pardir))
-            if sds_path is None:
+            sds = ds.get_superdataset()
+            if sds is None:
                 raise ValueError("No super dataset found for dataset %s" % ds)
 
-            return Dataset(sds_path).create_subdataset(
+            return sds.create_subdataset(
                 ds.path,
                 name=name,
                 description=description,

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -173,7 +173,9 @@ class Create(Interface):
                                 git_opts=git_opts,
                                 annex_opts=annex_opts,
                                 annex_init_opts=annex_init_opts)
-
+            # TODO: empty commit!
+            # vcs.commit( ... allow-empty ..)
+            
             return ds
 
     @staticmethod

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -20,54 +20,98 @@ from datalad.support.constraints import EnsureStr, EnsureNone, EnsureDType
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
+from datalad.interface.common_opts import git_opts, annex_opts, \
+    annex_init_opts, dataset_description, add_to_superdataset
 
 lgr = logging.getLogger('datalad.distribution.create')
 
 
 class Create(Interface):
-    """Create a new dataset.
+    """Create a new dataset from scratch.
 
-    This command initializes a new repository at a given location, or the
-    current directory.
+    This command initializes a new :term:`dataset` at a given location, or the
+    current directory. The new dataset can optionally be registered in an
+    existing :term:`superdataset` (the new dataset's path needs to be located
+    within the superdataset for that, and the superdataset will be detected
+    automatically). It is recommended to provide a brief description to label
+    the dataset's nature *and* location, e.g. "Michael's music on black
+    laptop". This helps humans to identify data locations in distributed
+    scenarios.  By default an identifier comprised of user and machine name,
+    plus path will be generated.
+
+    Plain Git repositories can be created via the [PY: `no_annex` PY][CMD: --no-annex CMD] flag.
+    However, the result will not be a full dataset, and, consequently,
+    not all features are supported (e.g. a description).
+
+    || REFLOW >>
+    To create a local version of a remote dataset use the
+    :func:`~datalad.api.install` command instead.
+    << REFLOW ||
+
+    .. note::
+      Power-user info: This command uses :command:`git init`, and
+      :command:`git annex init` to prepare the new dataset. Registering to a
+      superdataset is performed via a :command:`git submodule add` operation
+      in the discovered superdataset.
     """
 
     _params_ = dict(
-        loc=Parameter(
-            args=("loc",),
-            doc="""location where the dataset shall be  created.  If `None`,
-            is given a dataset will be created in the current working
-            directory""",
+        path=Parameter(
+            args=("path",),
+            metavar='PATH',
+            doc="""path where the dataset shall be created, directories
+            will be created as necessary. If no location is provided, a dataset
+            will be created in the current working directory. Either way the
+            command will error if the target directory is not empty.""",
             nargs='?',
             # put dataset 2nd to avoid useless conversion
             constraints=EnsureStr() | EnsureDataset() | EnsureNone()),
-        description=Parameter(
-            args=("-D", "--description",),
-            doc="""short description that humans can use to identify the
-            repository/location, e.g. "Precious data on my laptop."""""),
+        description=dataset_description,
+        add_to_super=add_to_superdataset,
         no_annex=Parameter(
             args=("--no-annex",),
-            doc="""flag that if given a plain Git repository will be created
-            without any annex""",
+            doc="""if set, a plain Git repository will be created without any
+            annex""",
             action='store_false'),
         annex_version=Parameter(
             args=("--annex-version",),
-            doc="""select particular annex repository version.  The list of
-            supported versions depends on the available git-annex version""",
+            doc="""select a particular annex repository version. The
+            list of supported versions depends on the available git-annex
+            version. This should be left untouched, unless you know what
+            you are doing""",
             constraints=EnsureDType(int) | EnsureNone()),
         annex_backend=Parameter(
             args=("--annex-backend",),
+            constraints=EnsureStr() | EnsureNone(),
             # not listing choices here on purpose to avoid future bugs
             doc="""set default hashing backend used by the new dataset.
             For a list of supported backends see the git-annex
-            documentation""",
+            documentation. The default is optimized for maximum compatibility
+            of datasets across platforms (especially those with limited
+            path lengths)""",
             nargs=1),
+        git_opts=git_opts,
+        annex_opts=annex_opts,
+        annex_init_opts=annex_init_opts,
     )
 
     @staticmethod
-    @datasetmethod(name='create', dataset_argname='loc')
+    @datasetmethod(name='create', dataset_argname='path')
     def __call__(
-            loc=None, description=None, no_annex=False, annex_version=None,
-            annex_backend='MD5E'):
+            path=None,
+            description=None,
+            add_to_super=False,
+            no_annex=False,
+            annex_version=None,
+            annex_backend='MD5E',
+            git_opts=None,
+            annex_opts=None,
+            annex_init_opts=None):
+        # if add_to_super:
+        #   find parent ds and call its create_subdataset() which calls this
+        #   function again, with add_to_super=False and afterwards added the
+        #   new subdataset to itself
+
         if description and no_annex:
             raise ValueError("Incompatible arguments: cannot specify description for "
                              "annex repo and declaring no annex repo.")

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -27,6 +27,7 @@ from datalad.support.constraints import EnsureDType
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
+from datalad.support.gitrepo import to_options
 from datalad.utils import getpwd
 
 from .dataset import Dataset
@@ -173,8 +174,9 @@ class Create(Interface):
                                 git_opts=git_opts,
                                 annex_opts=annex_opts,
                                 annex_init_opts=annex_init_opts)
-            # TODO: empty commit!
-            # vcs.commit( ... allow-empty ..)
+
+            vcs.commit(msg="datalad initial commit",
+                       options=to_options(allow_empty=True))
             
             return ds
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -335,6 +335,10 @@ class Dataset(object):
         -------
         Dataset or None
         """
+
+        # TODO: return only if self is subdataset of the superdataset
+        #       (meaning: registered as submodule)?
+
         from os import pardir
         sds_path = GitRepo.get_toppath(opj(self.path, pardir))
         if sds_path is None:

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -244,7 +244,6 @@ class Dataset(object):
         return _install_subds_inplace(ds=self, path=subds.path,
                                       relativepath=relpath(subds.path, self.path))
 
-
 #    def get_file_handles(self, pattern=None, fulfilled=None):
 #        """Get paths to all known file_handles, optionally matching a specific
 #        name pattern.

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -218,8 +218,6 @@ class Dataset(object):
         subds = Dataset(path)
 
         # create the dataset
-        # TODO: Does this require circular import (from datalad.api, which
-        #       imports dataset?)
         subds.create(description=description,
                      no_annex=no_annex,
                      annex_version=annex_version,
@@ -239,8 +237,12 @@ class Dataset(object):
                      # superdataset, if add_to_super is True.
                      add_to_super=False)
 
-        # TODO: add it as a submodule
-        raise NotImplementedError("TODO")
+        # add it as a submodule
+        # TODO: clean that part and move it in here (Dataset)
+        from .install import _install_subds_inplace
+        from os.path import relpath
+        return _install_subds_inplace(ds=self, path=subds.path,
+                                      relativepath=relpath(subds.path, self.path))
 
 
 #    def get_file_handles(self, pattern=None, fulfilled=None):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -24,6 +24,8 @@ from datalad.utils import swallow_logs
 lgr = logging.getLogger('datalad.dataset')
 
 
+# TODO: use the same piece for resolving paths against Git/AnnexRepo instances
+#       (see normalize_path)
 def resolve_path(path, ds=None):
     """Resolve a path specification (against a Dataset location)
 
@@ -239,6 +241,7 @@ class Dataset(object):
 
         # add it as a submodule
         # TODO: clean that part and move it in here (Dataset)
+        #       or call install to add the thing inplace
         from .install import _install_subds_inplace
         from os.path import relpath
         return _install_subds_inplace(ds=self, path=subds.path,

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -204,6 +204,45 @@ class Dataset(object):
         else:
             return submodules
 
+    def create_subdataset(self, path, name=None,
+                          description=None,
+                          no_annex=False,
+                          annex_version=None,
+                          annex_backend='MD5E',
+                          git_opts=None,
+                          annex_opts=None,
+                          annex_init_opts=None):
+
+        # TODO: use `name` for subdatasets. (not necessarily equals `path`)
+        # TODO: check whether path is in self?
+        subds = Dataset(path)
+
+        # create the dataset
+        # TODO: Does this require circular import (from datalad.api, which
+        #       imports dataset?)
+        subds.create(description=description,
+                     no_annex=no_annex,
+                     annex_version=annex_version,
+                     annex_backend=annex_backend,
+                     git_opts=git_opts,
+                     annex_opts=annex_opts,
+                     annex_init_opts=annex_init_opts,
+                     # Note:
+                     # adding to the superdataset is what we are doing herein!
+                     # add_to_super=True would lead to calling ourselves again
+                     # and again
+                     # While this is somewhat ugly, the issue behind this is a
+                     # necessarily slightly different logic of `create` in
+                     # comparison to other toplevel functions, which operate on
+                     # an existing dataset and possibly on subdatasets.
+                     # With `create` we suddenly need to operate on a
+                     # superdataset, if add_to_super is True.
+                     add_to_super=False)
+
+        # TODO: add it as a submodule
+        raise NotImplementedError("TODO")
+
+
 #    def get_file_handles(self, pattern=None, fulfilled=None):
 #        """Get paths to all known file_handles, optionally matching a specific
 #        name pattern.

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -249,7 +249,7 @@ class Dataset(object):
 
         # get absolute path (considering explicit vs relative):
         path = resolve_path(path, self)
-        from install import _with_sep
+        from .install import _with_sep
         if not path.startswith(_with_sep(self.path)):
             raise ValueError("path %s outside dataset %s" % (path, self))
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -54,8 +54,7 @@ class Dataset(object):
     __slots__ = ['_path', '_repo']
 
     def __init__(self, path):
-        from install import _with_sep
-        self._path = _with_sep(abspath(path))
+        self._path = abspath(path)
         self._repo = None
 
     def __repr__(self):
@@ -250,7 +249,8 @@ class Dataset(object):
 
         # get absolute path (considering explicit vs relative):
         path = resolve_path(path, self)
-        if not path.startswith(self.path):
+        from install import _with_sep
+        if not path.startswith(_with_sep(self.path)):
             raise ValueError("path %s outside dataset %s" % (path, self))
 
         subds = Dataset(path)

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -248,8 +248,6 @@ class Dataset(object):
           the newly created dataset
         """
 
-        # TODO: use `name` for subdatasets. (not necessarily equals `path`)
-
         # get absolute path (considering explicit vs relative):
         path = resolve_path(path, self)
         if not path.startswith(self.path):
@@ -283,7 +281,8 @@ class Dataset(object):
         from .install import _install_subds_inplace
         from os.path import relpath
         return _install_subds_inplace(ds=self, path=subds.path,
-                                      relativepath=relpath(subds.path, self.path))
+                                      relativepath=relpath(subds.path, self.path),
+                                      name=name)
 
 #    def get_file_handles(self, pattern=None, fulfilled=None):
 #        """Get paths to all known file_handles, optionally matching a specific

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -328,6 +328,20 @@ class Dataset(object):
         """
         return self.path is not None and self.repo is not None
 
+    def get_superdataset(self):
+        """Get the dataset's superdataset
+
+        Returns
+        -------
+        Dataset or None
+        """
+        from os import pardir
+        sds_path = GitRepo.get_toppath(opj(self.path, pardir))
+        if sds_path is None:
+            return None
+        else:
+            return Dataset(sds_path)
+
 
 @optional_args
 def datasetmethod(f, name=None, dataset_argname='dataset'):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -226,7 +226,6 @@ class Dataset(object):
           name of the subdataset
         description: str
           a human-readable description of the dataset, that helps to identify it.
-
           Note: Doesn't work with `no_annex`
         no_annex: bool
           whether or not to create a pure git repository

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -180,12 +180,12 @@ def _install_subds_from_flexible_source(ds, sm_path, sm_url, recursive):
         return subds
 
 
-def _install_subds_inplace(ds, path, relativepath):
+def _install_subds_inplace(ds, path, relativepath, name=None):
     """Register an existing repository in the repo tree as a submodule"""
     # FLOW GUIDE EXIT POINT
     # this is an existing repo and must be in-place turned into
     # a submodule of this dataset
-    ds.repo.add_submodule(relativepath, url=None)
+    ds.repo.add_submodule(relativepath, url=None, name=name)
     _fixup_submodule_dotgit_setup(ds, relativepath)
     # return newly added submodule as a dataset
     return Dataset(path)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -67,22 +67,12 @@ def test_create_curdir(path):
     subds = Dataset(opj(path, "some/what/deeper")).create(add_to_super=True)
     ok_(isinstance(subds, Dataset))
     ok_(subds.is_installed())
+    ok_clean_git(subds.path, annex=True)
 
-    # TODO:
-    # ds.get_subdatasets() doesn't work yet, since index.head is invalid.
-    # When committing, this changes to
-    # "InvalidGitRepositoryError: Gitmodule path u'some/what/deeper' did not
-    # exist in revision of parent commit HEAD"
-    #
-    # Note: The latter might be a conflict of gitpython in-memory index being
-    # committed, while the actual change to be committed was on disk?
-    #
-    # Note 2: Might be solved by empty commit!
-
-    # For now, just check .gitmodules:
-    with open(opj(path, ".gitmodules"), "r") as f:
-        lines = f.readlines()
-        assert_in("[submodule \"some/what/deeper\"]" + os.linesep, lines)
+    # subdataset is known to superdataset:
+    assert_in("some/what/deeper", ds.get_subdatasets())
+    # but wasn't committed:
+    ok_(ds.repo.dirty)
 
 
 @with_tempfile

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -74,6 +74,8 @@ def test_create_curdir(path):
     # but wasn't committed:
     ok_(ds.repo.dirty)
 
+    ok_(subds.get_superdataset() == ds)
+
 
 @with_tempfile
 def test_create(path):

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -76,6 +76,8 @@ def test_create_curdir(path):
     #
     # Note: The latter might be a conflict of gitpython in-memory index being
     # committed, while the actual change to be committed was on disk?
+    #
+    # Note 2: Might be solved by empty commit!
 
     # For now, just check .gitmodules:
     with open(opj(path, ".gitmodules"), "r") as f:

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -116,12 +116,9 @@ def test_create(path):
     ok_clean_git(sub_path_1, annex=False)
     eq_(added_subds.path, sub_path_1)
     assert_true(isdir(opj(added_subds.path, '.git')))
-    # will not list it unless committed
-    assert_not_in("sub", ds.get_subdatasets())
+    ok_(ds.repo.dirty)  # not committed yet
+    assert_in("sub", ds.get_subdatasets())
     ds.save("added submodule")
-    # will still not list it, because without a single commit, it doesn't enter
-    # the index
-    assert_not_in("sub", ds.get_subdatasets())
     # now for reals
     open(opj(added_subds.path, 'somecontent'), 'w').write('stupid')
     # next one will auto-annex the new file

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -58,7 +58,29 @@ from datalad.tests.utils import swallow_logs
 def test_create_curdir(path):
     with chpwd(path, mkdir=True):
         create()
-    ok_(Dataset(path).is_installed())
+    ds = Dataset(path)
+    ok_(ds.is_installed())
+
+    # simple addition to create and add a subdataset
+    # TODO: Move this test
+
+    subds = Dataset(opj(path, "some/what/deeper")).create(add_to_super=True)
+    ok_(isinstance(subds, Dataset))
+    ok_(subds.is_installed())
+
+    # TODO:
+    # ds.get_subdatasets() doesn't work yet, since index.head is invalid.
+    # When committing, this changes to
+    # "InvalidGitRepositoryError: Gitmodule path u'some/what/deeper' did not
+    # exist in revision of parent commit HEAD"
+    #
+    # Note: The latter might be a conflict of gitpython in-memory index being
+    # committed, while the actual change to be committed was on disk?
+
+    # For now, just check .gitmodules:
+    with open(opj(path, ".gitmodules"), "r") as f:
+        lines = f.readlines()
+        assert_in("[submodule \"some/what/deeper\"]" + os.linesep, lines)
 
 
 @with_tempfile

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -1,0 +1,129 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test create action
+
+"""
+
+
+
+import os
+import shutil
+from os.path import join as opj, abspath, isdir
+from os.path import exists
+from os.path import realpath
+
+from mock import patch
+
+from ..dataset import Dataset
+from datalad.api import create
+from datalad.api import install
+from datalad.consts import DATASETS_TOPURL
+from datalad.distribution.install import get_containing_subdataset
+from datalad.distribution.install import _get_installationpath_from_url
+from datalad.distribution.install import _get_git_url_from_source
+from datalad.utils import chpwd
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.exceptions import FileInGitError
+from datalad.support.gitrepo import GitRepo
+from datalad.support.gitrepo import GitCommandError
+from datalad.cmd import Runner
+
+from datalad.support.annexrepo import AnnexRepo
+from datalad.cmd import Runner
+
+from nose.tools import ok_, eq_, assert_false
+from datalad.tests.utils import with_tempfile, assert_in, with_tree,\
+    with_testrepos, assert_equal, assert_true
+from datalad.tests.utils import SkipTest
+from datalad.tests.utils import assert_cwd_unchanged, skip_if_on_windows
+from datalad.tests.utils import assure_dict_from_str, assure_list_from_str
+from datalad.tests.utils import ok_generator
+from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import ok_startswith
+from datalad.tests.utils import skip_if_no_module
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import serve_path_via_http
+from datalad.tests.utils import swallow_outputs
+from datalad.tests.utils import swallow_logs
+
+
+@with_tempfile
+def test_create_curdir(path):
+    with chpwd(path, mkdir=True):
+        create()
+    ok_(Dataset(path).is_installed())
+
+
+@with_tempfile
+def test_create(path):
+    # install doesn't create anymore
+    assert_raises(RuntimeError, Dataset(path).install)
+    # only needs a path
+    ds = create(path, no_annex=True)
+    ok_(ds.is_installed())
+    ok_clean_git(path, annex=False)
+    ok_(isinstance(ds.repo, GitRepo))
+
+    ds = create(path, description="funny")
+    ok_(ds.is_installed())
+    ok_clean_git(path, annex=False)
+    # any dataset created from scratch has an annex
+    ok_(isinstance(ds.repo, AnnexRepo))
+    # check default backend
+    assert_equal(
+        ds.repo.repo.config_reader().get_value("annex", "backends"),
+        'MD5E')
+    runner = Runner()
+    # check description in `info`
+    cmd = ['git-annex', 'info']
+    cmlout = runner.run(cmd, cwd=path)
+    assert_in('funny [here]', cmlout[0])
+
+
+    sub_path_1 = opj(path, "sub")
+    subds1 = create(sub_path_1)
+    ok_(subds1.is_installed())
+    ok_clean_git(sub_path_1, annex=False)
+    # wasn't installed into ds:
+    assert_not_in("sub", ds.get_subdatasets())
+
+    # add it inplace:
+    added_subds = ds.install("sub", source=sub_path_1)
+    ok_(added_subds.is_installed())
+    ok_clean_git(sub_path_1, annex=False)
+    eq_(added_subds.path, sub_path_1)
+    assert_true(isdir(opj(added_subds.path, '.git')))
+    # will not list it unless committed
+    assert_not_in("sub", ds.get_subdatasets())
+    ds.save("added submodule")
+    # will still not list it, because without a single commit, it doesn't enter
+    # the index
+    assert_not_in("sub", ds.get_subdatasets())
+    # now for reals
+    open(opj(added_subds.path, 'somecontent'), 'w').write('stupid')
+    # next one will auto-annex the new file
+    added_subds.save('initial commit', auto_add_changes=True)
+    # as the submodule never entered the index, even this one won't work
+    # ben: it currently does, since 'save' was changed to call git add as well
+    # as git annex add. Therefore outcommenting. Please review, whether this is
+    # intended behaviour. I think so.
+    # MIH: Now it need a flag to perform this (see #546)
+    ds.save('submodule with content', auto_add_changes=True)
+    # assert_not_in("sub", ds.get_subdatasets())
+    # # we need to install the submodule again in the parent
+    # # an actual final commit is not required
+    # added_subds = ds.install("sub", source=sub_path_1)
+    assert_in("sub", ds.get_subdatasets())
+
+    # next one directly created within ds:
+    sub_path_2 = opj(path, "sub2")
+    # installing something without a source into a dataset at a path
+    # that has no present content should not work
+    assert_raises(InsufficientArgumentsError, install, ds, path=sub_path_2)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -196,10 +196,6 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(subds.path, annex=False)
     # top is not:
     assert_raises(AssertionError, ok_clean_git, ds.path, annex=False)
-    # unless committed the subds should not show up in the parent
-    # this is the same behavior that 'git submodule status' implements
-    assert_not_in('sub', ds.get_subdatasets())
-    ds.save('addsub')
     assert_in('sub', ds.get_subdatasets())
 
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -91,7 +91,7 @@ def test_get_git_url_from_source():
 @with_tree(tree={'test.txt': 'whatever'})
 def test_get_containing_subdataset(path):
 
-    ds = create(path)
+    ds = create(path, force=True)
     ds.install(path='test.txt')
     ds.save("Initial commit")
     subds = ds.install("sub", source=path)
@@ -138,7 +138,7 @@ def test_install_plain_git(src, path):
                  'dir': {'testindir': 'someother',
                          'testindir2': 'none'}})
 def test_install_files(path):
-    ds = create(path)
+    ds = create(path, force=True)
     # install a single file
     eq_(ds.install('test.txt'), opj(path, 'test.txt'))
     # install it again, should given same result

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -87,6 +87,7 @@ def test_get_git_url_from_source():
     eq_(_get_git_url_from_source('ssh://somewhe.re/else'),
         'ssh://somewhe.re/else')
 
+
 @with_tree(tree={'test.txt': 'whatever'})
 def test_get_containing_subdataset(path):
 
@@ -107,81 +108,6 @@ def test_get_containing_subdataset(path):
                   opj(os.curdir, outside_path))
     assert_raises(ValueError, get_containing_subdataset, ds,
                   abspath(outside_path))
-
-
-@with_tempfile
-def test_create(path):
-    # install doesn't create anymore
-    assert_raises(RuntimeError, Dataset(path).install)
-    # only needs a path
-    ds = create(path, no_annex=True)
-    ok_(ds.is_installed())
-    ok_clean_git(path, annex=False)
-    ok_(isinstance(ds.repo, GitRepo))
-
-    ds = create(path, description="funny")
-    ok_(ds.is_installed())
-    ok_clean_git(path, annex=False)
-    # any dataset created from scratch has an annex
-    ok_(isinstance(ds.repo, AnnexRepo))
-    # check default backend
-    assert_equal(
-        ds.repo.repo.config_reader().get_value("annex", "backends"),
-        'MD5E')
-    runner = Runner()
-    # check description in `info`
-    cmd = ['git-annex', 'info']
-    cmlout = runner.run(cmd, cwd=path)
-    assert_in('funny [here]', cmlout[0])
-
-
-    sub_path_1 = opj(path, "sub")
-    subds1 = create(sub_path_1)
-    ok_(subds1.is_installed())
-    ok_clean_git(sub_path_1, annex=False)
-    # wasn't installed into ds:
-    assert_not_in("sub", ds.get_subdatasets())
-
-    # add it inplace:
-    added_subds = ds.install("sub", source=sub_path_1)
-    ok_(added_subds.is_installed())
-    ok_clean_git(sub_path_1, annex=False)
-    eq_(added_subds.path, sub_path_1)
-    assert_true(isdir(opj(added_subds.path, '.git')))
-    # will not list it unless committed
-    assert_not_in("sub", ds.get_subdatasets())
-    ds.save("added submodule")
-    # will still not list it, because without a single commit, it doesn't enter
-    # the index
-    assert_not_in("sub", ds.get_subdatasets())
-    # now for reals
-    open(opj(added_subds.path, 'somecontent'), 'w').write('stupid')
-    # next one will auto-annex the new file
-    added_subds.save('initial commit', auto_add_changes=True)
-    # as the submodule never entered the index, even this one won't work
-    # ben: it currently does, since 'save' was changed to call git add as well
-    # as git annex add. Therefore outcommenting. Please review, whether this is
-    # intended behaviour. I think so.
-    # MIH: Now it need a flag to perform this (see #546)
-    ds.save('submodule with content', auto_add_changes=True)
-    # assert_not_in("sub", ds.get_subdatasets())
-    # # we need to install the submodule again in the parent
-    # # an actual final commit is not required
-    # added_subds = ds.install("sub", source=sub_path_1)
-    assert_in("sub", ds.get_subdatasets())
-
-    # next one directly created within ds:
-    sub_path_2 = opj(path, "sub2")
-    # installing something without a source into a dataset at a path
-    # that has no present content should not work
-    assert_raises(InsufficientArgumentsError, install, ds, path=sub_path_2)
-
-
-@with_tempfile
-def test_create_curdir(path):
-    with chpwd(path, mkdir=True):
-        create()
-    ok_(Dataset(path).is_installed())
 
 
 @with_tree(tree={'test.txt': 'some', 'test2.txt': 'other'})
@@ -232,6 +158,7 @@ def test_install_dataset_from(url, path):
     ok_(ds.is_installed())
     ok_clean_git(path, annex=False)
 
+
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
 def test_install_dataset_from_just_source(url, path):
@@ -242,6 +169,7 @@ def test_install_dataset_from_just_source(url, path):
     ok_startswith(ds.path, path)
     ok_(ds.is_installed())
     ok_clean_git(ds.path, annex=False)
+
 
 @with_testrepos(flavors=['network'])
 @with_tempfile

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -1,0 +1,74 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Common interface options
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+from datalad.support.param import Parameter
+from datalad.support.constraints import EnsureInt, EnsureNone, EnsureStr
+
+dataset_description = Parameter(
+    args=("-D", "--description",),
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""short description of this dataset instance that humans can use to
+    identify the repository/location, e.g. "Precious data on my laptop.""")
+
+recursion_flag = Parameter(
+    args=("-r", "--recursive",),
+    action="store_true",
+    doc="""if set, recurse into potential subdataset""")
+
+recursion_limit = Parameter(
+    args=("--recursion-limit",),
+    metavar="LEVELS",
+    constraints=EnsureInt() | EnsureNone(),
+    doc="""limit recursion into subdataset to the given number of levels""")
+
+add_to_superdataset = Parameter(
+    args=("--add-to-super",),
+    doc="""add the new dataset as a component to a super dataset""",
+    action="store_true")
+
+git_opts = Parameter(
+    args=("--git-opts",),
+    metavar='STRING',
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""option string to be passed to :command:`git` calls""")
+
+annex_opts = Parameter(
+    args=("--annex-opts",),
+    metavar='STRING',
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""option string to be passed to :command:`git annex` calls""")
+
+annex_init_opts = Parameter(
+    args=("--annex-init-opts",),
+    metavar='STRING',
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""option string to be passed to :command:`git annex init` calls""")
+
+annex_add_opts = Parameter(
+    args=("--annex-add-opts",),
+    metavar='STRING',
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""option string to be passed to :command:`git annex add` calls""")
+
+annex_get_opts = Parameter(
+    args=("--annex-get-opts",),
+    metavar='STRING',
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""option string to be passed to :command:`git annex get` calls""")
+
+annex_copy_opts = Parameter(
+    args=("--annex-copy-opts",),
+    metavar='STRING',
+    constraints=EnsureStr() | EnsureNone(),
+    doc="""option string to be passed to :command:`git annex copy` calls""")

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -53,7 +53,7 @@ def test_unlock_raises(path, path2, path3):
                   unlock, dataset=None, path=[path2, path3])
 
     # let's be in a dataset,which is no annex:
-    create(loc=path, no_annex=True)
+    create(path=path, no_annex=True)
     ds = Dataset(path)
     assert_raises(ValueError, ds.unlock)
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -991,8 +991,13 @@ class AnnexRepo(GitRepo):
         self.precommit()
         if self.is_direct_mode():
             if not msg:
-                msg = "Commit"  # may be --allow-empty-message instead?
-            self.proxy(['git', 'commit',  '-m', msg] +
+                if options:
+                    if "--allow-empty-message" not in options:
+                        options.append("--allow-empty-message")
+                else:
+                    options = ["--allow-empty-message"]
+
+            self.proxy(['git', 'commit'] + (['-m', msg] if msg else []) +
                        (options if options else []), expect_stderr=True)
         else:
             super(AnnexRepo, self).commit(msg, options)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -126,7 +126,7 @@ class AnnexRepo(GitRepo):
         fix_it = False
         try:
             super(AnnexRepo, self).__init__(path, url, runner=runner,
-                                            create=create)
+                                            create=create, git_opts=git_opts)
         except GitCommandError as e:
             if create and "Clone succeeded, but checkout failed." in str(e):
                 lgr.warning("Experienced issues while cloning. "

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -70,8 +70,9 @@ class AnnexRepo(GitRepo):
     WEB_UUID = "00000000-0000-0000-0000-000000000001"
 
     def __init__(self, path, url=None, runner=None,
-                 direct=False, backend=None, always_commit=True, create=True, init=False,
-                 batch_size=None, version=None, description=None):
+                 direct=False, backend=None, always_commit=True, create=True,
+                 init=False, batch_size=None, version=None, description=None,
+                 git_opts=None, annex_opts=None, annex_init_opts=None):
         """Creates representation of git-annex repository at `path`.
 
         AnnexRepo is initialized by giving a path to the annex.
@@ -114,6 +115,10 @@ class AnnexRepo(GitRepo):
           short description that humans can use to identify the
           repository/location, e.g. "Precious data on my laptop"
         """
+
+        if git_opts or annex_opts or annex_init_opts:
+            raise NotImplementedError("TODO")
+
         fix_it = False
         try:
             super(AnnexRepo, self).__init__(path, url, runner=runner,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -979,18 +979,23 @@ class AnnexRepo(GitRepo):
         self._batched.close()
         super(AnnexRepo, self).precommit()
 
-    def commit(self, msg):
+    def commit(self, msg=None, options=None):
         """
 
         Parameters
         ----------
         msg: str
+        options: list of str
+          cmdline options for git-commit
         """
         self.precommit()
         if self.is_direct_mode():
-            self.proxy(['git', 'commit',  '-m', msg], expect_stderr=True)
+            if not msg:
+                msg = "Commit"  # may be --allow-empty-message instead?
+            self.proxy(['git', 'commit',  '-m', msg] +
+                       (options if options else []), expect_stderr=True)
         else:
-            super(AnnexRepo, self).commit(msg)
+            super(AnnexRepo, self).commit(msg, options)
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, force=False, **kwargs):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -117,7 +117,11 @@ class AnnexRepo(GitRepo):
         """
 
         if git_opts or annex_opts or annex_init_opts:
-            raise NotImplementedError("TODO")
+            lgr.warning("TODO: options passed to git, git-annex and/or "
+                        "git-annex-init are currently ignored.\n"
+                        "options received:\n"
+                        "git: %s\ngit-annex: %s\ngit-annex-init: %s" %
+                        (git_opts, annex_opts, annex_init_opts))
 
         fix_it = False
         try:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -618,9 +618,9 @@ class GitRepo(object):
         Parameters
         ----------
         msg: str
-            commit-message
-        options:
-            to be implemented. See options_decorator in annexrepo.
+          commit-message
+        options: list of str
+          cmdline options for git-commit
         """
 
         # TODO: for some commits we explicitly do not want a message since
@@ -629,17 +629,16 @@ class GitRepo(object):
         # convert to string anyways.... bleh
         if not msg:
             msg = "Commit"  # there is no good default
-        if options:
-            raise NotImplementedError
         self.precommit()
-        lgr.debug("Committing with msg=%r" % msg)
-        self.cmd_call_wrapper(self.repo.index.commit, msg)
-        #
-        #  Was blaming of too much state causes side-effects while interlaving with
-        #  git annex cmds so this snippet if to use outside git call
-        #self._git_custom_command([], ['git', 'commit'] + \
-        #                         (["-m", msg] if msg else []) + \
-        #                         (options if options else []))
+        if options:
+            # we can't pass all possible options to gitpython's implementation
+            # of commit. Therefore we need a direct call to git:
+            cmd = ['git', 'commit', "-m", msg] + options
+            lgr.debug("Committing via direct call of git: %s" % cmd)
+            self._git_custom_command([], cmd)
+        else:
+            lgr.debug("Committing with msg=%r" % msg)
+            self.cmd_call_wrapper(self.repo.index.commit, msg)
 
     def get_indexed_files(self):
         """Get a list of files in git's index

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -623,17 +623,18 @@ class GitRepo(object):
           cmdline options for git-commit
         """
 
-        # TODO: for some commits we explicitly do not want a message since
-        # it would be coming from e.g. staged merge. But it is not clear
-        # what gitpython would do about it. doc says that it would
-        # convert to string anyways.... bleh
         if not msg:
-            msg = "Commit"  # there is no good default
+            if options:
+                if "--allow-empty-message" not in options:
+                        options.append("--allow-empty-message")
+                else:
+                    options = ["--allow-empty-message"]
+
         self.precommit()
         if options:
             # we can't pass all possible options to gitpython's implementation
             # of commit. Therefore we need a direct call to git:
-            cmd = ['git', 'commit', "-m", msg] + options
+            cmd = ['git', 'commit'] + (["-m", msg] if msg else []) + options
             lgr.debug("Committing via direct call of git: %s" % cmd)
             self._git_custom_command([], cmd)
         else:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -367,7 +367,8 @@ class GitRepo(object):
     # default_git_odbt but still allows for faster testing etc.
     # May be eventually we would make it switchable _GIT_COMMON_OPTIONS = []
 
-    def __init__(self, path, url=None, runner=None, create=True, **kwargs):
+    def __init__(self, path, url=None, runner=None, create=True,
+                 git_opts=None, **kwargs):
         """Creates representation of git repository at `path`.
 
         If `url` is given, a clone is created at `path`.
@@ -406,6 +407,9 @@ class GitRepo(object):
           C='/my/path'   => -C /my/path
 
         """
+
+        if git_opts:
+            raise NotImplementedError("TODO")
 
         self.path = abspath(normpath(path))
         self.cmd_call_wrapper = runner or GitRunner(cwd=self.path)
@@ -446,7 +450,8 @@ class GitRepo(object):
         if create and not exists(opj(path, '.git')):
             try:
                 lgr.debug("Initialize empty Git repository at {0}".format(path))
-                self.repo = self.cmd_call_wrapper(gitpy.Repo.init, path, True,
+                self.repo = self.cmd_call_wrapper(gitpy.Repo.init, path,
+                                                  mkdir=True,
                                                   odbt=default_git_odbt,
                                                   **kwargs)
             except GitCommandError as e:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -409,7 +409,8 @@ class GitRepo(object):
         """
 
         if git_opts:
-            raise NotImplementedError("TODO")
+            lgr.warning("TODO: options passed to git are currently ignored.\n"
+                        "options received: %s" % git_opts)
 
         self.path = abspath(normpath(path))
         self.cmd_call_wrapper = runner or GitRunner(cwd=self.path)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -149,6 +149,7 @@ def test_GitRepo_remove(path):
 
     eq_(set(gr.remove('*', r=True, f=True)), {'file2', 'd2/f1', 'd2/f2'})
 
+
 @assert_cwd_unchanged
 @with_tempfile
 def test_GitRepo_commit(path):
@@ -162,6 +163,13 @@ def test_GitRepo_commit(path):
     gr.commit("Testing GitRepo.commit().")
     ok_clean_git(path, annex=False, untracked=[])
 
+    with open(opj(path, filename), 'w') as f:
+        f.write("changed content")
+
+    gr.add(filename)
+    gr.commit("commit with options", options=to_options(dry_run=True))
+    # wasn't actually committed:
+    ok_(gr.repo.is_dirty())
 
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile

--- a/datalad/tests/test_protocols.py
+++ b/datalad/tests/test_protocols.py
@@ -105,8 +105,12 @@ def test_ExecutionTimeProtocol(path1, path2):
     extracted_path = timer_protocol[2]['command'][1].split(',')[0][7:-1]
     assert_equal(normpath(extracted_path), normpath(path2))
 
-    assert_in("kwargs={'odbt': <class 'git.db.GitCmdObjectDB'>, 'mkdir': True}",
-              timer_protocol[2]['command'][2])
+    # kwargs needs to be in protocol, but order isn't relevant:
+    ok_(("kwargs={'odbt': <class 'git.db.GitCmdObjectDB'>, 'mkdir': True}"
+        in timer_protocol[2]['command'][2]) or
+        ("kwargs={'mkdir': True, 'odbt': <class 'git.db.GitCmdObjectDB'>}"
+        in timer_protocol[2]['command'][2]))
+
     ok_(timer_protocol[2]['end'] >= timer_protocol[2]['start'])
     ok_(timer_protocol[2]['duration'] >= 0)
 

--- a/datalad/tests/test_protocols.py
+++ b/datalad/tests/test_protocols.py
@@ -105,7 +105,8 @@ def test_ExecutionTimeProtocol(path1, path2):
     extracted_path = timer_protocol[2]['command'][1].split(',')[0][7:-1]
     assert_equal(normpath(extracted_path), normpath(path2))
 
-    assert_in("kwargs={'odbt': <class 'git.db.GitCmdObjectDB'>}", timer_protocol[2]['command'][2])
+    assert_in("kwargs={'odbt': <class 'git.db.GitCmdObjectDB'>, 'mkdir': True}",
+              timer_protocol[2]['command'][2])
     ok_(timer_protocol[2]['end'] >= timer_protocol[2]['start'])
     ok_(timer_protocol[2]['duration'] >= 0)
 


### PR DESCRIPTION
New implementation of `create`.
Note, that it now needs `force` in order to create a dataset in a non-empty directory.

General usage in python:

create a dataset:
`Dataset("/where/to/create").create()`
or
`datalad.api.create("/where/to/create")`

create a subdataset (not just inside another but including registering it as a submodule):

`Dataset("/super/sub").create(add_to_super=True)`
or
`Dataset("/super").create_subdataset("sub")`
Please note, that creation of a subdataset requires the superdataset to already exist, of course.
