### PR TITLE
BF: Use (bundled) git with GitPython, too.

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -12,6 +12,14 @@ distribution with the convenience of git-annex repositories as a backend."""
 
 # Other imports are interspersed with lgr.debug to ease troubleshooting startup
 # delays etc.
+
+# If there is a bundled git, make sure GitPython uses it too:
+from datalad.cmd import GitRunner
+_git_runner = GitRunner()
+if _git_runner._GIT_PATH:
+    import os
+    os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = os.path.join(_git_runner._GIT_PATH, 'git')
+
 from .config import ConfigManager
 cfg = ConfigManager()
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -15,10 +15,11 @@ distribution with the convenience of git-annex repositories as a backend."""
 
 # If there is a bundled git, make sure GitPython uses it too:
 from datalad.cmd import GitRunner
-_git_runner = GitRunner()
-if _git_runner._GIT_PATH:
+GitRunner._check_git_path()
+if GitRunner._GIT_PATH:
     import os
-    os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = os.path.join(_git_runner._GIT_PATH, 'git')
+    os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = \
+        os.path.join(GitRunner._GIT_PATH, 'git')
 
 from .config import ConfigManager
 cfg = ConfigManager()


### PR DESCRIPTION
While trying to debug remaining failures in PR #1237 , discovered we completely missed to use bundled git with GitPython.
Probably fixes these failures, since they are occuring while calling `git push` via GitPython, which then ignores `GIT_SSH_COMMAND` on Travis (that env. variable was introduced only in git 2.3), therefore wasn't calling `datalad sshrun`, but plain `ssh`, which in return led to not using bundled git on the remote end.