### PR TITLE
BF+RF+ENH(TST) add (GitRepo and Dataset)

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -11,8 +11,10 @@
 """
 
 import logging
+
 from os import curdir
 from os.path import isdir
+from collections import defaultdict
 
 from datalad.interface.base import Interface
 from datalad.interface.common_opts import recursion_flag
@@ -235,10 +237,10 @@ class Add(Interface):
         for ds, p, s in param_tuples:
             # it should not happen, that `path` as well as `source` are None:
             assert p or s
-
             if not s:
                 # we have a path only
-                if to_git:
+                # Do not try to add to annex whenever there is no annex
+                if to_git or not isinstance(ds.repo, AnnexRepo):
                     calls[ds.path]['g_add'].append(p)
                 else:
                     calls[ds.path]['a_add'].append(p)
@@ -258,10 +260,10 @@ class Add(Interface):
         # now do the actual add operations:
         # TODO: implement git/git-annex/git-annex-add options
 
-        return_values = []
+        datasets_return_values = defaultdict(list)
         for dspath in calls:
             ds = Dataset(dspath)
-
+            return_values = datasets_return_values[dspath]
             lgr.info("Processing dataset %s ..." % ds)
 
             # check every (sub-)dataset for annex once, since we can't add or
@@ -271,11 +273,13 @@ class Add(Interface):
             _is_annex = isinstance(ds.repo, AnnexRepo)
 
             if calls[ds.path]['g_add']:
-                return_values.extend(ds.repo.add(calls[dspath]['g_add'],
-                                                 git=True,
-                                                 git_options=git_opts))
+                lgr.debug("Adding %s to git", calls[dspath]['g_add'])
+                added = ds.repo.add(calls[dspath]['g_add'], git=True,
+                                  git_options=git_opts)
+                return_values.extend(added)
             if calls[ds.path]['a_add']:
                 if _is_annex:
+                    lgr.debug("Adding %s to annex", calls[dspath]['a_add'])
                     return_values.extend(
                         ds.repo.add(calls[dspath]['a_add'],
                                     git=False,
@@ -299,6 +303,7 @@ class Add(Interface):
             #       file name but the url
             if calls[ds.path]['addurl_s']:
                 if _is_annex:
+                    lgr.debug("Adding urls %s to annex", calls[dspath]['addurl_s'])
                     return_values.extend(
                         ds.repo.add_urls(calls[ds.path]['addurl_s'],
                                          options=annex_add_opts,
@@ -321,6 +326,8 @@ class Add(Interface):
             if calls[ds.path]['addurl_f']:
                 if _is_annex:
                     for f, u in calls[ds.path]['addurl_f']:
+                        lgr.debug("Adding urls %s to files in annex",
+                                  calls[dspath]['addurl_f'])
                         return_values.append(
                             ds.repo.add_url_to_file(f, u,
                                                     options=annex_add_opts,  # TODO: see above
@@ -336,16 +343,22 @@ class Add(Interface):
                           'note': "no annex at %s" % ds.path}
                          for f in calls[dspath]['addurl_f']]
                     )
+            return_values = None  # to avoid mis-use
 
-        if save and len(return_values):
-            # we got something added -> save
-            # everything we care about at this point should be staged already
-            Save.__call__(
-                message='[DATALAD] added content',
-                dataset=ds,
-                auto_add_changes=False,
-                recursive=False)
+        for dspath, return_values in datasets_return_values.items():
+            if save and len(return_values):
+                # we got something added -> save
+                # everything we care about at this point should be staged already
+                Save.__call__(
+                    message='[DATALAD] added content',
+                    dataset=ds,
+                    auto_add_changes=False,
+                    recursive=False)
 
+        # XXX or we could return entire datasets_return_values, could be useful
+        # that way.  But then should be unified with the rest of commands, e.g.
+        # get etc
+        return_values = sum(datasets_return_values.values(), [])
         return return_values
 
     @staticmethod

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import serve_path_via_http
 from datalad.utils import chpwd
+from datalad.utils import _path_
 
 from ..dataset import Dataset
 
@@ -115,19 +116,25 @@ def test_add_recursive(path):
 
     # add while also instructing annex to add in parallel 2 jobs (smoke testing
     # for that effect ATM)
-    ds.add(opj('dir', 'testindir'), recursive=True, jobs=2)
+    added1 = ds.add(opj('dir', 'testindir'), recursive=True, jobs=2)
+    # added to annex, so annex output record
+    eq_(added1, [{'file': _path_('dir/testindir'), 'command': 'add',
+                  'key': 'MD5E-s9--3f0f870d18d6ba60a79d9463ff3827ea',
+                  'success': True}])
     assert_in('testindir', Dataset(opj(path, 'dir')).repo.get_annexed_files())
 
-    ds.add(opj('dir', 'testindir2'), recursive=True, to_git=True)
+    added2 = ds.add(opj('dir', 'testindir2'), recursive=True, to_git=True)
+    # added to git, so parsed git output record
+    eq_(added2, [{'success': True, 'file': _path_('dir/testindir2')}])
     assert_in('testindir2', Dataset(opj(path, 'dir')).repo.get_indexed_files())
 
+    # We used to fail to add to pure git repository, but now it should all be
+    # just fine
     subds = ds.create('git-sub', no_annex=True)
     with open(opj(subds.path, 'somefile.txt'), "w") as f:
         f.write("bla bla")
     result = ds.add(opj('git-sub', 'somefile.txt'), recursive=True, to_git=False)
-    eq_(result, [{'file': opj(subds.path, 'somefile.txt'),
-                  'note': "no annex at %s" % subds.path,
-                  'success': False}])
+    eq_(result, [{'file': _path_('git-sub/somefile.txt'), 'success': True}])
 
 
 @with_tree(**tree_arg)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -634,7 +634,7 @@ class GitRepo(object):
         Parameters
         ----------
         files: list
-            list of paths to add
+          list of paths to add
         commit: bool
           whether or not to directly commit
         msg: str
@@ -653,10 +653,11 @@ class GitRepo(object):
 
         if files:
             try:
-
+                # without --verbose git 2.9.3  add does not return anything
                 add_out = self._git_custom_command(
-                    files, ['git', 'add'] + assure_list(git_options))
-
+                    files,
+                    ['git', 'add'] + assure_list(git_options) + ['--verbose']
+                )
                 # get all the entries
                 out = self._process_git_get_output(*add_out)
                 # Note: as opposed to git cmdline, force is True by default in
@@ -703,7 +704,7 @@ class GitRepo(object):
         modes when ran through proxy
         """
         return [{u'file': f, u'success': True}
-                for f in re.findall("'([^']*)'[\n$]", stdout)]
+                for f in re.findall("'(.*)'[\n$]", stdout)]
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, **kwargs):

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -117,8 +117,9 @@ def test_GitRepo_add(src, path):
     filename = get_most_obscure_supported_name()
     with open(opj(path, filename), 'w') as f:
         f.write("File to add to git")
