### PR TITLE
NF: RFC822-based meta data format targeting manual meta data entry scenarios

### DIFF
--- a/datalad/metadata/__init__.py
+++ b/datalad/metadata/__init__.py
@@ -73,7 +73,10 @@ def _get_base_dataset_metadata(ds_identifier):
     """
 
     meta = {
-        "@context": "http://schema.org/",
+        "@context": {
+            "@vocab": "http://schema.org/",
+            "doap": "http://usefulinc.com/ns/doap#",
+        },
         "type": "Dataset",
         # increment when changes to meta data representation are done
         "dcterms:conformsTo": "http://docs.datalad.org/metadata.html#v0-1",

--- a/datalad/metadata/parsers/__init__.py
+++ b/datalad/metadata/parsers/__init__.py
@@ -12,3 +12,4 @@
 # we can try to guess
 from . import bids
 from . import frictionless_datapackage
+from . import datalad_rfc822

--- a/datalad/metadata/parsers/datalad_rfc822.py
+++ b/datalad/metadata/parsers/datalad_rfc822.py
@@ -57,22 +57,34 @@ class MetadataParser(BaseMetadataParser):
         for header, dataladterm in \
                 (('name', 'name'),
                  ('license', 'license'),
-                 ('maintainer', 'author'),
-                 #('homepage', 'citation'),
-                 #('Funding', 'foaf:fundedBy'),
-                 ('description', 'description')):
+                 ('author', 'author'),
+                 ('maintainer', 'doap:maintainer'),
+                 ('audience', 'doap:audience'),
+                 ('homepage', 'doap:homepage'),
+                 ('version', 'doap:Version'),
+                 ('funding', 'foaf:fundedBy'),
+                 ('issue-tracker', 'bug-database'),
+                 ('cita-as', 'citation'),
+                 ('doi', 'sameAs'),
+                 ('description', None)):
             if not header in spec:
                 continue
             content = spec[header]
-            if header in ('description', 'license'):
-                title, content = _beautify_multiline_field(content)
+            if header == 'description':
+                short, long = _beautify_multiline_field(content)
+                meta['doap:shortdesc'] = short
+                meta['description'] = long
+            elif header == 'license':
                 # TODO if title looks like a URL, use it as @id
-                if title:
-                    meta[dataladterm] = [title, content]
+                label, desc = _beautify_multiline_field(content)
+                if label:
+                    meta[dataladterm] = [label, desc]
                 else:
-                    meta[dataladterm] = content
-            elif header in ('maintainer',):
+                    meta[dataladterm] = desc
+            elif header in ('maintainer', 'author'):
                 meta[dataladterm] = _split_list_field(content)
+            elif header == 'doi':
+                meta[dataladterm] = 'http://dx.doi.org/{}'.format(content)
             else:
                 meta[dataladterm] = content
 

--- a/datalad/metadata/parsers/datalad_rfc822.py
+++ b/datalad/metadata/parsers/datalad_rfc822.py
@@ -1,0 +1,78 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Parser for RFC822-based metadata specifications
+
+This is inspired by (and very similiar to) Debian's package meta data format.
+The main difference is that information spread across multiple files in Debian
+packages, is concentrated in one file.
+
+The main advantage of this format is that it is proven to be hand-editable,
+i.e. can be composed from scratch, by hand, in an editor -- with a good
+chance of producing syntax-compliant content with the first attempt.
+"""
+
+import rfc822
+from os.path import join as opj
+from datalad.metadata.parsers.base import BaseMetadataParser
+from datalad.interface.base import dedent_docstring
+
+
+def _split_list_field(content):
+    return [i.strip() for i in content.split(',') if i.strip()]
+
+
+def _beautify_multiline_field(content):
+    content = dedent_docstring(content)
+    lines = content.split('\n')
+    title = ''
+    if len(lines):
+        title = lines[0]
+    if len(lines) > 1:
+        content = ''
+        for l in lines[1:]:
+            l = l.strip()
+            content = '{}{}{}'.format(
+                content,
+                ' ' if len(content) and l != '.' and content[-1] != '\n' else '',
+                l if l != '.' else '\n')
+    return title, content
+
+
+class MetadataParser(BaseMetadataParser):
+    _metadata_compliance = "http://docs.datalad.org/metadata.html#v0-1"
+    _core_metadata_filenames = [opj('.datalad', 'control')]
+
+    def _get_metadata(self, ds_identifier, meta, full):
+        spec = rfc822.Message(open(self.get_core_metadata_filenames()[0]))
+
+        # loop over all recognized headers and translate them
+        for header, dataladterm in \
+                (('package', 'name'),
+                 ('license', 'license'),
+                 ('maintainer', 'author'),
+                 #('homepage', 'citation'),
+                 #('Funding', 'foaf:fundedBy'),
+                 ('description', 'description')):
+            if not header in spec:
+                continue
+            content = spec[header]
+            if header in ('description', 'license'):
+                title, content = _beautify_multiline_field(content)
+                # TODO if title looks like a URL, use it as @id
+                if title:
+                    meta[dataladterm] = [title, content]
+                else:
+                    meta[dataladterm] = content
+            elif header in ('maintainer',):
+                meta[dataladterm] = _split_list_field(content)
+            else:
+                meta[dataladterm] = content
+
+        meta['dcterms:conformsTo'] = self._metadata_compliance
+        return meta

