### PR TITLE
RF+ENH+BF: #959 reincarnated -- with  old install API (-s SOURCE PATH*)

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -47,6 +47,9 @@ def _generate_func_api():
         # update with provided kwarg args
         kwargs_.update(kwargs)
         assert (nargs == len(kwargs_))
+        # Get all arguments removing those possible ones used internally and
+        # which shouldn't be exposed outside anyways
+        [kwargs_.pop(k) for k in kwargs_ if k.startswith('_')]
         namespace = namedtuple("smth", kwargs_.keys())(**kwargs_)
         return namespace
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -267,8 +267,8 @@ def main(args=None):
             except InsufficientArgumentsError as exc:
                 # if the func reports inappropriate usage, give help output
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
-                cmdlineargs.subparser.print_usage()
-                sys.exit(1)
+                cmdlineargs.subparser.print_usage(sys.stderr)
+                sys.exit(2)
             except IncompleteResultsError as exc:
                 # we didn't get everything we wanted: still present what we got
                 # as usual, but exit with an error

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -274,7 +274,8 @@ def main(args=None):
                 # as usual, but exit with an error
                 if hasattr(cmdlineargs, 'result_renderer'):
                     cmdlineargs.result_renderer(exc.results, cmdlineargs)
-                lgr.error('could not perform all requested actions')
+                lgr.error('could not perform all requested actions: %s',
+                          exc.message)
                 sys.exit(1)
             except Exception as exc:
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -93,9 +93,10 @@ def _makeds(path, levels, ds=None):
         assert ds.is_installed()
         rpath = os.path.relpath(path, ds.path)
         out = install(
-            opj(os.curdir, rpath),
-            dataset=ds,
-            path=rpath)
+            rpath,
+            source=opj(os.curdir, rpath),
+            dataset=ds
+            )
         ds.repo.commit("subdataset %s installed." % rpath, _datalad_msg=True)
 
     if not levels:

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -240,6 +240,7 @@ class Dataset(object):
           If True, recurse into all subdatasets and report them too.
         recursion_limit: int or None
           If not None, set the number of subdataset levels to recurse into.
+
         Returns
         -------
         list(Dataset paths) or None
@@ -533,7 +534,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
     dataset : None or path or Dataset
       Some value identifying a dataset or `None`. In the latter case
       a dataset will be searched based on the process working directory.
-    check_installed : boold, optional
+    check_installed : bool, optional
       If True, an optional check whether the resolved dataset is
       properly installed will be performed.
     purpose : str, optional

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -119,20 +119,19 @@ class Dataset(object):
         GitRepo
         """
         if self._repo is None:
-            with swallow_logs():
-                for cls, ckw, kw in (
-                        (AnnexRepo, {'allow_noninitialized': True}, {'init': False}),
-                        (GitRepo, {}, {})
-                ):
-                    if cls.is_valid_repo(self._path, **ckw):
-                        try:
-                            lgr.debug("Detected %s at %s", cls, self._path)
-                            self._repo = cls(self._path, create=False, **kw)
-                            break
-                        except (InvalidGitRepositoryError, NoSuchPathError) as exc:
-                            lgr.debug("Oops -- guess on repo type was wrong?: %s", exc_str(exc))
-                            pass
-                        # version problems come as RuntimeError: DO NOT CATCH!
+            for cls, ckw, kw in (
+                    (AnnexRepo, {'allow_noninitialized': True}, {'init': False}),
+                    (GitRepo, {}, {})
+            ):
+                if cls.is_valid_repo(self._path, **ckw):
+                    try:
+                        lgr.debug("Detected %s at %s", cls, self._path)
+                        self._repo = cls(self._path, create=False, **kw)
+                        break
+                    except (InvalidGitRepositoryError, NoSuchPathError) as exc:
+                        lgr.debug("Oops -- guess on repo type was wrong?: %s", exc_str(exc))
+                        pass
+                    # version problems come as RuntimeError: DO NOT CATCH!
             if self._repo is None:
                 lgr.info("Failed to detect a valid repo at %s" % self.path)
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -119,19 +119,20 @@ class Dataset(object):
         GitRepo
         """
         if self._repo is None:
-            for cls, ckw, kw in (
-                    (AnnexRepo, {'allow_noninitialized': True}, {'init': False}),
-                    (GitRepo, {}, {})
-            ):
-                if cls.is_valid_repo(self._path, **ckw):
-                    try:
-                        lgr.debug("Detected %s at %s", cls, self._path)
-                        self._repo = cls(self._path, create=False, **kw)
-                        break
-                    except (InvalidGitRepositoryError, NoSuchPathError) as exc:
-                        lgr.debug("Oops -- guess on repo type was wrong?: %s", exc_str(exc))
-                        pass
-                    # version problems come as RuntimeError: DO NOT CATCH!
+            with swallow_logs():
+                for cls, ckw, kw in (
+                        (AnnexRepo, {'allow_noninitialized': True}, {'init': False}),
+                        (GitRepo, {}, {})
+                ):
+                    if cls.is_valid_repo(self._path, **ckw):
+                        try:
+                            lgr.debug("Detected %s at %s", cls, self._path)
+                            self._repo = cls(self._path, create=False, **kw)
+                            break
+                        except (InvalidGitRepositoryError, NoSuchPathError) as exc:
+                            lgr.debug("Oops -- guess on repo type was wrong?: %s", exc_str(exc))
+                            pass
+                        # version problems come as RuntimeError: DO NOT CATCH!
             if self._repo is None:
                 lgr.info("Failed to detect a valid repo at %s" % self.path)
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -129,11 +129,12 @@ class Dataset(object):
                             lgr.debug("Detected %s at %s", cls, self._path)
                             self._repo = cls(self._path, create=False, **kw)
                             break
-                        except (InvalidGitRepositoryError, NoSuchPathError, RuntimeError) as exc:
+                        except (InvalidGitRepositoryError, NoSuchPathError) as exc:
                             lgr.debug("Oops -- guess on repo type was wrong?: %s", exc_str(exc))
                             pass
-                if self._repo is None:
-                    lgr.info("Failed to detect a valid repo at %s" % self.path)
+                        # version problems come as RuntimeError: DO NOT CATCH!
+            if self._repo is None:
+                lgr.info("Failed to detect a valid repo at %s" % self.path)
 
         elif not isinstance(self._repo, AnnexRepo):
             # repo was initially set to be self._repo but might become AnnexRepo

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -130,11 +130,16 @@ class Dataset(object):
                             self._repo = cls(self._path, create=False, **kw)
                             break
                         except (InvalidGitRepositoryError, NoSuchPathError) as exc:
-                            lgr.debug("Oops -- guess on repo type was wrong?: %s", exc_str(exc))
+                            lgr.debug(
+                                "Oops -- guess on repo type was wrong?: %s",
+                                exc_str(exc))
                             pass
                         # version problems come as RuntimeError: DO NOT CATCH!
             if self._repo is None:
-                lgr.info("Failed to detect a valid repo at %s" % self.path)
+                # Often .repo is requested to 'sense' if anything is installed
+                # under, and if so -- to proceed forward. Thus log here only
+                # at DEBUG level and if necessary "complaint upstairs"
+                lgr.debug("Failed to detect a valid repo at %s" % self.path)
 
         elif not isinstance(self._repo, AnnexRepo):
             # repo was initially set to be self._repo but might become AnnexRepo
@@ -426,7 +431,12 @@ class Dataset(object):
             path = relpath(path, self.path)
 
         candidates = []
+        # TODO: this one would follow all the sub-datasets, which might
+        # be inefficient if e.g. there is lots of other sub-datasets already
+        # installed but under another sub-dataset.  There is a TODO 'pattern'
+        # option which we could use I guess eventually
         for subds in self.get_subdatasets(recursive=True,
+                                          #pattern=
                                           recursion_limit=recursion_limit,
                                           absolute=False):
             common = commonprefix((with_pathsep(subds), with_pathsep(path)))

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -365,6 +365,9 @@ class Dataset(object):
     def get_containing_subdataset(self, path, recursion_limit=None):
         """Get the (sub-)dataset containing `path`
 
+        Note: The "mount point" of a subdataset is classified as belonging to
+        that respective subdataset.
+
         Parameters
         ----------
         path : str

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -369,7 +369,7 @@ class Dataset(object):
         path = self.path
         sds_path = path if topmost else None
         while path:
-            par_path = opj(path, pardir)
+            par_path = normpath(opj(path, pardir))
             sds_path_ = GitRepo.get_toppath(par_path)
             if sds_path_ is None:
                 # no more parents, use previous found
@@ -391,11 +391,12 @@ class Dataset(object):
             # None was found
             return None
 
-        if realpath(self.path) != self.path:
-            # we had symlinks in the path but sds_path would have not
-            # so let's get "symlinked" version of the superdataset path
-            sds_relpath = relpath(sds_path, realpath(self.path))
-            sds_path = normpath(opj(self.path, sds_relpath))
+        # I think we might have accounted for it with use of normpath there??
+        # if realpath(self.path) != self.path:
+        #     # we had symlinks in the path but sds_path would have not
+        #     # so let's get "symlinked" version of the superdataset path
+        #     sds_relpath = relpath(sds_path, realpath(self.path))
+        #     sds_path = normpath(opj(self.path, sds_relpath))
         return Dataset(sds_path)
 
     def get_containing_subdataset(self, path, recursion_limit=None):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -369,6 +369,8 @@ class Dataset(object):
         path = self.path
         sds_path = path if topmost else None
         while path:
+            # normalize the path after adding .. so we guaranteed to not
+            # follow into original directory if path itself is a symlink
             par_path = normpath(opj(path, pardir))
             sds_path_ = GitRepo.get_toppath(par_path)
             if sds_path_ is None:
@@ -391,12 +393,9 @@ class Dataset(object):
             # None was found
             return None
 
-        # I think we might have accounted for it with use of normpath there??
-        # if realpath(self.path) != self.path:
-        #     # we had symlinks in the path but sds_path would have not
-        #     # so let's get "symlinked" version of the superdataset path
-        #     sds_relpath = relpath(sds_path, realpath(self.path))
-        #     sds_path = normpath(opj(self.path, sds_relpath))
+        # No postprocessing now should be necessary since get_toppath
+        # tries its best to not resolve symlinks now
+
         return Dataset(sds_path)
 
     def get_containing_subdataset(self, path, recursion_limit=None):

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -118,6 +118,8 @@ def _sort_paths_into_datasets(paths, out=None, dir_lookup=None,
 
 def _get(content_by_ds, refpath=None, source=None, jobs=None,
          fulfill_datasets=False):
+    """Loops through datasets and calls git-annex call where appropriate
+    """
     for ds_path in sorted(content_by_ds.keys()):
         cur_ds = Dataset(ds_path)
         content = content_by_ds[ds_path]
@@ -130,7 +132,8 @@ def _get(content_by_ds, refpath=None, source=None, jobs=None,
             results.append(cur_ds)
             if not fulfill_datasets:
                 lgr.debug(
-                    "Will not get any content in subdataset %s without recursion enabled",
+                    "Will not get any content in subdataset %s without "
+                    "recursion enabled",
                     cur_ds)
                 yield results
                 continue
@@ -216,11 +219,12 @@ class Get(Interface):
     fulfill a request.
 
     Known data locations for each requested file are evaluated and data are
-    obtained from the best/fastest/cheapest location, unless a specific
-    source is identified.
+    obtained from some available location (according to git-annex configuration
+    and possibly assigned remote priorities), unless a specific source is
+    specified.
 
     .. note::
-      Power-user info: This command used :command:`git annex get` to fulfill
+      Power-user info: This command uses :command:`git annex get` to fulfill
       file handles.
     """
 
