### PR TITLE
BF: Reproducible tarballs + few other BF/ENH

### DIFF
--- a/datalad/export/tarball.py
+++ b/datalad/export/tarball.py
@@ -30,8 +30,17 @@ def _datalad_export_plugin_call(dataset, output, argv=None):
         lgr.warn("tarball exporter ignores any additional options '{}'".format(
             argv))
 
+    repo = dataset.repo
+    committed_date = repo.get_committed_date()
+
     # could be used later on to filter files by some criterion
     def _filter_tarinfo(ti):
+        # Reset the date to match the one of the last commit, not from the
+        # filesystem since git doesn't track those at all
+        # TODO: use the date of the last commit when any particular
+        # file was changed -- would be the most kosher yoh thinks to the
+        # degree of our abilities
+        ti.mtime = committed_date
         return ti
 
     if output is None:
@@ -39,9 +48,6 @@ def _datalad_export_plugin_call(dataset, output, argv=None):
     else:
         if not output.endswith('.tar.gz'):
             output += '.tar.gz'
-
-    repo = dataset.repo
-    committed_date = repo.get_committed_date()
 
     root = dataset.path
     # use dir inside matching the output filename

--- a/datalad/export/tarball.py
+++ b/datalad/export/tarball.py
@@ -47,7 +47,7 @@ def _datalad_export_plugin_call(dataset, output, argv=None):
     # use dir inside matching the output filename
     # TODO: could be an option to the export plugin allowing empty value
     # for no leading dir
-    leading_dir = dataset.id # file_basename(output)
+    leading_dir = file_basename(output)
 
     # workaround for inability to pass down the time stamp
     with patch('time.time', return_value=committed_date), \

--- a/datalad/export/tests/test_tarball.py
+++ b/datalad/export/tests/test_tarball.py
@@ -47,6 +47,7 @@ def test_failure(path):
 def test_tarball(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
     ds.save(auto_add_changes=True)
+    committed_date = ds.repo.get_committed_date()
     with chpwd(path):
         _mod, tarball1 = ds.export('tarball')
         assert(not isabs(tarball1))
@@ -75,6 +76,7 @@ def test_tarball(path):
                 # any annex links resolved
                 assert_false(ti.issym())
                 ok_startswith(ti.name, prefix + '/')
+                assert_equal(ti.mtime, committed_date)
                 if '.datalad' not in ti.name:
                     # ignore any files in .datalad for this test to not be
                     # susceptible to changes in how much we generate a meta info

--- a/datalad/export/tests/test_tarball.py
+++ b/datalad/export/tests/test_tarball.py
@@ -17,11 +17,13 @@ import tarfile
 
 from datalad.api import Dataset
 from datalad.api import export
-from nose.tools import assert_true, assert_not_equal, assert_raises, \
-    assert_false, assert_equal
-from datalad.tests.utils import with_tree
 from datalad.utils import chpwd
 from datalad.utils import md5sum
+
+from datalad.tests.utils import with_tree
+from datalad.tests.utils import ok_startswith
+from datalad.tests.utils import assert_true, assert_not_equal, assert_raises, \
+    assert_false, assert_equal
 
 
 _dataset_template = {
@@ -59,21 +61,25 @@ def test_tarball(path):
     custom1_md5 = md5sum(custom_outname)
     # encodes the original tarball filename -> different checksum, despit
     # same content
-    # import pdb; pdb.set_trace()
     assert_not_equal(md5sum(default_outname), custom1_md5)
+    # should really sleep so if they stop using time.time - we know
     time.sleep(1.1)
     ds.export('tarball', output=custom_outname)
-    # encodes mtime -> different checksum, despite same content and name
+    # should not encode mtime, so should be identical
     assert_equal(md5sum(custom_outname), custom1_md5)
-    # check content
-    with tarfile.open(default_outname) as tf:
-        nfiles = 0
-        for ti in tf:
-            # any annex links resolved
-            assert_false(ti.issym())
-            if not '.datalad' in ti.name:
-                # ignore any files in .datalad for this test to not be
-                # susceptible to changes in how much we generate a meta info
-                nfiles += 1
-        # we have exactly three files, and expect no content for any directory
-        assert_equal(nfiles, 3)
+
+    def check_contents(outname, prefix):
+        with tarfile.open(outname) as tf:
+            nfiles = 0
+            for ti in tf:
+                # any annex links resolved
+                assert_false(ti.issym())
+                ok_startswith(ti.name, prefix + '/')
+                if '.datalad' not in ti.name:
+                    # ignore any files in .datalad for this test to not be
+                    # susceptible to changes in how much we generate a meta info
+                    nfiles += 1
+            # we have exactly three files, and expect no content for any directory
+            assert_equal(nfiles, 3)
+    check_contents(default_outname, 'datalad_%s' % ds.id)
+    check_contents(custom_outname, 'myexport')

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -201,11 +201,7 @@ class GitModel(object):
     def date(self):
         """Date of the last commit
         """
-        try:
-            commit = next(self.repo.get_branch_commits(self.branch))
-        except:
-            return None
-        return commit.committed_date
+        return self.repo.get_committed_date()
 
     @property
     def count_objects(self):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -803,8 +803,20 @@ class GitRepo(object):
         assert(len(bases) == 1)  # we do not do 'all' yet
         return bases[0].hexsha
 
-    def get_active_branch(self):
+    def get_committed_date(self, branch=None):
+        """Get the date stamp of the last commit (in a branch). None if no commit"""
+        try:
+            commit = next(
+                self.get_branch_commits(branch
+                                        or self.get_active_branch())
+            )
+        except Exception as exc:
+            lgr.debug("Got exception while trying to get last commit: %s",
+                      exc_str(exc))
+            return None
+        return commit.committed_date
 
+    def get_active_branch(self):
         return self.repo.active_branch.name
 
     def get_branches(self):


### PR DESCRIPTION
- BF for var name
- use output filename as prefix for lead dir within tarball
- "fix" mtime issue by mocking time.time to match time of the last commit
- RF -- new function within GitRepo `get_committed_date`