--- a/datalad/metadata/parsers/datalad_rfc822.py
+++ b/datalad/metadata/parsers/datalad_rfc822.py
@@ -55,7 +55,7 @@ class MetadataParser(BaseMetadataParser):
 
         # loop over all recognized headers and translate them
         for header, dataladterm in \
-                (('package', 'name'),
+                (('name', 'name'),
                  ('license', 'license'),
                  ('maintainer', 'author'),
                  #('homepage', 'citation'),

--- a/datalad/metadata/parsers/datalad_rfc822.py
+++ b/datalad/metadata/parsers/datalad_rfc822.py
@@ -46,7 +46,7 @@ def _beautify_multiline_field(content):
 
 class MetadataParser(BaseMetadataParser):
     _metadata_compliance = "http://docs.datalad.org/metadata.html#v0-1"
-    _core_metadata_filenames = [opj('.datalad', 'control')]
+    _core_metadata_filenames = [opj('.datalad', 'meta.rfc822')]
 
     def _get_metadata(self, ds_identifier, meta, full):
         spec = email.parser.Parser().parse(

--- a/datalad/metadata/parsers/datalad_rfc822.py
+++ b/datalad/metadata/parsers/datalad_rfc822.py
@@ -17,7 +17,7 @@ i.e. can be composed from scratch, by hand, in an editor -- with a good
 chance of producing syntax-compliant content with the first attempt.
 """
 
-import rfc822
+import email
 from os.path import join as opj
 from datalad.metadata.parsers.base import BaseMetadataParser
 from datalad.interface.base import dedent_docstring
@@ -49,7 +49,9 @@ class MetadataParser(BaseMetadataParser):
     _core_metadata_filenames = [opj('.datalad', 'control')]
 
     def _get_metadata(self, ds_identifier, meta, full):
-        spec = rfc822.Message(open(self.get_core_metadata_filenames()[0]))
+        spec = email.parser.Parser().parse(
+            open(self.get_core_metadata_filenames()[0]),
+            headersonly=True)
 
         # loop over all recognized headers and translate them
         for header, dataladterm in \

--- a/datalad/metadata/parsers/datalad_rfc822.py
+++ b/datalad/metadata/parsers/datalad_rfc822.py
@@ -64,7 +64,7 @@ class MetadataParser(BaseMetadataParser):
                  ('version', 'doap:Version'),
                  ('funding', 'foaf:fundedBy'),
                  ('issue-tracker', 'bug-database'),
-                 ('cita-as', 'citation'),
+                 ('cite-as', 'citation'),
                  ('doi', 'sameAs'),
                  ('description', None)):
             if not header in spec:

--- a/datalad/metadata/parsers/tests/test_bids.py
+++ b/datalad/metadata/parsers/tests/test_bids.py
@@ -57,7 +57,10 @@ def test_get_metadata(path):
         dumps(meta, sort_keys=True, indent=2),
         """\
 {
-  "@context": "http://schema.org/",
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "doap": "http://usefulinc.com/ns/doap#"
+  },
   "@id": "ID",
   "author": [
     "Mike One",

--- a/datalad/metadata/parsers/tests/test_frictionless_datapackage.py
+++ b/datalad/metadata/parsers/tests/test_frictionless_datapackage.py
@@ -65,7 +65,10 @@ def test_get_metadata(path):
         dumps(meta, sort_keys=True, indent=2),
         """\
 {
-  "@context": "http://schema.org/",
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "doap": "http://usefulinc.com/ns/doap#"
+  },
   "@id": "ID",
   "author": "Jane Doe <noemail@example.com>",
   "contributors": [

--- a/datalad/metadata/parsers/tests/test_rfc822.py
+++ b/datalad/metadata/parsers/tests/test_rfc822.py
@@ -71,6 +71,7 @@ def test_get_metadata(path):
   },
   "@id": "ID",
   "bug-database": "https://github.com/psychoinformatics-de/studyforrest-data-phase2/issues",
+  "citation": "Cool (2016)",
   "dcterms:conformsTo": "http://docs.datalad.org/metadata.html#v0-1",
   "description": "A text with arbitrary length and content that can span multiple\\nparagraphs (this is a new one)",
   "doap:Version": "1.0.0-rc3",

--- a/datalad/metadata/parsers/tests/test_rfc822.py
+++ b/datalad/metadata/parsers/tests/test_rfc822.py
@@ -54,9 +54,7 @@ Homepage: http://studyforrest.org
 Funding: BMBFGQ1411, NSF 1429999
 Issue-Tracker: https://github.com/psychoinformatics-de/studyforrest-data-phase2/issues
 Cite-As: Cool (2016)
-Donation: in beer
 DOI: 10.5281/zenodo.48421
-Registration: info@studyforrest.org
 
 """}})
 def test_get_metadata(path):
@@ -67,22 +65,27 @@ def test_get_metadata(path):
         dumps(meta, sort_keys=True, indent=2),
         """\
 {
-  "@context": "http://schema.org/",
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "doap": "http://usefulinc.com/ns/doap#"
+  },
   "@id": "ID",
-  "author": [
+  "bug-database": "https://github.com/psychoinformatics-de/studyforrest-data-phase2/issues",
+  "dcterms:conformsTo": "http://docs.datalad.org/metadata.html#v0-1",
+  "description": "A text with arbitrary length and content that can span multiple\\nparagraphs (this is a new one)",
+  "doap:Version": "1.0.0-rc3",
+  "doap:homepage": "http://studyforrest.org",
+  "doap:maintainer": [
     "Mike One <mike@example.com>",
     "Anna Two <anna@example.com>"
   ],
-  "dcterms:conformsTo": "http://docs.datalad.org/metadata.html#v0-1",
-  "description": [
-    "Basic summary",
-    "A text with arbitrary length and content that can span multiple\\nparagraphs (this is a new one)"
-  ],
+  "doap:shortdesc": "Basic summary",
+  "foaf:fundedBy": "BMBFGQ1411, NSF 1429999",
   "license": [
     "CC0",
     "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.\\nYou can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission."
   ],
   "name": "studyforrest_phase2",
+  "sameAs": "http://dx.doi.org/10.5281/zenodo.48421",
   "type": "Dataset"
 }""")
