### PR TITLE
ENH: publish --skip-failing

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -27,6 +27,7 @@ from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.utils import getpwd
+from datalad.dochelpers import exc_str
 
 from .dataset import EnsureDataset
 from .dataset import Dataset
@@ -93,6 +94,11 @@ class Publish(Interface):
             doc="recursively publish all subdatasets of the dataset. In order "
                 "to recursivley publish with all data, use '.' as `path` in "
                 "combination with `recursive`"),
+        skip_failing=Parameter(
+            args=("--skip-failing",),
+            action="store_true",
+            doc="skip failing sub-datasets (incombination with `recursive`) "
+                "instead of failing altogether"),
         path=Parameter(
             args=("path",),
             metavar='PATH',
@@ -112,7 +118,7 @@ class Publish(Interface):
 
     @staticmethod
     @datasetmethod(name='publish')
-    def __call__(dataset=None, to=None, path=None, recursive=False,
+    def __call__(dataset=None, to=None, path=None, recursive=False, skip_failing=False,
                  annex_copy_opts=None):
 
         # shortcut
@@ -195,7 +201,7 @@ class Publish(Interface):
                         publish_subs[d.path]['dataset'] = d
                         publish_subs[d.path]['files'].append(p)
 
-        results = []
+        published, skipped = [], []
 
         if publish_this:
 
@@ -250,7 +256,7 @@ class Publish(Interface):
             # Apparently, we can annex copy new files only, after this fetch. Figure it out!
             ds.repo.fetch(remote=dest_resolved)
 
-            results.append(ds)
+            published.append(ds)
 
             if publish_files or annex_copy_opts:
                 if not isinstance(ds.repo, AnnexRepo):
@@ -259,7 +265,7 @@ class Publish(Interface):
                         "part of an annex. ({0})".format(ds))
 
                 lgr.info("Publishing data of dataset {0} ...".format(ds))
-                results += ds.repo.copy_to(files=publish_files,
+                published += ds.repo.copy_to(files=publish_files,
                                            remote=dest_resolved,
                                            options=annex_copy_opts)
 
@@ -270,8 +276,16 @@ class Publish(Interface):
             # therefore force it.
             # TODO: There might be a better solution to avoid two calls of
             # publish() on the very same Dataset instance
-            results += Dataset(opj(ds.path, dspath)).publish(
-                to=to, recursive=recursive)
+            ds_ = Dataset(opj(ds.path, dspath))
+            try:
+                published_, skipped_ = ds_.publish(to=to, recursive=recursive)
+                published += published_
+                skipped += skipped_
+            except Exception as exc:
+                if not skip_failing:
+                    raise
+                lgr.warning("Skipped %s: %s", ds.path, exc_str(exc))
+                skipped += [ds_]
 
         for d in publish_subs:
             # recurse into subdatasets
@@ -279,28 +293,33 @@ class Publish(Interface):
             # TODO: need to fetch. see above
             publish_subs[d]['dataset'].repo.fetch(remote=to)
 
-            results += publish_subs[d]['dataset'].publish(
+            published_, skipped_ = publish_subs[d]['dataset'].publish(
                 to=to,
                 path=publish_subs[d]['files'],
                 recursive=recursive,
                 annex_copy_opts=annex_copy_opts)
+            published += published_
+            skipped += skipped_
 
-        return results
+        return published, skipped
 
     @staticmethod
-    def result_renderer_cmdline(res):
+    def result_renderer_cmdline(results):
         from datalad.ui import ui
-        if not res:
-            ui.message("Nothing was published")
-            return
-        msg = "{n} {obj} published:\n".format(
-            obj='items were' if len(res) > 1 else 'item was',
-            n=len(res))
-        for item in res:
-            if isinstance(item, Dataset):
-                msg += "Dataset: %s\n" % item.path
-            else:
-                msg += "File: %s\n" % item
-        ui.message(msg)
+        for res, res_label in zip(results, ('published', 'skipped')):
+            if not res:
+                if res_label == 'published':
+                    ui.message("Nothing was %s" % res_label)
+                continue
+            msg = "{n} {obj} {res_label}:\n".format(
+                obj='items were' if len(res) > 1 else 'item was',
+                n=len(res),
+                res_label=res_label)
+            for item in res:
+                if isinstance(item, Dataset):
+                    msg += "Dataset: %s\n" % item.path
+                else:
+                    msg += "File: %s\n" % item
+            ui.message(msg)
 
 

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -53,7 +53,7 @@ def test_publish_simple(origin, src_path, dst_path):
     source.repo.add_remote("target", dst_path)
 
     res = publish(dataset=source, to="target")
-    eq_(res, [source])
+    eq_(res, ([source], []))
 
     ok_clean_git(src_path, annex=False)
     ok_clean_git(dst_path, annex=False)
@@ -62,7 +62,7 @@ def test_publish_simple(origin, src_path, dst_path):
 
     # don't fail when doing it again
     res = publish(dataset=source, to="target")
-    eq_(res, [source])
+    eq_(res, ([source], []))
 
     ok_clean_git(src_path, annex=False)
     ok_clean_git(dst_path, annex=False)
@@ -82,7 +82,7 @@ def test_publish_simple(origin, src_path, dst_path):
     ok_clean_git(src_path, annex=False)
 
     res = publish(dataset=source)
-    eq_(res, [source])
+    eq_(res, ([source], []))
 
     ok_clean_git(dst_path, annex=False)
     eq_(list(target.get_branch_commits("master")),
@@ -130,10 +130,13 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # testing result list
     # (Note: Dataset lacks __eq__ for now. Should this be based on path only?)
-    assert_is_instance(res, list)
-    for item in res:
+    assert_is_instance(res, tuple)
+    assert_is_instance(res[0], list)
+    assert_is_instance(res[1], list)
+    eq_(res[1], [])  # nothing failed/was skipped
+    for item in res[0]:
         assert_is_instance(item, Dataset)
-    eq_({res[0].path, res[1].path, res[2].path},
+    eq_({res[0][0].path, res[0][1].path, res[0][2].path},
         {src_path, sub1.path, sub2.path})
 
     eq_(list(target.get_branch_commits("master")),
@@ -188,7 +191,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
     source.repo.fetch("target")
 
     res = publish(dataset=source, to="target", path=['test-annex.dat'])
-    eq_(res, [source, 'test-annex.dat'])
+    eq_(res, ([source, 'test-annex.dat'], []))
 
     eq_(list(target.get_branch_commits("master")),
         list(source.repo.get_branch_commits("master")))
@@ -203,7 +206,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     source.repo.fetch("target")
     res = publish(dataset=source, to="target", path=['.'])
-    eq_(res, [source, 'test-annex.dat'])
+    eq_(res, ([source, 'test-annex.dat'], []))
 
     source.repo.fetch("target")
     import glob
@@ -213,7 +216,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # collect result paths:
     result_paths = []
-    for item in res:
+    for item in res[0]:
         if isinstance(item, Dataset):
             result_paths.append(item.path)
         else:


### PR DESCRIPTION
not sure if that is how it should be, but at least it is working

anyways imho output of publish should be more about what was published, i.e. for which datasets anything (and what in particular) was pushed -- which branches, and tags... but that is a separate topic I guess