### PR TITLE
BF: SSH shared connections issues

### DIFF
--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -175,7 +175,6 @@ class AddSibling(Interface):
                                " URL for {1} dataset(s). {2}".format(
                                    name, len(conflicting), conflicting))
 
-        runner = Runner()
         successfully_added = list()
         for repo_name in repos:
             repo = repos[repo_name]['repo']
@@ -184,15 +183,12 @@ class AddSibling(Interface):
                     lgr.debug("Skipping {0}. Nothing to do.".format(repo_name))
                     continue
                 # rewrite url
-                cmd = ["git", "remote", "set-url", name, repos[repo_name]['url']]
+                repo.set_remote_url(name, repos[repo_name]['url'])
             else:
                 # add the remote
                 repo.add_remote(name, repos[repo_name]['url'])
             if pushurl:
-                cmd = ["git", "remote", "set-url", "--push", name,
-                       repos[repo_name]['pushurl']]
-                runner.run(cmd, cwd=repo.path)
-
+                repo.set_remote_url(name, repos[repo_name]['pushurl'], push=True)
             if fetch:
                 # fetch the remote so we are up to date
                 lgr.debug("Fetching sibling %s of %s", name, repo_name)

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -187,8 +187,7 @@ class AddSibling(Interface):
                 cmd = ["git", "remote", "set-url", name, repos[repo_name]['url']]
             else:
                 # add the remote
-                cmd = ["git", "remote", "add", name, repos[repo_name]['url']]
-            runner.run(cmd, cwd=repo.path)
+                repo.add_remote(name, repos[repo_name]['url'])
             if pushurl:
                 cmd = ["git", "remote", "set-url", "--push", name,
                        repos[repo_name]['pushurl']]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -297,6 +297,21 @@ class AnnexRepo(GitRepo):
                              " -S %s" % c.ctrl_path)
             writer.release()
 
+    def set_remote_url(self, name, url, push=False):
+        """Overrides method from GitRepo in order to set
+        remote.<name>.annex-ssh-options in case of a SSH remote."""
+
+        super(AnnexRepo, self).set_remote_url(name, url, push=push)
+        from datalad.support.network import is_ssh
+        if is_ssh(url):
+            c = ssh_manager.get_connection(url)
+            writer = self.repo.config_writer()
+            writer.set_value("remote \"%s\"" % name,
+                             "annex-ssh-options",
+                             "-o ControlMaster=auto"
+                             " -S %s" % c.ctrl_path)
+            writer.release()
+
     def __repr__(self):
         return "<AnnexRepo path=%s (%s)>" % (self.path, type(self))
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1315,6 +1315,26 @@ class GitRepo(object):
             else:
                 return None
 
+    def set_remote_url(self, name, url, push=False):
+        """Set the URL a remote is pointing to
+
+        Sets the URL of the remote `name`. Requires the remote to already exist.
+
+        Parameters
+        ----------
+        name: str
+          name of the remote
+        url: str
+        push: bool
+          if True, set the push URL, otherwise the fetch URL
+        """
+
+        cmd = ["git", "remote", "set-url"]
+        if push:
+            cmd.append("--push")
+        cmd += [name, url]
+        return self._git_custom_command('', cmd)
+
     def get_branch_commits(self, branch, limit=None, stop=None, value=None):
         """Return GitPython's commits for the branch
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -495,6 +495,14 @@ class GitRepo(object):
         path : str
         """
 
+        if is_ssh(url):
+            cnct = ssh_manager.get_connection(url)
+            cnct.open()
+            # TODO: with git <= 2.3 keep old mechanism:
+            #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
+            env = {'GIT_SSH_COMMAND': "ssh -S %s" % cnct.ctrl_path}
+        else:
+            env = None
         ntries = 5  # 3 is not enough for robust workaround
         for trial in range(ntries):
             try:
@@ -502,6 +510,7 @@ class GitRepo(object):
                 self.repo = self.cmd_call_wrapper(gitpy.Repo.clone_from,
                                                   url,
                                                   path,
+                                                  env=env,
                                                   odbt=default_git_odbt)
                 lgr.debug("Git clone completed")
                 break

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -125,7 +125,7 @@ class SSHConnection(object):
         if not exists(self.ctrl_path):
             # set control options
             ctrl_options = ["-o", "ControlMaster=auto",
-                            "-o", "ControlPersist=yes"] + self.ctrl_options
+                            "-o", "ControlPersist=15m"] + self.ctrl_options
             # create ssh control master command
             cmd = ["ssh"] + ctrl_options + [self.host, "exit"]
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -14,6 +14,7 @@ git calls to a ssh remote without the need to reauthenticate.
 """
 
 import logging
+from os.path import exists
 from subprocess import Popen
 from shlex import split as sh_split
 
@@ -111,15 +112,16 @@ class SSHConnection(object):
         connection, if it is not there already.
         """
 
