### PR TITLE
Choice 1 BF: do not log outputs by default (if config cannot yet be read)

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -133,8 +133,9 @@ class Runner(object):
                 self.__log_outputs = \
                     cfg.getbool('datalad.log', 'outputs', default=False)
             except ImportError:
-                # could be too early, then log!
-                return True
+                # could be too early, then DON'T log since might be sensitive!
+                # information
+                return False
         return self.__log_outputs
 
     # Two helpers to encapsulate formatting/output


### PR DESCRIPTION
this is an alternative to more "controlled", config specific handling of the runner's logging -- just do not log outputs by default before we can read config

Or should I push the alternative which then would not log outputs only for ConfigManager (regardless of log.outputs setting?)

Closes #1060 