### PR TITLE
RF: move create_test_dataset outside of tests/

### DIFF
--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -19,30 +19,15 @@ import tempfile
 
 from datalad.utils import get_tempfile_kwargs
 import os
-from os.path import join as opj, abspath, relpath, pardir, isabs, isdir, \
-    exists, islink, sep
-from datalad.distribution.dataset import Dataset, datasetmethod, \
-    resolve_path, EnsureDataset
+from os.path import join as opj, exists
+from datalad.distribution.dataset import Dataset
 from datalad.support.param import Parameter
-from datalad.support.constraints import EnsureStr, EnsureNone, EnsureInt, \
-    EnsureBool
+from datalad.support.constraints import EnsureStr, EnsureNone, EnsureInt
 from datalad.support.gitrepo import GitRepo
-from datalad.support.annexrepo import AnnexRepo, FileInGitError, \
-    FileNotInAnnexError
+from datalad.support.annexrepo import AnnexRepo
 from datalad.interface.base import Interface
-from datalad.cmd import CommandError
-from datalad.cmd import Runner
-from datalad.utils import expandpath, knows_annex, assure_dir, \
-    is_explicit_path, on_windows
-from datalad.tests.utils import with_tempfile, assert_raises
 
 lgr = logging.getLogger('datalad.distribution.tests')
-
-
-@with_tempfile(mkdir=True)
-def test_create(outdir):
-    from datalad.api import create
-    assert_raises(ValueError, create, outdir, description='Precious data', no_annex=True)
 
 
 def _parse_spec(spec):
@@ -65,12 +50,6 @@ def _parse_spec(spec):
             raise ValueError("Must have only min-max at level %d" % ilevel)
         out.append((min_, max_))
     return out
-
-
-def test_parse_spec():
-    from nose.tools import eq_
-    eq_(_parse_spec('0/3/-1'), [(0, 0), (3, 3), (0, 1)])
-    eq_(_parse_spec('4-10'), [(4, 10)])
 
 
 def _makeds(path, levels, ds=None):
@@ -153,7 +132,7 @@ class CreateTestDataset(Interface):
             random.seed(seed)
         if path is None:
             kw = get_tempfile_kwargs({}, prefix="ds")
-            path = tempfile.mktemp(mkdir=True, **kw)
+            path = tempfile.mkdtemp(**kw)
         else:
             # so we don't override anything
             assert not exists(path)
@@ -170,7 +149,7 @@ class CreateTestDataset(Interface):
         if not len(res):
             ui.message("No repos were created... oops")
             return
-        items= '\n'.join(map(str, res))
+        items = '\n'.join(map(str, res))
         msg = "{n} installed {obj} available at\n{items}".format(
             obj='items are' if len(res) > 1 else 'item is',
             n=len(res),

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -19,7 +19,7 @@ import tempfile
 
 from datalad.utils import get_tempfile_kwargs
 import os
-from os.path import join as opj, exists
+from os.path import join as opj, exists, isabs, abspath
 from datalad.distribution.dataset import Dataset
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone, EnsureInt
@@ -55,7 +55,9 @@ def _parse_spec(spec):
 def _makeds(path, levels, ds=None):
     # we apparently can't import api functionality within api
     from datalad.api import install
-
+    # To simplify managing all the file paths etc
+    if not isabs(path):
+        path = abspath(path)
     # make it a git (or annex??) repository... ok - let's do randomly one or another ;)
     RepoClass = GitRepo if random.randint(0, 1) else AnnexRepo
     lgr.info("Generating repo of class %s under %s", RepoClass, path)

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -1,0 +1,43 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test create testdataset helpers
+
+"""
+from glob import glob
+from os.path import join as opj
+
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import ok_
+from datalad.tests.utils import ok_clean_git
+from datalad.utils import swallow_logs
+from datalad.distribution.create_test_dataset import _parse_spec
+
+from nose.tools import eq_
+
+
+@with_tempfile(mkdir=True)
+def test_create(outdir):
+    from datalad.api import create
+    assert_raises(ValueError, create, outdir, description='Precious data', no_annex=True)
+
+
+def test_parse_spec():
+    eq_(_parse_spec('0/3/-1'), [(0, 0), (3, 3), (0, 1)])
+    eq_(_parse_spec('4-10'), [(4, 10)])
+
+
+def test_create_test_dataset():
+    # rudimentary smoke test
+    from datalad.api import create_test_dataset
+    with swallow_logs():
+        dss = create_test_dataset(spec='2/1-2')
+    ok_(4 <= len(dss) <= 6)  # at least four - two on top level, 1 in each
+    for ds in dss:
+        ok_clean_git(ds, annex=False)  # soem of them are annex but we just don't check
+        ok_(len(glob(opj(ds, 'file*'))))

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -16,6 +16,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_clean_git
 from datalad.utils import swallow_logs
+from datalad.utils import chpwd
 from datalad.distribution.create_test_dataset import _parse_spec
 
 from nose.tools import eq_
@@ -41,3 +42,11 @@ def test_create_test_dataset():
     for ds in dss:
         ok_clean_git(ds, annex=False)  # soem of them are annex but we just don't check
         ok_(len(glob(opj(ds, 'file*'))))
+
+
+@with_tempfile(mkdir=True)
+def test_create_test_dataset_new_relpath(topdir):
+    from datalad.api import create_test_dataset
+    with swallow_logs(), chpwd(topdir):
+        dss = create_test_dataset('testds', spec='1')
+    eq_(len(dss), 1)

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -49,6 +49,6 @@ _group_misc = (
          'add-archive-content'),
         ('datalad.interface.download_url', 'DownloadURL', 'download-url'),
         # very optional ones
-        ('datalad.distribution.tests.create_test_dataset', 'CreateTestDataset',
+        ('datalad.distribution.create_test_dataset', 'CreateTestDataset',
          'create-test-dataset'),
     ])


### PR DESCRIPTION
otherwise requires nose to run it... detected after trying to use datalad
installed under singularity container with no recommends installed

tests pointed out few hidden bugs ;-)