### PR TITLE
OPT: startuptime - shave off at least (probably more) 50ms

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -9,9 +9,6 @@
 """DataLad aims to expose (scientific) data available online as a unified data
 distribution with the convenience of git-annex repositories as a backend."""
 
-import atexit
-
-from .version import __version__
 from .log import lgr
 
 # Other imports are interspersed with lgr.debug to ease troubleshooting startup
@@ -23,8 +20,12 @@ cfg = ConfigManager()
 lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager
 ssh_manager = SSHManager()
+
+import atexit
 atexit.register(ssh_manager.close, allow_fail=False)
 atexit.register(lgr.log, 5, "Exiting")
+
+from .version import __version__
 
 
 def test(package='datalad', **kwargs):

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -24,6 +24,7 @@ lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager
 ssh_manager = SSHManager()
 atexit.register(ssh_manager.close, allow_fail=False)
+atexit.register(lgr.log, 5, "Exiting")
 
 
 def test(package='datalad', **kwargs):

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -10,7 +10,8 @@
 """
 
 import sys
-from mock import patch
+# OPT delay import for expensive mock until used
+#from mock import patch
 from six import PY2
 import six.moves.builtins as __builtin__
 builtins_name = '__builtin__' if PY2 else 'builtins'
@@ -79,6 +80,7 @@ class AutomagicIO(object):
 
         """
         # wrap it all for resilience to errors -- proxying must do no harm!
+        from mock import patch
         try:
             if self._in_open:
                 raise _EarlyExit

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -10,16 +10,17 @@
 
 __docformat__ = 'restructuredtext'
 
+import logging
+lgr = logging.getLogger('datalad.cmdline')
+
+lgr.log(5, "Importing cmdline.main")
 
 import argparse
-import logging
 import sys
-import os
 import textwrap
 from importlib import import_module
 
 import datalad
-from datalad.log import lgr
 
 from datalad.cmdline import helpers
 from datalad.support.exceptions import InsufficientArgumentsError
@@ -51,9 +52,16 @@ THE SOFTWARE.
 """
 
 
+# TODO:  OPT look into making setup_parser smarter to become faster
+# Now it seems to take up to 200ms to do all the parser setup
+# even though it might not be necessary to know about all the commands etc.
+# I wondered if it could somehow decide on what commands to worry about etc
+# by going through sys.args first
 def setup_parser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         return_subparsers=False):
+
+    lgr.log(5, "Starting to setup_parser")
     # delay since it can be a heavy import
     from ..interface.base import dedent_docstring, get_interface_groups, \
         get_cmdline_command_name, alter_interface_docs_for_cmdline
@@ -121,6 +129,7 @@ def setup_parser(
 
         for _intfspec in _interfaces:
             # turn the interface spec into an instance
+            lgr.log(5, "Importing module %s " % _intfspec[0])
             _mod = import_module(_intfspec[0], package='datalad')
             _intf = getattr(_mod, _intfspec[1])
             cmd_name = get_cmdline_command_name(_intfspec)
@@ -189,6 +198,7 @@ def setup_parser(
     datalad <command> --help"""),
                          75, initial_indent='', subsequent_indent=''))
     parts['datalad'] = parser
+    lgr.log(5, "Finished setup_parser")
     if return_subparsers:
         return parts
     else:
