### PR TITLE
crcns - provide option to crawl data straight from dataset page (tarballs) instead of nersc

### DIFF
--- a/datalad/crawler/pipelines/crcns.py
+++ b/datalad/crawler/pipelines/crcns.py
@@ -61,9 +61,22 @@ def extract_readme(data):
     yield {'filename': "README.txt"}
 
 
+# we might need to explicitly specify for some datasets to use_current_dir since
+# archives are already carrying the leading directory anyways...
+# actually probably wouldn't scale since within the same dataset we might need
+# some tarballs extracted one way, some other... so we might better rely on
+# stripping dirs in general BUT need to provide some sophistication, e.g. strip
+# iff directory matches archive name (without archive suffix)
+# hc-3 dataset is a good example of a mix etc... or may be just a parameter for
+# how many to strip (currently 2), but then we need to take care bout converting
+# if provided as a str from config
 def pipeline(dataset, dataset_category, versioned_urls=False, tarballs=True,
-             data_origin='checksums'):
+             data_origin='checksums', use_current_dir=False,
+             leading_dirs_depth=2):
     """Pipeline to crawl/annex an crcns dataset"""
+
+    if not isinstance(leading_dirs_depth, int):
+        leading_dirs_depth = int(leading_dirs_depth)
 
     dataset_url = 'http://crcns.org/data-sets/{dataset_category}/{dataset}'.format(**locals())
     lgr.info("Creating a pipeline for the crcns dataset %s" % dataset)
@@ -131,7 +144,8 @@ def pipeline(dataset, dataset_category, versioned_urls=False, tarballs=True,
                     strip_leading_dirs=True,
                     delete=True,
                     leading_dirs_consider=['crcns.*', dataset],
-                    leading_dirs_depth=2,
+                    leading_dirs_depth=leading_dirs_depth,
+                    use_current_dir=use_current_dir,
                     exclude='.*__MACOSX.*',  # some junk penetrates
                 ),
             ],

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -1,0 +1,16 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from .utils import _test_smoke_pipelines
+from ..crcns import pipeline, superdataset_pipeline
+
+
+def test_smoke_pipelines():
+    yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]
+    yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -24,8 +24,8 @@ from ..fcptable import pipeline, superdataset_pipeline
 
 
 def test_smoke_pipelines():
-    yield _test_smoke_pipelines, pipeline, 'bogus'
-    yield _test_smoke_pipelines, superdataset_pipeline, None
+    yield _test_smoke_pipelines, pipeline, ['bogus']
+    yield _test_smoke_pipelines, superdataset_pipeline, []
 
 
 @use_cassette('test_fcptable_dataset')

--- a/datalad/crawler/pipelines/tests/utils.py
+++ b/datalad/crawler/pipelines/tests/utils.py
@@ -23,5 +23,5 @@ def _test_smoke_pipelines(func, args, tmpdir):
     AnnexRepo(tmpdir, create=True)
     with chpwd(tmpdir):
         with swallow_logs():
-            for p in [func(args)]:
+            for p in [func(*args)]:
                 ok_(len(p) > 1)

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -24,6 +24,9 @@ from os.path import commonprefix
 from os.path import sep as opsep
 from os.path import islink
 from os.path import isabs
+from os.path import dirname
+from os.path import normpath
+
 from .base import Interface
 from ..consts import ARCHIVES_SPECIAL_REMOTE
 from ..support.param import Parameter
@@ -44,8 +47,13 @@ from ..log import logging
 lgr = logging.getLogger('datalad.interfaces.add_archive_content')
 
 
+# Shortcut note
+_KEY_OPT = "[PY: `key=True` PY][CMD: --key CMD]"
+_KEY_OPT_NOTE = "Note that it will be of no effect if %s is given" % _KEY_OPT
+
 # TODO: may be we could enable separate logging or add a flag to enable
 # all but by default to print only the one associated with this given action
