### PR TITLE
RF: `publish`

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -12,9 +12,8 @@
 
 import logging
 
-from os.path import join as opj
-
 from datalad.interface.base import Interface
+from datalad.interface.utils import filter_unmodified
 from datalad.interface.common_opts import annex_copy_opts, recursion_flag, \
     recursion_limit, git_opts, annex_opts
 from datalad.support.param import Parameter
@@ -22,20 +21,17 @@ from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import IncompleteResultsError
-from datalad.dochelpers import exc_str
-from datalad.utils import assure_list
 
 from .dataset import EnsureDataset
 from .dataset import Dataset
 from .dataset import datasetmethod
-from .dataset import require_dataset
 
 __docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.distribution.publish')
 
 # TODO: make consistent configurable output
+
 
 def _log_push_info(pi_list):
     from git.remote import PushInfo as PI
@@ -48,6 +44,92 @@ def _log_push_info(pi_list):
                 lgr.info(push_info.summary)
     else:
         lgr.warning("Nothing was pushed.")
+
+
+def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
+    published, skipped = [], []
+    # upstream refspec needed for update (merge) and subsequent push,
+    # in case there is no.
+    # no tracking refspec yet?
+    # TODO what if `to` was given, doesn't have tracking info in this case
+    set_upstream = refspec is None
+
+    # check if there are any differences wrt the to-be-published paths,
+    # and if not skip this dataset
+    if refspec:
+        # we have a matching branch on the other side
+        diff = ds.repo.repo.commit().diff(
+            refspec.replace(
+                'refs/heads/',
+                'refs/remotes/{}/'.format(remote)),
+            paths=paths)
+    else:
+        # there was no tracking branch, check the push target
+        active_branch = ds.repo.get_active_branch()
+        refspec = active_branch
+        if active_branch in ds.repo.repo.remotes[remote].refs:
+            # we know some remote state -> diff
+            diff = ds.repo.repo.commit().diff(
+                ds.repo.repo.remotes[remote].refs[active_branch],
+                paths=paths)
+        else:
+            # we don't have any remote state, need to push for sure
+            diff = True
+    if not diff:
+        return published, skipped
+
+    # in order to be able to use git's config to determine what to push,
+    # we need to annex merge first. Otherwise a git push might be
+    # rejected if involving all matching branches for example.
+    # Once at it, also push the annex branch right here.
+    if isinstance(ds.repo, AnnexRepo):
+        ds.repo.fetch(remote=remote)
+        ds.repo.merge_annex(remote)
+        _log_push_info(ds.repo.push(remote=remote,
+                                    refspec="git-annex:git-annex"))
+
+    # publishing of `remote` might depend on publishing other
+    # remote(s) first:
+    # define config var name for potential publication dependencies
+    depvar = 'remote.{}.datalad-publish-depends'.format(remote)
+    for d in ds.config.get(depvar, []):
+        lgr.info("Dependency detected: '%s'" % d)
+        # call this again to take care of the dependency first,
+        # but keep the paths the same, as the goal is to publish those
+        # to the primary remote, and not anything elase to a dependency
+        pblsh, skp = _publish_dataset(ds, d, None, paths)
+        published.extend(pblsh)
+        skipped.extend(skp)
+
+    lgr.info("Publishing {0} to {1}".format(ds, remote))
+
+    # we now know where to push to:
+    # TODO: what to push? default: git push --mirror if nothing configured?
+    # consider also: --follow-tags, --tags, --atomic
+
+    # Note: git's push.default is 'matching', which possibly doesn't
+    # work for first
+    # time publication (a branch, that doesn't exist on remote yet)
+    # But if we want to respect remote.*.push entries, etc. we need to
+    # not pass a specific refspec (like active branch) to `git push`
+    # by default.
+
+    _log_push_info(ds.repo.push(remote=remote,
+                                refspec=refspec,
+                                set_upstream=set_upstream))
+
+    published.append(ds)
+
+    if (paths or annex_copy_opts) and \
+            isinstance(ds.repo, AnnexRepo) and not \
+            ds.config.get('remote.{}.annex-ignore', False):
+        lgr.info("Publishing data of dataset {0} ...".format(ds))
+        pblshd = ds.repo.copy_to(files=paths,
+                                remote=remote,
+                                options=annex_copy_options)
+        published += pblshd
+
+    return published, skipped
 
 
 class Publish(Interface):
