### PR TITLE
NF: Remote git version sensing; SSH execution env conditions (fixes gh-1240)

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -238,7 +238,7 @@ class Runner(object):
 
     def run(self, cmd, log_stdout=True, log_stderr=True, log_online=False,
             expect_stderr=False, expect_fail=False,
-            cwd=None, env=None, shell=None):
+            cwd=None, env=None, shell=None, stdin=None):
         """Runs the command `cmd` using shell.
 
         In case of dry-mode `cmd` is just added to `commands` and it is
@@ -291,6 +291,9 @@ class Runner(object):
             Run command in a shell.  If not specified, then it runs in a shell
             only if command is specified as a string (not a list)
 
+        stdin: file descriptor
+            input stream to connect to stdin of the process.
+
         Returns
         -------
         (stdout, stderr)
@@ -327,7 +330,8 @@ class Runner(object):
                                         stderr=errstream,
                                         shell=shell,
                                         cwd=cwd or self.cwd,
-                                        env=env or self.env)
+                                        env=env or self.env,
+                                        stdin=stdin)
 
             except Exception as e:
                 prot_exc = e

--- a/datalad/cmdline/common_args.py
+++ b/datalad/cmdline/common_args.py
@@ -45,7 +45,7 @@ log_level = (
 )
 
 pbs_runner = (
-    'pbs-runner', ('-p', '--pbs-runner'),
+    'pbs-runner', ('--pbs-runner',),
     dict(choices=['condor'],
          default=None,
          help="""execute command by scheduling it via available PBS.  For settings, config file will be consulted""")

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -20,12 +20,14 @@ import sys
 import textwrap
 import shutil
 from importlib import import_module
+import os
 
 import datalad
 
 from datalad.cmdline import helpers
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
+from datalad.support.exceptions import CommandError
 from ..utils import setup_exceptionhook, chpwd
 from ..dochelpers import exc_str
 
@@ -288,6 +290,14 @@ def main(args=None):
                 lgr.error('could not perform all requested actions: %s',
                           exc_str(exc))
                 sys.exit(1)
+            except CommandError as exc:
+                # behave as if the command ran directly, importantly pass
+                # exit code as is
+                if exc.stdout:
+                    os.write(1, exc.stdout)
+                if exc.stderr:
+                    os.write(2, exc.stderr)
+                sys.exit(exc.code)
             except Exception as exc:
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
                 sys.exit(1)

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -127,7 +127,8 @@ def setup_parser(
     # API from them
     grp_short_descriptions = []
     interface_groups = get_interface_groups()
-    for grp_name, grp_descr, _interfaces in interface_groups:
+    for grp_name, grp_descr, _interfaces \
+                in sorted(interface_groups, key=lambda x: x[1]):
         # for all subcommand modules it can find
         cmd_short_descriptions = []
 
@@ -180,7 +181,8 @@ def setup_parser(
     console_width = shutil.get_terminal_size()[0] \
         if hasattr(shutil, 'get_terminal_size') else 80
 
-    for i, grp in enumerate(interface_groups):
+    for i, grp in enumerate(
+            sorted(interface_groups, key=lambda x: x[1])):
         grp_descr = grp[1]
         grp_cmds = grp_short_descriptions[i]
 

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -84,7 +84,8 @@ def test_help_np():
                   'Commands for meta data handling',
                   'Miscellaneous commands',
                   'General information',
-                  'Global options'})
+                  'Global options',
+                  'Plumbing commands'})
 
     # none of the lines must be longer than 80 chars
     # TODO: decide on   create-sibling and possibly

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -71,3 +71,9 @@ _group_misc = (
         ('datalad.distribution.create_test_dataset', 'CreateTestDataset',
          'create-test-dataset'),
     ])
+
+_group_plumbing = (
+    'Plumbing commands',
+    [
+        ('datalad.support.sshrun', 'SSHRun', 'sshrun'),
+    ])

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -41,7 +41,6 @@ from git.exc import NoSuchPathError
 from git.exc import InvalidGitRepositoryError
 from git.objects.blob import Blob
 
-from datalad import ssh_manager
 from datalad.cmd import Runner, GitRunner
 from datalad.dochelpers import exc_str
 from datalad.config import ConfigManager
@@ -595,11 +594,9 @@ class GitRepo(RepoInterface):
             pass
 
         if is_ssh(url):
-            cnct = ssh_manager.get_connection(url)
-            cnct.open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
-            env = {'GIT_SSH_COMMAND': "ssh -S %s" % cnct.ctrl_path}
+            env = {'GIT_SSH_COMMAND': "datalad sshrun"}
         else:
             env = None
         ntries = 5  # 3 is not enough for robust workaround
@@ -1375,12 +1372,10 @@ class GitRepo(RepoInterface):
                                      if rm.config_reader.has_option('fetchurl')
                                      else 'url')
             if is_ssh(fetch_url):
-                cnct = ssh_manager.get_connection(fetch_url)
-                cnct.open()
                 # TODO: with git <= 2.3 keep old mechanism:
                 #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
                 with rm.repo.git.custom_environment(
-                        GIT_SSH_COMMAND="ssh -S %s" % cnct.ctrl_path):
+                        GIT_SSH_COMMAND="datalad sshrun"):
                     fi_list += rm.fetch(refspec=refspec, progress=progress, **kwargs)
                     # TODO: progress +kwargs
             else:
@@ -1419,12 +1414,10 @@ class GitRepo(RepoInterface):
                 'fetchurl' if remote.config_reader.has_option('fetchurl')
                 else 'url')
         if is_ssh(fetch_url):
-            cnct = ssh_manager.get_connection(fetch_url)
-            cnct.open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with remote.repo.git.custom_environment(GIT_SSH="wrapper_script"):
             with remote.repo.git.custom_environment(
-                    GIT_SSH_COMMAND="ssh -S %s" % cnct.ctrl_path):
+                    GIT_SSH_COMMAND="datalad sshrun"):
                 return remote.pull(refspec=refspec, progress=progress, **kwargs)
                 # TODO: progress +kwargs
         else:
@@ -1503,12 +1496,10 @@ class GitRepo(RepoInterface):
                                      if rm.config_reader.has_option('pushurl')
                                      else 'url')
             if is_ssh(push_url):
-                cnct = ssh_manager.get_connection(push_url)
-                cnct.open()
                 # TODO: with git <= 2.3 keep old mechanism:
                 #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
                 with rm.repo.git.custom_environment(
-                        GIT_SSH_COMMAND="ssh -S %s" % cnct.ctrl_path):
+                        GIT_SSH_COMMAND="datalad sshrun"):
                     pi_list += rm.push(refspec=refspec, progress=progress, **kwargs)
                     # TODO: progress +kwargs
             else:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -40,6 +40,7 @@ from git.exc import NoSuchPathError
 from git.exc import InvalidGitRepositoryError
 from git.objects.blob import Blob
 
+from datalad import ssh_manager
 from datalad.cmd import Runner, GitRunner
 from datalad.dochelpers import exc_str
 from datalad.config import ConfigManager
@@ -593,6 +594,7 @@ class GitRepo(RepoInterface):
             pass
 
         if is_ssh(url):
+            ssh_manager.get_connection(url).open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
             env = {'GIT_SSH_COMMAND': "datalad sshrun"}
@@ -1371,6 +1373,7 @@ class GitRepo(RepoInterface):
                                      if rm.config_reader.has_option('fetchurl')
                                      else 'url')
             if is_ssh(fetch_url):
+                ssh_manager.get_connection(fetch_url).open()
                 # TODO: with git <= 2.3 keep old mechanism:
                 #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
                 with rm.repo.git.custom_environment(
@@ -1413,6 +1416,7 @@ class GitRepo(RepoInterface):
                 'fetchurl' if remote.config_reader.has_option('fetchurl')
                 else 'url')
         if is_ssh(fetch_url):
+            ssh_manager.get_connection(fetch_url).open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with remote.repo.git.custom_environment(GIT_SSH="wrapper_script"):
             with remote.repo.git.custom_environment(
@@ -1495,6 +1499,7 @@ class GitRepo(RepoInterface):
                                      if rm.config_reader.has_option('pushurl')
                                      else 'url')
             if is_ssh(push_url):
+                ssh_manager.get_connection(push_url).open()
                 # TODO: with git <= 2.3 keep old mechanism:
                 #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
                 with rm.repo.git.custom_environment(

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -23,7 +23,6 @@ from os.path import isabs
 from os.path import commonprefix
 from os.path import relpath
 from os.path import realpath
-from os.path import abspath
 from os.path import dirname
 from os.path import basename
 from os.path import curdir
@@ -1793,7 +1792,7 @@ class GitRepo(RepoInterface):
                     lgr.debug("detached HEAD in {0}".format(self))
                     return None, None
                 else:
-                    raise 
+                    raise
 
         track_remote = self.config.get('branch.{0}.remote'.format(branch), None)
         track_branch = self.config.get('branch.{0}.merge'.format(branch), None)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -83,7 +83,7 @@ class SSHConnection(object):
         # essential properties of the remote system
         self.remote_props = {}
 
-    def __call__(self, cmd):
+    def __call__(self, cmd, stdin=None):
         """Executes a command on the remote.
 
         It is the callers responsibility to properly quote commands
