### PR TITLE
Draft of a plugin based `export` command (takes unknown options)

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -228,24 +228,17 @@ def main(args=None):
         pass
 
     # parse cmd args
-    check_args = args if args else sys.argv
-    # make a cheap, but educated guess whether we might face arguments that
-    # are valid, but unknown to the configured parser
-    # ATM only the 'export' command has an extensible plugin mechanism that
-    # could get us into this situation
-    if 'export' in check_args:
-        # there is a non-zero chance that we will call the 'export' command
-        # call the parser in the most permissive way
-        cmdlineargs, unparsed_args = parser.parse_known_args(args)
+    cmdlineargs, unparsed_args = parser.parse_known_args(args)
+    if unparsed_args:
         if cmdlineargs.func.__self__.__name__ != 'Export':
-            # we guessed wrong, and need to redo parsing in strict mode
-            cmdlineargs = parser.parse_args(args)
+            lgr.error('unknown argument{}: {}'.format(
+                's' if len(unparsed_args) > 1 else '',
+                unparsed_args if len(unparsed_args) > 1 else unparsed_args[0]))
+            cmdlineargs.subparser.print_usage()
+            sys.exit(1)
         else:
             # store all unparsed arguments
             cmdlineargs.datalad_unparsed_args = unparsed_args
-    else:
-        # no chance the we need special argument handling
-        cmdlineargs = parser.parse_args(args)
 
     if cmdlineargs.change_path is not None:
         for path in cmdlineargs.change_path:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -236,13 +236,13 @@ def main(args=None):
     if 'export' in check_args:
         # there is a non-zero chance that we will call the 'export' command
         # call the parser in the most permissive way
-        cmdlineargs, exporter_args = parser.parse_known_args(args)
+        cmdlineargs, unparsed_args = parser.parse_known_args(args)
         if cmdlineargs.func.__self__.__name__ != 'Export':
             # we guessed wrong, and need to redo parsing in strict mode
             cmdlineargs = parser.parse_args(args)
         else:
             # store all unparsed arguments
-            cmdlineargs.exporter_args = exporter_args
+            cmdlineargs.datalad_unparsed_args = unparsed_args
     else:
         # no chance the we need special argument handling
         cmdlineargs = parser.parse_args(args)

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -93,10 +93,13 @@ class Export(Interface):
             if not hasattr(exmod, '_datalad_get_cmdline_help'):
                 lgr.error("export plugin '{}' does not provide help".format(exmod))
                 return
-            help, replacement = exmod._datalad_get_cmdline_help()
+            replacement = []
+            help = exmod._datalad_get_cmdline_help()
+            if isinstance(help, tuple):
+                help, replacement = help
             if replacement:
                 for in_s, out_s in replacement:
                     help = help.replace(in_s, out_s + ' ' * max(0, len(in_s) - len(out_s)))
-                print(help)
+            print(help)
             return
         # TODO call exporter function (if any)

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -22,6 +22,7 @@ from datalad.support.constraints import EnsureNone
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
+from datalad.dochelpers import exc_str
 
 from datalad.interface.base import Interface
 
@@ -71,8 +72,9 @@ class Export(Interface):
         import datalad.export as export_mod
         try:
             exmod = import_module('.%s' % (astype,), package=export_mod.__package__)
-        except ImportError:
-            raise ValueError("cannot find exporter '{}'".format(astype))
+        except ImportError as e:
+            raise ValueError("cannot load exporter '{}': {}".format(
+                astype, exc_str(e)))
         if getcmdhelp:
             # no result, but return the module to make the renderer do the rest
             return (exmod, None)

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -48,7 +48,6 @@ class Export(Interface):
             constraints=EnsureDataset() | EnsureNone()),
         astype=Parameter(
             args=("astype",),
-            metavar='TYPE',
             choices=_get_exporter_names(),
             doc="""label of the type or format the dataset shall be exported
             to."""),

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -15,10 +15,10 @@ __docformat__ = 'restructuredtext'
 import logging
 from glob import glob
 from os.path import join as opj, basename, dirname
+from importlib import import_module
 
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureStr
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
@@ -53,15 +53,38 @@ class Export(Interface):
             choices=_get_exporter_names(),
             doc="""label of the type or format the dataset shall be exported
             to."""),
