### PR TITLE
BF+ENH: add-sibling - make description match target_url if provided

### DIFF
--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -11,8 +11,7 @@
 
 import os
 import re
-from os.path import join as opj, abspath, basename, exists
-from os.path import relpath
+from os.path import join as opj, basename, exists
 
 from git.exc import GitCommandError
 
@@ -22,20 +21,19 @@ from datalad.utils import chpwd
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 
-from nose.tools import eq_, assert_false, assert_is_instance
-from datalad.tests.utils import with_tempfile, assert_in, with_tree,\
-    with_testrepos, assert_not_in
+from nose.tools import eq_, assert_false
+from datalad.tests.utils import with_tempfile, assert_in, \
+    with_testrepos
 from datalad.tests.utils import SkipTest
-from datalad.tests.utils import assert_cwd_unchanged, skip_if_on_windows
-from datalad.tests.utils import assure_dict_from_str, assure_list_from_str
-from datalad.tests.utils import ok_generator
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_exists
+from datalad.tests.utils import ok_endswith
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_set_equal
+from datalad.tests.utils import assert_not_equal
 from datalad.tests.utils import assert_no_errors_logged
 from datalad.tests.utils import get_mtimes_and_digests
 from datalad.tests.utils import swallow_logs
@@ -44,6 +42,7 @@ from datalad.utils import on_windows
 from datalad.utils import _path_
 
 import logging
+
 
 def _test_correct_publish(target_path, rootds=False, flat=True):
 
@@ -138,7 +137,11 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             target_dir=target_path)
     eq_("Target directory %s already exists." % target_path,
         str(cm.exception))
-
+    if src_is_annex:
+        target_description = AnnexRepo(target_path, create=False).get_description()
+        assert_not_equal(target_description, None)
+        assert_not_equal(target_description, target_path)
+        ok_endswith(target_description, target_path)
     # now, with force and correct url, which is also used to determine
     # target_dir
     # Note: on windows absolute path is not url conform. But this way it's easy
@@ -178,6 +181,11 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             ui=True,
         )
         assert_create_sshwebserver(existing='replace', **cpkwargs)
+        if src_is_annex:
+            target_description = AnnexRepo(target_path,
+                                           create=False).get_description()
+            eq_(target_description, target_path)
+
         eq_(target_path,
             source.repo.get_remote_url("local_target"))
         eq_("ssh://localhost" + target_path,

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1231,3 +1231,30 @@ def test_annex_version_handling(path):
             eq_(AnnexRepo.git_annex_version, None)
             # so we could still fail
             assert_raises(OutdatedExternalDependency, AnnexRepo, path)
+
+
+@with_tempfile
+@with_tempfile
+def test_get_description(path1, path2):
+    annex1 = AnnexRepo(path1, create=True)
+    # some content for git-annex branch
+    create_tree(path1, {'1.dat': 'content'})
+    annex1.add('1.dat', git=False)
+    annex1.commit("msg")
+    annex1_description = annex1.get_description()
+    assert_not_equal(annex1_description, path1)
+
+    annex2 = AnnexRepo(path2, create=True, description='custom 2')
+    assert_equal(annex2.get_description(), 'custom 2')
+    # not yet known
+    assert_equal(annex2.get_description(uuid=annex1.uuid), None)
+
+    annex2.add_remote('annex1', path1)
+    annex2.fetch('annex1')
+    # it will match the remote name
+    assert_equal(annex2.get_description(uuid=annex1.uuid),
+                 annex1_description + ' [annex1]')
+    # but let's remove the remote
+    annex1.merge_annex('annex1')
+    annex2.remove_remote('annex1')
+    assert_equal(annex2.get_description(uuid=annex1.uuid), annex1_description)


### PR DESCRIPTION
otherwise BF -- do not set it manually to the path (was introduced recently) and do not double 'annex init' it.  Not sure now why (and if) we needed it there -- but tests seems to pass, so I assume that everything is kosher even with removal of the 2nd possible annex init