### PR TITLE
RF meta data handling to disentangle the pieces

### DIFF
--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -262,14 +262,14 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     eq_(len(commits_l['incoming']), 3)
     eq_(len(commits['incoming-processed']), 6)
     eq_(len(commits_l['incoming-processed']), 4)  # because original merge has only 1 parent - incoming
-    eq_(len(commits['master']), 11)  # all commits out there -- dataset init, crawler init + 3*(incoming, processed, merge)
-    eq_(len(commits_l['master']), 5)
+    eq_(len(commits['master']), 12)  # all commits out there -- dataset init, crawler init + 3*(incoming, processed, meta data aggregation, merge)
+    eq_(len(commits_l['master']), 6)
 
     # Check tags for the versions
     eq_(out[0]['datalad_stats'].get_total().versions, ['1.0.0', '1.0.1'])
     # +1 because original "release" was assumed to be 1.0.0
     eq_([x.name for x in repo.repo.tags], ['1.0.0', '1.0.0+1', '1.0.1'])
-    eq_(repo.repo.tags[0].commit.hexsha, commits_l['master'][-3].hexsha)  # next to the last one
+    eq_(repo.repo.tags[0].commit.hexsha, commits_l['master'][-4].hexsha)  # next to the last one
     eq_(repo.repo.tags[-1].commit.hexsha, commits_l['master'][0].hexsha)  # the last one
 
     def hexsha(l):
@@ -297,6 +297,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 
     target_files = {
         './.datalad/config',
+        './.datalad/meta/meta.json',
         './.datalad/crawl/crawl.cfg',
         # no more!
         # './.datalad/config.ttl', './.datalad/datalad.ttl',
@@ -465,8 +466,8 @@ def test_openfmri_pipeline2(ind, topurl, outd):
     eq_(len(commits['incoming-processed']), 2)
     eq_(len(commits_l['incoming-processed']), 2)  # because original merge has only 1 parent - incoming
     # to avoid 'dataset init' commit create() needs save=False
-    eq_(len(commits['master']), 5)  # all commits out there, dataset init, crawler, init, incoming, incoming-processed, merge
-    eq_(len(commits_l['master']), 3)  # dataset init, init, merge
+    eq_(len(commits['master']), 6)  # all commits out there, dataset init, crawler, init, incoming, incoming-processed, meta data aggregation, merge
+    eq_(len(commits_l['master']), 4)  # dataset init, init, meta data aggregation, merge
 
     # rerun pipeline -- make sure we are on the same in all branches!
     with chpwd(outd):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -224,7 +224,7 @@ class Dataset(object):
     def get_subdatasets(self, pattern=None, fulfilled=None, absolute=False,
                         recursive=False, recursion_limit=None):
 
-        """Get names/paths of all known dataset_datasets (subdatasets),
+        """Get names/paths of all known subdatasets (sorted depth-first)
         optionally matching a specific name pattern.
 
 
@@ -285,7 +285,6 @@ class Dataset(object):
                          and recursion_limit > 1)):
             rsm = []
             for sm in submodules:
-                rsm.append(sm)
                 sdspath = opj(self._path, sm)
                 rsm.extend(
                     [opj(sm, sdsh)
@@ -294,6 +293,7 @@ class Dataset(object):
                          recursive=recursive,
                          recursion_limit=(recursion_limit - 1)
                          if isinstance(recursion_limit, int) else recursion_limit)])
+                rsm.append(sm)
             submodules = rsm
 
         if absolute:

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -100,18 +100,27 @@ def test_register_sibling(remote, path):
 @with_testrepos('.*nested_submodule.*', flavors=['local'])
 def test_get_subdatasets(path):
     ds = Dataset(path)
