### PR TITLE
RF: No error when trying to drop files in plain Git repo

### DIFF
--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -139,7 +139,8 @@ def test_uninstall_git_file(path):
     ok_file_under_git(ds.repo.path, 'INFO.txt')
 
     if not hasattr(ds.repo, 'drop'):
-        assert_raises(ValueError, ds.drop, path='INFO.txt')
+        # nothing can be dropped in a plain GitRepo
+        eq_([], ds.drop(path='INFO.txt'))
 
     with swallow_logs(new_level=logging.ERROR) as cml:
         assert_raises(ValueError, ds.uninstall, path="INFO.txt")

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -84,9 +84,7 @@ def _drop_files(ds, files, check):
         dropped = ds.repo.drop(files, options=opts)
         results.extend([opj(ds.path, f) for f in dropped])
     else:
-        # TODO think how to handle this best, when called `through` remove
-        # and it hits a plain git repo somewhere down below
-        raise ValueError("cannot uninstall, not an annex %s" % ds)
+        lgr.info("skip dropping files in %s, no annex", ds)
     return results
 
 


### PR DESCRIPTION
This can easily happen when calling `drop` on a hierarchy of datasets.
Maybe this is not even worth a message (it is not an error for sure),
as git annex will silently skip files that are in Git too.

Decided to go for an INFO message.