### PR TITLE
RF: use bundled git (or just the git alongside with git-annex)

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -112,4 +112,8 @@ def teardown_package():
     for path in _TEMP_PATHS_GENERATED:
         rmtemp(path, ignore_errors=True)
 
+    lgr.debug("Printing versioning information collected so far")
+    from datalad.support.external_versions import external_versions as ev
+    print(ev.dumps(query=True))
+
 lgr.log(5, "Done importing main __init__")

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -17,6 +17,7 @@ from git.exc import GitCommandError
 
 from ..dataset import Dataset
 from datalad.api import publish, install, create_sibling
+from datalad.cmd import GitRunner
 from datalad.utils import chpwd
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
@@ -77,8 +78,11 @@ def _test_correct_publish(target_path, rootds=False, flat=True):
 # but we can rely on it ATM only if "server" (i.e. localhost) has
 # recent enough git since then we expect an error msg to be spit out
 from datalad.support.external_versions import external_versions
+# But with custom GIT_PATH pointing to non-bundled annex, which would not be
+# used on remote, e
 assert_create_sshwebserver = (
-    assert_no_errors_logged(create_sibling)
+    assert_no_errors_logged(
+        create_sibling, skip_re='Git version >= 2.4 needed to configure remote')
     if external_versions['cmd:git'] >= '2.4'
     else create_sibling
 )

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -79,11 +79,10 @@ def _test_correct_publish(target_path, rootds=False, flat=True):
 # recent enough git since then we expect an error msg to be spit out
 from datalad.support.external_versions import external_versions
 # But with custom GIT_PATH pointing to non-bundled annex, which would not be
-# used on remote, e
+# used on remote, so we will compare against system-git
 assert_create_sshwebserver = (
-    assert_no_errors_logged(
-        create_sibling, skip_re='Git version >= 2.4 needed to configure remote')
-    if external_versions['cmd:git'] >= '2.4'
+    assert_no_errors_logged(create_sibling)
+    if external_versions['cmd:system-git'] >= '2.4'
     else create_sibling
 )
 
@@ -246,7 +245,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             # files which hook would manage to generate
             _path_('.git/info/refs'), '.git/objects/info/packs'
         }
-        if external_versions['cmd:git'] >= '2.4':
+        if external_versions['cmd:system-git'] >= '2.4':
             # on elderly git we don't change receive setting
             ok_modified_files.add(_path_('.git/config'))
         ok_modified_files.update({f for f in digests if f.startswith(_path_('.git/datalad/web'))})

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -40,7 +40,9 @@ class UnknownVersion:
 # Custom handlers
 #
 from datalad.cmd import Runner
+from datalad.cmd import GitRunner
 _runner = Runner()
+_git_runner = GitRunner()
 
 
 def _get_annex_version():
@@ -55,7 +57,7 @@ def _get_annex_version():
 
 def _get_git_version():
     """Return version of available git"""
-    return _runner.run('git version'.split())[0].split()[2]
+    return _git_runner.run('git version'.split())[0].split()[2]
 
 
 class ExternalVersions(object):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -55,9 +55,23 @@ def _get_annex_version():
         return out.split('\n')[0].split(':')[1].strip()
 
 
-def _get_git_version():
+def __get_git_version(runner):
     """Return version of available git"""
-    return _git_runner.run('git version'.split())[0].split()[2]
+    return runner.run('git version'.split())[0].split()[2]
+
+
+def _get_git_version():
+    """Return version of git we use (might be bundled)"""
+    return __get_git_version(_git_runner)
+
+
+def _get_system_git_version():
+    """Return version of git available system-wide
+
+    Might be different from the one we are using, which might be
+    bundled with git-annex
+    """
+    return __get_git_version(_runner)
 
 
 class ExternalVersions(object):
@@ -78,7 +92,8 @@ class ExternalVersions(object):
 
     CUSTOM = {
         'cmd:annex': _get_annex_version,
-        'cmd:git': _get_git_version
+        'cmd:git': _get_git_version,
+        'cmd:system-git': _get_system_git_version,
     }
 
     def __init__(self):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -165,7 +165,7 @@ class ExternalVersions(object):
         """Return dictionary (copy) of versions"""
         return self._versions.copy()
 
-    def dumps(self, indent=False, preamble="Versions:"):
+    def dumps(self, indent=False, preamble="Versions:", query=False):
         """Return listing of versions as a string
 
         Parameters
@@ -175,7 +175,12 @@ class ExternalVersions(object):
           is used). Otherwise returned in a single line
         preamble: str, optional
           What preamble to the listing to use
+        query : bool, optional
+          To query for versions of all "registered" custom externals, so to
+          get those which weren't queried for yet
         """
