### PR TITLE
BF+RF: tollerate spaces (and probably other interesting characters) in filenames

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -23,7 +23,7 @@ cfg = ConfigManager()
 lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager
 ssh_manager = SSHManager()
-atexit.register(ssh_manager.close)
+atexit.register(ssh_manager.close, allow_fail=False)
 
 
 def test(package='datalad', **kwargs):

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -129,7 +129,7 @@ class initiate_dataset(object):
             # we need first to initiate a git repository
             git_repo = GitRepo(path, create=True)
             # since we are initiating, that branch shouldn't exist yet, thus --orphan
-            git_repo.checkout(self.branch, options="--orphan")
+            git_repo.checkout(self.branch, options=["--orphan"])
             # TODO: RF whenevever create becomes a dedicated factory/method
             # and/or branch becomes an option for the "creator"
         backend = self.backend or cfg.get('crawl', 'default backend', default='MD5E')
@@ -661,7 +661,7 @@ class Annexificator(object):
                     if remote_branch in remote_branches:
                         lgr.info("Did not find branch %r locally. Checking out remote one %r"
                                  % (branch, remote_branch))
-                        self.repo.checkout(remote_branch, options='--track')
+                        self.repo.checkout(remote_branch, options=['--track'])
                         # refresh the list -- same check will come again
                         existing_branches = self.repo.get_branches()
                         break
@@ -670,14 +670,14 @@ class Annexificator(object):
                 if parent is None:
                     # new detached branch
                     lgr.info("Checking out a new detached branch %s" % (branch))
-                    self.repo.checkout(branch, options="--orphan")
+                    self.repo.checkout(branch, options=["--orphan"])
                     if self.repo.dirty:
                         self.repo.remove('.', r=True, f=True)  # TODO: might be insufficient if directories etc TEST/fix
                 else:
                     if parent not in existing_branches:
                         raise RuntimeError("Parent branch %s does not exist" % parent)
                     lgr.info("Checking out %s into a new branch %s" % (parent, branch))
-                    self.repo.checkout(parent, options="-b %s" % branch)
+                    self.repo.checkout(parent, options=["-b", branch])
             else:
                 lgr.info("Checking out an existing branch %s" % (branch))
                 self.repo.checkout(branch)

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -17,6 +17,8 @@ import os
 from os.path import join as opj, abspath, relpath, pardir, isabs, isdir, \
     exists, islink, sep, realpath
 
+from six.moves.urllib.parse import quote as urlquote
+
 from datalad.cmd import CommandError
 from datalad.cmd import Runner
 from datalad.distribution.dataset import Dataset, datasetmethod, \
@@ -31,7 +33,7 @@ from datalad.support.gitrepo import GitRepo, GitCommandError
 from datalad.support.param import Parameter
 from datalad.utils import expandpath, knows_annex, assure_dir, \
     is_explicit_path, on_windows, swallow_logs
-from datalad.support.network import RI
+from datalad.support.network import RI, URL
 from datalad.support.network import DataLadRI
 from datalad.support.network import is_url, is_datalad_compat_ri
 from datalad.utils import rmtree
@@ -131,8 +133,13 @@ def _install_subds_from_flexible_source(ds, sm_path, sm_url, recursive):
             url_suffix = '/.git'
             remote_url = remote_url[:-5]
         # attempt: submodule checkout at parent remote URL
+        # We might need to quote sm_path portion, e.g. for spaces etc
+        if remote_url and isinstance(RI(remote_url), URL):
+            sm_path_url = urlquote(sm_path)
+        else:
+            sm_path_url = sm_path
         clone_urls.append('{0}/{1}{2}'.format(
-            remote_url, sm_path, url_suffix))
+            remote_url, sm_path_url, url_suffix))
     # attempt: configured submodule URL
     # TODO: consider supporting DataLadRI here?  or would confuse
     #  git and we wouldn't want that (i.e. not allow pure git clone