@@ -136,238 +218,92 @@ class Publish(Interface):
             git_opts=None,
             annex_opts=None,
             annex_copy_opts=None):
-        # shortcut
-        ds = require_dataset(dataset, check_installed=True, purpose='publication')
-        assert(ds.repo is not None)
 
-        path = assure_list(path)
+        if since and not dataset:
+            raise InsufficientArgumentsError(
+                'Modification detection (--since) without a base dataset '
+                'is not supported')
 
-        # figure out, what to publish from what (sub)dataset:
-        publish_this = False   # whether to publish `ds`
-        publish_files = []     # which files to publish by `ds`
+        if dataset and not path:
+            # act on the whole dataset if nothing else was specified
+            path = dataset.path if isinstance(dataset, Dataset) else dataset
+        content_by_ds, unavailable_paths = Interface._prep(
+            path=path,
+            dataset=dataset,
+            recursive=recursive,
+            recursion_limit=recursion_limit)
+        if unavailable_paths:
+            raise ValueError(
+                'cannot publish content that is not available locally: %s',
+                unavailable_paths)
+        results = []
 
-        expl_subs = set()      # subdatasets to publish explicitly
-        publish_subs = dict()  # collect what to publish from subdatasets
-
-        if not path:
-            # publish `ds` itself, if nothing else is given:
-            publish_this = True
-        else:
-            for p in path:
-                subdatasets = ds.get_subdatasets()
-                if p in subdatasets:
-                    # p is a subdataset, that needs to be published itself
-                    expl_subs.add(p)
-                else:
-                    try:
-                        d = ds.get_containing_subdataset(p)
-                    except ValueError as e:
-                        # p is not in ds => skip:
-                        lgr.warning(str(e) + " - Skipped.")
-                        continue
-                    if d == ds:
-                        # p needs to be published from ds
-                        publish_this = True
-                        publish_files.append(p)
-                    else:
-                        # p belongs to subds `d`
-                        if not publish_subs[d.path]:
-                            publish_subs[d.path] = dict()
-                        if not publish_subs[d.d.path]['files']:
-                            publish_subs[d.d.path]['files'] = list()
-                        publish_subs[d.path]['dataset'] = d
-                        publish_subs[d.path]['files'].append(p)
-
-        if publish_this:
-            # Note: we need an upstream remote, if there's none given. We could
-            # wait for git push to complain, but we need to explicitly figure it
-            # out for pushing annex branch anyway and we might as well fail
-            # right here.
-
-            track_remote, track_branch = None, None
-
-            # keep `to` in case it's None for passing to recursive calls:
-            dest_resolved = to
+        # here is the plan
+        # 1. figure out remote to publish to
+        # 2. figure out which content needs to be published to this remote
+        # 3. look for any pre-publication dependencies of that remote
+        #    (i.e. remotes that need to be published to before)
+        # 4. publish the content needed to go to the primary remote to
+        #    the dependencies first, and to the primary afterwards
+        ds_remote_info = {}
+        for ds_path in content_by_ds:
+            ds = Dataset(ds_path)
+            # TODO move detection of publication dependencies into this loop too!
             if to is None:
-                # TODO: If possible, avoid resolution herein and rely on git
-                # (or GitRepo respectively), meaning: Just pass `None`
-                # ATM conflicts with _get_changed_datasets => figure it out
-
-                track_remote, track_branch = ds.repo.get_tracking_branch()
+                # we need an upstream remote, if there's none given. We could
+                # wait for git push to complain, but we need to explicitly
+                # figure it out for pushing annex branch anyway and we might as
+                # well fail right here.
+                track_remote, track_refspec = ds.repo.get_tracking_branch()
                 if track_remote:
-                    dest_resolved = track_remote
+                    ds_remote_info[ds_path] = dict(zip(
+                        ('remote', 'refspec'),
+                        (track_remote, track_refspec)))
+                elif skip_failing:
+                    lgr.warning(
+                        'Cannot determine target sibling, skipping %s',
+                        ds)
+                    ds_remote_info[ds_path] = None
                 else:
                     # we have no remote given and no upstream => fail
                     raise InsufficientArgumentsError(
-                        "No known default target for "
-                        "publication and none given.")
-
-        subds_prev_hexsha = {}
-        if recursive:
-            all_subdatasets = ds.get_subdatasets(fulfilled=True)
-
-            # TODO: dest_resolved => to?
-            # Note: This is a bug anyway, since in actual recursive call `to` is
-            # passed in order to be resolved by the subdatasets themselves
-            # (might be None), but when considering what subdatasets to be
-            # published, we assume `dest_resolved` is the same for all of them.
-
-            # ==> TODO: RF to consider `since` only for the current ds and then go on
-            # recursively.
-
-            subds_to_consider = \
-                Publish._get_changed_datasets(
-                    ds.repo, all_subdatasets, dest_resolved, since=since) \
-                if publish_this \
-                else all_subdatasets
-            # if we were returned a dict, we got subds_prev_hexsha
-            if isinstance(subds_to_consider, dict):
-                subds_prev_hexsha = subds_to_consider
-            for subds_path in subds_to_consider:
-                if path and '.' in path:
-                    # we explicitly are passing '.' to subdatasets in case of
-                    # `recursive`. Therefore these datasets are going into
-                    # `publish_subs`, instead of `expl_subs`:
-                    sub = Dataset(opj(ds.path, subds_path))
-                    publish_subs[sub.path] = dict()
-                    publish_subs[sub.path]['dataset'] = sub
-                    publish_subs[sub.path]['files'] = ['.']
+                        'Cannot determine target sibling for %s' % (ds,))
+            elif to not in ds.repo.get_remotes():
+                # unknown given remote
+                if skip_failing:
+                    lgr.warning(
+                        "Unknown target sibling '%s', skipping %s",
+                        to, ds)
+                    ds_remote_info[ds_path] = None
                 else:
-                    # we can recursively publish only, if there actually
-                    # is something
-                    expl_subs.add(subds_path)
+                    raise ValueError(
+                        "Unknown target sibling '%s' for %s" % (to, ds))
+            else:
+                # all good: remote given and is known
+                ds_remote_info[ds_path] = {'remote': to}
+            # TODO more per repo apriori checks here?
+
+        if dataset and since:
+            # remove all unmodified components from the spec
+            content_by_ds = filter_unmodified(
+                content_by_ds, dataset, since)
 
         published, skipped = [], []
