### PR TITLE
RF update (focus: single dataset operations)

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -183,7 +183,7 @@ class Add(Interface):
 
         if not content_by_ds:
             raise InsufficientArgumentsError(
-                "no existing content given to add")
+                "non-existing paths given to add")
 
         if dataset:
             # remeber the datasets associated with actual inputs

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -21,6 +21,7 @@ from datalad.api import uninstall
 from datalad.api import drop
 from datalad.api import remove
 from datalad.api import install
+from datalad.api import create
 from datalad.support.exceptions import InsufficientArgumentsError, CommandError
 from datalad.tests.utils import ok_
 from datalad.tests.utils import eq_
@@ -347,3 +348,17 @@ def test_kill(path):
     assert_raises(CommandError, ds.remove)
     eq_(ds.remove(recursive=True, check=False), [subds, ds])
     ok_(not exists(path))
+
+
+@with_tempfile()
+def test_remove_recreation(path):
+
+    # test recreation is possible and doesn't conflict with in-memory
+    # remainings of the old instances
+    # see issue #1311
+
+    ds = create(path)
+    ds.remove()
+    ds = create(path)
+    ok_clean_git(ds.path)
+    ok_(ds.is_installed())

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,28 +9,20 @@
 
 """
 
-import os
-from os.path import join as opj, abspath, basename
+from os.path import join as opj
 from ..dataset import Dataset
-from datalad.api import update, install, uninstall
-from datalad.utils import chpwd
+from datalad.api import install
 from datalad.utils import knows_annex
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 
-from nose.tools import ok_, eq_, assert_false, assert_is_instance
-from datalad.tests.utils import with_tempfile, assert_in, with_tree,\
+from nose.tools import eq_, assert_false, assert_is_instance
+from datalad.tests.utils import with_tempfile, assert_in, \
     with_testrepos, assert_not_in
 from datalad.tests.utils import SkipTest
-from datalad.tests.utils import assert_cwd_unchanged, skip_if_on_windows
-from datalad.tests.utils import assure_dict_from_str, assure_list_from_str
 from datalad.tests.utils import create_tree
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import assert_raises
 from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import skip_if_no_module
-from datalad.tests.utils import ok_clean_git, swallow_outputs
-from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import ok_clean_git
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -170,3 +170,8 @@ def test_newthings_coming_down(originpath, destpath):
     # no merge, only one sibling, no parameters should be specific enough
     ds.update()
     assert(knows_annex(ds.path))
+    # no branches appeared
+    eq_(ds.repo.get_branches(), ['master'])
+    # now merge
+    ds.update(merge=True)
+    eq_(sorted(ds.repo.get_branches()), ['git-annex', 'master'])

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -131,7 +131,8 @@ def test_update_fetch_all(src, remote_1, remote_2):
     assert_in("second.txt", ds.repo.get_files("sibling_2/master"))
 
     # no merge strategy for multiple remotes yet:
-    assert_raises(NotImplementedError, ds.update, merge=True, fetch_all=True)
+    # more clever now, there is a tracking branch that provides a remote
+    #assert_raises(NotImplementedError, ds.update, merge=True, fetch_all=True)
 
     # merge a certain remote:
     ds.update(sibling="sibling_1", merge=True)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -147,10 +147,6 @@ def test_update_fetch_all(src, remote_1, remote_2):
 @with_tempfile(mkdir=True)
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
-    # the dance of the next three lines is necessary, because our code uses
-    # the lack of refs in a remote as an indication that it is a special
-    # remote, consequently it would never even consider fetching from this
-    # repo... sad...
     create_tree(originpath, {'load.dat': 'heavy'})
     Dataset(originpath).add('load.dat')
     ds = install(source=originpath, path=destpath)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -175,6 +175,10 @@ def test_newthings_coming_down(originpath, destpath):
     assert_false(ds.repo.file_has_content(testfname))
     ds.get('.')
     ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')
+    # check that a new tag comes down
+    origin.tag('first!')
+    ds.update()
+    eq_(ds.repo.repo.tags[0].name, 'first!')
 
     # and now we destroy the remote annex
     origin._git_custom_command([], ['git', 'config', '--remove-section', 'annex'])
@@ -191,3 +195,7 @@ def test_newthings_coming_down(originpath, destpath):
     eq_(before_branches, ds.repo.get_branches())
     # annex branch got pruned
     eq_(['origin/HEAD', 'origin/master'], ds.repo.get_remote_branches())
+    # check that a new tag comes down even if repo types mismatch
+    origin.tag('second!')
+    ds.update()
+    eq_(ds.repo.repo.tags[-1].name, 'second!')

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -152,7 +152,13 @@ def test_update_fetch_all(src, remote_1, remote_2):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_newthings_coming_down(originpath, destpath):
-    GitRepo(originpath, create=True)
+    origin = GitRepo(originpath, create=True)
+    # the dance of the next three lines is necessary, because our code uses
+    # the lack of refs in a remote as an indication that it is a special
+    # remote, consequently it would never even consider fetching from this
+    # repo... sad...
+    create_tree(originpath, {'load.dat': 'heavy'})
+    Dataset(originpath).add('load.dat')
     ds = install(source=originpath, path=destpath)
     assert_is_instance(ds.repo, GitRepo)
     assert_in('origin', ds.repo.get_remotes())

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -30,6 +30,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import skip_if_no_module
 from datalad.tests.utils import ok_clean_git, swallow_outputs
+from datalad.tests.utils import ok_file_has_content
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
@@ -172,6 +173,12 @@ def test_newthings_coming_down(originpath, destpath):
     assert(knows_annex(ds.path))
     # no branches appeared
     eq_(ds.repo.get_branches(), ['master'])
-    # now merge
+    # now merge, and get an annex
     ds.update(merge=True)
-    eq_(sorted(ds.repo.get_branches()), ['git-annex', 'master'])
+    assert_in('git-annex', ds.repo.get_branches())
+    assert_is_instance(ds.repo, AnnexRepo)
+    # should be fully functional
+    testfname = opj(ds.path, 'load.dat')
+    assert_false(ds.repo.file_has_content(testfname))
+    ds.get('.')
+    ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -225,8 +225,6 @@ def test_update_volatile_subds(originpath, destpath):
     assert_false(exists(opj(ds.path, sname)))
 
     # re-introduce at origin
-    # cannot re-use 'subm 1' due to gh-1311
-    sname = 'subm 2'
     osm1 = origin.create(sname)
     create_tree(osm1.path, {'load.dat': 'heavy'})
     origin.add(opj(osm1.path, 'load.dat'))

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -76,6 +76,8 @@ def _uninstall_dataset(ds, check, has_super):
     if has_super and not exists(ds.path):
         # recreate an empty mountpoint to make Git happier
         os.makedirs(ds.path)
+    # invalidate loaded ConfigManager:
+    ds._cfg = None
     results.append(ds)
     return results
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -129,7 +129,9 @@ class Update(Interface):
 
 def _update_repo(repo, remote, merge, fetch_all):
     # fetch remote(s):
-    repo.fetch(remote=remote, all_=fetch_all)
+    repo.fetch(
+        remote=None if fetch_all else remote,
+        all_=fetch_all)
 
     # if `repo` is an annex and we didn't fetch the entire remote
     # anyway, explicitly fetch git-annex branch:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -109,7 +109,8 @@ class Update(Interface):
             repo = ds.repo
             # get all remotes which have references (would exclude
             # special remotes)
-            remotes = repo.get_remotes(with_refs_only=True)
+            remotes = repo.get_remotes(
+                **({'exclude_special_remotes': True} if isinstance(repo, AnnexRepo) else {}))
             if not remotes:
                 lgr.debug("No siblings known to dataset at %s\nSkipping",
                           repo.path)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -128,57 +128,57 @@ class Update(Interface):
 
 
 def _update_repo(repo, remote, merge, fetch_all):
-            # fetch remote(s):
-            repo.fetch(remote=remote, all_=fetch_all)
+    # fetch remote(s):
+    repo.fetch(remote=remote, all_=fetch_all)
 
-            # if `repo` is an annex and we didn't fetch the entire remote
-            # anyway, explicitly fetch git-annex branch:
+    # if `repo` is an annex and we didn't fetch the entire remote
+    # anyway, explicitly fetch git-annex branch:
 
-            # TODO: This isn't correct. `fetch_all` fetches all remotes.
-            # Apparently, we currently fetch an entire remote anyway. Is this
-            # what we want? Do we want to specify a refspec instead?
-            # yoh: we should leave it to git and its configuration.
-            # So imho we should just extract to fetch everything git would fetch
-            if knows_annex(repo.path) and not fetch_all:
-                if remote:
-                    # we are updating from a certain remote, so git-annex branch
-                    # should be updated from there as well:
-                    repo.fetch(remote=remote)
-                    # TODO: what does failing here look like?
-                else:
-                    # we have no remote given, therefore
-                    # check for tracking branch's remote:
+    # TODO: This isn't correct. `fetch_all` fetches all remotes.
+    # Apparently, we currently fetch an entire remote anyway. Is this
+    # what we want? Do we want to specify a refspec instead?
+    # yoh: we should leave it to git and its configuration.
+    # So imho we should just extract to fetch everything git would fetch
+    if knows_annex(repo.path) and not fetch_all:
+        if remote:
+            # we are updating from a certain remote, so git-annex branch
+            # should be updated from there as well:
+            repo.fetch(remote=remote)
+            # TODO: what does failing here look like?
+        else:
+            # we have no remote given, therefore
+            # check for tracking branch's remote:
 
-                    track_remote, track_branch = repo.get_tracking_branch()
-                    if track_remote:
-                        # we have a "tracking remote"
-                        repo.fetch(remote=track_remote)
+            track_remote, track_branch = repo.get_tracking_branch()
+            if track_remote:
+                # we have a "tracking remote"
+                repo.fetch(remote=track_remote)
 
-            # merge:
-            if merge:
-                lgr.info("Applying changes from tracking branch...")
-                # TODO: Adapt.
-                # TODO: Rethink default remote/tracking branch. See above.
-                # We need a "tracking remote" but custom refspec to fetch from
-                # that remote
-                cmd_list = ["git", "pull"]
-                if remote:
-                    cmd_list.append(remote)
-                    # branch needed, if not default remote
-                    # => TODO: use default remote/tracking branch to compare
-                    #          (see above, where git-annex is fetched)
-                    # => TODO: allow for passing a branch
-                    # (or more general refspec?)
-                    # For now, just use the same name
-                    cmd_list.append(repo.get_active_branch())
+    # merge:
+    if merge:
+        lgr.info("Applying changes from tracking branch...")
+        # TODO: Adapt.
+        # TODO: Rethink default remote/tracking branch. See above.
+        # We need a "tracking remote" but custom refspec to fetch from
+        # that remote
+        cmd_list = ["git", "pull"]
+        if remote:
+            cmd_list.append(remote)
+            # branch needed, if not default remote
+            # => TODO: use default remote/tracking branch to compare
+            #          (see above, where git-annex is fetched)
+            # => TODO: allow for passing a branch
+            # (or more general refspec?)
+            # For now, just use the same name
+            cmd_list.append(repo.get_active_branch())
 
-                std_out, std_err = repo._git_custom_command('', cmd_list)
-                lgr.info(std_out)
-                if knows_annex(repo.path):
-                    # annex-apply:
-                    lgr.info("Updating annex ...")
-                    std_out, std_err = repo._git_custom_command(
-                        '', ["git", "annex", "merge"])
-                    lgr.info(std_out)
+        std_out, std_err = repo._git_custom_command('', cmd_list)
+        lgr.info(std_out)
+        if knows_annex(repo.path):
+            # annex-apply:
+            lgr.info("Updating annex ...")
+            std_out, std_err = repo._git_custom_command(
+                '', ["git", "annex", "merge"])
+            lgr.info(std_out)
 
-                    # TODO: return value?
+            # TODO: return value?

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -20,6 +20,7 @@ from datalad.interface.base import Interface
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.utils import knows_annex
 from datalad.interface.common_opts import recursion_flag
@@ -142,6 +143,12 @@ def _update_repo(repo, remote, merge, fetch_all):
 
     # merge:
     if merge:
+        # we need to check whether we need to convert this dataset to
+        # annex, would would be the case when we presently have a git repo
+        # and the recent fetch brought evidence for a remote annex
+        if isinstance(repo, GitRepo) and knows_annex(repo.path):
+            lgr.info("Init annex at '%s' prior merge.", repo.path)
+            repo = AnnexRepo(repo.path, create=False)
         lgr.info("Merging updates...")
         if hasattr(repo, 'merge_annex'):
             # this runs 'annex sync' and should deal with anything

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -135,33 +135,10 @@ class Update(Interface):
 
 
 def _update_repo(repo, remote, merge, fetch_all):
-    # fetch remote(s):
+    # fetch remote
     repo.fetch(
         remote=None if fetch_all else remote,
         all_=fetch_all)
-
-    # if `repo` is an annex and we didn't fetch the entire remote
-    # anyway, explicitly fetch git-annex branch:
-
-    # TODO: This isn't correct. `fetch_all` fetches all remotes.
-    # Apparently, we currently fetch an entire remote anyway. Is this
-    # what we want? Do we want to specify a refspec instead?
-    # yoh: we should leave it to git and its configuration.
-    # So imho we should just extract to fetch everything git would fetch
-    if knows_annex(repo.path) and not fetch_all:
-        if remote:
-            # we are updating from a certain remote, so git-annex branch
-            # should be updated from there as well:
-            repo.fetch(remote=remote)
-            # TODO: what does failing here look like?
-        else:
-            # we have no remote given, therefore
-            # check for tracking branch's remote:
-
-            track_remote, track_branch = repo.get_tracking_branch()
-            if track_remote:
-                # we have a "tracking remote"
-                repo.fetch(remote=track_remote)
 
     # merge:
     if merge:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -142,7 +142,13 @@ def _update_repo(repo, remote, merge, fetch_all):
 
     # merge:
     if merge:
-        lgr.info("Applying changes from tracking branch...")
+        lgr.info("Merging updates...")
+        if hasattr(repo, 'merge_annex'):
+            # this runs 'annex sync' and should deal with anything
+            repo.merge_annex(remote=remote)
+        else:
+            # handle merge in plain git
+            pass
         # TODO: Adapt.
         # TODO: Rethink default remote/tracking branch. See above.
         # We need a "tracking remote" but custom refspec to fetch from
@@ -160,11 +166,3 @@ def _update_repo(repo, remote, merge, fetch_all):
 
         std_out, std_err = repo._git_custom_command('', cmd_list)
         lgr.info(std_out)
-        if knows_annex(repo.path):
-            # annex-apply:
-            lgr.info("Updating annex ...")
-            std_out, std_err = repo._git_custom_command(
-                '', ["git", "annex", "merge"])
-            lgr.info(std_out)
-
-            # TODO: return value?

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-from os.path import join as opj
 
 from datalad.interface.base import Interface
 from datalad.support.constraints import EnsureStr

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -123,6 +123,9 @@ class Update(Interface):
                 lgr.warning("'%s' not known to dataset %s\nSkipping",
                             sibling_, repo.path)
                 continue
+            if not sibling_ and len(remotes) == 1:
+                # there is only one remote, must be this one
+                sibling_ = remotes[0]
             if not sibling_ and len(remotes) > 1 and merge:
                 lgr.debug("Found multiple siblings:\n%s" % remotes)
                 raise NotImplementedError(

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -119,16 +119,10 @@ class Update(Interface):
                             sibling, repo.path)
                 continue
 
-            # Currently '--merge' works for single remote only:
-            # TODO: - condition still incomplete
-            #       - We can merge if a remote was given or there is a
-            #         tracking branch
-            #       - we also can fetch all remotes independently on whether or
-            #         not we merge a certain remote
             if not sibling and len(remotes) > 1 and merge:
-                lgr.debug("Found multiple remotes:\n%s" % remotes)
-                raise NotImplementedError("No merge strategy for multiple "
-                                          "remotes implemented yet.")
+                lgr.debug("Found multiple siblings:\n%s" % remotes)
+                raise NotImplementedError(
+                    "Multiple siblings, please specify from which to update.")
             lgr.info("Updating dataset '%s' ..." % repo.path)
             _update_repo(repo, sibling, merge, fetch_all)
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -138,7 +138,8 @@ def _update_repo(repo, remote, merge, fetch_all):
     # fetch remote
     repo.fetch(
         remote=None if fetch_all else remote,
-        all_=fetch_all)
+        all_=fetch_all,
+        prune=True)  # prune to not accumulate a mess over time
 
     # merge:
     if merge:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -114,17 +114,21 @@ class Update(Interface):
                 lgr.debug("No siblings known to dataset at %s\nSkipping",
                           repo.path)
                 continue
-            if sibling and sibling not in remotes:
+            if not sibling:
+                # nothing given, look for tracking branch
+                sibling_ = repo.get_tracking_branch()[0]
+            else:
+                sibling_ = sibling
+            if sibling_ and sibling_ not in remotes:
                 lgr.warning("'%s' not known to dataset %s\nSkipping",
-                            sibling, repo.path)
+                            sibling_, repo.path)
                 continue
-
-            if not sibling and len(remotes) > 1 and merge:
+            if not sibling_ and len(remotes) > 1 and merge:
                 lgr.debug("Found multiple siblings:\n%s" % remotes)
                 raise NotImplementedError(
                     "Multiple siblings, please specify from which to update.")
             lgr.info("Updating dataset '%s' ..." % repo.path)
-            _update_repo(repo, sibling, merge, fetch_all)
+            _update_repo(repo, sibling_, merge, fetch_all)
 
 
 def _update_repo(repo, remote, merge, fetch_all):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -19,7 +19,6 @@ from os.path import lexists, join as opj
 from datalad.interface.base import Interface
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
-from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.utils import knows_annex
@@ -144,7 +143,7 @@ def _update_repo(ds, remote, merge, fetch_all, reobtain_data):
     # we need to check whether we need to convert this dataset to
     # annex, would would be the case when we presently have a git repo
     # and the recent fetch brought evidence for a remote annex
-    if isinstance(repo, GitRepo) and knows_annex(repo.path):
+    if not isinstance(repo, AnnexRepo) and knows_annex(repo.path):
         lgr.info("Init annex at '%s' prior merge.", repo.path)
         repo = AnnexRepo(repo.path, create=False)
     lgr.info("Merging updates...")

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -39,6 +39,7 @@ from git import InvalidGitRepositoryError
 
 from datalad import ssh_manager
 from datalad.dochelpers import exc_str
+from datalad.dochelpers import borrowkwargs
 from datalad.utils import linux_distribution_name
 from datalad.utils import nothing_cm
 from datalad.utils import auto_repr
@@ -426,6 +427,30 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         super(AnnexRepo, self).set_remote_url(name, url, push=push)
         self._set_shared_connection(name, url)
+
+    @borrowkwargs(GitRepo)
+    def get_remotes(self, with_refs_only=False, exclude_special_remotes=True):
+        """Get known (special-) remotes of the repository
+
+        Parameters
+        ----------
+        exclude_special_remotes: bool, optional
+          if True, don't return annex special remotes
+
+        Returns
+        -------
+        remotes : list of str
+          List of names of the remotes
+        """
+        remotes = super(AnnexRepo, self).get_remotes(
+            with_refs_only=with_refs_only)
+
+        if exclude_special_remotes:
+            return [remote for remote in remotes
+                    if not self.config.has_option('remote.{}'.format(remote),
+                                                  'annex-externaltype')]
+        else:
+            return remotes
 
     def __repr__(self):
         return "<AnnexRepo path=%s (%s)>" % (self.path, type(self))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -429,7 +429,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._set_shared_connection(name, url)
 
     @borrowkwargs(GitRepo)
-    def get_remotes(self, with_refs_only=False, exclude_special_remotes=True):
+    def get_remotes(self, with_refs_only=False, exclude_special_remotes=False):
         """Get known (special-) remotes of the repository
 
         Parameters

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1610,13 +1610,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         assert(info.pop('command') == 'info')
         return info  # just as is for now
 
