### PR TITLE
General `create-sibling` RF and few enhancements

### DIFF
--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -195,7 +195,9 @@ class AddSibling(Interface):
             repoinfo = repos[repo_name]
             repo = repoinfo['repo']
             if repo_name in already_existing:
-                if repo_name not in conflicting and repo.get_remote_url(name) is not None:
+                if not force and \
+                        repo_name not in conflicting \
+                        and repo.get_remote_url(name) is not None:
                     lgr.debug("Skipping {0}. Nothing to do.".format(repo_name))
                     continue
                 # rewrite url
@@ -223,12 +225,14 @@ class AddSibling(Interface):
                 ds.config.reload()
 
             if publish_by_default:
+                dfltvar = "remote.{}.push".format(name)
+                if dfltvar in ds.config:
+                    ds.config.unset(dfltvar, where='local', reload=False)
                 for refspec in assure_list(publish_by_default):
                     lgr.info(
                         'Configure additional default publication refspec "%s"',
                         refspec)
-                    ds.config.add("remote.{}.push".format(name), refspec,
-                                  'local')
+                    ds.config.add(dfltvar, refspec, 'local')
                 ds.config.reload()
 
             assert isinstance(repo, GitRepo)  # just against silly code

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -35,7 +35,7 @@ from datalad.distribution.dataset import EnsureDataset, Dataset, \
 from datalad.support.exceptions import CommandError
 
 
-lgr = logging.getLogger('datalad.distribution.add_publication_target')
+lgr = logging.getLogger('datalad.distribution.add_sibling')
 
 
 class AddSibling(Interface):

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -59,7 +59,8 @@ def _create_dataset_sibling(
         shared,
         remote_git_version,
         publish_depends,
-        publish_by_default):
+        publish_by_default,
+        as_common_datasrc):
     localds_path = ds.path
     if not replicate_local_structure:
         ds_name = localds_path.replace("/", "-")
@@ -427,7 +428,8 @@ class CreateSibling(Interface):
                 shared,
                 remote_git_version,
                 publish_depends,
-                publish_by_default)
+                publish_by_default,
+                as_common_datasrc)
             if not path:
                 # nothing new was created
                 continue

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -356,6 +356,7 @@ class CreateSibling(Interface):
         # use common sorting implementation to discover all subdatasets
         content_by_ds, unavailable_paths = Interface._prep(
             # the base data set is the only path
+            path=ds.path,
             dataset=ds,
             recursive=recursive,
             recursion_limit=recursion_limit)

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -157,33 +157,26 @@ class CreateSibling(Interface):
             raise InsufficientArgumentsError(
                 "need at least an SSH URL")
 
-        if name is None and \
-                (target_url is not None or
-                 target_pushurl is not None):
-            raise ValueError("""insufficient information for adding the target
-            as a sibling (needs at least a name)""")
+        # check the login URL
+        sshri = RI(sshurl)
+        if not isinstance(sshri, SSHRI) \
+                and not (isinstance(sshri, URL) and sshri.scheme == 'ssh'):
+            raise ValueError(
+                "Unsupported SSH URL: '{0}', "
+                "use ssh://host/path or host:path syntax".format(sshurl))
+
+        if not name:
+            # use the hostname as default remote name
+            name = sshri.hostname
+            lgr.debug(
+                "No sibling name given, use URL hostname '%s' as sibling name",
+                name)
 
         # shortcut
         ds = require_dataset(dataset, check_installed=True,
                              purpose='creating a sibling')
 
         assert(ds is not None and sshurl is not None and ds.repo is not None)