@@ -123,7 +123,11 @@ class SSHConnection(object):
 
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True
-        return self.runner.run(ssh_cmd, expect_fail=True, expect_stderr=True)
+        return self.runner.run(
+            ssh_cmd,
+            expect_fail=True,
+            expect_stderr=True,
+            stdin=stdin)
 
     @property
     def runner(self):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -83,8 +83,8 @@ class SSHConnection(object):
         """
         self._runner = None
 
-        from datalad.support.network import SSHRI
-        if hasattr(sshri, 'scheme') and not sshri.scheme == 'ssh':
+        from datalad.support.network import SSHRI, is_ssh
+        if not is_ssh(sshri):
             raise ValueError(
                 "Non-SSH resource identifiers are not supported for SSH "
                 "connections: {}".format(sshri))
@@ -136,12 +136,12 @@ class SSHConnection(object):
         ssh_cmd += [self.sshri.as_str()] \
             + [cmd]
 
-        # TODO: pass expect parameters from above?
-        # Hard to explain to toplevel users ... So for now, just set True
         if log_output:
             kwargs = dict(log_stdout=True, log_stderr=True, log_online=False)
         else:
             kwargs = dict(log_stdout=False, log_stderr=False, log_online=True)
+        # TODO: pass expect parameters from above?
+        # Hard to explain to toplevel users ... So for now, just set True
         return self.runner.run(
             ssh_cmd,
             expect_fail=True,

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -85,8 +85,8 @@ class SSHConnection(object):
           stdout, stderr of the command run.
         """
 
