### PR TITLE
BF: create-test-dataset created a "dirty" dataset because of "installing" some bogus submodules

### DIFF
--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -32,7 +32,11 @@ lgr = logging.getLogger('datalad.distribution.tests')
 
 def _parse_spec(spec):
     out = []   # will return a list of tuples (min, max) for each layer
+    if not spec:
+        return out
     for ilevel, level in enumerate(spec.split('/')):
+        if not level:
+            continue
         minmax = level.split('-')
         if len(minmax) == 1:  # only abs number specified
             minmax = int(minmax[0])
@@ -52,7 +56,7 @@ def _parse_spec(spec):
     return out
 
 
-def _makeds(path, levels, ds=None):
+def _makeds(path, levels, ds=None, max_leading_dirs=2):
     """Create a hierarchy of datasets
 
     Used recursively, with current invocation generating datasets for the
@@ -68,6 +72,9 @@ def _makeds(path, levels, ds=None):
     ds : Dataset, optional
       Super-dataset which would contain a new dataset (thus its path whould be
       a parent of path. Note that ds needs to be installed.
+    max_leading_dirs : int, optional
+      Up to how many leading directories withing a dataset could lead to a
+      sub-dataset
 
     Yields
     ------
@@ -89,31 +96,40 @@ def _makeds(path, levels, ds=None):
     with open(fn, 'w') as f:
         f.write(fn)
     repo.add(fn, git=True, commit=True, msg="Added %s" % fn, _datalad_msg=True)
+
+    yield path
+
+    if levels:
+        # make a dataset for that one since we want to add sub datasets
+        ds_ = Dataset(path)
+        # Process the levels
+        level, levels_ = levels[0], levels[1:]
+        nrepos = random.randint(*level)  # how many subds to generate
+        for irepo in range(nrepos):
+            # we would like to have up to 2 leading dirs
+            subds_path = opj(*(['d%i' % i
+                                for i in range(random.randint(0, max_leading_dirs+1))]
+                               + ['r%i' % irepo]))
+            subds_fpath = opj(path, subds_path)
+            # yield all under
+            for d in _makeds(subds_fpath, levels_, ds=ds_):
+                yield d
+
     if ds:
         assert ds.is_installed()
         rpath = os.path.relpath(path, ds.path)
         out = install(
             rpath,
             source=opj(os.curdir, rpath),
-            dataset=ds
+            dataset=ds,
+            # currently would generate two commits -- first adding a submodule
+            # and then a dummy one (commented out below) talking about "installing".
+            # But may be this all would get automagically straightened out by
+            # GH #1169, so we could also have a sensible message on what was done
+            # if_dirty='ignore',
             )
-        ds.repo.commit("subdataset %s installed." % rpath, _datalad_msg=True)
+        # ds.repo.commit("subdataset %s installed." % rpath, _datalad_msg=True)
 
-    if not levels:
-        return
-
-    # make a dataset for that one since we want to add sub datasets
-    ds_ = Dataset(path)
-    level, levels_ = levels[0], levels[1:]
-    nrepos = random.randint(*level)  # how many subds to generate
-    for irepo in range(nrepos):
-        # we would like to have up to 2 leading dirs
-        subds_path = opj(*(['d%i' % i for i in range(random.randint(0, 3))] + ['r%i' % irepo]))
-        subds_fpath = opj(path, subds_path)
-        yield subds_fpath
-        # and all under
-        for d in _makeds(subds_fpath, levels_, ds=ds_):
-            yield d
 
 
 class CreateTestDataset(Interface):
@@ -144,8 +160,6 @@ class CreateTestDataset(Interface):
 
     @staticmethod
     def __call__(path=None, spec=None, seed=None):
-        if spec is None:
-            spec = "10/1-3/-2"  # 10 on top level, some random number from 1 to 3 at the 2nd, up to 2 on 3rd
         levels = _parse_spec(spec)
 
         if seed is not None:

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -16,7 +16,9 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_clean_git
 from datalad.utils import swallow_logs
+from datalad.utils import swallow_outputs
 from datalad.utils import chpwd
+from datalad.support.gitrepo import GitRepo
 from datalad.distribution.create_test_dataset import _parse_spec
 
 from nose.tools import eq_
@@ -31,22 +33,52 @@ def test_create(outdir):
 def test_parse_spec():
     eq_(_parse_spec('0/3/-1'), [(0, 0), (3, 3), (0, 1)])
     eq_(_parse_spec('4-10'), [(4, 10)])
+    eq_(_parse_spec(''), [])
 
 
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
-    with swallow_logs():
+    with swallow_logs(), swallow_outputs():
         dss = create_test_dataset(spec='2/1-2')
-    ok_(4 <= len(dss) <= 6)  # at least four - two on top level, 1 in each
+    ok_(5 <= len(dss) <= 7)  # at least five - 1 top, two on top level, 1 in each
     for ds in dss:
-        ok_clean_git(ds, annex=False)  # soem of them are annex but we just don't check
+        ok_clean_git(ds, annex=False)  # some of them are annex but we just don't check
         ok_(len(glob(opj(ds, 'file*'))))
 
 
-@with_tempfile(mkdir=True)
-def test_create_test_dataset_new_relpath(topdir):
+def test_create_1test_dataset():
+    # and just a single dataset
     from datalad.api import create_test_dataset
-    with swallow_logs(), chpwd(topdir):
-        dss = create_test_dataset('testds', spec='1')
+    with swallow_outputs():
+        dss = create_test_dataset()
     eq_(len(dss), 1)
+    ok_clean_git(dss[0], annex=False)
+
+
+@with_tempfile(mkdir=True)
+def test_new_relpath(topdir):
+    from datalad.api import create_test_dataset
+    with swallow_logs(), chpwd(topdir), swallow_outputs():
+        dss = create_test_dataset('testds', spec='1')
+    eq_(dss[0], opj(topdir, 'testds'))
+    eq_(len(dss), 2)  # 1 top + 1 sub-dataset as demanded
+    for ds in dss:
+        ok_clean_git(ds, annex=False)
+
+
+@with_tempfile()
+def test_hierarchy(topdir):
+    # GH 1178
+    from datalad.api import create_test_dataset
+    with swallow_logs(), swallow_outputs():
+        dss = create_test_dataset(topdir, spec='1/1')
+
+    eq_(len(dss), 3)
+    eq_(dss[0], topdir)
+    for ids, ds in enumerate(dss):
+        ok_clean_git(ds, annex=False)
+        # each one should have 2 commits (but the last one)-- one for file and
+        # another one for sub-dataset
+        repo = GitRepo(ds)
+        eq_(len(list(repo.get_branch_commits())), 1 + int(ids<2))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1429,7 +1429,7 @@ class GitRepo(object):
         cmd += [name, url]
         return self._git_custom_command('', cmd)
 
-    def get_branch_commits(self, branch, limit=None, stop=None, value=None):
+    def get_branch_commits(self, branch=None, limit=None, stop=None, value=None):
         """Return GitPython's commits for the branch
 
         Pretty much similar to what 'git log <branch>' does.