+
 
 class AddArchiveContent(Interface):
     """Add content of an archive under git annex control.
@@ -64,7 +72,7 @@ class AddArchiveContent(Interface):
             args=("-d", "--delete"),
             action="store_true",
             doc="""flag to delete original archive from the filesystem/git in current tree.
-                   Note that it will be of no effect if --key is given."""),
+                   %s""" % _KEY_OPT_NOTE),
         strip_leading_dirs=Parameter(
             args=("--strip-leading-dirs",),
             action="store_true",
@@ -82,6 +90,11 @@ class AddArchiveContent(Interface):
             doc="""regular expression(s) for directories to consider to strip away""",
             constraints=EnsureStr() | EnsureNone(),
         ),
+        use_archive_dir=Parameter(
+            args=("--use-archive-dir",),
+            action="store_true",
+            doc="""flag to extract archive under the directory where it is located, not under current
+               directory.  %s""" % _KEY_OPT_NOTE),
         # TODO: add option to extract under archive's original directory. Currently would extract in curdir
         existing=Parameter(
             args=("--existing",),
@@ -154,7 +167,7 @@ class AddArchiveContent(Interface):
 
         # TODO: interaction with archives cache whenever we make it persistent across runs
         archive=Parameter(
-            doc="archive file or a key (if --key option specified)",
+            doc="archive file or a key (if %s specified)" % _KEY_OPT,
             constraints=EnsureStr()),
     )
 
@@ -172,6 +185,7 @@ class AddArchiveContent(Interface):
     @staticmethod
     def __call__(archive, annex=None,
                  strip_leading_dirs=False, leading_dirs_depth=None, leading_dirs_consider=None,
+                 use_archive_dir=False,
                  delete=False, key=False, exclude=None, rename=None, existing='fail',
                  annex_options=None, copy=False, commit=True, allow_dirty=False,
                  stats=None, drop_after=False, delete_after=False):
@@ -188,37 +202,38 @@ class AddArchiveContent(Interface):
         # TODO: actually I see possibly us asking user either he wants to convert
         # his git repo into annex
         archive_path = archive
+        pwd = getpwd()
         if annex is None:
-            annex = get_repo_instance(class_=AnnexRepo)
+            annex = get_repo_instance(pwd, class_=AnnexRepo)
             if not isabs(archive):
-                # if not absolute -- relative to curdir and thus
-                archive_path = relpath(abspath(archive), annex.path)
+                # if not absolute -- relative to wd and thus
+                archive_path = normpath(opj(pwd, archive))
+                # abspath(archive) is not "good" since dereferences links in the path
+                # archive_path = abspath(archive)
         elif not isabs(archive):
             # if we are given an annex, then assume that given path is within annex, not
             # relative to PWD
             archive_path = opj(annex.path, archive)
+        annex_path = annex.path
+
+        archive_rpath = relpath(archive_path, annex_path)
 
         # TODO: somewhat too cruel -- may be an option or smth...
         if not allow_dirty and annex.dirty:
             # already saved me once ;)
             raise RuntimeError("You better commit all the changes and untracked files first")
 
-        # are we in a subdirectory of the repository? then we should add content under that
-        # subdirectory,
-        # get the path relative to the repo top
-        extract_relpath = relpath(getpwd(), annex.path) \
-            if commonprefix([realpath(getpwd()), annex.path]) == annex.path \
-            else None
-
         if not key:
             # we were given a file which must exist
-            if not exists(opj(annex.path, archive_path)):
+            if not exists(archive_path):
                 raise ValueError("Archive {} does not exist".format(archive))
             # TODO: support adding archives content from outside the annex/repo
             origin = archive
-            key = annex.get_file_key(archive_path)
+            key = annex.get_file_key(archive_rpath)
+            archive_dir = dirname(archive_path)
         else:
             origin = key
+            archive_dir = None  # We must not have anything to do with the location under .git/annex
 
         if not key:
             # TODO: allow for it to be under git???  how to reference then?
