### PR TITLE
ENH: start_website_in_docker + fixes along the way

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -31,3 +31,7 @@ DATASETS_TOPURL = "http://datasets.datalad.org/"
 WEB_META_LOG = join(DATALAD_GIT_DIR, 'logs')
 WEB_META_DIR = join(DATALAD_GIT_DIR, 'metadata')
 WEB_HTML_DIR = join(DATALAD_GIT_DIR, 'web')
+
+# Format to use for time stamps
+TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S%z"
+

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -103,11 +103,16 @@ class AddSibling(Interface):
             ds_basename: {'repo': ds.repo}
         }
         if recursive:
-            for subds in ds.get_subdatasets(recursive=True):
-                sub_path = opj(ds.path, subds)
-                repos[ds_basename + '/' + subds] = {
-#                repos[subds] = {
-                    'repo': GitRepo(sub_path, create=False)
+            for subds_name in ds.get_subdatasets(recursive=True):
+                subds_path = opj(ds.path, subds_name)
+                subds = Dataset(subds_path)
+                if not subds.is_installed():
+                    lgr.info("Skipping adding sibling for %s since it is not installed",
+                             subds)
+                    continue
+                repos[ds_basename + '/' + subds_name] = {
+#                repos[subds_name] = {
+                    'repo': GitRepo(subds_path, create=False)
                 }
 
         # Note: This is copied from create_publication_target_sshwebserver

--- a/datalad/distribution/create_publication_target_sshwebserver.py
+++ b/datalad/distribution/create_publication_target_sshwebserver.py
@@ -386,18 +386,19 @@ class CreatePublicationTargetSSHWebserver(Interface):
     @staticmethod
     def create_postupdate_hook(path, ssh, dataset):
         # location of post-update hook file, logs folder on remote target
-        hook_remote_target = opj(path, '.git', 'hooks', 'post-update')
-        logs_remote_target = opj(path, '.git', 'datalad', 'logs')
+        hooks_remote_dir = opj(path, '.git', 'hooks')
+        hook_remote_target = opj(hooks_remote_dir, 'post-update')
+        logs_remote_dir = opj(path, '.git', 'datalad', 'logs')
 
         # create json command for current dataset
         json_command = 'which datalad > /dev/null && (cd ..; GIT_DIR=$PWD/.git datalad ls -r --json file \'{}\';) &> "{}/{}" || :'
-        json_command = json_command.format(str(path), logs_remote_target, 'datalad-publish-hook-$(date +%Y-%m-%dT%H:%M:%S%z).log')
+        json_command = json_command.format(str(path), logs_remote_dir, 'datalad-publish-hook-$(date +%Y-%m-%dT%H:%M:%S%z).log')
 
         # collate content for post_update hook
         hook_content = '\n'.join(['#!/bin/bash', 'git update-server-info', json_command])
 
         # make datalad logs directory
-        ssh(['mkdir', '-p', logs_remote_target])
+        ssh(['mkdir', '-p', logs_remote_dir, hooks_remote_dir])
 
         with make_tempfile(content=hook_content) as tempf:  # create post_update hook script
             ssh.copy(tempf, hook_remote_target)             # upload hook to dataset
@@ -435,4 +436,4 @@ class CreatePublicationTargetSSHWebserver(Interface):
             mode = shared
 
         if mode:
-            ssh(['chmod', mode, '-R', dirname(webresources_remote)])
+            ssh(['chmod', mode, '-R', dirname(webresources_remote), opj(path, 'index.html')])

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -181,27 +181,26 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 
         # and we should be able to 'reconfigure'
         def process_digests_mtimes(digests, mtimes):
-            if external_versions['cmd:git'] >= '2.4':
-                # it should have triggered a hook, which would have created log and metadata files
-                check_metadata = False
-                for part in 'logs', 'metadata':
-                    metafiles = [k for k in digests if k.startswith(_path_('.git/datalad/%s/' % part))]
-                    # This is in effect ONLY if we have "compatible" datalad installed on remote
-                    # end. ATM we don't have easy way to guarantee that AFAIK (yoh),
-                    # so let's not check/enforce (TODO)
-                    # assert(len(metafiles) >= 1)  # we might have 2 logs if timestamps do not collide ;)
-                    # Let's actually do it to some degree
-                    if part == 'logs':
-                        # always should have those:
-                        assert (len(metafiles) >= 1)
-                        with open(opj(target_path, metafiles[0])) as f:
-                            if 'no datalad found' not in f.read():
-                                check_metadata = True
-                    if part == 'metadata':
-                        eq_(len(metafiles), bool(check_metadata))
-                    for f in metafiles:
-                        digests.pop(f)
-                        mtimes.pop(f)
+            # it should have triggered a hook, which would have created log and metadata files
+            check_metadata = False
+            for part in 'logs', 'metadata':
+                metafiles = [k for k in digests if k.startswith(_path_('.git/datalad/%s/' % part))]
+                # This is in effect ONLY if we have "compatible" datalad installed on remote
+                # end. ATM we don't have easy way to guarantee that AFAIK (yoh),
+                # so let's not check/enforce (TODO)
+                # assert(len(metafiles) >= 1)  # we might have 2 logs if timestamps do not collide ;)
+                # Let's actually do it to some degree
+                if part == 'logs':
+                    # always should have those:
+                    assert (len(metafiles) >= 1)
+                    with open(opj(target_path, metafiles[0])) as f:
+                        if 'no datalad found' not in f.read():
+                            check_metadata = True
+                if part == 'metadata':
+                    eq_(len(metafiles), bool(check_metadata))
+                for f in metafiles:
+                    digests.pop(f)
+                    mtimes.pop(f)
             # and just pop some leftovers from annex
             for f in list(digests):
                 if f.startswith('.git/annex/mergedrefs'):

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -227,13 +227,14 @@ def test_target_ssh_recursive(origin, src_path, target_path):
             sep = os.path.sep
         remote_name = 'remote-' + str(flat)
         # TODO: there is f.ckup with paths so assert_create fails ATM
-        #assert_create_sshwebserver(
-        create_publication_target_sshwebserver(
-            target=remote_name,
-            dataset=source,
-            sshurl="ssh://localhost" + target_path_,
-            target_dir=target_dir_tpl,
-            recursive=True)
+        # And let's test without explicit dataset being provided
+        with chpwd(source.path):
+            #assert_create_sshwebserver(
+            create_publication_target_sshwebserver(
+                target=remote_name,
+                sshurl="ssh://localhost" + target_path_,
+                target_dir=target_dir_tpl,
+                recursive=True)
 
         # raise if git repos were not created
         for suffix in [sep + 'subm 1', sep + 'subm 2', '']:

--- a/datalad/interface/crawl.py
+++ b/datalad/interface/crawl.py
@@ -20,7 +20,7 @@ from datalad.support.constraints import EnsureStr, EnsureChoice, EnsureNone
 from datalad.crawler.pipeline import initiate_pipeline_config
 from datalad.support.stats import ActivityStats
 from datalad.utils import assure_dir
-from datalad.utils import get_logfilename
+from datalad import utils
 
 from logging import getLogger
 lgr = getLogger('datalad.api.crawl')
@@ -157,7 +157,7 @@ class Crawl(Interface):
                 # explicit, that some sub-datasets might not need to be crawled, so they get
                 # skipped explicitly?
                 for ds_ in subdatasets:
-                    ds_logfile = get_logfilename(ds_, 'crawl')
+                    ds_logfile = utils.get_logfilename(ds_, 'crawl')
                     try:
                         # TODO: might be cool to be able to report a 'heart beat' from the swallow into pbar or smth
                         with swallow_logs(file_=ds_logfile) as cml:

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -683,8 +683,10 @@ def ds_traverse(rootds, parent=None, json=None, recursive=False, all=False):
     rootds_model = GitModel(rootds.repo)
     fs['tags'] = rootds_model.describe
     fs['branch'] = rootds_model.branch
+    index_file = opj(rootds.path, '.git', 'index')
     fs['index-mtime'] = time.strftime(u"%Y-%m-%d %H:%M:%S",
-                                      time.localtime(getmtime(opj(rootds.path, '.git', 'index'))))
+                                      time.localtime(getmtime(index_file))) \
+                        if exists(index_file) else ''
 
     # append children datasets info to current dataset
     fs['nodes'].extend(children)

