### PR TITLE
ENH: for each command with cmdline renderer have a "sibling_" in Python API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
     env:
     - DATALAD_LOGLEVEL=2
     - DATALAD_LOGTARGET=/dev/null
+    - DATALAD_API_ALWAYS_RENDER=1
   - python: 2.7
     env:
     # to test operation under root since also would consider FS "crippled" due to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,6 +341,9 @@ Refer datalad/config.py for information on how to add these environment variable
   Examples include test for s3, git_repositories, openfmri etc
 - *DATALAD_TESTS_SSH*: 
   Skips SSH tests if this flag is **not** set
+- *DATALAD_API_ALWAYS_RENDER*: 
+  Would make api functions always use a version with cmdline output renderer
+  (i.e. the one with `_` suffix)
 - *DATALAD_LOGTRACEBACK*: 
   Runs TraceBack function with collide set to True, if this flag is set to 'collide'.
   This replaces any common prefix between current traceback log and previous invocation with "..."

--- a/datalad/api.py
+++ b/datalad/api.py
@@ -16,6 +16,7 @@ def _generate_func_api():
     """Auto detect all available interfaces and generate a function-based
        API from them
     """
+    import os
     from importlib import import_module
     from inspect import isgenerator
     from collections import namedtuple
@@ -71,6 +72,7 @@ def _generate_func_api():
             "returning the result"
         return call_
 
+    always_render = os.environ.get('DATALAD_API_ALWAYS_RENDER')
     for grp_name, grp_descr, interfaces in get_interface_groups():
         for intfspec in interfaces:
             # turn the interface spec into an instance
@@ -93,8 +95,8 @@ def _generate_func_api():
             if hasattr(intf, 'result_renderer_cmdline'):
                 intf__ = call_gen(intf.__call__, intf.result_renderer_cmdline)
                 globals()[get_api_name(intfspec) + '_'] = intf__
-                # TODO: trigger by some env var to do that for any func
-                # globals()[get_api_name(intfspec)] = intf__
+                if always_render:
+                    globals()[get_api_name(intfspec)] = intf__
 
 
 def _fix_datasetmethod_docs():

--- a/datalad/api.py
+++ b/datalad/api.py
@@ -50,17 +50,18 @@ def _generate_func_api():
 
         @wraps(call)
         def call_(*args, **kwargs):
-            ret = call(*args, **kwargs)
+            ret1 = ret = call(*args, **kwargs)
             if isgenerator(ret):
                 # At first I thought we might just rerun it for output
                 # at the end, but that wouldn't work if command actually
                 # has a side-effect, i.e. actually doing something
                 # so we actually need to memoize all generated output and output
                 # it instead
-                ret = get_memoized_generator(ret)
+                from datalad.utils import saved_generator
+                ret, ret1 = saved_generator(ret)
 
             renderer(ret, _kwargs_to_namespace(call, args, kwargs))
-            return ret
+            return ret1
 
         # TODO: see if we could proxy the "signature" of function
         # call from the original one
@@ -92,6 +93,8 @@ def _generate_func_api():
             if hasattr(intf, 'result_renderer_cmdline'):
                 intf__ = call_gen(intf.__call__, intf.result_renderer_cmdline)
                 globals()[get_api_name(intfspec) + '_'] = intf__
+                # TODO: trigger by some env var to do that for any func
+                # globals()[get_api_name(intfspec)] = intf__
 
 
 def _fix_datasetmethod_docs():

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -229,7 +229,7 @@ def main(args=None):
 
     # parse cmd args
     cmdlineargs = parser.parse_args(args)
