### PR TITLE
RF save/add/create/get

### DIFF
--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -58,6 +58,7 @@ from ..consts import CRAWLER_META_CONFIG_FILENAME
 from ..utils import updated
 from ..dochelpers import exc_str
 from ..support.gitrepo import GitRepo
+from ..support.annexrepo import AnnexRepo
 from ..support.network import parse_url_opts
 from ..support.stats import ActivityStats
 from ..support.exceptions import PipelineNotSpecifiedError
@@ -412,7 +413,7 @@ def _find_pipeline(name):
             name += '.py'
 
         # first -- current directory
-        repo_path = GitRepo.get_toppath(curdir)
+        repo_path = AnnexRepo.get_toppath(curdir)
         if repo_path:
             yield opj(repo_path, CRAWLER_META_DIR, 'pipelines', name)
 
@@ -530,7 +531,7 @@ def get_repo_pipeline_config_path(repo_path=curdir):
     """Given a path within a repo, return path to the crawl.cfg"""
     if not exists(opj(repo_path, HANDLE_META_DIR)):
         # we need to figure out top path for the repo
-        repo_path = GitRepo.get_toppath(repo_path)
+        repo_path = AnnexRepo.get_toppath(repo_path)
         if not repo_path:
             return None
     return opj(repo_path, CRAWLER_META_CONFIG_PATH)
@@ -542,7 +543,7 @@ def get_repo_pipeline_script_path(repo_path=curdir):
     # tracked or smth like that
     if not exists(opj(repo_path, HANDLE_META_DIR)):
         # we need to figure out top path for the repo
-        repo_path = GitRepo.get_toppath(repo_path)
+        repo_path = AnnexRepo.get_toppath(repo_path)
         if not repo_path:
             return None
     pipelines = glob(opj(repo_path, CRAWLER_META_DIR, 'pipelines', '*.py'))

--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -56,9 +56,9 @@ from os import makedirs
 from ..consts import CRAWLER_META_DIR, HANDLE_META_DIR, CRAWLER_META_CONFIG_PATH
 from ..consts import CRAWLER_META_CONFIG_FILENAME
 from ..utils import updated
+from ..utils import get_dataset_root
 from ..dochelpers import exc_str
 from ..support.gitrepo import GitRepo
-from ..support.annexrepo import AnnexRepo
 from ..support.network import parse_url_opts
 from ..support.stats import ActivityStats
 from ..support.exceptions import PipelineNotSpecifiedError
@@ -413,7 +413,7 @@ def _find_pipeline(name):
             name += '.py'
 
         # first -- current directory
-        repo_path = AnnexRepo.get_toppath(curdir)
+        repo_path = get_dataset_root(curdir)
         if repo_path:
             yield opj(repo_path, CRAWLER_META_DIR, 'pipelines', name)
 
@@ -531,7 +531,7 @@ def get_repo_pipeline_config_path(repo_path=curdir):
     """Given a path within a repo, return path to the crawl.cfg"""
     if not exists(opj(repo_path, HANDLE_META_DIR)):
         # we need to figure out top path for the repo
-        repo_path = AnnexRepo.get_toppath(repo_path)
+        repo_path = get_dataset_root(repo_path)
         if not repo_path:
             return None
     return opj(repo_path, CRAWLER_META_CONFIG_PATH)
@@ -543,7 +543,7 @@ def get_repo_pipeline_script_path(repo_path=curdir):
     # tracked or smth like that
     if not exists(opj(repo_path, HANDLE_META_DIR)):
         # we need to figure out top path for the repo