-    gr.add(filename)
+    added = gr.add(filename)
 
+    assert_equal(added, {'success': True, 'file': filename})
     assert_in(filename, gr.get_indexed_files(),
               "%s not successfully added to %s" % (filename, path))
     # uncommitted:
@@ -131,7 +132,8 @@ def test_GitRepo_add(src, path):
     assert_raises(AssertionError, gr.add, filename, git=None)
 
     # include committing:
-    gr.add(filename, commit=True, msg="Add two files.")
+    added2 = gr.add(filename, commit=True, msg="Add two files.")
+    assert_equal(added2, {'success': True, 'file': filename})
 
     assert_in(filename, gr.get_indexed_files(),
               "%s not successfully added to %s" % (filename, path))


### PR DESCRIPTION
- (**change in behavior**) `datalad add` was useless in pure git repositories, unless explicit `--to-git` was added, which to me made little sense. So I have changed it so it does `git add` in pure git repos, instead of returning failure
- GitRepo.add didn't return anything, at least with recent git 2.9.3 unless --verbose option is added
- parsing of the add output was not working correctly for obscure filenames with ' in them
- `datalad add` was returning (I think) incorrect results in case of paths across multiple datasets were provided, since the last lucky `ds` value was used. Since output was not really tested much -- that bug was lingering happily around.  I have added some testing

P.S. now I just need to remember what the heck I was doing that I got to this issue ;)  ah, right -- I was under ~/datalad and was trying to save a bogus file so I could trigger regeneration of metadata cache. but was surprised that command seemingly succeeded but file was not added to git at all.