### PR TITLE
ENH+BF: NFS testing on travis + Dataset.close()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   matrix:
     - DATALAD_REPO_DIRECT=1
     - DATALAD_REPO_DIRECT=
+
 # Disabled since old folks don't want to change workflows of submitting through central authority
 #    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="
 #    - secure: "Az7Pzo5pSdAFTTX6XXzE4VUS3wnlIe1vi/+bfHBzDjxstDvZVkPjPzaIs6v/BLod43AYBl1v9dyJR4qnBnaVrUDLB3tC0emLhJ2qnw+8GKHSSImCwIOeZzg9QpXeVQovZUqQVQ3fg3KIWCIzhmJ59EbMQcI4krNDxk4WcXmyVfk="
@@ -79,9 +80,15 @@ matrix:
     env:
     # To make orthogonal test where it is not a symlink but a dir with spaces
     - TMPDIR="/tmp/d i r"
+  - python: 2.7
+    # Test under NFS mount
+    env:
+    - TMPDIR="/tmp/nfsmount"
+
   allow_failures:
   # For now, don't fail entirely when direct mode fails
   - env: DATALAD_REPO_DIRECT=1
+
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)
 #  - python: 3.5
@@ -114,6 +121,7 @@ install:
   # TMPDIRs
   - if [[ "${TMPDIR:-}" =~ .*/sym\ link ]]; then echo "Symlinking $TMPDIR"; ln -s /tmp "$TMPDIR"; fi
   - if [[ "${TMPDIR:-}" =~ .*/d\ i\ r ]]; then echo "mkdir $TMPDIR"; mkdir -p "$TMPDIR"; fi
+  - if [[ "${TMPDIR:-}" =~ .*/nfsmount ]]; then echo "mkdir $TMPDIR"; mkdir -p "$TMPDIR" "${TMPDIR}_"; sudo apt-get install -y nfs-kernel-server; sudo exportfs -o rw localhost:/tmp/nfsmount_; sudo mount -t nfs localhost:/tmp/nfsmount_ /tmp/nfsmount; fi
   # S3
   - if [ ! -z "$UNSET_S3_SECRETS" ]; then echo "usetting"; unset DATALAD_datalad_test_s3_key_id DATALAD_datalad_test_s3_secret_id; fi
   # Install grunt to test run javascript frontend tests

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -144,6 +144,15 @@ class Dataset(object):
             return False
         return realpath(self.path) == realpath(other.path)
 
+    def close(self):
+        """Perform operations which would close any possible process using this Dataset
+        """
+        repo = self._repo
+        self._repo = None
+        if repo:
+            # might take care about lingering batched processes etc
+            del repo
+
     @property
     def path(self):
         """path to the dataset"""

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -66,6 +66,11 @@ def _uninstall_dataset(ds, check, has_super):
     # TODO check that the relevant branched are pushed to a remote
     if ds.get_subdatasets(fulfilled=True):
         raise ValueError('to be uninstalled dataset has present subdatasets, forgot --recursive?')
+    # Close any possibly associated process etc with underlying repo.
+    # Otherwise - rmtree could fail to remove e.g. under NFS which would
+    # still have some files opened by them (thus having .nfs00000xxxx
+    # files) forbidding rmdir to work in rmtree
+    ds.close()
     if ds.is_installed():
         rmtree(ds.path)
     if has_super and not exists(ds.path):


### PR DESCRIPTION
as NFS testing revealed -- there is an issue with some outstanding git cat-file batched processes held up by GitRepo's which belong to Datasets.  Uninstalling implies that those GitRepo's should disappear, thus as a quick solution I have introduced `Dataset.close` which for now was used only in `uninstall`.