### PR TITLE
ENH: use assert_array_equal to compare to possibly help troubleshooting random failures

### DIFF
--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -181,6 +181,8 @@ def test_proxying_open_regular():
 def test_proxying_open_nibabel():
     if not nib:
         raise SkipTest("No nibabel found")
+    # cannot have numpy if nibabel is available
+    from numpy.testing import assert_array_equal
 
     d = np.empty((3, 3, 3))
     d[1, 1, 1] = 99
@@ -192,6 +194,6 @@ def test_proxying_open_nibabel():
 
     def verify_nii(f, mode="r"):
         ni = nib.load(f)
-        ok_(np.all(ni.get_data() == d))
+        assert_array_equal(ni.get_data(), d)
 
     yield _test_proxying_open, generate_nii, verify_nii


### PR DESCRIPTION

we had nd80 and nd15_04 bots failing, see e.g.
http://smaug.datalad.org:8020/builders/datalad-pr-docker-dl-nd15_04/builds/2063/steps/nosetests/logs/stdio
which seems to happen under heavy loads but otherwise didn't reproduce locally etc

so to see possibly what is going on switched to use more informative helper