### PR TITLE
BF: Skip datatsets in fcptable pipeline

### DIFF
--- a/datalad/crawler/pipelines/fcptable.py
+++ b/datalad/crawler/pipelines/fcptable.py
@@ -30,9 +30,8 @@ def superdataset_pipeline(url=TOPURL):
     return [
         crawl_url(url),
         xpath_match('//*[@class="tableHdr"]/td/strong/text()', output='dataset'),
-        skip_if(dataset='Cleveland CCF'),
-        skip_if(dataset='Durham_Madden'),
-        skip_if(dataset='NewYork_Test-Retest_Reliability'),
+        # skipping Cleveland and NewYork due to URL redirects, Durham due to lack of dataset tarball
+        skip_if({'dataset': 'Cleveland CCF | Durham_Madden | NewYork_Test-Retest_Reliability'}, re=True),
         assign({'dataset_name': '%(dataset)s'}, interpolate=True),
         annex.initiate_dataset(
             template="fcptable",

--- a/datalad/crawler/pipelines/fcptable.py
+++ b/datalad/crawler/pipelines/fcptable.py
@@ -31,7 +31,7 @@ def superdataset_pipeline(url=TOPURL):
         crawl_url(url),
         xpath_match('//*[@class="tableHdr"]/td/strong/text()', output='dataset'),
         # skipping Cleveland and NewYork due to URL redirects, Durham due to lack of dataset tarball
-        skip_if({'dataset': 'Cleveland CCF | Durham_Madden | NewYork_Test-Retest_Reliability'}, re=True),
+        skip_if({'dataset': 'Cleveland CCF|Durham_Madden|NewYork_Test-Retest_Reliability'}, re=True),
         assign({'dataset_name': '%(dataset)s'}, interpolate=True),
         annex.initiate_dataset(
             template="fcptable",
@@ -114,6 +114,8 @@ def pipeline(dataset):
             crawl_url(TOPURL),
             [
                 assign({'dataset': dataset}),
+                # skipping Cleveland and NewYork due to URL redirects, Durham due to lack of dataset tarball
+                skip_if({'dataset': 'Cleveland CCF|Durham_Madden|NewYork_Test-Retest_Reliability'}, re=True),
                 # first row was formatted differently so we need to condition it a bit
                 sub({'response': {'<div class="tableParam">([^<]*)</div>': r'\1'}}),
                 find_dataset(dataset),

--- a/datalad/crawler/pipelines/fcptable.py
+++ b/datalad/crawler/pipelines/fcptable.py
@@ -6,8 +6,7 @@ from os.path import lexists
 # Import necessary nodes
 from ..nodes.crawl_url import crawl_url
 from ..nodes.matches import xpath_match, a_href_match
-from ..nodes.misc import assign
-from ..nodes.misc import sub
+from ..nodes.misc import assign, skip_if, sub
 from ..nodes.misc import get_disposition_filename
 from ..nodes.misc import find_files
 from ..nodes.annex import Annexificator
@@ -20,12 +19,22 @@ TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
 
 def superdataset_pipeline(url=TOPURL):
+    """
+    Parameters
+    ----------
+    url: str
+       URL point to all datasets, hence the URL at the top
+    -------
+
+    """
     annex = Annexificator()
     lgr.info("Creating a FCP collection pipeline")
     return [
         crawl_url(url),
         xpath_match('//*[@class="tableHdr"]/td/strong/text()', output='dataset'),
-        # TODO: replace spaces
+        skip_if(dataset='Cleveland CCF'),
+        skip_if(dataset='Durham_Madden'),
+        skip_if(dataset='NewYork_Test-Retest_Reliability'),
         assign({'dataset_name': '%(dataset)s'}, interpolate=True),
         annex.initiate_dataset(
             template="fcptable",

--- a/datalad/crawler/pipelines/fcptable.py
+++ b/datalad/crawler/pipelines/fcptable.py
@@ -24,8 +24,6 @@ def superdataset_pipeline(url=TOPURL):
     ----------
     url: str
        URL point to all datasets, hence the URL at the top
-    -------
-
     """
     annex = Annexificator()
     lgr.info("Creating a FCP collection pipeline")


### PR DESCRIPTION
Temp workaround until redirect_url is complete- certain datasets have links which redirect to different url that must be crawled in order to grab tarballs rather than that original url being a tarball download itself.
Other datasets (Durham_Madden) have no links at all.
For now, will just skip those problematic datasets.

Working towards closing #655. 