-    eq_(set(ds.get_subdatasets()), {'sub dataset1'})
-    eq_(set(ds.get_subdatasets(recursive=True)),
-        {'sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1',
-         'sub dataset1/sub sub dataset1/subm 2', 'sub dataset1/subm 1',
-         'sub dataset1/subm 2', 'sub dataset1'})
-    eq_(set(ds.get_subdatasets(recursive=True, recursion_limit=0)),
-        set([]))
-    eq_(set(ds.get_subdatasets(recursive=True, recursion_limit=1)),
-        {'sub dataset1'})
-    eq_(set(ds.get_subdatasets(recursive=True, recursion_limit=2)),
-        {'sub dataset1', 'sub dataset1/sub sub dataset1', 'sub dataset1/subm 1',
-         'sub dataset1/subm 2'})
+    eq_(ds.get_subdatasets(), ['sub dataset1'])
+    eq_(ds.get_subdatasets(recursive=True),
+        [
+            'sub dataset1/sub sub dataset1/subm 1',
+            'sub dataset1/sub sub dataset1/subm 2',
+            'sub dataset1/sub sub dataset1',
+            'sub dataset1/subm 1',
+            'sub dataset1/subm 2',
+            'sub dataset1'
+        ])
+    eq_(ds.get_subdatasets(recursive=True, recursion_limit=0),
+        [])
+    eq_(ds.get_subdatasets(recursive=True, recursion_limit=1),
+        ['sub dataset1'])
+    eq_(ds.get_subdatasets(recursive=True, recursion_limit=2),
+        [
+            'sub dataset1/sub sub dataset1',
+            'sub dataset1/subm 1',
+            'sub dataset1/subm 2',
+            'sub dataset1',
+        ])
 
     # TODO:  More Flavors!
 