--- a/datalad/distribution/tests/test_add_sibling.py
+++ b/datalad/distribution/tests/test_add_sibling.py
@@ -99,11 +99,11 @@ def test_add_sibling(origin, repo_path):
                       force=True)
 
     eq_(set(res), {basename(source.path),
-                   opj(basename(source.path), "sub1"),
-                   opj(basename(source.path), "sub2")})
+                   opj(basename(source.path), "subm 1"),
+                   opj(basename(source.path), "subm 2")})
     for repo in [source.repo,
-                 GitRepo(opj(source.path, "sub1")),
-                 GitRepo(opj(source.path, "sub2"))]:
+                 GitRepo(opj(source.path, "subm 1")),
+                 GitRepo(opj(source.path, "subm 2"))]:
         assert_in("test-remote", repo.get_remotes())
         url = repo.get_remote_url("test-remote")
         pushurl = repo.get_remote_url("test-remote", push=True)
@@ -119,12 +119,12 @@ def test_add_sibling(origin, repo_path):
                       recursive=True,
                       force=True)
     eq_(set(res), {basename(source.path),
-                   opj(basename(source.path), "sub1"),
-                   opj(basename(source.path), "sub2")})
+                   opj(basename(source.path), "subm 1"),
+                   opj(basename(source.path), "subm 2")})
 
     for repo in [source.repo,
-                 GitRepo(opj(source.path, "sub1")),
-                 GitRepo(opj(source.path, "sub2"))]:
+                 GitRepo(opj(source.path, "subm 1")),
+                 GitRepo(opj(source.path, "subm 2"))]:
         assert_in("test-remote-2", repo.get_remotes())
         url = repo.get_remote_url("test-remote-2")
         pushurl = repo.get_remote_url("test-remote-2", push=True)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -86,7 +86,6 @@ def test_register_sibling(remote, path):
     assert_in('my_sibling', ds.repo.get_remotes())
     eq_(ds.repo.get_remote_url('my_sibling'), remote)
 
-
     ds.register_sibling('my_other_sibling', remote,
                         publish_url='http://fake.pushurl.com')
     assert_in('my_other_sibling', ds.repo.get_remotes())
@@ -99,11 +98,11 @@ def test_register_sibling(remote, path):
 @with_testrepos('.*nested_submodule.*', flavors=['local'])
 def test_get_subdatasets(path):
     ds = Dataset(path)
-    eq_(set(ds.get_subdatasets()), {'subdataset'})
+    eq_(set(ds.get_subdatasets()), {'sub dataset1'})
     eq_(set(ds.get_subdatasets(recursive=True)),
-        {'subdataset/subsubdataset', 'subdataset/subsubdataset/sub1',
-         'subdataset/subsubdataset/sub2', 'subdataset/sub1',
-         'subdataset/sub2', 'subdataset'})
+        {'sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1',
+         'sub dataset1/sub sub dataset1/subm 2', 'sub dataset1/subm 1',
+         'sub dataset1/subm 2', 'sub dataset1'})
     # TODO:  More Flavors!
 
 
@@ -118,11 +117,11 @@ def test_is_installed(src, path):
     AnnexRepo(path, src)
     ok_(ds.is_installed())
     # submodule still not installed:
-    subds = Dataset(opj(path, 'sub1'))
+    subds = Dataset(opj(path, 'subm 1'))
     assert_false(subds.is_installed())
     # get the submodule
     from datalad.cmd import Runner
-    Runner().run(['git', 'submodule', 'update', '--init', 'sub1'], cwd=path)
+    Runner().run(['git', 'submodule', 'update', '--init', 'subm 1'], cwd=path)
     ok_(subds.is_installed())
 
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -207,11 +207,11 @@ def test_install_subdataset(src, path):
     ds = install(path=path, source=src)
 
     # subdataset not installed:
-    subds = Dataset(opj(path, 'sub1'))
+    subds = Dataset(opj(path, 'subm 1'))
     assert_false(subds.is_installed())
 
     # install it:
-    ds.install('sub1')
+    ds.install('subm 1')
     assert_true(isdir(opj(subds.path, '.git')))
 
     ok_(subds.is_installed())
@@ -223,13 +223,13 @@ def test_install_subdataset(src, path):
     # Now the obnoxious install an annex file within not yet
     # initialized repository!
     with swallow_outputs():  # progress bar
-        ds.install(opj('sub2', 'test-annex.dat'))
-    subds2 = Dataset(opj(path, 'sub2'))
+        ds.install(opj('subm 2', 'test-annex.dat'))
+    subds2 = Dataset(opj(path, 'subm 2'))
     assert(subds2.is_installed())
     assert(subds2.repo.file_has_content('test-annex.dat'))
     # we shouldn't be able silently ignore attempt to provide source while
     # "installing" file under git