@@ -395,14 +399,15 @@ class Get(Interface):
         if not isinstance(res, list):
             res = [res]
         if not len(res):
-            ui.message("Got nothing")
+            ui.message("Got nothing new")
             return
 
         # provide summary
         nsuccess = sum(item.get('success', False) if isinstance(item, dict) else True
                        for item in res)
         nfailure = len(res) - nsuccess
-        msg = "Tried to get %d %s." % (len(res), single_or_plural("file", "files", len(res)))
+        msg = "Tried to get %d %s." % (
+            len(res), single_or_plural("file", "files", len(res)))
         if nsuccess:
             msg += " Got %d. " % nsuccess
         if nfailure:

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -26,6 +26,7 @@ from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_get_opts
 from datalad.interface.common_opts import jobs_opt
+from datalad.interface.common_opts import reckless_opt
 from datalad.interface.common_opts import verbose
 from datalad.support.constraints import EnsureInt
 from datalad.support.constraints import EnsureChoice
@@ -224,6 +225,7 @@ class Get(Interface):
             doc="""whether to obtain data for all file handles. If disabled, `get`
             operations are limited to dataset handles.[CMD:  This option prevents data
             for file handles from being obtained CMD]"""),
+        reckless=reckless_opt,
         git_opts=git_opts,
         annex_opts=annex_opts,
         annex_get_opts=annex_get_opts,
@@ -243,6 +245,7 @@ class Get(Interface):
             recursive=False,
             recursion_limit=None,
             get_data=True,
+            reckless=False,
             git_opts=None,
             annex_opts=None,
             annex_get_opts=None,
@@ -298,7 +301,7 @@ class Get(Interface):
             # any dataset at the very top
             assert ds.is_installed()
             # now actually obtain whatever is necessary to get to this path
-            containing_ds = install_necessary_subdatasets(ds, path)
+            containing_ds = install_necessary_subdatasets(ds, path, reckless)
             if containing_ds.path != ds.path:
                 lgr.debug("Installed %s to fulfill request for content for "
                           "path %s", containing_ds, path)
@@ -329,6 +332,7 @@ class Get(Interface):
                         # we count recursions from the input, hence we
                         # can start with the full number
                         recursion_limit,
+                        reckless,
                         # protect against magic marker misinterpretation
                         # only relevant for _get, hence replace here
                         start=content_path if content_path != curdir else None)

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -280,8 +280,11 @@ class Get(Interface):
             _sort_paths_into_datasets(resolved_paths,
                                       recursive=recursive,
                                       recursion_limit=recursion_limit)
-        lgr.debug("Found %i existing dataset(s) to get content in",
-                  len(content_by_ds))
+        lgr.debug(
+            "Found %i existing dataset(s) to get content in "
+            "and %d unavailable paths",
+            len(content_by_ds), len(unavailable_paths)
+        )
         # IMPORTANT NOTE re `content_by_ds`
         # each key is a subdataset that we need to get something in
         # if the value[0] is the subdataset's path, we want all of it

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -256,7 +256,7 @@ class Get(Interface):
             # Install.__call__ and done so to avoid creating another reusable
             # function which would need to duplicate all this heavy list of
             # kwargs
-            _return_paths=False
+            _return_datasets=False
     ):
 
         dataset_path = dataset.path if isinstance(dataset, Dataset) else dataset
@@ -371,13 +371,13 @@ class Get(Interface):
         results = list(chain.from_iterable(
             _get(content_by_ds, refpath=dataset_path, source=source, jobs=jobs,
                  get_data=get_data)))
-        # ??? should we in _return_paths case just return both content_by_ds
+        # ??? should we in _return_datasets case just return both content_by_ds
         # and unavailable_paths may be so we provide consistent across runs output
         # and then issue outside similar IncompleteResultsError?
         if unavailable_paths:  # and likely other error flags
             raise IncompleteResultsError(results)
         else:
-            return content_by_ds if _return_paths else results
+            return sorted(content_by_ds) if _return_datasets else results
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -12,6 +12,7 @@
 
 import logging
 
+from itertools import chain
 from os import curdir
 from os import linesep
 from os.path import isdir
@@ -199,13 +200,6 @@ def _recursive_install_subds_underneath(ds, recursion_limit, start=None):
     return content_by_ds
 
 
-def _unwind(generators):
-    res = []
-    for item in generators:
-        res.extend(item)
-    return res
-
-
 class Get(Interface):
     """Get any dataset content (files/directories/subdatasets).
 
@@ -386,9 +380,9 @@ class Get(Interface):
             lgr.warning('could not find and ignored paths: %s', unavailable_paths)
 
         # hand over to git-annex
-        return _unwind(
+        return list(chain.from_iterable(
             _get(content_by_ds, refpath=dataset_path, source=source, jobs=jobs,
-                 fulfill_datasets=fulfill_datasets))
+                 fulfill_datasets=fulfill_datasets)))
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -51,31 +51,6 @@ __docformat__ = 'restructuredtext'
 lgr = logging.getLogger('datalad.distribution.get')
 
 
-def _report_ifjustinstalled(ds, p, recursion_limit):
-    p_ds = None
-    fresh = None
-    try:
-        # where would the current dataset think this path belongs
-        present_container = ds.get_containing_subdataset(p, recursion_limit)
-        was_installed = present_container.is_installed()
-        # where does it actually belong
-        p_ds = install_necessary_subdatasets(ds, p)
-        # take note of whether the final subdataset just came to life
-        fresh = present_container.path != p_ds.path or not was_installed
-        if fresh:
-            lgr.debug("Installed necessary (sub-)datasets: %s", p_ds)
-    except PathOutsideRepositoryError as e:
-        lgr.warning(exc_str(e) + linesep + "Ignored.")
-    except Exception as e:
-        # skip p, if we didn't manage to install its containing
-        # subdataset
-        lgr.warning(
-            "Installation of necessary subdatasets for %s failed. Skipped.", p)
-        lgr.debug("Installation attempt failed with exception: %s",
-                  exc_str(e))
-    return p_ds, fresh
-
-
 def _sort_paths_into_datasets(paths, out=None, dir_lookup=None,
                               recursive=False, recursion_limit=None):
     """Returns dict of `existing dataset path`: `directory` mappings

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -375,7 +375,9 @@ class Get(Interface):
         # and unavailable_paths may be so we provide consistent across runs output
         # and then issue outside similar IncompleteResultsError?
         if unavailable_paths:  # and likely other error flags
-            raise IncompleteResultsError(results)
+            if _return_datasets:
+                results = sorted(set(content_by_ds).difference(unavailable_paths))
+            raise IncompleteResultsError(results, failed=unavailable_paths)
         else:
             return sorted(content_by_ds) if _return_datasets else results
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -179,6 +179,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, start=None):
             continue
         if not subds.is_installed():
             try:
+                lgr.info("Installing subdataset %s", subds.path)
                 subds = _install_subds_from_flexible_source(
                     ds, sub.path, sub.url)
                 # we want the entire thing, but mark this subdataset
@@ -351,7 +352,7 @@ class Get(Interface):
                         # a non-directory cannot have content underneath
                         continue
                     subds = Dataset(subdspath)
