### PR TITLE
ENH: silence logs during tests with new_level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
   #  env:
   #  - NOSE_WRAPPER="tools/eval_under_testloopfs"
   - python: 2.7
+    # By default no logs will be output. This one is to test with log output at INFO level
+    env:
+    - DATALAD_LOGLEVEL=INFO
+  - python: 2.7
     env:
     # to test operation under root since also would consider FS "crippled" due to
     # ability to rewrite R/O files
@@ -72,7 +76,7 @@ install:
 
 script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
-  - DATALAD_LOGLEVEL=INFO $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
+  - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -44,6 +44,11 @@ test.__test__ = False
 # Following fixtures are necessary at the top level __init__ for fixtures which
 # would cover all **/tests and not just datalad/tests/
 
+# To store settings which setup_package changes and teardown_package should return
+_test_states = {
+    'loglevel': None,
+    'DATALAD_LOGLEVEL': None,
+}
 
 def setup_package():
     import os
@@ -62,11 +67,33 @@ def setup_package():
             lgr.debug("Removing %s from the environment since it is empty", ev)
             os.environ.pop(ev)
 
+    DATALAD_LOGLEVEL = os.environ.get('DATALAD_LOGLEVEL', None)
+    if DATALAD_LOGLEVEL is None:
+        # very very silent.  Tests introspecting logs should use
+        # swallow_logs(new_level=...)
+        _test_states['loglevel'] = lgr.getEffectiveLevel()
+        lgr.setLevel(100)
+
+        # And we should also set it within environ so underlying commands also stay silent
+        _test_states['DATALAD_LOGLEVEL'] = DATALAD_LOGLEVEL
+        os.environ['DATALAD_LOGLEVEL'] = '100'
+    else:
+        # We are not overriding them, since explicitly were asked to have some log level
+        _test_states['loglevel'] = None
+
 
 def teardown_package():
     import os
     if os.environ.get('DATALAD_TESTS_NOTEARDOWN'):
         return
+
+    if _test_states['loglevel'] is not None:
+        lgr.setLevel(_test_states['loglevel'])
+        if _test_states['DATALAD_LOGLEVEL'] is None:
+            os.environ.pop('DATALAD_LOGLEVEL')
+        else:
+            os.environ['DATALAD_LOGLEVEL'] = _test_states['DATALAD_LOGLEVEL']
+
     from datalad.tests import _TEMP_PATHS_GENERATED
     from datalad.tests.utils import rmtemp
     if len(_TEMP_PATHS_GENERATED):

--- a/datalad/crawler/nodes/tests/test_s3.py
+++ b/datalad/crawler/nodes/tests/test_s3.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 # now with some recursive structure of directories
 
+import logging
 from ..s3 import crawl_s3
 from ..s3 import _strip_prefix
 from ..s3 import get_key_url
@@ -94,7 +95,7 @@ def test_crawl_s3_commit_versions(path):
     ]
 
     with externals_use_cassette('test_crawl_s3-pipeline1'):
-        with swallow_logs() as cml:
+        with swallow_logs(new_level=logging.WARN) as cml:
             out = run_pipeline(pipeline)
             assert_in("There is already a tag %s" % target_version, cml.out)
     # things are committed and thus stats are empty
@@ -141,7 +142,7 @@ def test_crawl_s3_commit_versions_one_at_a_time(path):
     ]
 
     with externals_use_cassette('test_crawl_s3-pipeline1'):
-        with swallow_logs() as cml:
+        with swallow_logs(new_level=logging.WARN) as cml:
             out = run_pipeline(pipeline)
             assert_not_in("There is already a tag %s" % target_version, cml.out)
     # things are committed and thus stats are empty
@@ -154,7 +155,7 @@ def test_crawl_s3_commit_versions_one_at_a_time(path):
     # and there should be 7 more, every time changing the total stats
     for t in range(1, 8):
         with externals_use_cassette('test_crawl_s3-pipeline1'):
-            with swallow_logs() as cml:
+            with swallow_logs(new_level=logging.WARN) as cml:
                 out = run_pipeline(pipeline)
                 assert_in("There is already a tag %s" % target_version, cml.out)
         total_stats_ = out[0]['datalad_stats'].get_total()
@@ -217,7 +218,7 @@ def test_crawl_s3_prefix():
     node = crawl_s3('datalad-test0-versioned')
     eq_(node.prefix, None)
 
-    with swallow_logs() as cml:
+    with swallow_logs(new_level=logging.WARN) as cml:
         node = crawl_s3('datalad-test0-versioned', prefix="dir")
         assert_in('adding /', cml.out)
     eq_(node.prefix, 'dir/')

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -76,7 +76,7 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     assert_true(annex.file_has_content(fn_extracted))
 
     annex.rm_url(fn_extracted, file_url)
-    with swallow_logs() as cm:
+    with swallow_logs(new_level=logging.WARN) as cm:
         assert_raises(RuntimeError, annex.drop, fn_extracted)
         in_("git-annex: drop: 1 failed", cm.out)
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -36,7 +36,7 @@ def test_AnnexRepo_instance_from_clone(src, dst):
 
     # do it again should raise GitCommandError since git will notice
     # there's already a git-repo at that path and therefore can't clone to `dst`
-    with swallow_logs() as cm:
+    with swallow_logs(new_level=logging.WARN) as cm:
         assert_raises(GitCommandError, AnnexRepo, dst, src)
         if git.__version__ != "1.0.2" and git.__version__ != "2.0.5":
             assert("already exists" in cm.out)

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -12,6 +12,7 @@ import sys
 import os
 import random
 import traceback
+import logging
 
 try:
     # optional direct dependency we might want to kick out
@@ -320,7 +321,7 @@ def test_assert_cwd_unchanged_not_masking_exceptions():
         os.chdir(os.pardir)
         raise ValueError("error exception")
 
-    with swallow_logs() as cml:
+    with swallow_logs(new_level=logging.WARN) as cml:
         with assert_raises(ValueError) as cm:
             do_chdir_value_error()
         # retrospect exception
@@ -340,7 +341,7 @@ def test_assert_cwd_unchanged_not_masking_exceptions():
         os.chdir(os.pardir)
         raise ValueError("error exception")
 
-    with swallow_logs() as cml:
+    with swallow_logs(new_level=logging.WARN) as cml:
         assert_raises(ValueError, do_chdir_value_error)
         eq_(orig_cwd, os.getcwd(),
             "assert_cwd_unchanged didn't return us back to %s" % orig_cwd)


### PR DESCRIPTION
Merged from #649 "so the idea is that tests should stay VERY silent unless explicit DATALAD_LOGLEVEL env variable instructs to maintain some level of reporting"

Closes #182 
Just fixed up a few of the tests left behind