### PR TITLE
RF: uninstall

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -304,7 +304,8 @@ class Dataset(object):
 
         if absolute:
             if edges:
-                return [(opj(self._path, ds), opj(self._path, sm))
+                return [(self._path if ds == curdir else opj(self._path, ds),
+                         opj(self._path, sm))
                         for ds, sm in submodules]
             else:
                 return [opj(self._path, sm) for sm in submodules]

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -42,7 +42,7 @@ def test_dont_trip_over_missing_subds(path):
     subds2 = ds1.install(source=ds2.path, path='subds2')
     assert_true(subds2.is_installed())
     assert_in('subds2', ds1.get_subdatasets())
-    subds2.uninstall(remove_handles=True, remove_history=True)
+    subds2.uninstall(remove_handles=True)
     assert_in('subds2', ds1.get_subdatasets())
     assert_false(subds2.is_installed())
     # this will deinit the submodule

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -42,7 +42,7 @@ def test_dont_trip_over_missing_subds(path):
     subds2 = ds1.install(source=ds2.path, path='subds2')
     assert_true(subds2.is_installed())
     assert_in('subds2', ds1.get_subdatasets())
-    subds2.uninstall(remove_handles=True)
+    subds2.uninstall()
     assert_in('subds2', ds1.get_subdatasets())
     assert_false(subds2.is_installed())
     # this will deinit the submodule

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -101,6 +101,7 @@ def test_register_sibling(remote, path):
 def test_get_subdatasets(path):
     ds = Dataset(path)
     eq_(ds.get_subdatasets(), ['sub dataset1'])
+    eq_(ds.get_subdatasets(edges=True), [(os.curdir, 'sub dataset1')])
     eq_(ds.get_subdatasets(recursive=True),
         [
             'sub dataset1/sub sub dataset1/subm 1',
@@ -109,6 +110,15 @@ def test_get_subdatasets(path):
             'sub dataset1/subm 1',
             'sub dataset1/subm 2',
             'sub dataset1'
+        ])
+    eq_(ds.get_subdatasets(recursive=True, edges=True),
+        [
+            ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1'),
+            ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 2'),
+            ('sub dataset1', 'sub dataset1/sub sub dataset1'),
+            ('sub dataset1', 'sub dataset1/subm 1'),
+            ('sub dataset1', 'sub dataset1/subm 2'),
+            (os.curdir, 'sub dataset1'),
         ])
     eq_(ds.get_subdatasets(recursive=True, recursion_limit=0),
         [])

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -321,5 +321,5 @@ def test_kill(path):
 
     # and we fail to uninstall since content can't be dropped
     assert_raises(CommandError, ds.uninstall)
-    eq_(ds.uninstall(kill=True), [ds])
+    eq_(ds.uninstall(kill=True, check=False), [ds])
     ok_(not exists(path))

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,6 +9,7 @@
 
 """
 
+import logging
 import os
 from os.path import join as opj, split as psplit
 from os.path import exists, lexists
@@ -17,6 +18,8 @@ from os.path import isdir
 from glob import glob
 
 from datalad.api import uninstall
+from datalad.api import drop
+from datalad.api import remove
 from datalad.api import install
 from datalad.support.exceptions import InsufficientArgumentsError, CommandError
 from datalad.tests.utils import ok_
@@ -31,6 +34,7 @@ from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.utils import chpwd
 from datalad.support.external_versions import external_versions
+from datalad.utils import swallow_logs
 
 from ..dataset import Dataset
 
@@ -43,13 +47,17 @@ def test_safetynet(path):
         with chpwd(p):
             # will never remove PWD, or anything outside the dataset
             for target in (ds.path, os.curdir, os.pardir, opj(os.pardir, os.pardir)):
-                assert_raises(ValueError, uninstall, path=target, remove_handles=True)
+                assert_raises(ValueError, uninstall, path=target)
 
 
 @with_tempfile()
-def test_uninstall_nonexisting(path):
+def test_uninstall_uninstalled(path):
+    # goal oriented error reporting. here:
+    # nothing installed, any removal was already a success before it started
     ds = Dataset(path)
-    assert_raises(ValueError, uninstall, dataset=ds)
+    eq_(ds.uninstall(), [])
+    eq_(ds.drop(), [])
+    eq_(ds.remove(), [])
 
 
 @with_tempfile()
@@ -61,7 +69,7 @@ def test_clean_subds_removal(path):
     eq_(sorted(ds.get_subdatasets()), ['one', 'two'])
     ok_clean_git(ds.path)
     # now kill one
-    res = ds.uninstall('one', remove_handles=True, kill=True)
+    res = ds.remove('one')
     eq_(res, [subds1])
     ok_(not subds1.is_installed())
     ok_clean_git(ds.path)
@@ -73,9 +81,13 @@ def test_clean_subds_removal(path):
 
 @with_testrepos('.*basic.*', flavors=['local'])
 def test_uninstall_invalid(path):
-    assert_raises(InsufficientArgumentsError, uninstall)
-    ds = Dataset(path)
-    assert_raises(Exception, uninstall, dataset=ds, path='not_existent')
+    ds = Dataset(path).create(force=True)
+    for method in (uninstall, remove, drop):
+        assert_raises(InsufficientArgumentsError, method)
+        # refuse to touch stuff outside the dataset
+        assert_raises(ValueError, method, dataset=ds, path='..')
+        # but it is only an error when there is actually something there
+        eq_(method(dataset=ds, path='../madeupnonexist'), [])
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
@@ -87,17 +99,17 @@ def test_uninstall_annex_file(path):
     ok_(ds.repo.file_has_content('test-annex.dat'))
 
     # remove file's content:
-    res = ds.uninstall(path='test-annex.dat')
+    res = ds.drop(path='test-annex.dat')
     # test it happened:
     ok_(not ds.repo.file_has_content('test-annex.dat'))
     ok_file_under_git(path, 'test-annex.dat', annexed=True)
     # test result:
-    eq_(res, ['test-annex.dat'])
+    eq_(res, [opj(ds.path, 'test-annex.dat')])
 
     ds.repo.get('test-annex.dat')
 
     # remove file:
-    ds.uninstall(path='test-annex.dat', remove_handles=True)
+    ds.remove(path='test-annex.dat')
     assert_raises(AssertionError, ok_file_under_git, path, 'test-annex.dat',
                   annexed=True)
     assert_raises(AssertionError, ok_file_under_git, path, 'test-annex.dat',
@@ -112,12 +124,15 @@ def test_uninstall_git_file(path):
     ok_(exists(opj(path, 'INFO.txt')))
     ok_file_under_git(path, 'INFO.txt')
 
-    # uninstalling data only doesn't make sense:
-    # this will only get a warning now
-    #assert_raises(ValueError, ds.uninstall, path='INFO.txt', data_only=True)
+    if not hasattr(ds.repo, 'drop'):
+        assert_raises(ValueError, ds.drop, path='INFO.txt')
+
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        ds.uninstall(path="INFO.txt")
+        assert_in("will not act on files", cml.out)
 
     # uninstall removes the file:
-    res = ds.uninstall(path='INFO.txt', remove_handles=True)
+    res = ds.remove(path='INFO.txt')
     assert_raises(AssertionError, ok_file_under_git, path, 'INFO.txt')
     ok_(not exists(opj(path, 'INFO.txt')))
     eq_(res, ['INFO.txt'])
@@ -137,9 +152,10 @@ def test_uninstall_subdataset(src, dst):
         annexed_files = subds.repo.get_annexed_files()
         subds.repo.get(annexed_files)
 
-        # uninstall data of subds:
-        res = ds.uninstall(path=subds_path)
-        ok_(all([f in res for f in annexed_files]))
+        # drop data of subds:
+        res = ds.drop(path=subds_path)
+
+        ok_(all([opj(subds.path, f) in res for f in annexed_files]))
         ok_(all([not i for i in subds.repo.file_has_content(annexed_files)]))
         # subdataset is still known
         assert_in(subds_path, ds.get_subdatasets())
@@ -153,7 +169,7 @@ def test_uninstall_subdataset(src, dst):
             raise SkipTest(
                 "Known problem with GitPython. See "
                 "https://github.com/gitpython-developers/GitPython/pull/521")
-        res = ds.uninstall(path=subds_path, remove_handles=True)
+        res = ds.uninstall(path=subds_path)
         subds = Dataset(opj(ds.path, subds_path))
         eq_(res[0], subds)
         ok_(not subds.is_installed())
@@ -181,15 +197,14 @@ def test_uninstall_multiple_paths(path):
     topfile = 'kill'
     deepfile = opj('deep', 'dir', 'kill')
     # use a tuple not a list! should also work
-    ds.uninstall((topfile, deepfile), recursive=True, check=False)
+    ds.drop((topfile, deepfile), recursive=True, check=False)
     ok_clean_git(ds.path)
     files_left = glob(opj(ds.path, '*', '*', '*')) + glob(opj(ds.path, '*'))
     ok_(all([f.endswith('keep') for f in files_left if exists(f) and not isdir(f)]))
     ok_(not ds.repo.file_has_content(topfile))
     ok_(not subds.repo.file_has_content(opj(*psplit(deepfile)[1:])))
-    # drop handles for all 'kill' files
-    ds.uninstall([topfile, deepfile], recursive=True, check=False,
-                 remove_handles=True)
+    # remove handles for all 'kill' files
+    ds.remove([topfile, deepfile], recursive=True, check=False)
     ok_clean_git(ds.path)
     files_left = glob(opj(ds.path, '*', '*', '*')) + glob(opj(ds.path, '*'))
     ok_(all([f.endswith('keep') for f in files_left if exists(f) and not isdir(f)]))
@@ -204,12 +219,13 @@ def test_uninstall_dataset(path):
     ok_(ds.is_installed())
     ok_clean_git(ds.path)
     # would only drop data
-    ds.uninstall()
+    ds.drop()
     # actually same as this, for cmdline compat reasons
-    ds.uninstall(path=[])
+    ds.drop(path=[])
     ok_clean_git(ds.path)
-    # removing all handles equal removal of entire dataset
-    ds.uninstall(remove_handles=True)
+    # removing entire dataset, in this case uninstall and remove do the
+    # same thing
+    ds.uninstall()
     # completely gone
     ok_(not ds.is_installed())
     ok_(not exists(ds.path))
@@ -230,7 +246,7 @@ def test_remove_file_handle_only(path):
     path_two = opj(ds.path, 'two')
     ok_(exists(path_two))
     # remove one handle, should not affect the other
-    ds.uninstall('two', remove_handles=True, check=False)
+    ds.remove('two', check=False)
     eq_(rpath_one, realpath(opj(ds.path, 'one')))
     ok_(exists(rpath_one))
     ok_(not exists(path_two))
@@ -252,9 +268,9 @@ def test_uninstall_recursive(path):
     ok_(exists(opj(ds.path, target_fname)))
     # doesn't have the minimum number of copies for a safe drop
     # TODO: better exception
-    assert_raises(CommandError, ds.uninstall, target_fname, recursive=True)
+    assert_raises(CommandError, ds.drop, target_fname, recursive=True)
     # this should do it
-    ds.uninstall(target_fname, check=False, recursive=True)
+    ds.drop(target_fname, check=False, recursive=True)
     # link is dead
     lname = opj(ds.path, target_fname)
     ok_(not exists(lname))
@@ -263,7 +279,7 @@ def test_uninstall_recursive(path):
     ok_clean_git(ds.path)
     # now same with actual handle removal
     # content is dropped already, so no checks in place anyway
-    ds.uninstall(target_fname, check=True, remove_handles=True, recursive=True)
+    ds.remove(target_fname, check=True, recursive=True)
     ok_(not exists(lname) and not lexists(lname))
     ok_clean_git(subds.path)
     ok_clean_git(ds.path)
@@ -276,8 +292,9 @@ def test_remove_dataset_hierarchy(path):
     ds.save(auto_add_changes=True)
     ok_clean_git(ds.path)
     # fail on missing --recursive because subdataset is present
-    assert_raises(ValueError, ds.uninstall, remove_handles=True)
-    ds.uninstall(remove_handles=True, recursive=True)
+    assert_raises(ValueError, ds.remove)
+    ok_clean_git(ds.path)
+    ds.remove(recursive=True)
     # completely gone
     ok_(not ds.is_installed())
     ok_(not exists(ds.path))
@@ -292,20 +309,13 @@ def test_careless_subdataset_uninstall(path):
     eq_(sorted(ds.get_subdatasets()), ['deep1', 'deep2'])
     ok_clean_git(ds.path)
     # now we kill the sub without the parent knowing
-    subds1.uninstall(remove_handles=True)
-    ok_(not exists(subds1.path))
-    ok_(ds.repo.dirty)
+    subds1.uninstall()
+    ok_(not subds1.is_installed())
+    # mountpoint exists
+    ok_(exists(subds1.path))
+    ok_clean_git(ds.path)
     # parent still knows the sub
     eq_(sorted(ds.get_subdatasets()), ['deep1', 'deep2'])
-    # save the parent later on
-    ds.save(auto_add_changes=True)
-    # subds still gone
-    # subdataset appearance is normalized to an empty directory
-    ok_(exists(subds1.path))
-    # parent still knows the sub
-    eq_(ds.get_subdatasets(), ['deep1', 'deep2'])
-    # and they lived happily ever after
-    ok_clean_git(ds.path)
 
 
 @with_tempfile()
@@ -315,11 +325,11 @@ def test_kill(path):
     with open(opj(ds.path, "file.dat"), 'w') as f:
         f.write("load")
     ds.repo.add("file.dat")
-    ds.create('deep1')
+    subds = ds.create('deep1')
     eq_(sorted(ds.get_subdatasets()), ['deep1'])
     ok_clean_git(ds.path)
 
     # and we fail to uninstall since content can't be dropped
     assert_raises(CommandError, ds.uninstall)
-    eq_(ds.uninstall(kill=True, check=False), [ds])
+    eq_(ds.remove(recursive=True, check=False), [subds, ds])
     ok_(not exists(path))

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -79,7 +79,7 @@ def test_clean_subds_removal(path):
     assert(not exists(subds1.path))
 
 
-@with_testrepos('.*basic.*', flavors=['local'])
+@with_testrepos('.*basic.*', flavors=['clone'])
 def test_uninstall_invalid(path):
     ds = Dataset(path).create(force=True)
     for method in (uninstall, remove, drop):

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -79,7 +79,7 @@ def test_update_simple(origin, src_path, dst_path):
     eq_([False], dest.repo.file_has_content(["update.txt"]))
 
     # smoke-test if recursive update doesn't fail if submodule is removed
-    dest.uninstall('subm 1', kill=True)
+    dest.remove('subm 1')
     dest.update(recursive=True)
     dest.update(merge=True, recursive=True)
 

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -14,9 +14,8 @@ __docformat__ = 'restructuredtext'
 
 import os
 import logging
-from itertools import chain
 
-from os.path import relpath, split as psplit
+from os.path import split as psplit
 from os.path import curdir
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.param import Parameter
@@ -31,8 +30,8 @@ from datalad.interface.common_opts import recursion_limit
 from datalad.interface.utils import get_normalized_path_arguments
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.utils import get_paths_by_dataset
+from datalad.interface.utils import path_is_under
 from datalad.utils import rmtree
-from datalad.utils import getpwd
 from datalad.utils import assure_list
 from datalad.utils import with_pathsep as _with_sep
 
@@ -249,16 +248,10 @@ class Uninstall(Interface):
             get_paths_by_dataset(path,
                                  recursive=recursive,
                                  recursion_limit=recursion_limit)
-        if remove_handles:
+        if remove_handles and path_is_under(content_by_ds):
             # behave like `rm -r` and refuse to remove where we are
-            pwd = getpwd()
-            for p in chain(*content_by_ds.values()):
-                rpath = relpath(p, start=pwd)
-                if rpath == os.curdir \
-                        or rpath == os.pardir \
-                        or set(psplit(rpath)) == {os.pardir}:
-                    raise ValueError(
-                        "refusing to remove current or parent directory")
+            raise ValueError(
+                "refusing to remove current or parent directory")
 
         if dataset_path and not content_by_ds:
             # we got a dataset, but there is nothing actually installed

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -178,7 +178,7 @@ class _Cinderella(Interface):
 
 
 class Drop(_Cinderella):
-    """
+    """Drop
     """
     _action = 'drop'
     _passive = 'dropped'
@@ -228,7 +228,7 @@ class Drop(_Cinderella):
 
 
 class Uninstall(_Cinderella):
-    """
+    """Uninstall
     """
     _action = 'uninstall'
     _passive = 'uninstalled'
@@ -292,7 +292,7 @@ class Uninstall(_Cinderella):
 
 
 class Remove(_Cinderella):
-    """
+    """Remove
     """
     _action = 'remove'
     _passive = 'removed'

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -26,7 +26,9 @@ _group_dataset = (
         ('datalad.distribution.get', 'Get'),
         ('datalad.distribution.add', 'Add'),
         ('datalad.distribution.publish', 'Publish'),
-        ('datalad.distribution.uninstall', 'Uninstall'),
+        ('datalad.distribution.uninstall', 'Uninstall', 'uninstall'),
+        ('datalad.distribution.uninstall', 'Drop', 'drop'),
+        ('datalad.distribution.uninstall', 'Remove', 'remove'),
         # N/I ATM
         # ('datalad.distribution.move', 'Move'),
         ('datalad.distribution.update', 'Update'),

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -26,9 +26,9 @@ _group_dataset = (
         ('datalad.distribution.get', 'Get'),
         ('datalad.distribution.add', 'Add'),
         ('datalad.distribution.publish', 'Publish'),
-        ('datalad.distribution.uninstall', 'Uninstall', 'uninstall'),
-        ('datalad.distribution.uninstall', 'Drop', 'drop'),
-        ('datalad.distribution.uninstall', 'Remove', 'remove'),
+        ('datalad.distribution.uninstall', 'Uninstall', 'uninstall', 'uninstall'),
+        ('datalad.distribution.uninstall', 'Drop', 'drop', 'drop'),
+        ('datalad.distribution.uninstall', 'Remove', 'remove', 'remove'),
         # N/I ATM
         # ('datalad.distribution.move', 'Move'),
         ('datalad.distribution.update', 'Update'),

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -141,6 +141,10 @@ class Save(Interface):
         ds = require_dataset(dataset, check_installed=True,
                              purpose='saving')
 
+        # make sure that all pending changes (batched annex operations, etc.)
+        # are actually reflected in Git
+        ds.repo.precommit()
+
         if not ds.repo.repo.is_dirty(
                 index=True,
                 working_tree=True,

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -597,7 +597,8 @@ def test_GitRepo_get_files(url, path):
         if rel_dir.startswith(".git"):
             continue
         for file_ in filenames:
-            os_files.add(opj(rel_dir, file_).lstrip("./"))
+            file_path = os.path.normpath(opj(rel_dir, file_))
+            os_files.add(file_path)
 
     # get the files via GitRepo:
     local_files = set(gr.get_files())

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -45,6 +45,7 @@ from ..utils import make_tempfile
 from ..utils import on_windows
 from ..utils import _path_
 from ..utils import get_timestamp_suffix
+from ..utils import get_trace
 
 from ..support.annexrepo import AnnexRepo
 
@@ -530,3 +531,32 @@ def test_path_prefix(tdir):
         eq_(get_path_prefix('d1'), 'd1')
         eq_(get_path_prefix('d1', 'd2'), opj(tdir, 'd1'))
         eq_(get_path_prefix('..'), '..')
+
+
+def test_get_trace():
+    assert_raises(ValueError, get_trace, [], 'bumm', 'doesntmatter')
+    eq_(get_trace([('A', 'B')], 'A', 'A'), None)
+    eq_(get_trace([('A', 'B')], 'A', 'B'), [])
+    eq_(get_trace([('A', 'B')], 'A', 'C'), None)
+    eq_(get_trace([('A', 'B'),
+                   ('B', 'C')], 'A', 'C'), ['B'])
+    # order of edges doesn't matter
+    eq_(get_trace([
+        ('B', 'C'),
+        ('A', 'B')
+        ], 'A', 'C'), ['B'])
+    # mixed rubbish
+    eq_(get_trace([
+        (1, 3),
+        ('B', 'C'),
+        (None, ('schwak', 7)),
+        ('A', 'B'),
+        ], 'A', 'C'), ['B'])
+    # long
+    eq_(get_trace([
+        ('B', 'C'),
+        ('A', 'B'),
+        ('distract', 'me'),
+        ('C', 'D'),
+        ('D', 'E'),
+        ], 'A', 'E'), ['B', 'C', 'D'])

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -109,10 +109,11 @@ class BasicAnnexTestRepo(TestRepo):
         annex_version = external_versions['cmd:annex']
         git_version = external_versions['cmd:git']
         self.create_file('INFO.txt',
+                         "Testrepo: %s\n"
                          "git: %s\n"
                          "annex: %s\n"
                          "datalad: %s\n"
-                         % (git_version, annex_version, __version__),
+                         % (self.__class__, git_version, annex_version, __version__),
                          annex=False)
 
 
@@ -130,9 +131,10 @@ class BasicGitTestRepo(TestRepo):
     def create_info_file(self):
         git_version = external_versions['cmd:git']
         self.create_file('INFO.txt',
+                         "Testrepo: %s\n"
                          "git: %s\n"
                          "datalad: %s\n"
-                         % (git_version, __version__),
+                         % (self.__class__, git_version, __version__),
                          annex=False)
 
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -376,7 +376,7 @@ else:
 def assure_tuple_or_list(obj):
     """Given an object, wrap into a tuple if not list or tuple
     """
-    if isinstance(obj, list) or isinstance(obj, tuple):
+    if isinstance(obj, (list, tuple)):
         return obj
     return (obj,)
 
@@ -391,7 +391,9 @@ def assure_list(s):
 
     if isinstance(s, list):
         return s
-    elif isinstance(s, tuple):
+    elif isinstance(s, text_type):
+        return [s]
+    elif hasattr(s, '__iter__'):
         return list(s)
     elif s is None:
         return []

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -24,17 +24,19 @@ Dataset operations
    generated/man/datalad-add
    generated/man/datalad-add-sibling
    generated/man/datalad-create
-   generated/man/datalad-get
    generated/man/datalad-create-sibling
    generated/man/datalad-create-sibling-github
-   generated/man/datalad-install
-   generated/man/datalad-rewrite-urls
-   generated/man/datalad-publish
-   generated/man/datalad-uninstall
-   generated/man/datalad-update
-   generated/man/datalad-save
-   generated/man/datalad-unlock
+   generated/man/datalad-drop
    generated/man/datalad-export
+   generated/man/datalad-get
+   generated/man/datalad-install
+   generated/man/datalad-publish
+   generated/man/datalad-remove
+   generated/man/datalad-rewrite-urls
+   generated/man/datalad-save
+   generated/man/datalad-update
+   generated/man/datalad-uninstall
+   generated/man/datalad-unlock
 
 Meta data handling
 ==================


### PR DESCRIPTION
This is a rewrite of `uninstall` that uses API semantics like `get` and `unlock` from #1113.

In addition to the unification with other commands this PR also changes to semantics of the specific options of uninstall. The documentation contains explains the new setup. In particular to function of `--kill` has changed substantially. Some of what `--kill` did before, is now done by default.

Content:

- [X] Basic rewrite
- [X] Adjust tests to work with new code
- [x] document change in API semantics
- [x] Fixes #863 
- [x] Fixes #1046 
- [x] Fixes #1078 
- [x] Fixes #1079 
- [x] Fixes #1105
- [ ] Fixes #1115