-

--- a/datalad/metadata/parsers/tests/test_rfc822.py
+++ b/datalad/metadata/parsers/tests/test_rfc822.py
@@ -34,7 +34,7 @@ def test_has_no_metadata(path):
 
 
 @with_tree(tree={'.datalad': {'meta.rfc822': """\
-Package: studyforrest_phase2
+Name: studyforrest_phase2
 Version: 1.0.0-rc3
 Description: Basic summary
  A text with arbitrary length and content that can span multiple
@@ -51,6 +51,13 @@ License: CC0
 Maintainer: Mike One <mike@example.com>,
             Anna Two <anna@example.com>,
 Homepage: http://studyforrest.org
+Funding: BMBFGQ1411, NSF 1429999
+Issue-Tracker: https://github.com/psychoinformatics-de/studyforrest-data-phase2/issues
+Cite-As: Cool (2016)
+Donation: in beer
+DOI: 10.5281/zenodo.48421
+Registration: info@studyforrest.org
+
 """}})
 def test_get_metadata(path):
 

--- a/datalad/metadata/parsers/tests/test_rfc822.py
+++ b/datalad/metadata/parsers/tests/test_rfc822.py
@@ -1,0 +1,81 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test BIDS meta data parser """
+
+from os.path import join as opj
+from simplejson import dumps
+from datalad.distribution.dataset import Dataset
+from datalad.metadata.parsers.datalad_rfc822 import MetadataParser
+from nose.tools import assert_true, assert_false, assert_equal
+from datalad.tests.utils import with_tree, with_tempfile
+
+
+@with_tree(tree={'.datalad': {'control': ''}})
+def test_has_metadata(path):
+    ds = Dataset(path)
+    p = MetadataParser(ds)
+    assert_true(p.has_metadata())
+    assert_equal(p.get_core_metadata_filenames(),
+                 [opj(path, '.datalad', 'control')])
+
+
+@with_tempfile(mkdir=True)
+def test_has_no_metadata(path):
+    ds = Dataset(path)
+    p = MetadataParser(ds)
+    assert_false(p.has_metadata())
+    assert_equal(p.get_core_metadata_filenames(), [])
+
+
+@with_tree(tree={'.datalad': {'control': """\
+Package: studyforrest_phase2
+Version: 1.0.0-rc3
+Description: Basic summary
+ A text with arbitrary length and content that can span multiple
+ .
+ paragraphs (this is a new one)
+License: CC0
+ The person who associated a work with this deed has dedicated the work to the
+ public domain by waiving all of his or her rights to the work worldwide under
+ copyright law, including all related and neighboring rights, to the extent
+ allowed by law.
+ .
+ You can copy, modify, distribute and perform the work, even for commercial
+ purposes, all without asking permission.
+Maintainer: Mike One <mike@example.com>,
+            Anna Two <anna@example.com>,
+Homepage: http://studyforrest.org
+"""}})
+def test_get_metadata(path):
+
+    ds = Dataset(path)
+    meta = MetadataParser(ds).get_metadata('ID')
+    assert_equal(
+        dumps(meta, sort_keys=True, indent=2),
+        """\
+{
+  "@context": "http://schema.org/",
+  "@id": "ID",
+  "author": [
+    "Mike One <mike@example.com>",
+    "Anna Two <anna@example.com>"
+  ],
+  "dcterms:conformsTo": "http://docs.datalad.org/metadata.html#v0-1",
+  "description": [
+    "Basic summary",
+    "A text with arbitrary length and content that can span multiple\\nparagraphs (this is a new one)"
+  ],
+  "license": [
+    "CC0",
+    "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.\\nYou can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission."
+  ],
+  "name": "studyforrest_phase2",
+  "type": "Dataset"
+}""")
+

--- a/datalad/metadata/parsers/tests/test_rfc822.py
+++ b/datalad/metadata/parsers/tests/test_rfc822.py
@@ -16,13 +16,13 @@ from nose.tools import assert_true, assert_false, assert_equal
 from datalad.tests.utils import with_tree, with_tempfile
 
 
-@with_tree(tree={'.datalad': {'control': ''}})
+@with_tree(tree={'.datalad': {'meta.rfc822': ''}})
 def test_has_metadata(path):
     ds = Dataset(path)
     p = MetadataParser(ds)
     assert_true(p.has_metadata())
     assert_equal(p.get_core_metadata_filenames(),
-                 [opj(path, '.datalad', 'control')])
+                 [opj(path, '.datalad', 'meta.rfc822')])
 
 
 @with_tempfile(mkdir=True)
@@ -33,7 +33,7 @@ def test_has_no_metadata(path):
     assert_equal(p.get_core_metadata_filenames(), [])
 
 
-@with_tree(tree={'.datalad': {'control': """\
+@with_tree(tree={'.datalad': {'meta.rfc822': """\
 Package: studyforrest_phase2
 Version: 1.0.0-rc3
 Description: Basic summary

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -265,7 +265,7 @@ class Search(Interface):
             hit = False
             hits = [False] * len(matchers)
             matched_fields = set()
-            if not mds.get('type', None) == 'Dataset':
+            if not mds.get('type', mds.get('schema:type', None)) == 'Dataset':
                 # we are presently only dealing with datasets
                 continue
             # TODO consider the possibility of nested and context/graph dicts

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -253,8 +253,8 @@ def test_aggregation(path):
     assert_equal(
         set(map(lambda x: tuple(sorted(x[1].keys())),
                 clone.search('child', report_matched=True,
-                             report=['type']))),
-        set([('name', 'type')])
+                             report=['schema:type']))),
+        set([('name', 'schema:type')])
     )
     # and if we ask report to be 'empty', we should get no fields
     child_res_empty = list(clone.search('child', report=''))

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -149,7 +149,7 @@ def test_aggregation(path):
     assert_equal(len(meta), 7)
     # same schema
     assert_equal(
-        7, sum([s.get('@context', None) == 'http://schema.org/' for s in meta]))
+            7, sum([s.get('@context', {'@vocab': None})['@vocab'] == 'http://schema.org/' for s in meta]))
     # three different IDs
     assert_equal(3, len(set([s.get('@id') for s in meta])))
     # and we know about all three datasets

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -1,8 +1,116 @@
 Meta data
 *********
 
-Versions
-========
+Datalad has built-in, modular, and extensible support for meta data in various
+formats. The core concept is that meta data is accessed via dedicated parsers
+in their native format, avoiding the need for mandatory conversion into a
+"standard" format. Via these parser datalad is capable of performing a certain
+amount of meta data homogenization, and standardization into a JSON-LD_
+compliant `linked data`_ structure for the purpose of meta data aggregation in
+:term:`superdataset`\ s.  Through this mechanism it is possible to obtain and
+query meta data of any number of :term:`subdataset`\ s without the need to
+actually install them.
+
+.. _JSON-LD: http://json-ld.org/
+.. _linked data: https://en.wikipedia.org/wiki/Linked_data
+
+This following sections provide an overview of supported meta data formats.
+
+RFC822-compliant meta data
+==========================
+
+This is a custom meta data format, inspired by the standard used for Debian
+software packages that is particularly suited for manual entry. This format is
+a good choice when meta data describing a dataset as a whole cannot be obtained
+from some other structured format. The syntax is :rfc:`822`-compliant. In other
+words: this is a text-based format that uses the syntax of email headers.
+Meta data must be placed in ``DATASETROOT/.datalad/meta.rfc822`` for this format.
+
+.. _RFC822: https://tools.ietf.org/html/rfc822
+
+Here is an example:
+
+.. code-block:: none
+
+  Name: myamazingdataset
+  Version: 1.0.0-rc3
+  Description: Basic summary
+   A text with arbitrary length and content that can span multiple
+   .
+   paragraphs (this is a new one)
+  License: CC0
+   The person who associated a work with this deed has dedicated the work to the
+   public domain by waiving all of his or her rights to the work worldwide under
+   copyright law, including all related and neighboring rights, to the extent
+   allowed by law.
+   .
+   You can copy, modify, distribute and perform the work, even for commercial
+   purposes, all without asking permission.
+  Homepage: http://example.com
+  Funding: Grandma's and Grandpa's support
+  Issue-Tracker: https://github.com/datalad/datalad/issues
+  Cite-As: Mike Author (2016). We made it. The breakthrough journal of unlikely
+    events. 1, 23-453.
+  DOI: 10.0000/nothere.48421
+
+The following fields are supported:
+
+``Audience``:
+  A description of the target audience of the dataset.
+``Author``:
+  A comma-delimited list of authors of the dataset, preferably in the format.
+  ``Firstname Lastname <Email Adress>``
+``Cite-as``:
+  Instructions on how to cite the dataset, or a structured citation.
+``Description``:
+  Description of the dataset as a whole. The first line should represent a
+  compact short description with no more than 6-8 words.
+``DOI``:
+  A `digital object identifier <https://en.wikipedia.org/wiki/Digital_object_identifier>`_
+  for the dataset.
+``Funding``:
+  Information on potential funding for the creation of the dataset and/or its
+  content. This field can also be used to acknowledge non-monetary support.
+``Homepage``:
+  A URL to a project website for the dataset.
+``Issue-tracker``:
+  A URL to an issue tracker where known problems are documented and/or new
+  reports can be submitted.
+``License``:
+  A description of the license or terms of use for the dataset. The first
+  lines should contain a list of license labels (e.g. CC0, PPDL) for standard
+  licenses, if possible. Full license texts or term descriptions can be
+  included.
+``Maintainer``:
+  Can be used in addition and analog to ``Author``, when authors (creators of
+  the data) need to be distinguished from maintainers of the dataset.
+``Name``:
+  A short name for the dataset. It may be beneficial to avoid special
+  characters, umlauts, spaces, etc. to enable widespread use of this name
+  for URL, catalog keys, etc. in unmodified form.
+``Version``:
+  A version for the dataset. This should be in a format that is alphanumerically
+  sortable and lead to a "greater" version for an update of a dataset.
+
+
+Brain Imaging Data Structure (BIDS)
+===================================
+
+Datalad has basic support for extraction of meta data from the `BIDS
+<http://bids.neuroimaging.io>`_ ``dataset_description.json`` file.
+
+Friction-less data packages
+===========================
+
+Datalad has basic support for extraction of meta data from `friction-less data
+packages <http://specs.frictionlessdata.io/data-packages>`_
+(``datapackage.json``).  file.
+
+JSON-LD meta data format
+========================
+
+This sections will describe the linked data meta data format used by datalad
+for aggregation and meta data query.
 
 .. _0.1:
 


### PR DESCRIPTION
Which invents as little as possible. Objectives:

1. Compact
2. Suitable for hand-editing (we have two JSON-based ones already)
3. Flexible enough to be able to capture pretty much anything I could think of

Choosing Debian's RFC822 felt natural. Pretty much all these files are composed by hand (that's proof enough).

The idea is to merge the various ideas from Debian's metadata files into a single spec file (control, copyright, ...). If necessary, we could have multiple files of course, but it doesn't look like we need it (yet).

At this point, the implementation represents the minimal technical infrastructure to support this format on a demo level, and to get the discussion going.