### PR TITLE
NF+ENH: annex.is_available, get_urls, +serialize mode for @normalize_paths

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1096,6 +1096,8 @@ def test_is_available(batch, direct, p):
     assert is_available(fname, remote='origin') is False
     # it is on the 'web'
     assert is_available(fname, remote='web') is True
+    # not effective somehow :-/  may be the process already running or smth
+    #with swallow_logs(), swallow_outputs():  # it will complain!
     assert is_available(fname, remote='unknown') is False
     assert_false(is_available("boguskey", key=True))
 


### PR DESCRIPTION
Somewhat undertested but should be all covered ;)

Named `is_available` although original annex call is `checkpresentkey` which IMHO is a misleading name especially if no remote is provided.  `is_available` imho is cleaner.

Needed to improve archive remotes, so they could ask annex either key (archive) is available in general.  made possible after annex allowed to query without asking specific remote name