+        getcmdhelp=Parameter(
+            args=('--help-type',),
+            dest='getcmdhelp',
+            action='store_true',
+            doc="""show help for a specific export type/format"""),
     )
 
     @staticmethod
     @datasetmethod(name='export')
-    def __call__(dataset, astype, **kwargs):
-        # TODO
-        # returns results
-        pass
+    def __call__(dataset, astype, getcmdhelp=False, **kwargs):
+        # get a handle on the relevant plugin module
+        import datalad.export as export_mod
+        exmod = import_module('.%s' % (astype,), package=export_mod.__package__)
+        if getcmdhelp:
+            # no result, but return the module to make the renderer do the rest
+            return (exmod, None)
+
+        ds = require_dataset(dataset, check_installed=True, purpose='exporting')
+        # call the plugin, either with the argv array from the cmdline call
+        # or directly with the kwargs
+        if 'datalad_unparsed_args' in kwargs:
+            result = exmod._datalad_export_plugin_call(
+                ds, argv=kwargs['datalad_unparsed_args'])
+        else:
+            result = exmod._datalad_export_plugin_call(ds, **kwargs)
+        return (exmod, result)
 
     @staticmethod
     def result_renderer_cmdline(res, args):
+        exmod, result = res
+        if args.getcmdhelp:
+            # the function that prints the help was returned as result
+            exmod._datalad_print_cmdline_help()
+            return
         # TODO call exporter function (if any)

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -69,7 +69,10 @@ class Export(Interface):
     def __call__(astype, dataset, getcmdhelp=False, output=None, **kwargs):
         # get a handle on the relevant plugin module
         import datalad.export as export_mod
-        exmod = import_module('.%s' % (astype,), package=export_mod.__package__)
+        try:
+            exmod = import_module('.%s' % (astype,), package=export_mod.__package__)
+        except ImportError:
+            raise ValueError("cannot find exporter '{}'".format(astype))
         if getcmdhelp:
             # no result, but return the module to make the renderer do the rest
             return (exmod, None)

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -1,0 +1,67 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from glob import glob
+from os.path import join as opj, basename, dirname
+
+from datalad.support.param import Parameter
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureStr
+from datalad.distribution.dataset import Dataset
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import datasetmethod
+from datalad.distribution.dataset import require_dataset
+
+from datalad.interface.base import Interface
+
+lgr = logging.getLogger('datalad.export')
+
+
+def _get_exporter_names():
+    basepath = dirname(__file__)
+    return [basename(e)[:-3]
+            for e in glob(opj(basepath, '*.py'))
+            if not e.endswith('__init__.py')]
+
+
+class Export(Interface):
+    """Export a dataset to another representation
+    """
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to export. If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory.""",
+            constraints=EnsureDataset() | EnsureNone()),
+        astype=Parameter(
+            args=("astype",),
+            metavar='TYPE',
+            choices=_get_exporter_names(),
+            doc="""label of the type or format the dataset shall be exported
+            to."""),
+    )
+
+    @staticmethod
+    @datasetmethod(name='export')
+    def __call__(dataset, astype, **kwargs):
+        # TODO
+        # returns results
+        pass
+
+    @staticmethod
+    def result_renderer_cmdline(res, args):
+        # TODO call exporter function (if any)

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -19,7 +19,6 @@ from importlib import import_module
 
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
-from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
@@ -62,7 +61,7 @@ class Export(Interface):
 
     @staticmethod
     @datasetmethod(name='export')
-    def __call__(dataset, astype, getcmdhelp=False, **kwargs):
+    def __call__(astype, dataset, getcmdhelp=False, **kwargs):
         # get a handle on the relevant plugin module
         import datalad.export as export_mod
         exmod = import_module('.%s' % (astype,), package=export_mod.__package__)

--- a/datalad/export/tarball.py
+++ b/datalad/export/tarball.py
@@ -33,7 +33,7 @@ def _datalad_export_plugin_call(dataset, output, argv=None):
     if output is None:
         output = "datalad_{}.tar.gz".format(dataset.id)
     else:
-        if not output.endswith('.tar.gz.'):
+        if not output.endswith('.tar.gz'):
             output += '.tar.gz'
 
     root = dataset.path

--- a/datalad/export/tarball.py
+++ b/datalad/export/tarball.py
@@ -39,7 +39,7 @@ def _datalad_export_plugin_call(dataset, output, argv=None):
     root = dataset.path
 
     with tarfile.open(output, "w:gz") as tar:
-        for rpath in dataset.repo.get_indexed_files():
+        for rpath in sorted(dataset.repo.get_indexed_files()):
             fpath = opj(root, rpath)
             if islink(fpath):
                 link_target = os.readlink(fpath)

--- a/datalad/export/tarball.py
+++ b/datalad/export/tarball.py
@@ -1,0 +1,60 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+import tarfile
+import os
+from os.path import join as opj, dirname, normpath, islink, isabs
+
+lgr = logging.getLogger('datalad.export.tarball')
+
+
+# PLUGIN API
+def _datalad_export_plugin_call(dataset, output, argv=None):
+    if argv:
+        lgr.warn("tarball exporter ignores any additional options '{}'".format(
+            argv))
+
+    # could be used later on to filter files by some criterion
+    def _filter_tarinfo(ti):
+        return ti
+
+    if output is None:
+        output = "datalad_{}.tar.gz".format(dataset.id)
+    else:
+        if not output.endswith('.tar.gz.'):
+            output += '.tar.gz'
+
+    root = dataset.path
+
+    with tarfile.open(output, "w:gz") as tar:
+        for rpath in dataset.repo.get_indexed_files():
+            fpath = opj(root, rpath)
+            if islink(fpath):
+                link_target = os.readlink(fpath)
+                if not isabs(link_target):
+                    link_target = normpath(opj(dirname(fpath), link_target))
+                fpath = link_target
+            # name in the tarball
+            aname = normpath(opj(dataset.id, rpath))
+            tar.add(
+                fpath,
+                arcname=aname,
+                recursive=False,
+                filter=_filter_tarinfo)
+
+
+# PLUGIN API
+def _datalad_get_cmdline_help():
+    return 'Just call it, and it will produce a tarball.'

--- a/datalad/export/tests/__init__.py
+++ b/datalad/export/tests/__init__.py
@@ -1,0 +1,13 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Interfaces tests
+
+"""
+
+__docformat__ = 'restructuredtext'

