### PR TITLE
WIP: Fixing direct mode / V6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ script:
   # Run tests
   - PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO
   # Generate documentation and run doctests
-  - PYTHONPATH=$PWD make -C docs html doctest
+  - PYTHONPATH=$PWD $NOSE_WRAPPER make -C docs html doctest
   # Run javascript tests
   - grunt test --verbose
   # do not run them with custom TMPDIR with spaces for now : https://github.com/datalad/datalad/issues/893

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
   matrix:
     - DATALAD_REPO_DIRECT=1
     - DATALAD_REPO_DIRECT=
-    - DATALAD_REPO_VERSION=6
 # Disabled since old folks don't want to change workflows of submitting through central authority
 #    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
 #    - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
     |____/   \__,_|  \__|  \__,_| |_____|  \__,_|  \__,_|
                                                   Read me
 
-[![Travis tests status](https://secure.travis-ci.org/datalad/datalad.png?branch=develop)](https://travis-ci.org/datalad/datalad) [![codecov.io](https://codecov.io/github/datalad/datalad/coverage.svg?branch=develop)](https://codecov.io/github/datalad/datalad?branch=develop) [![Documentation](https://readthedocs.org/projects/datalad/badge/?version=latest)](http://datalad.rtfd.org)
+[![Travis tests status](https://secure.travis-ci.org/datalad/datalad.png?branch=master)](https://travis-ci.org/datalad/datalad) [![codecov.io](https://codecov.io/github/datalad/datalad/coverage.svg?branch=master)](https://codecov.io/github/datalad/datalad?branch=master) [![Documentation](https://readthedocs.org/projects/datalad/badge/?version=latest)](http://datalad.rtfd.org)
 
-Note:  Development branch
 
 # 1000ft overview
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -12,6 +12,14 @@ distribution with the convenience of git-annex repositories as a backend."""
 
 # Other imports are interspersed with lgr.debug to ease troubleshooting startup
 # delays etc.
+
+# If there is a bundled git, make sure GitPython uses it too:
+from datalad.cmd import GitRunner
+_git_runner = GitRunner()
+if _git_runner._GIT_PATH:
+    import os
+    os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = os.path.join(_git_runner._GIT_PATH, 'git')
+
 from .config import ConfigManager
 cfg = ConfigManager()
 

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -254,14 +254,16 @@ def pipeline(dataset,
                                             ('ds005\.tgz', 'ds005_raw.tgz'),
                                             # had it split into this one with derived data separately and then joined
                                             ('ds007_01-20\.tgz', 'ds007_raw.tgz'),
+                                            ('ds000107_raw\.', 'ds000107.'),
                                             # generic
                                             ('^ds0*', '^ds'),
                                             ('\.(zip|tgz|tar\.gz)$', '.ext')
                                         ],
                                         # Had manually to do this for this one since there was a switch from
                                         # overlay layout to even bigger single one within a minor 2.0.1 "release"
+                                        # 158 -- 1.0.1 changed layout completely so should not be overlayed ATM
                                         overlay=None
-                                            if dataset in ('ds000007', 'ds000114', 'ds000119')
+                                            if dataset in ('ds000007', 'ds000114', 'ds000119', 'ds000158')
                                             else versions_overlay_level,  # use major.minor to define overlays
                                         #overlay=None, # use major.minor to define overlays
                                         exclude='(README|changelog).*'),

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -21,6 +21,7 @@ from datalad.interface.base import Interface
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 from datalad.interface.common_opts import nosave_opt
+from datalad.interface.common_opts import save_message_opt
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_add_opts
@@ -129,6 +130,7 @@ class Add(Interface):
             no effect. Regular files and directories are always added to
             their respective datasets, regardless of this setting."""),
         save=nosave_opt,
+        message=save_message_opt,
         git_opts=git_opts,
         annex_opts=annex_opts,
         annex_add_opts=annex_add_opts,
@@ -142,6 +144,7 @@ class Add(Interface):
             dataset=None,
             to_git=False,
             save=True,
+            message=None,
             recursive=False,
             recursion_limit=None,
             ds2super=False,
@@ -238,7 +241,7 @@ class Add(Interface):
             save_dataset_hierarchy(
                 content_by_ds,
                 base=dataset.path if dataset and dataset.is_installed() else None,
-                message='[DATALAD] added content')
+                message=message if message else '[DATALAD] added content')
 
         return results
 

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -12,42 +12,207 @@
 __docformat__ = 'restructuredtext'
 
 
-import logging
-import datalad
-from os.path import join as opj, abspath, basename, relpath, normpath, dirname
 from distutils.version import LooseVersion
 from glob import glob
+import logging
+from os.path import join as opj, relpath, normpath, dirname, curdir
 
-from datalad.support.network import RI, URL, SSHRI
-from datalad.support.gitrepo import GitRepo
-from datalad.support.param import Parameter
+import datalad
+from datalad import ssh_manager
+from datalad.cmd import CommandError
+from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
+from datalad.consts import TIMESTAMP_FMT
 from datalad.dochelpers import exc_str
-from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
-from datalad.support.constraints import EnsureChoice
-from datalad.support.annexrepo import AnnexRepo
-from ..interface.base import Interface
-from datalad.interface.common_opts import recursion_flag
+from datalad.distribution.add_sibling import AddSibling
+from datalad.distribution.dataset import EnsureDataset, Dataset, \
+    datasetmethod, require_dataset
+from datalad.interface.base import Interface
+from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import as_common_datasrc
 from datalad.interface.common_opts import publish_by_default
 from datalad.interface.common_opts import publish_depends
-from datalad.distribution.dataset import EnsureDataset, Dataset, \
-    datasetmethod, require_dataset
-from datalad.cmd import CommandError
-from datalad.utils import not_supported_on_windows, getpwd
-from .add_sibling import AddSibling
-from datalad import ssh_manager
+from datalad.interface.utils import filter_unmodified
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
+from datalad.support.constraints import EnsureChoice
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.network import RI
+from datalad.support.network import is_ssh
+from datalad.support.param import Parameter
 from datalad.utils import make_tempfile
-from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
-from datalad.consts import TIMESTAMP_FMT
+from datalad.utils import not_supported_on_windows
 from datalad.utils import _path_
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 
 
-class CreateSibling(Interface):
-    """Create dataset(s)'s sibling (e.g., on a web server).
+def _create_dataset_sibling(
+        name,
+        ds,
+        hierarchy_basepath,
+        ssh,
+        replicate_local_structure,
+        ssh_url,
+        target_dir,
+        target_url,
+        target_pushurl,
+        existing,
+        shared,
+        remote_git_version,
+        publish_depends,
+        publish_by_default,
+        as_common_datasrc):
+    localds_path = ds.path
+    ds_name = relpath(localds_path, start=hierarchy_basepath)
+    if not replicate_local_structure:
+        ds_name = '' if ds_name == curdir \
+            else '-{}'.format(ds_name.replace("/", "-"))
+        remoteds_path = target_dir.replace(
+            "%RELNAME",
+            ds_name)
+    else:
+        # TODO: opj depends on local platform, not the remote one.
+        # check how to deal with it. Does windows ssh server accept
+        # posix paths? vice versa? Should planned SSH class provide
+        # tools for this issue?
+        # see gh-1188
+        remoteds_path = normpath(opj(target_dir, ds_name))
 
-    Those (empty) datasets can then serve as a target for the `publish` command.
+    # construct a would-be ssh url based on the current dataset's path
+    ssh_url.path = remoteds_path
+    ds_sshurl = ssh_url.as_str()
+    # configure dataset's git-access urls
+    ds_target_url = target_url.replace('%RELNAME', ds_name) \
+        if target_url else ds_sshurl
+    # push, configure only if needed
+    ds_target_pushurl = None
+    if ds_target_url != ds_sshurl:
+        # not guaranteed that we can push via the primary URL
+        ds_target_pushurl = target_pushurl.replace('%RELNAME', ds_name) \
+            if target_pushurl else ds_sshurl
+
+    lgr.info("Creating target dataset {0} at {1}".format(
+        localds_path, remoteds_path))
+    # Must be set to True only if exists and existing='reconfigure'
+    # otherwise we might skip actions if we say existing='reconfigure'
+    # but it did not even exist before
+    only_reconfigure = False
+    if remoteds_path != '.':
+        # check if target exists
+        # TODO: Is this condition valid for != '.' only?
+        path_exists = True
+        try:
+            out, err = ssh(["ls", remoteds_path])
+        except CommandError as e:
+            if "No such file or directory" in e.stderr and \
+                    remoteds_path in e.stderr:
+                path_exists = False
+            else:
+                raise  # It's an unexpected failure here
+
+        if path_exists:
+            if existing == 'error':
+                raise RuntimeError(
+                    "Target directory {} already exists.".format(
+                        remoteds_path))
+            elif existing == 'skip':
+                return
+            elif existing == 'replace':
+                # enable write permissions to allow removing dir
+                ssh(["chmod", "+r+w", "-R", remoteds_path])
+                # remove target at path
+                ssh(["rm", "-rf", remoteds_path])
+                # if we succeeded in removing it
+                path_exists = False
+            elif existing == 'reconfigure':
+                only_reconfigure = True
+            else:
+                raise ValueError(
+                    "Do not know how to handle existing={}".format(
+                        repr(existing)))
+
+        if not path_exists:
+            try:
+                ssh(["mkdir", "-p", remoteds_path])
+            except CommandError as e:
+                lgr.error("Remotely creating target directory failed at "
+                          "%s.\nError: %s" % (remoteds_path, exc_str(e)))
+                return
+
+    # don't (re-)initialize dataset if existing == reconfigure
+    if not only_reconfigure:
+        # init git and possibly annex repo
+        if not CreateSibling.init_remote_repo(
+                remoteds_path, ssh, shared, ds,
+                description=target_url):
+            return
+
+    # at this point we have a remote sibling in some shape or form
+    # -> add as remote
+    lgr.debug("Adding the siblings")
+    AddSibling.__call__(
+        dataset=ds,
+        name=name,
+        url=ds_target_url,
+        pushurl=ds_target_pushurl,
+        recursive=False,
+        fetch=True,
+        force=existing in {'replace'},
+        as_common_datasrc=as_common_datasrc,
+        publish_by_default=publish_by_default,
+        publish_depends=publish_depends)
+
+    # check git version on remote end
+    lgr.info("Adjusting remote git configuration")
+    if remote_git_version and remote_git_version >= "2.4":
+        # allow for pushing to checked out branch
+        try:
+            ssh(["git", "-C", remoteds_path] +
+                ["config", "receive.denyCurrentBranch", "updateInstead"])
+        except CommandError as e:
+            lgr.error("git config failed at remote location %s.\n"
+                      "You will not be able to push to checked out "
+                      "branch. Error: %s", remoteds_path, exc_str(e))
+    else:
+        lgr.error("Git version >= 2.4 needed to configure remote."
+                  " Version detected on server: %s\nSkipping configuration"
+                  " of receive.denyCurrentBranch - you will not be able to"
+                  " publish updates to this repository. Upgrade your git"
+                  " and run with --existing=reconfigure"
+                  % remote_git_version)
+
+    # enable metadata refresh on dataset updates to publication server
+    lgr.info("Enabling git post-update hook ...")
+    try:
+        CreateSibling.create_postupdate_hook(
+            remoteds_path, ssh, ds)
+    except CommandError as e:
+        lgr.error("Failed to add json creation command to post update "
+                  "hook.\nError: %s" % exc_str(e))
+
+    return remoteds_path
+
+
+class CreateSibling(Interface):
+    """Create a dataset sibling on a UNIX-like SSH-accessible machine
+
+    Given a local dataset, and SSH login information this command creates
+    a remote dataset repository and configures it as a dataset sibling to
+    be used as a publication target (see `publish` command).
+
+    Various properties of the remote sibling can be configured (e.g. name
+    location on the server, read and write access URLs, and access
+    permissions.
+
+    Optionally, a basic web-viewer for DataLad datasets can be installed
+    at the remote location.
+
+    This command supports recursive processing of dataset hierarchies, creating
+    a remote sibling for each dataset in the hierarchy. By default, remote
+    siblings are created in hierarchical structure that reflects the
+    organization on the local file system. However, a simple templating
+    mechanism is provided to produce a flat list of datasets (see
+    --target-dir).
     """
 
     _params_ = dict(
@@ -66,15 +231,13 @@ class CreateSibling(Interface):
                 Unless overridden, this also serves the future dataset's access
                 URL and path on the server.""",
             constraints=EnsureStr()),
-        target=Parameter(
-            args=('target',),
-            metavar='TARGETNAME',
+        name=Parameter(
+            args=('-s', '--name',),
+            metavar='NAME',
             doc="""sibling name to create for this publication target.
                 If `recursive` is set, the same name will be used to label all
-                the subdatasets' siblings.  Note, this is just a
-                convenience option, siblings can also be added at a later point
-                in time.  When creation target datasets fails, no siblings are
-                added""",
+                the subdatasets' siblings. When creating a target dataset fails,
+                no sibling is added""",
             constraints=EnsureStr() | EnsureNone(),
             nargs="?"),
         target_dir=Parameter(
@@ -91,9 +254,9 @@ class CreateSibling(Interface):
                 possible to provide a template for generating different target
                 directory names for all (sub)datasets. Templates can contain
                 certain placeholder that are substituted for each (sub)dataset.
-                For example: "/mydirectory/dataset-%%NAME".\nSupported
+                For example: "/mydirectory/dataset%%RELNAME".\nSupported
                 placeholders:\n
-                %%NAME - the name of the datasets, with any slashes replaced by
+                %%RELNAME - the name of the datasets, with any slashes replaced by
                 dashes\n""",
             constraints=EnsureStr() | EnsureNone()),
         target_url=Parameter(
@@ -115,16 +278,17 @@ class CreateSibling(Interface):
                 placeholders) are supported.\n""",
             constraints=EnsureStr() | EnsureNone()),
         recursive=recursion_flag,
+        recursion_limit=recursion_limit,
         existing=Parameter(
             args=("--existing",),
             constraints=EnsureChoice('skip', 'replace', 'error', 'reconfigure'),
             metavar='MODE',
-            doc="""action to perform, if target directory exists already.
-                Dataset is skipped if 'skip'. 'replace' forces to (re-)init
-                the dataset, and to (re-)configure the dataset sibling,
-                i.e. its URL(s), in case it already exists. 'reconfigure'
-                updates metadata of the dataset sibling. 'error' causes
-                an exception to be raised.""",),
+            doc="""action to perform, if a sibling is already configured under the
+            given name and/or a target directory already exists.
+            In this case, a dataset can be skipped ('skip'), an existing target
+            directory be forcefully re-initialized, and the sibling (re-)configured
+            ('replace', implies 'reconfigure'), the sibling configuration be updated
+            only ('reconfigure'), or to error ('error').""",),
         shared=Parameter(
             args=("--shared",),
             metavar='false|true|umask|group|all|world|everybody|0xxx',
@@ -143,39 +307,107 @@ class CreateSibling(Interface):
         as_common_datasrc=as_common_datasrc,
         publish_depends=publish_depends,
         publish_by_default=publish_by_default,
+        since=Parameter(
+            args=("--since",),
+            constraints=EnsureStr() | EnsureNone(),
+            doc="""limit processing to datasets that have been changed since a given
+            state (by tag, branch, commit, etc). This can be used to create siblings
+            for recently added subdatasets."""),
     )
 
     @staticmethod
     @datasetmethod(name='create_sibling')
-    def __call__(sshurl, target=None, target_dir=None,
+    def __call__(sshurl, name=None, target_dir=None,
                  target_url=None, target_pushurl=None,
-                 dataset=None, recursive=False,
+                 dataset=None,
+                 recursive=False,
+                 recursion_limit=None,
                  existing='error', shared=False, ui=False,
                  as_common_datasrc=None,
                  publish_by_default=None,
-                 publish_depends=None):
+                 publish_depends=None,
+                 since=None):
 
-        if sshurl is None:
-            raise ValueError("""insufficient information for target creation
-            (needs at least a dataset and a SSH URL).""")
+        # there is no point in doing anything further
+        not_supported_on_windows(
+            "Support for SSH connections is not yet implemented in Windows")
 
-        if target is None and (target_url is not None or
-                               target_pushurl is not None):
-            raise ValueError("""insufficient information for adding the target
-            as a sibling (needs at least a name)""")
+        if not sshurl:
+            raise InsufficientArgumentsError(
+                "need at least an SSH URL")
 
-        # shortcut
+        # check the login URL
+        sshri = RI(sshurl)
+        if not is_ssh(sshri):
+            raise ValueError(
+                "Unsupported SSH URL: '{0}', "
+                "use ssh://host/path or host:path syntax".format(sshurl))
+
+        if not name:
+            # use the hostname as default remote name
+            name = sshri.hostname
+            lgr.debug(
+                "No sibling name given, use URL hostname '%s' as sibling name",
+                name)
+
         ds = require_dataset(dataset, check_installed=True,
                              purpose='creating a sibling')
 
+        # use common sorting implementation to discover all subdatasets
+        content_by_ds, unavailable_paths = Interface._prep(
+            # the base data set is the only path
+            path=ds.path,
+            dataset=ds,
+            recursive=recursive,
+            recursion_limit=recursion_limit)
+        # dataset arg was tested before, only existing dataset should be reported
+        assert(not unavailable_paths)
+
+        # anal verification
         assert(ds is not None and sshurl is not None and ds.repo is not None)
 
-        # determine target parameters:
-        sshri = RI(sshurl)
+        if since:
+            mod_subs = []
+            content_by_ds = filter_unmodified(content_by_ds, ds, since)
+            # look for those subdatasets that are listed as modified
+            # together with a .gitmodules change
+            for d, paths in content_by_ds.items():
+                if any(p.endswith('.gitmodules') for p in paths):
+                    mod_subs.extend(p for p in paths if p in content_by_ds)
+            content_by_ds = mod_subs
 
-        if not isinstance(sshri, SSHRI) \
-                and not (isinstance(sshri, URL) and sshri.scheme == 'ssh'):
-                    raise ValueError("Unsupported SSH URL: '{0}', use ssh://host/path or host:path syntax".format(sshurl))
+        # dataset instances
+        datasets = {p: Dataset(p) for p in content_by_ds}
+
+        # find datasets with existing remotes with the target name
+        remote_existing = [p for p in datasets
+                           if name in datasets[p].repo.get_remotes()]
+        if existing == 'error' and remote_existing:
+            raise ValueError(
+                "sibling '{name}' already configured for dataset{plural}: "
+                "{existing}. Specify alternative sibling name, or force "
+                "reconfiguration via --existing".format(
+                    name=name,
+                    existing=remote_existing,
+                    plural='s' if len(remote_existing) > 1 else ''))
+        if existing == 'skip':
+            # no need to process already configured datasets
+            lgr.info(
+                "Skipping dataset{plural} with an already configured "
+                "sibling '{name}': {existing}".format(
+                    name=name,
+                    existing=remote_existing,
+                    plural='s' if len(remote_existing) > 1 else ''))
+            datasets = {p: d for p, d in datasets.items()
+                        if p not in remote_existing}
+
+        if not datasets:
+            # we ruled out all possibilities
+            # TODO wait for gh-1218 and make better return values
+            lgr.info("No datasets qualify for sibling creation. "
+                     "Consider different settings for --existing "
+                     "or --since if this is unexpected")
+            return
 
         if target_dir is None:
             if sshri.path:
@@ -185,31 +417,14 @@ class CreateSibling(Interface):
 
         # TODO: centralize and generalize template symbol handling
         replicate_local_structure = False
-        if "%NAME" not in target_dir:
+        if "%RELNAME" not in target_dir:
             replicate_local_structure = True
 
-        # collect datasets to use:
-        datasets = dict()
-        datasets[basename(ds.path)] = ds
-        if recursive:
-            for subds in ds.get_subdatasets(recursive=True):
-                sub_path = opj(ds.path, subds)
-                # TODO: when enhancing Dataset/*Repo classes and therefore
-                # adapt to moved code, make proper distinction between name and
-                # path of a submodule, which are technically different. This
-                # probably will become important on windows as well as whenever
-                # we want to allow for moved worktrees.
-                datasets[basename(ds.path) + '/' + subds] = \
-                    Dataset(sub_path)
-
         # request ssh connection:
-        not_supported_on_windows("TODO")
         lgr.info("Connecting ...")
         ssh = ssh_manager.get_connection(sshurl)
         ssh.open()
-
-        # flag to check if at dataset_root
-        at_root = True
+        remote_git_version = CreateSibling.get_remote_git_version(ssh)
 
         # loop over all datasets, ordered from top to bottom to make test
         # below valid (existing directories would cause the machinery to halt)
@@ -219,109 +434,35 @@ class CreateSibling(Interface):
         for current_dspath in \
                 sorted(datasets.keys(), key=lambda x: x.count('/')):
             current_ds = datasets[current_dspath]
-            if not current_ds.is_installed():
-                lgr.info("Skipping %s since not installed locally", current_dspath)
+            path = _create_dataset_sibling(
+                name,
+                current_ds,
+                ds.path,
+                ssh,
+                replicate_local_structure,
+                sshri,
+                target_dir,
+                target_url,
+                target_pushurl,
+                existing,
+                shared,
+                remote_git_version,
+                publish_depends,
+                publish_by_default,
+                as_common_datasrc)
+            if not path:
+                # nothing new was created
                 continue
-            if not replicate_local_structure:
-                path = target_dir.replace("%NAME",
-                                          current_dspath.replace("/", "-"))
-            else:
-                # TODO: opj depends on local platform, not the remote one.
-                # check how to deal with it. Does windows ssh server accept
-                # posix paths? vice versa? Should planned SSH class provide
-                # tools for this issue?
-                path = normpath(opj(target_dir,
-                                    relpath(datasets[current_dspath].path,
-                                            start=ds.path)))
-
-            lgr.info("Creating target dataset {0} at {1}".format(current_dspath, path))
-            # Must be set to True only if exists and existing='reconfigure'
-            # otherwise we might skip actions if we say existing='reconfigure'
-            # but it did not even exist before
-            only_reconfigure = False
-            if path != '.':
-                # check if target exists
-                # TODO: Is this condition valid for != '.' only?
-                path_exists = True
-                try:
-                    out, err = ssh(["ls", path])
-                except CommandError as e:
-                    if "No such file or directory" in e.stderr and \
-                            path in e.stderr:
-                        path_exists = False
-                    else:
-                        raise  # It's an unexpected failure here
-
-                if path_exists:
-                    if existing == 'error':
-                        raise RuntimeError("Target directory %s already exists." % path)
-                    elif existing == 'skip':
-                        continue
-                    elif existing == 'replace':
-                        ssh(["chmod", "+r+w", "-R", path])  # enable write permissions to allow removing dir
-                        ssh(["rm", "-rf", path])            # remove target at path
-                        path_exists = False                 # if we succeeded in removing it
-                    elif existing == 'reconfigure':
-                        only_reconfigure = True
-                    else:
-                        raise ValueError("Do not know how to handle existing=%s" % repr(existing))
-
-                if not path_exists:
-                    try:
-                        ssh(["mkdir", "-p", path])
-                    except CommandError as e:
-                        lgr.error("Remotely creating target directory failed at "
-                                  "%s.\nError: %s" % (path, exc_str(e)))
-                        continue
-
-            # don't (re-)initialize dataset if existing == reconfigure
-            if not only_reconfigure:
-                # init git and possibly annex repo
-                if not CreateSibling.init_remote_repo(
-                        path, ssh, shared, datasets[current_dspath],
-                        description=target_url):
-                    continue
-
-            # check git version on remote end
-            lgr.info("Adjusting remote git configuration")
-            remote_git_version = CreateSibling.get_remote_git_version(ssh)
-            if remote_git_version and remote_git_version >= "2.4":
-                # allow for pushing to checked out branch
-                try:
-                    ssh(["git", "-C", path] +
-                        ["config", "receive.denyCurrentBranch", "updateInstead"])
-                except CommandError as e:
-                    lgr.error("git config failed at remote location %s.\n"
-                              "You will not be able to push to checked out "
-                              "branch. Error: %s", path, exc_str(e))
-            else:
-                lgr.error("Git version >= 2.4 needed to configure remote."
-                          " Version detected on server: %s\nSkipping configuration"
-                          " of receive.denyCurrentBranch - you will not be able to"
-                          " publish updates to this repository. Upgrade your git"
-                          " and run with --existing=reconfigure"
-                          % remote_git_version)
-
-            # enable metadata refresh on dataset updates to publication server
-            lgr.info("Enabling git post-update hook ...")
-            try:
-                CreateSibling.create_postupdate_hook(
-                    path, ssh, datasets[current_dspath])
-            except CommandError as e:
-                lgr.error("Failed to add json creation command to post update "
-                          "hook.\nError: %s" % exc_str(e))
+            remote_repos_to_run_hook_for.append(path)
 
             # publish web-interface to root dataset on publication server
-            if at_root and ui:
+            if current_dspath == ds.path and ui:
                 lgr.info("Uploading web interface to %s" % path)
-                at_root = False
                 try:
                     CreateSibling.upload_web_interface(path, ssh, shared, ui)
                 except CommandError as e:
                     lgr.error("Failed to push web interface to the remote "
                               "datalad repository.\nError: %s" % exc_str(e))
-
-            remote_repos_to_run_hook_for.append(path)
 
         # in reverse order would be depth first
         lgr.debug("Running post-update hooks in all created siblings")
@@ -335,24 +476,6 @@ class CreateSibling(Interface):
             except CommandError as e:
                 lgr.error("Failed to run post-update hook under path %s. "
                           "Error: %s" % (path, exc_str(e)))
-
-        if target:
-            # add the sibling(s):
-            lgr.debug("Adding the siblings")
-            if target_url is None:
-                target_url = sshurl
-            if target_pushurl is None and sshurl != target_url:
-                target_pushurl = sshurl
-            AddSibling()(dataset=ds,
-                         name=target,
-                         url=target_url,
-                         pushurl=target_pushurl,
-                         recursive=recursive,
-                         fetch=True,
-                         force=existing in {'replace'},
-                         as_common_datasrc=as_common_datasrc,
-                         publish_by_default=publish_by_default,
-                         publish_depends=publish_depends)
 
         # TODO: Return value!?
         #       => [(Dataset, fetch_url)]

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -35,40 +35,38 @@ from .add_sibling import AddSibling
 lgr = logging.getLogger('datalad.distribution.create_sibling_github')
 
 
-def _get_github_entity(gh, cred, github_user, github_passwd, github_organization):
-    # figure out authentication
-    if not (github_user and github_passwd):
-        # access to the system secrets
-        if github_user:
-            # check that they keystore knows about this user
-            if github_user != cred.get('user', github_user):
-                # there is a mismatch, we need to ask
-                creds = cred.enter_new()
-                github_user = creds['user']
-                github_passwd = creds['password']
+def _get_github_entity(gh, cred, github_login, github_passwd, github_organization):
+    if github_login == 'disabledloginfortesting':
+        raise gh.BadCredentialsException(403, 'no login specified')
+    if not (github_login and github_passwd):
+        # we don't have both
+        # check if there is an oauth token from
+        # https://github.com/sociomantic/git-hub
+        token = False
+        if not cred.is_known:
+            if not github_login:
+                # try find a token as login
+                github_login = cfg.get('hub.oauthtoken', None)
+                token = True
+            if not (github_login and (github_passwd or token)):
+                # still at least one missing, utilize the credential store
+                # to get auth info, pass potential passwd value along
+                cred.enter_new(
+                    user=github_login,
+                    password=github_passwd)
+        # now we should really have it
+        creds = cred()
+        github_login = creds['user']
+        github_passwd = creds['password']
 
-        # if a user is provided, go with it, don't even ask any store
-        if github_user is None and not cred.is_known:
-            # let's figure out authentication
-            if github_user is None:
-                # check if there is an oauth token from
-                # https://github.com/sociomantic/git-hub
-                github_user = cfg.get('hub.oauthtoken', None)
-
-        if github_user is None:
-            # still nothing, ask if necessary
-            creds = cred()
-            github_user = creds['user']
-            github_passwd = creds['password']
-
-    if not github_user:
-        raise gh.BadCredentialsException(403, 'no user specified')
+    if not github_login:
+        raise gh.BadCredentialsException(403, 'no login specified')
 
     # this will always succeed, but it might later throw an exception
     # if the credentials were wrong
-    # XXX make sure to wipe out known credentials if that happens
+    # and this case, known credentials are wiped out again below
     authed_gh = gh.Github(
-        github_user,
+        github_login,
         password=github_passwd)
 
     try:
@@ -91,7 +89,7 @@ def _get_github_entity(gh, cred, github_user, github_passwd, github_organization
 
 
 def _make_github_repos(
-        gh, github_user, github_passwd, github_organization, rinfo, existing,
+        gh, github_login, github_passwd, github_organization, rinfo, existing,
         access_protocol, dryrun):
     cred = UserPassword('github', 'https://github.com/login')
 
@@ -99,7 +97,7 @@ def _make_github_repos(
     entity = _get_github_entity(
         gh,
         cred,
-        github_user,
+        github_login,
         github_passwd,
         github_organization)
 
@@ -220,8 +218,8 @@ class CreateSiblingGithub(Interface):
             constraints=EnsureStr()),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
-        sibling_name=Parameter(
-            args=('--sibling-name',),
+        name=Parameter(
+            args=('-s', '--name',),
             metavar='NAME',
             doc="""name to represent the Github repository in the local
             dataset installation""",
@@ -234,11 +232,11 @@ class CreateSiblingGithub(Interface):
             siblings are discovered. 'skip': ignore; 'error': fail immediately;
             'reconfigure': use the existing repository and reconfigure the
             local dataset to use it as a sibling""",),
-        github_user=Parameter(
-            args=('--github-user',),
+        github_login=Parameter(
+            args=('--github-login',),
             constraints=EnsureStr() | EnsureNone(),
             metavar='NAME',
-            doc="""Github user name"""),
+            doc="""Github user name or access token"""),
         github_passwd=Parameter(
             args=('--github-passwd',),
             constraints=EnsureStr() | EnsureNone(),
@@ -272,9 +270,9 @@ class CreateSiblingGithub(Interface):
             dataset=None,
             recursive=False,
             recursion_limit=None,
-            sibling_name='github',
+            name='github',
             existing='error',
-            github_user=None,
+            github_login=None,
             github_passwd=None,
             github_organization=None,
             access_protocol='git',
@@ -310,10 +308,10 @@ class CreateSiblingGithub(Interface):
         # check for existing remote configuration
         filtered = []
         for d, mp in toprocess:
-            if sibling_name in d.repo.get_remotes():
+            if name in d.repo.get_remotes():
                 if existing == 'error':
                     msg = '{} already had a configured sibling "{}"'.format(
-                        d, sibling_name)
+                        d, name)
                     if dryrun:
                         lgr.error(msg)
                     else:
@@ -332,7 +330,7 @@ class CreateSiblingGithub(Interface):
 
         # actually make it happen on Github
         rinfo = _make_github_repos(
-            gh, github_user, github_passwd, github_organization, filtered,
+            gh, github_login, github_passwd, github_organization, filtered,
             existing, access_protocol, dryrun)
 
         # lastly configure the local datasets
@@ -340,12 +338,12 @@ class CreateSiblingGithub(Interface):
             if not dryrun:
                 # first make sure that annex doesn't touch this one
                 # but respect any existing config
-                ignore_var = 'remote.{}.annex-ignore'.format(sibling_name)
+                ignore_var = 'remote.{}.annex-ignore'.format(name)
                 if not ignore_var in d.config:
                     d.config.add(ignore_var, 'true', where='local')
                 AddSibling()(
                     dataset=d,
-                    name=sibling_name,
+                    name=name,
                     url=url,
                     recursive=False,
                     # TODO fetch=True, maybe only if one existed already
@@ -369,5 +367,5 @@ class CreateSiblingGithub(Interface):
                     "'{}'{} configured as sibling '{}' for {}".format(
                         url,
                         " (existing repository)" if existed else '',
-                        args.sibling_name,
+                        args.name,
                         d))

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -12,9 +12,8 @@
 
 import logging
 
-from os.path import join as opj
-
 from datalad.interface.base import Interface
+from datalad.interface.utils import filter_unmodified
 from datalad.interface.common_opts import annex_copy_opts, recursion_flag, \
     recursion_limit, git_opts, annex_opts
 from datalad.support.param import Parameter
@@ -22,20 +21,17 @@ from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import IncompleteResultsError
-from datalad.dochelpers import exc_str
-from datalad.utils import assure_list
 
 from .dataset import EnsureDataset
 from .dataset import Dataset
 from .dataset import datasetmethod
-from .dataset import require_dataset
 
 __docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.distribution.publish')
 
 # TODO: make consistent configurable output
+
 
 def _log_push_info(pi_list):
     from git.remote import PushInfo as PI
@@ -50,12 +46,112 @@ def _log_push_info(pi_list):
         lgr.warning("Nothing was pushed.")
 
 
+def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
+    published, skipped = [], []
+    # upstream refspec needed for update (merge) and subsequent push,
+    # in case there is no.
+    # no tracking refspec yet?
+    # TODO what if `to` was given, doesn't have tracking info in this case
+    set_upstream = refspec is None
+
+    # check if there are any differences wrt the to-be-published paths,
+    # and if not skip this dataset
+    if refspec:
+        # we have a matching branch on the other side
+        diff = ds.repo.repo.commit().diff(
+            refspec.replace(
+                'refs/heads/',
+                'refs/remotes/{}/'.format(remote)),
+            paths=paths)
+    else:
+        # there was no tracking branch, check the push target
+        active_branch = ds.repo.get_active_branch()
+        refspec = active_branch
+        if active_branch in ds.repo.repo.remotes[remote].refs:
+            # we know some remote state -> diff
+            diff = ds.repo.repo.commit().diff(
+                ds.repo.repo.remotes[remote].refs[active_branch],
+                paths=paths)
+        else:
+            # we don't have any remote state, need to push for sure
+            diff = True
+    if not diff:
+        return published, skipped
+
+    # in order to be able to use git's config to determine what to push,
+    # we need to annex merge first. Otherwise a git push might be
+    # rejected if involving all matching branches for example.
+    # Once at it, also push the annex branch right here.
+    if isinstance(ds.repo, AnnexRepo):
+        ds.repo.fetch(remote=remote)
+        ds.repo.merge_annex(remote)
+        _log_push_info(ds.repo.push(remote=remote,
+                                    refspec="git-annex:git-annex"))
+
+    # publishing of `remote` might depend on publishing other
+    # remote(s) first:
+    # define config var name for potential publication dependencies
+    depvar = 'remote.{}.datalad-publish-depends'.format(remote)
+    for d in ds.config.get(depvar, []):
+        lgr.info("Dependency detected: '%s'" % d)
+        # call this again to take care of the dependency first,
+        # but keep the paths the same, as the goal is to publish those
+        # to the primary remote, and not anything elase to a dependency
+        pblsh, skp = _publish_dataset(ds, d, None, paths)
+        published.extend(pblsh)
+        skipped.extend(skp)
+
+    lgr.info("Publishing {0} to {1}".format(ds, remote))
+
+    # we now know where to push to:
+    # TODO: what to push? default: git push --mirror if nothing configured?
+    # consider also: --follow-tags, --tags, --atomic
+
+    # Note: git's push.default is 'matching', which possibly doesn't
+    # work for first
+    # time publication (a branch, that doesn't exist on remote yet)
+    # But if we want to respect remote.*.push entries, etc. we need to
+    # not pass a specific refspec (like active branch) to `git push`
+    # by default.
+
+    _log_push_info(ds.repo.push(remote=remote,
+                                refspec=refspec,
+                                set_upstream=set_upstream))
+
+    published.append(ds)
+
+    if (paths or annex_copy_opts) and \
+            isinstance(ds.repo, AnnexRepo) and not \
+            ds.config.get('remote.{}.annex-ignore', False):
+        lgr.info("Publishing data of dataset {0} ...".format(ds))
+        pblshd = ds.repo.copy_to(files=paths,
+                                 remote=remote,
+                                 options=annex_copy_options)
+        published += pblshd
+
+    return published, skipped
+
+
 class Publish(Interface):
     """Publish a dataset to a known :term:`sibling`.
 
     This makes the last saved state of a dataset available to a sibling
-    or special remote data store of the dataset which must already exist
-    and be known to the dataset.
+    or special remote data store of a dataset. Any target sibling must already
+    exist and be known to the dataset.
+
+    Optionally, it is possible to limit publication to change sets relative
+    to a particular point in the version history of a dataset (e.g. a release
+    tag). By default, the state of the local dataset is evaluated against the
+    last known state of the target sibling. Actual publication is only attempted
+    if there was a change compared to the reference state, in order to speed up
+    processing of large collections of datasets. Evaluation with respect to
+    a particular "historic" state is only supported in conjunction with a
+    specified reference dataset. Change sets are also evaluated recursively, i.e.
+    only those subdatasets are published where a change was recorded that is
+    reflected in to current state of the top-level reference dataset.
+
+    Only publication of saved changes is supported. Any unsaved changes in a
+    dataset (hierarchy) have to be saved before publication.
 
     .. note::
       Power-user info: This command uses :command:`git push`, and :command:`git annex copy`
@@ -70,23 +166,19 @@ class Publish(Interface):
     #        upstream set up before, so you can use just "datalad publish" next
     #        time.
 
-    # TODO: Doc!
-
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
             metavar='DATASET',
-            doc="""specify the dataset to publish. If no dataset is given, an
-            attempt is made to identify the dataset based on the current
-            working directory""",
+            doc="""specify the (top-level) dataset to be published. If no dataset
+            is given, the datasets are determined based on the input arguments""",
             constraints=EnsureDataset() | EnsureNone()),
         to=Parameter(
             args=("--to",),
             metavar='LABEL',
-            doc="""sibling name identifying the publication target. If no
-            destination is given an attempt is made to identify the target
-            based on the dataset's configuration (i.e. a set up tracking
-            branch)""",
+            doc="""name of the target sibling. If no name is given an attempt is
+            made to identify the target based on the dataset's configuration
+            (i.e. a configured tracking branch)""",
             # TODO: See TODO at top of class!
             constraints=EnsureStr() | EnsureNone()),
         since=Parameter(
@@ -136,238 +228,89 @@ class Publish(Interface):
             git_opts=None,
             annex_opts=None,
             annex_copy_opts=None):
-        # shortcut
-        ds = require_dataset(dataset, check_installed=True, purpose='publication')
-        assert(ds.repo is not None)
 
-        path = assure_list(path)
+        if since and not dataset:
+            raise InsufficientArgumentsError(
+                'Modification detection (--since) without a base dataset '
+                'is not supported')
 
-        # figure out, what to publish from what (sub)dataset:
-        publish_this = False   # whether to publish `ds`
-        publish_files = []     # which files to publish by `ds`
+        if dataset and not path:
+            # act on the whole dataset if nothing else was specified
+            path = dataset.path if isinstance(dataset, Dataset) else dataset
+        content_by_ds, unavailable_paths = Interface._prep(
+            path=path,
+            dataset=dataset,
+            recursive=recursive,
+            recursion_limit=recursion_limit)
+        if unavailable_paths:
+            raise ValueError(
+                'cannot publish content that is not available locally: %s',
+                unavailable_paths)
 
-        expl_subs = set()      # subdatasets to publish explicitly
-        publish_subs = dict()  # collect what to publish from subdatasets
-
-        if not path:
-            # publish `ds` itself, if nothing else is given:
-            publish_this = True
-        else:
-            for p in path:
-                subdatasets = ds.get_subdatasets()
-                if p in subdatasets:
-                    # p is a subdataset, that needs to be published itself
-                    expl_subs.add(p)
-                else:
-                    try:
-                        d = ds.get_containing_subdataset(p)
-                    except ValueError as e:
-                        # p is not in ds => skip:
-                        lgr.warning(str(e) + " - Skipped.")
-                        continue
-                    if d == ds:
-                        # p needs to be published from ds
-                        publish_this = True
-                        publish_files.append(p)
-                    else:
-                        # p belongs to subds `d`
-                        if not publish_subs[d.path]:
-                            publish_subs[d.path] = dict()
-                        if not publish_subs[d.d.path]['files']:
-                            publish_subs[d.d.path]['files'] = list()
-                        publish_subs[d.path]['dataset'] = d
-                        publish_subs[d.path]['files'].append(p)
-
-        if publish_this:
-            # Note: we need an upstream remote, if there's none given. We could
-            # wait for git push to complain, but we need to explicitly figure it
-            # out for pushing annex branch anyway and we might as well fail
-            # right here.
-
-            track_remote, track_branch = None, None
-
-            # keep `to` in case it's None for passing to recursive calls:
-            dest_resolved = to
+        # here is the plan
+        # 1. figure out remote to publish to
+        # 2. figure out which content needs to be published to this remote
+        # 3. look for any pre-publication dependencies of that remote
+        #    (i.e. remotes that need to be published to before)
+        # 4. publish the content needed to go to the primary remote to
+        #    the dependencies first, and to the primary afterwards
+        ds_remote_info = {}
+        for ds_path in content_by_ds:
+            ds = Dataset(ds_path)
             if to is None:
-                # TODO: If possible, avoid resolution herein and rely on git
-                # (or GitRepo respectively), meaning: Just pass `None`
-                # ATM conflicts with _get_changed_datasets => figure it out
-
-                track_remote, track_branch = ds.repo.get_tracking_branch()
+                # we need an upstream remote, if there's none given. We could
+                # wait for git push to complain, but we need to explicitly
+                # figure it out for pushing annex branch anyway and we might as
+                # well fail right here.
+                track_remote, track_refspec = ds.repo.get_tracking_branch()
                 if track_remote:
-                    dest_resolved = track_remote
+                    ds_remote_info[ds_path] = dict(zip(
+                        ('remote', 'refspec'),
+                        (track_remote, track_refspec)))
+                elif skip_failing:
+                    lgr.warning(
+                        'Cannot determine target sibling, skipping %s',
+                        ds)
+                    ds_remote_info[ds_path] = None
                 else:
                     # we have no remote given and no upstream => fail
                     raise InsufficientArgumentsError(
-                        "No known default target for "
-                        "publication and none given.")
-
-        subds_prev_hexsha = {}
-        if recursive:
-            all_subdatasets = ds.get_subdatasets(fulfilled=True)
-
-            # TODO: dest_resolved => to?
-            # Note: This is a bug anyway, since in actual recursive call `to` is
-            # passed in order to be resolved by the subdatasets themselves
-            # (might be None), but when considering what subdatasets to be
-            # published, we assume `dest_resolved` is the same for all of them.
-
-            # ==> TODO: RF to consider `since` only for the current ds and then go on
-            # recursively.
-
-            subds_to_consider = \
-                Publish._get_changed_datasets(
-                    ds.repo, all_subdatasets, dest_resolved, since=since) \
-                if publish_this \
-                else all_subdatasets
-            # if we were returned a dict, we got subds_prev_hexsha
-            if isinstance(subds_to_consider, dict):
-                subds_prev_hexsha = subds_to_consider
-            for subds_path in subds_to_consider:
-                if path and '.' in path:
-                    # we explicitly are passing '.' to subdatasets in case of
-                    # `recursive`. Therefore these datasets are going into
-                    # `publish_subs`, instead of `expl_subs`:
-                    sub = Dataset(opj(ds.path, subds_path))
-                    publish_subs[sub.path] = dict()
-                    publish_subs[sub.path]['dataset'] = sub
-                    publish_subs[sub.path]['files'] = ['.']
+                        'Cannot determine target sibling for %s' % (ds,))
+            elif to not in ds.repo.get_remotes():
+                # unknown given remote
+                if skip_failing:
+                    lgr.warning(
+                        "Unknown target sibling '%s', skipping %s",
+                        to, ds)
+                    ds_remote_info[ds_path] = None
                 else:
-                    # we can recursively publish only, if there actually
-                    # is something
-                    expl_subs.add(subds_path)
+                    raise ValueError(
+                        "Unknown target sibling '%s' for %s" % (to, ds))
+            else:
+                # all good: remote given and is known
+                ds_remote_info[ds_path] = {'remote': to}
+
+        if dataset and since:
+            # remove all unmodified components from the spec
+            content_by_ds = filter_unmodified(
+                content_by_ds, dataset, since)
 
         published, skipped = [], []
-
-        for dspath in sorted(expl_subs):
-            # these datasets need to be pushed regardless of additional paths
-            # pointing inside them
-            # due to API, this may not happen when calling publish with paths,
-            # therefore force it.
-            # TODO: There might be a better solution to avoid two calls of
-            # publish() on the very same Dataset instance
-            ds_ = Dataset(opj(ds.path, dspath))
-            try:
-                # we could take local diff for the subdataset
-                # but may be we could just rely on internal logic within
-                # subdataset to figure out what it needs to publish.
-                # But we need to pass empty string one inside as is
-                pkw = {}
-                if since == '':
-                    pkw['since'] = since
-                else:
-                    # pass previous state for that submodule if known
-                    pkw['since'] = subds_prev_hexsha.get(dspath, None)
-                published_, skipped_ = ds_.publish(to=to, recursive=recursive, **pkw)
-                published += published_
-                skipped += skipped_
-            except Exception as exc:
-                if not skip_failing:
-                    raise
-                lgr.warning("Skipped %s: %s", ds.path, exc_str(exc))
-                skipped += [ds_]
-
-        for d in publish_subs:
-            # recurse into subdatasets
-
-            # TODO: need to fetch. see above
-            publish_subs[d]['dataset'].repo.fetch(remote=to)
-
-            published_, skipped_ = publish_subs[d]['dataset'].publish(
-                to=to,
-                path=publish_subs[d]['files'],
-                recursive=recursive,
-                annex_copy_opts=annex_copy_opts)
-            published += published_
-            skipped += skipped_
-
-        if publish_this:
-
-            # is `to` an already known remote?
-            if dest_resolved not in ds.repo.get_remotes():
-                # unknown remote
-                raise ValueError("No sibling '{0}' found for {1}."
-                                 "".format(dest_resolved, ds))
-
-            # in order to be able to use git's config to determine what to push,
-            # we need to annex merge first. Otherwise a git push might be
-            # rejected if involving all matching branches for example.
-            # Once at it, also push the annex branch right here.
-
-            # Q: Do we need to respect annex-ignore here? Does it make sense to
-            # publish to a remote without pushing the annex branch
-            # (if there is any)?
-            if isinstance(ds.repo, AnnexRepo):
-                ds.repo.fetch(remote=dest_resolved)
-                ds.repo.merge_annex(dest_resolved)
-                _log_push_info(ds.repo.push(remote=dest_resolved,
-                                            refspec="git-annex:git-annex"))
-
-            # upstream branch needed for update (merge) and subsequent push,
-            # in case there is no.
-            # no tracking branch yet?
-            set_upstream = track_branch is None
-
-            # publishing of `dest_resolved` might depend on publishing other
-            # remote(s) first:
-            # define config var name for potential publication dependencies
-            depvar = 'remote.{}.datalad-publish-depends'.format(dest_resolved)
-            for d in ds.config.get(depvar, []):
-                lgr.info("Dependency detected: '%s'" % d)
-                # Note: Additional info on publishing the dep. comes from within
-                # `ds.publish`.
-                ds.publish(path=path,
-                           to=d,
-                           since=since,
-                           skip_failing=skip_failing,
-                           recursive=recursive,
-                           recursion_limit=recursion_limit,
-                           git_opts=git_opts,
-                           annex_opts=annex_opts,
-                           annex_copy_opts=annex_copy_opts)
-
-            lgr.info("Publishing {0} to {1}".format(ds, dest_resolved))
-
-            # we now know where to push to:
-            # TODO: what to push? default: git push --mirror if nothing configured?
-            # consider also: --follow-tags, --tags, --atomic
-
-            # Note: git's push.default is 'matching', which possibly doesn't
-            # work for first
-            # time publication (a branch, that doesn't exist on remote yet)
-            # But if we want to respect remote.*.push entries, etc. we need to
-            # not pass a specific refspec (like active branch) to `git push`
-            # by default.
-
-            _log_push_info(ds.repo.push(remote=dest_resolved,
-                                        refspec=ds.repo.get_active_branch(),
-                                        set_upstream=set_upstream))
-
-            published.append(ds)
-
-            if publish_files or annex_copy_opts:
-                if not isinstance(ds.repo, AnnexRepo):
-                    # incomplete, since `git push` was done already:
-                    raise IncompleteResultsError(
-                        (published, skipped),
-                        failed=publish_files,
-                        msg="Cannot publish content of something, that is not "
-                            "an annex. ({0})".format(ds))
-                if ds.config.get('remote.{}.annex-ignore', False):
-                    # Q: Do we need a --force option here? annex allows to
-                    # ignore the ignore setting
-                    raise IncompleteResultsError(
-                        (published, skipped),
-                        failed=publish_files,
-                        msg="Sibling '{0}' of {1} is configured to be ignored "
-                            "by annex. No content was published."
-                            % (dest_resolved, ds))
-
-                lgr.info("Publishing data of dataset {0} ...".format(ds))
-                published += ds.repo.copy_to(files=publish_files,
-                                             remote=dest_resolved,
-                                             options=annex_copy_opts)
-
+        for ds_path in content_by_ds:
+            remote_info = ds_remote_info[ds_path]
+            if not remote_info:
+                # in case we are skipping
+                continue
+            # and publish
+            ds = Dataset(ds_path)
+            pblsh, skp = _publish_dataset(
+                ds,
+                remote=remote_info['remote'],
+                refspec=remote_info.get('refspec', None),
+                paths=content_by_ds[ds_path],
+                annex_copy_options=annex_copy_opts)
+            published.extend(pblsh)
+            skipped.extend(skp)
         return published, skipped
 
     @staticmethod
@@ -388,32 +331,3 @@ class Publish(Interface):
                 else:
                     msg += "File: %s\n" % item
             ui.message(msg)
-
-    @staticmethod
-    def _get_changed_datasets(repo, all_subdatasets, to, since=None):
-        if since == '' or not all_subdatasets:
-            # we are instructed to publish all
-            return all_subdatasets
-
-        if since is None:  # default behavior - only updated since last update
-            # so we figure out what was the last update
-            # XXX here we assume one to one mapping of names from local branches
-            # to the remote
-            # TODO: This seems to be the only thing left, that we need to know the
-            # remote `to` for (if not explicitly specified anyway). Otherwise
-            # we could figure it out at GitRepo level instead, which makes
-            # things easier, cleaner and more in line with git push.
-            active_branch = repo.get_active_branch()
-            since = '%s/%s' % (to, active_branch)
-
-            if since not in repo.get_remote_branches():
-                # we did not publish it before - so everything must go
-                return all_subdatasets
-
-        lgr.debug("Checking diff since %s for %s" % (since, all_subdatasets))
-        diff = repo.repo.commit().diff(since, all_subdatasets)
-        for d in diff:
-            # not sure if it could even track renames of subdatasets
-            # but let's "check"
-            assert(d.a_path == d.b_path)
-        return dict((d.b_path, d.b_blob.hexsha if d.b_blob else None) for d in diff)

--- a/datalad/distribution/tests/test_add_sibling.py
+++ b/datalad/distribution/tests/test_add_sibling.py
@@ -52,7 +52,7 @@ def test_add_sibling(origin, repo_path):
     with assert_raises(RuntimeError) as cm:
         add_sibling(dataset=source, name="test-remote",
                     url="http://some.remo.te/location/elsewhere")
-    assert_in("""'test-remote' already exists with conflicting URL""",
+    assert_in("""'test-remote' already exists with conflicting settings""",
               str(cm.exception))
 
     # don't fail with conflicting url, when using force:
@@ -68,7 +68,7 @@ def test_add_sibling(origin, repo_path):
         add_sibling(dataset=source, name="test-remote",
                     url="http://some.remo.te/location/elsewhere",
                     pushurl="ssh://push.it", force=False)
-    assert_in("""'test-remote' already exists with conflicting URL""",
+    assert_in("""'test-remote' already exists with conflicting settings""",
               str(cm.exception))
 
     # add push url (force):

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -32,7 +32,7 @@ def test_invalid_call(path):
     assert_raises(ValueError, create_sibling_github, 'bogus', dataset=path)
     ds = Dataset(path).create()
     # no user
-    assert_raises(gh.BadCredentialsException, ds.create_sibling_github, 'bogus', github_user='')
+    assert_raises(gh.BadCredentialsException, ds.create_sibling_github, 'bogus', github_login='disabledloginfortesting')
 
 
 @with_tempfile
@@ -49,13 +49,13 @@ def test_dont_trip_over_missing_subds(path):
     ds1.save(files=['subds2'])
     # see if it wants to talk to github (and fail), or if it trips over something
     # before
-    assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_user='')
+    assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting')
     # inject remote config prior run
     assert_not_in('github', ds1.repo.get_remotes())
     # fail on existing
     ds1.repo.add_remote('github', 'http://nothere')
-    assert_raises(ValueError, ds1.create_sibling_github, 'bogus', recursive=True, github_user='')
+    assert_raises(ValueError, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting')
     # talk to github when existing is OK
-    assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_user='', existing='reconfigure')
+    assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting', existing='reconfigure')
     # return happy emptiness when all is skipped
-    assert_equal(ds1.create_sibling_github('bogus', recursive=True, github_user='', existing='skip'), [])
+    assert_equal(ds1.create_sibling_github('bogus', recursive=True, github_login='disabledloginfortesting', existing='skip'), [])

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -43,7 +43,7 @@ def test_create_test_dataset():
         dss = create_test_dataset(spec='2/1-2')
     ok_(5 <= len(dss) <= 7)  # at least five - 1 top, two on top level, 1 in each
     for ds in dss:
-        ok_clean_git(ds, annex=False)  # some of them are annex but we just don't check
+        ok_clean_git(ds, annex=None)  # some of them are annex but we just don't check
         ok_(len(glob(opj(ds, 'file*'))))
 
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -254,7 +254,7 @@ def test_install_dataset_from_just_source(url, path):
     ok_startswith(ds.path, path)
     ok_(ds.is_installed())
     ok_(GitRepo.is_valid_repo(ds.path))
-    ok_clean_git(ds.path, annex=False)
+    ok_clean_git(ds.path, annex=None)
     assert_in('INFO.txt', ds.repo.get_indexed_files())
 
 
@@ -271,7 +271,7 @@ def test_install_dataset_from_just_source_via_path(url, path):
     ok_startswith(ds.path, path)
     ok_(ds.is_installed())
     ok_(GitRepo.is_valid_repo(ds.path))
-    ok_clean_git(ds.path, annex=False)
+    ok_clean_git(ds.path, annex=None)
     assert_in('INFO.txt', ds.repo.get_indexed_files())
 
 
@@ -382,12 +382,12 @@ def test_install_into_dataset(source, top_path):
     ok_(subds.is_installed())
     assert_in('sub', ds.get_subdatasets())
     # sub is clean:
-    ok_clean_git(subds.path, annex=False)
+    ok_clean_git(subds.path, annex=None)
     # top is not:
-    assert_raises(AssertionError, ok_clean_git, ds.path, annex=False)
+    assert_raises(AssertionError, ok_clean_git, ds.path, annex=None)
     ds.save('addsub')
     # now it is:
-    ok_clean_git(ds.path, annex=False)
+    ok_clean_git(ds.path, annex=None)
 
     # but we could also save while installing and there should be no side-effect
     # of saving any other changes if we state to not auto-save changes
@@ -414,16 +414,16 @@ def test_failed_install_multiple(top_path):
 
     create(_path_(top_path, 'ds1'))
     create(_path_(top_path, 'ds3'))
-    ok_clean_git(ds.path, annex=False, untracked=['ds1/', 'ds3/'])
+    ok_clean_git(ds.path, annex=None, untracked=['ds1/', 'ds3/'])
 
     # specify install with multiple paths and one non-existing
     with assert_raises(IncompleteResultsError) as cme:
         ds.install(['ds1', 'ds2', '///crcns', '///nonexisting', 'ds3'])
 
     # install doesn't add existing submodules -- add does that
-    ok_clean_git(ds.path, annex=False, untracked=['ds1/', 'ds3/'])
+    ok_clean_git(ds.path, annex=None, untracked=['ds1/', 'ds3/'])
     ds.add(['ds1', 'ds3'])
-    ok_clean_git(ds.path, annex=False)
+    ok_clean_git(ds.path, annex=None)
     # those which succeeded should be saved now
     eq_(ds.get_subdatasets(), ['crcns', 'ds1', 'ds3'])
     # and those which didn't -- listed

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -54,8 +54,8 @@ def test_publish_simple(origin, src_path, dst_path):
     res = publish(dataset=source, to="target")
     eq_(res, ([source], []))
 
-    ok_clean_git(src_path, annex=False)
-    ok_clean_git(dst_path, annex=False)
+    ok_clean_git(src_path, annex=None)
+    ok_clean_git(dst_path, annex=None)
     eq_(list(target.get_branch_commits("master")),
         list(source.repo.get_branch_commits("master")))
 
@@ -63,8 +63,8 @@ def test_publish_simple(origin, src_path, dst_path):
     res = publish(dataset=source, to="target")
     eq_(res, ([source], []))
 
-    ok_clean_git(src_path, annex=False)
-    ok_clean_git(dst_path, annex=False)
+    ok_clean_git(src_path, annex=None)
+    ok_clean_git(dst_path, annex=None)
     eq_(list(target.get_branch_commits("master")),
         list(source.repo.get_branch_commits("master")))
     eq_(list(target.get_branch_commits("git-annex")),
@@ -78,12 +78,12 @@ def test_publish_simple(origin, src_path, dst_path):
         f.write("Some additional stuff.")
     source.repo.add(opj(src_path, 'test_mod_file'), git=True,
                     commit=True, msg="Modified.")
-    ok_clean_git(src_path, annex=False)
+    ok_clean_git(src_path, annex=None)
 
     res = publish(dataset=source)
     eq_(res, ([source], []))
 
-    ok_clean_git(dst_path, annex=False)
+    ok_clean_git(dst_path, annex=None)
     eq_(list(target.get_branch_commits("master")),
         list(source.repo.get_branch_commits("master")))
     eq_(list(target.get_branch_commits("git-annex")),
@@ -152,7 +152,8 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     eq_(list(sub2_target.get_branch_commits("git-annex")),
         list(sub2.get_branch_commits("git-annex")))
 
-    # test for publishing with  --since.  By default since no changes, only current pushed
+    # test for publishing with  --since.
+    # By default since no changes, only current pushed
     res_ = publish(dataset=source, recursive=True)
     # only current one would get pushed
     eq_(set(r.path for r in res_[0]), {src_path})

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -54,8 +54,8 @@ def test_publish_simple(origin, src_path, dst_path):
     res = publish(dataset=source, to="target")
     eq_(res, ([source], []))
 
-    ok_clean_git(src_path, annex=None)
-    ok_clean_git(dst_path, annex=None)
+    ok_clean_git(source.repo, annex=None)
+    ok_clean_git(target, annex=None)
     eq_(list(target.get_branch_commits("master")),
         list(source.repo.get_branch_commits("master")))
 
@@ -63,8 +63,8 @@ def test_publish_simple(origin, src_path, dst_path):
     res = publish(dataset=source, to="target")
     eq_(res, ([source], []))
 
-    ok_clean_git(src_path, annex=None)
-    ok_clean_git(dst_path, annex=None)
+    ok_clean_git(source.repo, annex=None)
+    ok_clean_git(target, annex=None)
     eq_(list(target.get_branch_commits("master")),
         list(source.repo.get_branch_commits("master")))
     eq_(list(target.get_branch_commits("git-annex")),
@@ -78,7 +78,7 @@ def test_publish_simple(origin, src_path, dst_path):
         f.write("Some additional stuff.")
     source.repo.add(opj(src_path, 'test_mod_file'), git=True,
                     commit=True, msg="Modified.")
-    ok_clean_git(src_path, annex=None)
+    ok_clean_git(source.repo, annex=None)
 
     res = publish(dataset=source)
     eq_(res, ([source], []))

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -18,6 +18,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import chpwd
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import InsufficientArgumentsError
 
 from nose.tools import ok_, eq_, assert_false, assert_is_instance
 from datalad.tests.utils import with_tempfile, assert_in, with_tree,\
@@ -33,6 +34,18 @@ from datalad.tests.utils import skip_if_no_module
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_not_in
+
+
+@with_testrepos('submodule_annex', flavors=['local'])
+def test_invalid_call(origin):
+    ds = Dataset(origin)
+    ds.uninstall('subm 1', check=False)
+    # nothing
+    assert_raises(ValueError, publish, '/notthere')
+    # known, but not present
+    assert_raises(ValueError, publish, opj(ds.path, 'subm 1'))
+    # --since without dataset is not supported
+    assert_raises(InsufficientArgumentsError, publish, since='HEAD')
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
@@ -61,7 +74,8 @@ def test_publish_simple(origin, src_path, dst_path):
 
     # don't fail when doing it again
     res = publish(dataset=source, to="target")
-    eq_(res, ([source], []))
+    # and nothing is pushed
+    eq_(res, ([], []))
 
     ok_clean_git(source.repo, annex=None)
     ok_clean_git(target, annex=None)
@@ -108,7 +122,7 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     # subdatasets have no remote yet, so recursive publishing should fail:
     with assert_raises(ValueError) as cm:
         publish(dataset=source, to="target", recursive=True)
-    assert_in("No sibling 'target' found", exc_str(cm.exception))
+    assert_in("Unknown target sibling 'target'", exc_str(cm.exception))
 
     # now, set up targets for the submodules:
     sub1_target = GitRepo(sub1_pub, create=True)
@@ -152,26 +166,26 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
     eq_(list(sub2_target.get_branch_commits("git-annex")),
         list(sub2.get_branch_commits("git-annex")))
 
-    # test for publishing with  --since.
-    # By default since no changes, only current pushed
+    # test for publishing with  --since.  By default since no changes, nothing pushed
     res_ = publish(dataset=source, recursive=True)
-    # only current one would get pushed
-    eq_(set(r.path for r in res_[0]), {src_path})
+    eq_(set(r.path for r in res_[0]), set())
 
-    # all get pushed
+    # still nothing gets pushed, because orgin is up to date
     res_ = publish(dataset=source, recursive=True, since='HEAD^')
-    eq_(set(r.path for r in res_[0]), {src_path, sub1.path, sub2.path})
+    eq_(set(r.path for r in res_[0]), set([]))
 
     # Let's now update one subm
     with open(opj(sub2.path, "file.txt"), 'w') as f:
         f.write('')
-    sub2.add('file.txt')
-    sub2.commit("")
-    source.save("changed sub2", all_changes=True)
+    # add to subdataset, does not alter super dataset!
+    # MIH: use `to_git` because original test author used
+    # and explicit `GitRepo.add` -- keeping this for now
+    Dataset(sub2.path).add('file.txt', to_git=True)
 
     res_ = publish(dataset=source, recursive=True)
-    # only updated ones were published
-    eq_(set(r.path for r in res_[0]), {src_path, sub2.path})
+    # only updates published, i.e. just the subdataset
+    # super wasn't altered and there was no new annexed content
+    eq_(set(r.path for r in res_[0]), {sub2.path})
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
@@ -222,7 +236,9 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
 
     source.repo.fetch("target")
     res = publish(dataset=source, to="target", path=['.'])
-    eq_(res, ([source, 'test-annex.dat'], []))
+    # there is nothing to publish on 2nd attempt
+    #eq_(res, ([source, 'test-annex.dat'], []))
+    eq_(res, ([], []))
 
     source.repo.fetch("target")
     import glob
@@ -237,6 +253,8 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub):
             result_paths.append(item.path)
         else:
             result_paths.append(item)
-    eq_({source.path, opj(source.path, "subm 1"),
-         opj(source.path, "subm 2"), 'test-annex.dat'},
+    # only the subdatasets, targets are plain git repos, hence
+    # no file content is pushed, all content in super was pushed
+    # before
+    eq_({sub1.path, sub2.path},
         set(result_paths))

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -11,23 +11,20 @@
 
 import os
 import re
-from os.path import join as opj, basename, exists
-
-from git.exc import GitCommandError
+from os.path import join as opj, exists
 
 from ..dataset import Dataset
 from datalad.api import publish, install, create_sibling
-from datalad.cmd import GitRunner
 from datalad.utils import chpwd
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
-
+from datalad.support.network import urlquote
 from nose.tools import eq_, assert_false
 from datalad.tests.utils import with_tempfile, assert_in, \
     with_testrepos
-from datalad.tests.utils import SkipTest
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_exists
+from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import ok_endswith
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_raises
@@ -39,6 +36,7 @@ from datalad.tests.utils import assert_no_errors_logged
 from datalad.tests.utils import get_mtimes_and_digests
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import ok_
+from datalad.support.exceptions import InsufficientArgumentsError
 
 from datalad.utils import on_windows
 from datalad.utils import _path_
@@ -86,6 +84,27 @@ assert_create_sshwebserver = (
     else create_sibling
 )
 
+
+@with_tempfile(mkdir=True)
+def test_invalid_call(path):
+    # needs a SSH URL
+    assert_raises(InsufficientArgumentsError, create_sibling, '')
+    assert_raises(ValueError, create_sibling, 'http://ignore.me')
+    # needs an actual dataset
+    assert_raises(
+        ValueError,
+        create_sibling, 'localhost:/tmp/somewhere', dataset='/nothere')
+    # pre-configure a bogus remote
+    ds = Dataset(path).create()
+    ds.repo.add_remote('bogus', 'http://bogus.url.com')
+    # fails to reconfigure by default with generated
+    assert_raises(ValueError, ds.create_sibling, 'bogus:/tmp/somewhere')
+    # and also when given an existing name
+    assert_raises(
+        ValueError,
+        ds.create_sibling, 'localhost:/tmp/somewhere', name='bogus')
+
+
 @skip_ssh
 @with_testrepos('.*basic.*', flavors=['local'])
 @with_tempfile(mkdir=True)
@@ -96,25 +115,17 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
     source = install(src_path, source=origin)
 
     target_path = opj(target_rootpath, "basic")
-    # it will try to fetch it so would fail as well since sshurl is wrong
-    with swallow_logs(new_level=logging.ERROR) as cml, \
-        assert_raises(GitCommandError):
-            create_sibling(
-                dataset=source,
-                target="local_target",
-                sshurl="ssh://localhost",
-                target_dir=target_path,
-                ui=True)
-        # is not actually happening on one of the two basic cases -- TODO figure it out
-        # assert_in('enableremote local_target failed', cml.out)
+    with swallow_logs(new_level=logging.ERROR) as cml:
+        create_sibling(
+            dataset=source,
+            name="local_target",
+            sshurl="ssh://localhost",
+            target_dir=target_path,
+            ui=True)
+        assert_not_in('enableremote local_target failed', cml.out)
 
     GitRepo(target_path, create=False)  # raises if not a git repo
     assert_in("local_target", source.repo.get_remotes())
-    eq_("ssh://localhost", source.repo.get_remote_url("local_target"))
-    # should NOT be able to push now, since url isn't correct:
-    # TODO:  assumption is wrong if ~ does have .git! fix up!
-    assert_raises(GitCommandError, publish, dataset=source, to="local_target")
-
     # Both must be annex or git repositories
     src_is_annex = AnnexRepo.is_valid_repo(src_path)
     eq_(src_is_annex, AnnexRepo.is_valid_repo(target_path))
@@ -122,21 +133,16 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
     if src_is_annex:
         annex = AnnexRepo(src_path)
         local_target_cfg = annex.repo.remotes["local_target"].config_reader.get
-        # for some reason this was "correct"
-        # eq_(local_target_cfg('annex-ignore'), 'false')
-        # but after fixing creating siblings in
-        # 21f6dd012b2c7b9c0b8b348dcfb3b0ace7e8b2ec it started to fail
-        # I think it is legit since we are trying to fetch now before calling
-        # annex.enable_remote so it doesn't set it up, and fails before
-        assert_raises(Exception, local_target_cfg, 'annex-ignore')
-        # hm, but ATM wouldn't get a uuid since url is wrong
-        assert_raises(Exception, local_target_cfg, 'annex-uuid')
+        # basic config in place
+        eq_(local_target_cfg('annex-ignore'), 'false')
+        ok_(local_target_cfg('annex-uuid'))
 
-    # do it again without force:
+    # do it again without force, but use a different name to avoid initial checks
+    # for existing remotes:
     with assert_raises(RuntimeError) as cm:
         assert_create_sshwebserver(
             dataset=source,
-            target="local_target",
+            name="local_target_alt",
             sshurl="ssh://localhost",
             target_dir=target_path)
     eq_("Target directory %s already exists." % target_path,
@@ -156,10 +162,11 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 
         assert_create_sshwebserver(
             dataset=source,
-            target="local_target",
+            name="local_target",
             sshurl="ssh://localhost" + target_path,
+            publish_by_default='master',
             existing='replace')
-        eq_("ssh://localhost" + target_path,
+        eq_("ssh://localhost" + urlquote(target_path),
             source.repo.get_remote_url("local_target"))
         ok_(source.repo.get_remote_url("local_target", push=True) is None)
 
@@ -171,12 +178,14 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             local_target_cfg = annex.repo.remotes["local_target"].config_reader.get
             eq_(local_target_cfg('annex-ignore'), 'false')
             eq_(local_target_cfg('annex-uuid').count('-'), 4)  # valid uuid
+            # should be added too, even if URL matches prior state
+            eq_(local_target_cfg('push'), 'master')
 
         # again, by explicitly passing urls. Since we are on localhost, the
         # local path should work:
         cpkwargs = dict(
             dataset=source,
-            target="local_target",
+            name="local_target",
             sshurl="ssh://localhost",
             target_dir=target_path,
             target_url=target_path,
@@ -230,7 +239,8 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         orig_digests, orig_mtimes = get_mtimes_and_digests(target_path)
         process_digests_mtimes(orig_digests, orig_mtimes)
 
-        import time; time.sleep(0.1)  # just so that mtimes change
+        import time
+        time.sleep(0.1)  # just so that mtimes change
         assert_create_sshwebserver(existing='reconfigure', **cpkwargs)
         digests, mtimes = get_mtimes_and_digests(target_path)
         process_digests_mtimes(digests, mtimes)
@@ -268,23 +278,15 @@ def test_target_ssh_recursive(origin, src_path, target_path):
         target_path_ = target_dir_tpl = target_path + "-" + str(flat)
 
         if flat:
-            target_dir_tpl += "/%NAME"
+            target_dir_tpl += "/prefix%RELNAME"
             sep = '-'
         else:
             sep = os.path.sep
 
-        if flat:
-            # now that create_sibling also does fetch -- the related problem
-            # so skipping this early
-            raise SkipTest('TODO: Make publish work for flat datasets, it currently breaks')
-
         remote_name = 'remote-' + str(flat)
-        # TODO: there is f.ckup with paths so assert_create fails ATM
-        # And let's test without explicit dataset being provided
         with chpwd(source.path):
-            #assert_create_sshwebserver(
-            create_sibling(
-                target=remote_name,
+            assert_create_sshwebserver(
+                name=remote_name,
                 sshurl="ssh://localhost" + target_path_,
                 target_dir=target_dir_tpl,
                 recursive=True,
@@ -292,7 +294,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 
         # raise if git repos were not created
         for suffix in [sep + 'subm 1', sep + 'subm 2', '']:
-            target_dir = opj(target_path_, basename(src_path) if flat else "").rstrip(os.path.sep) + suffix
+            target_dir = opj(target_path_, 'prefix' if flat else "").rstrip(os.path.sep) + suffix
             # raise if git repos were not created
             GitRepo(target_dir, create=False)
 
@@ -303,3 +305,28 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 
         # now, push should work:
         publish(dataset=source, to=remote_name)
+
+
+@skip_ssh
+@with_testrepos('submodule_annex', flavors=['local'])
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_target_ssh_since(origin, src_path, target_path):
+    # prepare src
+    source = install(src_path, source=origin, recursive=True)[0]
+    eq_(len(source.get_subdatasets()), 2)
+    # get a new subdataset and make sure it is commited in the super
+    source.create('brandnew')
+    eq_(len(source.get_subdatasets()), 3)
+    ok_clean_git(source.path)
+
+    # and now we create a sibling for the new subdataset only
+    assert_create_sshwebserver(
+        name='dominique_carrera',
+        dataset=source,
+        sshurl="ssh://localhost" + target_path,
+        recursive=True,
+        since='HEAD~1')
+    # there is one thing in the target directory only, and that is the
+    # remote repo of the newly added subdataset
+    eq_(['brandnew'], os.listdir(target_path))

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -139,7 +139,8 @@ def test_uninstall_git_file(path):
     ok_file_under_git(ds.repo.path, 'INFO.txt')
 
     if not hasattr(ds.repo, 'drop'):
-        assert_raises(ValueError, ds.drop, path='INFO.txt')
+        # nothing can be dropped in a plain GitRepo
+        eq_([], ds.drop(path='INFO.txt'))
 
     with swallow_logs(new_level=logging.ERROR) as cml:
         assert_raises(ValueError, ds.uninstall, path="INFO.txt")

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -84,9 +84,7 @@ def _drop_files(ds, files, check):
         dropped = ds.repo.drop(files, options=opts)
         results.extend([opj(ds.path, f) for f in dropped])
     else:
-        # TODO think how to handle this best, when called `through` remove
-        # and it hits a plain git repo somewhere down below
-        raise ValueError("cannot uninstall, not an annex %s" % ds)
+        lgr.info("skip dropping files in %s, no annex", ds)
     return results
 
 

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -108,11 +108,21 @@ class Credential(object):
         self.set(**{f: v})
         return v
 
-    def enter_new(self):
-        """Enter new values for the credential fields"""
+    def enter_new(self, **kwargs):
+        """Enter new values for the credential fields
+
+        Parameters
+        ----------
+        **kwargs
+          Any given key value pairs with non-None values are used to set the
+          field `key` to the given value, without asking for user input
+        """
         # Use ui., request credential fields corresponding to the type
         for f in self._FIELDS:
-            if not self._is_field_optional(f):
+            if kwargs.get(f, None):
+                # use given value, don't ask
+                self.set(**{f: kwargs[f]})
+            elif not self._is_field_optional(f):
                 self._ask_and_set(f)
 
     def __call__(self):

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -295,6 +295,8 @@ class AddArchiveContent(Interface):
         else:
             lgr.debug("Special remote {} already exists".format(ARCHIVES_SPECIAL_REMOTE))
 
+        precommitted = False
+        delete_after_rpath = None
         try:
             old_always_commit = annex.always_commit
             annex.always_commit = False
@@ -310,7 +312,7 @@ class AddArchiveContent(Interface):
 
             # we need to create a temporary directory at the top level which would later be
             # removed
-            prefix_dir = basename(tempfile.mkdtemp(prefix=".datalad", dir=annex_path)) \
+            prefix_dir = basename(tempfile.mktemp(prefix=".datalad", dir=annex_path)) \
                 if delete_after \
                 else None
 
@@ -356,6 +358,8 @@ class AddArchiveContent(Interface):
 
                 if prefix_dir:
                     target_file = opj(prefix_dir, target_file)
+                    # but also allow for it in the orig
+                    target_file_orig = opj(prefix_dir, target_file_orig)
 
                 url = annexarchive.get_file_url(archive_key=key, file=extracted_file, size=os.stat(extracted_path).st_size)
 
@@ -434,8 +438,8 @@ class AddArchiveContent(Interface):
                     stats.add_git += 1
 
                 if delete_after:
-                    # forcing since it is only staged, not yet committed
-                    annex.remove(target_file_rpath, force=True)  # TODO: batch!
+                    # delayed removal so it doesn't interfer with batched processes since any pure
+                    # git action invokes precommit which closes batched processes. But we like to count
                     stats.removed += 1
 
                 # # chaining 3 annex commands, 2 of which not batched -- less efficient but more bullet proof etc
@@ -462,23 +466,42 @@ class AddArchiveContent(Interface):
 
             if outside_stats:
                 outside_stats += stats
+            if delete_after:
+                # force since not committed. r=True for -r (passed into git call
+                # to recurse)
+                delete_after_rpath = opj(extract_rpath, prefix_dir) if extract_rpath else prefix_dir
+                lgr.debug(
+                    "Removing extracted and annexed files under %s",
+                    delete_after_rpath
+                )
+                annex.remove(delete_after_rpath, r=True, force=True)
             if commit:
                 commit_stats = outside_stats if outside_stats else stats
-                annex.commit(
-                    "Added content extracted from %s %s\n\n%s" % (origin, archive, commit_stats.as_str(mode='full')),
-                    _datalad_msg=True
-                )
-                commit_stats.reset()
+                annex.precommit()  # so batched ones close and files become annex symlinks etc
+                precommitted = True
+                if annex.repo.is_dirty(untracked_files=False):
+                    annex.commit(
+                        "Added content extracted from %s %s\n\n%s" %
+                        (origin, archive, commit_stats.as_str(mode='full')),
+                        _datalad_msg=True
+                    )
+                    commit_stats.reset()
         finally:
             # since we batched addurl, we should close those batched processes
-            annex.precommit()
+            # if haven't done yet.  explicitly checked to avoid any possible
+            # "double-action"
+            if not precommitted:
+                annex.precommit()
 
-            if delete_after:
-                prefix_path = opj(annex_path, prefix_dir)
-                if exists(prefix_path):  # probably would always be there
-                    lgr.info("Removing temporary directory under which extracted files were annexed: %s",
-                             prefix_path)
-                    rmtree(prefix_path)
+            if delete_after_rpath:
+                delete_after_path = opj(annex_path, delete_after_rpath)
+                if exists(delete_after_path):  # should not be there
+                    # but for paranoid yoh
+                    lgr.warning(
+                        "Removing temporary directory under which extracted "
+                        "files were annexed and should have been removed: %s",
+                        delete_after_path)
+                    rmtree(delete_after_path)
 
             annex.always_commit = old_always_commit
             # remove what is left and/or everything upon failure

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -108,6 +108,12 @@ nosave_opt = Parameter(
     doc="""by default all modifications to a dataset are immediately saved. Given
     this option will disable this behavior.""")
 
+save_message_opt=Parameter(
+    args=("-m", "--message",),
+    metavar='MESSAGE',
+    doc="""a description of the state or the changes made to a dataset.""",
+    constraints=EnsureStr() | EnsureNone())
+
 reckless_opt = Parameter(
     args=("--reckless",),
     action="store_true",
@@ -141,7 +147,7 @@ as_common_datasrc = Parameter(
 publish_depends = Parameter(
     args=("--publish-depends",),
     metavar='SIBLINGNAME',
-    doc="""add a dependency such that the given exsiting sibling is
+    doc="""add a dependency such that the given existing sibling is
     always published prior to the new sibling. This equals setting a
     configuration item 'remote.SIBLINGNAME.datalad-publish-depends'.
     [PY: Multiple dependencies can be given as a list of sibling names

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -13,6 +13,7 @@
 __docformat__ = 'restructuredtext'
 
 import logging
+from os import curdir
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
@@ -22,6 +23,7 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import super_datasets_flag
+from datalad.interface.common_opts import save_message_opt
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import amend_pathspec_with_superdatasets
 from datalad.utils import with_pathsep as _with_sep
@@ -105,11 +107,7 @@ class Save(Interface):
             to those files are recorded in the new state.""",
             nargs='*',
             constraints=EnsureStr() | EnsureNone()),