-
-        for dspath in sorted(expl_subs):
-            # these datasets need to be pushed regardless of additional paths
-            # pointing inside them
-            # due to API, this may not happen when calling publish with paths,
-            # therefore force it.
-            # TODO: There might be a better solution to avoid two calls of
-            # publish() on the very same Dataset instance
-            ds_ = Dataset(opj(ds.path, dspath))
-            try:
-                # we could take local diff for the subdataset
-                # but may be we could just rely on internal logic within
-                # subdataset to figure out what it needs to publish.
-                # But we need to pass empty string one inside as is
-                pkw = {}
-                if since == '':
-                    pkw['since'] = since
-                else:
-                    # pass previous state for that submodule if known
-                    pkw['since'] = subds_prev_hexsha.get(dspath, None)
-                published_, skipped_ = ds_.publish(to=to, recursive=recursive, **pkw)
-                published += published_
-                skipped += skipped_
-            except Exception as exc:
-                if not skip_failing:
-                    raise
-                lgr.warning("Skipped %s: %s", ds.path, exc_str(exc))
-                skipped += [ds_]
-
-        for d in publish_subs:
-            # recurse into subdatasets
-
-            # TODO: need to fetch. see above
-            publish_subs[d]['dataset'].repo.fetch(remote=to)
-
-            published_, skipped_ = publish_subs[d]['dataset'].publish(
-                to=to,
-                path=publish_subs[d]['files'],
-                recursive=recursive,
-                annex_copy_opts=annex_copy_opts)
-            published += published_
-            skipped += skipped_
-
-        if publish_this:
-
-            # is `to` an already known remote?
-            if dest_resolved not in ds.repo.get_remotes():
-                # unknown remote
-                raise ValueError("No sibling '{0}' found for {1}."
-                                 "".format(dest_resolved, ds))
-
-            # in order to be able to use git's config to determine what to push,
-            # we need to annex merge first. Otherwise a git push might be
-            # rejected if involving all matching branches for example.
-            # Once at it, also push the annex branch right here.
-
-            # Q: Do we need to respect annex-ignore here? Does it make sense to
-            # publish to a remote without pushing the annex branch
-            # (if there is any)?
-            if isinstance(ds.repo, AnnexRepo):
-                ds.repo.fetch(remote=dest_resolved)
-                ds.repo.merge_annex(dest_resolved)
-                _log_push_info(ds.repo.push(remote=dest_resolved,
-                                            refspec="git-annex:git-annex"))
-
-            # upstream branch needed for update (merge) and subsequent push,
-            # in case there is no.
-            # no tracking branch yet?
-            set_upstream = track_branch is None
-
-            # publishing of `dest_resolved` might depend on publishing other
-            # remote(s) first:
-            # define config var name for potential publication dependencies
-            depvar = 'remote.{}.datalad-publish-depends'.format(dest_resolved)
-            for d in ds.config.get(depvar, []):
-                lgr.info("Dependency detected: '%s'" % d)
-                # Note: Additional info on publishing the dep. comes from within
-                # `ds.publish`.
-                ds.publish(path=path,
-                           to=d,
-                           since=since,
-                           skip_failing=skip_failing,
-                           recursive=recursive,
-                           recursion_limit=recursion_limit,
-                           git_opts=git_opts,
-                           annex_opts=annex_opts,
-                           annex_copy_opts=annex_copy_opts)
-
-            lgr.info("Publishing {0} to {1}".format(ds, dest_resolved))
-
-            # we now know where to push to:
-            # TODO: what to push? default: git push --mirror if nothing configured?
-            # consider also: --follow-tags, --tags, --atomic
-
-            # Note: git's push.default is 'matching', which possibly doesn't
-            # work for first
-            # time publication (a branch, that doesn't exist on remote yet)
-            # But if we want to respect remote.*.push entries, etc. we need to
-            # not pass a specific refspec (like active branch) to `git push`
-            # by default.
-
-            _log_push_info(ds.repo.push(remote=dest_resolved,
-                                        refspec=ds.repo.get_active_branch(),
-                                        set_upstream=set_upstream))
-
-            published.append(ds)
-
-            if publish_files or annex_copy_opts:
-                if not isinstance(ds.repo, AnnexRepo):
-                    # incomplete, since `git push` was done already:
-                    raise IncompleteResultsError(
-                        (published, skipped),
-                        failed=publish_files,
-                        msg="Cannot publish content of something, that is not "
-                            "an annex. ({0})".format(ds))
-                if ds.config.get('remote.{}.annex-ignore', False):
-                    # Q: Do we need a --force option here? annex allows to
-                    # ignore the ignore setting
-                    raise IncompleteResultsError(
-                        (published, skipped),
-                        failed=publish_files,
-                        msg="Sibling '{0}' of {1} is configured to be ignored "
-                            "by annex. No content was published."
-                            % (dest_resolved, ds))
-
-                lgr.info("Publishing data of dataset {0} ...".format(ds))
-                published += ds.repo.copy_to(files=publish_files,
-                                             remote=dest_resolved,
-                                             options=annex_copy_opts)
-
+        for ds_path in content_by_ds:
+            remote_info = ds_remote_info[ds_path]
+            if not remote_info:
+                # in case we are skipping
+                continue
+            # and publish
+            ds = Dataset(ds_path)
+            pblsh, skp = _publish_dataset(
+                ds,
+                remote=remote_info['remote'],
+                refspec=remote_info.get('refspec', None),
+                paths=content_by_ds[ds_path],
+                annex_copy_options=annex_copy_opts)
+            published.extend(pblsh)
+            skipped.extend(skp)
         return published, skipped
 
     @staticmethod
@@ -388,32 +324,3 @@ class Publish(Interface):
                 else:
                     msg += "File: %s\n" % item
             ui.message(msg)
