### PR TITLE
ENH various enhancements to search and around it

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -31,14 +31,13 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.network import is_datalad_compat_ri
 from datalad.utils import assure_list
-
+from datalad.utils import with_pathsep as _with_sep
 
 from .dataset import EnsureDataset
 from .dataset import datasetmethod
 from .dataset import Dataset
 from .dataset import resolve_path
 from .dataset import require_dataset
-from .dataset import _with_sep
 from .install import _get_git_url_from_source
 
 

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -30,14 +30,13 @@ from datalad.support.constraints import EnsureDType
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
-from datalad.support.gitrepo import to_options
 from datalad.utils import getpwd
+from datalad.utils import with_pathsep
 
 from .dataset import Dataset
 from .dataset import datasetmethod
 from .dataset import EnsureDataset
 from .dataset import resolve_path
-from .dataset import _with_sep
 
 
 __docformat__ = 'restructuredtext'
@@ -191,13 +190,13 @@ class Create(Interface):
         assert(path is not None)
 
         # check for sane subdataset path
-        real_targetpath = _with_sep(realpath(path))  # realpath OK
+        real_targetpath = with_pathsep(realpath(path))  # realpath OK
         if dataset is not None:
             # make sure we get to an expected state
             if dataset.is_installed():
                 handle_dirty_dataset(dataset, if_dirty)
             if not real_targetpath.startswith(  # realpath OK
-                    _with_sep(realpath(dataset.path))):  # realpath OK
+                    with_pathsep(realpath(dataset.path))):  # realpath OK
                 raise ValueError("path {} outside {}".format(path, dataset))
 
         # important to use the given Dataset object to avoid spurious ID

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -35,13 +35,13 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import PathOutsideRepositoryError
 from datalad.dochelpers import exc_str
 from datalad.dochelpers import single_or_plural
+from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
 
 from .dataset import Dataset
 from .dataset import EnsureDataset
 from .dataset import datasetmethod
 from .dataset import require_dataset
 from .dataset import resolve_path
-from .dataset import _with_sep
 from .utils import install_necessary_subdatasets
 
 __docformat__ = 'restructuredtext'

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -164,6 +164,18 @@ def _install_subds_from_flexible_source(ds, sm_path, sm_url, recursive):
                     '/'.join(sm_url_l[i:]),
                     url_suffix))
                 break
+
+    # TODO:
+    # here clone_urls might contain degenerate urls which should be
+    # normalized and not added into the pool of the ones to try if already
+    # there, e.g. I got
+    #  ['http://datasets.datalad.org/crcns/aa-1/.git', 'http://datasets.datalad.org/crcns/./aa-1/.git']
+    # upon  install aa-1
+
+    # TODO:
+    # We need to provide some error msg with InstallFailedError, since now
+    # it just swallows everything.
+
     # now loop over all candidates and try to clone
     subds = Dataset(opj(ds.path, sm_path))
     success = False

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -15,6 +15,7 @@ from os.path import join as opj, abspath, normpath
 
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
 from datalad.api import create
+from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.utils import chpwd, getpwd, rmtree
 from datalad.utils import _path_
 from datalad.support.gitrepo import GitRepo
@@ -229,6 +230,14 @@ def test_subdatasets(path):
     assert_true(subsubds.is_installed())
     eq_(subsubds.get_superdataset(), subds)
     eq_(subsubds.get_superdataset(topmost=True), ds)
+
+    # verify that '^' alias would work
+    with chpwd(subsubds.path):
+        dstop = Dataset('^')
+        eq_(dstop, ds)
+        # and while in the dataset we still can resolve into central one
+        dscentral = Dataset('///')
+        eq_(dscentral.path, LOCAL_CENTRAL_PATH)
 
     # TODO actual submodule checkout is still there
 

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -204,7 +204,7 @@ def test_subdatasets(path):
     ds.save("Hello!", version_tag=1)
     # Assuming that tmp location was not under a super-dataset
     eq_(ds.get_superdataset(), None)
-    eq_(ds.get_superdataset(topmost=True), None)
+    eq_(ds.get_superdataset(topmost=True), ds)
 
     # add itself as a subdataset (crazy, isn't it?)
     subds = ds.install('subds', source=path)
