### PR TITLE
RF: Make Dataset.id independent of annex.UUID and also for non-annex datasets

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -199,18 +199,19 @@ class Create(Interface):
                                 git_opts=git_opts,
                                 annex_opts=annex_opts,
                                 annex_init_opts=annex_init_opts)
-                # record the annex uuid of this repo for this afterlife
-                # to be able to track siblings and children
-                if 'datalad.annex.origin' in ds.config:
-                    # make sure we reset this variable completely, in case of a re-create
-                    ds.config.unset('datalad.annex.origin', where='dataset')
-                ds.config.add('datalad.annex.origin', vcs.uuid, where='dataset')
-                ds.repo.add('.datalad', git=True)
 
-            vcs.commit(msg="datalad initial commit",
+            # record the ID of this repo for the afterlife
+            # to be able to track siblings and children
+            id_var = 'datalad.dataset.id'
+            if id_var in ds.config:
+                # make sure we reset this variable completely, in case of a re-create
+                ds.config.unset(id_var, where='dataset')
+            ds.config.add(id_var, ds.id, where='dataset')
+
+           # save everthing
+            ds.repo.add('.datalad', git=True)
+            vcs.commit(msg="[DATALAD] initial commit",
                        options=to_options(allow_empty=True))
-            # reset ID, we have a VCS now
-            ds._id = None
             return ds
 
     @staticmethod

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -108,10 +108,10 @@ def test_create(path):
     cmd = ['git-annex', 'info']
     cmlout = runner.run(cmd, cwd=path)
     assert_in('funny [here]', cmlout[0])
-    # check annex uuid record
+    # check datset ID
     assert_equal(
-        ds.config.get_value('datalad.annex', 'origin'),
-        ds.repo.repo.config_reader().get_value('annex', 'uuid'))
+        ds.config.get_value('datalad.dataset', 'id'),
+        ds.id)
 
 
 @with_tempfile

--- a/datalad/distribution/tests/test_dataset_config.py
+++ b/datalad/distribution/tests/test_dataset_config.py
@@ -19,8 +19,8 @@ from datalad.api import create
 # Let's document any configuration option supported in this
 # reference configuration
 _config_file_content = """\
-[datalad "annex"]
-    origin = nothing
+[datalad "dataset"]
+    id = nothing
 """
 
 _dataset_config_template = {
@@ -35,7 +35,7 @@ def test_configuration_access(path):
     # there is something prior creation
     assert_true(ds.config is not None)
     # creation must change the uuid setting
-    assert_equal(ds.config['datalad.annex.origin'], 'nothing')
+    assert_equal(ds.config['datalad.dataset.id'], 'nothing')
     # create resets this value and records the actual uuid
     ds.create(force=True)
-    assert_equal(ds.config.get_value('datalad.annex', 'origin', default='nothing'), ds.id)
+    assert_equal(ds.config.get_value('datalad.dataset', 'id', default='nothing'), ds.id)

--- a/datalad/support/dsconfig.py
+++ b/datalad/support/dsconfig.py
@@ -157,6 +157,10 @@ class ConfigManager(object):
         """Returns list of configuration item names"""
         return self._store.keys()
 
+    def get(self, key, default=None):
+        """D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None."""
+        return self._store.get(key, default)
+
     #
     # Compatibility with ConfigParser API
     #
@@ -188,17 +192,13 @@ class ConfigManager(object):
                 return True
         return False
 
-    def get(self, section, option):
-        """Get an option value for the named section"""
-        return self._store['.'.join((section, option))]
-
     def getint(self, section, option):
         """A convenience method which coerces the option value to an integer"""
-        return int(self.get(section, option))
+        return int(self.get_value(section, option))
 
     def getfloat(self, section, option):
         """A convenience method which coerces the option value to a float"""
-        return float(self.get(section, option))
+        return float(self.get_value(section, option))
 
     # this is a hybrid of ConfigParser and dict API
     def items(self, section=None):
@@ -221,7 +221,7 @@ class ConfigManager(object):
         config parser.
         """
         try:
-            return self.get(section, option)
+            return self['.'.join((section, option))]
         except KeyError as e:
             # this strange dance is needed because gitpython does it this way
             if default is not None:

--- a/datalad/support/tests/test_dsconfig.py
+++ b/datalad/support/tests/test_dsconfig.py
@@ -79,21 +79,21 @@ def test_something(path, new_home):
 
     # always get all values
     assert_equal(
-        cfg.get('something', 'user'),
+        cfg.get('something.user'),
         ('name=Jane Doe', 'email=jd@example.com'))
-    assert_raises(KeyError, cfg.get, 'somedthing', 'user')
+    assert_raises(KeyError, cfg.__getitem__, 'somedthing.user')
     assert_equal(cfg.getfloat('onemore.complicated の beast with.dot', 'findme'), 5.0)
     assert_equal(cfg.getint('something', 'myint'), 3)
 
     # gitpython-style access
-    assert_equal(cfg.get('something', 'myint'), cfg.get_value('something', 'myint'))
+    assert_equal(cfg.get('something.myint'), cfg.get_value('something', 'myint'))
     assert_equal(cfg.get_value('doesnot', 'exist', default='oohaaa'), 'oohaaa')
     # weired, but that is how it is
     assert_raises(KeyError, cfg.get_value, 'doesnot', 'exist', default=None)
 
     # modification follows
     cfg.add('something.new', 'の')
-    assert_equal(cfg.get('something', 'new'), 'の')
+    assert_equal(cfg.get('something.new'), 'の')
     # sections are added on demand
     cfg.add('unheard.of', 'fame')
     assert_true(cfg.has_section('unheard.of'))


### PR DESCRIPTION
all with UUIDs