### PR TITLE
ENH+NF: if no dataset found during search -- ask to install our super-dataset under ~/datalad and/or search there

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -10,6 +10,7 @@
 """
 
 from os.path import join
+from os.path import expanduser
 
 # directory containing prepared metadata of a dataset repository:
 HANDLE_META_DIR = ".datalad"
@@ -27,6 +28,9 @@ DATALAD_GIT_DIR = join('.git', 'datalad')
 ARCHIVES_TEMP_DIR = join(DATALAD_GIT_DIR, 'tmp', 'archives')
 
 DATASETS_TOPURL = "http://datasets.datalad.org/"
+
+# Centralized deployment
+LOCAL_CENTRAL_PATH = join(expanduser('~'), 'datalad')
 
 WEB_META_LOG = join(DATALAD_GIT_DIR, 'logs')
 WEB_META_DIR = join(DATALAD_GIT_DIR, 'metadata')

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -31,7 +31,7 @@ from datalad.support.constraints import Constraint
 from datalad.utils import optional_args, expandpath, is_explicit_path
 from datalad.utils import swallow_logs
 from datalad.utils import getpwd
-from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.exceptions import NoDatasetArgumentFound
 from datalad.dochelpers import exc_str
 from datalad.support.dsconfig import ConfigManager
 
@@ -495,7 +495,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
     if dataset is None:  # possible scenario of cmdline calls
         dspath = GitRepo.get_toppath(getpwd())
         if not dspath:
-            raise InsufficientArgumentsError("No dataset found")
+            raise NoDatasetArgumentFound("No dataset found")
         dataset = Dataset(dspath)
 
     assert(dataset is not None)

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -198,6 +198,7 @@ def check_download_external_url(url, failed_str, success_str, d, url_final=None)
     # TODO -- more and more specific
 
 
+@skip_if_no_network
 @use_cassette('test_authenticate_external_portals', record_mode='once')
 def test_authenticate_external_portals():
     yield check_download_external_url, \

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -26,11 +26,14 @@ from ...tests.utils import assert_equal, assert_in, assert_raises, assert_not_eq
 from ...tests.utils import use_cassette
 from ...tests.utils import with_tempfile
 from ...tests.utils import with_tree
+from ...tests.utils import skip_if_no_network
 from datalad.interface.ls import ignored, fs_traverse, _ls_json, machinesize
 from os.path import exists, join as opj
 
 from datalad.downloaders.tests.utils import get_test_providers
 
+
+@skip_if_no_network
 @use_cassette('test_ls_s3')
 def test_ls_s3():
     url = 's3://datalad-test0-versioned/'

--- a/datalad/metadata/parsers/bids.py
+++ b/datalad/metadata/parsers/bids.py
@@ -59,7 +59,7 @@ def get_metadata(ds, ds_identifier):
     if 'BIDSVersion' in bids:
         compliance.append(
             'http://bids.neuroimaging.io/bids_spec{}.pdf'.format(
-                bids['BIDSVersion']))
+                bids['BIDSVersion'].strip()))
     else:
         compliance.append('http://bids.neuroimaging.io')
     meta['dcterms:conformsTo'] = compliance

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -119,11 +119,12 @@ class Search(Interface):
                         "Dataset installed under %s.  "
                         "Perform further operations using that dataset"
                         % installed.path)
-                    for r in installed.search(
+                    for loc, r in installed.search(
                             match,
                             report=report, report_matched=report_matched,
                             format=format, regex=regex):
-                        yield r
+                        full_loc = opj(installed.path, loc)
+                        yield full_loc, r
                     return
                 else:
                     reraise(*exc_info)

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -145,9 +145,9 @@ class Search(Interface):
                 else:
                     reraise(*exc_info)
 
-                ui.message(
-                    "Performing search using central dataset %r"
-                    % central_ds.path
+                lgr.info(
+                    "Performing search using central dataset %r",
+                    central_ds.path
                 )
                 for loc, r in central_ds.search(
                         match,

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -101,7 +101,7 @@ class Search(Interface):
 
     @staticmethod
     @datasetmethod(name='search')
-    def __call__(match, dataset, report=None, report_matched=False, format='custom', regex=False):
+    def __call__(match, dataset=None, report=None, report_matched=False, format='custom', regex=False):
 
         lgr.debug("Initiating search for match=%r and dataset %r",
                   match, dataset)
@@ -110,10 +110,17 @@ class Search(Interface):
         except NoDatasetArgumentFound:
             exc_info = sys.exc_info()
             if dataset is None:
+                if not ui.is_interactive:
+                    raise NoDatasetArgumentFound(
+                        "No DataLad dataset found at current location and "
+                        "current UI is not interactive to assist in installing "
+                        "one.  Please run `search` command interactively or "
+                        "under an existing DataLad dataset"
+                    )
                 # none was provided so we could ask user either he possibly wants
                 # to install our beautiful mega-duper-super-dataset?
                 # TODO: following logic could possibly benefit other actions.
-                if exists(LOCAL_CENTRAL_PATH):
+                if os.path.exists(LOCAL_CENTRAL_PATH):
                     central_ds = Dataset(LOCAL_CENTRAL_PATH)
                     if central_ds.is_installed():
                         if ui.yesno(
@@ -125,8 +132,8 @@ class Search(Interface):
                     else:
                         raise NoDatasetArgumentFound(
                             "No DataLad dataset found at current location and "
-                            "%r already exists but does not contain installed "
-                            "dataset." % LOCAL_CENTRAL_PATH)
+                            "%r already exists but does not contain an "
+                            "installed dataset." % LOCAL_CENTRAL_PATH)
                 elif ui.yesno(
                        title="No DataLad dataset found at current location",
                        text="Would you like to install stock DataLad "

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -129,6 +129,8 @@ class Search(Interface):
                                  "meta-dataset under % r and search within it?"
                                   % LOCAL_CENTRAL_PATH):
                             pass
+                        else:
+                            reraise(*exc_info)
                     else:
                         raise NoDatasetArgumentFound(
                             "No DataLad dataset found at current location and "

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -120,7 +120,9 @@ class Search(Interface):
                         "Perform further operations using that dataset"
                         % installed.path)
                     for r in installed.search(
-                            match, report=report, format=format, regex=regex):
+                            match,
+                            report=report, report_matched=report_matched,
+                            format=format, regex=regex):
                         yield r
                     return
                 else:

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -86,7 +86,14 @@ def test_search_outside1_install_central_ds(tdir, central_dspath):
             ui.add_responses('no')
             mock_install.reset_mock()
             with assert_raises(NoDatasetArgumentFound):
-                list(search("bu"))
+                list(search(".", regex=True))
+
+            # and if path exists and is a valid dataset and we say "no"
+            Dataset(central_dspath).create()
+            ui.add_responses('no')
+            mock_install.reset_mock()
+            with assert_raises(NoDatasetArgumentFound):
+                list(search(".", regex=True))
 
 _mocked_search_results = [
     ('ds1', {'f': 'v'}),

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -10,28 +10,20 @@
 """Some additional tests for search command (some are within test_base)"""
 
 from mock import patch
-from operator import itemgetter
-from six import PY2
 from datalad.api import Dataset, aggregate_metadata, install
-from datalad.metadata import get_metadata_type, get_metadata
-from nose.tools import assert_true, assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises
 from datalad.utils import chpwd
 from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_is_instance
 from datalad.tests.utils import assert_is_generator
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_testsui
 from datalad.support.exceptions import NoDatasetArgumentFound
 
-from datalad.dochelpers import exc_str
-import os
 from os.path import join as opj
-from datalad.support.exceptions import InsufficientArgumentsError
-from nose import SkipTest
 
 from datalad.api import search
-from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.metadata import search as search_mod
+
 
 @with_testsui(interactive=False)
 @with_tempfile(mkdir=True)

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -1,0 +1,85 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Some additional tests for search command (some are within test_base)"""
+
+from mock import patch
+from operator import itemgetter
+from six import PY2
+from datalad.api import Dataset, aggregate_metadata, install
+from datalad.metadata import get_metadata_type, get_metadata
+from nose.tools import assert_true, assert_equal, assert_raises
+from datalad.utils import chpwd
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_is_instance
+from datalad.tests.utils import assert_is_generator
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import with_testsui
+from datalad.support.exceptions import NoDatasetArgumentFound
+
+from datalad.dochelpers import exc_str
+import os
+from os.path import join as opj
+from datalad.support.exceptions import InsufficientArgumentsError
+from nose import SkipTest
+
+from datalad.api import search
+from datalad.consts import LOCAL_CENTRAL_PATH
+from datalad.metadata import search as search_mod
+
+@with_testsui(interactive=False)
+@with_tempfile(mkdir=True)
+def test_search_outside1_noninteractive_ui(tdir):
+    # we should raise an informative exception
+    with chpwd(tdir):
+        with assert_raises(NoDatasetArgumentFound) as cme:
+            list(search("bu"))
+        assert_in('UI is not interactive', str(cme.exception))
+
+
+@with_testsui(responses='yes')
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_search_outside1_install_central_ds(tdir, newhome):#, mocked_exists):
+    with chpwd(tdir):
+        # should fail since directory exists, but not a dataset
+        # should not even waste our response ;)
+        with patch.object(search_mod, 'LOCAL_CENTRAL_PATH', newhome):
+            gen = search("bu")
+            assert_is_generator(gen)
+            assert_raises(NoDatasetArgumentFound, next, gen)
+
+        # let's mock out even actual install/search calls
+        central_dspath = opj(newhome, "datalad")
+
+        mocked_results = [
+            ('ds1', {'f': 'v'}),
+            ('d2/ds2', {'f1': 'v1'})
+        ]
+        class mock_search(object):
+            def __call__(*args, **kwargs):
+                for loc, report in mocked_results:
+                    yield loc, report
+
+        with \
+            patch.object(search_mod, 'LOCAL_CENTRAL_PATH', central_dspath), \
+            patch('datalad.api.install',
+                  return_value=Dataset(central_dspath)) as mock_install, \
+            patch('datalad.distribution.dataset.Dataset.search',
+                  new_callable=mock_search):
+            gen = search(".", regex=True)
+            assert_is_generator(gen)
+            assert_equal(
+                list(gen), [(opj(central_dspath, loc), report)
+                            for loc, report in mocked_results])
+            mock_install.assert_called_once_with(central_dspath, source='///')
+
+        # now on subsequent run, we want to mock as if dataset already exists
+        # at central location and then do search again
+        # TODO

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -70,6 +70,12 @@ class InsufficientArgumentsError(ValueError):
     """To be raise instead of `ValueError` when use help output is desired"""
     pass
 