-        repo_path = AnnexRepo.get_toppath(repo_path)
+        repo_path = get_dataset_root(repo_path)
         if not repo_path:
             return None
     pipelines = glob(opj(repo_path, CRAWLER_META_DIR, 'pipelines', '*.py'))

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -120,7 +120,7 @@ class Add(Interface):
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         ds2super=Parameter(
-            args=("--ds2super", "--datasets-to-super",),
+            args=("-S", "--ds2super", "--datasets-to-super",),
             action='store_true',
             doc="""given paths of dataset (toplevel) locations will cause
             these datasets to be added to their respective superdatasets

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -358,7 +358,7 @@ class Add(Interface):
                 Save.__call__(
                     message='[DATALAD] added content',
                     dataset=ds,
-                    auto_add_changes=False,
+                    all_changes=False,
                     recursive=False)
             # TODO: you feels that this is some common logic we already have somewhere
             dsrelpath = relpath(dspath, dataset.path)

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -26,6 +26,7 @@ from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_add_opts
 from datalad.interface.common_opts import jobs_opt
 from datalad.interface.utils import save_dataset_hierarchy
+from datalad.interface.utils import _discover_trace_to_known
 from datalad.distribution.utils import _install_subds_inplace
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
@@ -66,30 +67,6 @@ def _discover_subdatasets_recursively(top, trace, spec, recursion_limit):
         if not isdir(path):
             continue
         _discover_subdatasets_recursively(path, trace, spec, recursion_limit)
-
-
-def _discover_trace_to_known(path, trace, spec):
-    # this beast walks the directory tree from a given `path` until
-    # it discoveres a known dataset (i.e. recorded in the spec)
-    # if it finds one, it commits any accummulated trace of visited
-    # datasets on this edge to the spec
-    valid_repo = GitRepo.is_valid_repo(path)
-    if valid_repo:
-        trace = trace + [path]
-        if path in spec:
-            # found a known repo, commit the trace
-            for i, p in enumerate(trace[:-1]):
-                spec[p] = spec.get(p, []) + [trace[i + 1]]
-            # this edge is done
-            return
-    for p in listdir(path):
-        if valid_repo and p == '.git':
-            # ignore gitdir to steed things up
-            continue
-        p = opj(path, p)
-        if not isdir(p):
-            continue
-        _discover_trace_to_known(p, trace, spec)
 
 
 class Add(Interface):

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -195,8 +195,7 @@ class Add(Interface):
                                             if not p == inpds]
                 # and lastly remove all entries that contain no path to avoid
                 # saving any staged content in the final step
-                content_by_ds = {d: content_by_ds[d] for d in content_by_ds
-                                 if content_by_ds[d]}
+                content_by_ds = {d: v for d, v in content_by_ds.items() if v}
 
         results = []
         # simple loop over datasets -- save happens later

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -221,6 +221,10 @@ class Add(Interface):
                     relativepath=relpath(subds_path, ds_path))
                 # make sure that .gitmodules is added to the list of files
                 toadd.append(opj(ds.path, '.gitmodules'))
+                # report added subdatasets -- add below won't do it
+                results.append({
+                    'success': True,
+                    'file': Dataset(subds_path)})
             # make sure any last minute additions make it to the saving stage
             content_by_ds[ds_path] = toadd
             added = ds.repo.add(
@@ -231,7 +235,7 @@ class Add(Interface):
                 a['file'] = opj(ds_path, a['file'])
             results.extend(added)
 
-        if save:
+        if results and save:
             save_dataset_hierarchy(
                 content_by_ds,
                 base=dataset.path if dataset and dataset.is_installed() else None,
@@ -248,7 +252,9 @@ class Add(Interface):
         if not isinstance(res, list):
             res = [res]
         if not len(res):
-            ui.message("Nothing was added")
+            ui.message("Nothing was added{}".format(
+                       '' if args.recursive else
+                       " (consider --recursive if that is unexpected)"))
             return
 
         msg = linesep.join([

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -25,10 +25,8 @@ from datalad.interface.common_opts import nosave_opt
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_add_opts
-from datalad.interface.common_opts import if_dirty_opt
 from datalad.interface.common_opts import jobs_opt
-from datalad.interface.utils import handle_dirty_dataset
-from datalad.interface.save import Save
+from datalad.interface.utils import save_dataset_hierarchy
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
@@ -59,18 +57,6 @@ class Add(Interface):
     register this new content with the dataset. With recursion enabled,
     files will be added to their respective subdatasets as well.
 
-    Alternatively, a source location can be given to indicate where to obtain
-    data from. If no `path` argument is provided in this case, the content will
-    be obtained from the source location and a default local name, derived from
-    the source location will be generated. Alternatively, an explicit `path`
-    can be given to override the default.
-
-    If more than one `path` argument and a source location are provided, the
-    `path` arguments will be sequentially used to complete the source URL/path
-    (be means of concatenation), and an attempt is made to obtain data from
-    those locations.
-
-
     || REFLOW >>
     By default all files are added to the dataset's :term:`annex`, i.e. only
     their content identity and availability information is tracked with Git.
@@ -84,7 +70,7 @@ class Add(Interface):
     << REFLOW ||
 
     .. note::
-      Power-user info: This command uses :command:`git annex add`, :command:`git annex addurl`, or
+      Power-user info: This command uses :command:`git annex add`, or
       :command:`git add` to incorporate new dataset content.
     """
 
@@ -102,13 +88,7 @@ class Add(Interface):
             doc="""path/name of the component to be added. The component
             must either exist on the filesystem already, or a `source`
             has to be provided.""",
-            nargs="*",
-            constraints=EnsureStr() | EnsureNone()),
-        source=Parameter(
-            args=("-s", "--source",),
-            metavar='URL/PATH',
-            doc="url or local path of the to be added component's source",
-            action="append",
+            nargs="+",
             constraints=EnsureStr() | EnsureNone()),
         to_git=Parameter(
             args=("--to-git",),
@@ -120,7 +100,6 @@ class Add(Interface):
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         save=nosave_opt,
-        if_dirty=if_dirty_opt,
         git_opts=git_opts,
         annex_opts=annex_opts,
         annex_add_opts=annex_add_opts,
@@ -131,248 +110,62 @@ class Add(Interface):
     @datasetmethod(name='add')
     def __call__(
             path=None,
-            source=None,
             dataset=None,
             to_git=False,
             save=True,
             recursive=False,
             recursion_limit=None,
-            if_dirty='ignore',
             git_opts=None,
             annex_opts=None,
             annex_add_opts=None,
             jobs=None):
 
         # parameter constraints:
-        if not path and not source:
-            raise InsufficientArgumentsError("insufficient information for "
-                                             "adding: requires at least a path "
-                                             "or a source.")
+        if not path:
+            raise InsufficientArgumentsError(
+                "insufficient information for adding: requires at least a path")
+        content_by_ds, unavailable_paths = Interface._prep(
+            path=path,
+            dataset=dataset,
+            recursive=recursive,
+            recursion_limit=recursion_limit)
+        if unavailable_paths:
+            lgr.warning("ignoring non-existent path(s): %s",
+                        unavailable_paths)
+        if not content_by_ds:
+            raise InsufficientArgumentsError(
+                "no existing content given to add")
 
-        # When called from cmdline `path` and `source` will be a list even if
-        # there is only one item.
-        # Make sure we deal with the same when called via python API:
-        # always yields list; empty if None
-        path = assure_list(path)
-        source = assure_list(source)
+        # TODO with --recursive for each input path traverse the directory
+        # tree until the end or until we hit a known dataset
+        # when we find an unknown dataset, add it to the spec, AND add it as
+        # a path to the spec of the parent
 
-        # TODO: Q: are the list operations in the following 3 blocks (resolving
-        #          paths, sources and datasets) guaranteed to be stable
-        #          regarding order?
+        # TODO use GitRepo.is_valid_repo(path) instead of GitRepo.get_top_path()
+        # does the same without a Git call
 
-        # resolve path(s):
-        # TODO: RF: resolve_path => datalad.utils => more general (repos => normalize paths)
-        resolved_paths = [resolve_path(p, dataset) for p in path]
+        results = []
+        # simple loop over datasets -- save happens later
+        # start deep down
+        for ds_path in sorted(content_by_ds, reverse=True):
+            ds = Dataset(ds_path)
+            # TODO if dir, could be untracked subdataset
+            # if dir, and repo, and there is a base dataset, install_inplace
+            added = ds.repo.add(
+                content_by_ds[ds_path],
+                git=to_git if isinstance(ds.repo, AnnexRepo) else True,
+                commit=False)
+            for a in added:
+                a['file'] = opj(ds_path, a['file'])
+            results.extend(added)
 
-        # must come after resolve_path()!!
-        # resolve dataset:
-        dataset = require_dataset(dataset, check_installed=True,
-                                  purpose='adding')
-        handle_dirty_dataset(dataset, if_dirty)
+        if save:
+            save_dataset_hierarchy(
+                content_by_ds,
+                base=dataset.path if dataset and dataset.is_installed() else None,
+                message='[DATALAD] added content')
 
-        # resolve source(s):
-        resolved_sources = []
-        for s in source:
-            if not is_datalad_compat_ri(s):
-                raise ValueError("invalid source parameter: %s" % s)
-            resolved_sources.append(_get_git_url_from_source(s))
-
-        # find (sub-)datasets to add things to (and fail on invalid paths):
-        if recursive:
-
-            # 1. Find the (sub-)datasets containing the given path(s):
-            # Note, that `get_containing_subdataset` raises if `p` is
-            # outside `dataset`, but it returns `dataset`, if `p` is inside
-            # a subdataset not included by `recursion_limit`. In the latter
-            # case, the git calls will fail instead.
-            # We could check for this right here and fail early, but this
-            # would lead to the need to discover the entire hierarchy no
-            # matter if actually required.
-            resolved_datasets = [dataset.get_containing_subdataset(
-                p, recursion_limit=recursion_limit) for p in resolved_paths]
-
-            # 2. Find implicit subdatasets to call add on:
-            # If there are directories in resolved_paths (Note,
-            # that this includes '.' and '..'), check for subdatasets
-            # beneath them. These should be called recursively with '.'.
-            # Therefore add the subdatasets to resolved_datasets and
-            # corresponding '.' to resolved_paths, in order to generate the
-            # correct call.
-            for p in resolved_paths:
-                if isdir(p):
-                    for subds_path in \
-                        dataset.get_subdatasets(absolute=True, recursive=True,
-                                                recursion_limit=recursion_limit):
-                        if subds_path.startswith(_with_sep(p)):
-                            resolved_datasets.append(Dataset(subds_path))
-                            resolved_paths.append(curdir)
-
-        else:
-            # if not recursive, try to add everything to dataset itself:
-            resolved_datasets = [dataset for i in range(len(resolved_paths))]
-
-        # we need a resolved dataset per path:
-        assert len(resolved_paths) == len(resolved_datasets)
-
-        # sort parameters for actual git/git-annex calls:
-        # (dataset, path, source)
-        from six.moves import zip_longest
-
-        param_tuples = list(zip_longest(resolved_datasets,
-                                        resolved_paths, resolved_sources))
-        # possible None-datasets in `param_tuples` were filled in by zip_longest
-        # and need to be replaced by `dataset`:
-        param_tuples = [(d if d is not None else dataset, p, s)
-                        for d, p, s in param_tuples]
-
-        calls = {d.path: {  # list of paths to 'git-add':
-                            'g_add': [],
-                            # list of paths to 'git-annex-add':
-                            'a_add': [],
-                            # list of sources to 'git-annex-addurl':
-                            'addurl_s': [],
-                            # list of (path, source) to
-                            # 'git-annex-addurl --file':
-                            'addurl_f': []
-                         } for d in [i for i, p, s in param_tuples]}
-
-        for ds, p, s in param_tuples:
-            # it should not happen, that `path` as well as `source` are None:
-            assert p or s
-            if not s:
-                # we have a path only
-                # Do not try to add to annex whenever there is no annex
-                if to_git or not isinstance(ds.repo, AnnexRepo):
-                    calls[ds.path]['g_add'].append(p)
-                else:
-                    calls[ds.path]['a_add'].append(p)
-            elif not p:
-                # we have a source only
-                if to_git:
-                    raise NotImplementedError("Can't add a remote source "
-                                              "directly to git.")
-                calls[ds.path]['addurl_s'].append(s)
-            else:
-                # we have a path and a source
-                if to_git:
-                    raise NotImplementedError("Can't add a remote source "
-                                              "directly to git.")
-                calls[ds.path]['addurl_f'].append((p, s))
-
-        # now do the actual add operations:
-        # TODO: implement git/git-annex/git-annex-add options
-
-        datasets_return_values = defaultdict(list)
-        for dspath in calls:
-            ds = Dataset(dspath)
-            return_values = datasets_return_values[dspath]
-            lgr.info("Processing dataset %s ..." % ds)
-
-            # check every (sub-)dataset for annex once, since we can't add or
-            # addurl anything, if there is no annex:
-            # TODO: Q: Alternatively, just call git-annex-init if there's no
-            # annex yet and we have an annex-add/annex-addurl request?
-            _is_annex = isinstance(ds.repo, AnnexRepo)
-
-            if calls[ds.path]['g_add']:
-                lgr.debug("Adding %s to git", calls[dspath]['g_add'])
-                added = ds.repo.add(calls[dspath]['g_add'], git=True,
-                                  git_options=git_opts)
-                return_values.extend(added)
-            if calls[ds.path]['a_add']:
-                if _is_annex:
-                    lgr.debug("Adding %s to annex", calls[dspath]['a_add'])
-                    return_values.extend(
-                        ds.repo.add(calls[dspath]['a_add'],
-                                    git=False,
-                                    jobs=jobs,
-                                    git_options=git_opts,
-                                    annex_options=annex_opts,
-                                    options=annex_add_opts
-                                    )
-                    )
-                else:
-                    lgr.debug("{0} is no annex. Skip 'annex-add' for "
-                              "files {1}".format(ds, calls[dspath]['a_add']))
-                    return_values.extend(
-                        [{'file': f,
-                          'success': False,
-                          'note': "no annex at %s" % ds.path}
-                         for f in calls[dspath]['a_add']]
-                    )
-
-            # TODO: AnnexRepo.add_urls' return value doesn't contain the created
-            #       file name but the url
-            if calls[ds.path]['addurl_s']:
-                if _is_annex:
-                    lgr.debug("Adding urls %s to annex", calls[dspath]['addurl_s'])
-                    return_values.extend(
-                        ds.repo.add_urls(calls[ds.path]['addurl_s'],
-                                         options=annex_add_opts,
-                                         # TODO: extra parameter for addurl?
-                                         git_options=git_opts,
-                                         annex_options=annex_opts,
-                                         jobs=jobs,
-                                         )
-                    )
-                else:
-                    lgr.debug("{0} is no annex. Skip 'annex-addurl' for "
-                              "files {1}".format(ds, calls[dspath]['addurl_s']))
-                    return_values.extend(
-                        [{'file': f,
-                          'success': False,
-                          'note': "no annex at %s" % ds.path}
-                         for f in calls[dspath]['addurl_s']]
-                    )
-
-            if calls[ds.path]['addurl_f']:
-                if _is_annex:
-                    for f, u in calls[ds.path]['addurl_f']:
-                        lgr.debug("Adding urls %s to files in annex",
-                                  calls[dspath]['addurl_f'])
-                        return_values.append(
-                            ds.repo.add_url_to_file(f, u,
-                                                    options=annex_add_opts,  # TODO: see above
-                                                    git_options=git_opts,
-                                                    annex_options=annex_opts,
-                                                    batch=True))
-                else:
-                    lgr.debug("{0} is no annex. Skip 'annex-addurl' for "
-                              "files {1}".format(ds, calls[dspath]['addurl_f']))
-                    return_values.extend(
-                        [{'file': f,
-                          'success': False,
-                          'note': "no annex at %s" % ds.path}
-                         for f in calls[dspath]['addurl_f']]
-                    )
-            return_values = None  # to avoid mis-use
-
-        # XXX or we could return entire datasets_return_values, could be useful
-        # that way.  But then should be unified with the rest of commands, e.g.
-        # get etc
-        return_values_flat = []
-        for dspath, return_values in datasets_return_values.items():
-            if save and len(return_values):
-                # we got something added -> save
-                # everything we care about at this point should be staged already
-                Save.__call__(
-                    message='[DATALAD] added content',
-                    dataset=ds,
-                    all_changes=False,
-                    recursive=False)
-            # TODO: you feels that this is some common logic we already have somewhere
-            dsrelpath = relpath(dspath, dataset.path)
-            if dsrelpath != curdir:
-                # we need ot adjust 'file' entry in each record
-                for return_value in return_values:
-                    if 'file' in return_value:
-                        return_value['file'] = opj(dsrelpath, return_value['file'])
-                    return_values_flat.append(return_value)
-            else:
-                return_values_flat.extend(return_values)
-
-
-        return return_values_flat
+        return results
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -167,7 +167,10 @@ class Add(Interface):
             # with --recursive for each input path traverse the directory
             # tree, when we find a dataset, add it to the spec, AND add it as
             # a path to the spec of the parent
-            for d in content_by_ds.keys():
+            # MIH: wrap in list() to avoid exception, because dict size might
+            # change, but we want to loop over all that are in at the start
+            # only
+            for d in list(content_by_ds.keys()):
                 for p in content_by_ds[d]:
                     _discover_subdatasets_recursively(
                         p,

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -273,7 +273,7 @@ class Create(Interface):
             Save.__call__(
                 message='[DATALAD] new dataset',
                 dataset=tbds,
-                auto_add_changes=False,
+                all_changes=False,
                 recursive=False)
 
         if dataset is not None and dataset.path != tbds.path:
@@ -288,7 +288,7 @@ class Create(Interface):
                 Save.__call__(
                     message='[DATALAD] added subdataset',
                     dataset=dataset,
-                    auto_add_changes=False,
+                    all_changes=False,
                     recursive=False)
 
         return tbds

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -265,8 +265,7 @@ class Create(Interface):
             gitattr.write('** annex.largefiles=nothing\n')
 
         # save everthing
-        # TODO use `add` without save
-        tbds.repo.add('.datalad', git=True)
+        tbds.add('.datalad', to_git=True, save=False)
 
         if save:
             save_dataset(
@@ -274,20 +273,13 @@ class Create(Interface):
                 paths=['.datalad'],
                 message='[DATALAD] new dataset')
 
-        if dataset is not None and dataset.path != tbds.path:
-            # TODO this needs to be RF'ed to call add on the subdataset
-            # we created a dataset in another dataset
-            # -> make submodule
-            from datalad.distribution.utils import _install_subds_inplace
-            subdsrelpath = relpath(realpath(tbds.path), realpath(dataset.path))  # realpath OK
-            _install_subds_inplace(ds=dataset, path=tbds.path,
-                                   relativepath=subdsrelpath)
-            # this will have staged the changes in the superdataset already
-            if save:
-                save_dataset(
-                    dataset,
-                    paths=[tbds.path, '.gitmodules'],
-                    message='[DATALAD] added subdataset')
+            # the next only makes sense if we saved the created dataset,
+            # otherwise we have no committed state to be registered
+            # in the parent
+            if dataset is not None and dataset.path != tbds.path:
+                # we created a dataset in another dataset
+                # -> make submodule
+                dataset.add(tbds.path, save=save, ds2super=True)
 
         return tbds
 

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -83,7 +83,7 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
 
     """
     # we apparently can't import api functionality within api
-    from datalad.api import install
+    from datalad.api import add
     # To simplify managing all the file paths etc
     if not isabs(path):
         path = abspath(path)
@@ -117,19 +117,10 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
 
     if ds:
         assert ds.is_installed()
-        rpath = os.path.relpath(path, ds.path)
-        out = install(
-            rpath,
-            source=opj(os.curdir, rpath),
+        out = add(
+            path,
             dataset=ds,
-            # currently would generate two commits -- first adding a submodule
-            # and then a dummy one (commented out below) talking about "installing".
-            # But may be this all would get automagically straightened out by
-            # GH #1169, so we could also have a sensible message on what was done
-            # if_dirty='ignore',
-            )
-        # ds.repo.commit("subdataset %s installed." % rpath, _datalad_msg=True)
-
+        )
 
 
 class CreateTestDataset(Interface):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -38,6 +38,7 @@ from datalad.utils import getpwd
 from datalad.utils import optional_args, expandpath, is_explicit_path, \
     with_pathsep
 from datalad.utils import swallow_logs
+from datalad.utils import get_dataset_root
 
 
 lgr = logging.getLogger('datalad.dataset')
@@ -393,7 +394,7 @@ class Dataset(object):
             # normalize the path after adding .. so we guaranteed to not
             # follow into original directory if path itself is a symlink
             par_path = normpath(opj(path, pardir))
-            sds_path_ = AnnexRepo.get_toppath(par_path)
+            sds_path_ = get_dataset_root(par_path)
             if sds_path_ is None:
                 # no more parents, use previous found
                 break
@@ -574,7 +575,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dataset = Dataset(dataset)
 
     if dataset is None:  # possible scenario of cmdline calls
-        dspath = AnnexRepo.get_toppath(getpwd())
+        dspath = get_dataset_root(getpwd())
         if not dspath:
             raise NoDatasetArgumentFound("No dataset found")
         dataset = Dataset(dspath)

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -393,7 +393,7 @@ class Dataset(object):
             # normalize the path after adding .. so we guaranteed to not
             # follow into original directory if path itself is a symlink
             par_path = normpath(opj(path, pardir))
-            sds_path_ = GitRepo.get_toppath(par_path)
+            sds_path_ = AnnexRepo.get_toppath(par_path)
             if sds_path_ is None:
                 # no more parents, use previous found
                 break
@@ -574,7 +574,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dataset = Dataset(dataset)
 
     if dataset is None:  # possible scenario of cmdline calls
-        dspath = GitRepo.get_toppath(getpwd())
+        dspath = AnnexRepo.get_toppath(getpwd())
         if not dspath:
             raise NoDatasetArgumentFound("No dataset found")
         dataset = Dataset(dspath)

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -37,6 +37,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.dochelpers import single_or_plural
+from datalad.utils import get_dataset_root
 
 from .dataset import Dataset
 from .dataset import EnsureDataset
@@ -229,7 +230,7 @@ class Get(Interface):
         # explore the unknown
         for path in sorted(unavailable_paths):
             # how close can we get?
-            dspath = AnnexRepo.get_toppath(path)
+            dspath = get_dataset_root(path)
             if dspath is None:
                 # nothing we can do for this path
                 continue

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -33,7 +33,6 @@ from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
-from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
@@ -230,7 +229,7 @@ class Get(Interface):
         # explore the unknown
         for path in sorted(unavailable_paths):
             # how close can we get?
-            dspath = GitRepo.get_toppath(path)
+            dspath = AnnexRepo.get_toppath(path)
             if dspath is None:
                 # nothing we can do for this path
                 continue

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -171,7 +171,7 @@ class Get(Interface):
     @staticmethod
     @datasetmethod(name='get')
     def __call__(
-            path,
+            path=None,
             source=None,
             dataset=None,
             recursive=False,
@@ -192,40 +192,28 @@ class Get(Interface):
     ):
         # IMPLEMENTATION CONCEPT:
         #
-        # 1. turn all input paths into absolute paths
-        # 2. Sort the world into existing handles and the rest
-        # 3. Try locate missing handles (obtain subdatasets along the way)
-        # 4. Expand into subdatasets with recursion enables (potentially
+        # 1. Sort the world into existing handles and the rest
+        # 2. Try locate missing handles (obtain subdatasets along the way)
+        # 3. Expand into subdatasets with recursion enables (potentially
         #    obtain even more subdatasets
-        # 5. Shoot info of which handles to get in each subdataset to,
+        # 4. Shoot info of which handles to get in each subdataset to,
         #    git-annex, once at the very end
 
-        # TODO: consider allowing an empty `path` argument, as with other commands,
-        # to indicate CWD
-        resolved_paths, dataset_path = get_normalized_path_arguments(
-            path, dataset, default=None)
-        if not resolved_paths:
+        dataset_path = dataset.path if isinstance(dataset, Dataset) else dataset
+        if not (dataset or path):
             raise InsufficientArgumentsError(
-                "`get` needs at least one path as argument")
-
-        # sort paths into the respective datasets
+                "Neither dataset nor target path(s) provided")
+        if dataset and not path:
+            # act on the whole dataset if nothing else was specified
+            path = dataset_path
+        # use lookup cache -- we need that info further down
         dir_lookup = {}
-        content_by_ds, unavailable_paths, nondataset_paths = \
-            get_paths_by_dataset(resolved_paths,
-                                 recursive=recursive,
-                                 recursion_limit=recursion_limit,
-                                 dir_lookup=dir_lookup)
-        lgr.debug(
-            "Found %i existing dataset(s) to get content in "
-            "and %d unavailable paths",
-            len(content_by_ds), len(unavailable_paths)
-        )
-        # IMPORTANT NOTE re `content_by_ds`
-        # each key is a subdataset that we need to get something in
-        # if the value[0] is the subdataset's path, we want all of it
-        # if the value[0] == curdir, we just installed it as part of
-        # resolving file handles and we did not say anything but "give
-        # me the dataset handle"
+        content_by_ds, unavailable_paths = Interface._prep(
+            path=path,
+            dataset=dataset,
+            recursive=recursive,
+            recursion_limit=recursion_limit,
+            dir_lookup=dir_lookup)
 
         # explore the unknown
         for path in sorted(unavailable_paths):
@@ -284,7 +272,7 @@ class Get(Interface):
         ## we have now done everything we could to obtain whatever subdataset
         ## to get something on the file system for previously unavailable paths
         ## check and sort one last
-        content_by_ds, unavailable_paths, nondataset_paths2 = \
+        content_by_ds, unavailable_paths, nondataset_paths = \
             get_paths_by_dataset(
                 unavailable_paths,
                 recursive=recursive,
@@ -292,8 +280,8 @@ class Get(Interface):
                 out=content_by_ds,
                 dir_lookup=dir_lookup)
 
-        nondataset_paths.extend(nondataset_paths2)
         if nondataset_paths:
+            # XXX likely can never get here
             lgr.warning(
                 "ignored paths that do not belong to any dataset: %s",
                 nondataset_paths)

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -56,7 +56,6 @@ from .utils import _get_flexible_source_candidates
 from .utils import _get_tracking_source
 from .utils import _clone_from_any_source
 from .utils import _handle_possible_annex_dataset
-from .utils import _save_installed_datasets
 
 __docformat__ = 'restructuredtext'
 
@@ -560,3 +559,19 @@ class Install(Interface):
             n=len(res),
             items=items)
         ui.message(msg)
+
+
+# TODO when `install` is RF'ed, this should be replaced by a more general
+# implementation
+def _save_installed_datasets(ds, installed_datasets):
+    paths = [relpath(subds.path, ds.path) for subds in installed_datasets]
+    paths_str = ", ".join(paths)
+    msg = "installed subdataset{}: {}".format(
+        "s" if len(paths) > 1 else "", paths_str)
+    lgr.info("Saving possible changes to {0} - {1}".format(
+        ds, msg))
+    ds.save(
+        files=paths + ['.gitmodules'],
+        message='[DATALAD] ' + msg,
+        all_changes=False,
+        recursive=False)

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import with_tree
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import SkipTest
@@ -245,3 +246,21 @@ def test_add_source(path, url, ds_dir):
     eq_(len(annexed), len(urls))
     # all files annexed (-2 for '.git' and '.datalad'):
     eq_(len(annexed), len(listdir(ds.path)) - 2)
+
+
+@with_tree(**tree_arg)
+def test_add_subdataset(path):
+    subds = create(opj(path, 'dir'), force=True)
+    ds = create(path, force=True)
+    ok_(subds.repo.dirty)
+    ok_(ds.repo.dirty)
+    assert_not_in('dir', ds.get_subdatasets())
+    # without a base dataset the next is interpreted as "add everything
+    # in subds to subds"
+    add(subds.path)
+    ok_clean_git(subds.path)
+    assert_not_in('dir', ds.get_subdatasets())
+    # but with a base directory we add the dataset subds as a subdataset
+    # to ds
+    ds.add(subds.path)
+    assert_in('dir', ds.get_subdatasets())

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -114,6 +114,7 @@ def test_add_recursive(path):
     ds.create(force=True, save=False)
     subds = ds.create('dir', force=True)
     ds.save("Submodule added.")
+    ok_(subds.repo.dirty)
 
     # no subds without recursive:
     ds.add('.', recursive=False)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -194,13 +194,14 @@ def test_nested_create(path):
     assert_raises(ValueError, ds.create, lvl2relpath)
     # XXX even force doesn't help, because (I assume) GitPython doesn't update
     # its representation of the Git index properly
-    assert_raises(CommandError, ds.create, lvl2relpath, force=True)
+    print('INVESTIGATE AND FIX THIS (from here till end)')
+    #assert_raises(CommandError, ds.create, lvl2relpath, force=True)
     # it is not GitPython's state that is at fault here, test with fresh
     # dataset isnstance
     ds = Dataset(ds.path)
-    assert_raises(CommandError, ds.create, lvl2relpath, force=True)
+    #assert_raises(CommandError, ds.create, lvl2relpath, force=True)
     # it seems we are at fault here
     rmtree(opj(lvl2path, '.git'))
-    assert_raises(CommandError, ds.repo.add_submodule, lvl2relpath)
+    #assert_raises(CommandError, ds.repo.add_submodule, lvl2relpath)
     # despite the failure:
     assert_in(lvl2relpath, ds.get_subdatasets())

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -198,3 +198,23 @@ def test_nested_create(path):
     # its representation of the Git index properly
     ds.create(lvl2relpath, force=True)
     assert_in(lvl2relpath, ds.get_subdatasets())
+
+
+# Imported from #1016
+@with_tree({'ds2': {'file1.txt': 'some'}})
+def test_saving_prior(topdir):
+    # the problem is that we might be saving what is actually needed to be
+    # "created"
+
+    # we would like to place this structure into a hierarchy of two datasets
+    # so we create first top one
+    ds1 = create(topdir, force=True)
+    # and everything is ok, stuff is not added BUT ds1 will be considered dirty
+    ok_(ds1.repo.dirty)
+    # And then we would like to initiate a sub1 subdataset
+    ds2 = create('ds2', dataset=ds1, force=True)
+    # But what will happen is file1.txt under ds2 would get committed first into
+    # ds1, and then the whole procedure actually crashes since because ds2/file1.txt
+    # is committed -- ds2 is already known to git and it just pukes with a bit
+    # confusing    'ds2' already exists in the index
+    assert_in('ds2', ds1.get_subdatasets())

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -155,7 +155,7 @@ def test_create_subdataset_hierarchy_from_top(path):
     ok_(subds.is_installed())
     subsubds = subds.create('subsub', force=True, if_dirty='ignore')
     ok_(subsubds.is_installed())
-    ds.save(recursive=True, auto_add_changes=True)
+    ds.save(recursive=True, all_changes=True)
     ok_clean_git(ds.path)
     ok_(ds.id != subds.id != subsubds.id)
 
@@ -171,7 +171,7 @@ def test_nested_create(path):
     os.makedirs(opj(ds.path, 'lvl1', 'empty'))
     with open(opj(lvl2path, 'file'), 'w') as f:
         f.write('some')
-    ok_(ds.save(auto_add_changes=True))
+    ok_(ds.save(all_changes=True))
     # later create subdataset in a fresh dir
     subds1 = ds.create(opj('lvl1', 'subds'))
     ok_clean_git(ds.path)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -272,7 +272,7 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "subsub", "some")).path, subsubds.path)
     # the top of a subdataset belongs to the subdataset
     eq_(ds.get_containing_subdataset(opj("sub", "subsub")).path, subsubds.path)
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
+    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     eq_(ds.get_containing_subdataset("some").path, ds.path)
@@ -282,10 +282,10 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     # # but now GitRepo disagrees...
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub")), ds.path)
     # and this stays, even if we give the mount point directory back
     os.makedirs(subds.path)
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub")), ds.path)
 
     outside_path = opj(os.pardir, "somewhere", "else")
     assert_raises(PathOutsideRepositoryError, ds.get_containing_subdataset,

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -20,6 +20,7 @@ from datalad.api import get
 from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.utils import chpwd, getpwd, rmtree
 from datalad.utils import _path_
+from datalad.utils import get_dataset_root
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 
@@ -272,7 +273,7 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "subsub", "some")).path, subsubds.path)
     # the top of a subdataset belongs to the subdataset
     eq_(ds.get_containing_subdataset(opj("sub", "subsub")).path, subsubds.path)
-    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
+    eq_(get_dataset_root(opj(ds.path, "sub", "subsub")), subsubds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     eq_(ds.get_containing_subdataset("some").path, ds.path)
@@ -282,10 +283,10 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     # # but now GitRepo disagrees...
-    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    eq_(get_dataset_root(opj(ds.path, "sub")), ds.path)
     # and this stays, even if we give the mount point directory back
     os.makedirs(subds.path)
-    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    eq_(get_dataset_root(opj(ds.path, "sub")), ds.path)
 
     outside_path = opj(os.pardir, "somewhere", "else")
     assert_raises(PathOutsideRepositoryError, ds.get_containing_subdataset,

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -51,7 +51,7 @@ def _make_dataset_hierarchy(path):
     with open(opj(origin_sub3.path, 'file_in_annex.txt'), "w") as f:
         f.write('content3')
     origin_sub4 = origin_sub3.create('sub4')
-    origin.save(recursive=True, auto_add_changes=True)
+    origin.save(recursive=True, all_changes=True)
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
 
@@ -195,7 +195,7 @@ def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
     origin = Dataset(o_path).create(force=True)
-    origin.save("Initial", auto_add_changes=True)
+    origin.save("Initial", all_changes=True)
 
     ds = install(c_path, source=o_path)
 
@@ -343,7 +343,7 @@ def test_get_mixed_hierarchy(src, path):
         f.write('content')
     origin.add('file_in_git.txt', to_git=True)
     origin_sub.add('file_in_annex.txt')
-    origin.save(auto_add_changes=True)
+    origin.save(all_changes=True)
 
     # now, install that thing:
     ds, subds = install(path, source=src, recursive=True)
@@ -382,7 +382,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     origin_subsub = origin_sub.create('subsub')
     with open(opj(origin_subsub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
-    origin.save(recursive=True, auto_add_changes=True)
+    origin.save(recursive=True, all_changes=True)
 
     ds = install(path, source=src)
     eq_(len(ds.get_subdatasets(fulfilled=True)), 0)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -73,20 +73,6 @@ def test_get_invalid_call(path, file_outside):
     ds.add("some.txt", to_git=True)
     ds.save("Initial commit.")
 
-    # no path given:
-    assert_raises(InsufficientArgumentsError, get, dataset=path,
-                  source="some", path=None)
-
-    # get on a plain git:
-    # MIH: why do we warn? user got what was desired. if they want technical
-    # background they better read books not warnings
-    #with swallow_logs(new_level=logging.WARNING) as cml:
-    #    # but we don't fail if not annex -- just inform
-    #    out = ds.get(curdir)
-    #    assert_in('Found no annex. Could not perform any get operation.',
-    #              cml.out)
-    #    eq_(out, [])
-
     # make it an annex:
     AnnexRepo(path, init=True, create=True)
     # call get again on a file in git:
@@ -112,17 +98,8 @@ def test_get_invalid_call(path, file_outside):
         eq_(len(result), 0)
         assert_in("ignored non-existing paths", cml.out)
 
-    # path outside repo:
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        result = ds.get(file_outside)
-        eq_(len(result), 0)
-        assert_in("ignored paths that do not belong to any dataset: ['{0}'".format(file_outside, ds),
-                  cml.out)
-
-    # TODO: annex --json doesn't report anything when get fails to do get a
-    # file from a specified source, where the file isn't available from.
-    # File report for Joey (plus other failures like not existing when
-    # called with --json)
+    # path outside repo errors as with most other commands:
+    assert_raises(ValueError, ds.get, file_outside)
 
 
 @with_testrepos('basic_annex', flavors='clone')
@@ -262,7 +239,7 @@ def test_get_recurse_subdatasets(src, path):
     # now, with a path not explicitly pointing within a
     # subdataset, but recursive option:
     # get everything:
-    result = ds.get('.', recursive=True)
+    result = ds.get(recursive=True)
 
     eq_(set([item.get('file') for item in result]), annexed_files)
     ok_(all(item.get('success', False) for item in result))

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -420,6 +420,9 @@ def test_failed_install_multiple(top_path):
     with assert_raises(IncompleteResultsError) as cme:
         ds.install(['ds1', 'ds2', '///crcns', '///nonexisting', 'ds3'])
 
+    # install doesn't add existing submodules -- add does that
+    ok_clean_git(ds.path, annex=False, untracked=['ds1/', 'ds3/'])
+    ds.add(['ds1', 'ds3'])
     ok_clean_git(ds.path, annex=False)
     # those which succeeded should be saved now
     eq_(ds.get_subdatasets(), ['crcns', 'ds1', 'ds3'])

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -484,7 +484,7 @@ def test_implicit_install(src, dst):
     with open(opj(origin_subsub.path, "file3.txt"), "w") as f:
         f.write("content3")
     origin_subsub.add("file3.txt")
-    origin_top.save(all_changes=True)
+    origin_top.save(recursive=True)
 
     # first, install toplevel:
     ds = install(dst, source=src)
@@ -522,7 +522,9 @@ def test_implicit_install(src, dst):
     # now implicit but without an explicit dataset to install into
     # (deriving from CWD):
     with chpwd(dst):
-        result = get(path=opj("sub", "subsub"))
+        # don't ask for the file content to make return value comparison
+        # simpler
+        result = get(path=opj("sub", "subsub"), get_data=False)
         ok_(sub.is_installed())
         ok_(subsub.is_installed())
         eq_(result, [subsub])
@@ -588,7 +590,8 @@ def test_install_recursive_repeat(src, path):
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
     sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.save(all_changes=True, recursive=True)
+    top_src.add('.', recursive=True)
+    ok_clean_git(top_src.path)
 
     # install top level:
     top_ds = install(path, source=src)
@@ -691,7 +694,7 @@ def test_install_noautoget_data(src, path):
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
     sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.save(all_changes=True, recursive=True)
+    top_src.add('.', recursive=True)
 
     # install top level:
     cdss = install(path, source=src, recursive=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -484,7 +484,7 @@ def test_implicit_install(src, dst):
     with open(opj(origin_subsub.path, "file3.txt"), "w") as f:
         f.write("content3")
     origin_subsub.add("file3.txt")
-    origin_top.save(auto_add_changes=True)
+    origin_top.save(all_changes=True)
 
     # first, install toplevel:
     ds = install(dst, source=src)
@@ -588,7 +588,7 @@ def test_install_recursive_repeat(src, path):
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
     sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.save(auto_add_changes=True, recursive=True)
+    top_src.save(all_changes=True, recursive=True)
 
     # install top level:
     top_ds = install(path, source=src)
@@ -691,7 +691,7 @@ def test_install_noautoget_data(src, path):
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
     sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.save(auto_add_changes=True, recursive=True)
+    top_src.save(all_changes=True, recursive=True)
 
     # install top level:
     cdss = install(path, source=src, recursive=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -399,10 +399,10 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
     # and we should achieve the same behavior if we create a dataset
-    # and then decide to "add" it
-    create(_path_(top_path, 'sub3'), if_dirty='ignore')
+    # and then decide to add it
+    create(_path_(top_path, 'sub3'))
     ok_clean_git(ds.path, untracked=['dummy.txt', 'sub3/'])
-    ds.install('sub3', if_dirty='ignore')
+    ds.add('sub3')
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -167,7 +167,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     sub2.add('file.txt')
     sub2.commit("")
     # TODO: Doesn't work:  https://github.com/datalad/datalad/issues/636
-    #source.save("changed sub2", auto_add_changes=True)
+    #source.save("changed sub2", all_changes=True)
     source.repo.commit("", options=['-a'])
 
     res_ = publish(dataset=source, recursive=True)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -65,7 +65,6 @@ def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
     subds2 = ds.create('two')
-    ds.save(all_changes=True)
     eq_(sorted(ds.get_subdatasets()), ['one', 'two'])
     ok_clean_git(ds.path)
     # now kill one
@@ -205,21 +204,19 @@ def test_uninstall_multiple_paths(path):
     subds = ds.create('deep', force=True)
     subds.add('.', recursive=True)
     ds.add('.', recursive=True)
-    ds.save(all_changes=True)
     ok_clean_git(ds.path)
     # drop content of all 'kill' files
-    # must not work without recursive
     topfile = 'kill'
     deepfile = opj('deep', 'dir', 'kill')
     # use a tuple not a list! should also work
-    ds.drop((topfile, deepfile), recursive=True, check=False)
+    ds.drop((topfile, deepfile), check=False)
     ok_clean_git(ds.path)
     files_left = glob(opj(ds.path, '*', '*', '*')) + glob(opj(ds.path, '*'))
     ok_(all([f.endswith('keep') for f in files_left if exists(f) and not isdir(f)]))
     ok_(not ds.repo.file_has_content(topfile))
     ok_(not subds.repo.file_has_content(opj(*psplit(deepfile)[1:])))
     # remove handles for all 'kill' files
-    ds.remove([topfile, deepfile], recursive=True, check=False)
+    ds.remove([topfile, deepfile], check=False)
     ok_clean_git(ds.path)
     files_left = glob(opj(ds.path, '*', '*', '*')) + glob(opj(ds.path, '*'))
     ok_(all([f.endswith('keep') for f in files_left if exists(f) and not isdir(f)]))
@@ -340,7 +337,7 @@ def test_kill(path):
     ds = Dataset(path).create()
     with open(opj(ds.path, "file.dat"), 'w') as f:
         f.write("load")
-    ds.repo.add("file.dat")
+    ds.add("file.dat")
     subds = ds.create('deep1')
     eq_(sorted(ds.get_subdatasets()), ['deep1'])
     ok_clean_git(ds.path)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -202,7 +202,7 @@ def test_uninstall_subdataset(src, dst):
     'kill': 'kill2'})
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
-    subds = ds.create('deep', force=True, if_dirty='ignore')
+    subds = ds.create('deep', force=True)
     subds.add('.', recursive=True)
     ds.add('.', recursive=True)
     ds.save(all_changes=True)
@@ -270,10 +270,10 @@ def test_remove_file_handle_only(path):
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
 def test_uninstall_recursive(path):
-    ds = Dataset(path).create(force=True, if_dirty='ignore')
-    subds = ds.create('deep', force=True, if_dirty='ignore')
+    ds = Dataset(path).create(force=True)
+    subds = ds.create('deep', force=True)
     # we add one file
-    eq_(len(subds.add('.', if_dirty='ignore')), 1)
+    eq_(len(subds.add('.')), 1)
     # save all -> all clean
     ds.save(all_changes=True, recursive=True)
     ok_clean_git(subds.path)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -65,7 +65,7 @@ def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
     subds2 = ds.create('two')
-    ds.save(auto_add_changes=True)
+    ds.save(all_changes=True)
     eq_(sorted(ds.get_subdatasets()), ['one', 'two'])
     ok_clean_git(ds.path)
     # now kill one
@@ -79,7 +79,7 @@ def test_clean_subds_removal(path):
     assert(not exists(subds1.path))
     # and now again, but this time remove something that is not installed
     ds.create('three')
-    ds.save(auto_add_changes=True)
+    ds.save(all_changes=True)
     eq_(sorted(ds.get_subdatasets()), ['three', 'two'])
     ds.uninstall('two')
     ok_clean_git(ds.path)
@@ -205,7 +205,7 @@ def test_uninstall_multiple_paths(path):
     subds = ds.create('deep', force=True, if_dirty='ignore')
     subds.add('.', recursive=True)
     ds.add('.', recursive=True)
-    ds.save(auto_add_changes=True)
+    ds.save(all_changes=True)
     ok_clean_git(ds.path)
     # drop content of all 'kill' files
     # must not work without recursive
@@ -275,7 +275,7 @@ def test_uninstall_recursive(path):
     # we add one file
     eq_(len(subds.add('.', if_dirty='ignore')), 1)
     # save all -> all clean
-    ds.save(auto_add_changes=True, recursive=True)
+    ds.save(all_changes=True, recursive=True)
     ok_clean_git(subds.path)
     ok_clean_git(ds.path)
     # now uninstall in subdataset through superdataset
@@ -305,7 +305,7 @@ def test_uninstall_recursive(path):
 def test_remove_dataset_hierarchy(path):
     ds = Dataset(path).create()
     ds.create('deep')
-    ds.save(auto_add_changes=True)
+    ds.save(all_changes=True)
     ok_clean_git(ds.path)
     # fail on missing --recursive because subdataset is present
     assert_raises(ValueError, ds.remove)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -86,7 +86,7 @@ def test_update_simple(origin, src_path, dst_path):
     # and now test recursive update with merging in differences
     create_tree(opj(source.path, 'subm 2'), {'load.dat': 'heavy'})
     source.save(message="saving changes within subm2",
-                recursive=True, auto_add_changes=True)
+                recursive=True, all_changes=True)
     dest.update(merge=True, recursive=True)
     # and now we can get new file
     dest.get('subm 2/load.dat')

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -33,7 +33,8 @@ from datalad.interface.utils import path_is_under
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import _discover_trace_to_known
 from datalad.utils import rmtree
-from datalad.support.annexrepo import AnnexRepo
+from datalad.utils import get_dataset_root
+
 
 lgr = logging.getLogger('datalad.distribution.uninstall')
 
@@ -347,7 +348,7 @@ class Remove(Interface):
             # we need to check whether any of these correspond
             # to a known subdataset, and add those to the list of
             # things to be removed
-            toppath = AnnexRepo.get_toppath(p)
+            toppath = get_dataset_root(p)
             if not toppath:
                 nonexistent_paths.append(p)
                 continue

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -400,8 +400,7 @@ class Remove(Interface):
         save_dataset_hierarchy(
             list(ds2save),
             base=dataset.path if dataset and dataset.is_installed() else None,
-            message='[DATALAD] removed content',
-            all_changes=False)
+            message='[DATALAD] removed content')
         return results
 
     @classmethod

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -252,7 +252,7 @@ class Uninstall(Interface):
                 'inappropriate arguments, see previous error message(s)')
 
         handle_dirty_datasets(
-            content_by_ds.keys(), mode=if_dirty, base=dataset)
+            content_by_ds, mode=if_dirty, base=dataset)
 
         results = []
 
@@ -357,7 +357,7 @@ class Remove(Interface):
                 "refusing to uninstall current or parent directory")
 
         handle_dirty_datasets(
-            content_by_ds.keys(), mode=if_dirty, base=dataset)
+            content_by_ds, mode=if_dirty, base=dataset)
 
         ds2save = set()
         results = []
@@ -401,7 +401,7 @@ class Remove(Interface):
             list(ds2save),
             base=dataset.path if dataset and dataset.is_installed() else None,
             message='[DATALAD] removed content',
-            auto_add_changes=False)
+            all_changes=False)
         return results
 
     @classmethod

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -414,7 +414,7 @@ class Remove(Interface):
 
         if dataset and dataset.is_installed():
             # forge chain from base dataset to any leaf dataset
-            # on order to save state changes all the way up
+            # in order to save state changes all the way up
             _discover_trace_to_known(dataset.path, [], content_by_ds)
 
         save_dataset_hierarchy(

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -33,7 +33,7 @@ from datalad.interface.utils import path_is_under
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import _discover_trace_to_known
 from datalad.utils import rmtree
-from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
 
 lgr = logging.getLogger('datalad.distribution.uninstall')
 
@@ -347,7 +347,7 @@ class Remove(Interface):
             # we need to check whether any of these correspond
             # to a known subdataset, and add those to the list of
             # things to be removed
-            toppath = GitRepo.get_toppath(p)
+            toppath = AnnexRepo.get_toppath(p)
             if not toppath:
                 nonexistent_paths.append(p)
                 continue

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -444,7 +444,7 @@ def _save_installed_datasets(ds, installed_datasets):
     paths = [relpath(subds.path, ds.path) for subds in installed_datasets]
     paths_str = ", ".join(paths)
     msg = "installed subdataset{}: {}".format(
-        "s" if len(paths_str) > 1 else "", paths_str)
+        "s" if len(paths) > 1 else "", paths_str)
     lgr.info("Saving possible changes to {0} - {1}".format(
         ds, msg))
     ds.save(

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -452,4 +452,3 @@ def _save_installed_datasets(ds, installed_datasets):
         message='[DATALAD] ' + msg,
         all_changes=False,
         recursive=False)
-

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -450,6 +450,6 @@ def _save_installed_datasets(ds, installed_datasets):
     ds.save(
         files=paths,
         message='[DATALAD] ' + msg,
-        auto_add_changes=False,
+        all_changes=False,
         recursive=False)
 

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -439,17 +439,3 @@ def _handle_possible_annex_dataset(dataset, reckless):
         repo = AnnexRepo(dataset.path, init=True)
         if reckless:
             repo._run_annex_command('untrust', annex_options=['here'])
-
-
-def _save_installed_datasets(ds, installed_datasets):
-    paths = [relpath(subds.path, ds.path) for subds in installed_datasets]
-    paths_str = ", ".join(paths)
-    msg = "installed subdataset{}: {}".format(
-        "s" if len(paths) > 1 else "", paths_str)
-    lgr.info("Saving possible changes to {0} - {1}".format(
-        ds, msg))
-    ds.save(
-        files=paths + ['.gitmodules'],
-        message='[DATALAD] ' + msg,
-        all_changes=False,
-        recursive=False)

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -23,6 +23,7 @@ from os.path import normpath
 
 from six.moves.urllib.parse import quote as urlquote
 
+
 from datalad.support.gitrepo import GitRepo
 from datalad.support.gitrepo import GitCommandError
 from datalad.support.annexrepo import AnnexRepo
@@ -448,7 +449,7 @@ def _save_installed_datasets(ds, installed_datasets):
     lgr.info("Saving possible changes to {0} - {1}".format(
         ds, msg))
     ds.save(
-        files=paths,
+        files=paths + ['.gitmodules'],
         message='[DATALAD] ' + msg,
         all_changes=False,
         recursive=False)

--- a/datalad/export/tests/test_tarball.py
+++ b/datalad/export/tests/test_tarball.py
@@ -46,7 +46,7 @@ def test_failure(path):
 @with_tree(_dataset_template)
 def test_tarball(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
-    ds.save(auto_add_changes=True)
+    ds.save(all_changes=True)
     committed_date = ds.repo.get_committed_date()
     with chpwd(path):
         _mod, tarball1 = ds.export('tarball')

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -315,7 +315,8 @@ class Interface(object):
             path=None,
             dataset=None,
             recursive=False,
-            recursion_limit=None):
+            recursion_limit=None,
+            dir_lookup=None):
         """Common input argument validation and pre-processing
 
         This method pre-processes the two most common input argument types:
@@ -346,6 +347,8 @@ class Interface(object):
           recursively
         recursion_limit : None or int
           Optional recursion limit specification (max levels of recursion)
+        dir_lookup : dict, optional
+          Passed to `get_paths_by_dataset`
 
         Returns
         -------
@@ -376,7 +379,8 @@ class Interface(object):
         content_by_ds, unavailable_paths, nondataset_paths = \
             get_paths_by_dataset(tosort,
                                  recursive=recursive,
-                                 recursion_limit=recursion_limit)
+                                 recursion_limit=recursion_limit,
+                                 dir_lookup=dir_lookup)
         if not path and dataset_path and recursive:
             # fish out the dataset path that we inserted above
             content_by_ds[dataset_path] = [p for p in content_by_ds[dataset_path]

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -381,7 +381,7 @@ class Interface(object):
             # fish out the dataset path that we inserted above
             content_by_ds[dataset_path] = [p for p in content_by_ds[dataset_path]
                                            if p != dataset_path]
-        if not path:
+        if not path and dataset_path:
             # no files given, but a dataset -> operate on whole dataset
             # but do not specify any paths to process -- needs to be tailored
             # by caller

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -43,8 +43,7 @@ shared_access_opt = Parameter(
 super_datasets_flag = Parameter(
     args=("-S", "--super-datasets",),
     action="store_true",
-    doc="""if set, traverse and save stats corresponding to the change
-    within super-datasets""")
+    doc="""if set, save a change in a dataset also in its superdataset""")
 
 git_opts = Parameter(
     args=("--git-opts",),

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -169,7 +169,8 @@ class Save(Interface):
         saved_ds = save_dataset_hierarchy(
             content_by_ds,
             base=dataset.path if dataset and dataset.is_installed() else None,
-            message=message)
+            message=message,
+            version_tag=version_tag)
 
         return saved_ds
 

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -15,7 +15,6 @@ __docformat__ = 'restructuredtext'
 import logging
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
-from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
@@ -26,6 +25,7 @@ from datalad.interface.common_opts import super_datasets_flag
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import amend_pathspec_with_superdatasets
 from datalad.utils import with_pathsep as _with_sep
+from datalad.utils import get_dataset_root
 
 from .base import Interface
 
@@ -42,7 +42,7 @@ def process_vanished_paths(unavailable_paths, content_by_ds):
         # we need to check whether any of these correspond
         # to a known subdataset, and add those to the list of
         # things to be removed
-        toppath = AnnexRepo.get_toppath(p)
+        toppath = get_dataset_root(p)
         if not toppath:
             nonexistent_paths.append(p)
             continue

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -177,8 +177,10 @@ class Save(Interface):
     @staticmethod
     def result_renderer_cmdline(res, args):
         from datalad.ui import ui
-        if res:
-            ui.message('Saved state: "{0}" by {1} [{2}]'.format(
-                res.message.splitlines()[0],
-                res.committer,
-                res.hexsha))
+        if not res:
+            return
+        for ds in res:
+            commit = ds.repo.repo.head.commit
+            ui.message('Saved state: {0} for {1}'.format(
+                commit.hexsha,
+                ds))

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -14,71 +14,67 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-import os
-from os.path import join as opj, isdir, realpath, relpath, pardir
-from os.path import isabs
-
+from os.path import curdir
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
+from datalad.support.gitrepo import GitRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
-from datalad.distribution.dataset import resolve_path
-from datalad.distribution.utils import _install_subds_inplace
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import super_datasets_flag
-from datalad.utils import assure_list
+from datalad.interface.utils import save_dataset_hierarchy
+from datalad.interface.utils import amend_pathspec_with_superdatasets
 from datalad.utils import with_pathsep as _with_sep
 
 from .base import Interface
 
-lgr = logging.getLogger('datalad.interface.commit')
+lgr = logging.getLogger('datalad.interface.save')
 
 
-def untracked_subdatasets_to_submodules(ds, consider_paths):
-    # treat special case of still untracked subdatasets.
-    # those need to become submodules now, as they are otherwise added
-    # without an entry in .gitmodules, and subsequently break Git's
-    # submodule functionality completely
-    new_modules = []
-    if not consider_paths:
-        # nothing to test
-        return new_modules
-
-    for utf in ds.repo.repo.untracked_files:
-        utf_abspath = opj(ds.path, utf)
-        if not isdir(utf_abspath):
-            # this cannot be a repository
+def process_vanished_paths(unavailable_paths, content_by_ds):
+    # presently unavailable paths could be, e.g., deleted files, or
+    # uninstalled subdatasets, or simply nothing -> figure it out and act
+    # accordingly
+    dsinfo = {}
+    nonexistent_paths = []
+    for p in unavailable_paths:
+        # we need to check whether any of these correspond
+        # to a known subdataset, and add those to the list of
+        # things to be removed
+        toppath = GitRepo.get_toppath(p)
+        if not toppath:
+            nonexistent_paths.append(p)
             continue
-
-        # test whether the potential submodule is scheduled for saving
-        utf_realpath = realpath(utf_abspath)
-        if any([utf_realpath.startswith(_with_sep(realpath(f)))
-                for f in consider_paths]):
-            # matches at least one path -> turn into submodule
-            _install_subds_inplace(
-                ds=ds,
-                path=utf_abspath,  # can be ignored, we don't need the return value
-                relativepath=utf.rstrip(os.sep),
-                name=None)
-            new_modules.append(utf.rstrip(os.sep))
-
-    return new_modules
-
-
-def deinit_deleted_submodules(ds):
-    # helper to inspect a repo and `deinit` all submodules that are reported
-    # as present, but the mountpoint doesn't exist
-    deleted = ds.repo.get_deleted_files()
-    deinited = []
-    for subdspath in ds.get_subdatasets(absolute=False, recursive=False):
-        if subdspath in deleted:
-            lgr.debug('deinit deleted subdataset {} in {}'.format(subdspath, ds))
-            ds.repo.deinit_submodule(subdspath)
-            deinited.append(subdspath)
-    return deinited
+        ds = Dataset(toppath)
+        dinfo = dsinfo.get(toppath,
+                           {'deleted': ds.repo.get_deleted_files(),
+                            'subds': ds.get_subdatasets(
+                                recursive=False, absolute=True)})
+        # cache for a potentially following request
+        dsinfo[toppath] = dinfo
+        if p in dinfo['subds']:
+            # test for subds needs to come first, as it would also show
+            # up in "deleted_files"
+            # this is a known subdataset that has vanished
+            lgr.debug('deinit vanished subdataset {} in {}'.format(p, ds))
+            # simply deinit to complete a "forced uninstallation", without
+            # an explicit "remove" there is nothing to be save in this
+            # case
+            ds.repo.deinit_submodule(p[len(_with_sep(ds.path)):])
+        elif p in dinfo['deleted']:
+            # vanished file -> 'git rm' it to stage the change
+            ds.repo.remove(p)
+            # record that we are "saving" this path
+            dpaths = content_by_ds.get(ds.path, [])
+            dpaths.append(p)
+            content_by_ds[ds.path] = dpaths
+        else:
+            # this is nothing we can anyhow handle
+            nonexistent_paths.append(p)
+    return content_by_ds, nonexistent_paths
 
 
 class Save(Interface):
@@ -101,9 +97,8 @@ class Save(Interface):
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc=""""specify the dataset to save. If
-            no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory.""",
+            doc=""""specify the dataset to save. If a dataset is given, but
+            no `files`, the entire dataset will be saved.""",
             constraints=EnsureDataset() | EnsureNone()),
         files=Parameter(
             args=("files",),
@@ -135,236 +130,50 @@ class Save(Interface):
     @staticmethod
     @datasetmethod(name='save')
     def __call__(message=None, files=None, dataset=None,
-                 auto_add_changes=False, version_tag=None,
+                 all_changes=False, version_tag=None,
                  recursive=False, recursion_limit=None, super_datasets=False):
-        # shortcut
-        ds = require_dataset(dataset, check_installed=True,
-                             purpose='saving')
+        if dataset:
+            dataset = require_dataset(
+                dataset, check_installed=True, purpose='saving')
+        content_by_ds, unavailable_paths = Interface._prep(
+            path=files,
+            dataset=dataset,
+            recursive=recursive,
+            recursion_limit=recursion_limit)
+        print('FROMPREP', content_by_ds)
+        if unavailable_paths:
+            lgr.warning("ignoring non-existent path(s): %s",
+                        unavailable_paths)
+        # here we know all datasets associated with any inputs
+        # so we can expand "all_changes" right here to avoid confusion
+        # wrt to "super" and "intermediate" datasets discovered later on
+        if all_changes:
+            # and we do this by replacing any given paths with the respective
+            # datasets' base path
+            for ds in content_by_ds:
+                content_by_ds[ds] = [ds]
 
-        # make sure that all pending changes (batched annex operations, etc.)
-        # are actually reflected in Git
-        ds.repo.precommit()
-
-        if not ds.repo.repo.is_dirty(
-                index=True,
-                working_tree=True,
-                untracked_files=True,
-                submodules=True):
-            # if we cannot see anything dirty at all, the only things we could
-            # do is tag
-            if version_tag:
-                ds.repo.tag(version_tag)
-            # take the easy one out
-            return
-
-        # always yields list; empty if None
-        files = assure_list(files)
-
-        # track what to be committed, so it becomes
-        # possible to decide when/what to save further down
-        # and one level up
-        orig_hexsha = ds.repo.get_hexsha()
-        to_commit = []
-
-        # before anything, let's deal with missing submodules that may have
-        # been rm'ed by the user
-        # this will not alter/amend the history of the dataset
-        deinit_deleted_submodules(ds)
-
-        # XXX path resolution needs to happen on the input argument, not the
-        # resolved dataset!
-        # otherwise we will not be able to figure out, whether there was an
-        # explicit dataset provided, or just a matching one resolved
-        # automatically.
-        # if files are provided but no dataset, we interpret them as
-        # CWD-related
-
-        if auto_add_changes:
-            # use the dataset's base path to indicate that everything
-            # should be saved
-            if files:
-                lgr.warning(
-                    "List of paths was provided to save but auto_add_changes "
-                    "was specified, so list of paths was ignored")
-            files = [ds.path]
-        else:
-            # make sure we apply the usual path interpretation logic
-            files = [resolve_path(p, dataset) for p in files]
-
-        new_submodules = untracked_subdatasets_to_submodules(ds, files)
-        if new_submodules:
-            # make sure that .gitmodules is added to the list of files
-            # to be committed.  Adding to index might not be enough iff
-            # custom files was provided
-            to_commit.append('.gitmodules')
-        to_commit.extend(new_submodules)
-
-        # now we should have a complete list of submodules to potentially
-        # recurse into
-        if recursive and (recursion_limit is None or recursion_limit > 0):
-            # what subdataset to touch?
-            subdss = []
-            if auto_add_changes:
-                # all installed 1st-level ones
-                # we only want immediate subdatasets, higher depths will come
-                # via recursion
-                subdss = [Dataset(opj(ds.path, subds_path))
-                          for subds_path in ds.get_subdatasets(
-                              recursive=False)]
-            elif files is not None:
-                # only subdatasets that contain any of the to-be-considered
-                # paths
-                # TODO:  the same deductions will be redone later again
-                #  very inefficient.  Should be just sorted into subds
-                #  once!
-                subdss = [ds.get_containing_subdataset(
-                    p, recursion_limit=1) for p in files]
-
-            # skip anything that isn't installed, or this dataset
-            subdss = [d for d in subdss if d.is_installed() and d != ds]
-
-            prop_recursion_limit = \
-                None if recursion_limit is None else max(recursion_limit - 1, 0)
-
-            for subds in subdss:
-                # TODO: just make use of get._sort_paths_into_datasets
-                # currently it is very inefficient since for the same ds
-                # it asks about subdatasets for every file!
-                subds_files = []  # files belonging to the subds
-                todo_files = []   # leftover files
-                for f in files:
-                    if ds.get_containing_subdataset(f, recursion_limit=1) == subds:
-                        subds_files.append(f)
-                    else:
-                        todo_files.append(f)
-                files = todo_files
-
-                subds_modified = Save.__call__(
-                    message=message,
-                    files=subds_files,
-                    dataset=subds,
-                    auto_add_changes=auto_add_changes,
-                    version_tag=version_tag,
-                    recursive=recursive and (prop_recursion_limit is None or prop_recursion_limit > 0),
-                    recursion_limit=prop_recursion_limit,
-                )
-                if subds_modified:
-                    # stage changes in this submodule
-                    subdspath = relpath(subds.path, ds.path)
-                    ds.repo.add(subdspath, git=True)
-                    to_commit.append(subdspath)
-
-        if files:  # could still be none without auto add changes
-            ds_subdatasets = ds.get_subdatasets(recursive=False)
-            subdatasets_paths = {
-                opj(ds.path, f) for f in ds_subdatasets
-            }
-            # TODO: also use some centralized sorting into sub-datasets
-            # e.g. one used in get
-            ds_files = [
-                f for f in files
-                if f in subdatasets_paths or
-                    ds.get_containing_subdataset(f, recursion_limit=1) == ds
-            ]
-            if len(ds_files):
-                # XXX Is there a better way to handle files in mixed repos?
-                ds.repo.add(ds_files)
-                ds.repo.add(ds_files, git=True)
-                to_commit.extend(ds_files)
-            # it might be that the file itself is the submodule, so we might
-            # need to commit .gitmodules
-            for f in files:
-                for subds in subdatasets_paths:
-                    if subds.rstrip('/') == f.rstrip('/'):
-                        to_commit.append('.gitmodules')
-                        break
-
-        _datalad_msg = False
-        if not message:
-            message = 'Recorded existing changes'
-            _datalad_msg = True
-
-        # extend with files yet to be committed in this dataset
-        to_commit.extend(files)
-
-        # anything should be staged by now
-        # however, staged submodule changes are not considered as
-        # `index`, hence `submodules` needs to be True too
-        # we can have an explicit list of stuff to save or (if no `files`
-        # provided) have staged stuff
-        if ds.repo.repo.is_dirty(
-                index=True,
-                working_tree=False,
-                untracked_files=False,
-                submodules=True):
-
-            # Analyze list of known to be committed files/submodules,
-            # see if nothing points outside, and then convert to relative paths
-            to_commit_rel = []
-            if to_commit:
-                repopath = ds.repo.path
-                for f in to_commit:
-                    if isabs(f):
-                        frel = relpath(f, repopath)
-                        if frel.startswith(pardir):
-                            # XXX may be just a warning and skip?
-                            raise RuntimeError(
-                                "Path %s outside of the dataset %s. Can't commit"
-                                % (f, ds)
-                            )
-                        f = frel
-                    to_commit_rel.append(f)
-                to_commit_rel = sorted(set(to_commit_rel))
-                if '.' in to_commit_rel:
-                    # we need to commit everything
-                    to_commit_rel = []
-
-            ds.repo.commit(message, options=to_commit_rel, _datalad_msg=_datalad_msg)
-        elif to_commit:
-            lgr.warning(
-                "Was instructed to commit %s files but repository is not dirty",
-                to_commit)
-        elif not auto_add_changes:
-            lgr.info(
-                'Nothing to save, consider auto-detection of changes, '
-                'if this is unexpected.')
-
-        # MIH: let's tag even if there was nothing commit. I'd forget this
-        # option too often...
-        if version_tag:
-            ds.repo.tag(version_tag)
-
-        _was_modified = ds.repo.get_hexsha() != orig_hexsha
-
-        # and now we could consider saving our changes within super-datasets
-        # Let's float up until we get to a non-dataset
         if super_datasets:
-            if _was_modified:
-                if version_tag:
-                    lgr.info("Version tag %s will not be applied to super datasets",
-                             version_tag)
-                superds = ds
-                while True:
-                    supersubds = superds
-                    superds = superds.get_superdataset(datalad_only=True)
-                    if not superds:
-                        break
-                    Save.__call__(
-                        message=message
-                            + " [origin: %s]" % relpath(ds.path, superds.path),
-                        files=[relpath(supersubds.path, superds.path)],
-                        dataset=superds,
-                        auto_add_changes=False,
-                        version_tag=None,
-                        recursive=False,
-                    )
-            else:
-                lgr.info(
-                    "Not trying to save super-datasets since no modifications")
+            content_by_ds = amend_pathspec_with_superdatasets(
+                content_by_ds,
+                # save up to and including the base dataset (if one is given)
+                # otherwise up to the very top
+                topmost=dataset if dataset else True)
 
-        # TODO: figure out what we should return for recursive/super_datasets
-        # shouldn't we return all commits???
-        return ds.repo.repo.head.commit if _was_modified else None
+        if dataset:
+            # stuff all paths also into the base dataset slot to make sure
+            # we get all links between relevant subdatasets
+            bp = content_by_ds.get(dataset.path, [])
+            for c in content_by_ds:
+                bp.extend(content_by_ds[c])
+            content_by_ds[dataset.path] = bp
+
+        saved_ds = save_dataset_hierarchy(
+            content_by_ds,
+            base=dataset.path if dataset and dataset.is_installed() else None,
+            message=message)
+
+        return saved_ds
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -13,8 +13,6 @@
 __docformat__ = 'restructuredtext'
 
 import logging
-
-from os.path import curdir
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.gitrepo import GitRepo
@@ -140,7 +138,6 @@ class Save(Interface):
             dataset=dataset,
             recursive=recursive,
             recursion_limit=recursion_limit)
-        print('FROMPREP', content_by_ds)
         if unavailable_paths:
             lgr.warning("ignoring non-existent path(s): %s",
                         unavailable_paths)
@@ -166,7 +163,7 @@ class Save(Interface):
             bp = content_by_ds.get(dataset.path, [])
             for c in content_by_ds:
                 bp.extend(content_by_ds[c])
-            content_by_ds[dataset.path] = bp
+            content_by_ds[dataset.path] = list(set(bp))
 
         saved_ds = save_dataset_hierarchy(
             content_by_ds,

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -155,7 +155,8 @@ class Save(Interface):
                 content_by_ds,
                 # save up to and including the base dataset (if one is given)
                 # otherwise up to the very top
-                topmost=dataset if dataset else True)
+                topmost=dataset if dataset else True,
+                limit_single=False)
 
         if dataset:
             # stuff all paths also into the base dataset slot to make sure

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -117,10 +117,10 @@ class Save(Interface):
             metavar='MESSAGE',
             doc="""a message to annotate the saved state.""",
             constraints=EnsureStr() | EnsureNone()),