--- a/datalad/interface/tests/test_crawl.py
+++ b/datalad/interface/tests/test_crawl.py
@@ -27,6 +27,7 @@ from ...support.stats import ActivityStats
 from ...utils import chpwd
 from ...utils import getpwd
 from ...utils import find_files
+from ...utils import _path_
 
 
 @assert_cwd_unchanged(ok_to_chdir=True)
@@ -52,6 +53,7 @@ def test_crawl_api_chdir(run_pipeline_, load_pipeline_from_config_, chpwd_):
 
 @assert_cwd_unchanged(ok_to_chdir=True)
 @patch('datalad.utils.chpwd')
+@patch('datalad.utils.get_logfilename', return_value="some.log")
 @patch('datalad.crawler.pipeline.get_repo_pipeline_script_path', return_value='script_path')
 @patch('datalad.crawler.pipeline.load_pipeline_from_config', return_value=['pipeline'])
 @patch('datalad.crawler.pipeline.run_pipeline',
@@ -72,7 +74,7 @@ def test_crawl_api_chdir(run_pipeline_, load_pipeline_from_config_, chpwd_):
 # Note that order of patched things as args is reverse for some reason :-/
 @with_tempfile(mkdir=True)
 def test_crawl_api_recursive(get_subdatasets_, run_pipeline_, load_pipeline_from_config_, get_repo_pipeline_script_path_,
-                             chpwd_, tdir):
+                             get_lofilename_, chpwd_, tdir):
     pwd = getpwd()
     with chpwd(tdir):
         output, stats = crawl(recursive=True)
