### PR TITLE
ENH: allow to drop all content after crawling (used in simple_s3), and assure_bool

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -1400,6 +1400,16 @@ class Annexificator(object):
             lgr.warning("Was asked to remove non-existing path %s", filename)
         yield data
 
+    def drop(self, all=False, force=False):
+        """Drop crawled file or all files if all is specified"""
+        def _drop(data):
+            if not all:
+                raise NotImplementedError("provide handling to drop specific file")
+            else:
+                lgr.debug("Dropping all files in %s", self.repo)
+                self.repo.drop([], options=['--all'] + ['--force'] if force else [])
+        return _drop
+
     def initiate_dataset(self, *args, **kwargs):
         """Thin proxy to initiate_dataset node which initiates dataset as a subdataset to current annexificator
         """

--- a/datalad/crawler/pipelines/simple_s3.py
+++ b/datalad/crawler/pipelines/simple_s3.py
@@ -52,6 +52,8 @@ def pipeline(bucket,
              archives=False,
              allow_dirty=False,
              backend='MD5E',
+             drop=False,
+             drop_force=False,
              **kwargs):
     """Pipeline to crawl/annex an arbitrary bucket
 
@@ -70,9 +72,15 @@ def pipeline(bucket,
     directory : {subdataset}, optional
       What to do when encountering a directory.  'subdataset' would initiate a new sub-dataset
       at that directory
+    drop : bool, optional
+      Drop all the files whenever done crawling
     """
 
     lgr.info("Creating a pipeline for the %s bucket", bucket)
+
+    # TODO: see if we could make it more generic!!!
+    # drop = assure_bool(drop)
+    # drop_force = assure_bool(drop_force)
 
     annex_kw = {}
 
@@ -147,4 +155,8 @@ def pipeline(bucket,
                                 **kwargs)
     else:
         pipeline = incoming_pipeline
+
+    if drop:
+        pipeline.append(annex.drop(all=True, force=drop_force))
+
     return pipeline

--- a/datalad/crawler/pipelines/simple_s3.py
+++ b/datalad/crawler/pipelines/simple_s3.py
@@ -19,6 +19,7 @@ from ...consts import DATALAD_SPECIAL_REMOTE
 from ...support.strings import get_replacement_dict
 
 from .simple_with_archives import pipeline as swa_pipeline
+from datalad.utils import assure_bool
 
 # Possibly instantiate a logger if you would like to log
 # during pipeline creation
