### PR TITLE
Fixing SSH shared connection issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ script:
   # Run tests
   - PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   # Generate documentation and run doctests
-  - PYTHONPATH=$PWD make -C docs html doctest
+  - PYTHONPATH=$PWD $NOSE_WRAPPER make -C docs html doctest
   # Run javascript tests
   - grunt test --verbose
   # do not run them with custom TMPDIR with spaces for now : https://github.com/datalad/datalad/issues/893

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -249,7 +249,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         try:
             if hasattr(self, '_batched') and self._batched is not None:
                 self._batched.close()
-            super(AnnexRepo, self).__del__()
         except TypeError as e:
             # Workaround:
             # most likely something wasn't accessible anymore; doesn't really
@@ -259,6 +258,11 @@ class AnnexRepo(GitRepo, RepoInterface):
             # thing to happen, since we check for things being None herein as
             # well as in super class __del__;
             # At least log it:
+            lgr.debug(exc_str(e))
+        try:
+            super(AnnexRepo, self).__del__()
+        except TypeError as e:
+            # see above
             lgr.debug(exc_str(e))
 
     def _set_shared_connection(self, remote_name, url):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -260,7 +260,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             # well as in super class __del__;
             # At least log it:
             lgr.debug(exc_str(e))
-            pass
 
     def _set_shared_connection(self, remote_name, url):
         """Make sure a remote with SSH URL uses shared connections.

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -254,11 +254,12 @@ class SSHManager(object):
           connection.close, and just log them at DEBUG level
         """
         if self._connections:
-            lgr.debug("Closing %d SSH connections..." % len(self._connections))
-            for cnct in self._connections:
-                if self._connections[cnct].ctrl_path in self._prev_connections:
-                    # don't close if connection wasn't opened by SSHManager
-                    continue
+            to_close = [c for c in self._connections
+                        # don't close if connection wasn't opened by SSHManager
+                        if self._connections[c].ctrl_path
+                        not in self._prev_connections]
+            lgr.debug("Closing %d SSH connections..." % len(to_close))
+            for cnct in to_close:
                 f = self._connections[cnct].close
                 if allow_fail:
                     f()
@@ -266,4 +267,5 @@ class SSHManager(object):
                     try:
                         f()
                     except Exception as exc:
-                        lgr.debug("Failed to close a connection: %s", exc_str(exc))
+                        lgr.debug("Failed to close a connection: "
+                                  "%s", exc_str(exc))

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -98,6 +98,10 @@ def test_ssh_manager_close_no_throw():
         def close(self):
             raise Exception("oh I am so bad")
 
+        @property
+        def ctrl_path(self):
+            return "whatever"
+
     manager._connections['bogus'] = bogus()
     assert_raises(Exception, manager.close)
     assert_raises(Exception, manager.close)

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -40,11 +40,11 @@ def test_ssh_get_connection():
     # deal with them):
     assert_raises(ValueError, manager.get_connection, 'localhost')
     # we can do what urlparse cannot
-    #assert_raises(ValueError, manager.get_connection, 'someone@localhost')
+    # assert_raises(ValueError, manager.get_connection, 'someone@localhost')
     # next one is considered a proper url by urlparse (netloc:'',
     # path='/localhost), but eventually gets turned into SSHRI(hostname='ssh',
     # path='/localhost') -- which is fair IMHO -> invalid test
-    #assert_raises(ValueError, manager.get_connection, 'ssh:/localhost')
+    # assert_raises(ValueError, manager.get_connection, 'ssh:/localhost')
 
 
 @skip_ssh
@@ -80,6 +80,11 @@ def test_ssh_open_close(tfile1):
 def test_ssh_manager_close():
 
     manager = SSHManager()
+
+    # check for previously existing sockets:
+    existed_before_1 = exists(opj(manager.socket_dir, 'localhost'))
+    existed_before_2 = exists(opj(manager.socket_dir, 'datalad-test'))
+
     manager.get_connection('ssh://localhost').open()
     manager.get_connection('ssh://datalad-test').open()
     ok_(exists(opj(manager.socket_dir, 'localhost')))
@@ -87,8 +92,18 @@ def test_ssh_manager_close():
 
     manager.close()
 
-    ok_(not exists(opj(manager.socket_dir, 'localhost')))
-    ok_(not exists(opj(manager.socket_dir, 'datalad-test')))
+    still_exists_1 = exists(opj(manager.socket_dir, 'localhost'))
+    still_exists_2 = exists(opj(manager.socket_dir, 'datalad-test'))
+
+    if existed_before_1:
+        ok_(still_exists_1)
+    else:
+        ok_(not still_exists_1)
+
+    if existed_before_2:
+        ok_(still_exists_2)
+    else:
+        ok_(not still_exists_2)
 
 
 def test_ssh_manager_close_no_throw():

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -87,6 +87,13 @@ def test_ssh_manager_close():
 
     manager.get_connection('ssh://localhost').open()
     manager.get_connection('ssh://datalad-test').open()
+
+    if existed_before_1 and existed_before_2:
+        # we need one connection to be closed and therefore being opened
+        # by `manager`
+        manager.get_connection('ssh://localhost').close()
+        manager.get_connection('ssh://localhost').open()
+
     ok_(exists(opj(manager.socket_dir, 'localhost')))
     ok_(exists(opj(manager.socket_dir, 'datalad-test')))
 
@@ -95,15 +102,8 @@ def test_ssh_manager_close():
     still_exists_1 = exists(opj(manager.socket_dir, 'localhost'))
     still_exists_2 = exists(opj(manager.socket_dir, 'datalad-test'))
 
-    if existed_before_1:
-        ok_(still_exists_1)
-    else:
-        ok_(not still_exists_1)
-
-    if existed_before_2:
-        ok_(still_exists_2)
-    else:
-        ok_(not still_exists_2)
+    ok_(existed_before_1 == still_exists_1)
+    ok_(existed_before_2 == still_exists_2)
 
 
 def test_ssh_manager_close_no_throw():

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -102,8 +102,8 @@ def test_ssh_manager_close():
     still_exists_1 = exists(opj(manager.socket_dir, 'localhost'))
     still_exists_2 = exists(opj(manager.socket_dir, 'datalad-test'))
 
-    ok_(existed_before_1 == still_exists_1)
-    ok_(existed_before_2 == still_exists_2)
+    eq_(existed_before_1, still_exists_1)
+    eq_(existed_before_2, still_exists_2)
 
 
 def test_ssh_manager_close_no_throw():


### PR DESCRIPTION
- BF/ENH: Don't close SSH connections, that were not opened by this instance of SSHManager

- Workaround: Unclear circumstances led to AnnexRepo.__del__ accessing NoneType object. Just ignore and log it.

Closes #1127