@@ -90,4 +92,5 @@ def test_crawl_api_recursive(get_subdatasets_, run_pipeline_, load_pipeline_from
         ],
         any_order=True
     )
-    assert_equal(list(find_files('.*', tdir, exclude_vcs=False)), [])  # no files were generated
+    assert_equal(list(find_files('.*', tdir, exclude_vcs=False)),
+                 [_path_(tdir, 'some.log')])  # no files were generated besides the log

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -430,9 +430,10 @@ def test_path_():
         assert(_path_(p) is p)  # nothing is done to it whatsoever
         eq_(_path_(p, 'd'), 'a/b/c/d')
 
+
 def test_get_timestamp_suffix():
-    assert_equal(get_timestamp_suffix(0), '-19691231190000')  # skynet DOB
-    assert_equal(get_timestamp_suffix(0, prefix="+"), '+19691231190000')
+    assert_equal(get_timestamp_suffix(0), '-1969-12-31T19:00:00+0000')  # skynet DOB
+    assert_equal(get_timestamp_suffix(0, prefix="+"), '+1969-12-31T19:00:00+0000')
     import time
     with patch.object(time, 'time', lambda: 1):
-        assert_equal(get_timestamp_suffix(), '-19691231190001')  # skynet is 1 sec old
+        assert_equal(get_timestamp_suffix(), '-1969-12-31T19:00:01+0000')  # skynet is 1 sec old

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -432,8 +432,8 @@ def test_path_():
 
 
 def test_get_timestamp_suffix():
