### PR TITLE
ENH: silence logs during tests, specify new_level explicitly where needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
   #  env:
   #  - NOSE_WRAPPER="tools/eval_under_testloopfs"
   - python: 2.7
+    # By default no logs will be output. This one is to test with log output at INFO level
+    env:
+    - DATALAD_LOGLEVEL=INFO
+  - python: 2.7
     env:
     # to test operation under root since also would consider FS "crippled" due to
     # ability to rewrite R/O files
@@ -72,7 +76,7 @@ install:
 
 script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
-  - DATALAD_LOGLEVEL=INFO $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
+  - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -44,6 +44,11 @@ test.__test__ = False
 # Following fixtures are necessary at the top level __init__ for fixtures which
 # would cover all **/tests and not just datalad/tests/
 
+# To store settings which setup_package changes and teardown_package should return
+_test_states = {
+    'loglevel': None,
+    'DATALAD_LOGLEVEL': None,
+}
 
 def setup_package():
     import os
@@ -62,11 +67,33 @@ def setup_package():
             lgr.debug("Removing %s from the environment since it is empty", ev)
             os.environ.pop(ev)
 
+    DATALAD_LOGLEVEL = os.environ.get('DATALAD_LOGLEVEL', None)
+    if DATALAD_LOGLEVEL is None:
+        # very very silent.  Tests introspecting logs should use
+        # swallow_logs(new_level=...)
+        _test_states['loglevel'] = lgr.getEffectiveLevel()
+        lgr.setLevel(100)
+
+        # And we should also set it within environ so underlying commands also stay silent
+        _test_states['DATALAD_LOGLEVEL'] = DATALAD_LOGLEVEL
+        os.environ['DATALAD_LOGLEVEL'] = '100'
+    else:
+        # We are not overriding them, since explicitly were asked to have some log level
+        _test_states['loglevel'] = None
+
 
 def teardown_package():
     import os
     if os.environ.get('DATALAD_TESTS_NOTEARDOWN'):
         return
+
+    if _test_states['loglevel'] is not None:
+        lgr.setLevel(_test_states['loglevel'])
+        if _test_states['DATALAD_LOGLEVEL'] is None:
+            os.environ.pop('DATALAD_LOGLEVEL')
+        else:
+            os.environ['DATALAD_LOGLEVEL'] = _test_states['DATALAD_LOGLEVEL']
+
     from datalad.tests import _TEMP_PATHS_GENERATED
     from datalad.tests.utils import rmtemp
     if len(_TEMP_PATHS_GENERATED):

--- a/datalad/crawler/nodes/tests/test_s3.py
+++ b/datalad/crawler/nodes/tests/test_s3.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 # now with some recursive structure of directories
 
+import logging
 from ..s3 import crawl_s3
 from ..s3 import _strip_prefix
 from ..s3 import get_key_url
@@ -94,7 +95,7 @@ def test_crawl_s3_commit_versions(path):
     ]
 
     with externals_use_cassette('test_crawl_s3-pipeline1'):
-        with swallow_logs() as cml:
+        with swallow_logs(new_level=logging.WARN) as cml:
             out = run_pipeline(pipeline)
             assert_in("There is already a tag %s" % target_version, cml.out)
     # things are committed and thus stats are empty
@@ -141,7 +142,7 @@ def test_crawl_s3_commit_versions_one_at_a_time(path):
     ]
 
     with externals_use_cassette('test_crawl_s3-pipeline1'):
-        with swallow_logs() as cml:
+        with swallow_logs(new_level=logging.WARN) as cml:
             out = run_pipeline(pipeline)
             assert_not_in("There is already a tag %s" % target_version, cml.out)
     # things are committed and thus stats are empty
@@ -154,7 +155,7 @@ def test_crawl_s3_commit_versions_one_at_a_time(path):
     # and there should be 7 more, every time changing the total stats
     for t in range(1, 8):
         with externals_use_cassette('test_crawl_s3-pipeline1'):
-            with swallow_logs() as cml:
+            with swallow_logs(new_level=logging.WARN) as cml:
                 out = run_pipeline(pipeline)
                 assert_in("There is already a tag %s" % target_version, cml.out)
         total_stats_ = out[0]['datalad_stats'].get_total()
@@ -217,7 +218,7 @@ def test_crawl_s3_prefix():
     node = crawl_s3('datalad-test0-versioned')
     eq_(node.prefix, None)
 
-    with swallow_logs() as cml:
+    with swallow_logs(new_level=logging.WARN) as cml:
         node = crawl_s3('datalad-test0-versioned', prefix="dir")
         assert_in('adding /', cml.out)
     eq_(node.prefix, 'dir/')


### PR DESCRIPTION
Closes #182 
but might need few more new_level uses if tests fail @glalteva  ;)

so the idea is that tests should stay VERY silent unless explicit DATALAD_LOGLEVEL env variable instructs to maintain some level of reporting