-        # set control options
-        ctrl_options = ["-o", "ControlMaster=auto", "-o", "ControlPersist=yes"] + self.ctrl_options
-        # create ssh control master command
-        cmd = ["ssh"] + ctrl_options + [self.host, "exit"]
+        if not exists(self.ctrl_path):
+            # set control options
+            ctrl_options = ["-o", "ControlMaster=auto", "-o", "ControlPersist=yes"] + self.ctrl_options
+            # create ssh control master command
+            cmd = ["ssh"] + ctrl_options + [self.host, "exit"]
 
-        # start control master:
-        lgr.debug("Try starting control master by calling:\n%s" % cmd)
-        proc = Popen(cmd)
-        proc.communicate(input="\n")  # why the f.. this is necessary?
+            # start control master:
+            lgr.debug("Try starting control master by calling:\n%s" % cmd)
+            proc = Popen(cmd)
+            proc.communicate(input="\n")  # why the f.. this is necessary?
 
     def close(self):
         """Closes the connection.

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -187,7 +187,7 @@ class SSHManager(object):
         if self._socket_dir is None:
             # TODO: centralize AppDirs (=> datalad.config?)
             from appdirs import AppDirs
-            self._socket_dir = AppDirs('datalad', 'datalad.org').user_config_dir
+            self._socket_dir = AppDirs('datalad', 'datalad.org').user_cache_dir
             assure_dir(self._socket_dir)
         return self._socket_dir
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -9,18 +9,21 @@
 
 """
 
+import logging
 import os
 from os.path import exists, isdir, getmtime, join as opj
 
-from nose.tools import ok_, assert_is_instance
-
-from datalad.support.sshconnector import SSHConnection, SSHManager
-from datalad.tests.utils import assert_raises, eq_
-from datalad.tests.utils import skip_ssh, with_tempfile, get_most_obscure_supported_name
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import eq_
+from datalad.tests.utils import skip_ssh
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import ok_
+from datalad.tests.utils import assert_is_instance
 
-import logging
+from ..sshconnector import SSHConnection, SSHManager
 
 
 @skip_ssh
@@ -45,7 +48,7 @@ def test_ssh_get_connection():
 
 
 @skip_ssh
-@with_tempfile(suffix=" \"`suffix:;& ", # get_most_obscure_supported_name(),
+@with_tempfile(suffix=" \"`suffix:;& ",  # get_most_obscure_supported_name(),
                content="1")
 def test_ssh_open_close(tfile1):
 
@@ -58,7 +61,8 @@ def test_ssh_open_close(tfile1):
 
     # use connection to execute remote command:
     out, err = c1(['ls', '-a'])
-    remote_ls = [entry for entry in out.splitlines() if entry != '.' and entry != '..']
+    remote_ls = [entry for entry in out.splitlines()
+                 if entry != '.' and entry != '..']
     local_ls = os.listdir(os.path.expanduser('~'))
     eq_(set(remote_ls), set(local_ls))
 
@@ -89,6 +93,7 @@ def test_ssh_manager_close():
 
 def test_ssh_manager_close_no_throw():
     manager = SSHManager()
+
     class bogus:
         def close(self):
             raise Exception("oh I am so bad")
@@ -125,7 +130,8 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
 
     # recursive copy tempdir to remote_url:targetdir
     targetdir = sourcedir + '.c opy'
-    ssh.copy(sourcedir, opj(remote_url, targetdir), recursive=True, preserve_attrs=True)
+    ssh.copy(sourcedir, opj(remote_url, targetdir),
+             recursive=True, preserve_attrs=True)
 
     # check if sourcedir copied to remote_url:targetdir
     ok_(isdir(targetdir))


### PR DESCRIPTION
Fixes issues with shared SSH connections. Led to asking for credentials several times.
- Cloning and  `datalad add-sibling` didn't correctly use this mechanic
- directory used for SSH control masters now depends on config item `datalad.locations.cache`
- Deal with existing but not running control masters
- let annex know about setting a remote's url
- time out for control master: 15 minutes

Closes #826 
Closes #865 
Closes #1032 

- [x] make socket location configurable

Note: More on the topic of publishing and siblings to come in another PR. Also more testing.