-                    lgr.info("Obtain content in %s underneath %s recursively",
+                    lgr.info("Obtaining content in %s underneath %s recursively",
                              subds, content_path)
                     cbysubds = _recursive_install_subds_underneath(
                         subds,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -334,8 +334,12 @@ class Get(Interface):
                         # a non-directory cannot have content underneath
                         continue
                     subds = Dataset(subdspath)
-                    lgr.info("Obtaining content in %s underneath %s recursively",
-                             subds, content_path)
+                    lgr.info(
+                        "Obtaining %s %s recursively",
+                        subds,
+                        ("underneath %s" % content_path
+                         if subds.path != content_path
+                         else ""))
                     cbysubds = _recursive_install_subds_underneath(
                         subds,
                         # `content_path` was explicitly given as input

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -21,6 +21,7 @@ from datalad.interface.base import Interface
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 from datalad.interface.common_opts import dataset_description
+from datalad.interface.common_opts import jobs_opt
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import git_clone_opts
 from datalad.interface.common_opts import annex_opts
@@ -141,7 +142,9 @@ class Install(Interface):
         git_opts=git_opts,
         git_clone_opts=git_clone_opts,
         annex_opts=annex_opts,
-        annex_init_opts=annex_init_opts)
+        annex_init_opts=annex_init_opts,
+        jobs=jobs_opt,
+    )
 
     @staticmethod
     @datasetmethod(name='install')
@@ -159,7 +162,8 @@ class Install(Interface):
             git_opts=None,
             git_clone_opts=None,
             annex_opts=None,
-            annex_init_opts=None):
+            annex_init_opts=None,
+            jobs=None):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`
@@ -196,6 +200,7 @@ class Install(Interface):
                 git_opts=git_opts,
                 annex_opts=annex_opts,
                 reckless=reckless,
+                jobs=jobs,
             )
 
             # first install, and then get
@@ -217,7 +222,6 @@ class Install(Interface):
                 # all commented out hint on inability to pass those options
                 # into underlying install-related calls.
                 # Also need to pass from get:
-                #  jobs
                 #  annex_get_opts
                 content_by_ds = Get.__call__(
                     to_get,

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -432,7 +432,8 @@ class Install(Interface):
             # this should not be, check if this is an error, or a reinstall
             # from the same source
             # this is where we would have installed this from
-            candidate_sources = _get_flexible_url_candidates(source)
+            candidate_sources = _get_flexible_url_candidates(
+                source, destination_dataset.path)
             # this is where it was installed from
             track_name, track_url = _get_tracking_source(destination_dataset)
             if track_url in candidate_sources or get_local_file_url(track_url):

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -429,7 +429,7 @@ class Install(Interface):
                 reckless)
         else:
             # FLOW GUIDE: 2.
-            lgr.info("Installing dataset at: {0}".format(path))
+            lgr.info("Installing dataset at {0} from {1}".format(path, source))
 
             # Currently assuming there is nothing at the target to deal with
             # and rely on failures raising from the git call ...

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -493,21 +493,27 @@ class Install(Interface):
                 recursion_limit=recursion_limit,
                 absolute=False)
 
-            rec_installed = Get.__call__(
-                subs,  # all at once
-                dataset=destination_dataset,
-                recursive=True,
-                recursion_limit=recursion_limit,
-                fulfill='all' if get_data else 'auto',
-                git_opts=git_opts,
-                annex_opts=annex_opts,
-                # TODO expose this
-                #annex_get_opts=annex_get_opts,
-            )
-            if isinstance(rec_installed, list):
-                installed_items.extend(rec_installed)
-            else:
-                installed_items.append(rec_installed)
+            if subs:
+                lgr.debug("Obtaining subdatasets of %s: %s",
+                          destination_dataset,
+                          subs)
+                rec_installed = Get.__call__(
+                    subs,  # all at once
+                    dataset=destination_dataset,
+                    recursive=True,
+                    recursion_limit=recursion_limit,
+                    fulfill='all' if get_data else 'auto',
+                    git_opts=git_opts,
+                    annex_opts=annex_opts,
+                    # TODO expose this
+                    #annex_get_opts=annex_get_opts,
+                )
+                # TODO do we want to filter this so `install` only returns
+                # the datasets?
+                if isinstance(rec_installed, list):
+                    installed_items.extend(rec_installed)
+                else:
+                    installed_items.append(rec_installed)
 
         if get_data:
             lgr.debug("Getting data of {0}".format(destination_dataset))

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -266,13 +266,13 @@ class Install(Interface):
     (remote) location identified via a URL or path. Optional recursion into
     potential subdatasets, and download of all referenced data is supported.
     The new dataset can be optionally registered in an existing
-    :term:`superdataset` (the new dataset's path needs to be located within the
-    superdataset for that, and the superdataset will be detected
-    automatically). It is recommended to provide a brief description to label
-    the dataset's nature *and* location, e.g. "Michael's music on black
-    laptop". This helps humans to identify data locations in distributed
-    scenarios.  By default an identifier comprised of user and machine name,
-    plus path will be generated.
+    :term:`superdataset` by identifying it via the `dataset` argument (the new
+    dataset's path needs to be located within the superdataset for that).
+
+    It is recommended to provide a brief description to label the dataset's
+    nature *and* location, e.g. "Michael's music on black laptop". This helps
+    humans to identify data locations in distributed scenarios.  By default an
+    identifier comprised of user and machine name, plus path will be generated.
 
     When only partial dataset content shall be obtained, it is recommended to
     use this command without the `get-data` flag, followed by a

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -513,7 +513,7 @@ class Install(Interface):
                     dataset=destination_dataset,
                     recursive=True,
                     recursion_limit=recursion_limit,
-                    fulfill='all' if get_data else 'auto',
+                    fulfill_datasets=get_data,
                     git_opts=git_opts,
                     annex_opts=annex_opts,
                     # TODO expose this

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -478,9 +478,10 @@ class Install(Interface):
 
         # everything done => save changes:
         if save and ds is not None:
-            # Note: The only possible changes are installed subdatasets, we
+            # Note: The only possible change is the installed subdataset, we
             # didn't know before.
-            lgr.info("Saving changes to {0}".format(ds))
+            lgr.info("Saving possible change to {0} installed {1}".format(
+                ds, relpath(path, ds.path)))
             ds.save(
                 message='[DATALAD] installed subdataset{0}:{1}'.format(
                     "s" if len(installed_items) > 1 else "",

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -167,10 +167,6 @@ class Install(Interface):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`
-        if path == []:
-            path = None
-        if path is None:
-            path = []
         path = assure_list(path)
 
         if not source and not path:
@@ -244,6 +240,11 @@ class Install(Interface):
 
             return installed_items[0] \
                 if len(installed_items) == 1 else installed_items
+
+        if source and path and len(path) > 1:
+            raise ValueError(
+                "install needs a single PATH when source is provided.  "
+                "Was given mutliple PATHs: %s" % str(path))
 
         # parameter constraints:
         if not source:

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -250,7 +250,7 @@ def _install_subds_from_flexible_source(ds, sm_path, sm_url):
 
 
 class Install(Interface):
-    """Install a dataset or subdataset.
+    """Install a dataset from a (remote) source.
 
     This command creates a local :term:`sibling` of an existing dataset from a
     (remote) location identified via a URL or path. Optional recursion into
@@ -281,6 +281,7 @@ class Install(Interface):
             # TODO: this probably changes to install into the dataset (add_to_super)
             # and to install the thing 'just there' without operating 'on' a dataset.
             # Adapt doc.
+            # MIH: `shouldn't this be the job of `add`?
             doc="""specify the dataset to perform the install operation on.  If
             no dataset is given, an attempt is made to identify the dataset
             in a parent directory of the current working directory and/or the

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -122,7 +122,7 @@ class Install(Interface):
             provided a destination path will be derived from a source URL
             similar to :command:`git clone`"""),
         source=Parameter(
-            args=('source',),
+            args=("-s", "--source"),
             metavar='SOURCE',
             doc="URL or local path of the installation source",
             constraints=EnsureStr() | EnsureNone()),

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -181,7 +181,7 @@ def _clone_from_any_source(sources, dest):
                 raise
 
 
-def _install_subds_from_flexible_source(ds, sm_path, sm_url, recursive):
+def _install_subds_from_flexible_source(ds, sm_path, sm_url):
     """Tries to obtain a given subdataset from several meaningful locations"""
 
     # shortcut
@@ -442,8 +442,7 @@ class Install(Interface):
             destination_dataset = _install_subds_from_flexible_source(
                 ds,
                 relativepath,
-                source,
-                recursive=False)
+                source)
         else:
             # FLOW GUIDE: 2.
             lgr.info("Installing dataset at: {0}".format(path))

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -231,12 +231,12 @@ class Install(Interface):
                     # save=save,
                     # git_clone_opts=git_clone_opts,
                     # annex_init_opts=annex_init_opts
-                    _return_paths=True,
+                    _return_datasets=True,
                     **common_kwargs
                 )
 
                 # compose content_by_ds into result
-                for dspath in sorted(content_by_ds):
+                for dspath in content_by_ds:
                     ds_ = Dataset(dspath)
                     if ds_.is_installed():
                         installed_items.append(ds_)

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -219,16 +219,24 @@ class Install(Interface):
                 # Also need to pass from get:
                 #  jobs
                 #  annex_get_opts
-                result = Get.__call__(
+                content_by_ds = Get.__call__(
                     to_get,
                     # description=description,
                     # if_dirty=if_dirty,
                     # save=save,
                     # git_clone_opts=git_clone_opts,
                     # annex_init_opts=annex_init_opts
+                    _return_paths=True,
                     **common_kwargs
                 )
-                installed_items += assure_list(result)
+
+                # compose content_by_ds into result
+                for dspath in sorted(content_by_ds):
+                    ds_ = Dataset(dspath)
+                    if ds_.is_installed():
+                        installed_items.append(ds_)
+                    else:
+                        lgr.warning("%s was not installed", ds_)
 
             return installed_items[0] \
                 if len(installed_items) == 1 else installed_items

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -52,7 +52,7 @@ from .dataset import EnsureDataset
 from .get import Get
 from .utils import _get_git_url_from_source
 from .utils import _install_subds_from_flexible_source
-from .utils import _get_flexible_url_candidates
+from .utils import _get_flexible_source_candidates
 from .utils import _get_tracking_source
 from .utils import _clone_from_any_source
 from .utils import _handle_possible_annex_dataset
@@ -365,7 +365,7 @@ class Install(Interface):
             # this should not be, check if this is an error, or a reinstall
             # from the same source
             # this is where we would have installed this from
-            candidate_sources = _get_flexible_url_candidates(
+            candidate_sources = _get_flexible_source_candidates(
                 source, destination_dataset.path)
             # this is where it was installed from
             track_name, track_url = _get_tracking_source(destination_dataset)
@@ -435,7 +435,7 @@ class Install(Interface):
             # and rely on failures raising from the git call ...
 
             # We possibly need to consider /.git URL
-            candidate_sources = _get_flexible_url_candidates(source)
+            candidate_sources = _get_flexible_source_candidates(source)
             _clone_from_any_source(candidate_sources, destination_dataset.path)
 
         # FLOW GUIDE: All four cases done.

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -357,7 +357,11 @@ class Install(Interface):
         if path is not None:
             # Should work out just fine for regular paths, so no additional
             # conditioning is necessary
-            path_ri = RI(path)
+            try:
+                path_ri = RI(path)
+            except Exception as e:
+                raise ValueError(
+                    "invalid path argument {}: ({})".format(path, exc_str(e)))
             try:
                 # Wouldn't work for SSHRI ATM, see TODO within SSHRI
                 path = resolve_path(path_ri.localpath, dataset)
@@ -370,7 +374,8 @@ class Install(Interface):
                     # between path and name of a submodule, we need to consider
                     # this.
                     # For now: Just raise
-                    raise ValueError("Invalid path argument {0}".format(path))
+                    raise ValueError(
+                        "Invalid destination path {0}".format(path))
 
         # `path` resolved, if there was any.
 

--- a/datalad/distribution/tests/test_add_sibling.py
+++ b/datalad/distribution/tests/test_add_sibling.py
@@ -36,7 +36,7 @@ from datalad.tests.utils import ok_clean_git
 def test_add_sibling(origin, repo_path):
 
     # prepare src
-    source = install(repo_path, source=origin), recursive=True)[0]
+    source = install(repo_path, source=origin, recursive=True)[0]
 
     res = add_sibling(dataset=source, name="test-remote",
                       url="http://some.remo.te/location")

--- a/datalad/distribution/tests/test_add_sibling.py
+++ b/datalad/distribution/tests/test_add_sibling.py
@@ -36,7 +36,7 @@ from datalad.tests.utils import ok_clean_git
 def test_add_sibling(origin, repo_path):
 
     # prepare src
-    source = install(origin, path=repo_path, recursive=True)[0]
+    source = install(repo_path, source=origin), recursive=True)[0]
 
     res = add_sibling(dataset=source, name="test-remote",
                       url="http://some.remo.te/location")

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -202,7 +202,7 @@ def test_subdatasets(path):
     eq_(ds.get_superdataset(topmost=True), ds)
 
     # add itself as a subdataset (crazy, isn't it?)
-    subds = ds.install(path, path='subds')
+    subds = ds.install('subds', source=path)
     assert_true(subds.is_installed())
     eq_(subds.get_superdataset(), ds)
     eq_(subds.get_superdataset(topmost=True), ds)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -225,6 +225,7 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "subsub", "some")).path, subsubds.path)
     # the top of a subdataset belongs to the subdataset
     eq_(ds.get_containing_subdataset(opj("sub", "subsub")).path, subsubds.path)
