### PR TITLE
BF+RF+ENH: cocktail of changes while was working on crcns/smaug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
 matrix:
   include:
   - python: 2.7
+    env:
+    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
+    - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="
   # no loop dev support on travis yet :-/ https://github.com/travis-ci/travis-ci/issues/2700
   #- python: 2.7
   #  env:

--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -350,7 +350,8 @@ def initiate_pipeline_config(template, template_func=None, template_kwargs=None,
         repo = GitRepo(path)
         repo.add(crawl_config_repo_path)
         if repo.dirty:
-            repo.commit("Initialized crawling configuration to use template %s" % template)
+            repo.commit("Initialized crawling configuration to use template %s" % template,
+                        _datalad_msg=True)
         else:
             lgr.debug("Repository is not dirty -- not committing")
 

--- a/datalad/crawler/pipelines/crcns.py
+++ b/datalad/crawler/pipelines/crcns.py
@@ -140,7 +140,7 @@ def pipeline(dataset, dataset_category, versioned_urls=False, tarballs=True,
         ],
         annex.switch_branch('incoming-processed'),
         [   # nested pipeline so we could skip it entirely if nothing new to be merged
-            annex.merge_branch('incoming', strategy='theirs', commit=False, skip_no_changes=False),
+            annex.merge_branch('incoming', strategy='theirs', commit=False),  #, skip_no_changes=False),
             [   # Pipeline to augment content of the incoming and commit it to master
                 find_files("\.(zip|tgz|tar(\..+)?)$", fail_if_none=tarballs),  # So we fail if none found -- there must be some! ;)),
                 annex.add_archive_content(

--- a/datalad/crawler/pipelines/tests/test_balsa.py
+++ b/datalad/crawler/pipelines/tests/test_balsa.py
@@ -237,8 +237,9 @@ def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     target_files = {
         './.datalad/crawl/crawl.cfg',
         './.datalad/crawl/statuses/incoming.json',
-        './file1.nii', './dir1/file2.nii',
         './.datalad/meta/balsa.json',
+        './.datalad/config',
+        './file1.nii', './dir1/file2.nii',
     }
 
     eq_(set(all_files), target_files)
@@ -339,10 +340,11 @@ def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     ok_file_under_git(fpath2, annexed=True)
 
     target_files = {
+        './.datalad/config',
         './.datalad/crawl/crawl.cfg',
         './.datalad/crawl/statuses/incoming.json',
-        './file1.nii', './dir1/file2.nii',
         './.datalad/meta/balsa.json',
+        './file1.nii', './dir1/file2.nii',
     }
 
     eq_(set(all_files), target_files)

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -297,6 +297,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     ok_file_under_git(t1w_fpath, annexed=True)
 
     target_files = {
+        './.datalad/config',
         './.datalad/crawl/crawl.cfg',
         # no more!
         # './.datalad/config.ttl', './.datalad/datalad.ttl',

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -99,6 +99,10 @@ class Create(Interface):
             doc="""if set, a plain Git repository will be created without any
             annex""",
             action='store_true'),
+        no_commit=Parameter(
+            args=("--no-commit",),
+            doc="""if set, do not commit automatically""",
+            action='store_true'),
         annex_version=Parameter(
             args=("--annex-version",),
             doc="""select a particular annex repository version. The
@@ -130,6 +134,7 @@ class Create(Interface):
             add_to_super=False,
             name=None,
             no_annex=False,
+            no_commit=False,
             annex_version=None,
             annex_backend='MD5E',
             git_opts=None,
@@ -157,54 +162,62 @@ class Create(Interface):
 
         if add_to_super:
             sds = ds.get_superdataset()
-            if sds is None:
-                raise ValueError("No super dataset found for dataset %s" % ds)
 
-            return sds.create_subdataset(
-                ds.path,
-                name=name,
-                description=description,
-                no_annex=no_annex,
-                annex_version=annex_version,
-                annex_backend=annex_backend,
-                git_opts=git_opts,
-                annex_opts=annex_opts,
-                annex_init_opts=annex_init_opts)
-
-        else:
-            if no_annex:
-                if description:
-                    raise ValueError("Incompatible arguments: cannot specify "
-                                     "description for annex repo and declaring "
-                                     "no annex repo.")
-                if annex_opts:
-                    raise ValueError("Incompatible arguments: cannot specify "
-                                     "options for annex and declaring no "
-                                     "annex repo.")
-                if annex_init_opts:
-                    raise ValueError("Incompatible arguments: cannot specify "
-                                     "options for annex init and declaring no "
-                                     "annex repo.")
-
-                lgr.info("Creating a new git repo at %s", ds.path)
-                vcs = GitRepo(ds.path, url=None, create=True,
-                              git_opts=git_opts)
+            if sds is not None:
+                return sds.create_subdataset(
+                    ds.path,
+                    name=name,
+                    description=description,
+                    no_annex=no_annex,
+                    annex_version=annex_version,
+                    annex_backend=annex_backend,
+                    git_opts=git_opts,
+                    annex_opts=annex_opts,
+                    annex_init_opts=annex_init_opts)
             else:
-                # always come with annex when created from scratch
-                lgr.info("Creating a new annex repo at %s", ds.path)
-                vcs = AnnexRepo(ds.path, url=None, create=True,
-                                backend=annex_backend,
-                                version=annex_version,
-                                description=description,
-                                git_opts=git_opts,
-                                annex_opts=annex_opts,
-                                annex_init_opts=annex_init_opts)
+                if isinstance(add_to_super, bool):
+                    raise ValueError("No super dataset found for dataset %s" % ds)
+                elif add_to_super == 'auto':
+                    pass  # we are cool to just make it happen without add_to_super
+                else:
+                    raise ValueError("Do not know how to handle add_to_super=%s"
+                                     % repr(add_to_super))
 
-            vcs.commit(msg="datalad initial commit",
-                       options=to_options(allow_empty=True))
-            # reset ID, we have a VCS now
-            ds._id = None
-            return ds
+        if no_annex:
+            if description:
+                raise ValueError("Incompatible arguments: cannot specify "
+                                 "description for annex repo and declaring "
+                                 "no annex repo.")
+            if annex_opts:
+                raise ValueError("Incompatible arguments: cannot specify "
+                                 "options for annex and declaring no "
+                                 "annex repo.")
+            if annex_init_opts:
+                raise ValueError("Incompatible arguments: cannot specify "
+                                 "options for annex init and declaring no "
+                                 "annex repo.")
+
+            lgr.info("Creating a new git repo at %s", ds.path)
+            vcs = GitRepo(ds.path, url=None, create=True,
+                          git_opts=git_opts)
+        else:
+            # always come with annex when created from scratch
+            lgr.info("Creating a new annex repo at %s", ds.path)
+            vcs = AnnexRepo(ds.path, url=None, create=True,
+                            backend=annex_backend,
+                            version=annex_version,
+                            description=description,
+                            git_opts=git_opts,
+                            annex_opts=annex_opts,
+                            annex_init_opts=annex_init_opts)
+
+        if not no_commit:
+            vcs.commit(msg="Initial commit",
+                       options=to_options(allow_empty=True),
+                       _datalad_msg=True)
+        # reset ID, we have a VCS now
+        ds._id = None
+        return ds
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -66,7 +66,7 @@ def _makeds(path, levels, ds=None):
     fn = opj(path, "file%d.dat" % random.randint(1, 1000))
     with open(fn, 'w') as f:
         f.write(fn)
-    repo.add(fn, git=True, commit=True, msg="Added %s" % fn)
+    repo.add(fn, git=True, commit=True, msg="Added %s" % fn, _datalad_msg=True)
     if ds:
         rpath = os.path.relpath(path, ds.path)
         out = install(
@@ -76,9 +76,9 @@ def _makeds(path, levels, ds=None):
         )
         # TODO: The following is to be adapted when refactoring AnnexRepo/GitRepo to make it uniform
         if isinstance(ds.repo, AnnexRepo):
-            ds.repo.commit("subdataset %s installed." % rpath)
+            ds.repo.commit("subdataset %s installed." % rpath, _datalad_msg=True)
         else:
-            ds.repo.commit("subdataset %s installed." % rpath)
+            ds.repo.commit("subdataset %s installed." % rpath, _datalad_msg=True)
 
     if not levels:
         return

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -237,8 +237,8 @@ class BaseDownloader(object):
                 content, "Download of the url %s has failed: " % url)
 
         if target_size and target_size != downloaded_size:
-            raise IncompleteDownloadError("Downloaded size %d differs from originally announced %d"
-                                          % (downloaded_size, target_size))
+            raise (IncompleteDownloadError if target_size > downloaded_size else UnaccountedDownloadError)(
+                "Downloaded size %d differs from originally announced %d" % (downloaded_size, target_size))
 
     def _download(self, url, path=None, overwrite=False, size=None, stats=None):
         """Download content into a file
@@ -405,6 +405,7 @@ class BaseDownloader(object):
 
         if cache:
             cache_key = msgpack.dumps(url)
+            lgr.debug("Loading content for url %s from cache", url)
             res = self.cache.get(cache_key)
             if res is not None:
                 try:

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -203,10 +203,15 @@ def test_authenticate_external_portals():
           "https://portal.nersc.gov/project/crcns/download/alm-1/checksums.md5", \
           "<form action=", \
           "datafiles/meta_data_files.tar.gz"
+    # seems to be gone
+    # yield check_download_external_url, \
+    #       'https://db.humanconnectome.org/data/archive/projects/HCP_500/subjects/100307/experiments/100307_CREST/resources/100307_CREST/files/unprocessed/3T/Diffusion/100307_3T_DWI_dir97_LR.bval', \
+    #       "failed", \
+    #       "2000 1005 2000 3000"
     yield check_download_external_url, \
-          'https://db.humanconnectome.org/data/archive/projects/HCP_500/subjects/100307/experiments/100307_CREST/resources/100307_CREST/files/unprocessed/3T/Diffusion/100307_3T_DWI_dir97_LR.bval', \
+          'https://db.humanconnectome.org/data/experiments/ConnectomeDB_E09797/resources/166768/files/filescans.csv', \
           "failed", \
-          "2000 1005 2000 3000"
+          "'Scan','FilePath'"
 test_authenticate_external_portals.tags = ['external-portal', 'network']
 
 

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -86,3 +86,6 @@ def test_reuse_session(tempfile, mocked_auth):
     with swallow_outputs():
         providers2.download(url_2versions_nonversioned1_ver2, path=tempfile, overwrite=True)
     assert_equal(mocked_auth.call_count, 2)
+
+    Providers.reset_default_providers()  # necessary to avoid side-effects from having a vcr'ed connection
+    # leaking through default provider's bucket, e.g. breaking test_mtime if ran after this one

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -468,7 +468,8 @@ class AddArchiveContent(Interface):
             if commit:
                 commit_stats = outside_stats if outside_stats else stats
                 annex.commit(
-                    "Added content extracted from %s %s\n\n%s" % (origin, archive, commit_stats.as_str(mode='full'))
+                    "Added content extracted from %s %s\n\n%s" % (origin, archive, commit_stats.as_str(mode='full')),
+                    _datalad_msg=True
                 )
                 commit_stats.reset()
         finally:

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -14,6 +14,9 @@ __docformat__ = 'restructuredtext'
 
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureInt, EnsureNone, EnsureStr
+from datalad.support.constraints import EnsureChoice
+from datalad.support.constraints import EnsureBool
+
 
 dataset_description = Parameter(
     args=("-D", "--description",),
@@ -34,8 +37,10 @@ recursion_limit = Parameter(
 
 add_to_superdataset = Parameter(
     args=("--add-to-super",),
-    doc="""add the new dataset as a component to a super dataset""",
-    action="store_true")
+    doc="""add the new dataset as a component to a super dataset. If 'auto',
+           adds to super-dataset if one is found.""",
+    constraints=EnsureChoice('auto') | EnsureBool(),
+)
 
 git_opts = Parameter(
     args=("--git-opts",),

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -325,9 +325,12 @@ def _ls_s3(loc, fast=False, recursive=False, all=False, config_file=None, list_c
     from boto.exception import S3ResponseError
     from ..support.configparserinc import SafeConfigParser  # provides PY2,3 imports
 
-    bucket_name, prefix = bucket_prefix.split('/', 1)
+    if '/' in bucket_prefix:
+        bucket_name, prefix = bucket_prefix.split('/', 1)
+    else:
+        bucket_name, prefix = bucket_prefix, None
 
-    if '?' in prefix:
+    if prefix and '?' in prefix:
         ui.message("We do not care about URL options ATM, they get stripped")
         prefix = prefix[:prefix.index('?')]
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -419,7 +419,7 @@ class AnnexRepo(GitRepo):
 
     @normalize_paths
     def add(self, files, git=False, backend=None, options=None, commit=False,
-            msg=None):
+            msg=None, _datalad_msg=False):
         """Add file(s) to the repository.
 
         Parameters
@@ -474,7 +474,7 @@ class AnnexRepo(GitRepo):
                     raise ValueError("Unexpected return type: %s" %
                                      type(return_list))
                 msg = self._get_added_files_commit_msg(file_list)
-            self.commit(msg)  # TODO: For consisteny: Also json return value (success)?
+            self.commit(msg, _datalad_msg=_datalad_msg)  # TODO: For consisteny: Also json return value (success)?
         return return_list
 
     def proxy(self, git_cmd, **kwargs):
@@ -1043,7 +1043,7 @@ class AnnexRepo(GitRepo):
         self._batched.close()
         super(AnnexRepo, self).precommit()
 
-    def commit(self, msg=None, options=None):
+    def commit(self, msg=None, options=None, _datalad_msg=False):
         """
 
         Parameters
@@ -1054,6 +1054,8 @@ class AnnexRepo(GitRepo):
         """
         self.precommit()
         if self.is_direct_mode():
+            if _datalad_msg:
+                msg = self._get_prefixed_commit_msg(msg)
             if not msg:
                 if options:
                     if "--allow-empty-message" not in options:
@@ -1064,7 +1066,7 @@ class AnnexRepo(GitRepo):
             self.proxy(['git', 'commit'] + (['-m', msg] if msg else []) +
                        (options if options else []), expect_stderr=True)
         else:
-            super(AnnexRepo, self).commit(msg, options)
+            super(AnnexRepo, self).commit(msg, options, _datalad_msg=_datalad_msg)
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, force=False, **kwargs):

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -81,6 +81,8 @@ class DownloadError(Exception):
 class IncompleteDownloadError(DownloadError):
     pass
 
+class UnaccountedDownloadError(IncompleteDownloadError):
+    pass
 
 class TargetFileAbsent(DownloadError):
     pass

--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -9,6 +9,8 @@
 """Adapters and decorators for keyrings
 """
 
+import os
+
 
 class Keyring(object):
     """Adapter to keyring module
@@ -42,7 +44,11 @@ class Keyring(object):
 
     # proxy few methods of interest explicitly, to be rebound to the module's
     def get(self, name, field):
-        return self._keyring.get_password(self._get_service_name(name), field)
+        # consult environment, might be provided there
+        val = self._keyring.get_password(self._get_service_name(name), field)
+        if val is None:
+            val = os.environ.get(('DATALAD_%s_%s' % (name, field)).replace('-', '_'), None)
+        return val
 
     def set(self, name, field, value):
         return self._keyring.set_password(self._get_service_name(name), field, value)

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -311,13 +311,14 @@ def get_versioned_url(url, guarantee_versioned=False, return_all=False, verify=F
             providers = Providers.from_config_files()
             s3url = "s3://%s/" % s3_bucket
             s3provider = providers.get_provider(s3url)
-            if s3provider.authenticator.bucket is not None:
+            if s3provider.authenticator.bucket is not None and s3provider.authenticator.bucket.name == s3_bucket:
                 # we have established connection before, so let's just reuse
                 bucket = s3provider.authenticator.bucket
             else:
                 bucket = s3provider.authenticator.authenticate(s3_bucket, s3provider.credential)  # s3conn or _get_bucket_connection(S3_TEST_CREDENTIAL)
         else:
             bucket = s3conn.get_bucket(s3_bucket)
+
         supports_versioning = True  # assume that it does
         try:
             supports_versioning = bucket.get_versioning_status()  # TODO cache
@@ -326,7 +327,6 @@ def get_versioned_url(url, guarantee_versioned=False, return_all=False, verify=F
             supports_versioning = 'maybe'
 
         if supports_versioning:
-
             all_keys = bucket.list_versions(fpath)
             # Filter and sort them so the newest one on top
             all_keys = [x for x in sorted(all_keys, key=lambda x: (x.last_modified, x.is_latest))

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -10,6 +10,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from collections import OrderedDict
 from six import binary_type, text_type
 import re
 
@@ -19,7 +20,7 @@ def get_replacement_dict(rules):
     if isinstance(rules, (binary_type, text_type)):
         rules = [rules]
 
-    pairs = {}
+    pairs = OrderedDict()
     for rule in rules:
         if isinstance(rule, (list, tuple)):
             if len(rule) == 2:

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -13,6 +13,33 @@ __docformat__ = 'restructuredtext'
 from six import binary_type, text_type
 import re
 
+def get_replacement_dict(rules):
+    """Given a string with replacement rules, produces a dict of from: to"""
+
+    if isinstance(rules, (binary_type, text_type)):
+        rules = [rules]
+
+    pairs = {}
+    for rule in rules:
+        if isinstance(rule, (list, tuple)):
+            if len(rule) == 2:
+                pairs.append(rule)
+            else:
+                raise ValueError("Got a rule %s which is not a string or a pair of values (from, to)"
+                                 % repr(rule))
+        if len(rule) <= 2:
+            raise ValueError("")
+        rule_split = rule[1:].split(rule[0])
+        if len(rule_split) != 2:
+            raise ValueError(
+                "Rename string must be of format '/pat1/replacement', "
+                "where / is an arbitrary character to decide replacement. "
+                "Got %s when trying to separate %s" % (rule_split, rule)
+            )
+        pairs[rule_split[0]] = rule_split[1]
+    return pairs
+
+
 def apply_replacement_rules(rules, s):
     """Apply replacement rules specified as a single string
 
@@ -33,20 +60,7 @@ def apply_replacement_rules(rules, s):
     str
     """
 
-    if isinstance(rules, (binary_type, text_type)):
-        rules = [rules]
-
-    for rule in rules:
-        if len(rule) <= 2:
-            raise ValueError("")
-        rule_split = rule[1:].split(rule[0])
-        if len(rule_split) != 2:
-            raise ValueError(
-                "Rename string must be of format '/pat1/replacement', "
-                "where / is an arbitrary character to decide replacement. "
-                "Got %s when trying to separate %s" % (rule_split, rule)
-            )
-        regexp, replacement = rule_split
+    for regexp, replacement in get_replacement_dict(rules).items():
         s = re.sub(regexp, replacement, s)
 
     return s

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -13,6 +13,7 @@
 
 from ..support.s3 import get_versioned_url
 from .utils import use_cassette
+from .utils import ok_startswith
 
 from nose.tools import eq_, assert_raises
 from datalad.tests.utils import skip_if_no_network
@@ -21,7 +22,7 @@ from ..downloaders.tests.utils import get_test_providers
 skip_if_no_network()  # ATM we don't ship fixtures, so if no network -- no network!
 
 
-@use_cassette('s3_test0')
+@use_cassette('s3_test_version_url')
 def test_version_url():
     get_test_providers('s3://openfmri/tarballs')  # to verify having credentials to access openfmri via S3
     for url_pref in ('http://openfmri.s3.amazonaws.com', 'https://s3.amazonaws.com/openfmri'):
@@ -49,4 +50,4 @@ def test_version_url():
     eq_(len(set(urls)), len(urls))  # all unique
     for url in urls:
         # so we didn't grab other files along with the same prefix
-        assert(url.startswith('http://datalad-test0-versioned.s3.amazonaws.com/2versions-removed-recreated.txt?versionId='))
+        ok_startswith(url, 'http://datalad-test0-versioned.s3.amazonaws.com/2versions-removed-recreated.txt?versionId=')

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -218,9 +218,9 @@ def put_file_under_git(path, filename=None, content=None, annexed=False):
     if annexed:
         if not isinstance(repo, AnnexRepo):
             repo = AnnexRepo(repo.path)
-        repo.add(file_repo_path, commit=True)
+        repo.add(file_repo_path, commit=True, _datalad_msg=True)
     else:
-        repo.add(file_repo_path, git=True)
+        repo.add(file_repo_path, git=True, _datalad_msg=True)
     ok_file_under_git(repo.path, file_repo_path, annexed)
     return repo
 


### PR DESCRIPTION
- added "private" argument to .commit to add our `[DATALAD] ` prefix which now used in many spots
- used `create ` command to initiate dataset
- `--no-commit` to create (if we know that we will commit anyways later)
- parametric renames (outside of tarballs and on extracted content) for crcns pipeline
- `add_to_super="auto"` to add to super only if there is a super
- fixed a test url to db.hcp url
- request non-compressed content  so our logic of checking download by size to match header works and (ideally a TODO item to enable back, but may be later)