-    if not cmdlineargs.change_path is None:
+    if cmdlineargs.change_path is not None:
         for path in cmdlineargs.change_path:
             chpwd(path)
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -10,6 +10,7 @@
 
 """
 
+import inspect
 import os
 import shutil
 import sys
@@ -479,3 +480,24 @@ def test_get_timestamp_suffix():
             assert(get_timestamp_suffix().startswith('-'))
     finally:
         time.tzset()
+
+
+def test_memoized_generator():
+    called = [0]
+
+    def g1(n):
+        """a generator"""
+        called[0] += 1
+        for i in range(n):
+            yield i
+
+    from ..utils import memoized_generator
+    ok_generator(g1(3))
+    g1_ = memoized_generator(g1(3))
+    ok_generator(g1_)
+    target = list(g1(3))
+    eq_(called[0], 1)
+    eq_(target, list(g1_))
+    eq_(called[0], 2)
+    eq_(target, list(g1_))
+    eq_(called[0], 2)  # no new call to make a generator

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -491,13 +491,16 @@ def test_memoized_generator():
         for i in range(n):
             yield i
 
-    from ..utils import memoized_generator
+    from ..utils import saved_generator
     ok_generator(g1(3))
-    g1_ = memoized_generator(g1(3))
+    g1_, g2_ = saved_generator(g1(3))
     ok_generator(g1_)
+    ok_generator(g2_)
     target = list(g1(3))
     eq_(called[0], 1)
     eq_(target, list(g1_))
     eq_(called[0], 2)
-    eq_(target, list(g1_))
+    eq_(target, list(g2_))
     eq_(called[0], 2)  # no new call to make a generator
+    # but we can't (ab)use 2nd time
+    eq_([], list(g2_))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -462,48 +462,27 @@ def unique(seq, key=None):
 
 
 #
-# Generators help
+# Generators helpers
 #
 
-@auto_repr
-class memoized_generator(object):
-    """Make a proxy for a generator, which if asked again would replay
+def saved_generator(gen):
+    """Given a generator returns two generators, where 2nd one just replays
 
-    So the thing is also a generator
+    So the first one would be going through the generated items and 2nd one
+    would be yielding saved items
     """
+    saved = []
 
-    def __init__(self, gen):
-        self._saved = None
-        self._replay_idx = 0
-        self.gen = gen
-        self._finished_gen = False
+    def gen1():
+        for x in gen:  # iterating over original generator
+            saved.append(x)
+            yield x
 
-    def __iter__(self):
-        return self
+    def gen2():
+        for x in saved:  # yielding saved entries
+            yield x
 
-    # Python 3 compatibility
-    def __next__(self):
-        return self.next()
-
-    def next(self):
-        if not self._finished_gen:
-            try:
-                element = next(self.gen)
-                if self._saved is None:
-                    self._saved = []
-                self._saved.append(element)
-            except StopIteration:
-                self._finished_gen = True
-                raise
-        else:
-            # we are replaying
-            if self._replay_idx >= len(self._saved):
-                self._replay_idx = 0
-                raise StopIteration
-            element = self._saved[self._replay_idx]
-            self._replay_idx += 1
-
-        return element
+    return gen1(), gen2()
 
 #
 # Decorators


### PR DESCRIPTION
If someone would work interactively with DataLad (E.g. in IPython shell), looking at all the data structures produced, or worse -- yielded, by DataLad might be to say the least inconvenient.  So it might be nice to provide a quick way to call Python API so it uses cmdline renderer. So, why not just to make such functios with '_' suffix.  So compare (and this one is actually a gentle example since returned structure manages to get formatted sensibly)

```ipython
In [2]: api.search('bids', report_matched=True)
Out[2]: <generator object __call__ at 0x7fc418404c30>

*In [3]: list(api.search('bids', report_matched=True))
Out[3]: 
[(u'openfmri/ds000001',
  {u'dc:conformsTo': [u'http://docs.datalad.org/metadata.html#v0-1',
    u'http://bids.neuroimaging.io/bids_spec1.0.0.pdf']}),
 (u'openfmri/ds000005',
  {u'dc:conformsTo': [u'http://docs.datalad.org/metadata.html#v0-1',
    u'http://bids.neuroimaging.io/bids_spec1.0.0rc4.pdf']}),
...
```
to 
```ipython
*In [4]: api.search_('bids', report_matched=True)
openfmri/ds000001:
 dc:conformsTo: http://docs.datalad.org/metadata.html#v0-1, http://bids.neuroimaging.io/bids_spec1.0.0.pdf
openfmri/ds000005:
 dc:conformsTo: http://docs.datalad.org/metadata.html#v0-1, http://bids.neuroimaging.io/bids_spec1.0.0rc4.pdf
```

edit 1:  with #902 it even renders it neatly in IPython! ;)
