### PR TITLE
create --annex-version 6 (or subsequent lock) places .datalad/config under annex, not git

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -261,9 +261,10 @@ class Create(Interface):
             where='dataset')
 
         # make sure that v6 annex repos never commit content under .datalad
-        with open(opj(tbds.path, '.gitattributes'), 'a') as gitattr:
-            gitattr.write('.datalad/** annex.largefiles=nothing\n')
-        tbds.repo.add('.gitattributes', git=True)
+        with open(opj(tbds.path, '.datalad', '.gitattributes'), 'a') as gitattr:
+            # TODO this will need adjusting, when annex'ed aggregate meta data
+            # comes around
+            gitattr.write('** annex.largefiles=nothing\n')
 
         # save everthing
         tbds.repo.add('.datalad', git=True)

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -14,7 +14,7 @@ import logging
 import uuid
 
 from os import listdir
-from os.path import isdir, realpath, relpath
+from os.path import isdir, realpath, relpath, join as opj
 
 from datalad.interface.base import Interface
 from datalad.interface.save import Save
@@ -259,6 +259,11 @@ class Create(Interface):
             id_var,
             tbds.id if tbds.id is not None else uuid.uuid1().urn.split(':')[-1],
             where='dataset')
+
+        # make sure that v6 annex repos never commit content under .datalad
+        with open(opj(tbds.path, '.gitattributes'), 'a') as gitattr:
+            gitattr.write('.datalad/** annex.largefiles=nothing\n')
+        tbds.repo.add('.gitattributes', git=True)
 
         # save everthing
         tbds.repo.add('.datalad', git=True)

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -85,7 +85,8 @@ def test_add_files(path):
         annexed = set(ds.repo.get_annexed_files())
         indexed = set(ds.repo.get_indexed_files())
         # ignore the initial config file in index:
-        indexed.remove('.datalad/config')
+        indexed.remove(opj('.datalad', 'config'))
+        indexed.remove(opj('.datalad', '.gitattributes'))
         if isinstance(arg[0], list):
             for x in arg[0]:
                 unstaged.remove(x)


### PR DESCRIPTION
again not sure how it has happened, and which branch I was using at that moment -- master or of currently WiP+BK #1011 but result is stunning:

``` shell
$> git log -p .datalad
commit 3c8c614cf24a9d02534ddcdb8ce879e3ff501723
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Fri Oct 14 16:03:44 2016 -0400

    [DATALAD] new dataset

diff --git a/.datalad/config b/.datalad/config
new file mode 100644
index 0000000..c9dce61
--- /dev/null
+++ b/.datalad/config
@@ -0,0 +1 @@
+/annex/objects/MD5E-s63--6c651a912b39c90ba19405e501bd951c
```

detected only upon

``` shell
(git)smaug:/mnt/datasets/datalad/crawl/dicoms[master]git
$> datalad aggregate-metadata --guess-native-type -r              
2016-10-15 09:26:26,923 [INFO   ] aggregating meta data for <Dataset path=/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/PHANTOM-20160909> (aggregate.py:107)
2016-10-15 09:26:27,016 [INFO   ] aggregating meta data for <Dataset path=/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/PHANTOM1_3> (aggregate.py:107)
2016-10-15 09:26:27,066 [WARNING] <Dataset path=/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/Philips-20131217> has not configured ID, skipping. (aggregate.py:78)
2016-10-15 09:26:27,131 [INFO   ] aggregating meta data for <Dataset path=/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test3> (aggregate.py:107)
fatal: bad config file line 1 in /mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test4-20161014/bids-output/.datalad/config
2016-10-15 09:26:27,441 [ERROR  ] Failed to run ['git', 'config', '-z', '-l', '--file', u'/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test4-20161014/bids-output/.datalad/config'] under u'/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test4-20161014/bids-output'. Exit code=128. out= err=None (cmd.py:352)
2016-10-15 09:26:27,442 [ERROR  ] CommandError: command '['git', 'config', '-z', '-l', '--file', u'/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test4-20161014/bids-output/.datalad/config']' failed with exitcode 128.
| Failed to run ['git', 'config', '-z', '-l', '--file', u'/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test4-20161014/bids-output/.datalad/config'] under u'/mnt/datasets/datalad/crawl/dicoms/dartmouth-phantoms/bids_test4-20161014/bids-output'. Exit code=128. out= err=None [cmd.py:run:353] (CommandError) (main.py:272)

```