-        message=Parameter(
-            args=("-m", "--message",),
-            metavar='MESSAGE',
-            doc="""a message to annotate the saved state.""",
-            constraints=EnsureStr() | EnsureNone()),
+        message=save_message_opt,
         all_changes=Parameter(
             args=("-a", "--all-changes"),
             doc="""save changes of all known components in datasets that contain
@@ -130,6 +128,10 @@ class Save(Interface):
     def __call__(message=None, files=None, dataset=None,
                  all_changes=False, version_tag=None,
                  recursive=False, recursion_limit=None, super_datasets=False):
+        if not dataset and not files:
+            # we got nothing at all -> save what is staged in the repo in "this" directory?
+            # we verify that there is an actual repo next
+            dataset = curdir
         if dataset:
             dataset = require_dataset(
                 dataset, check_installed=True, purpose='saving')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -64,7 +64,9 @@ def test_save(path):
     with open(opj(subds.path, "some_file.tst"), "w") as f:
         f.write("something")
     subds.add('.')
-    ok_clean_git(subds.path, annex=isinstance(ds.repo, AnnexRepo))
+    ok_clean_git(subds.path, annex=isinstance(subds.repo, AnnexRepo))
+    # Note/TODO: ok_clean_git is failing in direct mode, due to staged but
+    # uncommited .datalad (probably caused within create)
     ok_(ds.repo.dirty)
     # ensure modified subds is committed
     ds.save(all_changes=True)

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -13,6 +13,7 @@
 __docformat__ = 'restructuredtext'
 
 from os.path import join as opj
+from datalad.utils import chpwd
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
@@ -45,6 +46,22 @@ def test_save(path):
     ok_(ds.repo.dirty)
     ds.save("modified new_file.tst", all_changes=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    # save works without ds and files given in the PWD
+    with open(opj(path, "new_file.tst"), "w") as f:
+        f.write("rapunzel")
+    with chpwd(path):
+        save("love rapunzel", all_changes=True)
+    ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    # and also without `-a` when things are staged
+    with open(opj(path, "new_file.tst"), "w") as f:
+        f.write("exotic")
+    ds.repo.add("new_file.tst", git=True)
+    with chpwd(path):
+        save("love marsians", all_changes=False)
+    ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
+
 
     files = ['one.txt', 'two.txt']
     for fn in files:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -667,3 +667,97 @@ def _discover_trace_to_known(path, trace, spec):
         if not isdir(p):
             continue
         _discover_trace_to_known(p, trace, spec)
+
+
+def filter_unmodified(content_by_ds, refds, since):
+    """Filter per-dataset path specifications based on modification history.
+
+    This function takes a path specification dictionary, as produced by
+    `Interface._prep()` and filters it such that only that subset of paths
+    remains in the dictionary that correspdong to the set of changes in
+    the given reference dataset since a given state.
+
+    The change set is traced across all related subdatasets, i.e. if a submodule
+    in the reference dataset is reported as modified then all paths for any given
+    subdataset in the modified one are tested for changes too (based on the
+    state at which the parent dataset reports a change in the subdataset), and so
+    on.
+
+    In doing so, not only unmodified given paths are removed, but also modified
+    given paths are replaced by the set of actually modified paths within them.
+
+    Only commited changes are considered!
+
+    Parameters
+    ----------
+    content_by_ds : dict
+      Per-dataset path specifications, as produced ,for example, by
+      `Interface._prep()`
+    refds : Dataset or *Repo or path
+      Reference dataset for which to determine the initial change set
+    since : state
+      Any commit-ish/tree-ish supported by Git (tag, commit, branch, ...).
+      Changes between this given state and the most recent commit are
+      evaluated.
+
+    Returns
+    -------
+    dict
+      Filtered path spec dictionary. If `since` is not None, the output is
+      guaranteed to only contain paths to modified, and presently existing
+      components of subdatasets of the given reference dataset (and itself).
+    """
+    if since is None:
+        # we want all, subds not matching the ref are assumed to have been
+        # sorted out before (e.g. one level up)
+        return content_by_ds
+    # turn refds argument into a usable repo instance
+    if not hasattr(refds, 'path'):
+        # not a Repo or Dataset
+        refds_path = refds
+        refds = GitRepo(refds, create=False)
+    else:
+        refds_path = refds.path
+    repo = refds.repo
+    if hasattr(repo, 'repo'):
+        # TODO use GitRepo.diff() when available (gh-1217)
+        repo = repo.repo
+
+    # life is simple: we diff the base dataset, and kill anything that
+    # does not start with something that is in the diff
+    # we cannot really limit the diff paths easily because we might get
+    # or miss content (e.g. subdatasets) if we don't figure out which ones
+    # are known -- and we don't want that
+    diff = repo.commit().diff(since)
+    # get all modified paths (with original? commit) that are still
+    # present
+    modified = dict((opj(refds_path, d.b_path),
+                    d.b_blob.hexsha if d.b_blob else None)
+                    for d in diff)
+    if not modified:
+        # nothing modified nothing to report
+        return {}
+    # determine the subset that is a directory and hence is relevant for possible
+    # subdatasets
+    modified_dirs = {_with_sep(d) for d in modified if isdir(d)}
+    # find the subdatasets matching modified paths, this will also kick out
+    # any paths that are not in the dataset sub-hierarchy
+    mod_subs = {candds: paths
+                for candds, paths in content_by_ds.items()
+                if candds != refds_path and
+                any(_with_sep(candds).startswith(md) for md in modified_dirs)}
+    # now query the next level down
+    keep_subs = \
+        [filter_unmodified(mod_subs, subds_path, modified[subds_path])
+         for subds_path in mod_subs
+         if subds_path in modified]
+    # merge result list into a single dict
+    keep = {k: v for d in keep_subs for k, v in d.items()}
+
+    paths_refds = content_by_ds[refds_path]
+    keep[refds_path] = [m for m in modified
+                        if lexists(m) # still around
+                        and (m in paths_refds # listed file, or subds
+                        # or a modified path under a given directory
+                        or any(m.startswith(_with_sep(p)) for p in paths_refds))]
+    return keep

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -302,7 +302,22 @@ class AnnexRepo(GitRepo, RepoInterface):
         # flush pending changes, especially close batched annex processes to
         # make sure their changes are registered
         self.precommit()
-        return super(AnnexRepo, self).dirty
+
+        if self.is_direct_mode():
+            result = self._run_annex_command_json('status')
+            # JSON result for 'git annex status'
+            # {"status":"?","file":"filename"}
+            # ? -- untracked
+            # D -- deleted
+            # M -- modified
+            # A -- staged
+            # T -- type changed/unlocked
+            if not list(result):
+                return False
+            else:
+                return True
+        else:
+            return super(AnnexRepo, self).dirty
 
     @classmethod
     def _check_git_annex_version(cls):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -249,15 +249,30 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._batched = BatchedAnnexes(batch_size=batch_size)
 
     def __del__(self):
-        if hasattr(self, '_batched') and self._batched is not None:
-            self._batched.close()
-        super(AnnexRepo, self).__del__()
+        try:
+            if hasattr(self, '_batched') and self._batched is not None:
+                self._batched.close()
+        except TypeError as e:
+            # Workaround:
+            # most likely something wasn't accessible anymore; doesn't really
+            # matter since we wanted to delete it anyway.
+            #
+            # Nevertheless, in some cases might be an issue and it is a strange
+            # thing to happen, since we check for things being None herein as
+            # well as in super class __del__;
+            # At least log it:
+            lgr.debug(exc_str(e))
+        try:
+            super(AnnexRepo, self).__del__()
+        except TypeError as e:
+            # see above
+            lgr.debug(exc_str(e))
 
     def _set_shared_connection(self, remote_name, url):
         """Make sure a remote with SSH URL uses shared connections.
 
         Set ssh options for annex on a per call basis, using
-        '-c remote.<name>.annex-sshoptions'.
+        '-c remote.<name>.annex-ssh-options'.
 
         Note
         ----
@@ -1062,7 +1077,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # this doesn't use `merge` but `sync` in order to properly
         # trigger updating of maintained branches in e.g. v6 repos
         args = [remote] if remote else []
-        args = args.extend(['--no-push', '--no-pull'])
+        args.extend(['--no-push', '--no-pull'])
         self._run_annex_command('sync', annex_options=args)
 
     @normalize_path
@@ -1454,12 +1469,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             raise ValueError("Unknown value output=%r. Known are remotes and full" % output)
 
     # TODO:
-    #  I think we should make interface cleaner and less ambigious for those annex
-    #  commands which could operate on globs, files, and entire repositories, separating
-    #  those out, e.g. annex_info_repo, annex_info_files at least.
-    #  If we make our calling wrappers work without relying on invoking from repo topdir,
-    #  then returned filenames would not need to be mapped, so we could easily work on dirs
-    #  and globs.
+    # I think we should make interface cleaner and less ambigious for those annex
+    # commands which could operate on globs, files, and entire repositories, separating
+    # those out, e.g. annex_info_repo, annex_info_files at least.
+    # If we make our calling wrappers work without relying on invoking from repo topdir,
+    # then returned filenames would not need to be mapped, so we could easily work on dirs
+    # and globs.
     # OR if explicit filenames list - return list of matching entries, if globs/dirs -- return dict?
     @normalize_paths(map_filenames_back=True)
     def info(self, files, batch=False, fast=False):
@@ -2191,7 +2206,6 @@ class ProcessAnnexProgressIndicators(object):
 
             if pbar:
                 pbar.finish()
-
 
         if 'byte-progress' not in j:
             # some other thing than progress

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -401,8 +401,8 @@ class RI(object):
             # strictly speaking, but let's assume they do
             ri_ = self.as_str()
             if ri != ri_:
-                lgr.warning("Parsed version of %s %r differs from original %r",
-                            self.__class__.__name__, ri_, ri)
+                lgr.debug("Parsed version of %s %r differs from original %r",
+                          self.__class__.__name__, ri_, ri)
 
     @classmethod
     def _get_blank_fields(cls, **fields):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1446,3 +1446,29 @@ def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
     eq_(AnnexRepo.get_toppath(nested), repo2)
     # and if not under git, should return None
     eq_(AnnexRepo.get_toppath(tempdir), None)
+
+
+@with_testrepos(".*basic.*", flavors=['local'])
+@with_tempfile(mkdir=True)
+def test_AnnexRepo_add_submodule(source, path):
+
+    top_repo = AnnexRepo(path, create=True)
+
+    top_repo.add_submodule('sub', name='sub', url=source)
+    top_repo.commit('submodule added')
+    eq_([s.name for s in top_repo.get_submodules()], ['sub'])
+
+    if top_repo.is_direct_mode():
+        ok_clean_git_annex_proxy(path)
+    else:
+        ok_clean_git(path, annex=True)
+
+    ok_clean_git(opj(path, 'sub'), annex=False)
+
+
+def test_AnnexRepo_update_submodule():
+    raise SkipTest("TODO")
+
+
+def test_AnnexRepo_get_submodules():
+    raise SkipTest("TODO")

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1472,3 +1472,54 @@ def test_AnnexRepo_update_submodule():
 
 def test_AnnexRepo_get_submodules():
     raise SkipTest("TODO")
+
+
+@with_tempfile(mkdir=True)
+def test_AnnexRepo_dirty(path):
+
+    repo = AnnexRepo(path, create=True)
+    ok_(not repo.dirty)
+
+    # pure git operations:
+    # untracked file
+    with open(opj(path, 'file1.txt'), 'w') as f:
+        f.write('whatever')
+    ok_(repo.dirty)
+    # staged file
+    #import pdb; pdb.set_trace()
+    repo.add('file1.txt', git=True)
+    ok_(repo.dirty)
+    # clean again
+    repo.commit("file1.txt added")
+    ok_(not repo.dirty)
+    # modify to be the same
+    with open(opj(path, 'file1.txt'), 'w') as f:
+        f.write('whatever')
+    ok_(not repo.dirty)
+    # modified file
+    with open(opj(path, 'file1.txt'), 'w') as f:
+        f.write('something else')
+    ok_(repo.dirty)
+    # clean again
+    repo.add('file1.txt', git=True)
+    repo.commit("file1.txt modified")
+    ok_(not repo.dirty)
+
+    # annex operations:
+    # untracked file
+    with open(opj(path, 'file2.txt'), 'w') as f:
+        f.write('different content')
+    ok_(repo.dirty)
+    # annexed file
+    repo.add('file2.txt', git=False)
+    if not repo.is_direct_mode():
+        # in direct mode 'annex add' results in a clean repo
+        ok_(repo.dirty)
+        # commit
+        repo.commit("file2.txt annexed")
+    ok_(not repo.dirty)
+
+    # TODO: unlock/modify
+
+    # TODO: submodules
+

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -142,7 +142,7 @@ def test_AnnexRepo_set_direct_mode(src, dst):
 def test_AnnexRepo_annex_proxy(src, annex_path):
     ar = AnnexRepo.clone(src, annex_path)
     ar.set_direct_mode(True)
-    ok_clean_git_annex_proxy(path=annex_path)
+    ok_clean_git(path=annex_path, annex=True)
 
     # annex proxy raises in indirect mode:
     try:
@@ -621,16 +621,10 @@ def test_AnnexRepo_commit(src, path):
         f.write("File to add to git")
     ds.add(filename, git=True)
 
-    if ds.is_direct_mode():
-        assert_raises(AssertionError, ok_clean_git_annex_proxy, path)
-    else:
-        assert_raises(AssertionError, ok_clean_git, path, annex=True)
+    assert_raises(AssertionError, ok_clean_git, path, annex=True)
 
     ds.commit("test _commit")
-    if ds.is_direct_mode():
-        ok_clean_git_annex_proxy(path)
-    else:
-        ok_clean_git(path, annex=True)
+    ok_clean_git(path, annex=True)
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])
@@ -653,10 +647,7 @@ def test_AnnexRepo_add_to_annex(path_1, path_2):
     r2.set_direct_mode()
 
     for repo in [r1, r2]:
-        if repo.is_direct_mode():
-            ok_clean_git_annex_proxy(repo.path)
-        else:
-            ok_clean_git(repo.path, annex=True)
+        ok_clean_git(repo.path, annex=True)
         filename = get_most_obscure_supported_name()
         filename_abs = opj(repo.path, filename)
         with open(filename_abs, "w") as f:
@@ -681,10 +672,7 @@ def test_AnnexRepo_add_to_annex(path_1, path_2):
         ok_(repo.repo.is_dirty())
 
         repo.commit("Added file to annex.")
-        if repo.is_direct_mode():
-            ok_clean_git_annex_proxy(repo.path)
-        else:
-            ok_clean_git(repo.path, annex=True)
+        ok_clean_git(repo.path, annex=True)
 
         # now using commit/msg options:
         filename = "another.txt"
@@ -697,10 +685,7 @@ def test_AnnexRepo_add_to_annex(path_1, path_2):
         ok_(repo.file_has_content(filename))
 
         # and committed:
-        if repo.is_direct_mode():
-            ok_clean_git_annex_proxy(repo.path)
-        else:
-            ok_clean_git(repo.path, annex=True)
+        ok_clean_git(repo.path, annex=True)
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])
@@ -724,10 +709,7 @@ def test_AnnexRepo_add_to_git(path_1, path_2):
 
     for repo in [r1, r2]:
 