@@ -1437,7 +1437,8 @@ class GitRepo(object):
 
         Parameters
         ----------
-        branch: str
+        branch: str, optional
+          If not provided, assumes current branch
         limit: None | 'left-only', optional
           Limit which commits to report.  If None -- all commits (merged or not),
           if 'left-only' -- only the commits from the left side of the tree upon
@@ -1449,6 +1450,9 @@ class GitRepo(object):
           What to yield.  If None - entire commit object is yielded, if 'hexsha'
           only its hexsha
         """
+
+        if not branch:
+            branch = self.get_active_branch()
 
         try:
             _branch = self.repo.branches[branch]

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -728,12 +728,15 @@ def test_GitRepo_git_get_branch_commits(src):
     repo.add('*')
     repo.commit('committing')
 
+    commits_default = list(repo.get_branch_commits())
     commits = list(repo.get_branch_commits('master'))
+    eq_(commits, commits_default)
+
     eq_(len(commits), 1)
-    commits_stop0 = list(repo.get_branch_commits('master', stop=commits[0].hexsha))
+    commits_stop0 = list(repo.get_branch_commits(stop=commits[0].hexsha))
     eq_(commits_stop0, [])
-    commits_hexsha = list(repo.get_branch_commits('master', value='hexsha'))
-    commits_hexsha_left = list(repo.get_branch_commits('master', value='hexsha', limit='left-only'))
+    commits_hexsha = list(repo.get_branch_commits(value='hexsha'))
+    commits_hexsha_left = list(repo.get_branch_commits(value='hexsha', limit='left-only'))
     eq_([commits[0].hexsha], commits_hexsha)
     # our unittest is rudimentary ;-)
     eq_(commits_hexsha_left, commits_hexsha)


### PR DESCRIPTION
```shell
$> datalad create-test-dataset --spec 1/1 testds2
[INFO   ] Generating repo of class <class 'datalad.support.gitrepo.GitRepo'> under /tmp/testds2 
[INFO   ] Generating repo of class <class 'datalad.support.gitrepo.GitRepo'> under /tmp/testds2/d0/d1/d2/r0 
[INFO   ] <Dataset path=/tmp/testds2/d0/d1/d2/r0> was already installed from . Use `update` to obtain latest updates, or `get` or `install` with a path, not URL, to (re)fetch data and / or subdatasets 
[INFO   ] Generating repo of class <class 'datalad.support.annexrepo.AnnexRepo'> under /tmp/testds2/d0/d1/d2/r0/d0/d1/d2/r0 
[INFO   ] <Dataset path=/tmp/testds2/d0/d1/d2/r0/d0/d1/d2/r0> was already installed from . Use `update` to obtain latest updates, or `get` or `install` with a path, not URL, to (re)fetch data and / or subdatasets 
2 installed items are available at
/tmp/testds2/d0/d1/d2/r0
/tmp/testds2/d0/d1/d2/r0/d0/d1/d2/r0
(venv-tests) 2 10549.....................................:Thu 05 Jan 2017 01:19:00 PM EST:.
hopa:/tmp
$> cd -
/tmp/testds2
d0/  file790.dat
changes on filesystem:                                                                                                                
 d0/d1/d2/r0 | 2 +-
(venv-tests) 2 10550.....................................:Thu 05 Jan 2017 01:19:02 PM EST:.
(git)hopa:/tmp/testds2[master]
$> git diff
diff --git a/d0/d1/d2/r0 b/d0/d1/d2/r0
index 4362016..44ceaff 160000
--- a/d0/d1/d2/r0
+++ b/d0/d1/d2/r0
@@ -1 +1 @@
-Subproject commit 4362016140d3678d49d9a918a2937714f4680bfe
+Subproject commit 44ceaff1cf3668cc5d1550a239075ad49b385101
changes on filesystem:                                                                                                                
 d0/d1/d2/r0 | 2 +-
(venv-tests) 2 10551.....................................:Thu 05 Jan 2017 01:19:06 PM EST:.
(git)hopa:/tmp/testds2[master]
$> cd d0/d1/d2/r0 
d0/  file349.dat
(venv-tests) 2 10552.....................................:Thu 05 Jan 2017 01:19:14 PM EST:.

$> git log --stat 
commit 44ceaff1cf3668cc5d1550a239075ad49b385101
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Thu Jan 5 13:19:00 2017 -0500

    [DATALAD] subdataset d0/d1/d2/r0 installed.

commit 2d61df9a8e928a8df13ff8638c42cc56629f2a90
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Thu Jan 5 13:19:00 2017 -0500

    [DATALAD] auto-saved changes

 .gitmodules | 3 +++
 d0/d1/d2/r0 | 1 +
 2 files changed, 4 insertions(+)

commit 4362016140d3678d49d9a918a2937714f4680bfe
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Thu Jan 5 13:18:59 2017 -0500

    [DATALAD] Added /tmp/testds2/d0/d1/d2/r0/file349.dat

 file349.dat | 1 +
 1 file changed, 1 insertion(+)

(git)hopa:/tmp/testds2[master]
$> datalad ls -r .
.                         [git]  master  - 2017-01-05/13:19:00  X
d0/d1/d2/r0               [git]  master  - 2017-01-05/13:19:00  OK
d0/d1/d2/r0/d0/d1/d2/r0   [annex]  master  - 2017-01-05/13:19:00  OK

```
quickly looking at it -- seems to create additional level of subdatasets after committing correctly first...