-    assert_equal(get_timestamp_suffix(0), '-1969-12-31T19:00:00+0000')  # skynet DOB
-    assert_equal(get_timestamp_suffix(0, prefix="+"), '+1969-12-31T19:00:00+0000')
+    assert_equal(get_timestamp_suffix(0), '-1970-01-01T00:00:00+0000')  # skynet DOB
+    assert_equal(get_timestamp_suffix(0, prefix="+"), '+1970-01-01T00:00:00+0000')
     import time
     with patch.object(time, 'time', lambda: 1):
-        assert_equal(get_timestamp_suffix(), '-1969-12-31T19:00:01+0000')  # skynet is 1 sec old
+        assert_equal(get_timestamp_suffix(), '-1970-01-01T00:00:01+0000')  # skynet is 1 sec old

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -432,8 +432,18 @@ def test_path_():
 
 
 def test_get_timestamp_suffix():
-    assert_equal(get_timestamp_suffix(0), '-1970-01-01T00:00:00+0000')  # skynet DOB
-    assert_equal(get_timestamp_suffix(0, prefix="+"), '+1970-01-01T00:00:00+0000')
+    # we need to patch temporarily TZ
     import time
-    with patch.object(time, 'time', lambda: 1):
-        assert_equal(get_timestamp_suffix(), '-1970-01-01T00:00:01+0000')  # skynet is 1 sec old
+    try:
+        with patch.dict('os.environ', {'TZ': 'GMT'}):
+            time.tzset()
+            assert_equal(get_timestamp_suffix(0), '-1970-01-01T00:00:00+0000')  # skynet DOB
+            assert_equal(get_timestamp_suffix(0, prefix="+"), '+1970-01-01T00:00:00+0000')
+            # yoh found no way to mock things out and didn't want to provide
+            # explicit call to anything to get current time with the timezone, so disabling
+            # this test for now besides that it should return smth sensible ;)
+            #with patch.object(time, 'localtime', lambda: 1):
+            #    assert_equal(get_timestamp_suffix(), '-1970-01-01T00:00:01+0000')  # skynet is 1 sec old
+            assert(get_timestamp_suffix().startswith('-'))
+    finally:
+        time.tzset()

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -30,7 +30,8 @@ import glob
 from functools import wraps
 from time import sleep
 from inspect import getargspec
-from datalad.dochelpers import get_docstring_split
+# from datalad.dochelpers import get_docstring_split
+from datalad.consts import TIMESTAMP_FMT
 
 lgr = logging.getLogger("datalad.utils")
 
@@ -894,6 +895,7 @@ def _path_(*p):
         # Assume that all others as POSIX compliant so nothing to be done
         return opj(*p)
 
+
 def get_timestamp_suffix(time_=None, prefix='-'):
     """Return a time stamp (full date and time up to second)
 
@@ -901,7 +903,8 @@ def get_timestamp_suffix(time_=None, prefix='-'):
     """
     if time_ is None:
         time_ = time.time()
-    return time.strftime(prefix + "%Y%m%d%H%M%S", time.localtime(time_))
+    return time.strftime(prefix + TIMESTAMP_FMT, time.localtime(time_))
+
 
 def get_logfilename(dspath, cmd='datalad'):
     """Return a filename to use for logging under a dataset/repository

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -645,7 +645,8 @@ def swallow_logs(new_level=None, file_=None):
                 out_file = tempfile.mktemp(**kw)
             else:
                 out_file = file_
-            self._out = open(out_file, 'wa')
+            # PY3 requires clearly one or another.  race condition possible
+            self._out = open(out_file, 'a')
 
         def _read(self, h):
             with open(h.name) as f:
@@ -900,9 +901,12 @@ def get_timestamp_suffix(time_=None, prefix='-'):
 
     primarily to be used for generation of log files names
     """
