### PR TITLE
RF+ENH: dedicated [devel] + requirements-devel.txt mode of installation 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_install:
 
 install:
   # Install standalone build of git-annex for the recent enough version
-  - travis_retry sudo apt-get install git-annex-standalone zip
+  - travis_retry sudo apt-get install git-annex-standalone zip pandoc
   - travis_retry sudo apt-get install shunit2
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,19 +96,10 @@ install:
   - travis_retry sudo apt-get install shunit2
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
-  - git submodule update --init --recursive
   - cd ..; pip install -q codecov; cd -
-  - pip install -r requirements.txt
-  # Verify that setup.py build doesn't puke
-  - python setup.py build
-  - pip install -e .
+  - pip install -r requirements-devel.txt
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
-  # Install sphinx to build/test documentation.  Doesn't take a while, so doing in all envs
-  - pip install sphinx
-  - pip install sphinx_rtd_theme
-  # Specifically needed for tests here (e.g. example scripts testing)
-  - pip install nibabel
   # TMPDIRs
   - if [[ "${TMPDIR:-}" =~ .*/sym\ link ]]; then echo "Symlinking $TMPDIR"; ln -s /tmp "$TMPDIR"; fi
   - if [[ "${TMPDIR:-}" =~ .*/d\ i\ r ]]; then echo "mkdir $TMPDIR"; mkdir -p "$TMPDIR"; fi
@@ -119,24 +110,19 @@ install:
   - npm install grunt-contrib-qunit
 
 script:
-  - echo "Running tests"
+  # Verify that setup.py build doesn't puke
+  - python setup.py build
+  # Run tests
   - PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest
   # Run javascript tests
   - grunt test --verbose
-  # Run doc examples "tests"
-  # but for that we need first to install the beast and minimal installation
-  # must be sufficient
-  - pip install .
   # do not run them with custom TMPDIR with spaces for now : https://github.com/datalad/datalad/issues/893
   - if [[ ${TMPDIR:-} =~ ".* .*" ]]; then tools/testing/run_doc_examples; else echo "not running since has spaces"; fi
 
 after_success:
-  - /bin/ls -l /tmp/.coverage-entry*
-  - echo "BEFORE combining"; coverage report --show-missing
   - coverage combine -a /tmp/.coverage-entrypoints-*
-  - echo "AFTER combining"; coverage report --show-missing
   - codecov
 
 # makes it only more difficult to comprehend the failing output.  Enable only when necessary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ some of which you could also install from PyPi using pip  (prior installation of
 might be necessary)
 
 ```sh
-pip install -r requirements.txt
+pip install -r requirements-devel.txt
 ```
 
 and you will need to install recent git-annex using appropriate for your

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -2,4 +2,4 @@
 # Theoretically we don't want -e here but ATM pip would puke if just .[full] is provided
 # Since we use requirements.txt ATM only for development IMHO it is ok but
 # we need to figure out/complaint to pip folks
--e .[full]
+-e .[devel]

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,4 +1,3 @@
-# Now everything setup says by default for everything
 # Theoretically we don't want -e here but ATM pip would puke if just .[full] is provided
 # Since we use requirements.txt ATM only for development IMHO it is ok but
 # we need to figure out/complaint to pip folks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
-# Now everything setup says by default for everything
+# If you want to develop, use requirements-devel.txt
+
 # Theoretically we don't want -e here but ATM pip would puke if just .[full] is provided
-# Since we use requirements.txt ATM only for development IMHO it is ok but
-# we need to figure out/complaint to pip folks
--e .[full]
+# TODO -- figure it out and/or complain to pip folks
+# -e .[full]
+
+# this one should work but would copy entire . tree  so should be ran on a clean copy
+.[full]
+
+# doesn't install datalad itself
+# file://.#egg=datalad[full]

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,27 @@ requires = {
         'PyYAML',  # very optional
     ]
 }
+
 requires['full'] = sum(list(requires.values()), [])
+
+# Now add additional ones useful for development
+requires.update({
+    'devel-docs': [
+        # used for converting README.md -> .rst for long_description
+        'pypandoc',
+        # Documentation
+        'sphinx',
+        'sphinx-rtd-theme',
+    ],
+    'devel-utils': [
+        'nose-timer',
+        'line-profiler',
+        # necessary for accessing SecretStorage keyring (system wide Gnome
+        # keyring)
+        'dbus-python',
+    ]
+})
+requires['devel'] = sum(list(requires.values()), [])
 
 
 # let's not build manpages and examples automatically (gh-896)

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,10 @@ requires.update({
         'nose-timer',
         'line-profiler',
         # necessary for accessing SecretStorage keyring (system wide Gnome
-        # keyring)
-        'dbus-python',
+        # keyring)  but not installable on travis, IIRC since it needs connectivity
+        # to the dbus whenever installed or smth like that, thus disabled here
+        # but you might need it
+        # 'dbus-python',
     ],
     'devel-neuroimaging': [
         # Specifically needed for tests here (e.g. example scripts testing)

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,10 @@ requires.update({
         # necessary for accessing SecretStorage keyring (system wide Gnome
         # keyring)
         'dbus-python',
+    ],
+    'devel-neuroimaging': [
+        # Specifically needed for tests here (e.g. example scripts testing)
+        'nibabel',
     ]
 })
 requires['devel'] = sum(list(requires.values()), [])


### PR DESCRIPTION
Regular requirements.txt will now attempt to install as it should without -e (but that would entail copying entire working directory).  So if you are developing -- using requirements-devel.txt which would also make sure that you have ALL needed for development requirements (including sphinx, useful nose plugins etc)