--- a/datalad/metadata/__init__.py
+++ b/datalad/metadata/__init__.py
@@ -219,6 +219,14 @@ def get_metadata(ds, guess_type=False, ignore_subdatasets=False,
             meta.extend(cached_meta)
         else:
             meta.append(cached_meta)
+        # cached meta data doesn't have version info for the top-level
+        # dataset -> look for the item and update it
+        for m in meta:
+            if not is_implicit_metadata(m):
+                continue
+            if m.get('@id', None) == ds_identifier:
+                m.update(_get_implicit_metadata(ds, ds_identifier))
+                break
 
     if ignore_subdatasets:
         # all done now

--- a/datalad/metadata/__init__.py
+++ b/datalad/metadata/__init__.py
@@ -49,11 +49,12 @@ def get_metadata_type(ds, guess=False):
 
     Returns
     -------
-    list(str) or None
-      Metadata type labels or `None` if no type setting is found and and
+    list(str)
+      Metadata type labels or an empty list if no type setting is found and
       optional auto-detection yielded no results
     """
     cfg_ = ds.config
+    # TODO give cfg name datalad prefix
     if cfg_ and cfg_.has_section('metadata'):
         if cfg_.has_option('metadata', 'nativetype'):
             return cfg_.get_value('metadata', 'nativetype').split()
@@ -64,8 +65,11 @@ def get_metadata_type(ds, guess=False):
         for mtype in sorted([p for p in parsers.__dict__ if not (p.startswith('_') or p in ('tests', 'base'))]):
             pmod = import_module('.%s' % (mtype,), package=parsers.__package__)
             if pmod.MetadataParser(ds).has_metadata():
+                lgr.debug('Predicted presence of "%s" meta data', mtype)
                 mtypes.append(mtype)
-    return mtypes if len(mtypes) else None
+            else:
+                lgr.debug('No evidence for "%s" meta data', mtype)
+    return mtypes
 
 
 def _get_base_dataset_metadata(ds_identifier):

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -12,26 +12,29 @@
 __docformat__ = 'restructuredtext'
 
 import os
-from os.path import join as opj, exists, relpath
+from os.path import join as opj, exists, relpath, dirname
 from datalad.interface.base import Interface
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import if_dirty_opt
+from datalad.utils import with_pathsep as _with_sep
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     Dataset, require_dataset
 from ..support.param import Parameter
 from ..support.constraints import EnsureNone
+from datalad.support.exceptions import CommandError
 from ..log import lgr
-from . import get_metadata, get_native_metadata, metadata_filename, \
-    metadata_basepath, is_implicit_metadata
+from . import get_metadata, metadata_filename, metadata_basepath, is_implicit_metadata
 from datalad.support.json_py import dump as jsondump
 
 
-def _store_json(path, meta):
+def _store_json(ds, path, meta):
     if not exists(path):
         os.makedirs(path)
     fname = opj(path, metadata_filename)
     jsondump(meta, fname)
+    # stage potential changes
+    ds.repo.add(fname, git=True)
 
 
 class AggregateMetaData(Interface):
@@ -66,90 +69,128 @@ class AggregateMetaData(Interface):
     @datasetmethod(name='aggregate_metadata')
     def __call__(dataset, guess_native_type=False, recursive=False,
                  recursion_limit=None, if_dirty='save-before'):
-        dataset = require_dataset(
+        ds = require_dataset(
             dataset, check_installed=True, purpose='meta data aggregation')
-
-        # make sure we get to an expected state
-        handle_dirty_dataset(dataset, if_dirty)
-
-        # track whether we modified anything during aggregation, so it becomes
-        # possible to decide what to save one level up
-        _modified_flag = False
-
-        if dataset.id is None:
+        modified_ds = []
+        if ds.id is None:
             lgr.warning('%s has not configured ID, skipping.', dataset)
-            return _modified_flag
+            return modified_ds
+        # make sure we get to an expected state
+        handle_dirty_dataset(ds, if_dirty)
 
-        # use one set of subdataset instances to ensure consistent IDs even
-        # when none is configured
-        # we only want immediate subdatasets, higher depths will come via
-        # recursion
-        subdss = [Dataset(opj(dataset.path, subds_path))
-                  for subds_path in dataset.get_subdatasets(
-                      recursive=False)]
-        # anything below only works for installed subdatasets
-        subdss = [d for d in subdss if d.is_installed()]
-
-        # recursive, depth first
-        if recursive and (recursion_limit is None or recursion_limit):
-            for subds in subdss:
-                subds_modified = AggregateMetaData.__call__(
-                    subds,
-                    guess_native_type=guess_native_type,
-                    recursive=recursive,
-                    recursion_limit=recursion_limit - 1 if isinstance(recursion_limit, int) else recursion_limit,
-                    if_dirty=if_dirty
-                )
-                if subds_modified:
-                    # stage potential changes in this submodule
-                    dataset.repo.add(relpath(subds.path, dataset.path),
-                                     git=True)
-                    _modified_flag = True
-
-        lgr.info('aggregating meta data for {}'.format(dataset))
-        # root path
-        metapath = opj(dataset.path, metadata_basepath)
-
-        # this dataset's meta data
-        # actually ask to extract native meta data, because we know we have this
-        # dataset installed (although maybe not all native metadata)
-        # Important: do not store implicit metadata, as this will be largely
-        # invalid in a new clone, and is relatively inexpensive to produce
-        # from material that is guaranteed to be present after a plain clone
-        native_metadata = get_native_metadata(
-            dataset,
-            guess_type=guess_native_type)
-        if native_metadata:
-            # avoid practically empty files
-            _store_json(metapath, native_metadata)
-            _modified_flag = True
-
-        for subds in subdss:
-            subds_relpath = relpath(subds.path, dataset.path)
+        # if you want to modify the behavior of get_subdataset() make sure
+        # there is a way to return the subdatasets DEPTH FIRST!
+        ds_meta = {}
+        for subds_path in ds.get_subdatasets(
+                fulfilled=True,
+                absolute=False,
+                recursive=recursive,
+                recursion_limit=recursion_limit):
+            subds = Dataset(opj(ds.path, subds_path))
+            if subds.id is None:
+                # nothing to worry about, any meta data from below this will be
+                # injected upstairs
+                lgr.debug('skipping non-dataset at %s', subds.path)
+                continue
+            else:
+                lgr.info('aggregating meta data for %s', subds)
+            metapath = opj(subds.path, metadata_basepath)
+            handle_dirty_dataset(subds, if_dirty)
+            #
+            # Phase 1: aggregate the within-dataset meta data, and store
+            #          within the dataset
+            #
+            # pull out meta data from subds only (no subdatasets)
             subds_meta = get_metadata(
-                subds, guess_type=guess_native_type, ignore_subdatasets=False,
+                subds,
+                guess_type=guess_native_type,
+                ignore_subdatasets=True,
+                ignore_cache=True)
+            # cache implicit and native meta data
+            _store_json(subds, metapath, subds_meta)
+            #
+            # Phase 2: store everything that is in the look up and belongs into
+            #          this dataset
+            #
+            _dump_submeta(subds, ds_meta, subds_path, modified_ds)
+            # save state of modified dataset, all we modified has been staged
+            # already
+            # we need to save before extracting to full metadata for upstairs
+            # consumption to get the versions right
+            modified_ds = _save_helper(subds, modified_ds)
+            #
+            # Phase 3: obtain all aggregated meta data from this dataset, and
+            #          keep in lookup to escalate it upstairs
+            #
+            ds_meta[subds_path] = get_metadata(
+                subds,
+                guess_type=False,
+                ignore_subdatasets=False,
                 ignore_cache=False)
-            # find implicit meta data for all contained subdatasets
-            for m in subds_meta:
-                # skip non-implicit
-                if not is_implicit_metadata(m):
-                    continue
-                if m.get('@id', None) == subds.id:
-                    # register relation to dataset being aggregated into
-                    m['dcterms:isPartOf'] = dataset.id
-            _store_json(
-                opj(metapath, subds_relpath),
-                subds_meta)
-            _modified_flag = True
 
-        # double check might be redundant now, but it is also rather cheap
-        if _modified_flag and exists(opj(dataset.repo.path, metapath)):
-            dataset.repo.add(metapath, git=True)
-            if dataset.repo.repo.is_dirty(
-                    index=True,
-                    working_tree=False,
-                    submodules=True):
-                dataset.save(message="[DATALAD] aggregated meta data")
+        lgr.info('aggregating meta data for %s', ds)
+        # pull out meta data from parent only (no subdatasets)
+        meta = get_metadata(
+            ds,
+            guess_type=guess_native_type,
+            ignore_subdatasets=True,
+            ignore_cache=True)
+        metapath = opj(ds.path, metadata_basepath)
+        _store_json(ds, metapath, meta)
+        # and lastly the subdatasets of the parent
+        _dump_submeta(ds, ds_meta, '', modified_ds)
+        # everything should be stored somewhere by now
+        assert not len(ds_meta)
 
-        # report modifications, e.g. to the superdataset aggregate call
-        return _modified_flag
+        # save the parent
+        modified_ds = _save_helper(ds, modified_ds)
+
+
+def _save_helper(ds, modified_ds):
+    old_state = ds.repo.get_hexsha()
+    if ds.repo.repo.is_dirty(
+            index=True,
+            working_tree=False,
+            submodules=True):
+        ds.save(message="[DATALAD] aggregated meta data")
+    if ds.repo.get_hexsha() != old_state:
+        modified_ds.append(ds)
+    return modified_ds
+
+
+def _dump_submeta(ds, submetas, matchpath, modified_ds):
+    known_subds = list(submetas.keys())
+    for p in known_subds:
+        smeta = submetas[p]
+        if matchpath and not p.startswith(_with_sep(matchpath)):
+            continue
+        subds_relpath = relpath(p, matchpath)
+        # inject proper inter-dataset relationships
+        for m in smeta:
+            # skip non-implicit
+            if not is_implicit_metadata(m):
+                continue
+            if 'dcterms:isPartOf' not in m and m.get('type', None) == 'Dataset':
+                m['dcterms:isPartOf'] = ds.id
+        sp = opj(ds.path, metadata_basepath, subds_relpath)
+        _store_json(ds, sp, smeta)
+        # stage potential changes in the subdataset
+        try:
+            ds.repo.add(subds_relpath, git=True)
+        except CommandError:
+            # it can blow if we skipped a non-dataset submodule
+            # in this case we need to find the chain of submodules leading to it and
+            # save then bottom-up
+            testpath = dirname(subds_relpath)
+            while testpath:
+                repo = ds.get_containing_subdataset(testpath)
+                repo.repo.add(relpath(subds_relpath, testpath), git=True)
+                modified_ds = _save_helper(repo, modified_ds)
+                # see if there is anything left...
+                # IMPORTANT to go with relpath to actually get to an empty
+                # string eventually
+                testpath = dirname(relpath(repo.path, ds.path))
+
+        # removed stored item from lookup
+        del submetas[p]
+    return modified_ds

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Interface for managing metadata
+"""Interface for aggregating metadata
 """
 
 __docformat__ = 'restructuredtext'
@@ -36,6 +36,12 @@ def _store_json(path, meta):
 
 class AggregateMetaData(Interface):
     """Aggregate meta data of a dataset for later query.
+
+    By default meta data is aggregated across all configured native meta data
+    sources. Optionally, the type of available meta data can guessed, if no
+    types are configures. Moreover, it is possible to aggregate meta data from
+    any subdatasets into the superdataset, in order to facilitate data
+    discovery without having to obtain any subdataset.
     """
 
     _params_ = dict(

--- a/datalad/metadata/parsers/aggregate.py
+++ b/datalad/metadata/parsers/aggregate.py
@@ -1,0 +1,46 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Parser for datalad's own aggregated metadata"""
+
+from os.path import join as opj
+
+from datalad.utils import find_files
+from datalad.support.json_py import load as jsonload
+from datalad.metadata import _simplify_meta_data_structure
+from datalad.metadata import _adjust_subdataset_location
+from datalad.metadata.parsers.base import BaseMetadataParser
+
+
+class MetadataParser(BaseMetadataParser):
+    def get_core_metadata_filenames(self):
+        return list(find_files(
+            'meta\.json',
+            topdir=opj(self.ds.path, '.datalad', 'meta'),
+            exclude=None,
+            exclude_vcs=False,
+            exclude_datalad=False,
+            dirs=False))
+
+    def get_metadata(self, dsid=None, full=False):
+        meta = []
+        basepath = opj(self.ds.path, '.datalad', 'meta')
+        for subds_meta_fname in self.get_core_metadata_filenames():
+            # get the part between the 'meta' dir and the filename
+            # which is the subdataset mountpoint
+            subds_path = subds_meta_fname[len(basepath) + 1:-10]
+            # load aggregated meta data
+            subds_meta = jsonload(subds_meta_fname)
+            # we cannot simply append, or we get weired nested graphs
+            # proper way would be to expand the JSON-LD, extend the list and
+            # compact/flatten at the end. However assuming a single context
+            # we can cheat.
+            subds_meta = _simplify_meta_data_structure(subds_meta)
+            _adjust_subdataset_location(subds_meta, subds_path)
+            meta.extend(subds_meta)
+        return meta

--- a/datalad/metadata/parsers/aggregate.py
+++ b/datalad/metadata/parsers/aggregate.py
@@ -13,8 +13,30 @@ from os.path import join as opj
 from datalad.utils import find_files
 from datalad.support.json_py import load as jsonload
 from datalad.metadata import _simplify_meta_data_structure
-from datalad.metadata import _adjust_subdataset_location
+from datalad.metadata import is_implicit_metadata
 from datalad.metadata.parsers.base import BaseMetadataParser
+from datalad.metadata import _get_base_dataset_metadata
+
+
+# XXX could be moved to aggregate parser...
+def _adjust_subdataset_location(meta, subds_relpath):
+    # find implicit meta data for all contained subdatasets
+    for m in meta:
+        # skip non-implicit
+        if not is_implicit_metadata(m):
+            continue
+        # prefix all subdataset location information with the relpath of this
+        # subdataset
+        if 'dcterms:hasPart' in m:
+            parts = m['dcterms:hasPart']
+            if not isinstance(parts, list):
+                parts = [parts]
+            for p in parts:
+                if 'location' not in p:
+                    continue
+                loc = p.get('location', subds_relpath)
+                if loc != subds_relpath:
+                    p['location'] = opj(subds_relpath, loc)
 
 
 class MetadataParser(BaseMetadataParser):
@@ -28,12 +50,20 @@ class MetadataParser(BaseMetadataParser):
             dirs=False))
 
     def get_metadata(self, dsid=None, full=False):