-        auto_add_changes=Parameter(
-            args=("-a", "--auto-add-changes"),
-            doc="""automatically include all changes in the entire dataset,
-            independent of the current working directory.""",
+        all_changes=Parameter(
+            args=("-a", "--all-changes"),
+            doc="""save changes of all known components in datasets that contain
+            any of the given paths.""",
             action="store_true"),
         version_tag=Parameter(
             args=("--version-tag",),

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 import logging
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
-from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
@@ -42,7 +42,7 @@ def process_vanished_paths(unavailable_paths, content_by_ds):
         # we need to check whether any of these correspond
         # to a known subdataset, and add those to the list of
         # things to be removed
-        toppath = GitRepo.get_toppath(p)
+        toppath = AnnexRepo.get_toppath(p)
         if not toppath:
             nonexistent_paths.append(p)
             continue

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -36,7 +36,7 @@ def test_save(path):
     ds.repo.add("new_file.tst", git=True)
     ok_(ds.repo.dirty)
 
-    ds.save("add a new file", auto_add_changes=False)
+    ds.save("add a new file", all_changes=False)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     with open(opj(path, "new_file.tst"), "w") as f:
@@ -44,7 +44,7 @@ def test_save(path):
 
     ok_(ds.repo.dirty)
     # no need to git add before:
-    ds.save("modified new_file.tst", auto_add_changes=True)
+    ds.save("modified new_file.tst", all_changes=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     files = ['one.txt', 'two.txt']
@@ -61,11 +61,11 @@ def test_save(path):
     # modify subds
     with open(opj(subds.path, "some_file.tst"), "w") as f:
         f.write("something")
-    subds.save(auto_add_changes=True)
+    subds.save(all_changes=True)
     ok_clean_git(subds.path, annex=isinstance(ds.repo, AnnexRepo))
     ok_(ds.repo.dirty)
     # ensure modified subds is commited
-    ds.save(auto_add_changes=True)
+    ds.save(all_changes=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
 

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -43,7 +43,6 @@ def test_save(path):
         f.write("modify")
 
     ok_(ds.repo.dirty)
-    # no need to git add before:
     ds.save("modified new_file.tst", all_changes=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
@@ -52,7 +51,10 @@ def test_save(path):
         with open(opj(path, fn), "w") as f:
             f.write(fn)
 
-    ds.save("set of new files", files=[opj(path, f) for f in files])
+    ds.add([opj(path, f) for f in files])
+    # superfluous call to save (add saved it already), should not fail
+    # but report that nothing was saved
+    assert_false(ds.save("set of new files"))
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # create subdataset
@@ -61,7 +63,7 @@ def test_save(path):
     # modify subds
     with open(opj(subds.path, "some_file.tst"), "w") as f:
         f.write("something")
-    subds.save(all_changes=True)
+    subds.add('.')
     ok_clean_git(subds.path, annex=isinstance(ds.repo, AnnexRepo))
     ok_(ds.repo.dirty)
     # ensure modified subds is commited
@@ -78,40 +80,45 @@ def test_recursive_save(path):
     # subdataset presence already saved
     ok_clean_git(ds.path)
     subsubds = subds.create('subsub')
-    with open(opj(subsubds.path, 'test'), 'w') as f:
+    newfile_name = opj(subsubds.path, 'test')
+    with open(newfile_name, 'w') as f:
         f.write('some')
-    # does not save anything in the topdataset
-    assert_false(ds.save())
-    # auto-add will save addition of subsubds to subds
-    assert_true(ds.save(auto_add_changes=True))
-    # with recursive it will add the file in subsubds
-    assert_true(ds.save(auto_add_changes=True, recursive=True))
-    # add content to subsub and try saving
-    testfname = opj('sub', 'subsub', 'saveme')
+    # saves the status change of the subdataset due to the subsubdataset addition
+    assert_equal(ds.save(), [ds])
+
+    # make the new file known to its dataset
+    # with #1141 this would be
+    #ds.add(newfile_name, save=False)
+    subsubds.add(newfile_name, save=False)
+
+    # but remains dirty because of the untracked file down below
+    assert ds.repo.dirty
+    # auto-add will save nothing deep down without recursive
+    assert_equal(ds.save(all_changes=True), [])
+    # with recursive pick up the change in subsubds
+    assert_equal(ds.save(all_changes=True, recursive=True), [subsubds, subds, ds])
+    # modify content in subsub and try saving
+    testfname = newfile_name
+    subsubds.unlock(testfname)
     with open(opj(ds.path, testfname), 'w') as f:
         f.write('I am in here!')
     # the following should all do nothing
     # no auto_add
     assert_false(ds.save())
     # no recursive
-    assert_false(ds.save(auto_add_changes=True))
-    # no recursive and auto_add
-    assert_false(ds.save(recursive=True))
-    # even with explicit target, no recursive safe
-    assert_false(ds.save(files=[testfname]))
-    # insufficient recursion depth
-    for rlevel in (0, 1):
-        assert_false(ds.save(files=[testfname], recursive=True, recursion_limit=rlevel))
-    # and finally with the right settings
-    assert_true(ds.save(files=[testfname], recursive=True, recursion_limit=2))
+    assert_false(ds.save(all_changes=True))
+    # an explicit target saves only the corresponding dataset
+    assert_equal(ds.save(files=[testfname]), [subsubds])
+    # plain recursive without any files given will save the beast
+    assert_equal(ds.save(recursive=True), [subds, ds])
     # there is nothing else to save
-    assert_false(ds.save(auto_add_changes=True, recursive=True))
+    assert_false(ds.save(all_changes=True, recursive=True))
     # one more time and check that all datasets in the hierarchy get updated
     states = [d.repo.get_hexsha() for d in (ds, subds, subsubds)]
     testfname = opj('sub', 'subsub', 'saveme2')
     with open(opj(ds.path, testfname), 'w') as f:
         f.write('I am in here!')
-    assert_true(ds.save(auto_add_changes=True, recursive=True))
+    assert_true(ds.save(all_changes=True, recursive=True))
     newstates = [d.repo.get_hexsha() for d in (ds, subds, subsubds)]
     for old, new in zip(states, newstates):
         assert_not_equal(old, new)
@@ -131,15 +138,18 @@ def test_recursive_save(path):
     assert_equal(indexed_files, subds.repo.get_indexed_files())
     ok_clean_git(subds.repo, untracked=['testnew'],
                  index_modified=['subsub'], head_modified=['testadded'])
-    subsubds.save(message="saving", super_datasets=True,
-                  auto_add_changes=True)
+    subsubds.save(message="savingtestmessage", super_datasets=True,
+                  all_changes=True)
     ok_clean_git(subsubds.repo)
     # but its super should have got only the subsub saved
     # not the file we created
     ok_clean_git(subds.repo, untracked=['testnew'], head_modified=['testadded'])
 
     # check commits to have correct messages
+    # there are no more dedicated superdataset-save commits anymore, because
+    # superdatasets get saved as part of the processed hierarchy and can contain
+    # other parts in the commit (if so intructed)
     assert_equal(next(ds.repo.get_branch_commits('master')).message.rstrip(),
-                 'saving [origin: sub/subsub]')
+                 'savingtestmessage')
     assert_equal(next(subds.repo.get_branch_commits('master')).message.rstrip(),
-                 'saving [origin: subsub]')
+                 'savingtestmessage')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -152,7 +152,9 @@ def test_recursive_save(path):
     # there are no more dedicated superdataset-save commits anymore, because
     # superdatasets get saved as part of the processed hierarchy and can contain
     # other parts in the commit (if so instructed)
-    assert_equal(next(ds.repo.get_branch_commits('master')).message.rstrip(),
+    assert_equal(next(subsubds.repo.get_branch_commits('master')).message.rstrip(),
                  'savingtestmessage')
     assert_equal(next(subds.repo.get_branch_commits('master')).message.rstrip(),
+                 'savingtestmessage')
+    assert_equal(next(ds.repo.get_branch_commits('master')).message.rstrip(),
                  'savingtestmessage')

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -157,8 +157,7 @@ def make_demo_hierarchy_datasets(path, tree):
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)
-    # TODO replace next line with add('.', recursive=True) when #1172 is done
-    ds.save()
+    ds.add('.', recursive=True)
     ok_clean_git(ds.path)
     ds_bb = Dataset(opj(ds.path, 'b', 'bb'))
     ds_bba = Dataset(opj(ds_bb.path, 'bba'))
@@ -239,7 +238,7 @@ def test_get_dataset_directories(path):
     # only return hits below the search path
     assert_equal(sorted(get_dataset_directories(testdir2)), sorted([testdir3]))
     # empty subdataset mount points are reported too
-    subds.uninstall(check=False, recursive=True)
+    ds.uninstall(subds.path, check=False, recursive=True)
     ok_(not subds.is_installed())
     ok_(os.path.exists(subds.path))
     assert_equal(sorted(get_dataset_directories(path)), sorted([testdir, testdir2, testdir3, subdsdir]))

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -24,6 +24,7 @@ from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.utils import get_paths_by_dataset
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import get_dataset_directories
+from datalad.interface.save import Save
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.utils import _install_subds_inplace
 from datalad.api import save
@@ -242,3 +243,9 @@ def test_get_dataset_directories(path):
     ok_(not subds.is_installed())
     ok_(os.path.exists(subds.path))
     assert_equal(sorted(get_dataset_directories(path)), sorted([testdir, testdir2, testdir3, subdsdir]))
+
+
+def test_interface_prep():
+    # verify sanity if nothing was given, as it would look like from the
+    # cmdline
+    assert_equal(Save._prep(path=[], dataset=None), ({}, []))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -77,7 +77,8 @@ def handle_dirty_dataset(ds, mode, msg=None):
     elif mode == 'save-before':
         if not ds.is_installed():
             raise RuntimeError('dataset {} is not yet installed'.format(ds))
-        Save.__call__(dataset=ds, message=msg, auto_add_changes=True)
+        from datalad.interface.save import Save
+        Save.__call__(dataset=ds, message=msg, all_changes=True)
     else:
         raise ValueError("unknown if-dirty mode '{}'".format(mode))
 
@@ -108,7 +109,7 @@ def handle_dirty_datasets(dpaths,
             dpaths,
             base=base,
             message=msg,
-            auto_add_changes=True)
+            all_changes=True)
     elif mode == 'ignore':
         return
     elif mode == 'fail':
@@ -131,8 +132,9 @@ def save_dataset_hierarchy(
         dpaths,
         base=None,
         message='[DATALAD] saved changes',
-        auto_add_changes=False):
-    """Save a (disjoint) hierarchy of dataset.
+        all_changes=False,
+        version_tag=None):
+    """Save (disjoint) hierarchies of datasets.
 
     Saving is done in an order that guarantees that all to be saved
     datasets reflect any possible change of any other to be saved

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -335,11 +335,13 @@ def save_dataset(
     if isinstance(ds.repo, AnnexRepo):
         # to make this work without calling `git add` in addition,
         # this needs git-annex v6.20161210 (see #1027)
-        ds.repo.add(files, commit=False)
+        ds.repo.add([f for f in files if lexists(f)], commit=False)
     else:
         # --update will ignore any untracked files, sadly git-annex add
         # above does not
-        ds.repo.add(files, git_options=['--update'], commit=False)
+        # will complain about vanished files though, filter them here, but
+        # keep them for a later commit call
+        ds.repo.add([f for f in files if lexists(f)], git_options=['--update'], commit=False)
 
     _datalad_msg = False
     if not message:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -667,7 +667,7 @@ def get_dataset_directories(top, ignore_datalad=True):
             path = opj(top, n)
             if not isdir(path) or path in ignore:
                 pass
-            elif GitRepo.get_toppath(path) != refpath:
+            elif path != refpath and GitRepo.is_valid_repo(path):
                 # mount point, keep but don't dive into
                 dirs.append(path)
             else:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -31,6 +31,7 @@ from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge c
 from datalad.utils import assure_list
 from datalad.utils import get_trace
 from datalad.utils import walk
+from datalad.utils import get_dataset_root
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.distribution.dataset import Dataset
@@ -450,7 +451,7 @@ def untracked_subdatasets_to_submodules(ds, consider_paths):
                          for d in get_dataset_directories(testpath,
                                                           ignore_datalad=True)
                          # do not probe for paths in subdatasets
-                         if AnnexRepo.get_toppath(testpath) == ds.path])
+                         if get_dataset_root(testpath) == ds.path])
     # the difference are directories that could be an untracked subdataset
     subds_candidates = existing_dirs.difference(indexed_dirs)
     for cand_dspath in subds_candidates:
@@ -521,7 +522,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
             if not d:
                 d = curdir
         # this could be `None` if there is no git repo
-        dspath = dir_lookup.get(d, AnnexRepo.get_toppath(d))
+        dspath = dir_lookup.get(d, get_dataset_root(d))
         dir_lookup[d] = dspath
         if not dspath:
             nondataset_paths.append(path)
@@ -661,7 +662,7 @@ def get_dataset_directories(top, ignore_datalad=True):
         names[:] = legit_names
 
     # collects the directories
-    refpath = AnnexRepo.get_toppath(top)
+    refpath = get_dataset_root(top)
     if not refpath:
         raise ValueError("`top` path {} is not in a dataset".format(top))
     ignore = [opj(refpath, get_git_dir(refpath))]

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -176,7 +176,6 @@ def sort_paths_into_subdatasets(superds_path, target_subs, spec):
     for t in target_subs:
         trace = get_trace(
             subds_graph,
-            # need to strip separator to make `==` work
             superds_path,
             t)
         if not trace:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -450,7 +450,7 @@ def untracked_subdatasets_to_submodules(ds, consider_paths):
                          for d in get_dataset_directories(testpath,
                                                           ignore_datalad=True)
                          # do not probe for paths in subdatasets
-                         if GitRepo.get_toppath(testpath) == ds.path])
+                         if AnnexRepo.get_toppath(testpath) == ds.path])
     # the difference are directories that could be an untracked subdataset
     subds_candidates = existing_dirs.difference(indexed_dirs)
     for cand_dspath in subds_candidates:
@@ -521,7 +521,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
             if not d:
                 d = curdir
         # this could be `None` if there is no git repo
-        dspath = dir_lookup.get(d, GitRepo.get_toppath(d))
+        dspath = dir_lookup.get(d, AnnexRepo.get_toppath(d))
         dir_lookup[d] = dspath
         if not dspath:
             nondataset_paths.append(path)
@@ -661,7 +661,7 @@ def get_dataset_directories(top, ignore_datalad=True):
         names[:] = legit_names
 
     # collects the directories
-    refpath = GitRepo.get_toppath(top)
+    refpath = AnnexRepo.get_toppath(top)
     if not refpath:
         raise ValueError("`top` path {} is not in a dataset".format(top))
     ignore = [opj(refpath, get_git_dir(refpath))]

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -302,8 +302,7 @@ def test_aggregate_with_missing_or_duplicate_id(path):
     # a hierarchy of three (super/sub)datasets, each with some native metadata
     ds = Dataset(opj(path, 'origin')).create(force=True)
     subds = ds.create('sub', force=True)
-    subds.repo.remove(opj('.datalad', 'config'))
-    subds.save()
+    subds.remove(opj('.datalad', 'config'), if_dirty='ignore')
     assert_false(exists(opj(subds.path, '.datalad', 'config')))
     subsubds = subds.create('subsub', force=True)
     # aggregate from bottom to top, guess native data, no compacting of graph

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -109,7 +109,7 @@ def test_basic_metadata(path):
                  ['@context', 'dcterms:conformsTo'])
     ds.create(force=True, save=False)
     # with subdataset
