### PR TITLE
RF: Higher-level abstraction helper for command that do thing to dataset content items

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -17,10 +17,9 @@ from os import curdir
 from os.path import isdir
 from os.path import join as opj
 from os.path import relpath
-from os.path import lexists
-from os.path import dirname
 
 from datalad.interface.base import Interface
+from datalad.interface.utils import get_paths_by_dataset
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
@@ -39,7 +38,6 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.dochelpers import single_or_plural
 from datalad.utils import assure_list
-from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
 
 from .dataset import Dataset
 from .dataset import EnsureDataset
@@ -51,71 +49,6 @@ from .utils import _recursive_install_subds_underneath
 __docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.distribution.get')
-
-
-def _sort_paths_into_datasets(paths, out=None, dir_lookup=None,
-                              recursive=False, recursion_limit=None):
-    """Returns dict of `existing dataset path`: `directory` mappings
-
-    Any paths that are not part of a dataset or ignored.
-    """
-    # sort paths into the respective datasets
-    if dir_lookup is None:
-        dir_lookup = {}
-    if out is None:
-        out = {}
-    # paths that don't exist (yet)
-    unavailable_paths = []
-    for path in paths:
-        if not lexists(path):
-            # not there yet, impossible to say which ds it will actually
-            # be in, if any
-            unavailable_paths.append(path)
-            continue
-        # the path exists in some shape or form
-        if isdir(path):
-            # this could contain all types of additional content
-            d = path
-        else:
-            # for everything else we are interested in the container
-            d = dirname(path)
-            if not d:
-                d = curdir
-        # this could be `None` if there is no git repo
-        dspath = dir_lookup.get(d, GitRepo.get_toppath(d))
-        dir_lookup[d] = dspath
-        if not dspath:
-            lgr.warning("%s is not part of a dataset, ignored.", path)
-            continue
-        if isdir(path):
-            ds = Dataset(dspath)
-            # we need to doublecheck that this is not a subdataset mount
-            # point, in whic case get_toppath() would point to the parent
-            smpath = ds.get_containing_subdataset(
-                path, recursion_limit=1).path
-            if smpath != dspath:
-                # fix entry
-                dir_lookup[d] = smpath
-                # submodule still needs to be obtained
-                unavailable_paths.append(path)
-                continue
-            if recursive:
-                # make sure we get everything relevant in all _checked out_
-                # subdatasets, obtaining of previously unavailable subdataset
-                # else done elsewhere
-                subs = ds.get_subdatasets(fulfilled=True,
-                                          recursive=recursive,
-                                          recursion_limit=recursion_limit)
-                for sub in subs:
-                    subdspath = opj(dspath, sub)
-                    if subdspath.startswith(_with_sep(path)):
-                        # this subdatasets is underneath the search path
-                        # we want it all
-                        # be careful to not overwrite anything, in case
-                        # this subdataset has been processed before
-                        out[subdspath] = out.get(subdspath, [subdspath])
-        out[dspath] = out.get(dspath, []) + [path]
-    return out, unavailable_paths, dir_lookup
 
 
 def _get(content_by_ds, refpath=None, source=None, jobs=None,
@@ -283,10 +216,12 @@ class Get(Interface):
         lgr.debug('Resolved targets to get: %s', resolved_paths)
 
         # sort paths into the respective datasets
-        content_by_ds, unavailable_paths, dir_lookup = \
-            _sort_paths_into_datasets(resolved_paths,
-                                      recursive=recursive,
-                                      recursion_limit=recursion_limit)
+        dir_lookup = {}
+        content_by_ds, unavailable_paths = \
+            get_paths_by_dataset(resolved_paths,
+                                 recursive=recursive,
+                                 recursion_limit=recursion_limit,
+                                 dir_lookup=dir_lookup)
         lgr.debug(
             "Found %i existing dataset(s) to get content in "
             "and %d unavailable paths",
@@ -356,13 +291,13 @@ class Get(Interface):
         ## we have now done everything we could to obtain whatever subdataset
         ## to get something on the file system for previously unavailable paths
         ## check and sort one last
-        content_by_ds, unavailable_paths, dir_lookup = \
-            _sort_paths_into_datasets(
+        content_by_ds, unavailable_paths = \
+            get_paths_by_dataset(
                 unavailable_paths,
-                out=content_by_ds,
-                dir_lookup=dir_lookup,
                 recursive=recursive,
-                recursion_limit=recursion_limit)
+                recursion_limit=recursion_limit,
+                out=content_by_ds,
+                dir_lookup=dir_lookup)
 
         if unavailable_paths:
             lgr.warning('ignored non-existing paths: %s', unavailable_paths)

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -217,7 +217,7 @@ class Get(Interface):
 
         # sort paths into the respective datasets
         dir_lookup = {}
-        content_by_ds, unavailable_paths = \
+        content_by_ds, unavailable_paths, nondataset_paths = \
             get_paths_by_dataset(resolved_paths,
                                  recursive=recursive,
                                  recursion_limit=recursion_limit,
@@ -291,13 +291,19 @@ class Get(Interface):
         ## we have now done everything we could to obtain whatever subdataset
         ## to get something on the file system for previously unavailable paths
         ## check and sort one last
-        content_by_ds, unavailable_paths = \
+        content_by_ds, unavailable_paths, nondataset_paths2 = \
             get_paths_by_dataset(
                 unavailable_paths,
                 recursive=recursive,
                 recursion_limit=recursion_limit,
                 out=content_by_ds,
                 dir_lookup=dir_lookup)
+
+        nondataset_paths.extend(nondataset_paths2)
+        if nondataset_paths:
+            lgr.warning(
+                "ignored paths that do not belong to any dataset: %s",
+                nondataset_paths)
 
         if unavailable_paths:
             lgr.warning('ignored non-existing paths: %s', unavailable_paths)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -116,7 +116,7 @@ def test_get_invalid_call(path, file_outside):
     with swallow_logs(new_level=logging.WARNING) as cml:
         result = ds.get(file_outside)
         eq_(len(result), 0)
-        assert_in("{0} is not part of a dataset, ignored".format(file_outside, ds),
+        assert_in("ignored paths that do not belong to any dataset: ['{0}'".format(file_outside, ds),
                   cml.out)
 
     # TODO: annex --json doesn't report anything when get fails to do get a

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -170,7 +170,7 @@ class Uninstall(Interface):
             if_dirty='save-before'):
 
         # upfront check prior any resolution attempt to avoid disaster
-        if dataset is None and not path:
+        if path is None and dataset is None:
             raise InsufficientArgumentsError(
                 "insufficient information for uninstallation (needs at "
                 "least a dataset or a path. To uninstall an entire dataset "

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -16,19 +16,20 @@ import os
 import logging
 
 from os.path import relpath, split as psplit
+from os.path import curdir
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone
 from datalad.distribution.dataset import Dataset, EnsureDataset, \
-    datasetmethod, resolve_path, require_dataset
+    datasetmethod, require_dataset
 from datalad.interface.base import Interface
 from datalad.interface.save import Save
 from datalad.interface.common_opts import if_dirty_opt
 from datalad.interface.common_opts import recursion_flag
+from datalad.interface.utils import get_normalized_path_arguments
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.utils import rmtree
 from datalad.utils import getpwd
-from datalad.utils import assure_list
 
 lgr = logging.getLogger('datalad.distribution.uninstall')
 
@@ -182,20 +183,10 @@ class Uninstall(Interface):
         if not remove_data and not remove_handles:
             raise ValueError("instructed to neither drop data, nor remove handles: cannot perform")
 
+        path, dataset_path = get_normalized_path_arguments(
+            path, dataset, default=curdir)
+
         results = []
-
-        ds = require_dataset(
-            dataset, check_installed=True, purpose='uninstall')
-
-        # always yields list; empty if None
-        path = assure_list(path)
-        if not len(path):
-            # AKA "everything"
-            path.append(ds.path)
-
-        # XXX Important to resolve against `dataset` input argument, and
-        # not against the `ds` resolved dataset
-        path = [resolve_path(p, dataset) for p in path]
 
         if kill:
             lgr.warning("Force-removing %d paths", len(path))
@@ -204,6 +195,8 @@ class Uninstall(Interface):
                 results.append(p)
             return results
 
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='uninstall')
         # make sure we get to an expected state
         handle_dirty_dataset(ds, if_dirty)
 

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -13,19 +13,22 @@
 __docformat__ = 'restructuredtext'
 
 import logging
-from os.path import commonprefix
-from os.path import abspath
+from os import curdir
+from os.path import join as opj
 
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
-from datalad.utils import getpwd
+from datalad.distribution.dataset import resolve_path
+from datalad.interface.utils import get_paths_by_dataset
+from datalad.interface.common_opts import recursion_flag
+from datalad.interface.common_opts import recursion_limit
+from datalad.utils import assure_list
 
 from .base import Interface
 
@@ -50,80 +53,66 @@ class Unlock(Interface):
             no dataset is given, an attempt is made to identify the dataset
             based on the current working directory. If the latter fails, an
             attempt is made to identify the dataset based on `path` """,
-            constraints=EnsureDataset() | EnsureNone()),)
+            constraints=EnsureDataset() | EnsureNone()),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+    )
 
     @staticmethod
     @datasetmethod(name='unlock')
-    def __call__(path=None, dataset=None):
-        # shortcut
-        ds = dataset
+    def __call__(
+            path=None,
+            dataset=None,
+            recursive=False,
+            recursion_limit=None):
 
-        if isinstance(path, list):
-            if not len(path):
-                # normalize value to expected state when nothing was provided
-                path = None
-            elif len(path) == 1:
-                # we can simply continue with the function as called with a
-                # single argument
-                path = path[0]
+        if path is None and dataset is None:
+            raise InsufficientArgumentsError(
+                "insufficient arguments for unlocking: needs at least "
+                "a dataset or a path to unlock.")
 
-        if ds is not None and not isinstance(ds, Dataset):
-            ds = Dataset(ds)
-
-        if ds is None:
-            # try CWD:
-            dspath = GitRepo.get_toppath(getpwd())
-            if not dspath:
-                if path is None:
-                    raise InsufficientArgumentsError(
-                        "insufficient arguments for unlocking: needs at least "
-                        "a dataset or a path to unlock.")
-                # if we still have no dataset, try deriving it from path(s):
-                if isinstance(path, list):
-                    # several paths and no dataset given;
-                    # paths have to be absolute and have to have common prefix
-                    # in order to be able to find a dataset
-
-                    # TODO: maybe consider realpath?
-                    prefix = commonprefix(path)
-                    if not prefix:
-                        raise InsufficientArgumentsError(
-                            "insufficient information for unlocking: no "
-                            "dataset given and paths don't have a common base "
-                            "to check for a dataset")
-                    dspath = GitRepo.get_toppath(abspath(prefix))
-                else:
-                    # single path
-                    dspath = GitRepo.get_toppath(abspath(path))
-
-            if dspath is None:
-                raise InsufficientArgumentsError(
-                    "insufficient information for unlocking: no "
-                    "dataset given and none could be derived "
-                    "from given path(s) or current working directory")
-
-            ds = Dataset(dspath)
-
-        assert ds
-        assert ds.repo
-
-        if not isinstance(ds.repo, AnnexRepo):
-            # TODO: Introduce NoAnnexError
-            raise ValueError("No annex found in dataset (%s)." % ds.path)
-
-        # TODO: AnnexRepo().unlock() with proper return value
+        dataset_path = dataset.path if isinstance(dataset, Dataset) else dataset
+        path = assure_list(path)
         if not path:
-            files = []
-        elif isinstance(path, list):
-            files = path
-        else:
-            files = [path]
+            path = [curdir]
 
-        std_out, std_err = ds.repo._annex_custom_command(
-            files, ['git', 'annex', 'unlock'])
+        # resolve path(s):
+        resolved_paths = [resolve_path(p, dataset) for p in path]
+        if dataset:
+            # guarantee absolute paths
+            resolved_paths = [opj(dataset_path, p) for p in resolved_paths]
+        lgr.debug('Resolved targets to get: %s', resolved_paths)
 
-        return [line.split()[1] for line in std_out.splitlines()
-                if line.strip().endswith('ok')]
+        content_by_ds, unavailable_paths, nondataset_paths = \
+            get_paths_by_dataset(resolved_paths,
+                                 recursive=recursive,
+                                 recursion_limit=recursion_limit)
+
+        if nondataset_paths:
+            lgr.warning(
+                "ignored paths that do not belong to any dataset: %s",
+                nondataset_paths)
+        if unavailable_paths:
+            lgr.warning('ignored non-existing paths: %s', unavailable_paths)
+
+        unlocked = []
+        for ds_path in sorted(content_by_ds.keys()):
+            ds = Dataset(ds_path)
+
+            if not isinstance(ds.repo, AnnexRepo):
+                lgr.debug("'%s' has no annex, nothing to unlock",
+                          ds)
+                continue
+
+            files = content_by_ds[ds_path]
+
+            std_out, std_err = ds.repo._annex_custom_command(
+                files, ['git', 'annex', 'unlock'])
+
+            unlocked.extend(
+                [line.split()[1] for line in std_out.splitlines()
+                 if line.strip().endswith('ok')])
+        return unlocked
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 from os import curdir
-from os.path import join as opj
 
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
@@ -24,11 +23,10 @@ from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
-from datalad.distribution.dataset import resolve_path
+from datalad.interface.utils import get_normalized_path_arguments
 from datalad.interface.utils import get_paths_by_dataset
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
-from datalad.utils import assure_list
 
 from .base import Interface
 
@@ -71,17 +69,8 @@ class Unlock(Interface):
                 "insufficient arguments for unlocking: needs at least "
                 "a dataset or a path to unlock.")
 
-        dataset_path = dataset.path if isinstance(dataset, Dataset) else dataset
-        path = assure_list(path)
-        if not path:
-            path = [curdir]
-
-        # resolve path(s):
-        resolved_paths = [resolve_path(p, dataset) for p in path]
-        if dataset:
-            # guarantee absolute paths
-            resolved_paths = [opj(dataset_path, p) for p in resolved_paths]
-        lgr.debug('Resolved targets to get: %s', resolved_paths)
+        resolved_paths, dataset_path = get_normalized_path_arguments(
+            path, dataset, default=curdir)
 
         content_by_ds, unavailable_paths, nondataset_paths = \
             get_paths_by_dataset(resolved_paths,

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -70,7 +70,8 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
                          out=None, dir_lookup=None):
     """Sort a list of paths per dataset they are contained in.
 
-    Any paths that are not part of a dataset are ignored.
+    Any paths that are not part of a dataset, or presently unavailable are
+    reported.
 
     Parameter
     ---------
@@ -90,9 +91,10 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
 
     Returns
     -------
-    Tuple(dict, list)
-      Dict of `existing dataset path`: `path` mappings, and the list of currently
-      non-existing paths (possibly matching currently uninstalled datasets).
+    Tuple(dict, list, list)
+      Dict of `existing dataset path`: `path` mappings, the list of currently
+      non-existing paths (possibly matching currently uninstalled datasets),
+      and any paths that are not part of any dataset
 
     """
     # sort paths into the respective datasets
@@ -102,6 +104,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
         out = {}
     # paths that don't exist (yet)
     unavailable_paths = []
+    nondataset_paths = []
     for path in paths:
         if not lexists(path):
             # not there yet, impossible to say which ds it will actually
@@ -121,7 +124,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
         dspath = dir_lookup.get(d, GitRepo.get_toppath(d))
         dir_lookup[d] = dspath
         if not dspath:
-            lgr.warning("%s is not part of a dataset, ignored.", path)
+            nondataset_paths.append(path)
             continue
         if isdir(path):
             ds = Dataset(dspath)
@@ -151,4 +154,4 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
                         # this subdataset has been processed before
                         out[subdspath] = out.get(subdspath, [subdspath])
         out[dspath] = out.get(dspath, []) + [path]
-    return out, unavailable_paths
+    return out, unavailable_paths, nondataset_paths


### PR DESCRIPTION
For example `get` and `unlock` are highly similar in terms of what they should be doing to figure out which items to `get` or to `unlock`. Yet they use hardly the same lines of code.

Will try to identify and RF some of the common bits into more generic helpers.

Feel free to merge any time, despite possibly open TODOs. I do not intent to work on this for two months. Only low hanging fruit.

- [x] `unlock` can work recursively and across multiple disjoint datasets -- like `get`
- [x] `get` and `unlock` use more of the same codebase
- [x] common path input argument normalization
- [X] decide whether to allow `get` to work with an empty path argument (i.e. "get this") -> #1119