### PR TITLE
Robustify handling of README while aggregating BIDS

### DIFF
--- a/datalad/metadata/parsers/bids.py
+++ b/datalad/metadata/parsers/bids.py
@@ -8,10 +8,14 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """BIDS metadata parser (http://bids.neuroimaging.io)"""
 
+from io import open
 from os.path import join as opj, exists
 from datalad.support.json_py import load as jsonload
+from datalad.dochelpers import exc_str
 from datalad.metadata.parsers.base import BaseMetadataParser
 
+import logging
+lgr = logging.getLogger('datalad.meta.bids')
 
 class MetadataParser(BaseMetadataParser):
     _core_metadata_filenames = ['dataset_description.json']
@@ -36,7 +40,17 @@ class MetadataParser(BaseMetadataParser):
             # BIDS uses README to provide description, so if was not
             # explicitly provided to possibly override longer README, let's just
             # load README
-            meta['description'] = open(README_fname).read().strip()
+            try:
+                desc = open(README_fname, encoding="utf-8").read()
+            except UnicodeDecodeError as exc:
+                lgr.warning(
+                    "Failed to decode content of %s. "
+                    "Re-loading allowing for UTF-8 errors with replacement: %s"
+                    % (README_fname, exc_str(exc))
+                )
+                desc = open(README_fname, encoding="utf-8", errors="replace").read()
+
+            meta['description'] = desc.strip()
 
         compliance = ["http://docs.datalad.org/metadata.html#v0-1"]
 

--- a/datalad/metadata/parsers/tests/test_bids.py
+++ b/datalad/metadata/parsers/tests/test_bids.py
@@ -1,4 +1,4 @@
-# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -112,22 +112,24 @@ def test_get_metadata_with_description_and_README(path):
 }""")
 
 
+# actually does not demonstrate problem with unicode encountered in
+# https://github.com/datalad/datalad/issues/1138
 @with_tree(tree={'dataset_description.json': """
 {
     "Name": "test"
 }
 """,
-                 'README': """
+                 'README': u"""
 A very detailed
-description
+description с юникодом
 """})
 def test_get_metadata_with_README(path):
-
     ds = Dataset(path)
     meta = MetadataParser(ds).get_metadata('ID')
+    dump = dumps(meta, sort_keys=True, indent=2, ensure_ascii=False)
     assert_equal(
-        dumps(meta, sort_keys=True, indent=2),
-        """\
+        dump,
+        u"""\
 {
   "@context": {
     "@vocab": "http://schema.org/",
@@ -138,6 +140,6 @@ def test_get_metadata_with_README(path):
     "http://docs.datalad.org/metadata.html#v0-1",
     "http://bids.neuroimaging.io"
   ],
-  "description": "A very detailed\\ndescription",
+  "description": "A very detailed\\ndescription с юникодом",
   "name": "test"
 }""")


### PR DESCRIPTION
```shell
$> datalad --version                              
datalad 0.4.1.dev79

hopa:/tmp/ds000203
$> datalad aggregate-metadata --guess-native-type 
[INFO   ] aggregating meta data for <Dataset path=/tmp/ds000203> 
[ERROR  ] 'utf8' codec can't decode byte 0xf1 in position 253: invalid continuation byte [utf_8.py:decode:16] (UnicodeDecodeError) 
```
happens on saving aggregated json:
```shell
hopa:/tmp/ds000203
$> datalad --dbg aggregate-metadata --guess-native-type 
                                                                                 
[INFO   ] aggregating meta data for <Dataset path=/tmp/ds000203> 
Traceback (most recent call last):
  File "/home/yoh/proj/datalad/datalad/venv-tests/bin/datalad", line 11, in <module>
    load_entry_point('datalad', 'console_scripts', 'datalad')()
  File "/home/yoh/proj/datalad/datalad/datalad/cmdline/main.py", line 261, in main
    ret = cmdlineargs.func(cmdlineargs)
  File "/home/yoh/proj/datalad/datalad/datalad/interface/base.py", line 303, in call_from_parser
    return cls.__call__(**kwargs)
  File "/home/yoh/proj/datalad/datalad/datalad/metadata/aggregate.py", line 145, in __call__
    opj(ds.path, metadata_basepath))
  File "/home/yoh/proj/datalad/datalad/datalad/metadata/aggregate.py", line 170, in _within_metadata_store
    _store_json(ds, metapath, meta)
  File "/home/yoh/proj/datalad/datalad/datalad/metadata/aggregate.py", line 36, in _store_json
    jsondump(meta, fname)
  File "/home/yoh/proj/datalad/datalad/datalad/support/json_py.py", line 37, in dump
    **json_dump_kwargs)
  File "/usr/lib/python2.7/dist-packages/simplejson/__init__.py", line 276, in dump
    for chunk in iterable:
  File "/usr/lib/python2.7/dist-packages/simplejson/encoder.py", line 665, in _iterencode
    for chunk in _iterencode_list(o, _current_indent_level):
  File "/usr/lib/python2.7/dist-packages/simplejson/encoder.py", line 515, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib/python2.7/dist-packages/simplejson/encoder.py", line 602, in _iterencode_dict
    yield _encoder(value)
  File "/usr/lib/python2.7/dist-packages/simplejson/encoder.py", line 61, in encode_basestring
    s = s.decode('utf-8')
  File "/home/yoh/proj/datalad/datalad/venv-tests/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xf1 in position 253: invalid continuation byte
()
> /home/yoh/proj/datalad/datalad/venv-tests/lib/python2.7/encodings/utf_8.py(16)decode()
-> return codecs.utf_8_decode(input, errors, True)
```

and seems have worked (at least didn't crash) with 0.4.1:
```shell
hopa:/tmp/ds000203
$> deactivate
2 13956.....................................:Fri 25 Nov 2016 03:15:12 PM EST:.
hopa:/tmp/ds000203
$> datalad --dbg aggregate-metadata --guess-native-type
[INFO   ] aggregating meta data for <Dataset path=/tmp/ds000203> 
```

culprit obviously an added README which contains unicode but was not decoded properly