-        if repo.is_direct_mode():
-            ok_clean_git_annex_proxy(repo.path)
-        else:
-            ok_clean_git(repo.path, annex=True)
+        ok_clean_git(repo.path, annex=True)
         filename = get_most_obscure_supported_name()
         with open(opj(repo.path, filename), "w") as f:
             f.write("some")
@@ -738,10 +720,7 @@ def test_AnnexRepo_add_to_git(path_1, path_2):
         # uncommitted:
         ok_(repo.repo.is_dirty())
         repo.commit("Added file to annex.")
-        if repo.is_direct_mode():
-            ok_clean_git_annex_proxy(repo.path)
-        else:
-            ok_clean_git(repo.path, annex=True)
+        ok_clean_git(repo.path, annex=True)
 
         # now using commit/msg options:
         filename = "another.txt"
@@ -754,10 +733,7 @@ def test_AnnexRepo_add_to_git(path_1, path_2):
         assert_raises(FileInGitError, repo.get_file_key, filename)
 
         # and committed:
-        if repo.is_direct_mode():
-            ok_clean_git_annex_proxy(repo.path)
-        else:
-            ok_clean_git(repo.path, annex=True)
+        ok_clean_git(repo.path, annex=True)
 
 
 @ignore_nose_capturing_stdout