@@ -226,6 +241,16 @@ class AddArchiveContent(Interface):
                 "Provided file is not under annex.  We don't support yet adding everything "
                 "straight to git"
             )
+
+        # are we in a subdirectory of the repository? then we should add content under that
+        # subdirectory,
+        # get the path relative to the repo top
+        if use_archive_dir:
+            extract_relpath = relpath(archive_dir, annex_path)
+        else:
+            extract_relpath = relpath(pwd, annex_path) \
+                if commonprefix([pwd, annex_path]) == annex_path \
+                else None
 
         # and operate from now on the key or whereever content available "canonically"
         try:
@@ -240,7 +265,7 @@ class AddArchiveContent(Interface):
         from datalad.customremotes.archives import ArchiveAnnexCustomRemote
         # TODO: shouldn't we be able just to pass existing AnnexRepo instance?
         # TODO: we will use persistent cache so we could just (ab)use possibly extracted archive
-        annexarchive = ArchiveAnnexCustomRemote(path=annex.path, persistent_cache=True)
+        annexarchive = ArchiveAnnexCustomRemote(path=annex_path, persistent_cache=True)
         # We will move extracted content so it must not exist prior running
         annexarchive.cache.allow_existing = True
         earchive = annexarchive.cache[key_path]
@@ -270,7 +295,7 @@ class AddArchiveContent(Interface):
 
             # we need to create a temporary directory at the top level which would later be
             # removed
-            prefix_dir = basename(tempfile.mkdtemp(prefix=".datalad", dir=annex.path)) \
+            prefix_dir = basename(tempfile.mkdtemp(prefix=".datalad", dir=annex_path)) \
                 if delete_after \
                 else None
 
@@ -410,7 +435,7 @@ class AddArchiveContent(Interface):
             if delete and archive:
                 lgr.debug("Removing the original archive {}".format(archive))
                 # force=True since some times might still be staged and fail
-                annex.remove(archive_path, force=True)
+                annex.remove(archive_rpath, force=True)
 
             lgr.info("Finished adding %s: %s" % (archive, stats.as_str(mode='line')))
 
@@ -427,7 +452,7 @@ class AddArchiveContent(Interface):
             annex.precommit()
 
             if delete_after:
-                prefix_path = opj(annex.path, prefix_dir)
+                prefix_path = opj(annex_path, prefix_dir)
                 if exists(prefix_path):  # probably would always be there
                     lgr.info("Removing temporary directory under which extracted files were annexed: %s",
                              prefix_path)

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -90,8 +90,8 @@ class AddArchiveContent(Interface):
             doc="""regular expression(s) for directories to consider to strip away""",
             constraints=EnsureStr() | EnsureNone(),
         ),