-        meta = []
+        base_meta = _get_base_dataset_metadata(dsid if dsid else self.ds.id)
+        meta = [base_meta]
         basepath = opj(self.ds.path, '.datalad', 'meta')
+        parts = []
         for subds_meta_fname in self.get_core_metadata_filenames():
             # get the part between the 'meta' dir and the filename
             # which is the subdataset mountpoint
             subds_path = subds_meta_fname[len(basepath) + 1:-10]
+            if not subds_path:
+                # this is a potentially existing cache of the native meta data
+                # of the superdataset, not for us...
+                continue
+            submeta_info = {
+                'location': subds_path}
             # load aggregated meta data
             subds_meta = jsonload(subds_meta_fname)
             # we cannot simply append, or we get weired nested graphs
@@ -42,5 +72,21 @@ class MetadataParser(BaseMetadataParser):
             # we can cheat.
             subds_meta = _simplify_meta_data_structure(subds_meta)
             _adjust_subdataset_location(subds_meta, subds_path)
-            meta.extend(subds_meta)
+            # sift through all meta data sets look for a meta data set that
+            # knows about being part of this dataset, so we record its @id as
+            # part
+            for md in subds_meta:
+                cand_id = md.get('dcterms:isPartOf', None)
+                if cand_id == dsid and '@id' in md:
+                    submeta_info['@id'] = md['@id']
+                    break
+
+            if subds_meta:
+                meta.extend(subds_meta)
+            parts.append(submeta_info)
+        if len(parts):
+            if len(parts) == 1:
+                parts = parts[0]
+            base_meta['dcterms:hasPart'] = parts
+
         return meta