-        # TODO: Do we need to check for the connection to be open or just rely
-        # on possible ssh failing?
+        if not self.is_open():
+            self.open()
         cmd_list = cmd if isinstance(cmd, list) \
             else sh_split(cmd, posix=not on_windows)
             # windows check currently not needed, but keep it as a reminder

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -101,9 +101,9 @@ class SSHConnection(object):
             # locate annex and set the bundled vs. system Git machinery in motion
             self.get_annex_installdir()
 
-        remote_annex_install_dir = self.remote_props.get(
+        remote_annex_installdir = self.remote_props.get(
             'installdir:annex', None)
-        if remote_annex_install_dir:
+        if remote_annex_installdir:
             # make sure to use the bundled git version if any exists
             cmd = '{}; {}'.format(
                 'export "PATH={}:$PATH"'.format(remote_annex_installdir),

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -48,6 +48,21 @@ def _wrap_str(s):
     return "'%s'" % s
 
 
+def get_connection_hash(hostname, port='', username=''):
+    """Generate a hash based on SSH connection properties
+
+    This can be used for generating filenames that are unique
+    to a connection from and to a particular machine (with
+    port and login username). The hash also contains the local
+    host name.
+    """
+    return md5(
+        '{lhost}{rhost}{port}{username}'.format(
+            lhost=gethostname(),
+            rhost=hostname,
+            port=port,
+            username=username)).hexdigest()
+
 @auto_repr
 class SSHConnection(object):
     """Representation of a (shared) ssh connection.
@@ -319,12 +334,10 @@ class SSHManager(object):
             raise ValueError("Unsupported SSH URL: '{0}', use "
                              "ssh://host/path or host:path syntax".format(url))
 
-        conhash = md5(
-            '{lhost}{rhost}{port}{username}'.format(
-                lhost=gethostname(),
-                rhost=sshri.hostname,
-                port=sshri.port,
-                username=sshri.username)).hexdigest()
+        conhash = get_connection_hash(
+            sshri.hostname,
+            port=sshri.port,
+            username=sshri.username)
         # determine control master:
         ctrl_path = "%s/%s" % (self.socket_dir, conhash)
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -206,7 +206,7 @@ class SSHConnection(object):
             else [source]
 
         # add destination path
-        scp_cmd += ['%s:"%s"' % (self.host, destination)]
+        scp_cmd += ['%s:"%s"' % (self.sshri.hostname, destination)]
         return self.runner.run(scp_cmd)
 
     def get_annex_installdir(self):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -76,6 +76,8 @@ class SSHConnection(object):
         ----------
         cmd: list or str
           command to run on the remote
+        wrap_args : bool
+          Flag whether to quote argument string before passing them on to SSH
 
         Returns
         -------

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -83,7 +83,7 @@ class SSHConnection(object):
         # essential properties of the remote system
         self.remote_props = {}
 
-    def __call__(self, cmd, stdin=None):
+    def __call__(self, cmd, stdin=None, log_output=True):
         """Executes a command on the remote.
 
         It is the callers responsibility to properly quote commands
@@ -123,11 +123,16 @@ class SSHConnection(object):
 
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True
+        if log_output:
+            kwargs = dict(log_stdout=True, log_stderr=True, log_online=False)
+        else:
+            kwargs = dict(log_stdout=False, log_stderr=False, log_online=True)
         return self.runner.run(
             ssh_cmd,
             expect_fail=True,
             expect_stderr=True,
-            stdin=stdin)
+            stdin=stdin,
+            **kwargs)
 
     @property
     def runner(self):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -61,7 +61,7 @@ def get_connection_hash(hostname, port='', username=''):
             lhost=gethostname(),
             rhost=hostname,
             port=port,
-            username=username)).hexdigest()
+            username=username).encode('utf-8')).hexdigest()
 
 @auto_repr
 class SSHConnection(object):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -221,7 +221,7 @@ class SSHConnection(object):
         try:
             annex_install_dir = self(
                 # use sh -e to be able to fail at each stage of the process
-                "sh -e -c 'set -e;dirname $(readlink -f $(which git-annex-shell))'")[0].strip()
+                "sh -e -c 'dirname $(readlink -f $(which git-annex-shell))'")[0].strip()
         except CommandError as e:
             lgr.debug('Failed to locate remote git-annex installation: %s',
                       exc_str(e))

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -75,6 +75,8 @@ class SSHConnection(object):
                               if k in ('username', 'hostname', 'port')})
         self.ctrl_path = ctrl_path
         self.ctrl_options = ["-o", "ControlPath=" + self.ctrl_path]
