### PR TITLE
ENH: if 404ing download, but content provided - check content for "failed" messages

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -30,6 +30,7 @@ from ..dochelpers import borrowkwargs
 from logging import getLogger
 lgr = getLogger('datalad.downloaders')
 
+
 @auto_repr
 class BaseDownloader(object):
     """Base class for the downloaders"""

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -124,7 +124,16 @@ class HTTPBaseAuthenticator(Authenticator):
         response = self._post_credential(credentials, post_url, session)
 
         err_prefix = "Authentication to %s failed: " % post_url
-        check_response_status(response, err_prefix, session=session)
+        try:
+            check_response_status(response, err_prefix, session=session)
+        except DownloadError:
+            # It might have happened that the return code was 'incorrect'
+            # and we did get some feedback, which we could analyze to
+            # figure out actual problem.  E.g. in case of nersc of crcns
+            # it returns 404 (not found) with text in the html
+            if response is not None and response.text:
+                self.check_for_auth_failure(response.text, err_prefix)
+            raise
 
         response_text = response.text
         self.check_for_auth_failure(response_text, err_prefix)

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -25,6 +25,7 @@ from ..http import HTMLFormAuthenticator
 from ..http import HTTPDownloader
 from ...support.network import get_url_straight_filename
 from ...tests.utils import with_fake_cookies_db
+from ...tests.utils import with_testsui
 
 # BTW -- mock_open is not in mock on wheezy (Debian 7.x)
 try:
@@ -317,6 +318,42 @@ def test_HTMLFormAuthenticator_httpretty(d):
 
     # Unsuccesfull scenarios to test:
     # the provided URL at the end 404s, or another failure (e.g. interrupted download)
+
+
+@skip_if(not httpretty, "no httpretty")
+@without_http_proxy
+@httpretty.activate
+@with_tempfile(mkdir=True)
+@with_fake_cookies_db
+@with_testsui(responses=['yes'])  # will request to reentry it
+def test_HTMLFormAuthenticator_httpretty_authfail404(d):
+    # mimic behavior of nersc which 404s but provides feedback whenever
+    # credentials are incorrect.  In our case we should fail properly
+    credential = FakeCredential1(name='test', url=None)
+
+    was_called = []
+
+    def request_post_callback(request, uri, headers):
+        post_params = request.parsed_body
+        if post_params['password'][0] == 'testpassword2':
+            was_called.append('404')
+            return 404, headers, "Really 404"
+        else:
+            was_called.append('failed')
+            return 404, headers, "Failed"
+
+    httpretty.register_uri(httpretty.POST, url, body=request_post_callback)
+
+    # Also we want to test how would it work if cookie is available (may be)
+    authenticator = HTMLFormAuthenticator(dict(username="{user}",
+                                               password="{password}",
+                                               submit="CustomLogin"),
+                                          failure_re="Failed")
+
+    downloader = HTTPDownloader(credential=credential, authenticator=authenticator)
+    # first one goes with regular DownloadError -- was 404 with not matching content
+    assert_raises(DownloadError, downloader.download, url, path=d)
+    assert_equal(was_called, ['failed', '404'])
 
 
 class FakeCredential2(UserPassword):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -703,6 +703,7 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
     return newfunc
 with_testrepos.__test__ = False
 
+
 @optional_args
 def with_fake_cookies_db(func, cookies={}):
     """mock original cookies db with a fake one for the duration of the test


### PR DESCRIPTION
Happens with nersc portal