-
-    @staticmethod
-    def _get_changed_datasets(repo, all_subdatasets, to, since=None):
-        if since == '' or not all_subdatasets:
-            # we are instructed to publish all
-            return all_subdatasets
-
-        if since is None:  # default behavior - only updated since last update
-            # so we figure out what was the last update
-            # XXX here we assume one to one mapping of names from local branches
-            # to the remote
-            # TODO: This seems to be the only thing left, that we need to know the
-            # remote `to` for (if not explicitly specified anyway). Otherwise
-            # we could figure it out at GitRepo level instead, which makes
-            # things easier, cleaner and more in line with git push.
-            active_branch = repo.get_active_branch()
-            since = '%s/%s' % (to, active_branch)
-
-            if since not in repo.get_remote_branches():
-                # we did not publish it before - so everything must go
-                return all_subdatasets
-
-        lgr.debug("Checking diff since %s for %s" % (since, all_subdatasets))
-        diff = repo.repo.commit().diff(since, all_subdatasets)
-        for d in diff:
-            # not sure if it could even track renames of subdatasets
-            # but let's "check"
-            assert(d.a_path == d.b_path)
-        return dict((d.b_path, d.b_blob.hexsha if d.b_blob else None) for d in diff)

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -125,8 +125,8 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
             ds.config.get('remote.{}.annex-ignore', False):
         lgr.info("Publishing data of dataset {0} ...".format(ds))
         pblshd = ds.repo.copy_to(files=paths,
-                                remote=remote,
-                                options=annex_copy_options)
+                                 remote=remote,
+                                 options=annex_copy_options)
         published += pblshd
 
     return published, skipped