-
-        # determine target parameters:
-        sshri = RI(sshurl)
-
-        if not isinstance(sshri, SSHRI) \
-                and not (isinstance(sshri, URL) and sshri.scheme == 'ssh'):
-            raise ValueError(
-                "Unsupported SSH URL: '{0}', use ssh://host/path or host:path syntax".format(
-                    sshurl))
-
-        if not name:
-            # use the hostname
-            name = sshri.hostname
-            lgr.debug(
-                "No sibling name given, use URL hostname '%s' as sibling name",
-                name)
 
         # TODO add check if such a remote already exists and act based on
         # --existing

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -265,6 +265,7 @@ class CreateSibling(Interface):
                 # check how to deal with it. Does windows ssh server accept
                 # posix paths? vice versa? Should planned SSH class provide
                 # tools for this issue?
+                # see gh-1188
                 path = normpath(opj(target_dir,
                                     relpath(current_dspath,
                                             start=ds.path)))

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -189,9 +189,25 @@ def _create_dataset_sibling(
 
 
 class CreateSibling(Interface):
-    """Create dataset(s)'s sibling (e.g., on a web server).
+    """Create a dataset sibling on a UNIX-like SSH-accessible machine
 
-    Those (empty) datasets can then serve as a target for the `publish` command.
+    Given a local dataset, and SSH login information this command creates
+    a remote dataset repository and configures it as a dataset sibling to
+    be used as a publication target (see `publish` command).
+
+    Various properties of the remote sibling can be configured (e.g. name
+    location on the server, read and write access URLs, and access
+    permissions.
+
+    Optionally, a basic web-viewer for DataLad datasets can be installed
+    at the remote location.
+
+    This command supports recursive processing of dataset hierarchies, creating
+    a remote sibling for each dataset in the hierarchy. By default, remote
+    siblings are created in hierarchical structure that reflects the
+    organization on the local file system. However, a simple templating
+    mechanism is provided to produce a flat list of datasets (see
+    --target-dir).
     """
 
     _params_ = dict(

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -12,34 +12,34 @@
 __docformat__ = 'restructuredtext'
 
 
-import logging
-import datalad
-from os.path import join as opj, relpath, normpath, dirname
 from distutils.version import LooseVersion
 from glob import glob
+import logging
+from os.path import join as opj, relpath, normpath, dirname
 
-from datalad.support.network import RI, URL, SSHRI
-from datalad.support.param import Parameter
+import datalad
+from datalad import ssh_manager
+from datalad.cmd import CommandError
+from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
+from datalad.consts import TIMESTAMP_FMT
 from datalad.dochelpers import exc_str
-from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
-from datalad.support.constraints import EnsureChoice
-from datalad.support.annexrepo import AnnexRepo
-from ..interface.base import Interface
+from datalad.distribution.add_sibling import AddSibling
+from datalad.distribution.dataset import EnsureDataset, Dataset, \
+    datasetmethod, require_dataset
+from datalad.interface.base import Interface
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import as_common_datasrc
 from datalad.interface.common_opts import publish_by_default
 from datalad.interface.common_opts import publish_depends
-from datalad.distribution.dataset import EnsureDataset, Dataset, \
-    datasetmethod, require_dataset
-from datalad.cmd import CommandError
-from datalad.utils import not_supported_on_windows
-from .add_sibling import AddSibling
-from datalad import ssh_manager
-from datalad.utils import make_tempfile
-from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
-from datalad.consts import TIMESTAMP_FMT
-from datalad.utils import _path_
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
+from datalad.support.constraints import EnsureChoice
 from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.network import RI, URL, SSHRI
+from datalad.support.param import Parameter
+from datalad.utils import make_tempfile
+from datalad.utils import not_supported_on_windows
+from datalad.utils import _path_
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -244,6 +244,7 @@ class CreateSibling(Interface):
         lgr.info("Connecting ...")
         ssh = ssh_manager.get_connection(sshurl)
         ssh.open()
+        remote_git_version = CreateSibling.get_remote_git_version(ssh)
 
         # flag to check if at dataset_root
         at_root = True
@@ -318,7 +319,6 @@ class CreateSibling(Interface):
 
             # check git version on remote end
             lgr.info("Adjusting remote git configuration")
-            remote_git_version = CreateSibling.get_remote_git_version(ssh)
             if remote_git_version and remote_git_version >= "2.4":
                 # allow for pushing to checked out branch
                 try:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -47,11 +47,11 @@ lgr = logging.getLogger('datalad.distribution.create_sibling')
 
 def _create_dataset_sibling(
         name,
-        current_ds,
         ds,
+        hierarchy_basepath,
         ssh,
         replicate_local_structure,
-        sshri,
+        ssh_url,
         target_dir,
         target_url,
         target_pushurl,
@@ -60,22 +60,22 @@ def _create_dataset_sibling(
         remote_git_version,
         publish_depends,
         publish_by_default):
-    current_dspath = current_ds.path
+    localds_path = ds.path
     if not replicate_local_structure:
-        ds_name = current_dspath.replace("/", "-")
-        path = target_dir.replace("%NAME", ds_name)
+        ds_name = localds_path.replace("/", "-")
+        remoteds_path = target_dir.replace("%NAME", ds_name)
     else:
         # TODO: opj depends on local platform, not the remote one.
         # check how to deal with it. Does windows ssh server accept
         # posix paths? vice versa? Should planned SSH class provide
         # tools for this issue?
         # see gh-1188
-        ds_name = relpath(current_dspath, start=ds.path)
-        path = normpath(opj(target_dir, ds_name))
+        ds_name = relpath(localds_path, start=hierarchy_basepath)
+        remoteds_path = normpath(opj(target_dir, ds_name))
 
     # construct a would-be ssh url based on the current dataset's path
-    sshri.path = path
-    ds_sshurl = sshri.as_str()
+    ssh_url.path = remoteds_path
+    ds_sshurl = ssh_url.as_str()
     # configure dataset's git-access urls
     ds_target_url = target_url.replace('%NAME', ds_name) \
         if target_url else ds_sshurl
@@ -87,51 +87,58 @@ def _create_dataset_sibling(
             if target_pushurl else ds_sshurl
 
     lgr.info("Creating target dataset {0} at {1}".format(
-        current_dspath, path))
+        localds_path, remoteds_path))
     # Must be set to True only if exists and existing='reconfigure'
     # otherwise we might skip actions if we say existing='reconfigure'
     # but it did not even exist before
     only_reconfigure = False
-    if path != '.':
+    if remoteds_path != '.':
         # check if target exists
         # TODO: Is this condition valid for != '.' only?
         path_exists = True
         try:
-            out, err = ssh(["ls", path])
+            out, err = ssh(["ls", remoteds_path])
         except CommandError as e:
             if "No such file or directory" in e.stderr and \
-                    path in e.stderr:
+                    remoteds_path in e.stderr:
                 path_exists = False
             else:
                 raise  # It's an unexpected failure here
 
         if path_exists:
             if existing == 'error':
-                raise RuntimeError("Target directory %s already exists." % path)
+                raise RuntimeError(
+                    "Target directory {} already exists.".format(
+                        remoteds_path))
             elif existing == 'skip':
                 return
             elif existing == 'replace':
-                ssh(["chmod", "+r+w", "-R", path])  # enable write permissions to allow removing dir
-                ssh(["rm", "-rf", path])            # remove target at path
-                path_exists = False                 # if we succeeded in removing it
+                # enable write permissions to allow removing dir
+                ssh(["chmod", "+r+w", "-R", remoteds_path])
+                # remove target at path
+                ssh(["rm", "-rf", remoteds_path])
+                # if we succeeded in removing it
+                path_exists = False
             elif existing == 'reconfigure':
                 only_reconfigure = True
             else:
-                raise ValueError("Do not know how to handle existing=%s" % repr(existing))
+                raise ValueError(
+                    "Do not know how to handle existing={}".format(
+                        repr(existing)))
 
         if not path_exists:
             try:
-                ssh(["mkdir", "-p", path])
+                ssh(["mkdir", "-p", remoteds_path])
             except CommandError as e:
                 lgr.error("Remotely creating target directory failed at "
-                          "%s.\nError: %s" % (path, exc_str(e)))
+                          "%s.\nError: %s" % (remoteds_path, exc_str(e)))
                 return
 
     # don't (re-)initialize dataset if existing == reconfigure
     if not only_reconfigure:
         # init git and possibly annex repo
         if not CreateSibling.init_remote_repo(
-                path, ssh, shared, current_ds,
+                remoteds_path, ssh, shared, ds,
                 description=target_url):
             return
 
@@ -139,7 +146,7 @@ def _create_dataset_sibling(
     # -> add as remote
     lgr.debug("Adding the siblings")
     AddSibling.__call__(
-        dataset=current_ds,
+        dataset=ds,
         name=name,
         url=ds_target_url,
         pushurl=ds_target_pushurl,
@@ -155,12 +162,12 @@ def _create_dataset_sibling(
     if remote_git_version and remote_git_version >= "2.4":
         # allow for pushing to checked out branch
         try:
-            ssh(["git", "-C", path] +
+            ssh(["git", "-C", remoteds_path] +
                 ["config", "receive.denyCurrentBranch", "updateInstead"])
         except CommandError as e:
             lgr.error("git config failed at remote location %s.\n"
                       "You will not be able to push to checked out "
-                      "branch. Error: %s", path, exc_str(e))
+                      "branch. Error: %s", remoteds_path, exc_str(e))
     else:
         lgr.error("Git version >= 2.4 needed to configure remote."
                   " Version detected on server: %s\nSkipping configuration"
@@ -173,12 +180,12 @@ def _create_dataset_sibling(
     lgr.info("Enabling git post-update hook ...")
     try:
         CreateSibling.create_postupdate_hook(
-            path, ssh, current_ds)
+            remoteds_path, ssh, ds)
     except CommandError as e:
         lgr.error("Failed to add json creation command to post update "
                   "hook.\nError: %s" % exc_str(e))
 
-    return path
+    return remoteds_path
 
 
 class CreateSibling(Interface):
@@ -393,7 +400,7 @@ class CreateSibling(Interface):
             path = _create_dataset_sibling(
                 name,
                 current_ds,
-                ds,
+                ds.path,
                 ssh,
                 replicate_local_structure,
                 sshri,

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -35,7 +35,8 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
 from datalad.support.constraints import EnsureChoice
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.network import RI, URL, SSHRI
+from datalad.support.network import RI
+from datalad.support.network import is_ssh
 from datalad.support.param import Parameter
 from datalad.utils import make_tempfile
 from datalad.utils import not_supported_on_windows
@@ -166,8 +167,7 @@ class CreateSibling(Interface):
 
         # check the login URL
         sshri = RI(sshurl)
-        if not isinstance(sshri, SSHRI) \
-                and not (isinstance(sshri, URL) and sshri.scheme == 'ssh'):
+        if not is_ssh(sshri):
             raise ValueError(
                 "Unsupported SSH URL: '{0}', "
                 "use ssh://host/path or host:path syntax".format(sshurl))
@@ -398,7 +398,6 @@ class CreateSibling(Interface):
             except CommandError as e:
                 lgr.error("Failed to run post-update hook under path %s. "
                           "Error: %s" % (path, exc_str(e)))
-
 
         # TODO: Return value!?
         #       => [(Dataset, fetch_url)]

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -39,6 +39,7 @@ from datalad.utils import make_tempfile
 from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
 from datalad.consts import TIMESTAMP_FMT
 from datalad.utils import _path_
+from datalad.support.exceptions import InsufficientArgumentsError
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 
@@ -152,9 +153,9 @@ class CreateSibling(Interface):
                  publish_by_default=None,
                  publish_depends=None):
 
-        if sshurl is None:
-            raise ValueError("""insufficient information for target creation
-            (needs at least a dataset and a SSH URL).""")
+        if not sshurl:
+            raise InsufficientArgumentsError(
+                "need at least an SSH URL")
 
         if name is None and \
                 (target_url is not None or

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -153,6 +153,10 @@ class CreateSibling(Interface):
                  publish_by_default=None,
                  publish_depends=None):
 
+        # there is no point in doing anything further
+        not_supported_on_windows(
+            "Support for SSH connections is not yet implemented in Windows")
+
         if not sshurl:
             raise InsufficientArgumentsError(
                 "need at least an SSH URL")
@@ -207,7 +211,6 @@ class CreateSibling(Interface):
                     Dataset(sub_path)
 
         # request ssh connection:
-        not_supported_on_windows("TODO")
         lgr.info("Connecting ...")
         ssh = ssh_manager.get_connection(sshurl)
         ssh.open()

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -382,9 +382,6 @@ class CreateSibling(Interface):
         ssh.open()
         remote_git_version = CreateSibling.get_remote_git_version(ssh)
 
-        # flag to check if at dataset_root
-        at_root = True
-
         # loop over all datasets, ordered from top to bottom to make test
         # below valid (existing directories would cause the machinery to halt)
         # But we need to run post-update hook in depth-first fashion, so
@@ -411,18 +408,16 @@ class CreateSibling(Interface):
             if not path:
                 # nothing new was created
                 continue
+            remote_repos_to_run_hook_for.append(path)
 
             # publish web-interface to root dataset on publication server
-            if at_root and ui:
+            if current_dspath == ds.path and ui:
                 lgr.info("Uploading web interface to %s" % path)
-                at_root = False
                 try:
                     CreateSibling.upload_web_interface(path, ssh, shared, ui)
                 except CommandError as e:
                     lgr.error("Failed to push web interface to the remote "
                               "datalad repository.\nError: %s" % exc_str(e))
-
-            remote_repos_to_run_hook_for.append(path)
 
         # in reverse order would be depth first
         lgr.debug("Running post-update hooks in all created siblings")

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -18,7 +18,7 @@ from datalad.api import publish, install, create_sibling
 from datalad.utils import chpwd
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
-
+from datalad.support.network import urlquote
 from nose.tools import eq_, assert_false
 from datalad.tests.utils import with_tempfile, assert_in, \
     with_testrepos
@@ -165,7 +165,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             sshurl="ssh://localhost" + target_path,
             publish_by_default='master',
             existing='replace')
-        eq_("ssh://localhost" + target_path,
+        eq_("ssh://localhost" + urlquote(target_path),
             source.repo.get_remote_url("local_target"))
         ok_(source.repo.get_remote_url("local_target", push=True) is None)
 

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -163,6 +163,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             dataset=source,
             name="local_target",
             sshurl="ssh://localhost" + target_path,
+            publish_by_default='master',
             existing='replace')
         eq_("ssh://localhost" + target_path,
             source.repo.get_remote_url("local_target"))
@@ -176,6 +177,8 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             local_target_cfg = annex.repo.remotes["local_target"].config_reader.get
             eq_(local_target_cfg('annex-ignore'), 'false')
             eq_(local_target_cfg('annex-uuid').count('-'), 4)  # valid uuid
+            # should be added too, even if URL matches prior state
+            eq_(local_target_cfg('push'), 'master')
 
         # again, by explicitly passing urls. Since we are on localhost, the
         # local path should work:

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -38,6 +38,7 @@ from datalad.tests.utils import assert_no_errors_logged
 from datalad.tests.utils import get_mtimes_and_digests
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import ok_
+from datalad.support.exceptions import InsufficientArgumentsError
 
 from datalad.utils import on_windows
 from datalad.utils import _path_
@@ -84,6 +85,16 @@ assert_create_sshwebserver = (
     if external_versions['cmd:system-git'] >= '2.4'
     else create_sibling
 )
+
+
+def test_invalid_call():
+    # needs a SSH URL
+    assert_raises(InsufficientArgumentsError, create_sibling, '')
+    assert_raises(ValueError, create_sibling, 'http://ignore.me')
+    # needs an actual dataset
+    assert_raises(
+        ValueError,
+        create_sibling, 'localhost:/tmp/somewhere', dataset='/nothere')
 
 
 @skip_ssh

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -114,15 +114,14 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
     source = install(src_path, source=origin)
 
     target_path = opj(target_rootpath, "basic")
-    #with swallow_logs(new_level=logging.ERROR) as cml:
-    create_sibling(
-        dataset=source,
-        name="local_target",
-        sshurl="ssh://localhost",
-        target_dir=target_path,
-        ui=True)
-        # is not actually happening on one of the two basic cases -- TODO figure it out
-        # assert_in('enableremote local_target failed', cml.out)
+    with swallow_logs(new_level=logging.ERROR) as cml:
+        create_sibling(
+            dataset=source,
+            name="local_target",
+            sshurl="ssh://localhost",
+            target_dir=target_path,
+            ui=True)
+        assert_not_in('enableremote local_target failed', cml.out)
 
     GitRepo(target_path, create=False)  # raises if not a git repo
     assert_in("local_target", source.repo.get_remotes())

--- a/datalad/distribution/tests/test_target_ssh.py
+++ b/datalad/distribution/tests/test_target_ssh.py
@@ -11,9 +11,7 @@
 
 import os
 import re
-from os.path import join as opj, basename, exists
-
-from git.exc import GitCommandError
+from os.path import join as opj, exists
 
 from ..dataset import Dataset
 from datalad.api import publish, install, create_sibling
@@ -24,7 +22,6 @@ from datalad.support.annexrepo import AnnexRepo
 from nose.tools import eq_, assert_false
 from datalad.tests.utils import with_tempfile, assert_in, \
     with_testrepos
-from datalad.tests.utils import SkipTest
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_exists
 from datalad.tests.utils import ok_endswith
@@ -278,22 +275,14 @@ def test_target_ssh_recursive(origin, src_path, target_path):
         target_path_ = target_dir_tpl = target_path + "-" + str(flat)
 
         if flat:
-            target_dir_tpl += "/%NAME"
+            target_dir_tpl += "/prefix%RELNAME"
             sep = '-'
         else:
             sep = os.path.sep
 
-        if flat:
-            # now that create_sibling also does fetch -- the related problem
-            # so skipping this early
-            raise SkipTest('TODO: Make publish work for flat datasets, it currently breaks')
-
         remote_name = 'remote-' + str(flat)
-        # TODO: there is f.ckup with paths so assert_create fails ATM
-        # And let's test without explicit dataset being provided
         with chpwd(source.path):
-            #assert_create_sshwebserver(
-            create_sibling(
+            assert_create_sshwebserver(
                 name=remote_name,
                 sshurl="ssh://localhost" + target_path_,
                 target_dir=target_dir_tpl,
@@ -302,7 +291,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 
         # raise if git repos were not created
         for suffix in [sep + 'subm 1', sep + 'subm 2', '']:
-            target_dir = opj(target_path_, basename(src_path) if flat else "").rstrip(os.path.sep) + suffix
+            target_dir = opj(target_path_, 'prefix' if flat else "").rstrip(os.path.sep) + suffix
             # raise if git repos were not created
             GitRepo(target_dir, create=False)
 

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -141,7 +141,7 @@ as_common_datasrc = Parameter(
 publish_depends = Parameter(
     args=("--publish-depends",),
     metavar='SIBLINGNAME',
-    doc="""add a dependency such that the given exsiting sibling is
+    doc="""add a dependency such that the given existing sibling is
     always published prior to the new sibling. This equals setting a
     configuration item 'remote.SIBLINGNAME.datalad-publish-depends'.
     [PY: Multiple dependencies can be given as a list of sibling names


### PR DESCRIPTION
So far, mostly sorting checks to fail as early (and as cheap) as possible, plus some RF to use more common code. And now also various minor fixes and simplifications. Brought back previously disabled tests.

If you are happy about what you see feel free to click the merge button.

- [x] Fix #1233 
- [x] Implements --since to create siblings only for added subdatasets