--- a/datalad/export/tests/test_tarball.py
+++ b/datalad/export/tests/test_tarball.py
@@ -11,10 +11,12 @@
 
 from datalad.api import Dataset
 from datalad.api import export
-from nose.tools import assert_true, assert_equal, assert_raises
+from nose.tools import assert_true, assert_not_equal, assert_raises
 from datalad.tests.utils import with_tree, with_tempfile
 from datalad.utils import chpwd
+from datalad.utils import md5sum
 import os
+import time
 from os.path import join as opj
 
 
@@ -38,8 +40,20 @@ def test_failure(path):
 @with_tree(_dataset_template)
 def test_tarball(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
+    ds.save(auto_add_changes=True)
     with chpwd(path):
         ds.export('tarball')
-    assert_true(os.path.exists(opj(path, 'datalad_{}.tar.gz'.format(ds.id))))
-    ds.export('tarball', output=opj(path, 'myexport'))
-    assert_true(os.path.exists(opj(path, 'myexport.tar.gz'.format(ds.id))))
+    default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
+    assert_true(os.path.exists(default_outname))
+    custom_outname = opj(path, 'myexport.tar.gz')
+    # feed in without extension
+    ds.export('tarball', output=custom_outname[:-7])
+    assert_true(os.path.exists(custom_outname))
+    custom1_md5 = md5sum(custom_outname)
+    # encodes the original tarball filename -> different checksum, despit
+    # same content
+    assert_not_equal(md5sum(default_outname), custom1_md5)
+    time.sleep(1.1)
+    ds.export('tarball', output=custom_outname)
+    # encodes mtime -> different checksum, despit same content and name
+    assert_not_equal(md5sum(custom_outname), custom1_md5)

--- a/datalad/export/tests/test_tarball.py
+++ b/datalad/export/tests/test_tarball.py
@@ -1,0 +1,45 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test tarball exporter"""
+
+from datalad.api import Dataset
+from datalad.api import export
+from nose.tools import assert_true, assert_equal, assert_raises
+from datalad.tests.utils import with_tree, with_tempfile
+from datalad.utils import chpwd
+import os
+from os.path import join as opj
+
+
+_dataset_template = {
+    'ds': {
+        'file_up': 'some_content',
+        'dir': {
+            'file1_down': 'one',
+            'file2_down': 'two'}}}
+
+
+@with_tree(_dataset_template)
+def test_failure(path):
+    ds = Dataset(opj(path, 'ds')).create(force=True)
+    # unknown exporter
+    assert_raises(ValueError, ds.export, 'nah')
+    # non-existing dataset
+    assert_raises(ValueError, export, 'tarball', Dataset('nowhere'))
+
+
+@with_tree(_dataset_template)
+def test_tarball(path):
+    ds = Dataset(opj(path, 'ds')).create(force=True)
+    with chpwd(path):
+        ds.export('tarball')
+    assert_true(os.path.exists(opj(path, 'datalad_{}.tar.gz'.format(ds.id))))
+    ds.export('tarball', output=opj(path, 'myexport'))
+    assert_true(os.path.exists(opj(path, 'myexport.tar.gz'.format(ds.id))))

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -38,6 +38,7 @@ _group_dataset = (
          'rewrite-urls'),
         ('datalad.interface.unlock', 'Unlock', 'unlock'),
         ('datalad.interface.save', 'Save', 'save'),
+        ('datalad.export', 'Export', 'export'),
     ])
 
 _group_metadata = (

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -291,7 +291,6 @@ class Interface(object):
                            'result_renderer', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]
-            print argnames
         kwargs = {k: getattr(args, k) for k in argnames if k != 'self'}
         try:
             return cls.__call__(**kwargs)

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -279,7 +279,19 @@ class Interface(object):
     def call_from_parser(cls, args):
         # XXX needs safety check for name collisions
         from inspect import getargspec
-        argnames = getargspec(cls.__call__)[0]
+        argspec = getargspec(cls.__call__)
+        if argspec[2] is None:
+            # no **kwargs in the call receiver, pull argnames from signature
+            argnames = getargspec(cls.__call__)[0]
+        else:
+            # common options
+            # XXX define or better get from elsewhere
+            common_opts = ('change_path', 'common_debug', 'common_idebug', 'func',
+                           'help', 'log_level', 'logger', 'pbs_runner',
+                           'result_renderer', 'subparser')
+            argnames = [name for name in dir(args)
+                        if not (name.startswith('_') or name in common_opts)]
+            print argnames
         kwargs = {k: getattr(args, k) for k in argnames if k != 'self'}
         try:
             return cls.__call__(**kwargs)

--- a/datalad/tests/test_cmdline_main.py
+++ b/datalad/tests/test_cmdline_main.py
@@ -15,7 +15,8 @@ from mock import patch
 
 import datalad
 from ..cmdline.main import main
-from .utils import assert_equal, ok_, assert_raises, in_, ok_startswith
+from .utils import assert_equal, assert_raises, in_, ok_startswith
+
 
 def run_main(args, exit_code=0, expect_stderr=False):
     """Run main() of the datalad, do basic checks and provide outputs
@@ -41,9 +42,9 @@ def run_main(args, exit_code=0, expect_stderr=False):
             assert_equal(cm.exception.code, exit_code)  # exit code must be 0
             stdout = cmout.getvalue()
             stderr = cmerr.getvalue()
-            if expect_stderr == False:
+            if expect_stderr is False:
                 assert_equal(stderr, "")
-            elif expect_stderr == True:
+            elif expect_stderr is True:
                 # do nothing -- just return
                 pass
             else:
@@ -99,3 +100,8 @@ def test_help_np():
 def test_usage_on_insufficient_args():
     stdout, stderr = run_main(['install'], exit_code=1)
     ok_startswith(stdout, 'usage:')
+
+
+def test_subcmd_usage_on_unknown_args():
+    stdout, stderr = run_main(['install', '--murks'], exit_code=1)
+    in_('install', stdout)

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -33,6 +33,7 @@ Dataset operations
    generated/man/datalad-update
    generated/man/datalad-save
    generated/man/datalad-unlock
+   generated/man/datalad-export
 
 Meta data handling
 ==================


### PR DESCRIPTION
To try it on something real, you can clone this: https://github.com/mih/BIDS2ISATab

Link the script into `datalad/export` under some name. Example:

````
% ls -l datalad/export/sd_bidsisatab.py
lrwxrwxrwx 1 mih mih 40 Sep 23 08:19 datalad/export/sd_bidsisatab.py -> ../../../BIDS2ISATab/bids2isatab/main.py
````

TODO:

- [x] implement some plugin that we ship with datalad to make testing straightforward (export to tarball is an option): tarball export is implemented