@@ -1458,11 +1434,7 @@ def test_AnnexRepo_add_submodule(source, path):
     top_repo.commit('submodule added')
     eq_([s.name for s in top_repo.get_submodules()], ['sub'])
 
-    if top_repo.is_direct_mode():
-        ok_clean_git_annex_proxy(path)
-    else:
-        ok_clean_git(path, annex=True)
-
+    ok_clean_git(path, annex=True)
     ok_clean_git(opj(path, 'sub'), annex=False)
 
 
@@ -1486,7 +1458,6 @@ def test_AnnexRepo_dirty(path):
         f.write('whatever')
     ok_(repo.dirty)
     # staged file
-    #import pdb; pdb.set_trace()
     repo.add('file1.txt', git=True)
     ok_(repo.dirty)
     # clean again

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,17 +10,85 @@
 
 """
 
+import logging
 from functools import partial
+import os
 from os import mkdir
+from os.path import join as opj
+from os.path import basename
+from os.path import realpath
+from os.path import relpath
+from os.path import curdir
+from os.path import pardir
+from os.path import exists
 from shutil import copyfile
 from nose.tools import assert_not_is_instance
 
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlsplit
 
-from datalad.tests.utils import *
+import git
+from git import GitCommandError
+from mock import patch
+import gc
+
+from datalad.cmd import Runner
+
+from datalad.support.external_versions import external_versions
+
+from datalad.utils import on_windows
+from datalad.utils import chpwd
+from datalad.utils import rmtree
+from datalad.utils import linux_distribution_name
+
+from datalad.tests.utils import ignore_nose_capturing_stdout
+from datalad.tests.utils import assert_cwd_unchanged
+from datalad.tests.utils import with_testrepos
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import with_tree
+from datalad.tests.utils import create_tree
+from datalad.tests.utils import with_batch_direct
+from datalad.tests.utils import assert_is_instance
+from datalad.tests.utils import assert_false
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_is
+from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_re_in
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import assert_not_equal
+from datalad.tests.utils import assert_equal
+from datalad.tests.utils import assert_true
+from datalad.tests.utils import eq_
+from datalad.tests.utils import ok_
+from datalad.tests.utils import ok_git_config_not_empty
+from datalad.tests.utils import ok_annex_get
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import swallow_outputs
+from datalad.tests.utils import local_testrepo_flavors
+from datalad.tests.utils import serve_path_via_http
+from datalad.tests.utils import get_most_obscure_supported_name
+from datalad.tests.utils import SkipTest
+from datalad.tests.utils import skip_ssh
+from datalad.tests.utils import find_files
+
+from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import CommandNotAvailableError
+from datalad.support.exceptions import FileNotInAnnexError
+from datalad.support.exceptions import FileInGitError
+from datalad.support.exceptions import OutOfSpaceError
+from datalad.support.exceptions import RemoteNotAvailableError
+from datalad.support.exceptions import OutdatedExternalDependency
+from datalad.support.exceptions import MissingExternalDependency
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.exceptions import AnnexBatchCommandError
+
+from datalad.support.gitrepo import GitRepo
+
 # imports from same module:
-from ..annexrepo import *
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.annexrepo import ProcessAnnexProgressIndicators
 
 
 @ignore_nose_capturing_stdout
@@ -31,7 +99,7 @@ def test_AnnexRepo_instance_from_clone(src, dst):
 
     ar = AnnexRepo.clone(src, dst)
     assert_is_instance(ar, AnnexRepo, "AnnexRepo was not created.")
-    assert_true(os.path.exists(os.path.join(dst, '.git', 'annex')))
+    ok_(os.path.exists(os.path.join(dst, '.git', 'annex')))
 
     # do it again should raise GitCommandError since git will notice
     # there's already a git-repo at that path and therefore can't clone to `dst`
@@ -48,7 +116,7 @@ def test_AnnexRepo_instance_from_existing(path):
 
     ar = AnnexRepo(path)
     assert_is_instance(ar, AnnexRepo, "AnnexRepo was not created.")
-    assert_true(os.path.exists(os.path.join(path, '.git')))
+    ok_(os.path.exists(os.path.join(path, '.git')))
 
 
 @ignore_nose_capturing_stdout
@@ -61,7 +129,7 @@ def test_AnnexRepo_instance_brand_new(path):
 
     ar = AnnexRepo(path)
     assert_is_instance(ar, AnnexRepo, "AnnexRepo was not created.")
-    assert_true(os.path.exists(os.path.join(path, '.git')))
+    ok_(os.path.exists(os.path.join(path, '.git')))
 
 
 @assert_cwd_unchanged
@@ -75,7 +143,7 @@ def test_AnnexRepo_crippled_filesystem(src, dst):
     writer = ar.repo.config_writer()
     writer.set_value("annex", "crippledfilesystem", True)
     writer.release()
-    assert_true(ar.is_crippled_fs())
+    ok_(ar.is_crippled_fs())
     writer.set_value("annex", "crippledfilesystem", False)
     writer.release()
     assert_false(ar.is_crippled_fs())
@@ -90,7 +158,7 @@ def test_AnnexRepo_crippled_filesystem(src, dst):
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 def test_AnnexRepo_is_direct_mode(path):
 
-    ar = AnnexRepo(path, create=False)
+    ar = AnnexRepo(path)
     eq_(ar.config.getbool("annex", "direct", False),
         ar.is_direct_mode())
 
@@ -108,7 +176,7 @@ def test_AnnexRepo_is_direct_mode_gitrepo(path):
     dm = ar.is_direct_mode()
 
     if ar.is_crippled_fs() or on_windows:
-        assert_true(dm)
+        ok_(dm)
     else:
         assert_false(dm)
 
@@ -120,10 +188,11 @@ def test_AnnexRepo_set_direct_mode(src, dst):
 
     ar = AnnexRepo.clone(src, dst)
     ar.set_direct_mode(True)
-    assert_true(ar.is_direct_mode(), "Switching to direct mode failed.")
+    ok_(ar.is_direct_mode(), "Switching to direct mode failed.")
     if ar.is_crippled_fs():
         assert_raises(CommandNotAvailableError, ar.set_direct_mode, False)
-        assert_true(ar.is_direct_mode(),
+        ok_(
+            ar.is_direct_mode(),
             "Indirect mode on crippled fs detected. Shouldn't be possible.")
     else:
         ar.set_direct_mode(False)
@@ -155,13 +224,13 @@ def test_AnnexRepo_get_file_key(src, annex_path):
     ar = AnnexRepo.clone(src, annex_path)
 
     # test-annex.dat should return the correct key:
-    assert_equal(
+    eq_(
         ar.get_file_key("test-annex.dat"),
         'SHA256E-s4--181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b.dat')
 
     # and should take a list with an empty string as result, if a file wasn't
     # in annex:
-    assert_equal(
+    eq_(
         ar.get_file_key(["filenotpresent.wtf", "test-annex.dat"]),
         ['', 'SHA256E-s4--181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b.dat']
     )
@@ -176,8 +245,6 @@ def test_AnnexRepo_get_file_key(src, annex_path):
     assert_raises(IOError, ar.get_file_key, "filenotpresent.wtf")
 
 
-
-
 @with_tempfile(mkdir=True)
 def test_AnnexRepo_get_outofspace(annex_path):
     ar = AnnexRepo(annex_path, create=True)
@@ -189,10 +256,10 @@ def test_AnnexRepo_get_outofspace(annex_path):
         )
 
     with patch.object(AnnexRepo, '_run_annex_command', raise_cmderror) as cma, \
-        assert_raises(OutOfSpaceError) as cme:
+            assert_raises(OutOfSpaceError) as cme:
         ar.get("file")
     exc = cme.exception
-    assert_equal(exc.sizemore_msg, '905.6 MB')
+    eq_(exc.sizemore_msg, '905.6 MB')
     assert_re_in(".*annex (find|get). needs 905.6 MB more", str(exc))
 
 
@@ -213,17 +280,17 @@ def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     ar = AnnexRepo.clone(src, annex_path, direct=direct)
     testfiles = ["test-annex.dat", "test.dat"]
 
-    assert_equal(ar.file_has_content(testfiles), [False, False])
+    eq_(ar.file_has_content(testfiles), [False, False])
 
     ok_annex_get(ar, "test-annex.dat")
-    assert_equal(ar.file_has_content(testfiles, batch=batch), [True, False])
-    assert_equal(ar.file_has_content(testfiles[:1], batch=batch), [True])
+    eq_(ar.file_has_content(testfiles, batch=batch), [True, False])
+    eq_(ar.file_has_content(testfiles[:1], batch=batch), [True])
 
-    assert_equal(ar.file_has_content(testfiles + ["bogus.txt"], batch=batch),
-                 [True, False, False])
+    eq_(ar.file_has_content(testfiles + ["bogus.txt"], batch=batch),
+        [True, False, False])
 
     assert_false(ar.file_has_content("bogus.txt", batch=batch))
-    assert_true(ar.file_has_content("test-annex.dat", batch=batch))
+    ok_(ar.file_has_content("test-annex.dat", batch=batch))
 
 
 # 1 is enough to test
@@ -239,18 +306,18 @@ def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
     testfiles = ["test-annex.dat", "not-committed.txt", "INFO.txt"]
     # wouldn't change
     target_value = [True, False, False]
-    assert_equal(ar.is_under_annex(testfiles, batch=batch), target_value)
+    eq_(ar.is_under_annex(testfiles, batch=batch), target_value)
 
     ok_annex_get(ar, "test-annex.dat")
-    assert_equal(ar.is_under_annex(testfiles, batch=batch), target_value)
-    assert_equal(ar.is_under_annex(testfiles[:1], batch=batch), target_value[:1])
-    assert_equal(ar.is_under_annex(testfiles[1:], batch=batch), target_value[1:])
+    eq_(ar.is_under_annex(testfiles, batch=batch), target_value)
+    eq_(ar.is_under_annex(testfiles[:1], batch=batch), target_value[:1])
+    eq_(ar.is_under_annex(testfiles[1:], batch=batch), target_value[1:])
 
-    assert_equal(ar.is_under_annex(testfiles + ["bogus.txt"], batch=batch),
+    eq_(ar.is_under_annex(testfiles + ["bogus.txt"], batch=batch),
                  target_value + [False])
 
     assert_false(ar.is_under_annex("bogus.txt", batch=batch))
-    assert_true(ar.is_under_annex("test-annex.dat", batch=batch))
+    ok_(ar.is_under_annex("test-annex.dat", batch=batch))
 
 
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
@@ -274,54 +341,54 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
         ar.add_urls([testurl])
     l = ar.whereis(testfile)
     assert_in(ar.WEB_UUID, l)
-    assert_equal(len(l), 2)
-    assert_true(ar.file_has_content(testfile))
+    eq_(len(l), 2)
+    ok_(ar.file_has_content(testfile))
 
     # output='full'
     lfull = ar.whereis(testfile, output='full')
-    assert_equal(set(lfull), set(l))  # the same entries
-    non_web_remote = l[1-l.index(ar.WEB_UUID)]
+    eq_(set(lfull), set(l))  # the same entries
+    non_web_remote = l[1 - l.index(ar.WEB_UUID)]
     assert_in('urls', lfull[non_web_remote])
-    assert_equal(lfull[non_web_remote]['urls'], [])
+    eq_(lfull[non_web_remote]['urls'], [])
     assert_not_in('uuid', lfull[ar.WEB_UUID])  # no uuid in the records
-    assert_equal(lfull[ar.WEB_UUID]['urls'], [testurl])
+    eq_(lfull[ar.WEB_UUID]['urls'], [testurl])
 
     # --all and --key are incompatible
     assert_raises(CommandError, ar.whereis, [], options='--all', output='full', key=True)
 
     # output='descriptions'
     ldesc = ar.whereis(testfile, output='descriptions')
-    assert_equal(set(ldesc), set([v['description'] for v in lfull.values()]))
+    eq_(set(ldesc), set([v['description'] for v in lfull.values()]))
 
     # info w/ and w/o fast mode
     for fast in [True, False]:
         info = ar.info(testfile, fast=fast)
-        assert_equal(info['size'], 14)
+        eq_(info['size'], 14)
         assert(info['key'])  # that it is there
         info_batched = ar.info(testfile, batch=True, fast=fast)
-        assert_equal(info, info_batched)
+        eq_(info, info_batched)
         # while at it ;)
         with swallow_outputs() as cmo:
-            assert_equal(ar.info('nonexistent', batch=False), None)
-            assert_equal(ar.info('nonexistent-batch', batch=True), None)
+            eq_(ar.info('nonexistent', batch=False), None)
+            eq_(ar.info('nonexistent-batch', batch=True), None)
             eq_(cmo.out, '')
             eq_(cmo.err, '')
 
     # annex repo info
     repo_info = ar.repo_info(fast=False)
-    assert_equal(repo_info['local annex size'], 14)
-    assert_equal(repo_info['backend usage'], {'SHA256E': 1})
+    eq_(repo_info['local annex size'], 14)
+    eq_(repo_info['backend usage'], {'SHA256E': 1})
     # annex repo info in fast mode
     repo_info_fast = ar.repo_info(fast=True)
     # doesn't give much testable info, so just comparing a subset for match with repo_info info
-    assert_equal(repo_info_fast['semitrusted repositories'], repo_info['semitrusted repositories'])
+    eq_(repo_info_fast['semitrusted repositories'], repo_info['semitrusted repositories'])
     #import pprint; pprint.pprint(repo_info)
 
     # remove the remote
     ar.rm_url(testfile, testurl)
     l = ar.whereis(testfile)
     assert_not_in(ar.WEB_UUID, l)
-    assert_equal(len(l), 1)
+    eq_(len(l), 1)
 
     # now only 1 copy; drop should fail
     try:
@@ -330,25 +397,25 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
             assert_in('ERROR', cml.out)
             assert_in('drop: 1 failed', cml.out)
     except CommandError as e:
-        assert_equal(e.code, 1)
+        eq_(e.code, 1)
         assert_in('Could only verify the '
                   'existence of 0 out of 1 necessary copies', e.stdout)
         failed = True
 
-    assert_true(failed)
+    ok_(failed)
 
     # read the url using different method
     ar.add_url_to_file(testfile, testurl)
     l = ar.whereis(testfile)
     assert_in(ar.WEB_UUID, l)
-    assert_equal(len(l), 2)
-    assert_true(ar.file_has_content(testfile))
+    eq_(len(l), 2)
+    ok_(ar.file_has_content(testfile))
 
     # 2 known copies now; drop should succeed
     ar.drop(testfile)
     l = ar.whereis(testfile)
     assert_in(ar.WEB_UUID, l)
-    assert_equal(len(l), 1)
+    eq_(len(l), 1)
     assert_false(ar.file_has_content(testfile))
     lfull = ar.whereis(testfile, output='full')
     assert_not_in(non_web_remote, lfull) # not present -- so not even listed
@@ -360,21 +427,21 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
 
     # TODO: if we ask for whereis on all files, we should get for all files
     lall = ar.whereis('.')
-    assert_equal(len(lall), 2)
+    eq_(len(lall), 2)
     for e in lall:
         assert(isinstance(e, list))
     # but we don't know which one for which file. need a 'full' one for that
     lall_full = ar.whereis('.', output='full')
-    assert_true(ar.file_has_content(testfile2))
-    assert_true(lall_full[testfile2][non_web_remote]['here'])
-    assert_equal(set(lall_full), {testfile, testfile2})
+    ok_(ar.file_has_content(testfile2))
+    ok_(lall_full[testfile2][non_web_remote]['here'])
+    eq_(set(lall_full), {testfile, testfile2})
 
     # add a bogus 2nd url to testfile
 
     someurl = "http://example.com/someurl"
     ar.add_url_to_file(testfile, someurl, options=['--relaxed'])
     lfull = ar.whereis(testfile, output='full')
-    assert_equal(set(lfull[ar.WEB_UUID]['urls']), {testurl, someurl})
+    eq_(set(lfull[ar.WEB_UUID]['urls']), {testurl, someurl})
 
     # and now test with a file in subdirectory
     subdir = opj(dst, 'd')
@@ -382,28 +449,28 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     with swallow_outputs() as cmo:
         ar.add_url_to_file(testfile3, url=testurl3)
     ok_file_has_content(opj(dst, testfile3), 'more stuff')
-    assert_equal(set(ar.whereis(testfile3)), {ar.WEB_UUID, non_web_remote})
-    assert_equal(set(ar.whereis(testfile3, output='full').keys()), {ar.WEB_UUID, non_web_remote})
+    eq_(set(ar.whereis(testfile3)), {ar.WEB_UUID, non_web_remote})
+    eq_(set(ar.whereis(testfile3, output='full').keys()), {ar.WEB_UUID, non_web_remote})
 
     # and if we ask for both files
     info2 = ar.info([testfile, testfile3])
-    assert_equal(set(info2), {testfile, testfile3})
-    assert_equal(info2[testfile3]['size'], 10)
+    eq_(set(info2), {testfile, testfile3})
+    eq_(info2[testfile3]['size'], 10)
 
     full = ar.whereis([], options='--all', output='full')
-    assert_equal(len(full.keys()), 3)  # we asked for all files -- got 3 keys
+    eq_(len(full.keys()), 3)  # we asked for all files -- got 3 keys
     assert_in(ar.WEB_UUID, full['SHA256E-s10--a978713ea759207f7a6f9ebc9eaebd1b40a69ae408410ddf544463f6d33a30e1.txt'])
 
     # which would work even if we cd to that subdir, but then we should use explicit curdir
     with chpwd(subdir):
         cur_subfile = opj(curdir, 'sub.txt')
-        assert_equal(set(ar.whereis(cur_subfile)), {ar.WEB_UUID, non_web_remote})
-        assert_equal(set(ar.whereis(cur_subfile, output='full').keys()), {ar.WEB_UUID, non_web_remote})
+        eq_(set(ar.whereis(cur_subfile)), {ar.WEB_UUID, non_web_remote})
+        eq_(set(ar.whereis(cur_subfile, output='full').keys()), {ar.WEB_UUID, non_web_remote})
         testfiles = [cur_subfile, opj(pardir, testfile)]
         info2_ = ar.info(testfiles)
         # Should maintain original relative file names
-        assert_equal(set(info2_), set(testfiles))
-        assert_equal(info2_[cur_subfile]['size'], 10)
+        eq_(set(info2_), set(testfiles))
+        eq_(info2_[cur_subfile]['size'], 10)
 
 
 @with_testrepos('.*annex.*', flavors=['local', 'network'])
@@ -422,8 +489,8 @@ def test_AnnexRepo_migrating_backends(src, dst):
     f.close()
 
     ar.add(filename, backend='MD5')
-    assert_equal(ar.get_file_backend(filename), 'MD5')
-    assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+    eq_(ar.get_file_backend(filename), 'MD5')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
 
     # migrating will only do, if file is present
     ok_annex_get(ar, 'test-annex.dat')
@@ -433,13 +500,13 @@ def test_AnnexRepo_migrating_backends(src, dst):
         assert_raises(CommandNotAvailableError, ar.migrate_backend,
                       'test-annex.dat')
     else:
-        assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+        eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
         ar.migrate_backend('test-annex.dat')
-        assert_equal(ar.get_file_backend('test-annex.dat'), 'MD5')
+        eq_(ar.get_file_backend('test-annex.dat'), 'MD5')
 
         ar.migrate_backend('', backend='SHA1')
-        assert_equal(ar.get_file_backend(filename), 'SHA1')
-        assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA1')
+        eq_(ar.get_file_backend(filename), 'SHA1')
+        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
 
 
 tree1args = dict(
@@ -493,20 +560,20 @@ def test_AnnexRepo_backend_option(path, url):
 
     ar.add('firstfile', backend='SHA1')
     ar.add('secondfile')
-    assert_equal(ar.get_file_backend('firstfile'), 'SHA1')
-    assert_equal(ar.get_file_backend('secondfile'), 'MD5')
+    eq_(ar.get_file_backend('firstfile'), 'SHA1')
+    eq_(ar.get_file_backend('secondfile'), 'MD5')
 
     with swallow_outputs() as cmo:
         # must be added under different name since annex 20160114
         ar.add_url_to_file('remotefile2', url + 'remotefile', backend='SHA1')
-    assert_equal(ar.get_file_backend('remotefile2'), 'SHA1')
+    eq_(ar.get_file_backend('remotefile2'), 'SHA1')
 
     with swallow_outputs() as cmo:
         ar.add_urls([url + 'faraway'], backend='SHA1')
     # TODO: what's the annex-generated name of this?
     # For now, workaround:
-    assert_true(ar.get_file_backend(f) == 'SHA1'
-                for f in ar.get_indexed_files() if 'faraway' in f)
+    ok_(ar.get_file_backend(f) == 'SHA1'
+        for f in ar.get_indexed_files() if 'faraway' in f)
 
 
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
@@ -517,12 +584,12 @@ def test_AnnexRepo_get_file_backend(src, dst):
 
     ar = AnnexRepo.clone(src, dst)
 
-    assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
     if not ar.is_direct_mode():
         # no migration in direct mode
         ok_annex_get(ar, 'test-annex.dat', network=False)
         ar.migrate_backend('test-annex.dat', backend='SHA1')
-        assert_equal(ar.get_file_backend('test-annex.dat'), 'SHA1')
+        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
     else:
         assert_raises(CommandNotAvailableError, ar.migrate_backend,
                       'test-annex.dat', backend='SHA1')
@@ -546,7 +613,7 @@ def test_AnnexRepo_always_commit(path):
     # Now git-annex log should show the addition:
     out, err = repo._run_annex_command('log')
     out_list = out.rstrip(os.linesep).splitlines()
-    assert_equal(len(out_list), 1)
+    eq_(len(out_list), 1)
     assert_in(file1, out_list[0])
     # check git log of git-annex branch:
     # expected: initial creation, update (by annex add) and another
@@ -555,7 +622,7 @@ def test_AnnexRepo_always_commit(path):
     num_commits = len([commit
                        for commit in out.rstrip(os.linesep).split('\n')
                        if commit.startswith('commit')])
-    assert_equal(num_commits, 3)
+    eq_(num_commits, 3)
 
     repo.always_commit = False
     repo.add(file2)
@@ -565,7 +632,7 @@ def test_AnnexRepo_always_commit(path):
     num_commits = len([commit
                        for commit in out.rstrip(os.linesep).split('\n')
                        if commit.startswith('commit')])
-    assert_equal(num_commits, 3)
+    eq_(num_commits, 3)
 
     repo.always_commit = True
 
@@ -575,13 +642,13 @@ def test_AnnexRepo_always_commit(path):
     # show two commits.
     out, err = repo._run_annex_command('log')
     out_list = out.rstrip(os.linesep).splitlines()
-    assert_equal(len(out_list), 2, "Output:\n%s" % out_list)
+    eq_(len(out_list), 2, "Output:\n%s" % out_list)
     assert_in(file1, out_list[0])
     assert_in("recording state in git", out_list[1])
 
     out, err = repo._run_annex_command('log')
     out_list = out.rstrip(os.linesep).splitlines()
-    assert_equal(len(out_list), 2, "Output:\n%s" % out_list)
+    eq_(len(out_list), 2, "Output:\n%s" % out_list)
     assert_in(file1, out_list[0])
     assert_in(file2, out_list[1])
 
@@ -590,7 +657,7 @@ def test_AnnexRepo_always_commit(path):
     num_commits = len([commit
                        for commit in out.rstrip(os.linesep).split('\n')
                        if commit.startswith('commit')])
-    assert_equal(num_commits, 4)
+    eq_(num_commits, 4)
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
@@ -601,7 +668,7 @@ def test_AnnexRepo_on_uninited_annex(path):
     assert_false(annex.file_has_content('test-annex.dat'))
     with swallow_outputs():
         annex.get('test-annex.dat')
-        assert_true(annex.file_has_content('test-annex.dat'))
+        ok_(annex.file_has_content('test-annex.dat'))
 
 
 @assert_cwd_unchanged
@@ -638,7 +705,6 @@ def test_AnnexRepo_add_to_annex(path):
         f.write("some")
 
     out_json = repo.add(filename)
-
     # file is known to annex:
     if not repo.is_direct_mode():
         assert_true(os.path.islink(filename_abs),
@@ -653,7 +719,7 @@ def test_AnnexRepo_add_to_annex(path):
     ok_(repo.file_has_content(filename))
 
     # uncommitted:
-    ok_(repo.repo.is_dirty())
+    ok_(repo.dirty)
 
     repo.commit("Added file to annex.")
     ok_clean_git(repo.path, annex=True)
@@ -721,7 +787,7 @@ def test_AnnexRepo_get(src, dst):
     assert_false(annex.file_has_content("test-annex.dat"))
     with swallow_outputs():
         annex.get(testfile)
-    assert_true(annex.file_has_content("test-annex.dat"))
+    ok_(annex.file_has_content("test-annex.dat"))
     ok_file_has_content(testfile_abs, '123', strip=True)
 
     called = []
@@ -746,9 +812,8 @@ def test_AnnexRepo_get(src, dst):
                       side_effect=check_run, auto_spec=True), \
             swallow_outputs():
         annex.get(testfile, jobs=5)
-    assert_equal(called, ['find', 'get'])
+    eq_(called, ['find', 'get'])
     ok_file_has_content(testfile_abs, '123', strip=True)
-
 
 
 # TODO:
@@ -762,7 +827,7 @@ def _test_AnnexRepo_get_contentlocation(batch, path, work_dir_outside):
     fname = 'test-annex.dat'
     key = annex.get_file_key(fname)
     # TODO: see if we can avoid this or specify custom exception
-    assert_equal(annex.get_contentlocation(key, batch=batch), '')
+    eq_(annex.get_contentlocation(key, batch=batch), '')
 
     with swallow_outputs() as cmo:
         annex.get(fname)
@@ -823,7 +888,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     ar.add_url_to_file(testfile, testurl, batch=True)
 
     info = ar.info(testfile)
-    assert_equal(info['size'], 14)
+    eq_(info['size'], 14)
     assert(info['key'])
     # not even added to index yet since we this repo is with default batch_size
     assert_not_in(ar.WEB_UUID, ar.whereis(testfile))
@@ -861,9 +926,9 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     ar2 = AnnexRepo(dst, batch_size=1)
 
     with swallow_outputs():
-        assert_equal(len(ar2._batched), 0)
+        eq_(len(ar2._batched), 0)
         ar2.add_url_to_file(filename, testurl, batch=True)
-        assert_equal(len(ar2._batched), 1)  # we added one more with batch_size=1
+        eq_(len(ar2._batched), 1)  # we added one more with batch_size=1
     ar2.commit("added new file")  # would do nothing ATM, but also doesn't fail
     assert_in(filename, ar2.get_files())
     assert_in(ar.WEB_UUID, ar2.whereis(filename))
@@ -874,13 +939,13 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     # this poor bugger still wasn't added since we used default batch_size=0 on him
 
     # and closing the pipes now shoudn't anyhow affect things
-    assert_equal(len(ar._batched), 1)
+    eq_(len(ar._batched), 1)
     ar._batched.close()
-    assert_equal(len(ar._batched), 1)  # doesn't remove them, just closes
+    eq_(len(ar._batched), 1)  # doesn't remove them, just closes
     assert(not ar.dirty)
 
     ar._batched.clear()
-    assert_equal(len(ar._batched), 0)  # .clear also removes
+    eq_(len(ar._batched), 0)  # .clear also removes
 
     raise SkipTest("TODO: more, e.g. add with a custom backend")
     # TODO: also with different modes (relaxed, fast)
@@ -1278,45 +1343,45 @@ def test_ProcessAnnexProgressIndicators():
     # for regular lines -- should just return them without side-effects
     for l in irrelevant_lines + success_lines:
         with swallow_outputs() as cmo:
-            assert_equal(proc(l), l)
-            assert_equal(proc.pbars, {})
-            assert_equal(cmo.out, '')
-            assert_equal(cmo.err, '')
+            eq_(proc(l), l)
+            eq_(proc.pbars, {})
+            eq_(cmo.out, '')
+            eq_(cmo.err, '')
     # should process progress lines
-    assert_equal(proc(progress_lines[0]), None)
-    assert_equal(len(proc.pbars), 1)
+    eq_(proc(progress_lines[0]), None)
+    eq_(len(proc.pbars), 1)
     # but when we finish download -- should get cleared
-    assert_equal(proc(success_lines[0]), success_lines[0])
-    assert_equal(proc.pbars, {})
+    eq_(proc(success_lines[0]), success_lines[0])
+    eq_(proc.pbars, {})
     # and no side-effect of any kind in finish
-    assert_equal(proc.finish(), None)
+    eq_(proc.finish(), None)
 
     proc = ProcessAnnexProgressIndicators(expected={'key1': 100, 'key2': None})
     # when without any target downloads, there is no total_pbar
     assert(proc.total_pbar is not None)
-    assert_equal(proc.total_pbar._pbar.total, 100)  # as much as it knows at this point
+    eq_(proc.total_pbar._pbar.total, 100)  # as much as it knows at this point
     # for regular lines -- should still just return them without side-effects
     for l in irrelevant_lines:
         with swallow_outputs() as cmo:
-            assert_equal(proc(l), l)
-            assert_equal(proc.pbars, {})
-            assert_equal(cmo.out, '')
-            assert_equal(cmo.err, '')
+            eq_(proc(l), l)
+            eq_(proc.pbars, {})
+            eq_(cmo.out, '')
+            eq_(cmo.err, '')
     # should process progress lines
     # it doesn't swallow everything -- so there will be side-effects in output
     with swallow_outputs() as cmo:
-        assert_equal(proc(progress_lines[0]), None)
-        assert_equal(len(proc.pbars), 1)
+        eq_(proc(progress_lines[0]), None)
+        eq_(len(proc.pbars), 1)
         # but when we finish download -- should get cleared
-        assert_equal(proc(success_lines[0]), success_lines[0])
-        assert_equal(proc.pbars, {})
+        eq_(proc(success_lines[0]), success_lines[0])
+        eq_(proc.pbars, {})
         out = cmo.out
     assert out  # just assert that something was output
     assert proc.total_pbar is not None
     # and no side-effect of any kind in finish
     with swallow_outputs() as cmo:
-        assert_equal(proc.finish(), None)
-        assert_equal(proc.total_pbar, None)
+        eq_(proc.finish(), None)
+        eq_(proc.total_pbar, None)
 
 
 @with_tempfile
@@ -1331,19 +1396,19 @@ def test_get_description(path1, path2):
     assert_not_equal(annex1_description, path1)
 
     annex2 = AnnexRepo(path2, create=True, description='custom 2')
-    assert_equal(annex2.get_description(), 'custom 2')
+    eq_(annex2.get_description(), 'custom 2')
     # not yet known
-    assert_equal(annex2.get_description(uuid=annex1.uuid), None)
+    eq_(annex2.get_description(uuid=annex1.uuid), None)
 
     annex2.add_remote('annex1', path1)
     annex2.fetch('annex1')
     # it will match the remote name
-    assert_equal(annex2.get_description(uuid=annex1.uuid),
-                 annex1_description + ' [annex1]')
+    eq_(annex2.get_description(uuid=annex1.uuid),
+        annex1_description + ' [annex1]')
     # but let's remove the remote
-    annex1.merge_annex('annex1')
+    annex2.merge_annex('annex1')
     annex2.remove_remote('annex1')
-    assert_equal(annex2.get_description(uuid=annex1.uuid), annex1_description)
+    eq_(annex2.get_description(uuid=annex1.uuid), annex1_description)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -112,7 +112,7 @@ def test_GitRepo_equals(path1, path2):
 
 
 @assert_cwd_unchanged
-@with_testrepos(flavors=local_testrepo_flavors)
+@with_testrepos('.*git.*', flavors=local_testrepo_flavors)
 @with_tempfile
 def test_GitRepo_add(src, path):
 
@@ -140,7 +140,7 @@ def test_GitRepo_add(src, path):
 
     assert_in(filename, gr.get_indexed_files(),
               "%s not successfully added to %s" % (filename, path))
-    ok_clean_git(path, annex=False)
+    ok_clean_git(path)
 
 
 @assert_cwd_unchanged
@@ -417,7 +417,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     eq_([u'origin/master', u'origin/new_branch'],
         [commit.name for commit in fetched])
 
-    ok_clean_git(clone.path, annex=False)
+    ok_clean_git(clone.path)
     assert_in("origin/new_branch", clone.get_remote_branches())
     assert_in(filename, clone.get_files("origin/new_branch"))
     assert_false(exists(opj(clone_path, filename)))  # not checked out
@@ -440,7 +440,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 
     fetched = repo.fetch(remote="ssh-remote")
     assert_in('ssh-remote/master', [commit.name for commit in fetched])
-    ok_clean_git(repo.path, annex=False)
+    ok_clean_git(repo.path)
 
     # the connection is known to the SSH manager, since fetch() requested it:
     assert_in(socket_path, ssh_manager._connections)
@@ -859,7 +859,7 @@ def test_submodule_deinit(path):
     ok_(not top_repo.repo.submodule('subm 1').module_exists())
 
 
-@with_testrepos(".*basic.*", flavors=['local'])
+@with_testrepos(".*basic_git.*", flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_GitRepo_add_submodule(source, path):
 
@@ -868,8 +868,8 @@ def test_GitRepo_add_submodule(source, path):
     top_repo.add_submodule('sub', name='sub', url=source)
     top_repo.commit('submodule added')
     eq_([s.name for s in top_repo.get_submodules()], ['sub'])
-    ok_clean_git(path, annex=False)
-    ok_clean_git(opj(path, 'sub'), annex=False)
+    ok_clean_git(path)
+    ok_clean_git(opj(path, 'sub'))
 
 
 def test_GitRepo_update_submodule():

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -440,7 +440,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 
     fetched = repo.fetch(remote="ssh-remote")
     assert_in('ssh-remote/master', [commit.name for commit in fetched])
-    ok_clean_git(repo.path)
+    ok_clean_git(repo)
 
     # the connection is known to the SSH manager, since fetch() requested it:
     assert_in(socket_path, ssh_manager._connections)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -864,6 +864,27 @@ def test_submodule_deinit(path):
     ok_(not top_repo.repo.submodule('subm 1').module_exists())
 
 
+@with_testrepos(".*basic.*", flavors=['local'])
+@with_tempfile(mkdir=True)
+def test_GitRepo_add_submodule(source, path):
+
+    top_repo = GitRepo(path, create=True)
+
+    top_repo.add_submodule('sub', name='sub', url=source)
+    top_repo.commit('submodule added')
+    eq_([s.name for s in top_repo.get_submodules()], ['sub'])
+    ok_clean_git(path, annex=False)
+    ok_clean_git(opj(path, 'sub'), annex=False)
+
+
+def test_GitRepo_update_submodule():
+    raise SkipTest("TODO")
+
+
+def test_GitRepo_get_submodules():
+    raise SkipTest("TODO")
+
+
 def test_kwargs_to_options():
 
     class Some(object):

--- a/datalad/tests/test_network.py
+++ b/datalad/tests/test_network.py
@@ -127,7 +127,7 @@ def test_url_eq():
 
 def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
     """just a helper to carry out few checks on urls"""
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         ri_ = cls(**fields)
         murl = RI(ri)
         eq_(murl.__class__, cls)  # not just a subclass
@@ -285,7 +285,7 @@ def test_url_samples():
 
     # actually this one is good enough to trigger a warning and I still don't know
     # what it should exactly be!?
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         weired_str = 'weired://'
         weired_url = RI(weired_str)
         repr(weired_url)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -147,58 +147,92 @@ def ok_clean_git_annex_proxy(path):
     """
     # TODO: May be let's make a method of AnnexRepo for this purpose
 