-    sub = ds.create('sub', force=True, if_dirty='ignore')
+    sub = ds.create('sub', force=True)
     ds.save()
     meta = get_metadata(ds)
     assert_equal(
@@ -138,8 +138,8 @@ def test_aggregation(path):
         assert_raises(InsufficientArgumentsError, aggregate_metadata, None)
     # a hierarchy of three (super/sub)datasets, each with some native metadata
     ds = Dataset(opj(path, 'origin')).create(force=True)
-    subds = ds.create('sub', force=True, if_dirty='ignore')
-    subsubds = subds.create('subsub', force=True, if_dirty='ignore')
+    subds = ds.create('sub', force=True)
+    subsubds = subds.create('subsub', force=True)
     # aggregate from bottom to top, guess native data, no compacting of graph
     # should yield 6 meta data sets, one implicit, and one native per dataset
     # and a second natiev set for the topmost dataset
@@ -301,11 +301,11 @@ def test_aggregation(path):
 def test_aggregate_with_missing_or_duplicate_id(path):
     # a hierarchy of three (super/sub)datasets, each with some native metadata
     ds = Dataset(opj(path, 'origin')).create(force=True)
-    subds = ds.create('sub', force=True, if_dirty='ignore')
+    subds = ds.create('sub', force=True)
     subds.repo.remove(opj('.datalad', 'config'))
     subds.save()
     assert_false(exists(opj(subds.path, '.datalad', 'config')))
-    subsubds = subds.create('subsub', force=True, if_dirty='ignore')
+    subsubds = subds.create('subsub', force=True)
     # aggregate from bottom to top, guess native data, no compacting of graph
     # should yield 6 meta data sets, one implicit, and one native per dataset
     # and a second native set for the topmost dataset
@@ -386,7 +386,7 @@ def test_ignore_nondatasets(path):
         assert_true(Dataset(subm_path).is_installed())
         assert_equal(meta, _kill_time(get_metadata(ds)))
         # making it a submodule has no effect either
-        ds.save(all_changes=True)
+        ds.add(subpath)
         assert_equal(len(ds.get_subdatasets()), n_subm + 1)
         assert_equal(meta, _kill_time(get_metadata(ds)))
         n_subm += 1

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -172,7 +172,7 @@ def test_aggregation(path):
     assert_true(success)
 
     # save the toplevel dataset only (see below)
-    ds.save('with aggregated meta data', auto_add_changes=True)
+    ds.save('with aggregated meta data', all_changes=True)
 
     # now clone the beast to simulate a new user installing an empty dataset
     clone = install(opj(path, 'clone'), source=ds.path)
@@ -386,7 +386,7 @@ def test_ignore_nondatasets(path):
         assert_true(Dataset(subm_path).is_installed())
         assert_equal(meta, _kill_time(get_metadata(ds)))
         # making it a submodule has no effect either
-        ds.save(auto_add_changes=True)
+        ds.save(all_changes=True)
         assert_equal(len(ds.get_subdatasets()), n_subm + 1)
         assert_equal(meta, _kill_time(get_metadata(ds)))
         n_subm += 1

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -311,6 +311,31 @@ class AnnexRepo(GitRepo):
         return 0 if not exists(fpath) else os.stat(fpath).st_size
 
     @classmethod
+    def get_toppath(cls, path, follow_up=True):
+        """Return top-level of a repository given the path.
+
+        Parameters
+        -----------
+        follow_up : bool
+          If path has symlinks -- they get resolved by git.  If follow_up is
+          True, we will follow original path up until we hit the same resolved
+          path.  If no such path found, resolved one would be returned.
+
+        Return None if no parent directory contains a git repository.
+        """
+
+        # first try plain git result:
+        toppath = GitRepo.get_toppath(path=path, follow_up=follow_up)
+        if toppath == '':
+            # didn't fail, so git itself didn't come to the conclusion
+            # there is no repo, but we have no actual result;
+            # might be an annex in direct mode
+            toppath = GitRepo.get_toppath(path=path, follow_up=follow_up,
+                                          git_options=['-c', 'core.bare=False'])
+
+        return toppath
+
+    @classmethod
     def is_valid_repo(cls, path, allow_noninitialized=False):
         """Return True if given path points to an annex repository"""
         initialized_annex = GitRepo.is_valid_repo(path) and \

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -82,7 +82,7 @@ class CommandNotAvailableError(CommandError):
     pass
 
 
-class FileNotInAnnexError(CommandError, IOError):
+class FileNotInAnnexError(IOError, CommandError):
     """Thrown if a file is not under control of git-annex.
     """
     def __init__(self, cmd="", msg="", code=None, filename=""):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -817,7 +817,10 @@ class GitRepo(object):
         #       Note: repo.tree(treeish).hexsha
         if branch is None:
             try:
-                return self.repo.active_branch.object.hexsha
+                # do not use
+                #self.repo.active_branch.object.hexsha
+                # but HEAD to be able to cope with detached heads
+                return self.repo.head.object.hexsha
             except ValueError as exc:
                 if 'does not exist' in str(exc):
                     return None

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -581,7 +581,7 @@ class GitRepo(object):
             ((not only_remote) and any((b == 'git-annex' for b in self.get_branches())))
 
     @classmethod
-    def get_toppath(cls, path, follow_up=True):
+    def get_toppath(cls, path, follow_up=True, git_options=None):
         """Return top-level of a repository given the path.
 
         Parameters
@@ -590,13 +590,19 @@ class GitRepo(object):
           If path has symlinks -- they get resolved by git.  If follow_up is
           True, we will follow original path up until we hit the same resolved
           path.  If no such path found, resolved one would be returned.
+        git_options: list of str
+          options to be passed to the git rev-parse call
 
         Return None if no parent directory contains a git repository.
         """
+        cmd = ['git']
+        if git_options:
+            cmd.extend(git_options)
+        cmd += ["rev-parse", "--show-toplevel"]
         try:
             with swallow_logs():
                 toppath, err = Runner().run(
-                    ["git", "rev-parse", "--show-toplevel"],
+                    cmd,
                     cwd=path,
                     log_stdout=True, log_stderr=True,
                     expect_fail=True, expect_stderr=True)
@@ -604,7 +610,8 @@ class GitRepo(object):
         except CommandError:
             return None
         except OSError:
-            toppath = GitRepo.get_toppath(dirname(path))
+            toppath = GitRepo.get_toppath(dirname(path), follow_up=follow_up,
+                                          git_options=git_options)
 
         if follow_up:
             path_ = path

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1372,3 +1372,22 @@ def test_get_description(path1, path2):
     annex1.merge_annex('annex1')
     annex2.remove_remote('annex1')
     assert_equal(annex2.get_description(uuid=annex1.uuid), annex1_description)
+
+
+@with_testrepos(flavors=local_testrepo_flavors)
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
+
+    reporeal = realpath(repo)
+    eq_(AnnexRepo.get_toppath(repo, follow_up=False), reporeal)
+    eq_(AnnexRepo.get_toppath(repo), repo)
+    # Generate some nested directory
+    AnnexRepo(repo2, create=True)
+    repo2real = realpath(repo2)
+    nested = opj(repo2, "d1", "d2")
+    os.makedirs(nested)
+    eq_(AnnexRepo.get_toppath(nested, follow_up=False), repo2real)
+    eq_(AnnexRepo.get_toppath(nested), repo2)
+    # and if not under git, should return None
+    eq_(AnnexRepo.get_toppath(tempdir), None)

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -106,8 +106,10 @@ def test_custom_versions():
     ev = ExternalVersions()
     assert(ev['cmd:annex'] > '6.20160101')  # annex must be present and recentish
     assert_equal(set(ev.versions.keys()), {'cmd:annex'})
-    # since we are using bundled version of git -- should be really recent
-    assert(ev['cmd:git'] > '2.10')  # git must be present and recentish
+    # some older git version don't support files to be passed to
+    # `commit` call under some conditions and this will lead to diverse
+    # errors
+    assert(ev['cmd:git'] > '2.0')  # git must be present and recentish
     assert(isinstance(ev['cmd:git'], LooseVersion))
     assert_equal(set(ev.versions.keys()), {'cmd:annex', 'cmd:git'})
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -633,15 +633,18 @@ def test_GitRepo_get_files(url, path):
 
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
-def test_GitRepo_get_toppath(repo, tempdir):
+@with_tempfile
+def test_GitRepo_get_toppath(repo, tempdir, repo2):
     reporeal = realpath(repo)
     eq_(GitRepo.get_toppath(repo, follow_up=False), reporeal)
     eq_(GitRepo.get_toppath(repo), repo)
     # Generate some nested directory
-    nested = opj(repo, "d1", "d2")
+    GitRepo(repo2, create=True)
+    repo2real = realpath(repo2)
+    nested = opj(repo2, "d1", "d2")
     os.makedirs(nested)
-    eq_(GitRepo.get_toppath(nested, follow_up=False), reporeal)
-    eq_(GitRepo.get_toppath(nested), repo)
+    eq_(GitRepo.get_toppath(nested, follow_up=False), repo2real)
+    eq_(GitRepo.get_toppath(nested), repo2)
     # and if not under git, should return None
     eq_(GitRepo.get_toppath(tempdir), None)
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -46,6 +46,7 @@ from ..utils import on_windows
 from ..utils import _path_
 from ..utils import get_timestamp_suffix
 from ..utils import get_trace
+from ..utils import get_dataset_root
 
 from ..support.annexrepo import AnnexRepo
 
@@ -578,3 +579,24 @@ def test_get_trace():
         ('C', 'D'),
         ('D', 'E'),
         ], 'A', 'E'), ['B', 'C', 'D'])
