### PR TITLE
BF: import mock before proxying everything, proxy "exists" and test on nibabel

### DIFF
--- a/datalad/__main__.py
+++ b/datalad/__main__.py
@@ -89,6 +89,7 @@ def main(argv=None):
         }
         # Since used explicitly -- activate the beast
         aio = AutomagicIO(activate=True)
+        lgr.info("Running code of %s", progname)
         runctx(code, globs, globs)
         # TODO: see if we could hide our presence from the final tracebacks if execution fails
     except IOError as err:

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -30,6 +30,12 @@ try:
 except ImportError:
     h5py = None
 
+try:
+    import nibabel as nib
+    import numpy as np
+except ImportError:
+    nib = None
+
 # somewhat superseeded by  test_proxying_open_regular but still does
 # some additional testing, e.g. non-context manager style of invocation
 @with_testrepos('basic_annex', flavors=['clone'])
@@ -79,12 +85,12 @@ def test_proxying_open_testrepobased(repo):
 @with_tempfile(mkdir=True)
 def _test_proxying_open(generate_load, verify_load, repo):
     annex = AnnexRepo(repo, create=True)
-    fpath1 = opj(repo, "test.dat")
-    fpath2 = opj(repo, 'd1', 'd2', 'test2.dat')
+    fpath1 = opj(repo, "test")
+    fpath2 = opj(repo, 'd1', 'd2', 'test2')
     # generate load
-    generate_load(fpath1)
+    fpath1 = generate_load(fpath1) or fpath1
     os.makedirs(dirname(fpath2))
-    generate_load(fpath2)
+    fpath2 = generate_load(fpath2) or fpath2
     annex.add([fpath1, fpath2])
     verify_load(fpath1)
     verify_load(fpath2)
@@ -156,3 +162,22 @@ def test_proxying_open_regular():
             eq_(f.read(), "123")
 
     yield _test_proxying_open, generate_dat, verify_dat
+
+
+def test_proxying_open_nibabel():
+    if not nib:
+        raise SkipTest("No nibabel found")
+
+    d = np.empty((3, 3, 3))
+    d[1, 1, 1] = 99
+
+    def generate_nii(f):
+        f = f + '.nii.gz'
+        nib.Nifti1Image(d.copy(), np.eye(4)).to_filename(f)
+        return f
+
+    def verify_nii(f, mode="r"):
+        ni = nib.load(f)
+        ok_(np.all(ni.get_data() == d))
+
+    yield _test_proxying_open, generate_nii, verify_nii


### PR DESCRIPTION
seems to work ;)
```shell
hopa:~/proj/experiments/movie-localizers/data/studyforrest/studyforrest-data-templatetransforms
$> python -m datalad ./apply_warp.py sub-06/bold3Tp2 
[INFO   ] Activating DataLad's AutoMagicIO 
[INFO   ] Running code of ./apply_warp.py 
processing  sub-06/bold3Tp2
  Failed to get annex.uuid configuration of repository origin
[INFO   ] File sub-06/bold3Tp2/brain.nii.gz has no content -- retrieving 
                                                                                                                
  Failed to get annex.uuid configuration of repository origin                                                   
  Failed to get annex.uuid configuration of repository origin
  Failed to get annex.uuid configuration of repository origin
[INFO   ] File sub-06/bold3Tp2/in_grpbold3Tp2/subj2tmpl_warp.nii.gz has no content -- retrieving 
                                                                                                                
  Failed to get annex.uuid configuration of repository origin                                                   
  Failed to get annex.uuid configuration of repository origin
```
but needs fixing up haing a flood of those "Failed to get annex.uuid"messages

will merge if tests pass -- it only gets better I bet ;)