### PR TITLE
BF/ENH: Make use of remote.<name>.annexurl

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -157,11 +157,15 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
         lgr.info("Publishing data of dataset {0} ...".format(ds))
         # overwrite URL with pushurl if any, reason:
         # https://git-annex.branchable.com/bugs/annex_ignores_pushurl_and_uses_only_url_upon___34__copy_--to__34__/
+        # Note: This shouldn't happen anymore with newly added siblings.
+        #       But for now check for it, until we agree on how to fix existing
+        #       ones.
         pushurl = ds.config.get('remote.{}.pushurl'.format(remote), None)
-        if pushurl:
+        annexurl = ds.config.get('remote.{}.annexurl'.format(remote), None)
+        if pushurl and not annexurl:
             annex_copy_options = '{}{}'.format(
                 annex_copy_options if annex_copy_options else '',
-                ' -c "remote.{}.url={}"'.format(remote, pushurl))
+                ' -c "remote.{}.annexurl={}"'.format(remote, pushurl))
         pblshd = ds.repo.copy_to(files=paths,
                                  remote=remote,
                                  options=annex_copy_options)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1874,7 +1874,10 @@ class AnnexRepo(GitRepo, RepoInterface):
           name of the remote
         url: str
         push: bool
-          if True, set the push URL, otherwise the fetch URL
+          if True, set the push URL, otherwise the fetch URL;
+          if True, additionally set annexurl to `url`, to make sure annex uses
+          it to talk to the remote, since access via fetch URL might be
+          restricted.
         """
 
         if push:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1863,6 +1863,28 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return None
 
+    def set_remote_url(self, name, url, push=False):
+        """Set the URL a remote is pointing to
+
+        Sets the URL of the remote `name`. Requires the remote to already exist.
+
+        Parameters
+        ----------
+        name: str
+          name of the remote
+        url: str
+        push: bool
+          if True, set the push URL, otherwise the fetch URL
+        """
+
+        if push:
+            # if we are to set a push url, also set 'annexUrl' for this remote,
+            # in order to make git-annex use it, when talking to the remote.
+            # (see http://git-annex.branchable.com/bugs/annex_ignores_pushurl_and_uses_only_url_upon___34__copy_--to__34__/)
+            var = 'remote.{0}.{1}'.format(name, 'annexurl')
+            self.config.set(var, url, where='local', reload=True)
+        super(AnnexRepo, self).set_remote_url(name, url, push)
+
 
 # TODO: Why was this commented out?
 # @auto_repr

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1548,8 +1548,6 @@ class GitRepo(RepoInterface):
         """
 
         var = 'remote.{0}.{1}'.format(name, 'pushurl' if push else 'url')
-        #if var in self.config:  # git-config unset exits non-zero otherwise
-        #    self.config.unset(var, where='local', reload=False)
         self.config.set(var, url, where='local', reload=True)
 
     def get_branch_commits(self, branch=None, limit=None, stop=None, value=None):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -56,6 +56,7 @@ from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_re_in
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_not_equal
+from datalad.tests.utils import assert_equal
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_clean_git_annex_proxy
@@ -1510,3 +1511,27 @@ def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
     eq_(AnnexRepo.get_toppath(nested), repo2)
     # and if not under git, should return None
     eq_(AnnexRepo.get_toppath(tempdir), None)
+
+
+@with_tempfile(mkdir=True)
+def test_AnnexRepo_set_remote_url(path):
+
+    ar = AnnexRepo(path, create=True)
+    ar.add_remote('some', 'http://example.com/.git')
+    assert_equal(ar.config['remote.some.url'],
+                 'http://example.com/.git')
+    assert_not_in('remote.some.annexurl', ar.config.keys())
+    # change url:
+    ar.set_remote_url('some', 'http://believe.it')
+    assert_equal(ar.config['remote.some.url'],
+                 'http://believe.it')
+    assert_not_in('remote.some.annexurl', ar.config.keys())
+
+    # set push url:
+    ar.set_remote_url('some', 'ssh://whatever.ru', push=True)
+    assert_equal(ar.config['remote.some.pushurl'],
+                 'ssh://whatever.ru')
+    assert_in('remote.some.annexurl', ar.config.keys())
+    assert_equal(ar.config['remote.some.annexurl'],
+                 'ssh://whatever.ru')
+

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1046,3 +1046,21 @@ def test_GitRepo_gitignore(path):
     with assert_raises(GitIgnoreError) as cme:
         gr.add(['ignore.me', 'dontigno.re', opj('ignore-sub.me', 'a_file.txt')])
     eq_(set(cme.exception.paths), {'ignore.me', 'ignore-sub.me'})
+
+
+@with_tempfile(mkdir=True)
+def test_GitRepo_set_remote_url(path):
+
+    gr = GitRepo(path, create=True)
+    gr.add_remote('some', 'http://example.com/.git')
+    assert_equal(gr.config['remote.some.url'],
+                 'http://example.com/.git')
+    # change url:
+    gr.set_remote_url('some', 'http://believe.it')
+    assert_equal(gr.config['remote.some.url'],
+                 'http://believe.it')
+
+    # set push url:
+    gr.set_remote_url('some', 'ssh://whatever.ru', push=True)
+    assert_equal(gr.config['remote.some.pushurl'],
+                 'ssh://whatever.ru')


### PR DESCRIPTION
Solves the `annex copy` issue, we discussed during last hangout, when `git annex` doesn't use the provided pushurl to talk to a remote.

Implementing joey's solution.

See:
http://git-annex.branchable.com/bugs/annex_ignores_pushurl_and_uses_only_url_upon___34__copy_--to__34__