+
+
+@with_tempfile(mkdir=True)
+def test_get_dataset_root(path):
+    eq_(get_dataset_root('/nonexistent'), None)
+    with chpwd(path):
+        repo = AnnexRepo(os.curdir, create=True)
+        subdir = opj('some', 'deep')
+        fname = opj(subdir, 'dummy')
+        os.makedirs(subdir)
+        with open(fname, 'w') as f:
+            f.write('some')
+        repo.add(fname)
+        # we can find this repo
+        eq_(get_dataset_root(os.curdir), os.curdir)
+        # and we get the type of path that we fed in
+        eq_(get_dataset_root(abspath(os.curdir)), abspath(os.curdir))
+        # subdirs are no issue
+        eq_(get_dataset_root(subdir), os.curdir)
+        # non-dir paths are no issue
+        eq_(get_dataset_root(fname), os.curdir)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -15,7 +15,6 @@ import time
 
 import logging
 import shutil
-import stat
 import os
 import sys
 import tempfile
@@ -35,6 +34,7 @@ from os.path import isabs, normpath, expandvars, expanduser, abspath, sep
 from os.path import isdir
 from os.path import relpath
 from os.path import stat
+from os.path import dirname
 
 
 from six import text_type, binary_type, string_types
@@ -1157,6 +1157,31 @@ def walk(top, func, arg):
             continue
         if stat.S_ISDIR(st.st_mode):
             walk(name, func, arg)
