### PR TITLE
RF: Do not place default push config on publish anymore

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import re
 from os.path import curdir
 
 from datalad.interface.base import Interface
@@ -129,21 +130,50 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
         ds.repo.fetch(remote=remote)
         ds.repo.merge_annex(remote)
 
-    # we now know where to push to:
     # Note: git's push.default is 'matching', which doesn't work for first
     # time publication (a branch, that doesn't exist on remote yet)
     # But if we want to respect remote.*.push entries, etc. we need to
     # not pass a specific refspec (like active branch) to `git push`
     # by default.
+    # hence we amend any existing config on the fly
     # TODO: what else to push by default?
     # consider also: --follow-tags, --tags, --atomic
-    lgr.debug("Push to '%s'", remote)
-    pushvar = 'remote.{}.push'.format(remote)
-    if not ds.config.get(pushvar, None):
-        # no default push targets configured for this remote, leave our mark
-        ds.config.add(pushvar, 'master', where='local')
+    # make sure we push
+    things2push = []
+    current_branch = ds.repo.get_active_branch()
+    if current_branch:  # possibly make this conditional on a switch
+        # TODO: this should become it own helper
         if isinstance(ds.repo, AnnexRepo):
-            ds.config.add(pushvar, 'git-annex', where='local')
+            # annex could manage this branch
+            if current_branch.startswith('annex/direct') \
+                    and ds.config.getbool('annex', 'direct', default=False):
+                # this is a "fake" annex direct mode branch
+                # we want to publish the underlying branch
+                current_branch = current_branch[12:]
+            match_adjusted = re.match(
+                'adjusted/(.*)\([a-z]*\)',
+                current_branch)
+            if match_adjusted:
+                # adjusted/master(...)
+                current_branch = match.group(1)
+        things2push.append(current_branch)
+    if isinstance(ds.repo, AnnexRepo):
+        things2push.append('git-annex')
+    # check that all our magic found valid branches
+    things2push = [t for t in things2push if t in ds.repo.get_branches()]
+    # check that we don't ask to push things that are already configured
+    # -> would cause error
+    # TODO need to find a way to properly do this, when wildcards are used
+    # in the push configuration variable
+    things2push = [t for t in things2push
+                   if t not in ds.config.get('remote.{}.push'.format(remote), [])]
+    # now we know what to push where
+    lgr.debug("Attempt to push '%s' to sibling '%s'", things2push, remote)
+    # configure targets for the next push call
+    # those will be incremental to any remote..push setting in the config
+    ds.repo.repo.git(
+        c=['remote.{}.push={}'.format(remote, thing)
+           for thing in things2push])
     _log_push_info(ds.repo.push(remote=remote))
 
     published.append(ds)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -81,6 +81,7 @@ def test_publish_simple(origin, src_path, dst_path):
 
     # 'target/master' should be tracking branch at this point, so
     # try publishing without `to`:
+    # MIH: Nope, we don't automatically add this anymore
 
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
@@ -89,7 +90,7 @@ def test_publish_simple(origin, src_path, dst_path):
                     commit=True, msg="Modified.")
     ok_clean_git(source.repo, annex=None)
 
-    res = publish(dataset=source)
+    res = publish(dataset=source, to='target')
     eq_(res, ([source], []))
 
     ok_clean_git(dst_path, annex=None)


### PR DESCRIPTION
Instead temporarily amend the push config to push the current branch, or rather the underlying branch in case of managed branches.

We may want to have this behavior to be conditioned on an explicit switch, or to only be active when there is no push config at all. Which would help with the issue that it presently cannot handle wildcard expressions for push config.

ATM it makes sense to me to do it like this.

This is work towards a resolution of gh-1275

