### PR TITLE
RF: deprecate use of coveralls in favor of codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
   - git submodule update --init --recursive
-  - cd ..; pip install -q coveralls codecov; cd -
+  - cd ..; pip install -q codecov; cd -
   - pip install -r requirements.txt
   # Verify that setup.py build doesn't puke
   - python setup.py build
@@ -105,7 +105,6 @@ script:
   - PYTHONPATH=$PWD make -C docs html doctest
 
 after_success:
-  - coveralls
   - codecov
 
 # makes it only more difficult to comprehend the failing output.  Enable only when necessary


### PR DESCRIPTION
I find coveralls more annoying (all the announcements, reporting decreased coverage whenever it is actually improved, etc) and prefer codecov (browser extensions, more elaborate summary etc).