+
+
+def get_dataset_root(path):
+    """Return the root of an existent dataset containing a given path
+
+    Parameters
+    ----------
+    path : str
+      Path to an existing file or directory.
+
+    Returns
+    -------
+    path or None
+      The root path is returned in the same absolute or relative form
+      as the input argument. If no associated dataset exists, or the
+      input path doesn't exist, None is returned.
+    """
+    suffix = os.sep + opj('.git', 'objects')
+    if not isdir(path):
+        path = dirname(path)
+    while not exists(path + suffix):
+        path = opj(path, os.pardir)
+        if not exists(path):
+            return None
+    return normpath(path)
 
 
 lgr.log(5, "Done importing datalad.utils")

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1162,17 +1162,9 @@ def walk(top, func, arg):
 def get_dataset_root(path):
     """Return the root of an existent dataset containing a given path
 
-    Parameters
-    ----------
-    path : str
-      Path to an existing file or directory.
-
-    Returns
-    -------
-    path or None
-      The root path is returned in the same absolute or relative form
-      as the input argument. If no associated dataset exists, or the
-      input path doesn't exist, None is returned.
+    The root path is returned in the same absolute or relative form
+    as the input argument. If no associated dataset exists, or the
+    input path doesn't exist, None is returned.
     """
     suffix = os.sep + opj('.git', 'objects')
     if not isdir(path):


### PR DESCRIPTION
High-level summary of the desired changes -- after staring two weeks at the code, trying to come up with something that makes more sense, is easier to test, and minimizes the places in the code where similar things happen:

- `save` will no longer do half of the work of `add` -- it will only operate on content that was "added" by other means before. that being said, once the clean version is implemented we can and should reevaluate the scope again
- `save` will no longer do half of the work of `uninstall` and `remove`. only paths to things that presently exist on the file system will be dealt with -- no convenience deinit of vanished submodules, no (possibly dangerous) `git rm` of vanished files anymore. maybe there will be a `fix-this-mess` command later on, and maybe it will triggered by `save`, but clean implementation first
- "surgical" save: only path that we given explicitly (or implicitely via something like `all_changes=True` will be saved. Even if other changes were staged already.
- three layers of functionality are envisioned:
   1. toplevel API: throw it any number of paths in any number of datasets in any order and it will do the right thing with the respective datasets (flags will enable modes such as "also save this one in the superdataset", or "record all changes to known components")
   2. intermediate: give it a dictionary with datasets to touch and the paths to safe in them, and it will figure out the order of processing, discover possibly required intermediate datasets to handle in order to fulfill a request and do the right thing
   3. low: given a single dataset and a list of paths to save, it will save that content in this single dataset -- regardless of the type of content (file, directory, subdataset state)

To be addressed issues:
- [x] #1175 (parts of)
- [x] #1174 
- [x] #1173 
- [x] #1172 
- [x] #1141 
- [x] #1140 
- [x] #1109 
- [x] #1106 (50% of it)
- [x] #1096 
- [x] #1016 
- [x] #1004 

Also contains:

- [x] #1119 
