### PR TITLE
BF: do not place bash regex pattern within "" for =~

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,8 @@ install:
   # Specifically needed for tests here (e.g. example scripts testing)
   - pip install nibabel
   # TMPDIRs
-  - if [ ! -z "$TMPDIR" ] && [[ $TMPDIR =~ ".*/sym link" ]]; then echo "Symlinking $TMPDIR"; ln -s /tmp "$TMPDIR"; fi
-  - if [ ! -z "$TMPDIR" ] && [ "$TMPDIR" = "/tmp/d i r" ]; then mkdir -p "$TMPDIR"; fi
+  - if [[ "${TMPDIR:-}" =~ .*/sym\ link ]]; then echo "Symlinking $TMPDIR"; ln -s /tmp "$TMPDIR"; fi
+  - if [[ "${TMPDIR:-}" =~ .*/d\ i\ r ]]; then echo "mkdir $TMPDIR"; mkdir -p "$TMPDIR"; fi
   # S3
   - if [ ! -z "$UNSET_S3_SECRETS" ]; then echo "usetting"; unset DATALAD_datalad_test_s3_key_id DATALAD_datalad_test_s3_secret_id; fi
   # Install grunt to test run javascript frontend tests


### PR DESCRIPTION
Apparently those scenarios did not play at all, which lead to failures
on OSX buildbot within https://github.com/datalad/datalad/pull/959#issuecomment-250915262
without Travis failing at all