-    def get_annexed_files(self):
+    def get_annexed_files(self, with_content_only=False):
         """Get a list of files in annex
         """
-        # TODO: Review!
-
-        out, err = self._run_annex_command('find',
-                                           annex_options=['--include', "*"])
+        # TODO: Review!!
+        args = [] if with_content_only else ['--include', "*"]
+        out, err = self._run_annex_command('find', annex_options=args)
         # TODO: JSON
         return out.splitlines()
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1066,16 +1066,59 @@ class AnnexRepo(GitRepo, RepoInterface):
     def merge_annex(self, remote=None):
         """Merge git-annex branch
 
+        Merely calls `sync` with the appropriate arguments.
+
         Parameters
         ----------
         remote: str, optional
           Name of a remote to be "merged".
         """
-        # this doesn't use `merge` but `sync` in order to properly
-        # trigger updating of maintained branches in e.g. v6 repos
-        args = [remote] if remote else []
-        # would commit any dirty files, we don't want that
-        args.extend(['--no-push', '--no-pull', '--no-commit', '--no-content'])
+        self.sync(
+            remotes=remote, push=False, pull=False, commit=False, content=False,
+            all=False)
+
+    def sync(self, remotes=None, push=True, pull=True, commit=True,
+             content=False, all=False, fast=False):
+        """Synchronize local repository with remotes
+
+        Use  this  command  when you want to synchronize the local repository
+        with one or more of its remotes. You can specify the remotes (or
+        remote groups) to sync with by name; the default if none are specified
+        is to sync with all remotes.
+
+        Parameters
+        ----------
+        remotes: str, list(str), optional
+          Name of one or more remotes to be sync'ed.
+        push : bool
+          By default, git pushes to remotes.
+        pull : bool
+          By default, git pulls from remotes
+        commit : bool
+          A commit is done by default. Disable to avoid  committing local
+          changes.
+        content : bool
+          Normally, syncing does not transfer the contents of annexed
+          files.  This option causes the content of files in the work tree
+          to also be uploaded and downloaded as necessary.
+        all : bool
+          This option, when combined with `content`, makes all available
+          versions of all files be synced, when preferred content settings
+          allow
+        fast : bool
+          Only sync with the remotes with the lowest annex-cost value
+          configured
+        """
+        args = []
+        for label, arg in (('push', push),
+                           ('pull', pull),
+                           ('commit', commit),
+                           ('content', content)):
+            args.append('--{}{}'.format('' if arg else 'no-', label))
+        for label, arg in (('all', all), ('fast', fast)):
+            if arg:
+                args.append('--{}'.format(label))
+        args.extend(assure_list(remotes))
         self._run_annex_command('sync', annex_options=args)
 
     @normalize_path

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1056,7 +1056,7 @@ class GitRepo(RepoInterface):
         #         self.repo.git.branch(r=True).splitlines()]
 
     def get_remotes(self, with_refs_only=False):
-        """
+        """Get known remotes of the repository
 
         Parameters
         ----------


### PR DESCRIPTION
`update` is now practically a frontend for `annex sync`.

Please comment @bpoldrack @yarikoptic 

- [x] implements `--reobtain-data`
- [x] adds missing tests: #705, #712, #868 
- [x] verify safe operation when upstream removes subdatasets that are installed locally
- [x] can upgrade a GitRepo to an AnnexRepo if needed #1307
- [x] NF: AnnexRepo.sync(), reimplemented AnnexRepo.merge_annex() with it.

From my PoV this step is complete. There is more TODO, (#1199) but there is no need to wait for it .