### PR TITLE
BF: few fixes (spaces in submod names + submodules treatment) install

### DIFF
--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -19,6 +19,7 @@ from os.path import join as opj, abspath, relpath, pardir, isabs, isdir, \
 
 from six.moves.urllib.parse import quote as urlquote
 
+from datalad.dochelpers import exc_str
 from datalad.cmd import CommandError
 from datalad.cmd import Runner
 from datalad.distribution.dataset import Dataset, datasetmethod, \
@@ -451,7 +452,7 @@ class Install(Interface):
         # FLOW GUIDE
         #
         # at this point we know nothing about the
-        # installation targether
+        # installation target
         ###################################################
         try:
             # it is simplest to let annex tell us what we are dealing with
@@ -462,9 +463,9 @@ class Install(Interface):
                 # this is not an annex repo, but we raise exceptions
                 # to be able to treat them alike in the special case handling
                 # below
-                if not exists(path):
-                    raise IOError("path doesn't exist yet, might need special handling")
-                elif relativepath in vcs.get_indexed_files():
+                # TODO: inefficient to ask for all files, we need to check
+                # with GitRepo if it knows about the file
+                if relativepath in vcs.get_indexed_files():
                     # relativepath is in git
                     raise FileInGitError("We need to handle it as known to git")
                 else:
@@ -582,7 +583,7 @@ class Install(Interface):
             else:
                 return None
 
-        except IOError:
+        except IOError as exc:
             ###################################################
             # FLOW GUIDE
             #
@@ -592,7 +593,7 @@ class Install(Interface):
             # - an entire untracked/unknown existing subdataset
             # - non-existing content that should be installed from `source`
             ###################################################
-            lgr.log(5, "IOError logic")
+            lgr.log(5, "IOError logic: %s", exc_str(exc))
             # we can end up here in two cases ATM
             if (exists(path) or islink(path)) or source is None:
                 # FLOW GUIDE

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -734,7 +734,7 @@ class DataLadRI(RI, RegexBasedURLMixin):
         """
         if self.remote:
             raise NotImplementedError("not supported ATM to reference additional remotes")
-        return "{}{}".format(DATASETS_TOPURL, self.path)
+        return "{}{}".format(DATASETS_TOPURL, urlquote(self.path))
 
 
 def _split_colon(s, maxsplit=1):


### PR DESCRIPTION
This is not complete.  I was aiming to fix more of install logic (check for submodules should happen even for annex repos etc), but then also got hurt by remaining "creativism" of install uses in test_install and non-uniform handling of paths to datasets if they contain symlinks (I have TMPDIR=$HOME/.tmp  which is a symlink to /tmp, to reveal all kinds of gory failures).  So let's see first how these fixes hold, and they might resolve issues for @debanjum trying to 'install -r datasets ///' (another culprit found was using proxy -- don't use it for this call).  I will try to get a fresher look into it tomorrow as well

Should at least partially address https://github.com/datalad/datalad/issues/693