### PR TITLE
Enh webinterface upload optional

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -134,14 +134,18 @@ class CreateSibling(Interface):
             for multi-users (this could include access by a webserver!).
             Possible values for this option are identical to those of
             `git init --shared` and are described in its documentation.""",
-            constraints=EnsureStr() | EnsureBool()),)
+            constraints=EnsureStr() | EnsureBool()),
+        ui=Parameter(
+            args=("--ui",),
+            action="store_true",
+            doc="""publish a web interface for the dataset""",),)
 
     @staticmethod
     @datasetmethod(name='create_sibling')
     def __call__(sshurl, target=None, target_dir=None,
                  target_url=None, target_pushurl=None,
                  dataset=None, recursive=False,
-                 existing='error', shared=False):
+                 existing='error', shared=False, ui=False):
 
         if sshurl is None:
             raise ValueError("""insufficient information for target creation
@@ -316,7 +320,7 @@ class CreateSibling(Interface):
                     ssh(['git', '-C', path, 'annex', 'init', path])
 
             # publish web-interface to root dataset on publication server
-            if at_root:
+            if at_root and ui:
                 lgr.info("Uploading web interface to %s" % path)
                 at_root = False
                 try:

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -98,7 +98,8 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             dataset=source,
             target="local_target",
             sshurl="ssh://localhost",
-            target_dir=target_path)
+            target_dir=target_path,
+            ui=True)
         # is not actually happening on one of the two basic cases -- TODO figure it out
         # assert_in('enableremote local_target failed', cml.out)
 
@@ -167,7 +168,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             target_url=target_path,
             target_pushurl="ssh://localhost" +
                            target_path,
-        )
+            ui=True,)
         assert_create_sshwebserver(existing='replace', **cpkwargs)
         eq_(target_path,
             source.repo.get_remote_url("local_target"))
@@ -261,7 +262,8 @@ def test_target_ssh_recursive(origin, src_path, target_path):
                 target=remote_name,
                 sshurl="ssh://localhost" + target_path_,
                 target_dir=target_dir_tpl,
-                recursive=True)
+                recursive=True,
+                ui=True)
 
         # raise if git repos were not created
         for suffix in [sep + 'subm 1', sep + 'subm 2', '']:


### PR DESCRIPTION
Make uploading webinterface optional. Allows user to alternate name of index.html if it may conflict with pre-existing index.html in dataset.

Refer issue #825 for more details