### PR TITLE
ENH+RF:  datalad add  progress indication + passing --jobs  into annex

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -22,6 +22,7 @@ from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_add_opts
 from datalad.interface.common_opts import if_dirty_opt
+from datalad.interface.common_opts import jobs_opt
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.save import Save
 from datalad.support.constraints import EnsureStr
@@ -118,7 +119,9 @@ class Add(Interface):
         if_dirty=if_dirty_opt,
         git_opts=git_opts,
         annex_opts=annex_opts,
-        annex_add_opts=annex_add_opts)
+        annex_add_opts=annex_add_opts,
+        jobs=jobs_opt
+    )
 
     @staticmethod
     @datasetmethod(name='add')
@@ -133,7 +136,8 @@ class Add(Interface):
             if_dirty='ignore',
             git_opts=None,
             annex_opts=None,
-            annex_add_opts=None):
+            annex_add_opts=None,
+            jobs=None):
 
         # parameter constraints:
         if not path and not source:
@@ -275,6 +279,7 @@ class Add(Interface):
                     return_values.extend(
                         ds.repo.add(calls[dspath]['a_add'],
                                     git=False,
+                                    jobs=jobs,
                                     git_options=git_opts,
                                     annex_options=annex_opts,
                                     options=annex_add_opts
@@ -299,7 +304,8 @@ class Add(Interface):
                                          options=annex_add_opts,
                                          # TODO: extra parameter for addurl?
                                          git_options=git_opts,
-                                         annex_options=annex_opts
+                                         annex_options=annex_opts,
+                                         jobs=jobs,
                                          )
                     )
                 else:

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -113,7 +113,9 @@ def test_add_recursive(path):
     assert_raises(CommandError, ds.add, opj('dir', 'testindir'),
                   recursive=True, recursion_limit=0)
 
-    ds.add(opj('dir', 'testindir'), recursive=True)
+    # add while also instructing annex to add in parallel 2 jobs (smoke testing
+    # for that effect ATM)
+    ds.add(opj('dir', 'testindir'), recursive=True, jobs=2)
     assert_in('testindir', Dataset(opj(path, 'dir')).repo.get_annexed_files())
 
     ds.add(opj('dir', 'testindir2'), recursive=True, to_git=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -763,23 +763,23 @@ def test_AnnexRepo_get(src, dst):
 
     called = []
     # for some reason yoh failed mock to properly just call original func
-    orig_run = annex._run_annex_command_json
+    orig_run = annex._run_annex_command
 
-    def check_run(cmd, args, **kwargs):
+    def check_run(cmd, annex_options, **kwargs):
         called.append(cmd)
         if cmd == 'find':
-            assert_not_in('-J5', args)
+            assert_not_in('-J5', annex_options)
         elif cmd == 'get':
-            assert_in('-J5', args)
+            assert_in('-J5', annex_options)
         else:
             raise AssertionError(
                 "no other commands so far should be ran. Got %s, %s" %
-                (cmd, args)
+                (cmd, annex_options)
             )
-        return orig_run(cmd, args, **kwargs)
+        return orig_run(cmd, annex_options=annex_options, **kwargs)
 
     annex.drop(testfile)
-    with patch.object(AnnexRepo, '_run_annex_command_json',
+    with patch.object(AnnexRepo, '_run_annex_command',
                       side_effect=check_run, auto_spec=True), \
             swallow_outputs():
         annex.get(testfile, jobs=5)


### PR DESCRIPTION
as @agramfort pointed out -- ATM `datalad add BUNCHOFFILES` just stays silent for a while and then spits out its long list.  This PR adds a progress bar (based on file sizes, but also with total count) and exposes `--jobs` option, allowing to make checksumming faster

Resulted also in some refactorings etc ;)  Let's see now if anything got broken