### PR TITLE
BF: do not reuse s3 bucket session in the test

### DIFF
--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -165,7 +165,10 @@ class S3Downloader(BaseDownloader):
         bucket_name = self._parse_url(url)[0]
         if allow_old and self._bucket:
             if self._bucket.name == bucket_name:
-                lgr.debug("S3 session: Reusing previous bucket")
+                lgr.debug(
+                    "S3 session: Reusing previous connection to bucket %s",
+                    bucket_name
+                )
                 return True  # we used old
             else:
                 lgr.warning("No support yet for multiple buckets per S3Downloader")

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -57,7 +57,11 @@ def test_s3_download_basic():
 def test_mtime(tempfile):
     url = url_2versions_nonversioned1_ver2
     with swallow_outputs():
-        get_test_providers(url).download(url, path=tempfile)
+        # without allow_old=False it might be reusing previous connection
+        # which had already vcr tape for it, leading to failure.
+        # TODO:  make allow_old configurable and then within tests disallow
+        # allow_old
+        get_test_providers(url).download(url, path=tempfile, allow_old_session=False)
     assert_equal(os.stat(tempfile).st_mtime, 1446873817)
 
     # and if url is wrong


### PR DESCRIPTION
otherwise uses another vcr tape leading to failed test

since we aren't testing those ATM on travis - I will just merge it if it doesn't break anything else