### PR TITLE
BF/RF: instead of using -c remote..push, pass refspecs into push invocation

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -38,7 +38,7 @@ lgr = logging.getLogger('datalad.distribution.publish')
 # TODO: make consistent configurable output
 
 
-def _log_push_info(pi_list):
+def _log_push_info(pi_list, log_nothing=True):
     from git.remote import PushInfo as PI
 
     error = False
@@ -50,7 +50,8 @@ def _log_push_info(pi_list):
             else:
                 lgr.debug('Pushed: %s', push_info.summary)
     else:
-        lgr.debug("Pushed: nothing")
+        if log_nothing:
+            lgr.debug("Pushed: nothing")
     return error
 
 
@@ -173,6 +174,11 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
     # now we know what to push where
     lgr.debug("Attempt to push '%s' to sibling '%s'", things2push, remote)
     _log_push_info(ds.repo.push(remote=remote, refspec=things2push))
+    if things2push and ds.config.get('remote.{}.push'.format(remote)):
+        # since current state of ideas is to push both auto-detected and the
+        # possibly prescribed, if anything was, let's push again to possibly
+        # push left-over prescribed ones.
+        _log_push_info(ds.repo.push(remote=remote), log_nothing=False)
 
     published.append(ds)
 

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -155,7 +155,10 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
                 current_branch)
             if match_adjusted:
                 # adjusted/master(...)
-                current_branch = match.group(1)
+                # TODO:  this code is not tested
+                # see https://codecov.io/gh/datalad/datalad/src/17e67045a088ae0372b38aa4d8d46ecf7c821cb7/datalad/distribution/publish.py#L156
+                # and thus probably broken -- test me!
+                current_branch = match_adjusted.group(1)
         things2push.append(current_branch)
     if isinstance(ds.repo, AnnexRepo):
         things2push.append('git-annex')
@@ -169,12 +172,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options):
                    if t not in ds.config.get('remote.{}.push'.format(remote), [])]
     # now we know what to push where
     lgr.debug("Attempt to push '%s' to sibling '%s'", things2push, remote)
-    # configure targets for the next push call
-    # those will be incremental to any remote..push setting in the config
-    ds.repo.repo.git(
-        c=['remote.{}.push={}'.format(remote, thing)
-           for thing in things2push])
-    _log_push_info(ds.repo.push(remote=remote))
+    _log_push_info(ds.repo.push(remote=remote, refspec=things2push))
 
     published.append(ds)
 


### PR DESCRIPTION
should fix failing test
  see discussions after merge in https://github.com/datalad/datalad/pull/1308

includes an "easter egg" fix ;)