@@ -49,6 +50,7 @@ def pipeline(bucket,
              rename=None,
              directory=None,
              archives=False,
+             allow_dirty=False,
              backend='MD5E',
              **kwargs):
     """Pipeline to crawl/annex an arbitrary bucket
@@ -73,6 +75,13 @@ def pipeline(bucket,
     lgr.info("Creating a pipeline for the %s bucket", bucket)
 
     annex_kw = {}
+
+    to_http = assure_bool(to_http)
+    tag = assure_bool(tag)
+    archives = assure_bool(archives)
+    no_annex = assure_bool(no_annex)
+    allow_dirty = assure_bool(allow_dirty)
+
     if not to_http:
         annex_kw['special_remotes'] = [DATALAD_SPECIAL_REMOTE]
 
@@ -81,6 +90,7 @@ def pipeline(bucket,
         backend=backend,
         no_annex=no_annex,
         skip_problematic=skip_problematic,
+        allow_dirty=allow_dirty,
         # Primary purpose of this one is registration of all URLs with our
         # upcoming "ultimate DB" so we don't get to git anything
         # options=["-c", "annex.largefiles=exclude=CHANGES* and exclude=changelog.txt and exclude=dataset_description.json and exclude=README* and exclude=*.[mc]"]

--- a/datalad/crawler/pipelines/simple_s3.py
+++ b/datalad/crawler/pipelines/simple_s3.py
@@ -89,6 +89,8 @@ def pipeline(bucket,
     archives = assure_bool(archives)
     no_annex = assure_bool(no_annex)
     allow_dirty = assure_bool(allow_dirty)
+    drop = assure_bool(drop)
+    drop_force = assure_bool(drop_force)
 
     if not to_http:
         annex_kw['special_remotes'] = [DATALAD_SPECIAL_REMOTE]

--- a/datalad/crawler/pipelines/tests/test_simple_s3.py
+++ b/datalad/crawler/pipelines/tests/test_simple_s3.py
@@ -7,10 +7,9 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from os.path import join as opj
+from glob import glob
 
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines as _tsp
-from ...nodes.annex import initiate_dataset
 from ....utils import chpwd
 from ....utils import _path_
 from ....tests.utils import eq_
@@ -18,12 +17,13 @@ from ....tests.utils import assert_false
 from ....tests.utils import with_tempfile
 from ....tests.utils import use_cassette
 from ....tests.utils import externals_use_cassette
+from ....tests.utils import skip_if_no_network
 from ..simple_s3 import pipeline
 from datalad.api import crawl_init
 from datalad.api import crawl
 from datalad.api import create
 from datalad.support.annexrepo import AnnexRepo
-from glob import glob
+from datalad.downloaders.tests.utils import get_test_providers
 
 from logging import getLogger
 lgr = getLogger('datalad.crawl.tests')
@@ -41,7 +41,9 @@ def test_smoke_pipelines():
 
 @with_tempfile
 @use_cassette('test_simple_s3_test0_nonversioned_crawl')
+@skip_if_no_network
 def test_drop(path):
+    get_test_providers('s3://datalad-test0-nonversioned')  # to verify having s3 credentials
     create(path)
     # unfortunately this doesn't work without force dropping since I guess vcr
     # stops and then gets queried again for the same tape while testing for

--- a/datalad/crawler/pipelines/tests/test_simple_s3.py
+++ b/datalad/crawler/pipelines/tests/test_simple_s3.py
@@ -13,14 +13,17 @@ from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines as _tsp
 from ...nodes.annex import initiate_dataset
 from ....utils import chpwd
 from ....utils import _path_
-from ....tests.utils import with_tree
-from ....tests.utils import eq_, assert_not_equal, ok_, assert_raises
+from ....tests.utils import eq_
+from ....tests.utils import assert_false
 from ....tests.utils import with_tempfile
-from ....tests.utils import serve_path_via_http
-from ....tests.utils import ok_file_has_content
-from ....tests.utils import ok_file_under_git
+from ....tests.utils import use_cassette
+from ....tests.utils import externals_use_cassette
 from ..simple_s3 import pipeline
-
+from datalad.api import crawl_init
+from datalad.api import crawl
+from datalad.api import create
+from datalad.support.annexrepo import AnnexRepo
+from glob import glob
 
 from logging import getLogger
 lgr = getLogger('datalad.crawl.tests')
@@ -34,3 +37,29 @@ def test_smoke_pipelines():
     yield _tsp, pipeline, ["b"], dict(to_http=True)
     yield _tsp, pipeline, ["b"], dict(to_http=True, archive=True)
     yield _tsp, pipeline, ["b"], dict(to_http=True, directory="subdataset", prefix="some/")
+
+
+@with_tempfile
+@use_cassette('test_simple_s3_test0_nonversioned_crawl')
+def test_drop(path):
+    create(path)
+    # unfortunately this doesn't work without force dropping since I guess vcr
+    # stops and then gets queried again for the same tape while testing for
+    # drop :-/
+    with externals_use_cassette('test_simple_s3_test0_nonversioned_crawl_ext'), \
+         chpwd(path):
+        crawl_init(template="simple_s3",
+                   args=dict(
+                       bucket="datalad-test0-nonversioned",
+                       drop=True,
+                       drop_force=True  # so test goes faster
+                   ),
+                   save=True
+                   )
+        crawl()
+    # test that all was dropped
+    repo = AnnexRepo(path, create=False)
+    files = glob(_path_(path, '*'))
+    eq_(len(files), 8)
+    for f in files:
+        assert_false(repo.file_has_content(f))

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -56,6 +56,7 @@ from .utils import SkipTest
 from .utils import assert_cwd_unchanged, skip_if_on_windows
 from .utils import assure_dict_from_str, assure_list_from_str
 from .utils import assure_unicode
+from .utils import assure_bool
 from .utils import ok_generator
 from .utils import assert_not_in
 from .utils import assert_raises
@@ -318,6 +319,16 @@ def test_assure_dict_from_str():
     assert_equal(assure_dict_from_str(
         dict(__ac_name='{user}', __ac_password='{password}', cookies_enabled='', submit='Log in')), dict(
              __ac_name='{user}', __ac_password='{password}', cookies_enabled='', submit='Log in'))
+
+
+def test_assure_bool():
+    for values, t in [
+        (['True', 1, '1', 'yes', 'on'], True),
+        (['False', 0, '0', 'no', 'off'], False)
+    ]:
+        for v in values:
+            eq_(assure_bool(v), t)
+    assert_raises(ValueError, assure_bool, "unknown")
 
 
 def test_any_re_search():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -36,7 +36,7 @@ from os.path import isdir
 from os.path import relpath
 
 
-from six import text_type, binary_type
+from six import text_type, binary_type, string_types
 
 # from datalad.dochelpers import get_docstring_split
 from datalad.consts import TIMESTAMP_FMT
@@ -448,6 +448,23 @@ def assure_dict_from_str(s, **kwargs):
 def assure_unicode(s, encoding='utf-8'):
     """Convert/decode to unicode (PY2) or str (PY3) if of 'binary_type'"""
     return s.decode(encoding) if isinstance(s, binary_type) else s
+
+def assure_bool(s):
+    """Convert value into boolean following convention for strings
+
+    to recognize on,True,yes as True, off,False,no as False
+    """
+    if isinstance(s, string_types):
+        if s.isdigit():
+            return bool(int(s))
+        sl = s.lower()
+        if sl in {'y', 'yes', 'true', 'on'}:
+            return True
+        elif sl in {'n', 'no', 'false', 'off'}:
+            return False
+        else:
+            raise ValueError("Do not know how to treat %r as a boolean" % s)
+    return bool(s)
 
 
 def unique(seq, key=None):


### PR DESCRIPTION
@datalad/developers -- it feels like I need to adopt arguments treatment for crawler pipeline functions similar to as it is happening in cmdline -- to assure correct data types etc... I wonder how easy it would be ;)