### PR TITLE
ENH: BIDS -- read README as the description if none provided in dataset_description.json

### DIFF
--- a/datalad/metadata/parsers/bids.py
+++ b/datalad/metadata/parsers/bids.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """BIDS metadata parser (http://bids.neuroimaging.io)"""
 
+from os.path import join as opj
 from datalad.support.json_py import load as jsonload
 from datalad.metadata.parsers.base import BaseMetadataParser
 
@@ -29,7 +30,15 @@ class MetadataParser(BaseMetadataParser):
                                       ('Description', 'description')):
             if bidsterm in bids:
                 meta[dataladterm] = bids[bidsterm]
+
+        if 'description' not in meta:
+            # BIDS uses README to provide description, so if was not
+            # explicitly provided to possibly override longer README, let's just
+            # load README
+            meta['description'] = open(opj(self.ds.path, 'README')).read().strip()
+
         compliance = ["http://docs.datalad.org/metadata.html#v0-1"]
+
         # special case
         if bids.get('BIDSVersion'):
             compliance.append(

--- a/datalad/metadata/parsers/bids.py
+++ b/datalad/metadata/parsers/bids.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """BIDS metadata parser (http://bids.neuroimaging.io)"""
 
-from os.path import join as opj
+from os.path import join as opj, exists
 from datalad.support.json_py import load as jsonload
 from datalad.metadata.parsers.base import BaseMetadataParser
 
@@ -31,11 +31,12 @@ class MetadataParser(BaseMetadataParser):
             if bidsterm in bids:
                 meta[dataladterm] = bids[bidsterm]
 
-        if 'description' not in meta:
+        README_fname = opj(self.ds.path, 'README')
+        if not meta.get('description') and exists(README_fname):
             # BIDS uses README to provide description, so if was not
             # explicitly provided to possibly override longer README, let's just
             # load README
-            meta['description'] = open(opj(self.ds.path, 'README')).read().strip()
+            meta['description'] = open(README_fname).read().strip()
 
         compliance = ["http://docs.datalad.org/metadata.html#v0-1"]
 

--- a/datalad/metadata/parsers/tests/test_bids.py
+++ b/datalad/metadata/parsers/tests/test_bids.py
@@ -78,3 +78,66 @@ def test_get_metadata(path):
   "license": "PDDL",
   "name": "studyforrest_phase2"
 }""")
+
+
+@with_tree(tree={'dataset_description.json': """
+{
+    "Name": "test",
+    "Description": "Some description"
+}
+""",
+                 'README': """
+A very detailed
+description
+"""})
+def test_get_metadata_with_description_and_README(path):
+
+    ds = Dataset(path)
+    meta = MetadataParser(ds).get_metadata('ID')
+    assert_equal(
+        dumps(meta, sort_keys=True, indent=2),
+        """\
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "doap": "http://usefulinc.com/ns/doap#"
+  },
+  "@id": "ID",
+  "dcterms:conformsTo": [
+    "http://docs.datalad.org/metadata.html#v0-1",
+    "http://bids.neuroimaging.io"
+  ],
+  "description": "Some description",
+  "name": "test"
+}""")
+
+
+@with_tree(tree={'dataset_description.json': """
+{
+    "Name": "test"
+}
+""",
+                 'README': """
+A very detailed
+description
+"""})
+def test_get_metadata_with_README(path):
+
+    ds = Dataset(path)
+    meta = MetadataParser(ds).get_metadata('ID')
+    assert_equal(
+        dumps(meta, sort_keys=True, indent=2),
+        """\
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "doap": "http://usefulinc.com/ns/doap#"
+  },
+  "@id": "ID",
+  "dcterms:conformsTo": [
+    "http://docs.datalad.org/metadata.html#v0-1",
+    "http://bids.neuroimaging.io"
+  ],
+  "description": "A very detailed\\ndescription",
+  "name": "test"
+}""")


### PR DESCRIPTION
as the bible says!  well -- somewhat.

Here I read README only if original Description is not provided.  BIDS somewhat says "in addition".
So I wondered if some alternative solution should be used, e.g.

1. append content README to description even if description was provided (there are a few openfmri datasets which have both, README and description;  more datasets have no descriptions but do have README)
2. add a new field (e.g. `description-long`) to our schema to contain content of README.

What do you think @mih ?