@@ -206,6 +216,7 @@ def setup_parser(
 
 
 def main(args=None):
+    lgr.log(5, "Starting main(%r)", args)
     # PYTHON_ARGCOMPLETE_OK
     parser = setup_parser()
     try:
@@ -247,3 +258,5 @@ def main(args=None):
             sys.exit(1)
     if hasattr(cmdlineargs, 'result_renderer'):
         cmdlineargs.result_renderer(ret)
+
+lgr.log(5, "Done importing cmdline.main")

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -10,6 +10,10 @@
 """
 
 import logging
+lgr = logging.getLogger('datalad.dataset')
+
+lgr.log(5, "Importing dataset")
+
 from os.path import abspath, join as opj, normpath
 from six import string_types, PY2
 from functools import wraps
@@ -23,7 +27,6 @@ from datalad.utils import swallow_logs
 from datalad.utils import getpwd
 from datalad.support.exceptions import InsufficientArgumentsError
 
-lgr = logging.getLogger('datalad.dataset')
 
 
 # TODO: use the same piece for resolving paths against Git/AnnexRepo instances

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -24,7 +24,6 @@ from .base import Interface
 from ..ui import ui
 from ..utils import swallow_logs
 from ..dochelpers import exc_str
-from ..support.s3 import get_key_url
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr, EnsureNone
 
@@ -408,6 +407,8 @@ def _ls_s3(loc, fast=False, recursive=False, all=False, config_file=None, list_c
                 # Skip this one
                 ui.message("")
                 continue
+            # OPT: delayed import
+            from ..support.s3 import get_key_url
             url = get_key_url(e, schema='http')
             try:
                 _ = urlopen(Request(url))

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -848,4 +848,4 @@ def get_local_file_url(fname):
         furl = str(URL(scheme='file', path=fname))
     return furl
 
-lgr.log(5, "Finished importing support.network")
+lgr.log(5, "Done importing support.network")

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -7,6 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+import logging
+lgr = logging.getLogger('datalad.network')
+
+lgr.log(5, "Importing support.network")
 import calendar
 import email.utils
 import gzip
@@ -31,12 +35,9 @@ from six.moves.urllib.error import URLError
 from datalad.utils import on_windows
 from datalad.consts import DATASETS_TOPURL
 
-from datalad.utils import auto_repr
 # TODO not sure what needs to use `six` here yet
-import requests
-
-import logging
-lgr = logging.getLogger('datalad.network')
+# !!! Lazily import requests where needed -- needs 30ms or so
+# import requests
 
 
 def get_response_disposition_filename(s):
@@ -164,11 +165,12 @@ def iso8601_to_epoch(datestr):
     return calendar.timegm(iso8601.parse_date(datestr).timetuple())
 
 
-def __urlopen_requests(url, header_vals=None):
+def __urlopen_requests(url):
     # XXX Workaround for now for ... broken code
     if isinstance(url, Request):
         url = url.get_full_url()
-    return requests.Session().get(url)
+    from requests import Session
+    return Session().get(url)
 
 
 def retry_urlopen(url, retries=3):
@@ -845,3 +847,5 @@ def get_local_file_url(fname):
         # TODO:  need to fix for all the encoding etc
         furl = str(URL(scheme='file', path=fname))
     return furl
+
+lgr.log(5, "Finished importing support.network")

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -12,12 +12,14 @@
 
 __docformat__ = 'restructuredtext'
 
+from logging import getLogger
+lgr = getLogger('datalad.ui')
+
+lgr.log(5, "Starting importing ui")
+
 from .dialog import ConsoleLog, DialogUI, UnderAnnexUI
 from .dialog import UnderTestsUI
 from ..utils import is_interactive
-
-from logging import getLogger
-lgr = getLogger('datalad.ui')
 
 # TODO: implement logic on selection of the ui based on the cfg and environment
 # e.g. we cannot use DialogUI if session is not interactive
@@ -69,4 +71,8 @@ class _UI_Switcher(object):
             return super(_UI_Switcher, self).__setattr__(key, value)
         return setattr(self._ui, key, value)
 
+lgr.log(5, "Initiating UI switcher")
+
 ui = _UI_Switcher()
+
+lgr.log(5, "Done importing ui")

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -12,13 +12,20 @@
 
 __docformat__ = 'restructuredtext'
 
+from logging import getLogger
+lgr = getLogger('datalad.ui.dialog')
+
+lgr.log(5, "Starting importing ui.dialog")
+
 import os
 import sys
 import time
 
 from six import PY2
 import getpass
-from mock import patch
+
+#!!! OPT adds >100ms to import time!!!
+# from mock import patch
 from collections import deque
 from copy import copy
 
@@ -111,6 +118,7 @@ def getpass_echo(prompt='Password: ', stream=None):
         #     if out == '\n':
         #         return
         #     stream.write(out)
+        from mock import patch
         with patch('termios.ECHO', 255**2):
             #patch.object(stream, 'write', _no_emptyline_write(stream)):
             return getpass.getpass(prompt=prompt, stream=stream)
@@ -248,3 +256,5 @@ class UnderTestsUI(DialogUI):
         self.clear_responses()
         assert not len(responses), \
             "Still have some responses left: %s" % repr(self._responses)
+
+lgr.log(5, "Done importing ui.dialog")


### PR DESCRIPTION
added also bunch of log lines to simplify timing of the imports

atm good portion happens somewhere during initial logging setup or just finding the entry point or smth like that -- see that there is 200ms until first log line:
```
$> date --rfc-3339='ns'; time DATALAD_LOGLEVEL=1 datalad; date --rfc-3339=ns        
2016-08-11 21:27:02.994538754-04:00
2016-08-11 21:27:03,207 [Level 5] Instantiating config (__init__.py:16)
2016-08-11 21:27:03,208 [DEBUG  ] Reading files: ['/etc/datalad/datalad.cfg', '/etc/xdg/datalad/config', '/home/yoh/.config/datalad/datalad.cfg', '.datalad/config'] (configparserinc.py:144)
2016-08-11 21:27:03,208 [Level 5] Instantiating ssh manager (__init__.py:20)
2016-08-11 21:27:03,235 [Level 5] Done importing main __init__ (__init__.py:109)
2016-08-11 21:27:03,235 [Level 5] Importing cmdline.main (main.py:16)
2016-08-11 21:27:03,237 [Level 5] Done importing cmdline.main (main.py:262)
2016-08-11 21:27:03,237 [Level 5] Starting main(None) (main.py:219)
2016-08-11 21:27:03,237 [Level 5] Starting to setup_parser (main.py:64)
2016-08-11 21:27:03,238 [Level 5] Starting importing ui (__init__.py:18)
2016-08-11 21:27:03,238 [Level 5] Starting importing ui.dialog (dialog.py:18)
2016-08-11 21:27:03,238 [Level 5] Done importing ui.dialog (dialog.py:260)
2016-08-11 21:27:03,239 [Level 5] Initiating UI switcher (__init__.py:74)
2016-08-11 21:27:03,239 [DEBUG  ] UI set to DialogUI(out=<file>) (__init__.py:52)
2016-08-11 21:27:03,239 [Level 5] Done importing ui (__init__.py:78)
2016-08-11 21:27:03,240 [Level 5] Importing module datalad.distribution.create  (main.py:132)
2016-08-11 21:27:03,266 [Level 5] Importing support.network (network.py:13)
2016-08-11 21:27:03,274 [Level 5] Done importing support.network (network.py:851)
2016-08-11 21:27:03,274 [Level 5] Importing dataset (dataset.py:15)
2016-08-11 21:27:03,278 [Level 5] Importing module datalad.distribution.install  (main.py:132)
2016-08-11 21:27:03,279 [Level 5] Importing module datalad.distribution.publish  (main.py:132)
2016-08-11 21:27:03,280 [Level 5] Importing module datalad.distribution.uninstall  (main.py:132)
2016-08-11 21:27:03,282 [Level 5] Importing module datalad.distribution.update  (main.py:132)
2016-08-11 21:27:03,283 [Level 5] Importing module datalad.distribution.create_publication_target_sshwebserver  (main.py:132)
2016-08-11 21:27:03,288 [Level 5] Importing module datalad.distribution.add_sibling  (main.py:132)
2016-08-11 21:27:03,289 [Level 5] Importing module datalad.distribution.modify_subdataset_urls  (main.py:132)
2016-08-11 21:27:03,290 [Level 5] Importing module datalad.interface.unlock  (main.py:132)
2016-08-11 21:27:03,291 [Level 5] Importing module datalad.interface.save  (main.py:132)
2016-08-11 21:27:03,292 [Level 5] Importing module datalad.interface.test  (main.py:132)
2016-08-11 21:27:03,292 [Level 5] Importing module datalad.interface.crawl  (main.py:132)
2016-08-11 21:27:03,295 [Level 5] Importing module datalad.interface.crawl_init  (main.py:132)
2016-08-11 21:27:03,296 [Level 5] Importing module datalad.interface.ls  (main.py:132)
2016-08-11 21:27:03,297 [Level 5] Importing module datalad.interface.clean  (main.py:132)
2016-08-11 21:27:03,298 [Level 5] Importing module datalad.interface.add_archive_content  (main.py:132)
2016-08-11 21:27:03,300 [Level 5] Importing module datalad.interface.download_url  (main.py:132)
2016-08-11 21:27:03,301 [Level 5] Importing module datalad.distribution.create_test_dataset  (main.py:132)
2016-08-11 21:27:03,302 [Level 5] Finished setup_parser (main.py:201)
usage: datalad [-h] [-l {critical,error,warning,info,debug,1,2,3,4,5,6,7,8,9}]
               [-p {condor}] [--version] [--dbg] [--idbg] [-C PATH]
               {create,install,publish,uninstall,update,create-publication-target-sshwebserver,add-sibling,modify-subdataset-urls,unlock,save,test,crawl,crawl-init,ls,clean,add-archive-content,download-url,create-test-dataset}
               ...
datalad: error: too few arguments
2016-08-11 21:27:03,305 [Level 5] Exiting (atexit.py:24)
DATALAD_LOGLEVEL=1 datalad  0.27s user 0.05s system 96% cpu 0.326 total
2016-08-11 21:27:03.322714001-04:00
```