+        if self.sshri.port:
+            self.ctrl_options += ['-p', '{}'.format(self.sshri.port)]
 
         # essential properties of the remote system
         self.remote_props = {}
@@ -114,8 +116,6 @@ class SSHConnection(object):
         # we cannot perform any sort of escaping, because it will limit
         # what we can do on the remote, e.g. concatenate commands with '&&'
         ssh_cmd = ["ssh"] + self.ctrl_options
-        if self.sshri.port:
-            ssh_cmd += ['-p', self.sshri.port]
         ssh_cmd += [self.sshri.as_str()] \
             + [cmd]
 
@@ -133,7 +133,7 @@ class SSHConnection(object):
         if not exists(self.ctrl_path):
             return False
         # check whether controlmaster is still running:
-        cmd = ["ssh", "-O", "check"] + self.ctrl_options + [self.sshri.hostname]
+        cmd = ["ssh", "-O", "check"] + self.ctrl_options + [self.sshri.as_str()]
         out, err = self.runner.run(cmd)
         if "Master running" not in err:
             # master exists but isn't running
@@ -156,7 +156,7 @@ class SSHConnection(object):
         ctrl_options = ["-o", "ControlMaster=auto",
                         "-o", "ControlPersist=15m"] + self.ctrl_options
         # create ssh control master command