-        use_archive_dir=Parameter(
-            args=("--use-archive-dir",),
+        use_current_dir=Parameter(
+            args=("--use-current-dir",),
             action="store_true",
             doc="""flag to extract archive under the directory where it is located, not under current
                directory.  %s""" % _KEY_OPT_NOTE),
@@ -185,7 +185,7 @@ class AddArchiveContent(Interface):
     @staticmethod
     def __call__(archive, annex=None,
                  strip_leading_dirs=False, leading_dirs_depth=None, leading_dirs_consider=None,
-                 use_archive_dir=False,
+                 use_current_dir=False,
                  delete=False, key=False, exclude=None, rename=None, existing='fail',
                  annex_options=None, copy=False, commit=True, allow_dirty=False,
                  stats=None, drop_after=False, delete_after=False):
@@ -245,12 +245,12 @@ class AddArchiveContent(Interface):
         # are we in a subdirectory of the repository? then we should add content under that
         # subdirectory,
         # get the path relative to the repo top
-        if use_archive_dir:
-            extract_relpath = relpath(archive_dir, annex_path)
+        if commonprefix([pwd, annex_path]) != annex_path:
+            extract_relpath = None
         else:
             extract_relpath = relpath(pwd, annex_path) \
-                if commonprefix([pwd, annex_path]) == annex_path \
-                else None
+                if use_current_dir \
+                else relpath(archive_dir, annex_path)
 
         # and operate from now on the key or whereever content available "canonically"
         try:

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -129,11 +129,11 @@ def test_add_archive_content(path_orig, url, repo_path):
     # -- in caching and overwrite check
     assert_in("already exists", str(cme.exception))
     # but should do fine if overrides are allowed
-    add_archive_content(opj('1u', '1.tar.gz'), existing='overwrite')
+    add_archive_content(opj('1u', '1.tar.gz'), existing='overwrite', use_current_dir=True)
     d1_basic_checks()
-    add_archive_content(opj('2u', '1.tar.gz'), existing='archive-suffix')
-    add_archive_content(opj('3u', '1.tar.gz'), existing='archive-suffix')
-    add_archive_content(opj('4u', '1.tar.gz'), existing='archive-suffix')
+    add_archive_content(opj('2u', '1.tar.gz'), existing='archive-suffix', use_current_dir=True)
+    add_archive_content(opj('3u', '1.tar.gz'), existing='archive-suffix', use_current_dir=True)
+    add_archive_content(opj('4u', '1.tar.gz'), existing='archive-suffix', use_current_dir=True)
     # rudimentary test
     assert_equal(sorted(map(basename, glob(opj(repo_path, '1', '1*')))),
                  ['1 f-1.1.txt', '1 f-1.2.txt', '1 f-1.txt', '1 f.txt'])
@@ -251,17 +251,17 @@ def test_add_archive_use_archive_dir(repo_path):
         repo.commit("added 1.tar.gz")
 
         ok_archives_caches(repo.path, 0)
-        add_archive_content(archive_path, strip_leading_dirs=True)
+        add_archive_content(archive_path, strip_leading_dirs=True, use_current_dir=True)
         ok_(not exists(opj('4u', '1 f.txt')))
         ok_file_under_git(repo.path, '1 f.txt', annexed=True)
         ok_archives_caches(repo.path, 0)
 
         # and now let's extract under archive dir
-        add_archive_content(archive_path, strip_leading_dirs=True, use_archive_dir=True)
+        add_archive_content(archive_path, strip_leading_dirs=True)
         ok_file_under_git(repo.path, opj('4u', '1 f.txt'), annexed=True)
         ok_archives_caches(repo.path, 0)
 
-        add_archive_content(opj('4u', 'sub.tar.gz'), use_archive_dir=True)
+        add_archive_content(opj('4u', 'sub.tar.gz'))
         ok_file_under_git(repo.path, opj('4u', 'sub', '2 f.txt'), annexed=True)
         ok_archives_caches(repo.path, 0)
 

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -32,7 +32,7 @@ from ...tests.utils import swallow_logs
 from ...utils import chpwd, getpwd, rmtemp
 from ...utils import find_files
 from ...utils import rmtree
-
+from ... import lgr
 from ...api import add_archive_content, clean
 
 
@@ -65,6 +65,18 @@ tree1args = dict(
                     ('d2', (
                         ('2d', ''),)
                      )),),),),
+    )
+)
+
+tree4uargs = dict(
+    tree=(
+        ('4u', {  # updated file content
+          '1.tar.gz': {
+             '1 f.txt': '1 f load4',
+              'sub.tar.gz': {
+                  '2 f.txt': '2 f'
+              }
+        }}),
     )
 )
 
@@ -224,6 +236,34 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 
 # looking for the future tagging of lengthy tests
 test_add_archive_content.tags = ['integration']
