### PR TITLE
ENH: silence git logger if we are the first to "access" it

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -192,6 +192,12 @@ class LoggerHelper(object):
             log_level = getattr(logging, level.upper())
 
         self.lgr.setLevel(log_level)
+        # and set other related/used loggers to the same level to prevent their
+        # talkativity, if they are not yet known to this python session, so we
+        # have little chance to "override" possibly set outside levels
+        for dep in ('git',):
+            if dep not in logging.Logger.manager.loggerDict:
+                logging.getLogger(dep).setLevel(log_level)
 
     def get_initialized_logger(self, logtarget=None):
         """Initialize and return the logger


### PR DESCRIPTION
Otherwise it dumps all kinds of debugging info into "captured logging"
of nose making it difficult to work with tests using git module

now it looks like

```shell
$> nosetests -s -v datalad/distribution/tests/test_update.py:test_update_simple
                                                                                                                
FAIL

======================================================================
FAIL: datalad.distribution.tests.test_update.test_update_simple
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/yoh/proj/datalad/datalad/datalad/tests/utils.py", line 706, in newfunc
    t(*(arg + (uri,)), **kw)
  File "/home/yoh/proj/datalad/datalad/datalad/tests/utils.py", line 536, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/yoh/proj/datalad/datalad/datalad/tests/utils.py", line 536, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/yoh/proj/datalad/datalad/datalad/distribution/tests/test_update.py", line 91, in test_update_simple
    ok_file_has_content(opj(dest.path, 'subm 2', 'load.dat'), 'heavy')
  File "/home/yoh/proj/datalad/datalad/datalad/tests/utils.py", line 374, in ok_file_has_content
    ok_exists(path)
  File "/home/yoh/proj/datalad/datalad/datalad/tests/utils.py", line 369, in ok_exists
    assert exists(path), 'path %s does not exist' % path
AssertionError: path /tmp/datalad_temp_test_update_simplepmstB4/subm 2/load.dat does not exist
-------------------- >> begin captured logging << --------------------
datalad.utils: Level 5: Importing datalad.utils
datalad.utils: Level 5: Done importing datalad.utils
datalad.cmd: DEBUG: Running: ['git', 'config', '-z', '-l']
datalad.cmd: Level 8: Finished running ['git', 'config', '-z', '-l'] with status 0
datalad.ui: Level 5: Starting importing ui
datalad.ui.dialog: Level 5: Starting importing ui.dialog
datalad.ui.dialog: Level 5: Done importing ui.dialog
datalad.ui: Level 5: Initiating UI switcher
datalad.ui: DEBUG: UI set to DialogUI(out=<file>)
datalad.ui: Level 5: Done importing ui
--------------------- >> end captured logging << ---------------------
```
instead of before pages of 
```
-------------------- >> begin captured logging << --------------------
git.cmd: DEBUG: Popen(['git', 'init'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_HE_auy, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'init'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_X_WZ9y, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'init'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_NMTbVw, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'init'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_qWQ9Ue, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'init'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_oqbdqn, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'cat-file', '--batch-check'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_HE_auy, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'cat-file', '--batch'], cwd=/home/yoh/.tmp/datalad_temp_testrepo_HE_auy, universal_newlines=False, shell=None)
git.cmd: DEBUG: Popen(['git', 'cat-file',...
```

and stuff comes back if desired by setting our log level to DEBUG