### PR TITLE
BF: manpage only if manpage_version==datalad_version

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -21,6 +21,7 @@ from tempfile import NamedTemporaryFile
 from ..cmd import Runner
 from ..log import is_interactive
 from ..utils import getpwd
+from ..version import __version__
 
 from logging import getLogger
 lgr = getLogger('datalad.cmdline')
@@ -31,11 +32,16 @@ class HelpAction(argparse.Action):
             # lets use the manpage on mature systems ...
             try:
                 import subprocess
+                man_th = subprocess.check_output(
+                    ['zgrep', '\\.TH', '/usr/share/man/man1/datalad.1.gz'])
+                man_version = man_th.split(' ')[4]
+                if __version__ not in man_version:
+                    raise ValueError
                 subprocess.check_call(
                     'man %s 2> /dev/null' % parser.prog.replace(' ', '-'),
                     shell=True)
                 sys.exit(0)
-            except (subprocess.CalledProcessError, OSError):
+            except (subprocess.CalledProcessError, OSError, IndexError, ValueError):
                 # ...but silently fall back if it doesn't work
                 pass
         if option_string == '-h':

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -32,10 +32,19 @@ class HelpAction(argparse.Action):
             # lets use the manpage on mature systems ...
             try:
                 import subprocess
+                # extract version field from datalad manpage if present, swallow_error_logs
                 man_th = subprocess.check_output(
-                    ['zgrep', '\\.TH', '/usr/share/man/man1/datalad.1.gz'])
-                man_version = man_th.split(' ')[4]
-                if __version__ not in man_version:
+                    ['zgrep', '\\.TH', '/usr/share/man/man1/datalad.1.gz'],
+                    stderr=subprocess.STDOUT)
+                man_version = man_th.split(' ')[5].strip(" '\"\t\n")
+
+                # extract current datalad version
+                datalad_version = '.'.join(
+                    __version__.split('.')[:3]
+                ).strip(" '\"\t\n")  # e.g 2.0.3.dev84 ~> 2.0.3
+
+                # don't show manpage if man_version not equal to current datalad_version
+                if datalad_version != man_version:
                     raise ValueError
                 subprocess.check_call(
                     'man %s 2> /dev/null' % parser.prog.replace(' ', '-'),

--- a/datalad/tests/test_cmdline_main.py
+++ b/datalad/tests/test_cmdline_main.py
@@ -66,8 +66,7 @@ def test_version():
 
 
 def test_help_np():
-    with patch.dict('os.environ', {'DATALAD_HELP2MAN': '1'}):
-        stdout, stderr = run_main(['--help-np'])
+    stdout, stderr = run_main(['--help-np'])
 
     # Let's extract section titles:
     # enough of bin/datalad and .tox/py27/bin/datalad -- guarantee consistency! ;)

--- a/formatters.py
+++ b/formatters.py
@@ -21,6 +21,7 @@ class ManPageFormatter(argparse.HelpFormatter):
                  section=1,
                  ext_sections=None,
                  authors=None,
+                 version=None
                  ):
 
         super(ManPageFormatter, self).__init__(prog)
@@ -29,6 +30,7 @@ class ManPageFormatter(argparse.HelpFormatter):
         self._section = 1
         self._today = datetime.date.today().strftime('%Y\\-%m\\-%d')
         self._ext_sections = ext_sections
+        self._version = version
 
     def _get_formatter(self, **kwargs):
         return self.formatter_class(prog=self.prog, **kwargs)
@@ -58,8 +60,9 @@ class ManPageFormatter(argparse.HelpFormatter):
         return usage
 
     def _mk_title(self, prog):
