### PR TITLE
Dataset ID and metadata handling #986 #949 #997

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import uuid
 
 from os import listdir
 from os.path import isdir, realpath, relpath
@@ -236,13 +237,16 @@ class Create(Interface):
             for nt in native_metadata_type:
                 tbds.config.add('datalad.metadata.nativetype', nt)
 
-        # record the ID of this repo for the afterlife
+        # record an ID for this repo for the afterlife
         # to be able to track siblings and children
         id_var = 'datalad.dataset.id'
         if id_var in tbds.config:
             # make sure we reset this variable completely, in case of a re-create
             tbds.config.unset(id_var, where='dataset')
-        tbds.config.add(id_var, tbds.id, where='dataset')
+        tbds.config.add(
+            id_var,
+            tbds.id if tbds.id is not None else uuid.uuid1().urn.split(':')[-1],
+            where='dataset')
 
         # save everthing
         tbds.repo.add('.datalad', git=True)

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-import uuid
 from functools import wraps
 from os.path import abspath
 from os.path import commonprefix
@@ -151,15 +150,11 @@ class Dataset(object):
         Returns
         -------
         str
-          This is either a stored UUID, or if there is none: the UUID of the
-          dataset's annex, or a new generated UUID.
+          This is either a stored UUID, or `None`.
         """
         if self._id is None:
             # if we have one on record, stick to it!
             self._id = self.config.get('datalad.dataset.id', None)
-            if self._id is None:
-                # fall back on self-made ID
-                self._id = uuid.uuid1().urn.split(':')[-1]
         return self._id
 
     @property

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -298,17 +298,19 @@ def test_require_dataset(path):
 @with_tempfile(mkdir=True)
 def test_dataset_id(path):
     ds = Dataset(path)
+    assert_equal(ds.id, None)
+    ds.create()
     dsorigid = ds.id
     # ID is always a UUID
     assert_equal(ds.id.count('-'), 4)
     assert_equal(len(ds.id), 36)
-    # creating a new object for the same path (no ID on record)
-    # does not yields the same ID
+    # creating a new object for the same path
+    # yields the same ID
     newds = Dataset(path)
     assert_false(ds is newds)
-    assert_true(ds.id != newds.id)
+    assert_equal(ds.id, newds.id)
     # recreating the dataset does NOT change the id
-    ds.create(no_annex=True)
+    ds.create(no_annex=True, force=True)
     assert_equal(ds.id, dsorigid)
     # even adding an annex doesn't
     ds.create(force=True)

--- a/datalad/metadata/__init__.py
+++ b/datalad/metadata/__init__.py
@@ -72,13 +72,15 @@ def _get_base_dataset_metadata(ds_identifier):
     """Return base metadata as dict for a given ds_identifier
     """
 
-    return {
+    meta = {
         "@context": "http://schema.org/",
-        "@id": ds_identifier,
         "type": "Dataset",
         # increment when changes to meta data representation are done
         "dcterms:conformsTo": "http://docs.datalad.org/metadata.html#v0-1",
     }
+    if ds_identifier is not None:
+        meta["@id"] = ds_identifier
+    return meta
 
 
 def _get_implicit_metadata(ds, ds_identifier=None, subdatasets=None):
@@ -144,12 +146,11 @@ def _get_implicit_metadata(ds, ds_identifier=None, subdatasets=None):
     subdss = []
     # we only want immediate subdatasets
     for subds in subdatasets:
-        subds_id = subds.id
         submeta = {
             'location': relpath(subds.path, ds.path),
             'type': 'Dataset'}
-        if not subds_id.startswith('_:'):
-            submeta['@id'] = subds_id
+        if subds.id:
+            submeta['@id'] = subds.id
         subdss.append(submeta)
     if len(subdss):
         if len(subdss) == 1:

--- a/datalad/metadata/__init__.py
+++ b/datalad/metadata/__init__.py
@@ -146,6 +146,8 @@ def _get_implicit_metadata(ds, ds_identifier=None, subdatasets=None):
     subdss = []
     # we only want immediate subdatasets
     for subds in subdatasets:
+        if subds.id is None:
+            continue
         submeta = {
             'location': relpath(subds.path, ds.path),
             'type': 'Dataset'}

--- a/datalad/metadata/__init__.py
+++ b/datalad/metadata/__init__.py
@@ -261,7 +261,7 @@ def get_metadata(ds, guess_type=False, ignore_subdatasets=False,
     # for any subdataset that is actually registered (avoiding stale copies)
     for subds in subdss:
         subds_path = relpath(subds.path, ds.path)
-        if ignore_cache and subds.is_installed():
+        if ignore_cache and subds.is_installed() and subds.id:
             # simply pull meta data from actual subdataset and go to next part
             subds_meta = get_metadata(
                 subds, guess_type=guess_type,
@@ -301,7 +301,9 @@ def get_metadata(ds, guess_type=False, ignore_subdatasets=False,
             for md in subds_meta:
                 cand_id = md.get('dcterms:isPartOf', None)
                 if cand_id == ds_identifier and '@id' in md:
-                    has_part[subds_path]['@id'] = md['@id']
+                    partinfo = has_part.get(subds_path, {})
+                    partinfo['@id'] = md['@id']
+                    has_part[subds_path] = partinfo
                     break
 
         # hand over subdataset meta data

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -25,7 +25,6 @@ from ..log import lgr
 from . import get_metadata, get_native_metadata, metadata_filename, \
     metadata_basepath, is_implicit_metadata
 from datalad.support.json_py import dump as jsondump
-from datalad.config import ConfigManager
 
 
 def _store_json(path, meta):
@@ -71,10 +70,7 @@ class AggregateMetaData(Interface):
         # possible to decide what to save one level up
         _modified_flag = False
 
-        # check for OLD datasets without a configured ID, and save the current
-        # one it
-        dsonly_cfg = ConfigManager(dataset, dataset_only=True)
-        if 'datalad.dataset.id' not in dsonly_cfg:
+        if dataset.id is None:
             lgr.warning('%s has not configured ID, skipping.', dataset)
             return _modified_flag
 

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -83,6 +83,8 @@ class AggregateMetaData(Interface):
                       recursive=False)]
         # anything below only works for installed subdatasets
         subdss = [d for d in subdss if d.is_installed()]
+        # if it's not kosher we ain't gonna have it
+        subdss = [d for d in subdss if d.id is not None]
 
         # recursive, depth first
         if recursive and (recursion_limit is None or recursion_limit):

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -125,7 +125,11 @@ class Search(Interface):
         try:
             ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
             if ds.id is None:
-                raise NoDatasetArgumentFound
+                raise NoDatasetArgumentFound(
+                    "There seems to be a repository which lacks a DataLad's "
+                    "dataset id, thus not considered to be a dataset. "
+                    "You can use 'datalad create --force %s' command to "
+                    "'initiate' that repository as a DataLad dataset" % ds.path)
         except NoDatasetArgumentFound:
             exc_info = sys.exc_info()
             if dataset is None:

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -124,6 +124,8 @@ class Search(Interface):
                   match, dataset)
         try:
             ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
+            if ds.id is None:
+                raise NoDatasetArgumentFound
         except NoDatasetArgumentFound:
             exc_info = sys.exc_info()
             if dataset is None:

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -104,7 +104,7 @@ def test_basic_metadata(path):
     ds = Dataset(opj(path, 'origin'))
     meta = get_metadata(ds)
     assert_equal(sorted(meta[0].keys()),
-                 ['@context', '@id', 'dcterms:conformsTo', 'type'])
+                 ['@context', 'dcterms:conformsTo', 'type'])
     ds.create(force=True, save=False)
     # with subdataset
     sub = ds.create('sub', force=True, if_dirty='ignore')

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -149,3 +149,12 @@ def test_our_metadataset_search(tdir):
         out = cmo.out
     assert yaml.load(out)
 
+
+@with_tempfile
+def test_search_non_dataset(tdir):
+    from datalad.support.gitrepo import GitRepo
+    GitRepo(tdir, create=True)
+    with assert_raises(NoDatasetArgumentFound) as cme:
+        list(search('smth', dataset=tdir))
+    # Should instruct user how that repo could become a datalad dataset
+    assert_in("datalad create --force", str(cme.exception))


### PR DESCRIPTION
ATTENTION: This should not be touch until after #1050 is in!

Looking into this I found that we have to decide how to deal with plain repositories. I was under the impression that we are moving towards caring for datalad datasets, not any repository. But given the recent misconceptions:

What about the case where a dataset, contains a repository submodule (no dataset), which in turn contains a dataset.

IMHO the only clean way is to ignore anything from the submodule downward (including the submodule). If we ignore it in the metadata, we should likely ignore it in things like `get_subdataset()`, to avoid proliferation of dataset flavors. If we don't want to ignore it, we have to be able to describe it, hence plain repos will keep getthing an ID ... IWO things stay the way they are and issues  like #986 are invalid.

If we want to ignore it, how can we tell a subdataset from a submodule without having it installed?

Likewise, what if I have a plain repository that contains submodules which are dataset? While the top is not a dataset? Do we have to consider it to be one nevertheless, because it would make sense to search in it? In this case the resolution of #997 becomes more complicated than it seemed at first.

Decision please.