-    ar = AnnexRepo(path)
-    cwd = getpwd()
-    chpwd(path)
-
-    try:
-        out = ar.proxy(['git', 'status'])
-    except CommandNotAvailableError as e:
-        raise SkipTest
-    finally:
-        chpwd(cwd)
-
-    assert_in(
-        "nothing to commit", out[0],
-        msg="git-status output via proxy not plausible: %s" % out[0]
-    )
+    if isinstance(path, AnnexRepo):
+        ar = path
+    else:
+        ar = AnnexRepo(path)
+        # Note: Possible exception while trying to instantiate AnnexRepo
+        # intended to be thrown in order to have a failure in the assertion
+    ok_(not ar.dirty)
 
 
-def ok_clean_git(path, annex=True, head_modified=[], index_modified=[], untracked=[]):
+def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
+                 untracked=[]):
     """Verify that under given path there is a clean git repository
 
     it exists, .git exists, nothing is uncommitted/dirty/staged
+
+    Parameters
+    ----------
+    path: str or Repo
+      in case of a str: path to the repository's base dir;
+      Note, that passing a Repo instance prevents detecting annex. This might be
+      useful in case of a non-initialized annex, a GitRepo is pointing to.
+    annex: bool or None
+      explicitly set to True or False to indicate, that an annex is (not)
+      expected; set to None to autodetect, whether there is an annex.
+      Default: None.
     """