@@ -238,6 +238,10 @@ def test_subdatasets(path):
         # and while in the dataset we still can resolve into central one
         dscentral = Dataset('///')
         eq_(dscentral.path, LOCAL_CENTRAL_PATH)
+
+    with chpwd(ds.path):
+        dstop = Dataset('^')
+        eq_(dstop, ds)
 
     # TODO actual submodule checkout is still there
 

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -33,10 +33,10 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import assert_re_in
-from datalad.utils import swallow_logs
+from datalad.utils import swallow_logs, with_pathsep
 
 from ..dataset import Dataset
-from ..dataset import _with_sep
+from ..dataset import with_pathsep
 
 
 @with_tempfile(mkdir=True)
@@ -179,7 +179,7 @@ def test_get_recurse_dirs(o_path, c_path):
                  opj('subdir', 'file2.txt'),
                  opj('subdir', 'subsubdir', 'file3.txt'),
                  opj('subdir', 'subsubdir', 'file4.txt')]
-    files_in_sub = [f for f in file_list if f.startswith(_with_sep('subdir'))]
+    files_in_sub = [f for f in file_list if f.startswith(with_pathsep('subdir'))]
 
     # no content present:
     ok_(not any(ds.repo.file_has_content(file_list)))

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -25,10 +25,10 @@ from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import resolve_path
-from datalad.distribution.dataset import _with_sep
 from datalad.distribution.utils import _install_subds_inplace
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.utils import assure_list
+from datalad.utils import with_pathsep as _with_sep
 
 from .base import Interface
 

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -195,8 +195,9 @@ def test_aggregation(path):
         child_res = list(clone.search('child'))
         assert_equal(len(child_res), 2)
         # little helper to match names
-        def assert_names(res, names):
-            assert_equal(list(map(itemgetter(0), res)), names)
+        def assert_names(res, names, path=clone.path):
+            assert_equal(list(map(itemgetter(0), res)),
+                         [opj(path, n) for n in names])
         # should yield (location, report) tuples
         assert_names(child_res, ['sub', 'sub/subsub'])
 
@@ -236,13 +237,10 @@ def test_aggregation(path):
         )
 
         # more tests on returned paths:
-        assert_equal(list(map(itemgetter(0),
-                              clone.search('datalad'))),
-                     ['.', 'sub', 'sub/subsub'])
+        assert_names(clone.search('datalad'), ['.', 'sub', 'sub/subsub'])
         # if we clone subdataset and query for value present in it and its kid
-        assert_equal(list(map(itemgetter(0),
-                              clone.install('sub').search('datalad'))),
-                     ['.', 'subsub'])
+        clone_sub = clone.install('sub')
+        assert_names(clone_sub.search('datalad'), ['.', 'subsub'], clone_sub.path)
 
         # Test 'and' for multiple search entries
         assert_equal(len(list(clone.search(['child', 'bids']))), 2)

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -16,6 +16,7 @@ from datalad.metadata import get_metadata_type, get_metadata
 from nose.tools import assert_true, assert_equal, assert_raises, assert_false
 from datalad.tests.utils import with_tree, with_tempfile
 from datalad.utils import chpwd
+from datalad.utils import assure_unicode
 from datalad.dochelpers import exc_str
 import os
 from os.path import join as opj, exists
@@ -134,10 +135,7 @@ def test_aggregation(path):
     assert_equal(3, len(set([s.get('@id') for s in meta])))
     # and we know about all three datasets
     for name in ('mother_äöü東', 'child_äöü東', 'grandchild_äöü東'):
-        if PY2:
-            assert_true(sum([s.get('name', None) == name.decode('utf-8') for s in meta]))
-        else:
-            assert_true(sum([s.get('name', None) == name for s in meta]))
+        assert_true(sum([s.get('name', None) == assure_unicode(name) for s in meta]))
     assert_equal(
         meta[0]['dcterms:hasPart']['@id'],
         subds.id)
@@ -287,7 +285,4 @@ def test_aggregate_with_missing_id(path):
         ds, guess_type=False, ignore_subdatasets=False, ignore_cache=False)
     # and we know nothing subsub
     for name in ('grandchild_äöü東',):
