### PR TITLE
 ENH+BF: ls --long option, otherwise list shorter listing/stats + fixed not lsing all versions without -a

### DIFF
--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -189,7 +189,7 @@ def test_ls_json(topdir):
         for recursive in [True, False]:
             for state in ['file', 'delete']:
                 with swallow_logs(), swallow_outputs():
-                    ds = _ls_json(topdir, json=state, all=all_, recursive=recursive)
+                    ds = _ls_json(topdir, json=state, all_=all_, recursive=recursive)
 
                 # subdataset should have its json created and deleted when all=True else not
                 subds_metahash = get_metahash('/')
@@ -221,7 +221,7 @@ def test_ls_json(topdir):
                 # run non-recursive dataset traversal after subdataset metadata already created
                 # to verify sub-dataset metadata being picked up from its metadata file in such cases
                 if state == 'file' and all_ and not recursive:
-                    ds = _ls_json(topdir, json='file', all=False)
+                    ds = _ls_json(topdir, json='file', all_=False)
                     subds = [item for item in ds['nodes'] if item['name'] == ('subdsfile.txt' or 'subds')][0]
                     assert_equal(subds['size']['total'], '3 Bytes')
 


### PR DESCRIPTION
was working to address #837 that `ls` was listing all versions for s3:// urls.  while at it moved '--all' into '--long' for datasets ls, since in --all, inline with ls of s3:// we will later report on all versions (joey already have done 'annex info' for specified treeish)