-        cmd = ["ssh"] + ctrl_options + [self.sshri.hostname, "exit"]
+        cmd = ["ssh"] + ctrl_options + [self.sshri.as_str(), "exit"]
 
         # start control master:
         lgr.debug("Try starting control master by calling:\n%s" % cmd)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -39,14 +39,7 @@ from datalad.utils import assure_dir
 from datalad.utils import auto_repr
 from datalad.cmd import Runner
 
-lgr = logging.getLogger('datalad.ssh')
-
-
-def _wrap_str(s):
-    """Helper to wrap argument into '' to be passed over ssh cmdline"""
-    s = s.replace("'", r'\'')
-    return "'%s'" % s
-
+lgr = logging.getLogger('datalad.support.sshconnector')
 
 def get_connection_hash(hostname, port='', username=''):
     """Generate a hash based on SSH connection properties

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -17,6 +17,7 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import os
+import sys
 
 from datalad.support.param import Parameter
 from datalad.interface.base import Interface
@@ -51,6 +52,6 @@ class SSHRun(Interface):
             login,
             ':{}'.format(port) if port else '')
         ssh = ssh_manager.get_connection(sshurl)
-        out, err = ssh(cmd)
+        out, err = ssh(cmd, stdin=sys.stdin)
         os.write(1, out)
         os.write(2, err)

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -25,7 +25,12 @@ from datalad import ssh_manager
 
 
 class SSHRun(Interface):
-    """
+    """Run command on remote machines via SSH.
+
+    This is a replacement for a small part of the functionality of SSH.
+    In addition to SSH alaon, this command can make use ofdatalad's SSH
+    connection management. Its primary use case is to be used with Git
+    as 'core.sshCommand' or via "GIT_SSH_COMMAND".
     """
 
     _params_ = dict(

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -1,0 +1,51 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""SSH command to expose datalad's connection management to 3rd-party tools
+
+Primary use case is to be used with git as core.sshCommand
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import os
+
+from datalad.support.param import Parameter
+from datalad.interface.base import Interface
+
+from datalad import ssh_manager
+
+
+class SSHRun(Interface):
+    """
+    """
+
+    _params_ = dict(
+        login=Parameter(
+            args=("login",),
+            doc="[user@]hostname"),
+        cmd=Parameter(
+            args=("cmd",),
+            doc="command for remote execution"),
+        port=Parameter(
+            args=("-p", '--port'),
+            doc="port to connect to on the remote host"),
+    )
+
+    @staticmethod
+    def __call__(login, cmd, port=None):
+        sshurl = 'ssh://{}{}'.format(
+            login,
+            ':{}'.format(port) if port else '')
+        ssh = ssh_manager.get_connection(sshurl)
+        out, err = ssh(cmd)
+        os.write(1, out)
+        os.write(2, err)

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -52,6 +52,6 @@ class SSHRun(Interface):
             login,
             ':{}'.format(port) if port else '')
         ssh = ssh_manager.get_connection(sshurl)
-        out, err = ssh(cmd, stdin=sys.stdin)
+        out, err = ssh(cmd, stdin=sys.stdin, log_output=False)
         os.write(1, out)
         os.write(2, err)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -36,6 +36,8 @@ from datalad.cmd import Runner
 
 from datalad.support.external_versions import external_versions
 
+from datalad.support.sshconnector import get_connection_hash
+
 from datalad.utils import on_windows
 from datalad.utils import chpwd
 from datalad.utils import rmtree
@@ -1029,8 +1031,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     rm2 = AnnexRepo(remote_2_path, create=False)
 
     # check whether we are the first to use these sockets:
-    socket_1 = opj(ssh_manager.socket_dir, 'datalad-test')
-    socket_2 = opj(ssh_manager.socket_dir, 'localhost')
+    socket_1 = opj(ssh_manager.socket_dir, get_connection_hash('datalad-test'))
+    socket_2 = opj(ssh_manager.socket_dir, get_connection_hash('localhost'))
     datalad_test_was_open = exists(socket_1)
     localhost_was_open = exists(socket_2)
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -17,6 +17,8 @@ from datalad.tests.utils import *
 from datalad.tests.utils_testrepos import BasicAnnexTestRepo
 from datalad.utils import getpwd, chpwd
 
+from datalad.support.sshconnector import get_connection_hash
+
 # imports from same module:
 # we want to test everything in gitrepo:
 from ..gitrepo import *
@@ -431,7 +433,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 
     remote_repo = GitRepo(remote_path, create=False)
     url = "ssh://localhost" + abspath(remote_path)
-    socket_path = opj(ssh_manager.socket_dir, 'localhost')
+    socket_path = opj(ssh_manager.socket_dir, get_connection_hash('localhost'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -459,7 +461,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
 
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + abspath(remote_path)
-    socket_path = opj(ssh_manager.socket_dir, 'localhost')
+    socket_path = opj(ssh_manager.socket_dir, get_connection_hash('localhost'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -494,7 +496,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
 
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + abspath(remote_path)
-    socket_path = opj(ssh_manager.socket_dir, 'localhost')
+    socket_path = opj(ssh_manager.socket_dir, get_connection_hash('localhost'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -13,6 +13,8 @@ import logging
 import os
 from os.path import exists, isdir, getmtime, join as opj
 
+from datalad.support.external_versions import external_versions
+
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import eq_
 from datalad.tests.utils import skip_ssh
@@ -181,4 +183,8 @@ def test_ssh_git_props():
     remote_url = 'ssh://localhost'
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
-    ok_(not ssh.is_open())
+    eq_(ssh.get_annex_version(),
+        external_versions['cmd:annex'])
+    # cannot compare to locally detected, might differ depending on
+    # how annex was installed
+    ok_(ssh.get_git_version())

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -23,7 +23,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import ok_
 from datalad.tests.utils import assert_is_instance
 
-from ..sshconnector import SSHConnection, SSHManager
+from ..sshconnector import SSHConnection, SSHManager, sh_quote
 
 
 @skip_ssh
@@ -48,7 +48,7 @@ def test_ssh_get_connection():
 
 
 @skip_ssh
-@with_tempfile(suffix=" \"`suffix:;& ",  # get_most_obscure_supported_name(),
+@with_tempfile(suffix=' "`suffix:;& ',  # get_most_obscure_supported_name(),
                content="1")
 def test_ssh_open_close(tfile1):
 
@@ -60,14 +60,14 @@ def test_ssh_open_close(tfile1):
     ok_(exists(path))
 
     # use connection to execute remote command:
-    out, err = c1(['ls', '-a'])
+    out, err = c1('ls -a')
     remote_ls = [entry for entry in out.splitlines()
                  if entry != '.' and entry != '..']
     local_ls = os.listdir(os.path.expanduser('~'))
     eq_(set(remote_ls), set(local_ls))
 
     # now test for arguments containing spaces and other pleasant symbols
-    out, err = c1(['ls', '-l', tfile1])
+    out, err = c1('ls -l {}'.format(sh_quote(tfile1)))
     assert_in(tfile1, out)
     eq_(err, '')
 
@@ -167,6 +167,13 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
             eq_(content, fp.read())
 
     ssh.close()
+
+
+@skip_ssh
+def test_ssh_compound_cmds():
+    ssh = SSHManager().get_connection('ssh://localhost')
+    out, err = ssh('[ 1 = 2 ] && echo no || echo success')
+    eq_(out.strip(), 'success')
 
 
 @skip_ssh

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -167,3 +167,11 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
             eq_(content, fp.read())
 
     ssh.close()
+
+
+@skip_ssh
+def test_ssh_git_props():
+    remote_url = 'ssh://localhost'
+    manager = SSHManager()
+    ssh = manager.get_connection(remote_url)
+    ok_(not ssh.is_open())

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import ok_
 from datalad.tests.utils import assert_is_instance
 
 from ..sshconnector import SSHConnection, SSHManager, sh_quote
+from ..sshconnector import get_connection_hash
 
 
 @skip_ssh
@@ -56,7 +57,7 @@ def test_ssh_open_close(tfile1):
 
     manager = SSHManager()
     c1 = manager.get_connection('ssh://localhost')
-    path = opj(manager.socket_dir, 'localhost')
+    path = opj(manager.socket_dir, get_connection_hash('localhost'))
     c1.open()
     # control master exists:
     ok_(exists(path))
@@ -96,8 +97,8 @@ def test_ssh_manager_close():
         manager.get_connection('ssh://localhost').close()
         manager.get_connection('ssh://localhost').open()
 
-    ok_(exists(opj(manager.socket_dir, 'localhost')))
-    ok_(exists(opj(manager.socket_dir, 'datalad-test')))
+    ok_(exists(opj(manager.socket_dir, get_connection_hash('localhost'))))
+    ok_(exists(opj(manager.socket_dir, get_connection_hash('datalad-test'))))
 
     manager.close()
 

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -17,6 +17,8 @@ from nose.tools import assert_raises, assert_equal
 from .. import __main__, __version__
 from ..auto import AutomagicIO
 
+from datalad.tests.utils import skip_ssh
+from datalad.cmdline.main import main
 
 @patch('sys.stdout', new_callable=StringIO)
 def test_main_help(stdout):
@@ -41,3 +43,9 @@ def test_main_run_a_script(stdout, mock_activate):
     # And we have "activated"
     mock_activate.assert_called_once_with()
 
+@skip_ssh
+def test_exit_code():
+    # will relay actual exit code on CommandError
+    with assert_raises(SystemExit) as cme:
+        main(['sshrun', 'localhost', 'exit 42'])
+    assert_equal(cme.exception.code, 42)

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -279,3 +279,14 @@ def test_git_path(dir_):
     # As soon as we use any GitRepo we should get _GIT_PATH set in the Runner
     repo = GitRepo(dir_, create=True)
     assert GitRunner._GIT_PATH is not None
+
+
+@with_tempfile(mkdir=True)
+def test_runner_stdin(path):
+    runner = Runner()
+    with open(opj(path, "test_input.txt"), "w") as f:
+        f.write("whatever")
+
+    with swallow_outputs() as cmo, open(opj(path, "test_input.txt"), "r") as fake_input:
+        runner.run(['cat'], log_stdout=False, stdin=fake_input)
+        assert_in("whatever", cmo.out)

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -61,3 +61,11 @@ Miscellaneous commands
    generated/man/datalad-download-url
    generated/man/datalad-ls
    generated/man/datalad-test
+
+Plumbing commands
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-sshrun


### PR DESCRIPTION
NF: Remote git version sensing; SSH execution env conditions (fixes gh-1240)
    
With this change, remote SSH calls will try to use a bundles Git version if any exists (or can be found next to git-annex). This should work for explicit calls to git, as well as any implicit  calls made by other (proxy) commands.

This required some changes in the way we call SSH. Most notably we need to send commands as a single string (not a list), and we need to quote path arguments prior to sending them to SSH.

TODO:

- [x] Open SSH connection on demand
- [x] New `SSHConnection.is_open()`
- [x] RF `SSHConnection.__call__()` to accept a single command string. This is also the way Git will send commands along
- [x] Auto-sensing of Git version, Git-annex version and installation location, as will as detection of bundles Git installations
- [x] Proper control path filename encoding of host, user and port, following SSH recommendations
- [x] Use hash as control path filename to not give away information on shared locations
- [x] Implementation of an `sshrun` command to be used by us as `GIT_SSH_COMMAND`
- [x] RF to be able to generate control paths in the tests too. All failing tests are due to inappropriate assumptions on the control path value after RF
- [x] When `CommandError` reaches the top level, datalad as a whole fails with the same error and exit code as the underlying error.
- [ ] #1247 