-    if time_ is None:
-        time_ = time.time()
-    return time.strftime(prefix + TIMESTAMP_FMT, time.gmtime(time_))
+    args = []
+    if time_ is not None:
+        if isinstance(time_, int):
+            time_ = time.gmtime(time_)
+        args.append(time_)
+    return time.strftime(prefix + TIMESTAMP_FMT, *args)
 
 
 def get_logfilename(dspath, cmd='datalad'):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -641,8 +641,7 @@ def swallow_logs(new_level=None, file_=None):
         """
         def __init__(self):
             if file_ is None:
-                kw = dict()
-                get_tempfile_kwargs(kw, prefix="logs")
+                kw = get_tempfile_kwargs({}, prefix="logs")
                 out_file = tempfile.mktemp(**kw)
             else:
                 out_file = file_

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -902,7 +902,7 @@ def get_timestamp_suffix(time_=None, prefix='-'):
     """
     if time_ is None:
         time_ = time.time()
-    return time.strftime(prefix + TIMESTAMP_FMT, time.localtime(time_))
+    return time.strftime(prefix + TIMESTAMP_FMT, time.gmtime(time_))
 
 
 def get_logfilename(dspath, cmd='datalad'):

--- a/tools/testing/conf/apache-ssh-supervisor.conf
+++ b/tools/testing/conf/apache-ssh-supervisor.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+
+[program:apache2]
+command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"

--- a/tools/testing/conf/etc/apt/apt.conf.d/99apt-cacher
+++ b/tools/testing/conf/etc/apt/apt.conf.d/99apt-cacher
@@ -1,2 +1,2 @@
 #Acquire::http { Proxy "http://172.17.42.1:3142"; };
-#Acquire::http { Proxy "http://smaug.datalad.org:3142"; };
+Acquire::http { Proxy "http://smaug.datalad.org:3142"; };

--- a/tools/testing/conf/etc/apt/apt.conf.d/99apt-cacher
+++ b/tools/testing/conf/etc/apt/apt.conf.d/99apt-cacher
@@ -1,2 +1,2 @@
 #Acquire::http { Proxy "http://172.17.42.1:3142"; };
-Acquire::http { Proxy "http://smaug.datalad.org:3142"; };
+#Acquire::http { Proxy "http://smaug.datalad.org:3142"; };