+
+class NoDatasetArgumentFound(InsufficientArgumentsError):
+    """To be raised when expecting having a dataset but none was provided"""
+    pass
+
+
 #
 # Downloaders
 #

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -41,6 +41,7 @@ from nose.tools import \
     raises, ok_, eq_, make_decorator
 
 from nose.tools import assert_set_equal
+from nose.tools import assert_is_instance
 from nose import SkipTest
 
 from ..cmd import Runner
@@ -321,8 +322,13 @@ def ok_annex_get(ar, files, network=True):
     else:
         ok_(all(has_content))
 
+
 def ok_generator(gen):
     assert_true(inspect.isgenerator(gen), msg="%s is not a generator" % gen)
+
+
+assert_is_generator = ok_generator  # just an alias
+
 
 def ok_archives_caches(repopath, n=1, persistent=None):
     """Given a path to repository verify number of archives
@@ -976,7 +982,7 @@ def get_most_obscure_supported_name(tdir):
 
 
 @optional_args
-def with_testsui(t, responses=None):
+def with_testsui(t, responses=None, interactive=True):
     """Switch main UI to be 'tests' UI and possibly provide answers to be used"""
 
     @wraps(t)
@@ -984,7 +990,7 @@ def with_testsui(t, responses=None):
         from datalad.ui import ui
         old_backend = ui.backend
         try:
-            ui.set_backend('tests')
+            ui.set_backend('tests' if interactive else 'tests-noninteractive')
             if responses:
                 ui.add_responses(responses)
             ret = t(*args, **kwargs)
@@ -995,7 +1001,11 @@ def with_testsui(t, responses=None):
         finally:
             ui.set_backend(old_backend)
 
+    if not interactive and responses is not None:
+        raise ValueError("Non-interactive UI cannot provide responses")
+
     return newfunc
+
 with_testsui.__test__ = False
 
 

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -48,6 +48,7 @@ class _UI_Switcher(object):
                 'dialog': DialogUI,
                 'annex': UnderAnnexUI,
                 'tests': UnderTestsUI,
+                'tests-noninteractive': ConsoleLog,
             }[backend]()
         lgr.debug("UI set to %s" % self._ui)
         self._backend = backend

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -101,6 +101,10 @@ class ConsoleLog(object):
             pbar = progressbars[backend]
         return pbar(*args, out=self.out, **kwargs)
 
+    @property
+    def is_interactive(self):
+        return isinstance(self, InteractiveUI)
+
 
 def getpass_echo(prompt='Password: ', stream=None):
     """Q&D workaround until we have proper 'centralized' UI -- just use getpass BUT enable echo


