### PR TITLE
ENH: Commit history of files using GitRepo

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -812,7 +812,6 @@ class GitRepo(object):
         [str]
           content of file_ as a list of lines.
         """
-
         content_str = self.repo.commit(branch).tree[file_].data_stream.read()
 
         # in python3 a byte string is returned. Need to convert it:
@@ -825,6 +824,23 @@ class GitRepo(object):
         else:
             return content_str.splitlines()
         # TODO: keep splitlines?
+
+    def get_files_history(self, files, branch='HEAD'):
+        """
+
+        Parameters
+        ----------
+        files: list
+          list of files, only commits with queried files are considered
+        branch: str
+          Name of the branch to query. Default: HEAD.
+
+        Returns
+        -------
+        [iterator]
+        yielding Commit items generator from branch history associated with files
+        """
+        return gitpy.objects.commit.Commit.iter_items(self.repo, branch, paths=files)
 
     def _gitpy_custom_call(self, cmd, cmd_args=None, cmd_options=None,
                            git_options=None, env=None,


### PR DESCRIPTION
Returns generator containing commit objects in reverse chronological order.
Useful for finding last commit date of files in dataset for web-interface metadata generator(`ls_json`) etc

Currently this is too slow for actually using on the datasets.datalad itself.
Being able to emulate `git rev-list` functionality through GitPython would be ideal.
Something like `git rev-list -1 HEAD --timestamp -- <filename>` for getting last commit timestamp

refer: [yarik's comment](https://github.com/datalad/datalad/pull/541/files/99d6483ec08afbc984bdbc87d8fc10d6a7df7495#r67255549)