--- a/tools/testing/start_website_in_docker
+++ b/tools/testing/start_website_in_docker
@@ -1,0 +1,96 @@
+#!/bin/bash
+#emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*- 
+#ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+# Helper to generate a Docker instance mapping user uder docker into your USER/UID/GID
+# and allowing to run tox within that clean automatically generated according to
+# README.md's apt-get lines environment
+#
+set -e
+export PS4=+
+#set -x
+set -u
+
+DL_DIST=${1:-jessie}
+
+topdir=$(realpath `dirname $0`)
+cd `dirname $0`
+dockerfile=$topdir/start_website_in_docker-Dockerfile
+# echo "D: $DL_APT"
+sed -e "s,DL_DIST,$DL_DIST,g" \
+    -e "s,DL_USER,$USER,g" \
+    -e "s,DL_UID,`id -u`,g" \
+    -e "s,DL_GID,`id -g`,g" \
+    -e "s,DL_GIT_USER_EMAIL,`git config --get user.email`,g" \
+    -e "s,DL_GIT_USER_NAME,`git config --get user.name`,g" \
+    $dockerfile.in >| $dockerfile
+
+#DL_APT=$(grep '^\(apt-get\|pip\)' ./../../README.md)
+
+{
+    # grep '^apt-get ' $topdir/../../README.md | sed -e 's|python-{|python{,3}-{|g'; \
+    echo "eatmydata apt-get install -q -y datalad python-pip python-virtualenv;"
+    echo "eatmydata apt-get install -q -y libffi-dev libssl-dev;"
+    # Install dependencies and remove system wide datalad
+    echo "eatmydata dpkg --purge datalad python-datalad;"
+} | while read aptline; do
+    sed -i -e "s|\(\(.*\)DL_APT\(.*\)\)|\2$aptline\3\n\1|g" $dockerfile
+    :
+done
+sed -e '/DL_APT/d' -i $dockerfile
+
+echo "I: copy authorized keys so they become avail inside"
+cp ~/.ssh/authorized_keys $topdir/conf/
+
+tag=datalad:website_${USER}_$DL_DIST
+echo "I: tag $tag"
+if docker images | grep -q datalad.*test_README.*$DL_DIST; then
+    echo "I: tag already exists -- skipping rebuilding"
+else
+    docker build -t $tag -f $dockerfile . #&& rm Dockerfile
+    #docker build --no-cache=True -t $tag -f $dockerfile . #&& rm Dockerfile
+fi
+
+topgitdir=`realpath ${topdir}/../..`
+echo "I: top git dir $topgitdir"
+
+#set -x
+docker_id=`docker ps | awk "/\\<$tag\\>/{print \\$1}"`
+echo "D: looking for a docker with tag '$tag': $docker_id"
+if [ -z "$docker_id" ]; then
+    echo "I: Starting new container with apache running"
+    docker_id=`docker run -d \
+     -v $topgitdir:/home/$USER/datalad \
+     -p 127.0.0.1:8081:80 \
+     -p 127.0.0.1:2221:22 \
+     $tag`
+    echo "Started container $docker_id"
+    echo "I: installing datalad inside (in development mode)"
+
+    # crap -- in sid image finishes witgh
+    #  Segmentation fault (core dumped)
+    # yoh@8c3178bd7ea7:~/datalad$ echo $?
+    # 139
+    docker exec $docker_id bash -c "cd datalad; pip install -e.[full]"
+else:
+    echo "Using running container $docker_id"
+fi
+
+cat <<EOF
+-------------------------
+You now should be able to upload to this host under ssh://localhost:2221:/var/www/html,
+which should then be made available under http://localhost:8081 .
+It is recommended to create ~/.ssh/config entry
+
+Host dataladlocalhost
+ Port 2221
+ Hostname localhost
+ StrictHostKeyChecking no
+
+EOF

--- a/tools/testing/start_website_in_docker
+++ b/tools/testing/start_website_in_docker
@@ -78,8 +78,16 @@ if [ -z "$docker_id" ]; then
     # yoh@8c3178bd7ea7:~/datalad$ echo $?
     # 139
     docker exec $docker_id bash -c "cd datalad; pip install -e.[full]"
-else:
+else
     echo "Using running container $docker_id"
+fi
+
+docker_git_version=`docker exec $docker_id git --version 2>&1 | cut -d ' ' -f 3`
+if dpkg --compare-versions $docker_git_version lt 2.4; then
+    echo "I: too old of a git, let's symlink the one from git-annex-standalone"
+    for f in git git-receive-pack git-upload-pack; do
+        docker exec $docker_id ln -sf /usr/lib/git-annex.linux/$f /usr/local/bin/$f
+    done
 fi
 
 cat <<EOF

--- a/tools/testing/start_website_in_docker-Dockerfile.in
+++ b/tools/testing/start_website_in_docker-Dockerfile.in
@@ -19,7 +19,7 @@ RUN apt-get update
 RUN apt-get install -y -q eatmydata
 RUN bash -c "DL_APT"
 # Some rudimentary tools if we need to do anything within docker
-RUN bash -c "eatmydata apt-get install -y -q vim less"
+RUN bash -c "eatmydata apt-get install -y -q vim less man-db"
 RUN apt-get clean
 
 # Let's setup user matching user
@@ -31,7 +31,7 @@ RUN eatmydata apt-get update && eatmydata apt-get install -y --force-yes apache2
 # Install and configure openssh server
 RUN eatmydata apt-get install -q -y openssh-server
 
-RUN chown DL_USER /var/www
+RUN chown DL_USER -R /var/www/html
 
 USER DL_USER
 