-        if PY2:
-            assert_false(sum([s.get('name', '') == name.decode('utf-8') for s in meta]))
-        else:
-            assert_false(sum([s.get('name', '') == name for s in meta]))
+        assert_false(sum([s.get('name', '') == assure_unicode(name) for s in meta]))

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -194,8 +194,19 @@ def test_aggregation(path):
 
         child_res = list(clone.search('child'))
         assert_equal(len(child_res), 2)
+        # little helper to match names
+        def assert_names(res, names):
+            assert_equal(list(map(itemgetter(0), res)), names)
         # should yield (location, report) tuples
-        assert_equal(list(map(itemgetter(0), child_res)), ['sub', 'sub/subsub'])
+        assert_names(child_res, ['sub', 'sub/subsub'])
+
+        # test searching among specified properties only
+        assert_names(clone.search('i', search='name'), ['sub', 'sub/subsub'])
+        assert_names(clone.search('i', search='keywords'), ['.'])
+        # case shouldn't matter
+        assert_names(clone.search('i', search='Keywords'), ['.'])
+        assert_names(clone.search('i', search=['name', 'keywords']),
+                     ['.', 'sub', 'sub/subsub'])
 
         # without report_matched, we are getting none of the fields
         assert(all([not x for x in map(itemgetter(1), child_res)]))

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -112,8 +112,10 @@ class _mock_search(object):
 def _check_mocked_install(central_dspath, mock_install):
     gen = search(".", regex=True)
     assert_is_generator(gen)
