### PR TITLE
ENH: fail AnnexRepo if outdated annex (demand at least 20160808)

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -36,17 +36,18 @@ class MissingExternalDependency(RuntimeError):
     """External dependency is missing error"""
 
     def __init__(self, name, ver=None, msg=""):
-        super(MissingExternalDependency, self).__init__(msg)
+        super(MissingExternalDependency, self).__init__()
         self.name = name
         self.ver = ver
+        self.msg = msg
 
     def __str__(self):
-        to_str = "%s: dependency '%s'" % (self.__class__.__name__, self.name)
+        to_str = str(self.name)
         if self.ver:
             to_str += " of version >= %s" % self.ver
-        to_str += " is missing.\n"
+        to_str += " is missing."
         if self.msg:
-            to_str += ".\n%s" % self.msg
+            to_str += " %s" % self.msg
         return to_str
 
 
@@ -59,9 +60,10 @@ class OutdatedExternalDependency(MissingExternalDependency):
 
     def __str__(self):
         to_str = super(OutdatedExternalDependency, self).__str__()
-        to_str += " Found version %s" % self.ver_present \
+        to_str += ". You have version %s" % self.ver_present \
             if self.ver_present else \
             " Some unknown version of dependency found."
+        return to_str
 
 
 class AnnexBatchCommandError(CommandError):

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -32,6 +32,38 @@ class CommandError(RuntimeError):
         return to_str
 
 
+class MissingExternalDependency(RuntimeError):
+    """External dependency is missing error"""
+
+    def __init__(self, name, ver=None, msg=""):
+        super(MissingExternalDependency, self).__init__(msg)
+        self.name = name
+        self.ver = ver
+
+    def __str__(self):
+        to_str = "%s: dependency '%s'" % (self.__class__.__name__, self.name)
+        if self.ver:
+            to_str += " of version >= %s" % self.ver
+        to_str += " is missing.\n"
+        if self.msg:
+            to_str += ".\n%s" % self.msg
+        return to_str
+
+
+class OutdatedExternalDependency(MissingExternalDependency):
+    """External dependency is present but outdated"""
+
+    def __init__(self, name, ver=None, ver_present=None, msg=""):
+        super(OutdatedExternalDependency, self).__init__(name, ver=ver, msg=msg)
+        self.ver_present = ver_present
+
+    def __str__(self):
+        to_str = super(OutdatedExternalDependency, self).__str__()
+        to_str += " Found version %s" % self.ver_present \
+            if self.ver_present else \
+            " Some unknown version of dependency found."
+
+
 class AnnexBatchCommandError(CommandError):
     """Thrown if a batched command to annex fails
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -39,17 +39,19 @@ lgr.log(5, "Importing datalad.utils")
 #
 # Some useful variables
 #
-_platform_system = platform.system().lower()
-on_windows = _platform_system == 'windows'
-on_osx = _platform_system == 'darwin'
-on_linux = _platform_system == 'linux'
+platform_system = platform.system().lower()
+on_windows = platform_system == 'windows'
+on_osx = platform_system == 'darwin'
+on_linux = platform_system == 'linux'
 try:
-    linux_distribution = platform.linux_distribution()
+    linux_distribution_name, linux_distribution_release \
+        = platform.linux_distribution()[:2]
     on_debian_wheezy = on_linux \
-                       and linux_distribution[0] == 'debian' \
-                       and linux_distribution[1].startswith('7.')
+                       and linux_distribution_name == 'debian' \
+                       and linux_distribution_release.startswith('7.')
 except:  # pragma: no cover
     on_debian_wheezy = False
+    linux_distribution_name = linux_distribution_release = None
 
 #
 # Little helpers


### PR DESCRIPTION
As discovered/reported in #897 we might be silently ignoring important failures of annex because it being outdated.  So we better complain out loud (ie crash) if we have outdated annex.

But this is also a precursor somewhat for providing progress output from annex get.

Since imho we better fail as early as necessary in case of oudated git-annex, I will merge this one if tests pass