--- a/tools/testing/start_website_in_docker-Dockerfile.in
+++ b/tools/testing/start_website_in_docker-Dockerfile.in
@@ -1,0 +1,73 @@
+FROM neurodebian:DL_DIST
+MAINTAINER Yaroslav Halchenko <yoh@datalad.org>
+
+USER root
+
+# Speed up installation using our apt cacher
+#RUN mkdir /etc/apt/apt.conf.d/
+COPY conf/etc/apt/apt.conf.d/99apt-cacher /etc/apt/apt.conf.d/99apt-cacher
+RUN chmod a+r /etc/apt/apt.conf.d/99apt-cacher
+
+# Make deb-src avail
+RUN sed -i -e 's,^deb\(.*\),deb\1\ndeb-src\1,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list
+
+# Assure popcon doesn't kick in
+RUN bash -c "echo 'debconf debconf/frontend select noninteractive' | debconf-set-selections -"
+
+RUN apt-get update
+# Use bash for extended syntax
+RUN apt-get install -y -q eatmydata
+RUN bash -c "DL_APT"
+# Some rudimentary tools if we need to do anything within docker
+RUN bash -c "eatmydata apt-get install -y -q vim less"
+RUN apt-get clean
+
+# Let's setup user matching user
+RUN groupadd --gid DL_GID -r DL_USER && useradd -m --uid DL_UID -g DL_USER DL_USER
+
+# Install and configure apache
+RUN eatmydata apt-get update && eatmydata apt-get install -y --force-yes apache2
+
+# Install and configure openssh server
+RUN eatmydata apt-get install -q -y openssh-server
+
+RUN chown DL_USER /var/www
+
+USER DL_USER
+
+WORKDIR /home/DL_USER
+# Prepare system for working with Git
+RUN git config --global user.email "DL_GIT_USER_EMAIL"
+RUN git config --global user.name "DL_GIT_USER_NAME"
+# RUN git clone git://github.com/datalad/datalad
+RUN mkdir datalad
+
+# WORKDIR /home/DL_USER/datalad
+
+#
+# Need to clone and install datalad system-wide but there is a problem that
+# we can't mount hostdir at build time:
+# https://github.com/docker/docker/issues/14080
+# http://stackoverflow.com/questions/26050899/how-to-mount-host-volumes-into-docker-containers-in-dockerfile-during-build
+# so this will not be done now but rather will be done once container started
+# from this image
+# Probably actually better so image could be reused for multiple instances of the container
+#
+
+# Fall back to root, so we have full control to start webserver etc
+USER root
+
+RUN mkdir /home/DL_USER/.ssh
+COPY conf/authorized_keys /home/DL_USER/.ssh/authorized_keys
+RUN bash -c "chown DL_USER -R /home/DL_USER/.ssh; chmod go-rwx -R /home/DL_USER/.ssh"
+
+# We will need a supervisor to run both apache and sshd
+# based on https://docs.docker.com/engine/admin/using_supervisord/
+RUN mkdir -p /var/lock/apache2 /var/run/apache2 /var/run/sshd /var/log/supervisor
+RUN eatmydata apt-get install -y -q supervisor
+COPY conf/apache-ssh-supervisor.conf /etc/supervisor/conf.d/supervisord.conf
+
+# ENTRYPOINT ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+RUN apt-get clean
+EXPOSE 22 80 443
+CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
`tools/testing/start_website_in_docker` script could be run to build and start a docker container which would expose http on port 8081 to localhost and ssh to 2221. so it would be easy to play/test with webfrontend and publishing more safely.
as a part of it, on elderly systems it would symlink git-annex-standalone's git into usr/local/bin/ since otherwise we can't test `datalad ls` since we want freshish git.

along the way fixed up 
- creation of hooks directory (somehow was not created somehow although repo was initialized)
- permissions to index.html
- depth first running of hooks (so all the meta information properly bubbles up upon 'reconfigure' action)

quick review/merge would be appreciated