### PR TITLE
RF+BF: Move positional args to be the first in __call__ signature

### DIFF
--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -79,7 +79,7 @@ class AddSibling(Interface):
 
     @staticmethod
     @datasetmethod(name='add_sibling')
-    def __call__(dataset=None, name=None, url=None,
+    def __call__(name=None, url=None, dataset=None,
                  pushurl=None, recursive=False, force=False):
 
         # TODO: Detect malformed URL and fail?

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -281,8 +281,8 @@ class Install(Interface):
 
     @staticmethod
     @datasetmethod(name='install')
-    def __call__(dataset=None, path=None, source=None, recursive=False,
-                 add_data_to_git=False):
+    def __call__(path=None, source=None, dataset=None,
+                 recursive=False, add_data_to_git=False):
         lgr.debug("Installation attempt started")
         # shortcut
         ds = dataset

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -118,7 +118,7 @@ class Publish(Interface):
 
     @staticmethod
     @datasetmethod(name='publish')
-    def __call__(dataset=None, to=None, path=None, recursive=False, skip_failing=False,
+    def __call__(path=None, dataset=None, to=None, recursive=False, skip_failing=False,
                  annex_copy_opts=None):
 
         # shortcut

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -118,7 +118,7 @@ class Uninstall(Interface):
 
     @staticmethod
     @datasetmethod(name='uninstall')
-    def __call__(dataset=None, path=None, data_only=False, recursive=False,
+    def __call__(path=None, dataset=None, data_only=False, recursive=False,
                  fast=False):
 
         # Note: copy logic from install to resolve dataset and path:

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -73,7 +73,7 @@ class Save(Interface):
 
     @staticmethod
     @datasetmethod(name='save')
-    def __call__(message=None, dataset=None, files=None,
+    def __call__(message=None, files=None, dataset=None,
                  auto_add_changes=False, version_tag=None):
         # shortcut
         ds = dataset

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -54,7 +54,7 @@ class Unlock(Interface):
 
     @staticmethod
     @datasetmethod(name='unlock')
-    def __call__(dataset=None, path=None):
+    def __call__(path=None, dataset=None):
         # shortcut
         ds = dataset
 

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -9,7 +9,12 @@
 '''Unit tests for Python API functionality.'''
 
 import re
+from inspect import getargspec
+
 from nose.tools import assert_true, assert_false
+from nose import SkipTest
+from nose.tools import eq_
+
 from datalad.tests.utils import assert_in
 
 
@@ -27,3 +32,41 @@ def test_basic_setup():
 
     assert_in('Parameters', api.Dataset.install.__doc__)
     assert_in('Parameters', api.Dataset.create.__doc__)
+
+
+def _test_consistent_order_of_args(intf, spec_posargs):
+    f = getattr(intf, '__call__')
+    args, varargs, varkw, defaults = getargspec(f)
+    # now verify that those spec_posargs are first among args
+    if not spec_posargs:
+        raise SkipTest("no positional args") # print intf, "skipped"
+#    else:
+#        print intf, spec_posargs
+    if intf.__name__ == 'Save':
+        # it makes sense there to have most command argument first
+        # -- the message. But we don't enforce it on cmdline so it is
+        # optional
+        spec_posargs.add('message')
+    eq_(set(args[:len(spec_posargs)]), spec_posargs)
+
+
+def test_consistent_order_of_args():
+    from datalad.interface.base import get_interface_groups
+
+    from importlib import import_module
+
+    for grp_name, grp_descr, interfaces in get_interface_groups():
+        for intfspec in interfaces:
+            # turn the interface spec into an instance
+            mod = import_module(intfspec[0], package='datalad')
+            intf = getattr(mod, intfspec[1])
+            spec = getattr(intf, '_params_', dict())
+
+            # figure out which of the specs are "positional"
+            spec_posargs = {
+                name
+                for name, param in spec.items()
+                if param.cmd_args and not param.cmd_args[0].startswith('-')
+            }
+            # we have information about positional args
+            yield _test_consistent_order_of_args, intf, spec_posargs


### PR DESCRIPTION
Moved everywhere positional args to be the first BESIDES in `save` where message is the first argument, used already in docs, and kinda makes sense but may be then we should make it really the first arg of cmdline interface?  cons -- divergence from git cmdline api

Closes #675 