-    from datalad.support.gitrepo import GitRepo
-    if isinstance(path, GitRepo):
-        path = path.path
 
-    ok_(exists(path))
-    ok_(exists(join(path, '.git')))
-    if annex:
-        ok_(exists(join(path, '.git', 'annex')))
-    repo = git.Repo(path)
+    if isinstance(path, AnnexRepo):
+        if annex is None:
+            annex = True
+        # if `annex` was set to False, but we find an annex => fail
+        assert_is(annex, True)
+        r = path
+    elif isinstance(path, GitRepo):
+        if annex is None:
+            annex = False
+        # explicitly given GitRepo instance doesn't make sense with 'annex' True
+        assert_is(annex, False)
+        r = path
+    else:
+        # 'path' is an actual path
+        try:
+            r = AnnexRepo(path, init=False, create=False)
+            if annex is None:
+                annex = True
+            # if `annex` was set to False, but we find an annex => fail
+            assert_is(annex, True)
+        except Exception:
+            # Instantiation failed => no annex
+            r = GitRepo(path, init=False, create=False)
+            if annex is None:
+                annex = False
+            # explicitly given GitRepo instance doesn't make sense with
+            # 'annex' True
+            assert_is(annex, False)
 
-    if repo.index.entries.keys():
-        ok_(repo.head.is_valid())
+    if annex and r.is_direct_mode():
+        ok_(not r.dirty)
+    else:
+        ok_(exists(r.path))
+        ok_(exists(join(r.path, '.git')))
+        if annex:
+            ok_(exists(join(r.path, '.git', 'annex')))
 