@@ -136,8 +136,22 @@ class Publish(Interface):
     """Publish a dataset to a known :term:`sibling`.
 
     This makes the last saved state of a dataset available to a sibling
-    or special remote data store of the dataset which must already exist
-    and be known to the dataset.
+    or special remote data store of a dataset. Any target sibling must already
+    exist and be known to the dataset.
+
+    Optionally, it is possible to limit publication to change sets relative
+    to a particular point in the version history of a dataset (e.g. a release
+    tag). By default, the state of the local dataset is evaluated against the
+    last known state of the target sibling. Actual publication is only attempted
+    if there was a change compared to the reference state, in order to speed up
+    processing of large collections of datasets. Evaluation with respect to
+    a particular "historic" state is only supported in conjunction with a
+    specified reference dataset. Change sets are also evaluated recursively, i.e.
+    only those subdatasets are published where a change was recorded that is
+    reflected in to current state of the top-level reference dataset.
+
+    Only publication of saved changes is supported. Any unsaved changes in a
+    dataset (hierarchy) have to be saved before publication.
 
     .. note::
       Power-user info: This command uses :command:`git push`, and :command:`git annex copy`
@@ -152,23 +166,19 @@ class Publish(Interface):
     #        upstream set up before, so you can use just "datalad publish" next
     #        time.
 
-    # TODO: Doc!
-
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
             metavar='DATASET',
-            doc="""specify the dataset to publish. If no dataset is given, an
-            attempt is made to identify the dataset based on the current
-            working directory""",
+            doc="""specify the (top-level) dataset to be published. If no dataset
+            is given, the datasets are determined based on the input arguments""",
             constraints=EnsureDataset() | EnsureNone()),
         to=Parameter(
             args=("--to",),
             metavar='LABEL',
-            doc="""sibling name identifying the publication target. If no
-            destination is given an attempt is made to identify the target
-            based on the dataset's configuration (i.e. a set up tracking
-            branch)""",
+            doc="""name of the target sibling. If no name is given an attempt is
+            made to identify the target based on the dataset's configuration
+            (i.e. a configured tracking branch)""",
             # TODO: See TODO at top of class!
             constraints=EnsureStr() | EnsureNone()),
         since=Parameter(
@@ -236,7 +246,6 @@ class Publish(Interface):
             raise ValueError(
                 'cannot publish content that is not available locally: %s',
                 unavailable_paths)
-        results = []
 
         # here is the plan
         # 1. figure out remote to publish to
@@ -248,7 +257,6 @@ class Publish(Interface):
         ds_remote_info = {}
         for ds_path in content_by_ds:
             ds = Dataset(ds_path)
-            # TODO move detection of publication dependencies into this loop too!
             if to is None:
                 # we need an upstream remote, if there's none given. We could
                 # wait for git push to complain, but we need to explicitly
@@ -281,7 +289,6 @@ class Publish(Interface):
             else:
                 # all good: remote given and is known
                 ds_remote_info[ds_path] = {'remote': to}
-            # TODO more per repo apriori checks here?
 
         if dataset and since:
             # remove all unmodified components from the spec

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -168,7 +168,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     # test for publishing with  --since.  By default since no changes, nothing pushed
     res_ = publish(dataset=source, recursive=True)
-    eq_(set(r.path for r in res_[0]), set([]))
+    eq_(set(r.path for r in res_[0]), set())
 
     # still nothing gets pushed, because orgin is up to date
     res_ = publish(dataset=source, recursive=True, since='HEAD^')

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -18,6 +18,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import chpwd
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import InsufficientArgumentsError
 
 from nose.tools import ok_, eq_, assert_false, assert_is_instance
 from datalad.tests.utils import with_tempfile, assert_in, with_tree,\
@@ -33,6 +34,18 @@ from datalad.tests.utils import skip_if_no_module
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_not_in
+
+
+@with_testrepos('submodule_annex', flavors=['local'])
+def test_invalid_call(origin):
+    ds = Dataset(origin)
+    ds.uninstall('subm 1', check=False)
+    # nothing
+    assert_raises(ValueError, publish, '/notthere')
+    # known, but not present
+    assert_raises(ValueError, publish, opj(ds.path, 'subm 1'))
+    # --since without dataset is not supported
+    assert_raises(InsufficientArgumentsError, publish, since='HEAD')
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
@@ -61,7 +74,8 @@ def test_publish_simple(origin, src_path, dst_path):
 
     # don't fail when doing it again
     res = publish(dataset=source, to="target")
-    eq_(res, ([source], []))
+    # and nothing is pushed
+    eq_(res, ([], []))
 
     ok_clean_git(src_path, annex=False)
     ok_clean_git(dst_path, annex=False)
@@ -108,7 +122,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     # subdatasets have no remote yet, so recursive publishing should fail:
     with assert_raises(ValueError) as cm:
         publish(dataset=source, to="target", recursive=True)
-    assert_in("No sibling 'target' found", exc_str(cm.exception))
+    assert_in("Unknown target sibling 'target'", exc_str(cm.exception))
 
     # now, set up targets for the submodules:
     sub1_target = GitRepo(sub1_pub, create=True)
@@ -152,25 +166,26 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     eq_(list(sub2_target.get_branch_commits("git-annex")),
         list(sub2.get_branch_commits("git-annex")))
 
-    # test for publishing with  --since.  By default since no changes, only current pushed
+    # test for publishing with  --since.  By default since no changes, nothing pushed
     res_ = publish(dataset=source, recursive=True)
-    # only current one would get pushed
-    eq_(set(r.path for r in res_[0]), {src_path})
+    eq_(set(r.path for r in res_[0]), set([]))
 
-    # all get pushed
+    # still nothing gets pushed, because orgin is up to date
     res_ = publish(dataset=source, recursive=True, since='HEAD^')
-    eq_(set(r.path for r in res_[0]), {src_path, sub1.path, sub2.path})
+    eq_(set(r.path for r in res_[0]), set([]))
 
     # Let's now update one subm
     with open(opj(sub2.path, "file.txt"), 'w') as f:
         f.write('')
-    sub2.add('file.txt')
-    sub2.commit("")
-    source.save("changed sub2", all_changes=True)
+    # add to subdataset, does not alter super dataset!
+    # MIH: use `to_git` because original test author used
+    # and explicit `GitRepo.add` -- keeping this for now
+    Dataset(sub2.path).add('file.txt', to_git=True)
 
     res_ = publish(dataset=source, recursive=True)
-    # only updated ones were published
-    eq_(set(r.path for r in res_[0]), {src_path, sub2.path})
+    # only updates published, i.e. just the subdataset
+    # super wasn't altered and there was no new annexed content
+    eq_(set(r.path for r in res_[0]), {sub2.path})
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
@@ -221,7 +236,9 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     source.repo.fetch("target")
     res = publish(dataset=source, to="target", path=['.'])
-    eq_(res, ([source, 'test-annex.dat'], []))
+    # there is nothing to publish on 2nd attempt
+    #eq_(res, ([source, 'test-annex.dat'], []))
+    eq_(res, ([], []))
 
     source.repo.fetch("target")
     import glob
@@ -236,6 +253,8 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
             result_paths.append(item.path)
         else:
             result_paths.append(item)
-    eq_({source.path, opj(source.path, "subm 1"),
-         opj(source.path, "subm 2"), 'test-annex.dat'},
+    # only the subdatasets, targets are plain git repos, hence
+    # no file content is pushed, all content in super was pushed
+    # before
+    eq_({sub1.path, sub2.path},
         set(result_paths))

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -18,6 +18,7 @@ from os.path import relpath
 from nose.tools import assert_raises, assert_equal
 from datalad.tests.utils import with_tempfile, assert_not_equal
 from datalad.tests.utils import with_tree
+from datalad.tests.utils import create_tree
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import ok_
 from datalad.interface.utils import handle_dirty_dataset
@@ -273,8 +274,7 @@ def test_filter_unmodified(path):
 
     # modify one subdataset
     added_path = opj(subb.path, 'added')
-    with open(added_path, 'w') as f:
-        f.write('test')
+    create_tree(subb.path, {'added': 'test'})
     subb.add('added')
 
     # still nothing was modified compared to orig commit, because the base

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -24,6 +24,7 @@ from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.utils import get_paths_by_dataset
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import get_dataset_directories
+from datalad.interface.utils import filter_unmodified
 from datalad.interface.save import Save
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.utils import _install_subds_inplace
@@ -249,3 +250,65 @@ def test_interface_prep():
     # verify sanity if nothing was given, as it would look like from the
     # cmdline
     assert_equal(Save._prep(path=[], dataset=None), ({}, []))
+
+
+@with_tree(demo_hierarchy['b'])
+def test_filter_unmodified(path):
+    ds = Dataset(path).create(force=True)
+    suba = ds.create('ba', force=True)
+    subb = ds.create('bb', force=True)
+    subsub = ds.create(opj('bb', 'bba', 'bbaa'), force=True)
+    ds.add('.', recursive=True)
+    ok_clean_git(path)
+
+    spec, unavail = Save._prep('.', ds, recursive=True)
+    # just to be sure -- find all datasets, and just datasets
+    assert_equal(len(spec), 4)
+    for r, p in spec.items():
+        assert_equal([r], p)
+
+    orig_base_commit = ds.repo.repo.commit()
+    # nothing was modified compared to the status quo, output must be empty
+    assert_equal({}, filter_unmodified(spec, ds, orig_base_commit))
+
+    # modify one subdataset
+    added_path = opj(subb.path, 'added')
+    with open(added_path, 'w') as f:
+        f.write('test')
+    subb.add('added')
+
+    # still nothing was modified compared to orig commit, because the base
+    # dataset does not have the recent change saved
+    assert_equal({}, filter_unmodified(spec, ds, orig_base_commit))
+
+    ds.save(all_changes=True)
+
+    modspec, unavail = Save._prep('.', ds, recursive=True)
+    # arg sorting is not affected
+    assert_equal(spec, modspec)
+
+    # only the actually modified components per dataset are kept
+    assert_equal(
+        {
+            ds.path: [subb.path],
+            subb.path: [added_path]
+        },
+        filter_unmodified(spec, ds, orig_base_commit))
+
+    # deal with removal (force insufiicient copies error)
+    ds.remove(opj(subsub.path, 'file_bbaa'), check=False)
+    #import pdb; pdb.set_trace()
+    # saves all the way up
+    ok_clean_git(path)
+
+    modspec, unavail = Save._prep('.', ds, recursive=True)
+    # arg sorting is again not affected
+    assert_equal(spec, modspec)
+    # only the actually modified components per dataset are kept
+    assert_equal(
+        {
+            ds.path: [subb.path],
+            subb.path: [added_path, subsub.path],
+            subsub.path: []
+        },
+        {d: sorted(p) for d, p in filter_unmodified(spec, ds, orig_base_commit).items()})

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -667,3 +667,84 @@ def _discover_trace_to_known(path, trace, spec):
         if not isdir(p):
             continue
         _discover_trace_to_known(p, trace, spec)
+
+
+def filter_unmodified(content_by_ds, refds, since):
+    """Filter per-dataset path specifications based on modification history.
+
+    This function takes a path specification dictionary, as produced by
+    `Interface._prep()` and filters it such that only that subset of paths
+    remains in the dictionary that correspdong to the set of changes in
+    the given reference dataset since a given state.
+
+    The change set is traced across all related subdatasets, i.e. if a submodule
+    in the reference dataset is reported as modified then all paths for any given
+    subdataset in the modified one are tested for changes too (based on the
+    state at which the parent dataset reports a change in the subdataset), and so
+    on.
+
+    In doing so, not only unmodified given paths are removed, but also modified
+    given paths are replaced by the set of actually modified paths within them.
+
+    Only commited changes are considered!
+
+    Parameters
+    ----------
+    content_by_ds : dict
+      Per-dataset path specifications, as produced ,for example, by
+      `Interface._prep()`
+    refds : Dataset
+      Instance of a reference dataset for which to determine the initial
+      change set
+    since : state
+      Any commit-ish/tree-ish supported by Git (tag, commit, branch, ...).
+      Changes between this given state and the most recent commit are
+      evaluated.
+
+    Returns
+    -------
+    dict
+      Filtered path spec dictionary. The output is guaranteed to only contain
+      paths to modified, and presently existing components of subdatasets
+      of the given reference dataset (and itself).
+    """
+    # life is simple: we diff the base dataset, and kill anything that
+    # does not start with something that is in the diff
+    # we cannot really limit the diff paths easily because we might get
+    # or miss content (e.g. subdatasets) if we don't figure out which ones
+    # are known -- and we don't want that
+    diff = refds.repo.repo.commit().diff(since)
+    # get all modified paths (with original? commit) that are still
+    # present
+    modified = dict((opj(refds.path, d.b_path),
+                    # talk to @yaricoptic about the next line
+                    d.b_blob.hexsha if d.b_blob else None)
+                    for d in diff)
+    if not modified:
+        # nothing modified nothing to report
+        return {}
+    # determine the subset that is a directory and hence is relevant for possible
+    # subdatasets
+    modified_dirs = {_with_sep(d) for d in modified if isdir(d)}
+    # find the subdatasets matching modified paths, this will also kick out
+    # any paths that are not in the dataset sub-hierarchy
+    mod_subs = {candds: paths
+                for candds, paths in content_by_ds.items()
+                if candds != refds.path and
+                any(_with_sep(candds).startswith(md) for md in modified_dirs)}
+    # now query the next level down
+    # XXX new `since` could be None, see above @yarikoptic must share wisdom
+    keep_subs = \
+        [filter_unmodified(mod_subs, Dataset(subds_path), modified[subds_path])
+         for subds_path in mod_subs
+         if subds_path in modified]
+    # merge result list into a single dict
+    keep = {k: v for d in keep_subs for k, v in d.items()}
+
+    paths_refds = content_by_ds[refds.path]
+    keep[refds.path] = [m for m in modified
+                        if lexists(m) # still around
+                        and (m in paths_refds # listed file, or subds
+                        # or a modified path under a given directory
+                        or any(m.startswith(_with_sep(p)) for p in paths_refds))]
+    return keep


### PR DESCRIPTION
This refurbishes `publish` in the following ways:

- [X] provide a generic replacement of the `--since` functionality that was built into `publish`, and RF it to make use of it. This  could be used in other places too. Such as "`get` data for all files that were changed `--since`". Which could be used for the presently not-implemented `update --reobtain-data` (ping #1199).
- [X] reimplement `publish` to perform upfront checks and sorting without recursive self-invocation at the top-level. Recursive calls are still used to handle publication dependencies, but only a cheap helper call is used for this purpose
- [X] let `publish` look harder to figure out if anything needs to be pushed at all
- [x] sift through the function signature to see what kind of values/object should be passed to yield most flexibility
- [x] reevaluate where in the logic publication dependencies should be detected and acted upon