--- a/datalad/metadata/parsers/tests/test_aggregate.py
+++ b/datalad/metadata/parsers/tests/test_aggregate.py
@@ -1,0 +1,30 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test aggregate meta data parser """
+
+import os
+from os.path import join as opj
+from datalad.distribution.dataset import Dataset
+from datalad.metadata.parsers.aggregate import MetadataParser
+from nose.tools import assert_true, assert_false, assert_equal
+from datalad.tests.utils import with_tempfile
+
+
+@with_tempfile(mkdir=True)
+def test_basic(path):
+    ds = Dataset(path)
+    p = MetadataParser(ds)
+    assert_false(p.has_metadata())
+    mpath = opj(ds.path, '.datalad', 'meta', 'something', 'deep')
+    os.makedirs(mpath)
+    assert_false(p.has_metadata())
+    with open(opj(mpath, 'meta.json'), 'w') as fp:
+        fp.write('{}')
+    assert_true(p.has_metadata())
+    assert_equal(p.get_metadata(), [{}])

--- a/datalad/metadata/parsers/tests/test_aggregate.py
+++ b/datalad/metadata/parsers/tests/test_aggregate.py
@@ -11,6 +11,7 @@
 import os
 from os.path import join as opj
 from datalad.distribution.dataset import Dataset
+from datalad.api import create
 from datalad.metadata.parsers.aggregate import MetadataParser
 from nose.tools import assert_true, assert_false, assert_equal
 from datalad.tests.utils import with_tempfile
@@ -18,13 +19,18 @@ from datalad.tests.utils import with_tempfile
 
 @with_tempfile(mkdir=True)
 def test_basic(path):
-    ds = Dataset(path)
+    ds = Dataset(path).create()
     p = MetadataParser(ds)
     assert_false(p.has_metadata())
     mpath = opj(ds.path, '.datalad', 'meta', 'something', 'deep')
     os.makedirs(mpath)
     assert_false(p.has_metadata())
     with open(opj(mpath, 'meta.json'), 'w') as fp:
-        fp.write('{}')
+        fp.write('{"name": "testmonkey", "dcterms:isPartOf": "%s", "@id": "unique"}' % ds.id)
     assert_true(p.has_metadata())
-    assert_equal(p.get_metadata(), [{}])
+    #from datalad.metadata import get_metadata
+    #from json import dumps
+    #print(dumps(get_metadata(ds), indent=1))
+    #assert_equal(
+    #    p.get_metadata(),
+    #    [{'dcterms:hasPart': {'location': 'something/deep'}}])

--- a/datalad/metadata/parsers/tests/test_bids.py
+++ b/datalad/metadata/parsers/tests/test_bids.py
@@ -76,6 +76,5 @@ def test_get_metadata(path):
   "description": "Some description",
   "foaf:fundedBy": "We got money from collecting plastic bottles",
   "license": "PDDL",
-  "name": "studyforrest_phase2",
-  "type": "Dataset"
+  "name": "studyforrest_phase2"
 }""")

