### PR TITLE
RF: tune up .travis.yml to set some global vars (TESTS_SSH, secure ones)...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ env:
     # will be used in the matrix, where neither other variable is used
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
-    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
-    - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="
+# Disabled since old folks don't want to change workflows of submitting through central authority
+#    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
+#    - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
     # ability to rewrite R/O files
     - NOSE_WRAPPER="sudo -E"
     # no key authentication for root:
-    - unset -v DATALAD_TESTS_SSH
+    - DATALAD_TESTS_SSH=
   - python: 2.7
     env:
     - DATALAD_TESTS_NONETWORK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 2.7
   - 3.3
   - 3.4
-  - 3.5
 
 cache:
   - apt
@@ -60,6 +59,10 @@ matrix:
     env:
     # To make orthogonal test where it is not a symlink but a dir with spaces
     - TMPDIR="/tmp/d i r"
+  - python: 3.5
+    # we would need to migrate to boto3 to test it fully, but SSH should work
+    env:
+    -  DATALAD_TESTS_SSH=1
 
 before_install:
   # The ultimate one-liner setup for NeuroDebian repository
@@ -97,6 +100,7 @@ install:
 
 script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
+  - echo "I: Running tests"
   - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     # ability to rewrite R/O files
     - NOSE_WRAPPER="sudo -E"
     # no key authentication for root:
-    - DATALAD_TESTS_SSH=
+    - DATALAD_TESTS_SSH=0
   - python: 2.7
     env:
     - DATALAD_TESTS_NONETWORK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,25 @@
 # travis-ci.org definition for DataLad build
 language: python
 
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+
 cache:
   - apt
 
-matrix:
-  include:
-  - python: 2.7
-    env:
+env:
+  global:
+    # will be used in the matrix, where neither other variable is used
+    - DATALAD_TESTS_SSH=1
     - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
     - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="
-  # no loop dev support on travis yet :-/ https://github.com/travis-ci/travis-ci/issues/2700
-  #- python: 2.7
-  #  env:
-  #  - NOSE_WRAPPER="tools/eval_under_testloopfs"
+
+matrix:
+  include:
+  # Additional custom ones
   - python: 2.7
     # By default no logs will be output. This one is to test with log output at INFO level
     env:
@@ -53,21 +59,6 @@ matrix:
     env:
     # To make orthogonal test where it is not a symlink but a dir with spaces
     - TMPDIR="/tmp/d i r"
-  - python: 3.3
-  - python: 3.4
-  # Those aren't yet ready since lxml I believe fails to install
-  #- python: pypy
-  #- python: pypy3
-# not there -- don't try!
-# - python: 3.5
-# can't since coverage doesn't support it yet: https://bitbucket.org/ned/coveragepy/issues/391/getargspec-was-finally-removed-will-not-be
-# - python: nightly
-
-env:
-  # to overcome problem with system-wide installed boto on travis
-  # see https://github.com/travis-ci/travis-ci/issues/5246
-  - BOTO_CONFIG=/tmp/nowhere
-  - DATALAD_TESTS_SSH=1
 
 before_install:
   # The ultimate one-liner setup for NeuroDebian repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ install:
 
 script:
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
-  - echo "I: Running tests"
+  - echo "Running tests"
   - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 env:
   global:
     # will be used in the matrix, where neither other variable is used
+    - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
     - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
     - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ matrix:
   - python: 3.5
     # we would need to migrate to boto3 to test it fully, but SSH should work
     env:
-    -  DATALAD_TESTS_SSH=1
+    - DATALAD_TESTS_SSH=1
+    - UNSET_S3_SECRETS=1
 
 before_install:
   # The ultimate one-liner setup for NeuroDebian repository
@@ -94,6 +95,8 @@ install:
   # TMPDIRs
   - if [ ! -z "$TMPDIR" ] && [ "$TMPDIR" = "/tmp/sym link" ]; then echo "Symlinking $TMPDIR"; ln -s /tmp "$TMPDIR"; fi
   - if [ ! -z "$TMPDIR" ] && [ "$TMPDIR" = "/tmp/d i r" ]; then mkdir -p "$TMPDIR"; fi
+  # S3
+  - if [ ! -z "$UNSET_S3_SECRETS" ]; then echo "usetting"; unset DATALAD_datalad_test_s3_key_id DATALAD_datalad_test_s3_secret_id; fi
   # Install grunt to test run javascript frontend tests
   - npm install grunt
   - npm install grunt-contrib-qunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,13 @@ matrix:
     env:
     # To make orthogonal test where it is not a symlink but a dir with spaces
     - TMPDIR="/tmp/d i r"
-  - python: 3.5
-    # we would need to migrate to boto3 to test it fully, but SSH should work
-    env:
-    - DATALAD_TESTS_SSH=1
-    - UNSET_S3_SECRETS=1
+# Causes complete laptop or travis instance crash atm, but survives in a docker
+# need to figure it out (looks like some PID explosion)
+#  - python: 3.5
+#    # we would need to migrate to boto3 to test it fully, but SSH should work
+#    env:
+#    - DATALAD_TESTS_SSH=1
+#    - UNSET_S3_SECRETS=1
 
 before_install:
   # The ultimate one-liner setup for NeuroDebian repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,10 +102,8 @@ install:
   - npm install grunt-contrib-qunit
 
 script:
-  - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   - echo "Running tests"
   - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
-  - if [ ! -z "$DATALAD_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest
   # Run javascript tests

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -764,7 +764,8 @@ def skip_ssh(func):
     def newfunc(*args, **kwargs):
         if on_windows:
             raise SkipTest("SSH currently not available on windows.")
-        if not os.environ.get('DATALAD_TESTS_SSH'):
+        test_ssh = os.environ.get('DATALAD_TESTS_SSH', '').lower()
+        if test_ssh in ('', '0', 'false', 'no'):
             raise SkipTest("Run this test by setting DATALAD_TESTS_SSH")
         return func(*args, **kwargs)
     return newfunc

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py35
 #,flake8
 
 [testenv]


### PR DESCRIPTION
and then tune ups through the matrix + py 3.5 now

also testing submission from origin, to see how coverage would react

edit:  ended up disabling py 3.5 (causes some meltdown atm), and removing secure vars since other devs don't want to submit through central repo atm.