### PR TITLE
BF: In-line conditionals were not honored for parameter docs

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -53,7 +53,6 @@ def get_interface_groups():
 
 
 def dedent_docstring(text):
-    import textwrap
     """Remove uniform indentation from a multiline docstring"""
     # Problem is that first line might often have no offset, so might
     # need to be ignored from dedent call
@@ -85,12 +84,12 @@ def alter_interface_docs_for_api(docs):
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        '\[CMD:\s.*\sCMD\]',
+        '\[CMD:\s[^\[\]]*\sCMD\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\[PY:\s(.*)\sPY\]',
+        '\[PY:\s([^\[\]]*)\sPY\]',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
@@ -122,12 +121,12 @@ def alter_interface_docs_for_cmdline(docs):
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        '\[PY:\s.*\sPY\]',
+        '\[PY:\s[^\[\]]*\sPY\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\[CMD:\s(.*)\sCMD\]',
+        '\[CMD:\s([^\[\]]*)\sCMD\]',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
@@ -207,10 +206,13 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
             if defaults_idx >= 0:
                 if not param.constraints is None:
                     param.constraints(defaults[defaults_idx])
+            orig_docs = param._doc
+            param._doc = alter_interface_docs_for_api(param._doc)
             doc += param.get_autodoc(
                 arg,
                 default=defaults[defaults_idx] if defaults_idx >= 0 else None,
                 has_default=defaults_idx >= 0)
+            param._doc = orig_docs
             doc += '\n'
     doc += suffix if suffix else u""
     # assign the amended docs

--- a/datalad/interface/tests/test_docs.py
+++ b/datalad/interface/tests/test_docs.py
@@ -57,10 +57,8 @@ demo_paramdoc = """\
     Parameters
     ----------
     dataset : Dataset or None, optional
-      specify the dataset to perform the install operation on. If no
+      something [PY: python only PY] inbetween [CMD: cmdline only CMD] appended [PY: more python PY]
       dataset is given, an attempt is made to identify the dataset based
-      on the current working directory and/or the `path` given.
-      Constraints: Value must be a Dataset or a valid identifier of a
       Dataset (e.g. a path), or value must be `None`. [Default: None]
 """
 
@@ -90,6 +88,12 @@ def test_alter_interface_docs_for_api():
     assert_not_in('REFLOW', alt)
     assert_in("Some Python-only bits Multiline!", alt)
 
+    altpd = alter_interface_docs_for_api(demo_paramdoc)
+    assert_in('python', altpd)
+    assert_in('inbetween', altpd)
+    assert_in('appended', altpd)
+    assert_not_in('cmdline', altpd)
+
 
 def test_alter_interface_docs_for_cmdline():
     alt = alter_interface_docs_for_cmdline(demo_doc)
@@ -113,3 +117,9 @@ def test_alter_interface_docs_for_cmdline():
     eq_(alter_interface_docs_for_cmdline(
         ':term:`one` bla bla :term:`two` bla'),
         'one bla bla two bla')
+
+    altpd = alter_interface_docs_for_cmdline(demo_paramdoc)
+    assert_not_in('python', altpd)
+    assert_in('inbetween', altpd)
+    assert_in('appended', altpd)
+    assert_in('cmdline', altpd)


### PR DESCRIPTION
This is kinda ugly, because we need to save and restore the original
docs. Otherwise the entire search/replace setup needs to be redone
to be able to cope with indented blocks -- giant time sink....