+
+
+@assert_cwd_unchanged(ok_to_chdir=True)
+@with_tree(**tree4uargs)
+def test_add_archive_use_archive_dir(repo_path):
+    direct = False  # TODO: test on undirect, but too long ATM
+    repo = AnnexRepo(repo_path, create=True, direct=direct)
+    with chpwd(repo_path):
+        # Let's add first archive to the repo with default setting
+        archive_path = opj('4u', '1.tar.gz')
+        with swallow_outputs():
+            repo.add(archive_path)
+        repo.commit("added 1.tar.gz")
+
+        ok_archives_caches(repo.path, 0)
+        add_archive_content(archive_path, strip_leading_dirs=True)
+        ok_(not exists(opj('4u', '1 f.txt')))
+        ok_file_under_git(repo.path, '1 f.txt', annexed=True)
+        ok_archives_caches(repo.path, 0)
+
+        # and now let's extract under archive dir
+        add_archive_content(archive_path, strip_leading_dirs=True, use_archive_dir=True)
+        ok_file_under_git(repo.path, opj('4u', '1 f.txt'), annexed=True)
+        ok_archives_caches(repo.path, 0)
+
+        add_archive_content(opj('4u', 'sub.tar.gz'), use_archive_dir=True)
+        ok_file_under_git(repo.path, opj('4u', 'sub', '2 f.txt'), annexed=True)
+        ok_archives_caches(repo.path, 0)
 
 
 class TestAddArchiveOptions():

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -21,6 +21,7 @@ import os
 import tempfile
 from os.path import join as opj, exists, abspath, basename, isabs, normpath, relpath, pardir, isdir
 from os.path import split as ops, sep as opsep
+from os.path import realpath
 from six import next
 from six.moves.urllib.parse import unquote as urlunquote
 
@@ -202,7 +203,9 @@ def _get_cached_filename(archive):
     """
     #return "%s_%s" % (basename(archive), hashlib.md5(archive).hexdigest()[:5])
     # per se there is no reason to maintain any long original name here.
-    return hashlib.md5(archive.encode()).hexdigest()[:10]
+    archive_cached = hashlib.md5(realpath(archive).encode()).hexdigest()[:10]
+    lgr.debug("Cached directory for archive %s is %s", archive, archive_cached)
+    return archive_cached
 
 
 import string
@@ -505,5 +508,3 @@ class ExtractedArchive(object):
                 self.clean()
         except:
             pass
-
-

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -63,11 +63,12 @@ class FileInGitError(FileNotInAnnexError):
 class FileNotInRepositoryError(FileNotInAnnexError):
     """Thrown if a file is not in the repository at all.
     """
+    pass
 
 
 class InsufficientArgumentsError(ValueError):
     """To be raise instead of `ValueError` when use help output is desired"""
-
+    pass
 
 #
 # Downloaders

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -153,11 +153,6 @@ def _normalize_path(base_dir, path):
         # so realpath only its directory, to get "inline" with
         # realpath(base_dir) above
         path = opj(realpath(dirname(path)), basename(path))
-        if commonprefix([path, base_dir]) != base_dir:
-            raise FileNotInRepositoryError(msg="Path outside repository: %s"
-                                               % path, filename=path)
-        else:
-            pass
     # Executive decision was made to not do this kind of magic!
     #
     # elif commonprefix([realpath(getpwd()), base_dir]) == base_dir:
@@ -167,11 +162,15 @@ def _normalize_path(base_dir, path):
     # BUT with relative curdir/pardir start it would assume relative to curdir
     #
     elif path.startswith(_curdirsep) or path.startswith(_pardirsep):
-         path = opj(realpath(getpwd()), path)
+         path = normpath(opj(realpath(getpwd()), path))
     else:
         # We were called from outside the repo. Therefore relative paths
         # are interpreted as being relative to self.path already.
         return path
+
+    if commonprefix([path, base_dir]) != base_dir:
+        raise FileNotInRepositoryError(msg="Path outside repository: %s"
+                                           % path, filename=path)
 
     return relpath(path, start=base_dir)
 


### PR DESCRIPTION
quick one -- will merge if it  doesn't break anything somehow

actually now includes also solution for #685 which was detected while looking at the crawled crcns datasets.  It changes the behaviour that tarballs extracted by default along side the tarball.  from memory -- shouldn't effect other existing crawling pipelines since tarballs usually are crawled in incoming within the root directory of the repository

Closes #685 