### PR TITLE
RF: Ignore dataset without ID on aggregate

### DIFF
--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -75,14 +75,8 @@ class AggregateMetaData(Interface):
         # one it
         dsonly_cfg = ConfigManager(dataset, dataset_only=True)
         if 'datalad.dataset.id' not in dsonly_cfg:
-            dsonly_cfg.add(
-                'datalad.dataset.id',
-                dataset.id,
-                where='dataset',
-                reload=False)
-            dataset.repo.add(opj('.datalad', 'config'), git=True)
-            dataset.save(message="[DATALAD] record generated dataset ID")
-            _modified_flag = True
+            lgr.warning('%s has not configured ID, skipping.', dataset)
+            return _modified_flag
 
         # use one set of subdataset instances to ensure consistent IDs even
         # when none is configured


### PR DESCRIPTION
This is implemented, but I believe they should also be ignore by `get_metadata()` -- that is not yet done.