-        eq_(sorted(repo.untracked_files), sorted(untracked))
+        repo = r.repo
 
-        if not head_modified and not index_modified:
-            # get string representations of diffs with index to ease
-            # troubleshooting
-            head_diffs = [str(d) for d in repo.index.diff(repo.head.commit)]
-            index_diffs = [str(d) for d in repo.index.diff(None)]
-            eq_(head_diffs, [])
-            eq_(index_diffs, [])
-        else:
-            if head_modified:
-                # we did ask for interrogating changes
-                head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
-                eq_(head_modified_, head_modified)
-            if index_modified:
-                index_modified_ = [d.a_path for d in repo.index.diff(None)]
-                eq_(index_modified_, index_modified)
+        if repo.index.entries.keys():
+            ok_(repo.head.is_valid())
+
+            eq_(sorted(repo.untracked_files), sorted(untracked))
+
+            if not head_modified and not index_modified:
+                # get string representations of diffs with index to ease
+                # troubleshooting
+                head_diffs = [str(d) for d in repo.index.diff(repo.head.commit)]
+                index_diffs = [str(d) for d in repo.index.diff(None)]
+                eq_(head_diffs, [])
+                eq_(index_diffs, [])
+            else:
+                if head_modified:
+                    # we did ask for interrogating changes
+                    head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
+                    eq_(head_modified_, head_modified)
+                if index_modified:
+                    index_modified_ = [d.a_path for d in repo.index.diff(None)]
+                    eq_(index_modified_, index_modified)
 
 
 def ok_file_under_git(path, filename=None, annexed=False):


### PR DESCRIPTION
- [x] Workaround direct mode issue with git 2.11.0 as pointed out in #1208 and #1179
- [ ] fix `ok_clean_git` and `Repo.dirty` wrt to direct mode and V6 (#1180, #1132)
- [ ] more testing for submodule commands
- [x] `Repo.add_submodule` works in direct mode and V6
- [ ] `Repo.update_submodule` works in direct mode and V6
- [ ] `Repo.deinit_submodule` works in direct mode and V6

Closes #1208 
Closes #1180 