### PR TITLE
ENH: Annex V6 default build added to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   matrix:
     - DATALAD_REPO_DIRECT=1
     - DATALAD_REPO_DIRECT=
+    - DATALAD_REPO_VERSION=6
 # Disabled since old folks don't want to change workflows of submitting through central authority
 #    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
 #    - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 python:
   - 2.7
-  - 3.3
   - 3.4
 
 cache:

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -14,6 +14,8 @@ __docformat__ = 'restructuredtext'
 
 from appdirs import AppDirs
 from datalad.support.constraints import EnsureBool
+from datalad.support.constraints import EnsureInt
+
 dirs = AppDirs("datalad", "datalad.org")
 
 
@@ -153,5 +155,17 @@ definitions = {
     'datalad.cmd.protocol.prefix': {
         'ui': ('question', {
                'title': 'Sets a prefix to add before the command call times are noted by DATALAD_CMD_PROTOCOL.'}),
+    },
+    'datalad.repo.direct': {
+        'ui': ('yesno', {
+               'title': 'Direct Mode for git-annex repositories',
+               'text': 'Set this flag to create annex repositories in direct mode by default'}),
+        'type': EnsureBool(),
+    },
+    'datalad.repo.version': {
+        'ui': ('question', {
+               'title': 'git-annex repository version',
+               'text': 'Specifies the repository version for git-annex to be used by default'}),
+        'type': EnsureInt(),
     },
 }


### PR DESCRIPTION
Addressing #1143 as agreed on in hangout.

Should add builds with V6 as default.
When we started having a look at these, should change to V6 for all builds instead of dedicated ones.