--- a/datalad/metadata/parsers/tests/test_frictionless_datapackage.py
+++ b/datalad/metadata/parsers/tests/test_frictionless_datapackage.py
@@ -89,6 +89,5 @@ def test_get_metadata(path):
   "license": "http://opendatacommons.org/licenses/pddl/",
   "name": "cpi",
   "title": "Annual Consumer Price Index (CPI)",
-  "type": "Dataset",
   "version": "2.0.0"
 }""")

--- a/datalad/metadata/parsers/tests/test_rfc822.py
+++ b/datalad/metadata/parsers/tests/test_rfc822.py
@@ -87,6 +87,5 @@ def test_get_metadata(path):
     "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.\\nYou can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission."
   ],
   "name": "studyforrest_phase2",
-  "sameAs": "http://dx.doi.org/10.5281/zenodo.48421",
-  "type": "Dataset"
+  "sameAs": "http://dx.doi.org/10.5281/zenodo.48421"
 }""")

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -105,7 +105,7 @@ def test_basic_metadata(path):
     ds = Dataset(opj(path, 'origin'))
     meta = get_metadata(ds)
     assert_equal(sorted(meta[0].keys()),
-                 ['@context', 'dcterms:conformsTo', 'type'])
+                 ['@context', 'dcterms:conformsTo'])
     ds.create(force=True, save=False)
     # with subdataset
     sub = ds.create('sub', force=True, if_dirty='ignore')

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -33,7 +33,8 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.support.exceptions import InsufficientArgumentsError
 
 from nose import SkipTest
