### PR TITLE
BF: remove all extracted files at once for delete_after to not interfer with batched processes

### DIFF
--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -296,6 +296,7 @@ class AddArchiveContent(Interface):
             lgr.debug("Special remote {} already exists".format(ARCHIVES_SPECIAL_REMOTE))
 
         precommitted = False
+        delete_after_rpath = None
         try:
             old_always_commit = annex.always_commit
             annex.always_commit = False
@@ -311,7 +312,7 @@ class AddArchiveContent(Interface):
 
             # we need to create a temporary directory at the top level which would later be
             # removed
-            prefix_dir = basename(tempfile.mkdtemp(prefix=".datalad", dir=annex_path)) \
+            prefix_dir = basename(tempfile.mktemp(prefix=".datalad", dir=annex_path)) \
                 if delete_after \
                 else None
 
@@ -492,7 +493,7 @@ class AddArchiveContent(Interface):
             if not precommitted:
                 annex.precommit()
 
-            if delete_after:
+            if delete_after_rpath:
                 delete_after_path = opj(annex_path, delete_after_rpath)
                 if exists(delete_after_path):  # should not be there
                     # but for paranoid yoh

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -381,7 +381,11 @@ class TestAddArchiveOptions():
         with assert_raises(Exception), \
                 swallow_logs():
             self.annex.whereis(key1, key=True, output='full')
+        commits_prior = list(self.annex.get_branch_commits('git-annex'))
         add_archive_content('1.tar', annex=self.annex, strip_leading_dirs=True, delete_after=True)
+        commits_after = list(self.annex.get_branch_commits('git-annex'))
+        # There should be a single commit for all additions +1 to initiate datalad-archives gh-1258
+        assert_equal(len(commits_after), len(commits_prior) + 2)
         assert_equal(prev_files, list(find_files('.*', self.annex.path)))
         w = self.annex.whereis(key1, key=True, output='full')
         assert_equal(len(w), 2)  # in archive, and locally since we didn't drop

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -400,6 +400,8 @@ class TestAddArchiveOptions():
         w = self.annex.whereis(key1, key=True, output='full')
         assert_equal(len(w), 1)  # in archive
 
+        # there should be no .datalad temporary files hanging around
+        self.assert_no_trash_left_behind()
 
     def test_add_delete_after_and_drop_subdir(self):
         os.mkdir(opj(self.annex.path, 'subdir'))
@@ -425,6 +427,8 @@ class TestAddArchiveOptions():
             assert_equal(len(commits_after), len(commits_prior) + 2)
             assert_equal(len(commits_after_master), len(commits_prior_master))
             assert(add_out is self.annex)
+            # there should be no .datalad temporary files hanging around
+            self.assert_no_trash_left_behind()
 
             # and if we add some untracked file, redo, there should be no changes
             # to master and file should remain not committed
@@ -439,3 +443,11 @@ class TestAddArchiveOptions():
             assert_equal(len(list(self.annex.get_branch_commits())),
                          len(commits_prior_master))
 
+            # there should be no .datalad temporary files hanging around
+            self.assert_no_trash_left_behind()
+
+    def assert_no_trash_left_behind(self):
+        assert_equal(
+            list(find_files('\.datalad..*', self.annex.path, dirs=True)),
+            []
+        )


### PR DESCRIPTION
Closes #1258