+    eq_(GitRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     eq_(ds.get_containing_subdataset("some").path, ds.path)
@@ -233,6 +234,11 @@ def test_get_containing_subdataset(path):
     shutil.rmtree(subds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
+    # # but now GitRepo disagrees...
+    eq_(GitRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    # and this stays, even if we give the mount point directory back
+    os.makedirs(subds.path)
+    eq_(GitRepo.get_toppath(opj(ds.path, "sub")), ds.path)
 
     outside_path = opj(os.pardir, "somewhere", "else")
     assert_raises(PathOutsideRepositoryError, ds.get_containing_subdataset,

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -12,6 +12,7 @@
 import os
 import shutil
 from os.path import join as opj, abspath, normpath
+from os.path import join as realpath
 
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
 from datalad.api import create
@@ -252,7 +253,7 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "subsub", "some")).path, subsubds.path)
     # the top of a subdataset belongs to the subdataset
     eq_(ds.get_containing_subdataset(opj("sub", "subsub")).path, subsubds.path)
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
+    eq_(GitRepo.get_toppath(opj(ds.path, "sub", "subsub")), realpath(subsubds.path))
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     eq_(ds.get_containing_subdataset("some").path, ds.path)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -223,12 +223,16 @@ def test_get_containing_subdataset(path):
     subsubds = subds.create("subsub")
 
     eq_(ds.get_containing_subdataset(opj("sub", "subsub", "some")).path, subsubds.path)
+    # the top of a subdataset belongs to the subdataset
+    eq_(ds.get_containing_subdataset(opj("sub", "subsub")).path, subsubds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
+    eq_(ds.get_containing_subdataset("sub").path, subds.path)
     eq_(ds.get_containing_subdataset("some").path, ds.path)
     # make sure the subds is found, even when it is not present, but still
     # known
     shutil.rmtree(subds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
+    eq_(ds.get_containing_subdataset("sub").path, subds.path)
 
     outside_path = opj(os.pardir, "somewhere", "else")
     assert_raises(PathOutsideRepositoryError, ds.get_containing_subdataset,

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -345,7 +345,7 @@ def test_get_mixed_hierarchy(src, path):
     origin.save(auto_add_changes=True)
 
     # now, install that thing:
-    ds, subds = install(path, source=src), recursive=True)
+    ds, subds = install(path, source=src, recursive=True)
     ok_(subds.repo.file_has_content("file_in_annex.txt") is False)
 
     # and get:

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -277,7 +277,7 @@ def test_get_greedy_recurse_subdatasets(src, path):
     ds = install(src, path=path)
 
     # GIMME EVERYTHING
-    ds.get(['subm 1', 'subm 2'], fulfill='all')
+    ds.get(['subm 1', 'subm 2'], fulfill_datasets=True)
 
     # We got all content in the subdatasets
     subds1, subds2 = [Dataset(d) for d in ds.get_subdatasets(absolute=True)]

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -111,6 +111,7 @@ def test_get_invalid_call(path, file_outside):
 def test_get_single_file(path):
 
     ds = Dataset(path)
+    ok_(ds.is_installed())
     ok_(ds.repo.file_has_content('test-annex.dat') is False)
     result = ds.get("test-annex.dat")
     eq_(len(result), 1)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -352,3 +352,20 @@ def test_autoresolve_multiple_datasets(src, path):
         eq_(len(results), 2)
         ok_(ds1.repo.file_has_content('test-annex.dat') is True)
         ok_(ds2.repo.file_has_content('test-annex.dat') is True)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_get_autoresolve_recurse_subdatasets(src, path):
+
+    origin = Dataset(src).create()
+    origin_sub = origin.create('sub')
+    origin_subsub = origin_sub.create('subsub')
+    with open(opj(origin_subsub.path, 'file_in_annex.txt'), "w") as f:
+        f.write('content')
+    origin.save(recursive=True, auto_add_changes=True)
+
+    ds = install(src, path=path)
+
+    result = get(opj(ds.path, 'sub'), recursive=True)
+    print result

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -143,7 +143,7 @@ def test_get_multiple_files(path, url, ds_dir):
     origin.add(file_list)
     origin.save("initial")
 
-    ds = install(path, path=ds_dir)
+    ds = install(ds_dir, source=path)
 
     # no content present:
     ok_(not any(ds.repo.file_has_content(file_list)))
@@ -179,7 +179,7 @@ def test_get_recurse_dirs(o_path, c_path):
     origin = Dataset(o_path).create(force=True)
     origin.save("Initial", auto_add_changes=True)
 
-    ds = install(o_path, path=c_path)
+    ds = install(c_path, source=o_path)
 
     file_list = ['file1.txt',
                  opj('subdir', 'file2.txt'),
@@ -210,7 +210,7 @@ def test_get_recurse_dirs(o_path, c_path):
 @with_tempfile(mkdir=True)
 def test_get_recurse_subdatasets(src, path):
 
-    ds = install(src, path=path)
+    ds = install(path, source=src)
 
     # ask for the two subdatasets specifically. This will obtain them,
     # but not any content of any files in them
@@ -274,7 +274,7 @@ def test_get_recurse_subdatasets(src, path):
 @with_tempfile(mkdir=True)
 def test_get_greedy_recurse_subdatasets(src, path):
 
-    ds = install(src, path=path)
+    ds = install(path, source=src)
 
     # GIMME EVERYTHING
     ds.get(['subm 1', 'subm 2'], fulfill_datasets=True)
@@ -290,7 +290,7 @@ def test_get_greedy_recurse_subdatasets(src, path):
 @with_tempfile(mkdir=True)
 def test_get_install_missing_subdataset(src, path):
 
-    ds = install(src, path=path)
+    ds = install(path, source=src)
     subs = [Dataset(s_path) for s_path in ds.get_subdatasets(absolute=True)]
     ok_(all([not sub.is_installed() for sub in subs]))
 
@@ -327,7 +327,7 @@ def test_get_mixed_hierarchy(src, path):
     origin.save(auto_add_changes=True)
 
     # now, install that thing:
-    ds, subds = install(src, path=path, recursive=True)
+    ds, subds = install(path, source=src), recursive=True)
     ok_(subds.repo.file_has_content("file_in_annex.txt") is False)
 
     # and get:
@@ -345,8 +345,8 @@ def test_get_mixed_hierarchy(src, path):
 @with_tempfile(mkdir=True)
 def test_autoresolve_multiple_datasets(src, path):
     with chpwd(path):
-        ds1 = install(src, path='ds1')
-        ds2 = install(src, path='ds2')
+        ds1 = install('ds1', source=src)
+        ds2 = install('ds2', source=src)
         results = get([opj('ds1', 'test-annex.dat')] + glob(opj('ds2', '*.dat')))
         # each ds has one file
         eq_(len(results), 2)
@@ -365,7 +365,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
         f.write('content')
     origin.save(recursive=True, auto_add_changes=True)
 
-    ds = install(src, path=path)
+    ds = install(path, source=src)
     eq_(len(ds.get_subdatasets(fulfilled=True)), 0)
 
     results = get(opj(ds.path, 'sub'), recursive=True)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -366,6 +366,14 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     origin.save(recursive=True, auto_add_changes=True)
 
     ds = install(src, path=path)
+    eq_(len(ds.get_subdatasets(fulfilled=True)), 0)
 
-    result = get(opj(ds.path, 'sub'), recursive=True)
-    print result
+    results = get(opj(ds.path, 'sub'), recursive=True)
+    eq_(len(ds.get_subdatasets(fulfilled=True, recursive=True)), 2)
+    subsub = Dataset(opj(ds.path, 'sub', 'subsub'))
+    ok_(subsub.is_installed())
+    assert_in(subsub, results)
+    # 'subsub' did not exist prior the get-call above, hence while it
+    # is now installed its file handles are not fulfilled
+    ok_(Dataset(opj(ds.path, 'sub', 'subsub')).repo.file_has_content(
+        "file_in_annex.txt") is False)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -15,6 +15,7 @@ import re
 
 from os import curdir
 from os.path import join as opj, basename
+from glob import glob
 
 from datalad.api import get
 from datalad.api import install
@@ -34,6 +35,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import assert_re_in
 from datalad.utils import swallow_logs
+from datalad.utils import chpwd
 
 from ..dataset import Dataset
 from ..dataset import _with_sep
@@ -337,3 +339,14 @@ def test_get_mixed_hierarchy(src, path):
         eq_(result[0]['file'], opj("subds", "file_in_annex.txt"))
         ok_(result[0]['success'] is True)
         ok_(subds.repo.file_has_content("file_in_annex.txt") is True)
+
+
+@with_testrepos('submodule_annex', flavors='local')
+@with_tempfile(mkdir=True)
+def test_autoresolve_multiple_datasets(src, path):
+    with chpwd(path):
+        ds1 = install(src, path='ds1')
+        ds2 = install(src, path='ds2')
+        results = get([opj('ds1', 'test-annex.dat')] + glob(opj('ds2', '*.dat')))
+        # for now -- doesn't even get here
+        ok_(len(result))

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -404,13 +404,13 @@ def test_recurse_existing(src, path):
     # make sure recursion_limit works as expected across a range of depths
     for depth in range(len(origin_ds)):
         datasets = assure_list(
-            install(src, path, recursive=True, recursion_limit=depth))
+            install(path, source=src, recursive=True, recursion_limit=depth))
         # we expect one dataset per level
         eq_(len(datasets), depth + 1)
         rmtree(path)
 
     # now install all but the last two levels, no data
-    root, sub1, sub2 = install(src, path, recursive=True, recursion_limit=2)
+    root, sub1, sub2 = install(path, source=src, recursive=True, recursion_limit=2)
     ok_(sub2.repo.file_has_content('file_in_annex.txt') is False)
     sub3 = Dataset(opj(sub2.path, 'sub3'))
     ok_(not sub3.is_installed())
@@ -434,7 +434,7 @@ def test_recurse_existing(src, path):
 @with_tempfile(mkdir=True)
 def test_get_in_unavailable_subdataset(src, path):
     origin_ds = _make_dataset_hierarchy(src)
-    root = install(src, path)
+    root = install(path, source=src)
     targetpath = opj('sub1', 'sub2')
     targetabspath = opj(root.path, targetpath)
     get(targetabspath)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -94,13 +94,13 @@ def test_get_invalid_call(path, file_outside):
     with swallow_logs(new_level=logging.WARNING) as cml:
         result = ds.get("NotExistingFile.txt")
         eq_(len(result), 0)
-        assert_in("NotExistingFile.txt not found. Ignored.", cml.out)
+        assert_in("could not find and ignored", cml.out)
 
     # path outside repo:
     with swallow_logs(new_level=logging.WARNING) as cml:
         result = ds.get(file_outside)
         eq_(len(result), 0)
-        assert_in("path {0} not within repository {1}".format(file_outside, ds),
+        assert_in("{0} is not part of a dataset, ignored".format(file_outside, ds),
                   cml.out)
 
     # TODO: annex --json doesn't report anything when get fails to do get a
@@ -348,5 +348,7 @@ def test_autoresolve_multiple_datasets(src, path):
         ds1 = install(src, path='ds1')
         ds2 = install(src, path='ds2')
         results = get([opj('ds1', 'test-annex.dat')] + glob(opj('ds2', '*.dat')))
-        # for now -- doesn't even get here
-        ok_(len(result))
+        # each ds has one file
+        eq_(len(results), 2)
+        ok_(ds1.repo.file_has_content('test-annex.dat') is True)
+        ok_(ds2.repo.file_has_content('test-annex.dat') is True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -131,8 +131,10 @@ def test_insufficient_args():
 @with_tempfile(mkdir=True)
 def test_invalid_args(path):
     assert_raises(ValueError, install, 'Zoidberg', path='Zoidberg')
-    # install to a remote location
+    # install to an invalid URL
     assert_raises(ValueError, install, 'Zoidberg', path='ssh://mars:Zoidberg')
+    # install to a remote location
+    assert_raises(ValueError, install, 'Zoidberg', path='ssh://mars/Zoidberg')
     # make fake dataset
     ds = create(path)
     assert_raises(ValueError, install, 'Zoidberg', path='/higherup.', dataset=ds)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -16,6 +16,8 @@ from os.path import join as opj
 from os.path import isdir
 from os.path import exists
 from os.path import realpath
+from os.path import basename
+from os.path import dirname
 
 from mock import patch
 
@@ -697,3 +699,12 @@ def test_install_noautoget_data(src, path):
     # and none of those should have any data for their annexed files yet
     for ds in cdss:
         assert_false(any(ds.repo.file_has_content(ds.repo.get_annexed_files())))
+
+
+@with_tempfile
+@with_tempfile
+def test_install_source_relpath(src, dest):
+    ds1 = create(src)
+    src_ = basename(src)
+    with chpwd(dirname(src)):
+        ds2 = install(dest, source=src_)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -221,6 +221,7 @@ def test_install_simple_local(src, path):
         ok_clean_git(path, annex=True)
         # no content was installed:
         ok_(not ds.repo.file_has_content('test-annex.dat'))
+        uuid_before = ds.repo.uuid
 
     # installing it again, shouldn't matter:
     with swallow_logs(new_level=logging.INFO) as cml:
@@ -228,6 +229,8 @@ def test_install_simple_local(src, path):
         cml.assert_logged(msg="{0} was already installed from".format(ds),
                           regex=False, level="INFO")
         ok_(ds.is_installed())
+        if isinstance(origin.repo, AnnexRepo):
+            eq_(uuid_before, ds.repo.uuid)
 
 
 @with_testrepos(flavors=['local-url', 'network', 'local'])

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -532,7 +532,7 @@ def test_install_recursive_repeat(src, path):
     ok_(subsub.is_installed() is False)
 
     # install again, now with data and recursive, but recursion_limit 1:
-    result = get(os.curdir, dataset=path, fulfill='all', recursive=True, recursion_limit=1)
+    result = get(os.curdir, dataset=path, fulfill_datasets=True, recursive=True, recursion_limit=1)
     # top-level dataset was not reobtained
     assert_not_in(top_ds, result)
     assert_in(sub1, result)
@@ -543,7 +543,7 @@ def test_install_recursive_repeat(src, path):
     ok_(sub2.repo.file_has_content('sub2file.txt') is True)
 
     # install sub1 again, recursively:
-    top_ds.get('sub 1', recursive=True, fulfill='all')
+    top_ds.get('sub 1', recursive=True, fulfill_datasets=True)
     ok_(subsub.is_installed())
     ok_(subsub.repo.file_has_content('subsubfile.txt'))
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -180,7 +180,7 @@ def test_install_datasets_root(tdir):
         # do it a second time:
         with swallow_logs(new_level=logging.INFO) as cml:
             result = install("///")
-            assert_in("appears to be installed already.", cml.out)
+            assert_in("was already installed from", cml.out)
             eq_(result, ds)
 
         # and a third time into an existing something, that is not a dataset:
@@ -225,7 +225,7 @@ def test_install_simple_local(src, path):
     # installing it again, shouldn't matter:
     with swallow_logs(new_level=logging.INFO) as cml:
         ds = install(src, path=path)
-        cml.assert_logged(msg="{0} appears to be installed already.".format(ds),
+        cml.assert_logged(msg="{0} was already installed from".format(ds),
                           regex=False, level="INFO")
         ok_(ds.is_installed())
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -396,6 +396,12 @@ def test_install_into_dataset(source, top_path):
     eq_(subds_.path, opj(ds.path, "sub2"))  # for paranoid yoh ;)
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
+    # and we should achieve the same behavior if we create a dataset
+    # and then decide to "add" it
+    create(_path_(top_path, 'sub3'), if_dirty='ignore')
+    ok_clean_git(ds.path, untracked=['dummy.txt', 'sub3/'])
+    ds.install('sub3', if_dirty='ignore')
+    ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -238,7 +238,7 @@ def test_install_simple_local(src, path):
 @with_tempfile
 def test_install_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
-        ds = install(url)
+        ds = install(source=url)
 
     ok_startswith(ds.path, path)
     ok_(ds.is_installed())

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -295,9 +295,9 @@ def test_install_recursive(src, path_nr, path_r):
 
     # now recursively:
     ds_list = install(src, path=path_r, recursive=True)
-    # installed a dataset and two subdatasets:
+    # installed a dataset and two subdatasets
     eq_(len(ds_list), 3)
-    ok_(all([isinstance(i, Dataset) for i in ds_list]))
+    eq_(sum([isinstance(i, Dataset) for i in ds_list]), 3)
     # we recurse top down during installation, so toplevel should appear at
     # first position in returned list
     eq_(ds_list[0].path, path_r)
@@ -329,9 +329,9 @@ def test_install_recursive_with_data(src, path):
 
     # now again; with data:
     ds_list = install(src, path=path, recursive=True, get_data=True)
-    # installed a dataset and two subdatasets:
-    eq_(len(ds_list), 3)
-    ok_(all([isinstance(i, Dataset) for i in ds_list]))
+    # installed a dataset and two subdatasets, and two files:
+    eq_(len(ds_list), 5)
+    eq_(sum([isinstance(i, Dataset) for i in ds_list]), 3)
     # we recurse top down during installation, so toplevel should appear at
     # first position in returned list
     eq_(ds_list[0].path, path)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -532,7 +532,7 @@ def test_install_recursive_repeat(src, path):
     ok_(subsub.is_installed() is False)
 
     # install again, now with data and recursive, but recursion_limit 1:
-    result = get(os.curdir, dataset=path, recursive=True, recursion_limit=1)
+    result = get(os.curdir, dataset=path, fulfill='all', recursive=True, recursion_limit=1)
     # top-level dataset was not reobtained
     assert_not_in(top_ds, result)
     assert_in(sub1, result)
@@ -543,7 +543,7 @@ def test_install_recursive_repeat(src, path):
     ok_(sub2.repo.file_has_content('sub2file.txt') is True)
 
     # install sub1 again, recursively:
-    top_ds.get('sub 1', recursive=True)
+    top_ds.get('sub 1', recursive=True, fulfill='all')
     ok_(subsub.is_installed())
     ok_(subsub.repo.file_has_content('subsubfile.txt'))
 
@@ -623,6 +623,6 @@ def test_install_noautoget_data(src, path):
     # install top level:
     cdss = install(src, path=path, recursive=True)
     # there should only be datasets in the list of installed items,
-    # and non of those should have any data for there annexed files yet
+    # and none of those should have any data for their annexed files yet
     for ds in cdss:
         assert_false(any(ds.repo.file_has_content(ds.repo.get_annexed_files())))

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -40,7 +40,7 @@ from datalad.tests.utils import assert_not_in
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
-    source = install(src_path, source=origin), recursive=True)[0]
+    source = install(src_path, source=origin, recursive=True)[0]
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote("origin")
@@ -97,7 +97,7 @@ def test_publish_simple(origin, src_path, dst_path):
 def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # prepare src
-    source = install(src_path, source=origin), recursive=True)[0]
+    source = install(src_path, source=origin, recursive=True)[0]
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
@@ -182,7 +182,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # prepare src
-    source = install(src_path, source=origin), recursive=True)[0]
+    source = install(src_path, source=origin, recursive=True)[0]
     source.repo.get('test-annex.dat')
 
     # create plain git at target:

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -40,7 +40,7 @@ from datalad.tests.utils import assert_not_in
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
-    source = install(origin, path=src_path, recursive=True)[0]
+    source = install(src_path, source=origin), recursive=True)[0]
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote("origin")
@@ -97,7 +97,7 @@ def test_publish_simple(origin, src_path, dst_path):
 def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # prepare src
-    source = install(origin, path=src_path, recursive=True)[0]
+    source = install(src_path, source=origin), recursive=True)[0]
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
@@ -182,7 +182,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # prepare src
-    source = install(origin, path=src_path, recursive=True)[0]
+    source = install(src_path, source=origin), recursive=True)[0]
     source.repo.get('test-annex.dat')
 
     # create plain git at target:

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -89,7 +89,7 @@ assert_create_sshwebserver = (
 def test_target_ssh_simple(origin, src_path, target_rootpath):
 
     # prepare src
-    source = install(origin, path=src_path)
+    source = install(src_path, source=origin)
 
     target_path = opj(target_rootpath, "basic")
     # it will try to fetch it so would fail as well since sshurl is wrong
@@ -256,7 +256,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
-    source = install(origin, path=src_path, recursive=True)[0]
+    source = install(src_path, source=origin), recursive=True)[0]
 
     sub1 = Dataset(opj(src_path, "subm 1"))
     sub2 = Dataset(opj(src_path, "subm 2"))

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -256,7 +256,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
-    source = install(src_path, source=origin), recursive=True)[0]
+    source = install(src_path, source=origin, recursive=True)[0]
 
     sub1 = Dataset(opj(src_path, "subm 1"))
     sub2 = Dataset(opj(src_path, "subm 2"))

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -84,7 +84,7 @@ def test_uninstall_invalid(path):
     if hasattr(ds.repo, 'drop'):
         assert_raises(Exception, uninstall, dataset=ds, path='not_existent')
     else:
-        eq_(uninstall('not_existent', source=dataset=ds)), [])
+        eq_(uninstall(dataset=ds, path='not_existent'), [])
 
 
 @with_testrepos('basic_annex', flavors=['clone'])

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -83,7 +83,7 @@ def test_uninstall_invalid(path):
     if hasattr(ds.repo, 'drop'):
         assert_raises(Exception, uninstall, dataset=ds, path='not_existent')
     else:
-        eq_(uninstall(dataset=ds, path='not_existent'), [])
+        eq_(uninstall('not_existent', source=dataset=ds)), [])
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
@@ -135,7 +135,7 @@ def test_uninstall_git_file(path):
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):
 
-    ds = install(src, path=dst, recursive=True)[0]
+    ds = install(dst, source=src), recursive=True)[0]
     ok_(ds.is_installed())
     for subds_path in ds.get_subdatasets():
         subds = Dataset(opj(ds.path, subds_path))

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -136,7 +136,7 @@ def test_uninstall_git_file(path):
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):
 
-    ds = install(dst, source=src), recursive=True)[0]
+    ds = install(dst, source=src, recursive=True)[0]
     ok_(ds.is_installed())
     for subds_path in ds.get_subdatasets():
         subds = Dataset(opj(ds.path, subds_path))

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -37,13 +37,13 @@ from datalad.tests.utils import ok_clean_git, swallow_outputs
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
-    source = install(origin, path=src_path, recursive=True)[0]
+    source = install(src_path, source=origin), recursive=True)[0]
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote("origin")
 
     # get a clone to update later on:
-    dest = install(src_path, path=dst_path, recursive=True)[0]
+    dest = install(dst_path, source=src_path), recursive=True)[0]
     # test setup done;
     # assert all fine
     ok_clean_git(dst_path)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -37,7 +37,7 @@ from datalad.tests.utils import ok_clean_git, swallow_outputs
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
-    source = install(src_path, source=origin), recursive=True)[0]
+    source = install(src_path, source=origin, recursive=True)[0]
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote("origin")

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -43,7 +43,7 @@ def test_update_simple(origin, src_path, dst_path):
     source.repo.remove_remote("origin")
 
     # get a clone to update later on:
-    dest = install(dst_path, source=src_path), recursive=True)[0]
+    dest = install(dst_path, source=src_path, recursive=True)[0]
     # test setup done;
     # assert all fine
     ok_clean_git(dst_path)

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -22,6 +22,7 @@ from os.path import dirname
 from mock import patch
 
 from datalad.distribution.utils import _get_flexible_source_candidates
+from datalad.distribution.utils import _get_flexible_source_candidates_for_submodule
 
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import with_tempfile
@@ -78,3 +79,33 @@ def test_get_flexible_source_candidates():
     # when source is not relative, but base_url is specified as just the destination path,
     # not really a "base url" as name was suggesting, then it should be ignored
     eq_(f('http://e.c/p', '/path'), ['http://e.c/p', 'http://e.c/p/.git'])
+
+
+@with_tempfile
+@with_tempfile
+def test_get_flexible_source_candidates_for_submodule(t, t2):
+    f = _get_flexible_source_candidates_for_submodule
+    # for now without mocking -- let's just really build a dataset
+    from datalad.api import create
+    from datalad.api import install
+    ds = create(t)
+    clone = install(t2, source=t)
+
+    # first one could just know about itself or explicit url provided
+    sshurl = 'ssh://e.c'
+    httpurl = 'http://e.c'
+    sm_httpurls = [httpurl, httpurl + '/.git']
+    eq_(f(ds, 'sub'), [])
+    eq_(f(ds, 'sub', sshurl), [sshurl])
+    eq_(f(ds, 'sub', httpurl), sm_httpurls)
+    eq_(f(ds, 'sub', None), [])  # otherwise really we have no clue were to get from
+
+    # but if we work on dsclone then it should also add urls deduced from its
+    # own location default remote for current branch
+    eq_(f(clone, 'sub'), [t + '/sub'])
+    eq_(f(clone, 'sub', sshurl), [t + '/sub', sshurl])
+    eq_(f(clone, 'sub', httpurl), [t + '/sub'] + sm_httpurls)
+    eq_(f(clone, 'sub'), [t + '/sub'])  # otherwise really we have no clue were to get from
+    # TODO: check that http:// urls for the dataset itself get resolved
+
+    # TODO: many more!!

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -62,15 +62,19 @@ def test_get_flexible_source_candidates():
               ):
         eq_(_get_flexible_source_candidates(s), [s])
     # Now a few relative ones
-    eq_(f('../r', base_url='.'), ['../r'])
-    eq_(f('../r', base_url='ssh://host/path'), ['ssh://host/r'])
-    eq_(f('sub', base_url='ssh://host/path'), ['ssh://host/path/sub'])
-    eq_(f('../r', base_url='http://e.c/p'), ['http://e.c/r', 'http://e.c/r/.git'])
-    eq_(f('sub', base_url='http://e.c/p'), ['http://e.c/p/sub', 'http://e.c/p/sub/.git'])
+    eq_(f('../r', '.'), ['../r'])
+    eq_(f('../r', 'ssh://host/path'), ['ssh://host/r'])
+    eq_(f('sub', 'ssh://host/path'), ['ssh://host/path/sub'])
+    eq_(f('../r', 'http://e.c/p'), ['http://e.c/r', 'http://e.c/r/.git'])
+    eq_(f('sub', 'http://e.c/p'), ['http://e.c/p/sub', 'http://e.c/p/sub/.git'])
 
     # tricky ones
-    eq_(f('sub', base_url='http://e.c/p/.git'), ['http://e.c/p/sub/.git'])
-    eq_(f('../s1/s2', base_url='http://e.c/p/.git'), ['http://e.c/s1/s2/.git'])
+    eq_(f('sub', 'http://e.c/p/.git'), ['http://e.c/p/sub/.git'])
+    eq_(f('../s1/s2', 'http://e.c/p/.git'), ['http://e.c/s1/s2/.git'])
 
     # incorrect ones will stay incorrect
-    eq_(f('../s1/s2', base_url='http://e.c/.git'), ['http://e.c/../s1/s2/.git'])
+    eq_(f('../s1/s2', 'http://e.c/.git'), ['http://e.c/../s1/s2/.git'])
+
+    # when source is not relative, but base_url is specified as just the destination path,
+    # not really a "base url" as name was suggesting, then it should be ignored
+    eq_(f('http://e.c/p', '/path'), ['http://e.c/p', 'http://e.c/p/.git'])

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -1,0 +1,76 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test distribution utils
+
+"""
+
+import logging
+import os
+
+from os.path import join as opj
+from os.path import isdir
+from os.path import exists
+from os.path import realpath
+from os.path import basename
+from os.path import dirname
+
+from mock import patch
+
+from datalad.distribution.utils import _get_flexible_source_candidates
+
+from datalad.tests.utils import create_tree
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import with_tree
+from datalad.tests.utils import with_testrepos
+from datalad.tests.utils import eq_
+from datalad.tests.utils import ok_
+from datalad.tests.utils import assert_false
+from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import ok_startswith
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import serve_path_via_http
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import use_cassette
+from datalad.tests.utils import skip_if_no_network
+from datalad.utils import _path_
+from datalad.utils import rmtree
+
+
+def test_get_flexible_source_candidates():
+    f = _get_flexible_source_candidates
+    # for http and https (dummy transport) we should get /.git source added
+    eq_(f('http://e.c'), ['http://e.c', 'http://e.c/.git'])
+    eq_(f('http://e.c/s/p'), ['http://e.c/s/p', 'http://e.c/s/p/.git'])
+    # for those candidates should be just the original address, since git
+    # understands those just fine
+    for s in ('http://e.c/.git',
+              '/',
+              'relative/path',
+              'smallrelative',
+              './neighbor',
+              '../../look/into/parent/bedroom',
+              'p:somewhere',
+              'user@host:/full/path',
+              ):
+        eq_(_get_flexible_source_candidates(s), [s])
+    # Now a few relative ones
+    eq_(f('../r', base_url='.'), ['../r'])
+    eq_(f('../r', base_url='ssh://host/path'), ['ssh://host/r'])
+    eq_(f('sub', base_url='ssh://host/path'), ['ssh://host/path/sub'])
+    eq_(f('../r', base_url='http://e.c/p'), ['http://e.c/r', 'http://e.c/r/.git'])
+    eq_(f('sub', base_url='http://e.c/p'), ['http://e.c/p/sub', 'http://e.c/p/sub/.git'])
+
+    # tricky ones
+    eq_(f('sub', base_url='http://e.c/p/.git'), ['http://e.c/p/sub/.git'])
+    eq_(f('../s1/s2', base_url='http://e.c/p/.git'), ['http://e.c/s1/s2/.git'])
+
+    # incorrect ones will stay incorrect
+    eq_(f('../s1/s2', base_url='http://e.c/.git'), ['http://e.c/../s1/s2/.git'])

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -408,3 +408,17 @@ def _handle_possible_annex_dataset(dataset, reckless):
         if reckless:
             repo._run_annex_command('untrust', annex_options=['here'])
 
+
+def _save_installed_datasets(ds, installed_datasets):
+    paths = [relpath(subds.path, ds.path) for subds in installed_datasets]
+    paths_str = ", ".join(paths)
+    msg = "installed subdataset{}: {}".format(
+        "s" if len(paths_str) > 1 else "", paths_str)
+    lgr.info("Saving possible changes to {0} - {1}".format(
+        ds, msg))
+    ds.save(
+        files=paths,
+        message='[DATALAD] ' + msg,
+        auto_add_changes=False,
+        recursive=False)
+

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -125,8 +125,6 @@ def install_necessary_subdatasets(ds, path, reckless):
     Dataset
       the last (deepest) subdataset, that was installed
     """
-    from .install import _install_subds_from_flexible_source
-
     assert ds.is_installed()
 
     # figuring out what dataset to start with:

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -402,7 +402,7 @@ def _handle_possible_annex_dataset(dataset, reckless):
                 "sources, if possible (reckless)", dataset.path)
             dataset.config.add(
                 'annex.hardlink', 'true', where='local', reload=True)
-        lgr.info("Initializing annex repo at %s", dataset.path)
+        lgr.debug("Initializing annex repo at %s", dataset.path)
         repo = AnnexRepo(dataset.path, init=True)
         if reckless:
             repo._run_annex_command('untrust', annex_options=['here'])

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -230,8 +230,9 @@ def _install_subds_from_flexible_source(ds, sm_path, sm_url, reckless):
         clone_url = _clone_from_any_source(clone_urls, subds.path)
     except GitCommandError as e:
         raise InstallFailedError(
-            "Failed to install dataset %s from %s (%s)",
-            subds, clone_urls, e)
+            msg="Failed to install dataset %s from %s (%s)" % (
+                subds, clone_urls, exc_str(e))
+            )
     # do fancy update
     if sm_path in ds.get_subdatasets(absolute=False, recursive=False):
         lgr.debug("Update cloned subdataset {0} in parent".format(subds))

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -138,8 +138,7 @@ def install_necessary_subdatasets(ds, path):
         _install_subds_from_flexible_source(
             cur_par_ds,
             submodule.path,
-            submodule.url,
-            recursive=False)
+            submodule.url)
 
         cur_par_ds = cur_subds
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -194,7 +194,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
             doc += '\n'
         doc += "Parameters\n----------\n"
         for i, arg in enumerate(args):