+    # we no longer do any custom path tune up from the one returned by search
+    # so should match what search returns
     assert_equal(
-        list(gen), [(opj(central_dspath, loc), report)
+        list(gen), [(loc, report)
                     for loc, report in _mocked_search_results])
     mock_install.assert_called_once_with(central_dspath, source='///')
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -1,4 +1,5 @@
 # emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -17,6 +18,7 @@ import sys
 import logging
 from mock import patch
 from six import PY3
+from six import text_type
 
 from operator import itemgetter
 from os.path import dirname, normpath, pardir, basename
@@ -51,6 +53,7 @@ from .utils import with_tempfile, assert_in, with_tree
 from .utils import SkipTest
 from .utils import assert_cwd_unchanged, skip_if_on_windows
 from .utils import assure_dict_from_str, assure_list_from_str
+from .utils import assure_unicode
 from .utils import ok_generator
 from .utils import assert_not_in
 from .utils import assert_raises
@@ -504,3 +507,10 @@ def test_memoized_generator():
     eq_(called[0], 2)  # no new call to make a generator
     # but we can't (ab)use 2nd time
     eq_([], list(g2_))
+
+
+def test_assure_unicode():
+    ok_(isinstance(assure_unicode("m"), text_type))
+    ok_(isinstance(assure_unicode('grandchild_äöü東'), text_type))
+    ok_(isinstance(assure_unicode(u'grandchild_äöü東'), text_type))
+    eq_(assure_unicode('grandchild_äöü東'), u'grandchild_äöü東')

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -30,6 +30,7 @@ from ..utils import updated
 from os.path import join as opj, abspath, exists
 from ..utils import rotree, swallow_outputs, swallow_logs, setup_exceptionhook, md5sum
 from ..utils import getpwd, chpwd
+from ..utils import get_path_prefix
 from ..utils import auto_repr
 from ..utils import find_files
 from ..utils import line_profile
@@ -514,3 +515,18 @@ def test_assure_unicode():
     ok_(isinstance(assure_unicode('grandchild_äöü東'), text_type))
     ok_(isinstance(assure_unicode(u'grandchild_äöü東'), text_type))
     eq_(assure_unicode('grandchild_äöü東'), u'grandchild_äöü東')
+
+
+@with_tempfile(mkdir=True)
+def test_path_prefix(tdir):
+    eq_(get_path_prefix('/d1/d2', '/d1/d2'), '')
+    # so we are under /d1/d2 so path prefix is ..
+    eq_(get_path_prefix('/d1/d2', '/d1/d2/d3'), '..')
+    eq_(get_path_prefix('/d1/d2/d3', '/d1/d2'), 'd3')
+    # but if outside -- full path
+    eq_(get_path_prefix('/d1/d2', '/d1/d20/d3'), '/d1/d2')
+    with chpwd(tdir):
+        eq_(get_path_prefix('.'), '')
+        eq_(get_path_prefix('d1'), 'd1')
+        eq_(get_path_prefix('d1', 'd2'), opj(tdir, 'd1'))
+        eq_(get_path_prefix('..'), '..')

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -439,6 +439,11 @@ def assure_dict_from_str(s, **kwargs):
     return out
 
 
+def assure_unicode(s, encoding='utf-8'):
+    """Convert/decode to unicode (PY2) or str (PY3) if of 'binary_type'"""
+    return s.decode(encoding) if isinstance(s, binary_type) else s
+
+
 def unique(seq, key=None):
     """Given a sequence return a list only with unique elements while maintaining order
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -8,13 +8,10 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import collections
+import hashlib
 import re
 import six.moves.builtins as __builtin__
 import time
-
-from os.path import curdir, basename, exists, realpath, islink, join as opj, isabs, normpath, expandvars, expanduser, abspath
-from os.path import isdir
-from six import text_type, binary_type
 
 import logging
 import shutil
@@ -26,13 +23,20 @@ import platform
 import gc
 import glob
 
+from contextlib import contextmanager
 from functools import wraps
 from time import sleep
 from inspect import getargspec
-import hashlib
-from os.path import sep as dirsep
-from contextlib import contextmanager
 
+from os.path import sep as dirsep
+from os.path import commonprefix
+from os.path import curdir, basename, exists, realpath, islink, join as opj
+from os.path import isabs, normpath, expandvars, expanduser, abspath, sep
+from os.path import isdir
+from os.path import relpath
+
+
+from six import text_type, binary_type
 
 # from datalad.dochelpers import get_docstring_split
 from datalad.consts import TIMESTAMP_FMT
@@ -889,6 +893,37 @@ class chpwd(object):
             self.__class__(self._prev_pwd, logsuffix="(coming back)")
 
 
+def with_pathsep(path):
+    """Little helper to guarantee that path ends with /"""
+    return path + sep if not path.endswith(sep) else path
+
+
+def get_path_prefix(path, pwd=None):
+    """Get path prefix (for current directory)
+
+    Returns relative path to the topdir, if we are under topdir, and if not
+    absolute path to topdir.  If `pwd` is not specified - current directory
+    assumed
+    """
+    pwd = pwd or getpwd()
+    if not isabs(path):
+        # if not absolute -- relative to pwd
+        path = opj(getpwd(), path)
+    path_ = with_pathsep(path)
+    pwd_ = with_pathsep(pwd)
+    common = commonprefix((path_, pwd_))
+    if common.endswith(sep) and common in {path_, pwd_}:
+        # we are in subdir or above the path = use relative path
+        location_prefix = relpath(path, pwd)
+        # if benign "here" - cut off
+        if location_prefix in (curdir, curdir + sep):
+            location_prefix = ''
+        return location_prefix
+    else:
+        # just return absolute path
+        return path
+
+
 def knows_annex(path):
     """Returns whether at a given path there is information about an annex
 
@@ -1017,3 +1052,4 @@ def get_logfilename(dspath, cmd='datalad'):
 
 
 lgr.log(5, "Done importing datalad.utils")
+


### PR DESCRIPTION
Closes #964 -- use -s option to specify fields/properties to search)
Closes #912 -- use -d^ to search from the very top of current datasets hierarchy, -d/// to search central one

There were some refactoring along the way (`assert_unicode`, moved `_with_sep` into utils, etc). Overall tried to keep amount of possible conflicts to minimum with WiP work... but no guarantees ;)

Try search now with those options -- it is quite neat IMHO

couldn't resist so now we are spitting out suggestions in case none of the properties was found:

```
(git)hopa:~datalad/datalad[enh-search-fields]git
$> datalad search -d/// -slocati a
2016-09-30 21:01:16,349 [WARNING] Found no properties which matched one of the one you specified (locati).  May be you meant one among: homepage, citation, contributors, license, author, type, description, title, dc:ispartof, id, dc:haspart, version, location, keywords, foaf:fundedby, dc:conformsto, dc:modified, schema:availablefrom, name.
| Suggestions:
|  location for locati (search.py:335)
```