-        return '.TH {0} {1} {2}\n'.format(prog, self._section,
-                                          self._today)
+        name_version = "\"{0} {1}\"".format(prog, self._version)
+        return '.TH {0} {1} {2} {3}\n'.format(prog, self._section,
+                                              self._today, name_version)
 
     def _make_name(self, parser):
         """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 import platform
 
 from glob import glob
-from os.path import sep as pathsep, join as opj, dirname
+from os.path import sep as pathsep
 
 from setuptools import setup, find_packages
 
@@ -17,13 +17,8 @@ from setuptools import setup, find_packages
 from distutils.command.build_py import build_py
 from setup_support import BuildManPage, BuildRSTExamplesFromScripts
 
-# This might entail lots of imports which might not yet be available
-# so let's do ad-hoc parsing of the version.py
-#import datalad.version
-with open(opj(dirname(__file__), 'datalad', 'version.py')) as f:
-    version_lines = list(filter(lambda x: x.startswith('__version__'), f))
-assert(len(version_lines) == 1)
-version = version_lines[0].split('=')[1].strip(" '\"\t\n")
+# datalad version to be installed
+version = BuildManPage.version()
 
 # Only recentish versions of find_packages support include
 # datalad_pkgs = find_packages('.', include=['datalad*'])

--- a/setup_support.py
+++ b/setup_support.py
@@ -57,7 +57,7 @@ class BuildManPage(Command):
         self._today = datetime.date.today()
 
     @property
-    def version():
+    def version(self):
         # This might entail lots of imports which might not yet be available
         # so let's do ad-hoc parsing of the version.py
         with open(opj(dirname(__file__), 'datalad', 'version.py')) as f:

--- a/setup_support.py
+++ b/setup_support.py
@@ -58,6 +58,8 @@ class BuildManPage(Command):
 
     @property
     def version():
+        # This might entail lots of imports which might not yet be available
+        # so let's do ad-hoc parsing of the version.py
         with open(opj(dirname(__file__), 'datalad', 'version.py')) as f:
             version_lines = list(filter(lambda x: x.startswith('__version__'), f))
         assert(len(version_lines) == 1)

--- a/setup_support.py
+++ b/setup_support.py
@@ -56,8 +56,7 @@ class BuildManPage(Command):
         self.announce('Writing man page(s) to %s' % self.manpath)
         self._today = datetime.date.today()
 
-    @staticmethod
-    def version():
+    def version(self):
         # This might entail lots of imports which might not yet be available
         # so let's do ad-hoc parsing of the version.py
         with open(opj(dirname(__file__), 'datalad', 'version.py')) as f:

--- a/setup_support.py
+++ b/setup_support.py
@@ -7,7 +7,7 @@
 
 
 import os
-from os.path import join as opj
+from os.path import dirname, join as opj
 
 from distutils.core import Command
 from distutils.errors import DistutilsOptionError
@@ -56,6 +56,13 @@ class BuildManPage(Command):
         self.announce('Writing man page(s) to %s' % self.manpath)
         self._today = datetime.date.today()
 
+    @property
+    def version():
+        with open(opj(dirname(__file__), 'datalad', 'version.py')) as f:
+            version_lines = list(filter(lambda x: x.startswith('__version__'), f))
+        assert(len(version_lines) == 1)
+        return version_lines[0].split('=')[1].strip(" '\"\t\n")
+
     def run(self):
 
         dist = self.distribution
@@ -78,7 +85,7 @@ class BuildManPage(Command):
                 cmdname = "{0}{1}".format(
                     'datalad-' if cmdname != 'datalad' else '',
                     cmdname)
-                format = cls(cmdname, ext_sections=sections)
+                format = cls(cmdname, ext_sections=sections, version=self.version)
                 formatted = format.format_man_page(p)
                 with open(opj(opath, '{0}.{1}'.format(
                         cmdname,

--- a/setup_support.py
+++ b/setup_support.py
@@ -56,8 +56,8 @@ class BuildManPage(Command):
         self.announce('Writing man page(s) to %s' % self.manpath)
         self._today = datetime.date.today()
 
-    @property
-    def version(self):
+    @staticmethod
+    def version():
         # This might entail lots of imports which might not yet be available
         # so let's do ad-hoc parsing of the version.py
         with open(opj(dirname(__file__), 'datalad', 'version.py')) as f:
@@ -87,7 +87,7 @@ class BuildManPage(Command):
                 cmdname = "{0}{1}".format(
                     'datalad-' if cmdname != 'datalad' else '',
                     cmdname)
-                format = cls(cmdname, ext_sections=sections, version=self.version)
+                format = cls(cmdname, ext_sections=sections, version=self.version())
                 formatted = format.format_man_page(p)
                 with open(opj(opath, '{0}.{1}'.format(
                         cmdname,


### PR DESCRIPTION
`datalad --help` now verifes `manpage_version == current _datalad_version` before showing manpage else falls back to showing normal help

addresses issue #619