### PR TITLE
TST: Show that we are needlessly being inefficient with local file URLs

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -51,6 +51,7 @@ from datalad.utils import updated
 from .external_versions import external_versions
 from .exceptions import CommandError
 from .exceptions import FileNotInRepositoryError
+from .network import RI
 from .network import is_ssh
 
 # shortcuts
@@ -424,6 +425,16 @@ class GitRepo(object):
         if git_opts:
             lgr.warning("TODO: options passed to git are currently ignored.\n"
                         "options received: %s" % git_opts)
+
+        # try to get a local path from `url`:
+        if url is not None:
+            try:
+                if not isinstance(url, RI):
+                    url = RI(url).localpath
+                else:
+                    url = url.localpath
+            except ValueError:
+                pass
 
         self.path = abspath(normpath(path))
         self.cmd_call_wrapper = runner or GitRunner(cwd=self.path)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -12,6 +12,7 @@
 
 from nose.tools import assert_is_instance
 
+import os
 from datalad.tests.utils import *
 from datalad.tests.utils_testrepos import BasicAnnexTestRepo
 from datalad.utils import getpwd, chpwd
@@ -916,3 +917,33 @@ def test_get_deleted(path):
     eq_(repo.get_deleted_files(), ['test1'])
     rmtree(opj(path, 'deep'))
     eq_(sorted(repo.get_deleted_files()), [opj('deep', 'test2'), 'test1'])
+
+
+@with_tempfile
+def test_optimized_cloning(path):
+    # make test repo with one fiel and one commit
+    originpath = opj(path, 'origin')
+    repo = GitRepo(originpath, create=True)
+    with open(opj(originpath, 'test'), 'w') as f:
+        f.write('some')
+    repo.add('test')
+    repo.commit('init')
+    ok_clean_git(originpath, annex=False)
+    from glob import glob
+
+    def _get_inodes(repo):
+        return dict(
+            [(os.path.join(*o.split(os.sep)[-2:]),
+              os.stat(o).st_ino)
+             for o in glob(os.path.join(repo.repo.git_dir,
+                                        'objects', '*', '*'))])
+
+    origin_inodes = _get_inodes(repo)
+    # now clone it in different ways and see what happens to the object storage
+    from datalad.support.network import get_local_file_url
+    clonepath = opj(path, 'clone')
+    for src in (originpath, get_local_file_url(originpath)):
+        clone = GitRepo(clonepath, url=src, create=True)
+        clone_inodes = _get_inodes(clone)
+        eq_(origin_inodes, clone_inodes, msg='with src={}'.format(src))
+        rmtree(clonepath)


### PR DESCRIPTION
Reason: Git disabled some optimizations (hardlinking) for local clones
when it gets a URL. Maybe we want to convert such URL, or force `clone
--local`