+        if query:
+            [self[k] for k in self.CUSTOM]
         if indent and (indent is True):
             indent = ' '
         items = ["%s=%s" % (k, self._versions[k]) for k in sorted(self._versions)]

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -111,9 +111,13 @@ def test_custom_versions():
     assert(isinstance(ev['cmd:git'], LooseVersion))
     assert_equal(set(ev.versions.keys()), {'cmd:annex', 'cmd:git'})
 
+    # and there is also a version of system-wide installed git, which might
+    # differ from cmd:git but should be at least good old 1.7
+    assert(ev['cmd:system-git'] > '1.7')
+
     ev.CUSTOM = {'bogus': lambda: 1 / 0}
     assert_equal(ev['bogus'], None)
-    assert_equal(set(ev.versions.keys()), {'cmd:annex', 'cmd:git'})
+    assert_equal(set(ev.versions), {'cmd:annex', 'cmd:git', 'cmd:system-git'})
 
 
 def test_ancient_annex():

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -106,7 +106,8 @@ def test_custom_versions():
     ev = ExternalVersions()
     assert(ev['cmd:annex'] > '6.20160101')  # annex must be present and recentish
     assert_equal(set(ev.versions.keys()), {'cmd:annex'})
-    assert(ev['cmd:git'] > '1.7')  # git must be present and recentish
+    # since we are using bundled version of git -- should be really recent
+    assert(ev['cmd:git'] > '2.10')  # git must be present and recentish
     assert(isinstance(ev['cmd:git'], LooseVersion))
     assert_equal(set(ev.versions.keys()), {'cmd:annex', 'cmd:git'})
 

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -20,6 +20,7 @@ from .utils import ok_, eq_, assert_is, assert_equal, assert_false, \
     assert_true, assert_greater, assert_raises, assert_in, SkipTest
 
 from ..cmd import Runner, link_file_load
+from ..cmd import GitRunner
 from ..support.exceptions import CommandError
 from ..support.protocol import DryRunProtocol
 from .utils import with_tempfile, assert_cwd_unchanged, \
@@ -270,3 +271,11 @@ def test_runner_failure(dir_):
         runner.run(failing_cmd, cwd=dir_)
         assert_in('notexistent.dat not found', cml.out)
     assert_equal(1, cme.exception.code)
+
+
+@with_tempfile(mkdir=True)
+def test_git_path(dir_):
+    from ..support.gitrepo import GitRepo
+    # As soon as we use any GitRepo we should get _GIT_PATH set in the Runner
+    repo = GitRepo(dir_, create=True)
+    assert GitRunner._GIT_PATH is not None

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1030,15 +1030,18 @@ def with_testsui(t, responses=None, interactive=True):
 with_testsui.__test__ = False
 
 
-def assert_no_errors_logged(func):
+def assert_no_errors_logged(func, skip_re=None):
     """Decorator around function to assert that no errors logged during its execution"""
     @wraps(func)
     def new_func(*args, **kwargs):
         with swallow_logs(new_level=logging.ERROR) as cml:
             out = func(*args, **kwargs)
             if cml.out:
-                raise AssertionError("Expected no errors to be logged, but log output is %s"
-                                     % cml.out)
+                if not (skip_re and re.search(skip_re, cml.out)):
+                    raise AssertionError(
+                        "Expected no errors to be logged, but log output is %s"
+                        % cml.out
+                    )
         return out
 
     return new_func


### PR DESCRIPTION
So we could avoid weird bugs in elderly gits and gain more consistency

WiP since I am still thinking on how to deal with (testing) remote git, so create_sibling could make use of bundled git when testing against localhost... we could try to pass the environment variables via SendEnv option of ssh  or other ways, but I wonder if we should really...

edit 2:  I am wondering if we should then do similar detection on the remote end while establishing ssh connection(s).  That could slow things down a bit though then :-/ and pure -o SendEnv wouldn't be an acceptable  solution since requires sshd configuration to allow passing those variables (by default only locale settings are allowed to be passed).  So the only way I found to make it work is by prepending each invocation with explicit adjusted PATH:

```shell
$> ssh -p 2221 172.17.0.2 'git --version'       
git version 2.1.4

$> ssh -p 2221 172.17.0.2 'PATH=/usr/lib/git-annex.linux:/bin:/usr/bin git --version'     
git version 2.11.0
```

so in principle it is doable I guess and might be beneficial for some deployments... what do you think @mih and @bpoldrack ?

edit 3:  so for now decided not to mess with the "use bundled git on the remote end" and since anyways we don't run tests on remote hosts (only on localhost, see #1183 for a wishlist), decided just to fix up tests to skip appropriately on localhosts having no up to date system-wide git (so pretty much retaining similar to before behavior).  I think travis testing is happy (yet to finish last ones) and will merge whenever they finish