### PR TITLE
ENH: better use recentish tqdm and then no need for custom options

### DIFF
--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -8,8 +8,12 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 from os.path import exists
+from requests.exceptions import InvalidURL
+
 from ....utils import chpwd
+from ....dochelpers import exc_str
 from ....tests.utils import assert_true, assert_raises, assert_false
+from ....tests.utils import SkipTest
 from ....tests.utils import with_tempfile, skip_if_no_network, use_cassette
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
 from datalad.crawler.pipelines.fcptable import *
@@ -51,11 +55,18 @@ def _test_dataset(dataset, error, create, skip, tmpdir):
             ]
         ]
 
+        try:
+            run_pipeline(pipe)
+        except InvalidURL as exc:
+            raise SkipTest(
+                "This version of requests considers %s to be invalid.  "
+                "See https://github.com/kennethreitz/requests/issues/3683#issuecomment-261947670 : %s"
+                % (TOPURL, exc_str(exc)))
+
         if error:
             assert_raises(RuntimeError, run_pipeline, pipe)
             return
 
-        run_pipeline(pipe)
         if skip:
             assert_false(exists("README.txt"))
             return

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -55,6 +55,10 @@ def _test_dataset(dataset, error, create, skip, tmpdir):
             ]
         ]
 
+        if error:
+            assert_raises((InvalidURL, RuntimeError), run_pipeline, pipe)
+            return
+
         try:
             run_pipeline(pipe)
         except InvalidURL as exc:
@@ -62,10 +66,6 @@ def _test_dataset(dataset, error, create, skip, tmpdir):
                 "This version of requests considers %s to be invalid.  "
                 "See https://github.com/kennethreitz/requests/issues/3683#issuecomment-261947670 : %s"
                 % (TOPURL, exc_str(exc)))
-
-        if error:
-            assert_raises(RuntimeError, run_pipeline, pipe)
-            return
 
         if skip:
             assert_false(exists("README.txt"))

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -65,7 +65,7 @@ try:
         _default_pbar_params = \
             dict(smoothing=0, miniters=1, mininterval=0) \
             if external_versions['tqdm'] < '4.10.0' \
-            else {}
+            else dict(mininterval=0)
 
         def __init__(self, label='', fill_text=None, maxval=None, unit='B', out=sys.stdout):
             super(tqdmProgressBar, self).__init__(maxval=maxval)

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -46,22 +46,38 @@ progressbars = {}
 
 try:
     from tqdm import tqdm
+    from datalad.support.external_versions import external_versions
+    from datalad.utils import updated
 
     class tqdmProgressBar(ProgressBarBase):
         """Adapter for tqdm.ProgressBar"""
 
         backend = 'tqdm'
 
+        # TQDM behaved a bit suboptimally with older versions -- either was
+        # completely resetting time/size in global pbar, or not updating
+        # "slave" pbars, so we had to
+        # set miniters to 1, and mininterval to 0, so it always updates
+        # amd smoothing to 0 so it produces at least consistent average.
+        # But even then it is somewhat flawed.
+        # Newer versions seems to behave more consistently so do not require
+        # those settings
+        _default_pbar_params = \
+            dict(smoothing=0, miniters=1, mininterval=0) \
+            if external_versions['tqdm'] < '4.10.0' \
+            else {}
+
         def __init__(self, label='', fill_text=None, maxval=None, unit='B', out=sys.stdout):
             super(tqdmProgressBar, self).__init__(maxval=maxval)
-            self._pbar_params = dict(desc=label, unit=unit,
-                                     unit_scale=True, total=maxval, file=out)
+            self._pbar_params = updated(
+                self._default_pbar_params,
+                dict(desc=label, unit=unit,
+                     unit_scale=True, total=maxval, file=out))
             self._pbar = None
 
         def _create(self):
             if self._pbar is None:
-                # set miniters to 1, and mininterval to 0, so it always updates
-                self._pbar = tqdm(miniters=1, mininterval=0, **self._pbar_params)
+                self._pbar = tqdm(**self._pbar_params)
 
         def update(self, size, increment=False):
             self._create()


### PR DESCRIPTION
Discovered during demos that global pbar did not behave properly.  There seems to be
a number of issues within older tqdm and fresh one addresses them.  So we just need a
fresh tqdm, but I do not think we need to hard demand it until it is present everywhere

I have submitted request to have pkg updated in debian, after we get it there and in neurodebian -- we will boost versioned dependency

Paired with a fix (workaround) for a problem resolving domains with underscores in recent requests  (https://github.com/kennethreitz/requests/issues/3683#issuecomment-261947670), fix for which is WiP