### PR TITLE
Homogenization of `update` API

### DIFF
--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -23,7 +23,6 @@ from datalad.support.gitrepo import GitRepo
 from datalad.support.param import Parameter
 from datalad.utils import knows_annex
 
-from .dataset import Dataset
 from .dataset import EnsureDataset
 from .dataset import datasetmethod
 from .dataset import require_dataset
@@ -51,9 +50,8 @@ class Update(Interface):
         merge=Parameter(
             args=("--merge",),
             action="store_true",
-            doc="merge changes from sibling `name` or the remote branch, "
-                "configured to be the tracking branch if no sibling was "
-                "given", ),
+            doc="""merge obtained changes from either the sibling `name` or the
+            default sibling""", ),
         # TODO: How to document it without using the term 'tracking branch'?
         recursive=Parameter(
             args=("-r", "--recursive"),
@@ -76,9 +74,6 @@ class Update(Interface):
                  reobtain_data=False):
         """
         """
-        # TODO: Is there an 'update filehandle' similar to install and publish?
-        # What does it mean?
-
         if reobtain_data:
             # TODO: properly define, what to do
             raise NotImplementedError("TODO: Option '--reobtain-data' not "
@@ -94,7 +89,6 @@ class Update(Interface):
                                 for sub_path in
                                 ds.get_subdatasets(recursive=True, fulfilled=True)]
         # only work on those which are installed
-
 
         # TODO: current implementation disregards submodules organization,
         #  it just updates/merge each one individually whenever in the simplest

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -43,7 +43,7 @@ class Update(Interface):
         path=Parameter(
             args=("path",),
             metavar="PATH",
-            doc="path/name of the component to be dropped",
+            doc="path to be updated",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()),
         name=Parameter(

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -130,9 +130,12 @@ class Update(Interface):
                 raise NotImplementedError("No merge strategy for multiple "
                                           "remotes implemented yet.")
             lgr.info("Updating dataset '%s' ..." % repo.path)
+            _update_repo(repo, name, merge, fetch_all)
 
+
+def _update_repo(repo, remote, merge, fetch_all):
             # fetch remote(s):
-            repo.fetch(remote=name, all_=fetch_all)
+            repo.fetch(remote=remote, all_=fetch_all)
 
             # if `repo` is an annex and we didn't fetch the entire remote
             # anyway, explicitly fetch git-annex branch:
@@ -143,10 +146,10 @@ class Update(Interface):
             # yoh: we should leave it to git and its configuration.
             # So imho we should just extract to fetch everything git would fetch
             if knows_annex(repo.path) and not fetch_all:
-                if name:
+                if remote:
                     # we are updating from a certain remote, so git-annex branch
                     # should be updated from there as well:
-                    repo.fetch(remote=name)
+                    repo.fetch(remote=remote)
                     # TODO: what does failing here look like?
                 else:
                     # we have no remote given, therefore
@@ -165,8 +168,8 @@ class Update(Interface):
                 # We need a "tracking remote" but custom refspec to fetch from
                 # that remote
                 cmd_list = ["git", "pull"]
-                if name:
-                    cmd_list.append(name)
+                if remote:
+                    cmd_list.append(remote)
                     # branch needed, if not default remote
                     # => TODO: use default remote/tracking branch to compare
                     #          (see above, where git-annex is fetched)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -75,8 +75,8 @@ class Update(Interface):
     @staticmethod
     @datasetmethod(name='update')
     def __call__(
-            name=None,
             path=None,
+            name=None,
             merge=False,
             dataset=None,
             recursive=False,


### PR DESCRIPTION
Update to bring `update` more in line with the more recently refurbished commands.

- [x] Unify with other commands and say "what to update" rather than "from where" as the primary argument(s)