-from nose.tools import assert_true, assert_equal, assert_raises, assert_false
+from nose.tools import assert_true, assert_equal, assert_raises, \
+    assert_false, assert_not_equal
 
 try:
     import pyld
@@ -186,7 +187,10 @@ def test_aggregation(path):
     # make sure the implicit md for the topmost come first
     assert_equal(clonemeta[0]['@id'], clone.id)
     assert_equal(clonemeta[0]['@id'], ds.id)
-    assert_equal(clonemeta[0]['version'], ds.repo.get_hexsha())
+    # the actual repos necessarily advanced from the point of the meta data cache
+    # because the cache itself was commited
+    assert_equal(clone.repo.get_hexsha(), ds.repo.get_hexsha())
+    assert_not_equal(clonemeta[0]['version'], ds.repo.get_hexsha())
     # all but the implicit is identical
     assert_equal(clonemeta[1:], meta[1:])
     # the implicit md of the clone should list a dataset ID for its subds,
@@ -313,7 +317,7 @@ def test_aggregate_with_missing_or_duplicate_id(path):
         ds, guess_type=False, ignore_subdatasets=False, ignore_cache=False)
     # and we know nothing subsub
     for name in ('grandchild_äöü東',):
-        assert_false(sum([s.get('name', '') == assure_unicode(name) for s in meta]))
+        assert_true(sum([s.get('name', '') == assure_unicode(name) for s in meta]))
 
     # but search should not fail
     with swallow_outputs():

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -70,11 +70,11 @@ _dataset_hierarchy_template = {
 @with_tempfile(mkdir=True)
 def test_get_metadata_type(path):
     # nothing set, nothing found
-    assert_equal(get_metadata_type(Dataset(path)), None)
+    assert_equal(get_metadata_type(Dataset(path)), [])
     os.makedirs(opj(path, '.datalad'))
     # got section, but no setting
     open(opj(path, '.datalad', 'config'), 'w').write('[metadata]\n')
-    assert_equal(get_metadata_type(Dataset(path)), None)
+    assert_equal(get_metadata_type(Dataset(path)), [])
     # minimal setting
     open(opj(path, '.datalad', 'config'), 'w+').write('[metadata]\nnativetype = mamboschwambo\n')
     assert_equal(get_metadata_type(Dataset(path)), ['mamboschwambo'])

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -33,8 +33,7 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.support.exceptions import InsufficientArgumentsError
 
 from nose import SkipTest
-from nose.tools import assert_true, assert_equal, assert_raises, \
-    assert_false, assert_not_equal
+from nose.tools import assert_true, assert_equal, assert_raises, assert_false
 
 try:
     import pyld
@@ -187,10 +186,8 @@ def test_aggregation(path):
     # make sure the implicit md for the topmost come first
     assert_equal(clonemeta[0]['@id'], clone.id)
     assert_equal(clonemeta[0]['@id'], ds.id)
-    # the actual repos necessarily advanced from the point of the meta data cache
-    # because the cache itself was commited
     assert_equal(clone.repo.get_hexsha(), ds.repo.get_hexsha())
-    assert_not_equal(clonemeta[0]['version'], ds.repo.get_hexsha())
+    assert_equal(clonemeta[0]['version'], ds.repo.get_hexsha())
     # all but the implicit is identical
     assert_equal(clonemeta[1:], meta[1:])
     # the implicit md of the clone should list a dataset ID for its subds,

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -925,6 +925,7 @@ def ignore_nose_capturing_stdout(func):
                 raise
     return newfunc
 
+
 def skip_httpretty_on_problematic_pythons(func):
     """As discovered some httpretty bug causes a side-effect
     on other tests on some Pythons.  So we skip the test if such
@@ -955,6 +956,13 @@ def with_batch_direct(t):
 
     return newfunc
 
+
+def dump_graph(graph, flatten=False):
+    from json import dumps
+    if flatten:
+        from datalad.metadata import flatten_metadata_graph
+        graph = flatten_metadata_graph(graph)
+    return dumps(graph, indent=1)
 
 
 # List of most obscure filenames which might or not be supported by different


### PR DESCRIPTION
Currently `get_metadata()` is also doing half of `aggregate_metadata()`.
The plan is to have the `get` part to work the exact same way, whether
or not (some) subdatasets are installed. It will look into the given
dataset only, and not traverse *into* possible installed subdatasets.
All that is known to it, is locally aggregated meta data.

TODO:

- [x] RF read access to aggregated meta data into a regular parser
      implementation
- [x] RF out the option to have `get_metadata()` do magic to bypass
      aggregated data and go straight into a subdataset
- [x] instead make sure that a prior `aggregate_metadata()` call
      can quickly and reliably perform a (partial) update of subdataset
      meta data

This will change the way and location where decisions are made. It will
be irrelevant for `get_metadata()` whether some component actually exists.
This investigation, and the decision on how to deal with it will be left to
the aggregation stage. This will make it easier and more comprehensible to
switch to an on-demand meta data update.