-            if arg == 'self':
+            if arg == 'self' or arg.startswith('_'):
                 continue
             # we need a parameter spec for each argument
             if not arg in params:
@@ -235,7 +235,7 @@ class Interface(object):
         if not defaults is None:
             ndefaults = len(defaults)
         for i, arg in enumerate(args):
-            if arg == 'self':
+            if arg == 'self' or arg.startswith('_'):
                 continue
             param = cls._params_[arg]
             defaults_idx = ndefaults - len(args) + i

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -174,6 +174,13 @@ def alter_interface_docs_for_cmdline(docs):
     return docs
 
 
+def is_api_arg(arg):
+    """Return True if argument is our API argument or self or used for internal
+    purposes
+    """
+    return arg != 'self' and not arg.startswith('_')
+
+
 def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
     """Generate a useful docstring from a parameter spec
 
@@ -194,7 +201,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
             doc += '\n'
         doc += "Parameters\n----------\n"
         for i, arg in enumerate(args):
-            if arg == 'self' or arg.startswith('_'):
+            if not is_api_arg(arg):
                 continue
             # we need a parameter spec for each argument
             if not arg in params:
@@ -235,7 +242,7 @@ class Interface(object):
         if not defaults is None:
             ndefaults = len(defaults)
         for i, arg in enumerate(args):
-            if arg == 'self' or arg.startswith('_'):
+            if not is_api_arg(arg):
                 continue
             param = cls._params_[arg]
             defaults_idx = ndefaults - len(args) + i
@@ -291,7 +298,7 @@ class Interface(object):
                            'result_renderer', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]
-        kwargs = {k: getattr(args, k) for k in argnames if k != 'self'}
+        kwargs = {k: getattr(args, k) for k in argnames if is_api_arg(k)}
         try:
             return cls.__call__(**kwargs)
         except KeyboardInterrupt as exc:

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -96,6 +96,16 @@ nosave_opt = Parameter(
     doc="""by default all modifications to a dataset are immediately saved. Given
     this option will disable this behavior.""")
 
+reckless_opt = Parameter(
+    args=("--reckless",),
+    action="store_true",
+    doc="""Set up the dataset to be able to obtain content in the
+    cheapest/fastest possible way, even if this poses a potential
+    risk the data integrity (e.g. hardlink files from a local clone
+    of the dataset). Use with care, and limit to "read-only" use
+    cases. With this flag the installed dataset will be marked as
+    untrusted.""")
+
 jobs_opt = Parameter(
     args=("-J", "--jobs"),
     metavar="NJOBS",

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -174,7 +174,7 @@ def test_ls_json(topdir):
     ds.add(path='subdsfile.txt')
     ds.save("Hello!", version_tag=1)
     # add a subdataset
-    ds.install(topdir, path='subds')
+    ds.install('subds', source=topdir)
 
     git = GitRepo(opj(topdir, 'dir', 'subgit'), create=True)                    # create git repo
     git.add(opj(topdir, 'dir', 'subgit', 'fgit.txt'), commit=True)              # commit to git to init git repo

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -125,7 +125,11 @@ class Search(Interface):
         try:
             ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
             if ds.id is None:
-                raise NoDatasetArgumentFound
+                raise NoDatasetArgumentFound(
+                    "There seems to be a repository which lacks a DataLad's "
+                    "dataset id, thus not considered to be a dataset. "
+                    "You can use 'datalad create --force %s' command to "
+                    "'initiate' that repository as a DataLad dataset" % ds.path)
         except NoDatasetArgumentFound:
             exc_info = sys.exc_info()
             if dataset is None:

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -162,7 +162,7 @@ class Search(Interface):
                              "meta-dataset under %r?"
                              % LOCAL_CENTRAL_PATH):
                     from datalad.api import install
-                    central_ds = install('///', path=LOCAL_CENTRAL_PATH)
+                    central_ds = install(LOCAL_CENTRAL_PATH, source='///')
                     ui.message(
                         "You can in future refer to that dataset using -d///"
                     )

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -116,7 +116,7 @@ def test_basic_metadata(path):
          'dcterms:hasPart', 'dcterms:modified', 'type', 'version'])
     assert_equal(meta[0]['type'], 'Dataset')
     # clone and get relationship info in metadata
-    sibling = install(opj(path, 'sibling'), source=opj(path, 'origin')
+    sibling = install(opj(path, 'sibling'), source=opj(path, 'origin'))
     sibling_meta = get_metadata(sibling)
     assert_equal(sibling_meta[0]['@id'], ds.id)
     # origin should learn about the clone
@@ -170,7 +170,7 @@ def test_aggregation(path):
     ds.save('with aggregated meta data', auto_add_changes=True)
 
     # now clone the beast to simulate a new user installing an empty dataset
-    clone = install(opj(path, source=ds.path), 'clone')
+    clone = install(opj(path, 'clone'), source=ds.path)
     # ID mechanism works
     assert_equal(ds.id, clone.id)
 
@@ -192,7 +192,7 @@ def test_aggregation(path):
         subds.id)
 
     # now obtain a subdataset in the clone and the IDs should be updated
-    clone.install('sub')
+    clone.install(source='sub')  # TEMP -- should work without source=. get is still buggy somewhere!
     partial = get_metadata(clone, guess_type=False, ignore_cache=True)
     # ids don't change
     assert_equal(partial[0]['@id'], clonemeta[0]['@id'])
@@ -267,7 +267,7 @@ def test_aggregation(path):
     # more tests on returned paths:
     assert_names(clone.search('datalad'), ['.', 'sub', 'sub/subsub'])
     # if we clone subdataset and query for value present in it and its kid
-    clone_sub = clone.install('sub')
+    clone_sub = clone.install(source='sub')  # TEMP should work without source!  somewhere get is still buggy
     assert_names(clone_sub.search('datalad'), ['.', 'subsub'], clone_sub.path)
 
     # Test 'and' for multiple search entries

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -192,7 +192,7 @@ def test_aggregation(path):
         subds.id)
 
     # now obtain a subdataset in the clone and the IDs should be updated
-    clone.install(source='sub')  # TEMP -- should work without source=. get is still buggy somewhere!
+    clone.install('sub')
     partial = get_metadata(clone, guess_type=False, ignore_cache=True)
     # ids don't change
     assert_equal(partial[0]['@id'], clonemeta[0]['@id'])
@@ -267,7 +267,7 @@ def test_aggregation(path):
     # more tests on returned paths:
     assert_names(clone.search('datalad'), ['.', 'sub', 'sub/subsub'])
     # if we clone subdataset and query for value present in it and its kid
-    clone_sub = clone.install(source='sub')  # TEMP should work without source!  somewhere get is still buggy
+    clone_sub = clone.install('sub')
     assert_names(clone_sub.search('datalad'), ['.', 'subsub'], clone_sub.path)
 
     # Test 'and' for multiple search entries

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -97,7 +97,7 @@ def test_basic_metadata(path):
          'dcterms:hasPart', 'dcterms:modified', 'type', 'version'])
     assert_equal(meta[0]['type'], 'Dataset')
     # clone and get relationship info in metadata
-    sibling = install(opj(path, 'origin'), path=opj(path, 'sibling'), )
+    sibling = install(opj(path, 'sibling'), source=opj(path, 'origin')
     sibling_meta = get_metadata(sibling)
     assert_equal(sibling_meta[0]['@id'], ds.id)
     # origin should learn about the clone
@@ -151,7 +151,7 @@ def test_aggregation(path):
     ds.save('with aggregated meta data', auto_add_changes=True)
 
     # now clone the beast to simulate a new user installing an empty dataset
-    clone = install(ds.path, path=opj(path, 'clone'))
+    clone = install(opj(path, source=ds.path), 'clone')
     # ID mechanism works
     assert_equal(ds.id, clone.id)
 

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -118,7 +118,7 @@ def _check_mocked_install(central_dspath, mock_install):
     assert_equal(
         list(gen), [(loc, report)
                     for loc, report in _mocked_search_results])
-    mock_install.assert_called_once_with('///', path=central_dspath)
+    mock_install.assert_called_once_with(central_dspath, source='///')
 
 
 @with_tempfile

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -149,3 +149,12 @@ def test_our_metadataset_search(tdir):
         out = cmo.out
     assert yaml.load(out)
 
+
+@with_tempfile
+def test_search_non_dataset(tdir):
+    from datalad.support.gitrepo import GitRepo
+    GitRepo(tdir, create=True)
+    with assert_raises(NoDatasetArgumentFound) as cme:
+        list(search('smth', dataset=tdir))
+    # Should instruct user how that repo could become a datalad dataset
+    assert_in("datalad create --force", str(cme.exception))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -467,7 +467,7 @@ class AnnexRepo(GitRepo):
         # fetched
 
         if '--key' not in options:
-            lgr.info("Obtaining information on what files need to be obtained")
+            lgr.debug("Determine what files need to be obtained")
             # Let's figure out first which files/keys and of what size to download
             expected_downloads = {}
             fetch_files = []

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -25,10 +25,12 @@ class CommandError(RuntimeError):
         self.stderr = stderr
 
     def __str__(self):
-        to_str = "%s: command '%s'" % (self.__class__.__name__, self.cmd)
+        to_str = "%s: " % self.__class__.__name__
+        if self.cmd:
+            to_str += "command '%s'" % (self.cmd,)
         if self.code:
             to_str += " failed with exitcode %d" % self.code
-        to_str += ".\n%s" % self.msg
+        to_str += "\n%s" % self.msg
         return to_str
 
 

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -182,9 +182,10 @@ class IncompleteResultsError(RuntimeError):
     Any results produced nevertheless are to be passed as `results`,
     and become available via the `results` attribute.
     """
-    def __init__(self, results, **kwargs):
-        super(IncompleteResultsError, self).__init__(**kwargs)
+    def __init__(self, results=None, failed=None, msg=None):
+        super(IncompleteResultsError, self).__init__(msg)
         self.results = results
+        self.failed = failed
 
 
 class InstallFailedError(CommandError):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -16,6 +16,7 @@ from distutils.version import StrictVersion, LooseVersion
 
 from datalad.dochelpers import exc_str
 from datalad.log import lgr
+from .exceptions import CommandError
 
 __all__ = ['UnknownVersion', 'ExternalVersions', 'external_versions']
 
@@ -43,8 +44,12 @@ _runner = Runner()
 
 def _get_annex_version():
     """Return version of available git-annex"""
-    return _runner.run('git annex version --raw'.split())[0]
-
+    try:
+        return _runner.run('git annex version --raw'.split())[0]
+    except CommandError:
+        # fall back on method that could work with older installations
+        out, err = _runner.run(['git', 'annex', 'version'])
+        return out.split('\n')[0].split(':')[1].strip()
 
 def _get_git_version():
     """Return version of available git"""

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -558,10 +558,15 @@ class GitRepo(object):
             ((not only_remote) and any((b == 'git-annex' for b in self.get_branches())))
 
     @classmethod
