### PR TITLE
BF: Robustify annex version detection

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -17,6 +17,7 @@ from distutils.version import StrictVersion, LooseVersion
 
 from datalad.dochelpers import exc_str
 from datalad.log import lgr
+from .exceptions import CommandError
 
 __all__ = ['UnknownVersion', 'ExternalVersions', 'external_versions']
 
@@ -44,8 +45,12 @@ _runner = Runner()
 
 def _get_annex_version():
     """Return version of available git-annex"""
-    return _runner.run('git annex version --raw'.split())[0]
-
+    try:
+        return _runner.run('git annex version --raw'.split())[0]
+    except CommandError:
+        # fall back on method that could work with older installations
+        out, err = _runner.run(['git', 'annex', 'version'])
+        return out.split('\n')[0].split(':')[1].strip()
 
 def _get_git_version():
     """Return version of available git"""

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -11,7 +11,9 @@ from os import linesep
 
 from ...version import __version__
 from ..external_versions import ExternalVersions, StrictVersion
+from ..exceptions import CommandError
 
+from mock import patch
 from nose.tools import assert_true, assert_false
 from nose.tools import assert_equal, assert_greater_equal, assert_greater
 from nose.tools import assert_raises
@@ -109,3 +111,16 @@ def test_custom_versions():
     ev.CUSTOM = {'bogus': lambda: 1/0}
     assert_equal(ev['bogus'], None)
     assert_equal(set(ev.versions.keys()), {'cmd:annex', 'cmd:git'})
+
+
+def test_ancient_annex():
+
+    class _runner(object):
+        def run(self, cmd):
+            if '--raw' in cmd:
+                raise CommandError
+            return "git-annex version: 0.1", ""
+
+    ev = ExternalVersions()
+    with patch('datalad.support.external_versions._runner', _runner()):
+        assert_equal(ev['cmd:annex'], '0.1')


### PR DESCRIPTION
Closes #897 
picked up @mih commit from the #959 -- now comparison would work as prescribed:
```shell
hopa(precise-amd64):~/datalad/labs/haxby/raiders
$> datalad get sub011
2016-10-14 23:03:59,317 [ERROR  ] git-annex of version >= 6.20160808 is missing. Visit http://git-annex.branchable.com/install/. You have version 5.20140517.4 [annexrepo.py:_check_git_annex_version:259] (OutdatedExternalDependency) 
```