### PR TITLE
ENH: publish --since . By default publish only subdatasets what has changed

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -256,11 +256,8 @@ class Publish(Interface):
         if publish_this:
             # upstream branch needed for update (merge) and subsequent push,
             # in case there is no.
-            if track_branch is None:
-                # no tracking branch yet:
-                set_upstream = True
-            else:
-                set_upstream = False
+            # no tracking branch yet?
+            set_upstream = track_branch is None
 
             # is `to` an already known remote?
             if dest_resolved not in ds.repo.get_remotes():
@@ -327,7 +324,6 @@ class Publish(Interface):
 
     @staticmethod
     def _get_changed_datasets(repo, all_subdatasets, to, since=None):
-
         if since == '':
             # we are instructed to publish all
             return all_subdatasets

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -138,11 +138,7 @@ class Publish(Interface):
         publish_this = False   # whether to publish `ds`
         publish_files = []     # which files to publish by `ds`
 
-        # it is important to publish parent dataset after children
-        # so possible updates of meta-information on the server
-        # triggered from the hook(s) work out correctly.  Thus -- collecting
-        # them into a list
-        expl_subs = []         # subdatasets to publish explicitly
+        expl_subs = set()      # subdatasets to publish explicitly
         publish_subs = dict()  # collect what to publish from subdatasets
 
         if not path:
@@ -153,7 +149,7 @@ class Publish(Interface):
                 subdatasets = ds.get_subdatasets()
                 if p in subdatasets:
                     # p is a subdataset, that needs to be published itself
-                    expl_subs.append(p)
+                    expl_subs.add(p)
                 else:
                     try:
                         d = get_containing_subdataset(ds, p)
@@ -212,11 +208,11 @@ class Publish(Interface):
                 else:
                     # we can recursively publish only, if there actually
                     # is something
-                    expl_subs.append(subds_path)
+                    expl_subs.add(subds_path)
 
         published, skipped = [], []
 
-        for dspath in expl_subs:
+        for dspath in sorted(expl_subs):
             # these datasets need to be pushed regardless of additional paths
             # pointing inside them
             # due to API, this may not happen when calling publish with paths,

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -320,7 +320,7 @@ class Publish(Interface):
 
     @staticmethod
     def _get_changed_datasets(repo, all_subdatasets, to, since=None):
-        if since == '':
+        if since == '' or not all_subdatasets:
             # we are instructed to publish all
             return all_subdatasets
 
@@ -335,10 +335,11 @@ class Publish(Interface):
                 # we did not publish it before - so everything must go
                 return all_subdatasets
 
+        lgr.debug("Checking diff since %s for %s" % (since, all_subdatasets))
         diff = repo.repo.commit().diff(since, all_subdatasets)
         for d in diff:
             # not sure if it could even track renames of subdatasets
             # but let's "check"
-            assert(d.a_name == d.b_name)
-        changed_subdatasets = [d.b_name for d in diff]
+            assert(d.a_path == d.b_path)
+        changed_subdatasets = [d.b_path for d in diff]
         return changed_subdatasets

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -350,4 +350,4 @@ class Publish(Interface):
             # not sure if it could even track renames of subdatasets
             # but let's "check"
             assert(d.a_path == d.b_path)
-        return dict((d.b_path, d.b_blob.hexsha) for d in diff)
+        return dict((d.b_path, d.b_blob.hexsha if d.b_blob else None) for d in diff)

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -232,7 +232,7 @@ class Publish(Interface):
                 pkw = {}
                 if since == '':
                     pkw['since'] = since
-                elif since is None:
+                else:
                     # pass previous state for that submodule if known
                     pkw['since'] = subds_prev_hexsha.get(dspath, None)
                 published_, skipped_ = ds_.publish(to=to, recursive=recursive, **pkw)
@@ -350,4 +350,4 @@ class Publish(Interface):
             # not sure if it could even track renames of subdatasets
             # but let's "check"
             assert(d.a_path == d.b_path)
-        return dict((d.a_path, d.a_blob.hexsha) for d in diff)
+        return dict((d.b_path, d.b_blob.hexsha) for d in diff)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -662,7 +662,7 @@ class GitRepo(object):
         if options:
             # we can't pass all possible options to gitpython's implementation
             # of commit. Therefore we need a direct call to git:
-            cmd = ['git', 'commit'] + (["-m", msg] if msg else []) + options
+            cmd = ['git', 'commit'] + (["-m", msg if msg else ""]) + options
             lgr.debug("Committing via direct call of git: %s" % cmd)
             self._git_custom_command([], cmd)
         else:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -368,6 +368,22 @@ else:
         # Runner().run(['touch', '-h', '-d', '@%s' % mtime, filepath])
 
 
+def assure_list(s):
+    """Given not a list, would place it into a list. If None - empty list is returned
+
+    Parameters
+    ----------
+    s: list or anything
+    """
+
+    if isinstance(s, list):
+        return s
+    elif s is None:
+        return []
+    else:
+        return [s]
+
+
 def assure_list_from_str(s, sep='\n'):
     """Given a multiline string convert it to a list of return None if empty
 


### PR DESCRIPTION
For me it is needed from usability perspective. Publishing current crawled collection is already a matter of minutes even if only 1 sub-dataset has changed.  So I have decided to suggest this approach of publishing only what has changed since last time

- [x]  test the logic(s) and various values for --since (could be improved with sub-subdatasets for testing propagation of setting)
- [ ]  shouldn't try to push even the current dataset if nothing has changed (up for discussion?)
- [x]  do figure out in the super-dataset previous 'since' for sub-dataset and provide it in. Otherwise I cannot "redo" e.g. "publish --since=HEAD^" with effect in sub-datasets as well

Not sure yet on the interplay with all the additional logic there with publishing specific files/paths.  It might just work since those would be added explicitly for pushing while analyzing paths, so might just work  ;-)

cons:
- it checks only current branch so nohow checks for those refs which were possibly set in .git/config to be pushed.   But we can't check AFAIK anyways if e.g. tags are present on the remote, so explicit pushing (`--since=`) would be needed
- relies on assumption that super-datasets got properly updated/committed if sub-datasets were modified

Closes #704