### PR DESCRIPTION
Couldn't resist

edit1: does work correctly now:

```
$> rm -rf datasets.datalad.org; datalad search -R BIDS
No DataLad dataset found at current location
Would you like to install stock DataLad meta-dataset? (choices: yes, no): 

ERROR: '' is not among choices: ['yes', 'no']. Repeat your answer
No DataLad dataset found at current location
Would you like to install stock DataLad meta-dataset? (choices: yes, no): yes

2016-09-20 12:16:18,024 [INFO   ] Installing <Dataset path=/tmp/datasets.datalad.org> from http://datasets.datalad.org/ (install.py:372)
Dataset installed under /tmp/datasets.datalad.org.  Perform further operations using that dataset
openfmri/ds000001:
 dc:conformsTo: http://docs.datalad.org/metadata.html#v0-1, http://bids.neuroimaging.io/bids_spec1.0.0.pdf
openfmri/ds000005:
 dc:conformsTo: http://docs.datalad.org/metadata.html#v0-1, http://bids.neuroimaging.io/bids_spec1.0.0rc4.pdf
openfmri/ds000006:
 dc:conformsTo: http://docs.datalad.org/metadata.html#v0-1, http://bids.neuroimaging.io/bids_spec1.0.0rc4.pdf
openfmri/ds000007:
```

now logic is fully tested ;)   also includes a little fix/workaround for BIDS version "aggregation"