-    assert_raises(FileInGitError, ds.install, opj('sub2', 'INFO.txt'), source="http://bogusbogus")
+    assert_raises(FileInGitError, ds.install, opj('subm 2', 'INFO.txt'), source="http://bogusbogus")
 
 
 @with_tree(tree={

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -49,7 +49,7 @@ def test_publish_simple(origin, src_path, dst_path):
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
-    target.checkout("TMP", "-b")
+    target.checkout("TMP", ["-b"])
     source.repo.add_remote("target", dst_path)
 
     res = publish(dataset=source, to="target")
@@ -107,7 +107,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
-    target.checkout("TMP", "-b")
+    target.checkout("TMP", ["-b"])
     source.repo.add_remote("target", dst_path)
 
     # subdatasets have no remote yet, so recursive publishing should fail:
@@ -117,11 +117,11 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # now, set up targets for the submodules:
     sub1_target = GitRepo(sub1_pub, create=True)
-    sub1_target.checkout("TMP", "-b")
+    sub1_target.checkout("TMP", ["-b"])
     sub2_target = GitRepo(sub2_pub, create=True)
-    sub2_target.checkout("TMP", "-b")
-    sub1 = GitRepo(opj(src_path, 'sub1'), create=False)
-    sub2 = GitRepo(opj(src_path, 'sub2'), create=False)
+    sub2_target.checkout("TMP", ["-b"])
+    sub1 = GitRepo(opj(src_path, 'subm 1'), create=False)
+    sub2 = GitRepo(opj(src_path, 'subm 2'), create=False)
     sub1.add_remote("target", sub1_pub)
     sub2.add_remote("target", sub2_pub)
 
@@ -170,16 +170,16 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # create plain git at target:
     target = AnnexRepo(dst_path, create=True)
-    target.checkout("TMP", "-b")
+    target.checkout("TMP", ["-b"])
     source.repo.add_remote("target", dst_path)
 
     # now, set up targets for the submodules:
     sub1_target = GitRepo(sub1_pub, create=True)
-    sub1_target.checkout("TMP", "-b")
+    sub1_target.checkout("TMP", ["-b"])
     sub2_target = GitRepo(sub2_pub, create=True)
-    sub2_target.checkout("TMP", "-b")
-    sub1 = GitRepo(opj(src_path, 'sub1'), create=False)
-    sub2 = GitRepo(opj(src_path, 'sub2'), create=False)
+    sub2_target.checkout("TMP", ["-b"])
+    sub1 = GitRepo(opj(src_path, 'subm 1'), create=False)
+    sub2 = GitRepo(opj(src_path, 'subm 2'), create=False)
     sub1.add_remote("target", sub1_pub)
     sub2.add_remote("target", sub2_pub)
 
@@ -221,6 +221,6 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
             result_paths.append(item.path)
         else:
             result_paths.append(item)
-    eq_({source.path, opj(source.path, "sub1"),
-         opj(source.path, "sub2"), 'test-annex.dat'},
+    eq_({source.path, opj(source.path, "subm 1"),
+         opj(source.path, "subm 2"), 'test-annex.dat'},
         set(result_paths))

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -139,9 +139,9 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 
     # raise if git repos were not created:
     t_super = GitRepo(opj(target_path, basename(src_path)), create=False)
-    t_sub1 = GitRepo(opj(target_path, basename(src_path) + "-sub1"),
+    t_sub1 = GitRepo(opj(target_path, basename(src_path) + "-subm 1"),
                      create=False)
-    t_sub2 = GitRepo(opj(target_path, basename(src_path) + "-sub2"),
+    t_sub2 = GitRepo(opj(target_path, basename(src_path) + "-subm 2"),
                      create=False)
 
     for repo in [source.repo, sub1.repo, sub2.repo]:

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -129,8 +129,8 @@ def test_target_ssh_recursive(origin, src_path, target_path):
         AnnexRepo(opj(src_path, subds), init=True,
                   create=False).checkout("master")
 
-    sub1 = Dataset(opj(src_path, "sub1"))
-    sub2 = Dataset(opj(src_path, "sub2"))
+    sub1 = Dataset(opj(src_path, "subm 1"))
+    sub2 = Dataset(opj(src_path, "subm 2"))
 
     create_publication_target_sshwebserver(dataset=source,
                                            sshurl="ssh://localhost",

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -223,7 +223,7 @@ class AnnexRepo(GitRepo):
         return GitRepo.is_valid_repo(path) and \
                exists(opj(path, '.git', 'annex'))
 
-    def add_remote(self, name, url, options=''):
+    def add_remote(self, name, url, options=[]):
         """Overrides method from GitRepo in order to set
         remote.<name>.annex-ssh-options in case of a SSH remote."""
         super(AnnexRepo, self).add_remote(name, url, options)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1224,7 +1224,7 @@ class GitRepo(object):
         # TODO: May be check for the need of -b options herein?
 
         self._git_custom_command(
-            '', ['git', 'checkout'] + options + [name],
+            '', ['git', 'checkout'] + options + [str(name)],
             expect_stderr=True
         )
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -942,35 +942,42 @@ class GitRepo(object):
 
 # TODO: --------------------------------------------------------------------
 
-    def add_remote(self, name, url, options=''):
-        """
+    def add_remote(self, name, url, options=[]):
+        """Register remote pointing to a url
         """
 
-        return self._git_custom_command('', 'git remote add %s %s %s' %
-                                 (options, name, url))
+        return self._git_custom_command(
+            '', ['git', 'remote', 'add'] + options + [name, url]
+        )
 
     def remove_remote(self, name):
-        """
+        """Remove existing remote
         """
 
-        return self._git_custom_command('', 'git remote remove %s' % name)
+        return self._git_custom_command(
+            '', ['git', 'remote', 'remove', name]
+        )
 
     def show_remotes(self, name='', verbose=False):
         """
         """
 
-        v = "-v" if verbose else ""
-        out, err = self._git_custom_command('', 'git remote %s show %s' %
-                                            (v, name))
+        options = ["-v"] if verbose else []
+        name = [name] if name else []
+        out, err = self._git_custom_command(
+            '', ['git', 'remote'] + options + ['show'] + name
+        )
         return out.rstrip(linesep).splitlines()
 
-    def update_remote(self, name='', verbose=False):
+    def update_remote(self, name=None, verbose=False):
         """
         """
-
-        v = "-v" if verbose else ''
-        self._git_custom_command('', 'git remote %s update %s' % (name, v),
-                                 expect_stderr=True)
+        options = ["-v"] if verbose else []
+        name = [name] if name else []
+        self._git_custom_command(
+            '', ['git', 'remote'] + name + ['update'] + options,
+            expect_stderr=True
+        )
 
     # TODO: centralize all the c&p code in fetch, pull, push
     # TODO: document **kwargs passed to gitpython
@@ -1211,29 +1218,35 @@ class GitRepo(object):
                 return
             yield fvalue(c)
 
-    def checkout(self, name, options=''):
+    def checkout(self, name, options=[]):
         """
         """
         # TODO: May be check for the need of -b options herein?
 
-        self._git_custom_command('', 'git checkout %s %s' % (options, name),
-                                 expect_stderr=True)
+        self._git_custom_command(
+            '', ['git', 'checkout'] + options + [name],
+            expect_stderr=True
+        )
 
     # TODO: Before implementing annex merge, find usages and check for a needed
     # change to call super().merge
     def merge(self, name, options=[], msg=None, **kwargs):
         if msg:
             options = options + ["-m", msg]
-        self._git_custom_command('', ['git', 'merge'] + options + [name],
-                                 **kwargs)
+        self._git_custom_command(
+            '', ['git', 'merge'] + options + [name],
+            **kwargs
+        )
 
     def remove_branch(self, branch):
-        self._git_custom_command('', 'git branch -D %s' % branch)
+        self._git_custom_command(
+            '', ['git', 'branch', '-D', branch]
+        )
 
-    def ls_remote(self, remote, options=None):
-        self._git_custom_command('', 'git ls-remote %s %s' %
-                                 (options if options is not None else '',
-                                  remote))
+    def ls_remote(self, remote, options=[]):
+        self._git_custom_command(
+            '', ['git', 'ls-remote'] + options + [remote]
+        )
         # TODO: Return values?
     
     @property
@@ -1361,7 +1374,9 @@ class GitRepo(object):
           Custom tag label.
         """
         # TODO later to be extended with tagging particular commits and signing
-        self._git_custom_command('', 'git tag "{0}"'.format(tag))
+        self._git_custom_command(
+            '', ['git', 'tag', str(tag)]
+        )
 
     def get_tracking_branch(self, branch=None):
         """Get the tracking branch for `branch` if there is any.

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -78,10 +78,16 @@ class SSHConnection(object):
 
         # TODO: Do we need to check for the connection to be open or just rely
         # on possible ssh failing?
-
-        ssh_cmd = ["ssh"] + self.ctrl_options + [self.host] + cmd if isinstance(cmd, list) \
+        cmd_list = cmd if isinstance(cmd, list) \
             else sh_split(cmd, posix=not on_windows)
             # windows check currently not needed, but keep it as a reminder
+        # The safest best while dealing with any special characters is to wrap
+        # entire argument into "" while escaping possibly present " inside.
+        # Actually repr seems to achieve the same goal at least with basic symbols
+        # I guess for the ` & and other symbols used in the shell -- yet to figure out
+        # how to escape it reliably
+        cmd_list = list(map(repr, cmd_list))
+        ssh_cmd = ["ssh"] + self.ctrl_options + [self.host] + cmd_list
 
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -32,6 +32,10 @@ from datalad.cmd import Runner
 
 lgr = logging.getLogger('datalad.ssh')
 
+def _wrap_str(s):
+    """Helper to wrap argument into '' to be passed over ssh cmdline"""
+    s = s.replace("'", r'\'')
+    return "'%s'" % s
 
 @auto_repr
 class SSHConnection(object):
@@ -83,10 +87,9 @@ class SSHConnection(object):
             # windows check currently not needed, but keep it as a reminder
         # The safest best while dealing with any special characters is to wrap
         # entire argument into "" while escaping possibly present " inside.
-        # Actually repr seems to achieve the same goal at least with basic symbols
         # I guess for the ` & and other symbols used in the shell -- yet to figure out
-        # how to escape it reliably
-        cmd_list = list(map(repr, cmd_list))
+        # how to escape it reliably.
+        cmd_list = list(map(_wrap_str, cmd_list))
         ssh_cmd = ["ssh"] + self.ctrl_options + [self.host] + cmd_list
 
         # TODO: pass expect parameters from above?

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -181,7 +181,7 @@ def test_GitRepo_get_indexed_files(src, path):
 
     runner = Runner()
     out = runner(['git', 'ls-files'], cwd=path)
-    out_list = filter(bool, out[0].split('\n'))
+    out_list = list(filter(bool, out[0].split('\n')))
 
     for item in idx_list:
         assert_in(item, out_list, "%s not found in output of git ls-files in %s" % (item, path))

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -171,6 +171,7 @@ def test_GitRepo_commit(path):
     # wasn't actually committed:
     ok_(gr.repo.is_dirty())
 
+
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile
 def test_GitRepo_get_indexed_files(src, path):
@@ -180,7 +181,7 @@ def test_GitRepo_get_indexed_files(src, path):
 
     runner = Runner()
     out = runner(['git', 'ls-files'], cwd=path)
-    out_list = out[0].split()
+    out_list = filter(bool, out[0].split('\n'))
 
     for item in idx_list:
         assert_in(item, out_list, "%s not found in output of git ls-files in %s" % (item, path))
@@ -390,7 +391,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     clone = GitRepo(clone_path, orig_path)
     filename = get_most_obscure_supported_name()
 
-    origin.checkout("new_branch", "-b")
+    origin.checkout("new_branch", ['-b'])
     with open(opj(orig_path, filename), 'w') as f:
         f.write("New file.")
     origin.add(filename)
@@ -444,7 +445,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     repo.add_remote("ssh-remote", url)
 
     # modify remote:
-    remote_repo.checkout("ssh-test", "-b")
+    remote_repo.checkout("ssh-test", ['-b'])
     with open(opj(remote_repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
     remote_repo.add("ssh_testfile.dat")
@@ -479,7 +480,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     repo.add_remote("ssh-remote", url)
 
     # modify local repo:
-    repo.checkout("ssh-test", "-b")
+    repo.checkout("ssh-test", ['-b'])
     with open(opj(repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
     repo.add("ssh_testfile.dat")
@@ -536,7 +537,7 @@ def test_GitRepo_remote_update(path1, path2, path3):
         f.write("git2 in master")
     git2.add('masterfile')
     git2.commit("Add something to master.")
-    git2.checkout('branch2', '-b')
+    git2.checkout('branch2', ['-b'])
     with open(opj(path2, 'branch2file'), 'w') as f:
         f.write("git2 in branch2")
     git2.add('branch2file')
@@ -547,7 +548,7 @@ def test_GitRepo_remote_update(path1, path2, path3):
         f.write("git3 in master")
     git3.add('masterfile')
     git3.commit("Add something to master.")
-    git3.checkout('branch3', '-b')
+    git3.checkout('branch3', ['-b'])
     with open(opj(path3, 'branch3file'), 'w') as f:
         f.write("git3 in branch3")
     git3.add('branch3file')
@@ -589,7 +590,7 @@ def test_GitRepo_get_files(url, path):
     eq_(local_files, os_files)
 
     # create a different branch:
-    gr.checkout('new_branch', '-b')
+    gr.checkout('new_branch', ['-b'])
     filename = 'another_file.dat'
     with open(opj(path, filename), 'w') as f:
         f.write("something")
@@ -676,7 +677,7 @@ def test_GitRepo_get_merge_base(src):
 
     # Let's create a detached branch
     branch2 = "_detach_"
-    repo.checkout(branch2, options="--orphan")
+    repo.checkout(branch2, options=["--orphan"])
     # it will have all the files
     # Must not do:  https://github.com/gitpython-developers/GitPython/issues/375
     # repo.git_add('.')
@@ -805,7 +806,7 @@ def test_get_tracking_branch(o_path, c_path):
     clone = GitRepo(c_path, o_path)
     eq_(('origin', 'refs/heads/master'), clone.get_tracking_branch())
 
-    clone.checkout('new_branch', '-b')
+    clone.checkout('new_branch', ['-b'])
     eq_((None, None), clone.get_tracking_branch())
 
     eq_(('origin', 'refs/heads/master'), clone.get_tracking_branch('master'))
@@ -815,21 +816,21 @@ def test_get_tracking_branch(o_path, c_path):
 def test_submodule_deinit(path):
 
     top_repo = GitRepo(path, create=False)
-    eq_(['sub1', 'sub2'], [s.name for s in top_repo.get_submodules()])
-    top_repo.update_submodule('sub1', init=True)
-    top_repo.update_submodule('sub2', init=True)
+    eq_(['subm 1', 'subm 2'], [s.name for s in top_repo.get_submodules()])
+    top_repo.update_submodule('subm 1', init=True)
+    top_repo.update_submodule('subm 2', init=True)
     ok_(all([s.module_exists() for s in top_repo.get_submodules()]))
 
     # modify submodule:
-    with open(opj(top_repo.path, 'sub1', 'file_ut.dat'), "w") as f:
+    with open(opj(top_repo.path, 'subm 1', 'file_ut.dat'), "w") as f:
         f.write("some content")
 
     assert_raises(GitCommandError, top_repo.deinit_submodule, 'sub1')
 
     # using force should work:
-    top_repo.deinit_submodule('sub1', force=True)
+    top_repo.deinit_submodule('subm 1', force=True)
 
-    ok_(not top_repo.repo.submodule('sub1').module_exists())
+    ok_(not top_repo.repo.submodule('subm 1').module_exists())
 
 
 def test_kwargs_to_options():

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -45,7 +45,9 @@ def test_ssh_get_connection():
 
 
 @skip_ssh
-def test_ssh_open_close():
+@with_tempfile(suffix=" \"`suffix:;& ", # get_most_obscure_supported_name(),
+               content="1")
+def test_ssh_open_close(tfile1):
 
     manager = SSHManager()
     c1 = manager.get_connection('ssh://localhost')
@@ -59,6 +61,11 @@ def test_ssh_open_close():
     remote_ls = [entry for entry in out.splitlines() if entry != '.' and entry != '..']
     local_ls = os.listdir(os.path.expanduser('~'))
     eq_(set(remote_ls), set(local_ls))
+
+    # now test for arguments containing spaces and other pleasant symbols
+    out, err = c1(['ls', '-l', tfile1])
+    assert_in(tfile1, out)
+    eq_(err, '')
 
     c1.close()
     # control master doesn't exist anymore:

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -36,7 +36,7 @@ def test_point_to_github(url):
 def test_clone(src, tempdir):
     # Verify that all our repos are clonable
     r = Runner()
-    output = r.run(["git" , "clone", src, tempdir", log_online=True)
+    output = r.run(["git" , "clone", src, tempdir], log_online=True)
     #status, output = getstatusoutput("git clone %(src)s %(tempdir)s" % locals())
     ok_(os.path.exists(os.path.join(tempdir, ".git")))
     # TODO: requires network for sure! ;)

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -36,7 +36,7 @@ def test_point_to_github(url):
 def test_clone(src, tempdir):
     # Verify that all our repos are clonable
     r = Runner()
-    output = r.run("git clone %(src)s %(tempdir)s" % locals(), log_online=True)
+    output = r.run(["git" , "clone", src, tempdir", log_online=True)
     #status, output = getstatusoutput("git clone %(src)s %(tempdir)s" % locals())
     ok_(os.path.exists(os.path.join(tempdir, ".git")))
     # TODO: requires network for sure! ;)

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -140,12 +140,12 @@ class SubmoduleDataset(BasicAnnexTestRepo):
         from datalad.cmd import Runner
         runner = Runner()
         kw = dict(cwd=self.path, expect_stderr=True)
-        runner.run(['git', 'submodule', 'add', annex.url, 'sub1'], **kw)
-        runner.run(['git', 'submodule', 'add', annex.url, 'sub2'], **kw)
-        runner.run(['git', 'commit', '-m', 'Added sub1 and sub2.'], **kw)
+        runner.run(['git', 'submodule', 'add', annex.url, 'subm 1'], **kw)
+        runner.run(['git', 'submodule', 'add', annex.url, 'subm 2'], **kw)
+        runner.run(['git', 'commit', '-m', 'Added subm 1 and subm 2.'], **kw)
         runner.run(['git', 'submodule', 'update', '--init', '--recursive'], **kw)
         # init annex in subdatasets
-        for s in ('sub1', 'sub2'):
+        for s in ('subm 1', 'subm 2'):
             runner.run(['git', 'annex', 'init'],
                        cwd=opj(self.path, s), expect_stderr=True)
 
@@ -159,18 +159,18 @@ class NestedDataset(BasicAnnexTestRepo):
         from datalad.cmd import Runner
         runner = Runner()
         kw = dict(expect_stderr=True)
-        runner.run(['git', 'submodule', 'add', ds.url, 'subdataset'],
+        runner.run(['git', 'submodule', 'add', ds.url, 'sub dataset1'],
                    cwd=self.path, **kw)
-        runner.run(['git', 'submodule', 'add', ds.url, 'subsubdataset'],
-                   cwd=opj(self.path, 'subdataset'), **kw)
-        runner.run(['git', 'commit', '-m', 'Added subdataset.'],
-                   cwd=opj(self.path, 'subdataset'), **kw)
+        runner.run(['git', 'submodule', 'add', ds.url, 'sub sub dataset1'],
+                   cwd=opj(self.path, 'sub dataset1'), **kw)
+        runner.run(['git', 'commit', '-m', 'Added sub dataset.'],
+                   cwd=opj(self.path, 'sub dataset1'), **kw)
         runner.run(['git', 'commit', '-a', '-m', 'Added subdatasets.'],
                    cwd=self.path, **kw)
         runner.run(['git', 'submodule', 'update', '--init', '--recursive'],
                    cwd=self.path, **kw)
         # init all annexes
-        for s in ('', 'subdataset', opj('subdataset', 'subsubdataset')):
+        for s in ('', 'sub dataset1', opj('sub dataset1', 'sub sub dataset1')):
             runner.run(['git', 'annex', 'init'],
                        cwd=opj(self.path, s), expect_stderr=True)
 
@@ -182,7 +182,7 @@ class InnerSubmodule(object):
 
     @property
     def path(self):
-        return opj(self._ds.path, 'subdataset', 'sub1')
+        return opj(self._ds.path, 'sub dataset1', 'subm 1')
 
     @property
     def url(self):


### PR DESCRIPTION
Should probably close #673 and #691, #696

The best way to test that most of the commands can tolerate spaces, was to make our tests repos (submodules) have spaces in their names.  Also made them somewhat unique so later we could quickly RF possibly to add more obscurity etc