-    def get_toppath(cls, path):
+    def get_toppath(cls, path, follow_up=True):
         """Return top-level of a repository given the path.
 
-        If path has symlinks -- they get resolved.
+        Parameters
+        -----------
+        follow_up : bool
+          If path has symlinks -- they get resolved by git.  If follow_up is
+          True, we will follow original path up until we hit the same resolved
+          path.  If no such path found, resolved one would be returned.
 
         Return None if no parent directory contains a git repository.
         """
@@ -572,11 +577,23 @@ class GitRepo(object):
                     cwd=path,
                     log_stdout=True, log_stderr=True,
                     expect_fail=True, expect_stderr=True)
-                return toppath.rstrip('\n\r')
+                toppath = toppath.rstrip('\n\r')
         except CommandError:
             return None
         except OSError:
-            return GitRepo.get_toppath(dirname(path))
+            toppath = GitRepo.get_toppath(dirname(path))
+
+        if follow_up:
+            path_ = path
+            path_prev = ""
+            while path_ and path_ != path_prev:  # on top /.. = /
+                if realpath(path_) == toppath:
+                    toppath = path_
+                    break
+                path_prev = path_
+                path_ = dirname(path_)
+
+        return toppath
 
     # classmethod so behavior could be tuned in derived classes
     @classmethod

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -492,6 +492,13 @@ class RI(object):
         else:
             return self._fields[item]
 
+    def __setattr__(self, item, value):
+        if item.startswith('_') or item not in self._FIELDS:
+            super(RI, self).__setattr__(item, value)
+        else:
+            self._fields[item] = value
+            self._str = None
+
 
 class URL(RI):
     """Universal resource locator

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -357,6 +357,10 @@ class RI(object):
             # RI class was used as a factory
             cls = _guess_ri_cls(ri)
 
+        if cls is RI:
+            # should we fail or just pretend we are nothing??? ;-) XXX
+            raise ValueError("Could not deduce RI type for %r" % (ri,))
+
         ri_obj = super(RI, cls).__new__(cls)
         # Store internally original str
         ri_obj._str = ri

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -632,13 +632,16 @@ def test_GitRepo_get_files(url, path):
 @with_tempfile(mkdir=True)
 def test_GitRepo_get_toppath(repo, tempdir):
     reporeal = realpath(repo)
-    eq_(GitRepo.get_toppath(repo), reporeal)
+    eq_(GitRepo.get_toppath(repo, follow_up=False), reporeal)
+    eq_(GitRepo.get_toppath(repo), repo)
     # Generate some nested directory
     nested = opj(repo, "d1", "d2")
     os.makedirs(nested)
-    eq_(GitRepo.get_toppath(nested), reporeal)
+    eq_(GitRepo.get_toppath(nested, follow_up=False), reporeal)
+    eq_(GitRepo.get_toppath(nested), repo)
     # and if not under git, should return None
     eq_(GitRepo.get_toppath(tempdir), None)
+
 
 def test_GitRepo_dirty():
     trepo = BasicAnnexTestRepo()

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -9,6 +9,7 @@
 
 import logging
 
+from os.path import join as opj
 from collections import OrderedDict
 
 from .utils import eq_, neq_, ok_, nok_, assert_raises
@@ -144,10 +145,20 @@ def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
 
     if localpath:
         eq_(ri_.localpath, localpath)
+        old_localpath = ri_.localpath  # for a test below
     else:
         # if not given -- must be a remote url, should raise exception
         with assert_raises(ValueError):
             ri_.localpath
+
+    # do changes in the path persist?
+    old_str = str(ri_)
+    ri_.path = newpath = opj(ri_.path, 'sub')
+    eq_(ri_.path, newpath)
+    neq_(str(ri_), old_str)
+    if localpath:
+        eq_(ri_.localpath, opj(old_localpath, 'sub'))
+
 
 
 def test_url_base():

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -1,0 +1,112 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_basic_principles:
+
+****************
+Basic principles
+****************
+
+DataLad was designed so it could be used both as a command-line tool, and as
+a Python module. Sections following this one (:ref:`chap_cmdline` and :ref:`chap_modref`)
+provide detailed description of the commands and functions of the two interfaces.  This section
+presents common concepts.  Although examples will be presented using command line
+interface commands, all functionality with identically named functions and options
+are available through Python API.
+
+Distribution
+============
+
+Organization
+------------
+
+DataLad "distribution" is just a :term:`superdataset` which organizes multiple
+:term:`dataset`'s using standard git mechanism of sub-modules.
+
+install vs get
+--------------
+
+``install`` and ``get`` commands, both in Python and command line interfaces, might
+seem confusingly similar at first. Both of them could be used to install
+any number of subdatasets, and fetch content of the data files.  Differences lie
+primarily in their default behaviour and outputs, and thus intended use.
+Both ``install`` and ``get`` take local paths as their arguments, but their
+default behavior and output might differ;
+
+- **install** primarily operates and reports at the level of **datasets**, and
+  returns as a result dataset(s)
+  which either were just installed, or were installed previously already under
+  specified locations.   So result should be the same if the same ``install``
+  command ran twice on the same datasets.  It **does not fetch** data files by
+  default
+
+- **get** primarily operates at the level of **paths** (datasets, directories, and/or
+  files). As a result it returns only what was installed (datasets) or fetched
+  (files).  So result of rerunning the same ``get`` command should report that
+  nothing new was installed or fetched.  It **fetches** data files by default.
+
+In how both commands operate on provided paths, it could be said that
+``install == get -n``, and ``install -g == get``.  But ``install`` also has ability to
+install new datasets from remote locations given their URLs (e.g.,
+``http://datasets.datalad.org/`` for our super-dataset) and SSH targets (e.g.,
+``[login@]host:path``) if they are provided as the argument to its call or
+explicitly as ``--source`` option.  If ``datalad install --source URL DESTINATION`` (command
+line example) is used, then dataset from URL gets installed under PATH. In case of
+``datalad install URL`` invocation, PATH is taken from the last name within URL similar to
+how ``git clone`` does it.  If former specification allows to specify only a single
+URL and a PATH at a time, later one can take multiple remote locations from which
+datasets could be installed.
+
+So, as a rule of thumb -- if you want to install from external URL or fetch a
+sub-dataset without downloading data files stored under annex -- use ``install``.
+In Python API ``install`` is also to be used when you want to receive in output the
+corresponding Dataset object to operate on, and be able to use it even if you
+rerun the script.
+If you would like to fetch data (possibly while installing any necessary to be
+installed sub-dataset to get to the file) -- use ``get``.
+
+
+URL shortcuts
+-------------
+
+``///`` could be used to point to our canonical :term:`superdataset` at
+http://datasets.datalad.org/ , which is largely generated through automated
+crawling (see :ref:`chap_crawler`) of data portals.  Some common examples in command line
+interface:
+
+``datalad install ///``
+    install our canonical super-dataset (alone, no sub-datasets installed during
+    this command) under `datasets.datalad.org/` directory in your current directory
+``datalad install -r ///openfmri``
+    install openfmri super-dataset from our website, with all sub-datasets
+    under `openfmri/` directory in your current directory
+``datalad install -g -J3 -r ///labs/haxby``
+    install Dr. James V. Haxby lab's super-dataset with all sub-datasets, while
+    fetching all data files (present in current version) in 3 parallel processes.
+
+
+Dataset argument
+----------------
+
+All commands which operate with/on datasets (e.g., `install`, `uninstall`, etc.)
+have `dataset` argument (`-d` or `--dataset` in command line) which takes path
+to the dataset you want to operate on. If you specify dataset explicitly,
+then any relative path you provide as argument to the command will be taken
+relative to the top directory of that dataset.  If no dataset argument is
+provided, relative paths are taken relative to current directory.
+
+There are also some "shortcut" values for dataset argument you might find useful:
+
+``///``
+   "central" dataset located under `$HOME/datalad/`.  You could install it by running
+   ```datalad install -s /// $HOME/datalad``` or simply by running
+   ```datalad search smth``` in interactive shell session outside of any dataset,
+   which will present you with a choice to install it for you.
+   So running ``datalad install -d/// crcns`` will install crcns subdataset
+   under your `$HOME/datalad/crcns`.  It is analogous to running
+   ```datalad install $HOME/datalad/crcns```.
+``^``
+   top-most super-dataset containing dataset of your current location.  E.g., if
+   you are under `$HOME/datalad/openfmri/ds000001/sub-01` directory and want to
+   search meta-data of the entire super-dataset you are under (in this case `///`), run
+   ``datalad search -d^ [something to search]``.

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -90,10 +90,10 @@ Dataset argument
 
 All commands which operate with/on datasets (e.g., `install`, `uninstall`, etc.)
 have `dataset` argument (`-d` or `--dataset` in command line) which takes path
-to the dataset you want to operate on. If you specify dataset explicitly,
-then any relative path you provide as argument to the command will be taken
+to the dataset you want to operate on. If you specify a dataset explicitly,
+then any relative path you provide as an argument to the command will be taken
 relative to the top directory of that dataset.  If no dataset argument is
-provided, relative paths are taken relative to current directory.
+provided, relative paths are taken relative to the current directory.
 
 There are also some "shortcut" values for dataset argument you might find useful:
 

--- a/docs/source/crawler/basics.rst
+++ b/docs/source/crawler/basics.rst
@@ -1,5 +1,10 @@
-Basic principles
-================
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_crawler_basics:
+
+DataLad Crawler 101
+===================
 
 Nodes
 -----

--- a/docs/source/crawler/index.rst
+++ b/docs/source/crawler/index.rst
@@ -1,6 +1,11 @@
-******************************************************************************
-Automatic creation and maintnenance of datasets by crawling external resources
-******************************************************************************
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_crawler:
+
+*****************************************************************************
+Automatic creation and maintenance of datasets by crawling external resources
+*****************************************************************************
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ Commands and API
 .. toctree::
    :maxdepth: 2
 
+   basics
    cmdline
    modref
 


### PR DESCRIPTION
See #959 for many discussions on the topic.

- [x] logic in install on handling PATH/SOURCE is still the old one, needs to be RFed as well
- [x] tests must be fixed
- [x] additional tests (may be as well mocked up) for install to invoke correct actions (e.g. calling get)
- [x] Issues which came up while testing #959 (I think all were addressed by @mih or by me by now)
- [x] Should close #1000 
- [x] Should close #1001 
- [x] Decide possibly how to avoid having `_`-prefixed argument in `Get.__call__`  (discussed with @bpoldrack , and agreed that if needs changing, could be done later)
- [x] Provide documentation outlining similarities and differences between `install` and `get` commands
- [x] add `-J` (jobs) option to `install` to pass to `get`

For future PRs
- Unify options between `get` and `install` APIs more  addressing those commented out ones which are specific only to get or to install currently

https://github.com/mih/datalad/pull/13 shows changes on top of original (and improved) rf-getinstall from @mih