### PR TITLE
ENH+RF: generate our customremotes (datalad, datalad-archives) with the same UUID

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -29,6 +29,14 @@ ARCHIVES_SPECIAL_REMOTE = 'datalad-archives'
 DATALAD_SPECIAL_REMOTE = 'datalad'
 DATALAD_GIT_DIR = join('.git', 'datalad')
 
+# pregenerated using
+# python3 -c 'from datalad.customremotes.base import generate_uuids as guuid; print(guuid())'
+DATALAD_SPECIAL_REMOTES_UUIDS = {
+    # should not be changed from now on!
+    DATALAD_SPECIAL_REMOTE: 'cf13d535-b47c-5df6-8590-0793cb08a90a',
+    ARCHIVES_SPECIAL_REMOTE: 'c04eb54b-4b4e-5755-8436-866b043170fa'
+}
+
 ARCHIVES_TEMP_DIR = join(DATALAD_GIT_DIR, 'tmp', 'archives')
 ANNEX_TEMP_DIR = join('.git', 'annex', 'tmp')
 

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -49,6 +49,7 @@ from ...support.annexrepo import AnnexRepo
 from ...support.stats import ActivityStats
 from ...support.versions import get_versions
 from ...support.exceptions import AnnexBatchCommandError
+from ...support.external_versions import external_versions
 from ...support.network import get_url_straight_filename, get_url_disposition_filename
 
 from ... import cfg
@@ -58,6 +59,7 @@ from ..pipeline import CRAWLER_PIPELINE_SECTION
 from ..pipeline import initiate_pipeline_config
 from ..dbs.files import PhysicalFileStatusesDB, JsonFileStatusesDB
 from ..dbs.versions import SingleVersionDB
+from datalad.customremotes.base import init_datalad_remote
 from datalad.dochelpers import exc_str
 
 from logging import getLogger
@@ -322,11 +324,7 @@ class Annexificator(object):
                         lgr.info("Enabling existing special remote %s" % remote)
                         self.repo.enable_remote(remote)
                     else:
-                        lgr.info("Initiating special remote %s" % remote)
-                        self.repo.init_remote(
-                            remote,
-                            ['encryption=none', 'type=external', 'autoenable=true',
-                             'externaltype=%s' % remote])
+                        init_datalad_remote(self.repo, remote, autoenable=True)
 
         self.mode = mode
         self.options = options or []

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -574,4 +574,34 @@ class AnnexCustomRemote(object):
     #def get_GETCONFIG SETCONFIG  SETCREDS  GETCREDS  GETUUID  GETGITDIR  SETWANTED  GETWANTED
     #SETSTATE GETSTATE SETURLPRESENT  SETURLMISSING
 
+
+def generate_uuids():
+    """Generate UUIDs for our remotes. Even though quick, for consistency pre-generated and recorded in consts.py"""
+    import uuid
+    return {
+        remote: str(uuid.uuid5(uuid.NAMESPACE_URL, 'http://datalad.org/specialremotes/%s' % remote))
+        for remote in {'datalad', 'datalad-archives'}
+    }
+
+
+def init_datalad_remote(repo, remote, encryption=None, autoenable=False, opts=[]):
+    """Initialize datalad special remote"""
+    from datalad.support.external_versions import external_versions
+    from datalad.consts import DATALAD_SPECIAL_REMOTES_UUIDS
+    lgr.info("Initiating special remote %s" % remote)
+    remote_opts = [
+        'encryption=%s' % str(encryption).lower(),
+        'type=external',
+        'autoenable=%s' % str(bool(autoenable)).lower(),
+        'externaltype=%s' % remote
+    ]
+    if external_versions['cmd:annex'] >= '6.20170208':
+        # use unique uuid for our remotes
+        # This should help with merges of disconnected repos etc
+        # ATM only datalad/datalad-archives is expected,
+        # so on purpose getitem
+        remote_opts.append('uuid=%s' % DATALAD_SPECIAL_REMOTES_UUIDS[remote])
+    return repo.init_remote(remote, remote_opts + opts)
+
+
 lgr.log(5, "Done importing datalad.customremotes.main")

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -41,6 +41,8 @@ from ..utils import getpwd, rmtree, file_basename
 from ..utils import md5sum
 from ..utils import assure_tuple_or_list
 
+from datalad.customremotes.base import init_datalad_remote
+
 from six import string_types
 
 from ..log import logging
@@ -287,11 +289,7 @@ class AddArchiveContent(Interface):
 
         # TODO: check if may be it was already added
         if ARCHIVES_SPECIAL_REMOTE not in annex.get_remotes():
-            lgr.debug("Adding new special remote {}".format(ARCHIVES_SPECIAL_REMOTE))
-            annex.init_remote(
-                ARCHIVES_SPECIAL_REMOTE,
-                ['encryption=none', 'type=external', 'externaltype=%s' % ARCHIVES_SPECIAL_REMOTE,
-                 'autoenable=true'])
+            init_datalad_remote(annex, ARCHIVES_SPECIAL_REMOTE, autoenable=True)
         else:
             lgr.debug("Special remote {} already exists".format(ARCHIVES_SPECIAL_REMOTE))
 

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -36,6 +36,9 @@ from ...utils import find_files
 from ...utils import rmtree
 from datalad.log import lgr
 from ...api import add_archive_content, clean
+from datalad.support.external_versions import external_versions
+from datalad.consts import DATALAD_SPECIAL_REMOTES_UUIDS
+from datalad.consts import ARCHIVES_SPECIAL_REMOTE
 
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import ok_clean_git
@@ -89,6 +92,11 @@ def test_add_archive_dirs(path_orig, url, repo_path):
                         leading_dirs_depth=2,
                         use_current_dir=False,
                         exclude='.*__MACOSX.*')  # some junk penetrates
+
+    if external_versions['cmd:annex'] >= '6.20170208':
+        # should have fixed remotes
+        eq_(repo.get_description(uuid=DATALAD_SPECIAL_REMOTES_UUIDS[ARCHIVES_SPECIAL_REMOTE]),
+            '[%s]' % ARCHIVES_SPECIAL_REMOTE)
 
     all_files = sorted(find_files('.'))
     target_files = {

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -25,6 +25,7 @@ from ..utils import swallow_logs
 from ..version import __version__
 from . import _TEMP_PATHS_GENERATED
 
+from datalad.customremotes.base import init_datalad_remote
 
 @add_metaclass(ABCMeta)
 class TestRepo(object):
@@ -46,10 +47,7 @@ class TestRepo(object):
             # and manage to handle all http urls and requests:
             if self.REPO_CLASS is AnnexRepo and \
                     os.environ.get('DATALAD_TESTS_DATALADREMOTE'):
-                self.repo.init_remote(
-                    'datalad',
-                    ['encryption=none', 'type=external', 'autoenable=true',
-                     'externaltype=datalad'])
+                init_datalad_remote(self.repo, 'datalad', autoenable=True)
 
         self._created = False
 


### PR DESCRIPTION
This should be legit (confirmed with joey) since they just provide a service
to fetch stuff from e.g. archives or some data sources (like web remote).

This will be handy in cases of merging two different repositories, which had
those remotes initiated independently.  Currently it would generate multiple
special remotes then different uuids and the same name