### PR TITLE
WIP: RF: new decorator approach

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -105,32 +105,25 @@ def _generate_func_api():
                 if always_render:
                     globals()[get_api_name(intfspec)] = intf__
 
-
-def _fix_datasetmethod_docs():
-    """Fix up dataset methods docstrings which didn't get proper docs
-    """
-    from six import PY2
-    for attr in dir(Dataset):
-        try:
-            func = getattr(Dataset, attr)
-            orig_func = getattr(func, '__orig_func__')
-        except AttributeError:
-            continue
-        if PY2:
-            func = func.__func__
-        orig__doc__ = func.__doc__
-        if orig__doc__ and orig__doc__.strip():  # pragma: no cover
-            raise RuntimeError(
-                "No meaningful docstring should have been assigned before now. Got %r"
-                % orig__doc__
-            )
-        func.__doc__ = orig_func.__doc__
+            # apply new docs to datasetmethods, too:
+            try:
+                d_method = getattr(Dataset, get_api_name(intfspec))
+            except AttributeError:
+                continue
+            # d_method is a wrapt.decorator._BoundAdapterWrapper;
+            # actual function: d_method.im_func
+            d_method = d_method.im_func
+            orig__doc__ = d_method.func_doc
+            if orig__doc__ and orig__doc__.strip():  # pragma: no cover
+                raise RuntimeError(
+                    "No meaningful docstring should have been assigned before "
+                    "now. Got %r" % orig__doc__
+                )
+            d_method.func_doc = intf.__call__.__doc__
 
 
 # Invoke above helpers
 _generate_func_api()
-_fix_datasetmethod_docs()
 
 # Be nice and clean up the namespace properly
 del _generate_func_api
-del _fix_datasetmethod_docs

--- a/datalad/api.py
+++ b/datalad/api.py
@@ -105,24 +105,8 @@ def _generate_func_api():
                 if always_render:
                     globals()[get_api_name(intfspec)] = intf__
 
-            # apply new docs to datasetmethods, too:
-            try:
-                d_method = getattr(Dataset, get_api_name(intfspec))
-            except AttributeError:
-                continue
-            # d_method is a wrapt.decorator._BoundAdapterWrapper;
-            # actual function: d_method.im_func
-            d_method = d_method.im_func
-            orig__doc__ = d_method.func_doc
-            if orig__doc__ and orig__doc__.strip():  # pragma: no cover
-                raise RuntimeError(
-                    "No meaningful docstring should have been assigned before "
-                    "now. Got %r" % orig__doc__
-                )
-            d_method.func_doc = intf.__call__.__doc__
 
-
-# Invoke above helpers
+# Invoke above helper
 _generate_func_api()
 
 # Be nice and clean up the namespace properly

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -563,11 +563,14 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
         # If bound function is used with wrong signature (especially by
         # explicitly passing a dataset, let's raise a proper exception instead
         # of a 'list index out of range', that is not very telling to the user.
-        if len(args) >= len(orig_pos) or dataset_argname in kwargs:
+        if len(args) >= len(orig_pos):
             raise TypeError("{0}() takes at most {1} arguments ({2} given):"
                             " {3}".format(name, len(orig_pos), len(args),
                                           ['self'] + [a for a in orig_pos
                                                       if a != dataset_argname]))
+        if dataset_argname in kwargs:
+            raise TypeError("{}() got an unexpected keyword argument {}"
+                            "".format(name, dataset_argname))
         kwargs[dataset_argname] = instance
         ds_index = orig_pos.index(dataset_argname)
         for i in range(0, len(args)):
@@ -581,7 +584,7 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
     return f
 
 
-# Note: Cannot be defined with constraints.py, since then dataset.py needs to
+# Note: Cannot be defined within constraints.py, since then dataset.py needs to
 # be imported from constraints.py, which needs to be imported from dataset.py
 # for another constraint
 class EnsureDataset(Constraint):
@@ -594,8 +597,6 @@ class EnsureDataset(Constraint):
         else:
             raise ValueError("Can't create Dataset from %s." % type(value))
 
-    # TODO: Proper description? Mentioning Dataset class doesn't make sense for
-    # commandline doc!
     def short_description(self):
         return "Dataset"
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -45,6 +45,7 @@ from datalad.utils import optional_args, expandpath, is_explicit_path, \
 from datalad.utils import swallow_logs
 from datalad.utils import get_dataset_root
 from datalad.utils import knows_annex
+from datalad.utils import better_wraps
 
 
 lgr = logging.getLogger('datalad.dataset')
@@ -545,16 +546,16 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
     if not name:
         name = f.func_name if PY2 else f.__name__
 
-    @wraps(f)
+    @better_wraps(f)
     def apply_func(*args, **kwargs):
-        """Wrapper function to assign arguments of the bound function to
-        original function.
+        # Wrapper function to assign arguments of the bound function to
+        # original function.
+        #
+        # Note
+        # ----
+        # This wrapper is NOT returned by the decorator, but only used to bind
+        # the function `f` to the Dataset class.
 
-        Note
-        ----
-        This wrapper is NOT returned by the decorator, but only used to bind
-        the function `f` to the Dataset class.
-        """
         kwargs = kwargs.copy()
         from inspect import getargspec
         orig_pos = getargspec(f).args
@@ -577,9 +578,6 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
         return f(**kwargs)
 
     setattr(Dataset, name, apply_func)
-    # So we could post-hoc later adjust the documentation string which is assigned
-    # within .api
-    apply_func.__orig_func__ = f
     return f
 
 

--- a/datalad/distribution/tests/test_dataset_binding.py
+++ b/datalad/distribution/tests/test_dataset_binding.py
@@ -45,6 +45,10 @@ def test_decorator():
     # raises proper TypeError:
     assert_raises(TypeError, ds.func, 1, 2, ds, False)
 
+    # keyword argument 'dataset' is invalidated in Dataset-bound function:
+    # raises proper TypeError:
+    assert_raises(TypeError, ds.func, 1, 2, dataset='whatever')
+
     # test name parameter:
     @datasetmethod(name="new_name")
     def another(some, dataset=None):

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -312,3 +312,28 @@ def test_filter_unmodified(path):
             subsub.path: []
         },
         {d: sorted(p) for d, p in filter_unmodified(spec, ds, orig_base_commit).items()})
+
+
+def test_eval_results():
+
+    from ..base import Interface
+    from datalad.distribution.dataset import datasetmethod
+    from datalad.interface.utils import eval_results
+    from inspect import getargspec
+
+    class FakeCommand(Interface):
+
+        @staticmethod
+        @datasetmethod(name='fake_command')
+        @eval_results
+        def __call__(number, dataset=None):
+
+            for i in range(number):
+                yield i
+
+    result = FakeCommand().__call__(2)
+    assert_equal(result, [0, 1])
+    result = Dataset('/does/not/matter').fake_command(3)
+    assert_equal(result, [0, 1, 2])
+    assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])
+    assert_equal(getargspec(FakeCommand.__call__)[0], ['number', 'dataset'])

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -321,7 +321,10 @@ from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
 
+from ..utils import build_doc_as_class_decorator
 
+
+@build_doc_as_class_decorator
 class Test_Utils(Interface):
     """TestUtil's fake command"""
 
@@ -340,7 +343,7 @@ class Test_Utils(Interface):
     @staticmethod
     @datasetmethod(name='fake_command')
     @eval_results
-    @build_doc
+    #@build_doc
     def __call__(number, dataset=None):
 
         for i in range(number):
@@ -356,10 +359,10 @@ def test_eval_results():
 
 
 
-    Test_Utils().__call__(1)
-    Test_Utils().__call__(1)
-    Test_Utils().__call__(1)
-    Test_Utils().__call__(1)
+    #Test_Utils().__call__(1)
+    #Test_Utils().__call__(1)
+    #Test_Utils().__call__(1)
+    #Test_Utils().__call__(1)
 
     # test docs
     doc1 = Dataset.fake_command.__doc__

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -297,7 +297,6 @@ def test_filter_unmodified(path):
 
     # deal with removal (force insufiicient copies error)
     ds.remove(opj(subsub.path, 'file_bbaa'), check=False)
-    #import pdb; pdb.set_trace()
     # saves all the way up
     ok_clean_git(path)
 

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -349,14 +349,17 @@ class Test_Utils(Interface):
 
 def test_eval_results():
 
-    from datalad.utils import swallow_logs
     import logging
-    # test eval_results is able to determine the call, a method of which it is
-    # decorating:
-    with swallow_logs(new_level=logging.DEBUG) as cml:
-        Dataset('/does/not/matter').fake_command(3)
-        cml.assert_logged("Determined class of decorated function: {}"
-                          "".format(Test_Utils().__class__), level='DEBUG')
+
+    lgr = logging.getLogger('datalad.interface.tests.test_utils')
+    lgr.warning("START TEST")
+
+
+
+    Test_Utils().__call__(1)
+    Test_Utils().__call__(1)
+    Test_Utils().__call__(1)
+    Test_Utils().__call__(1)
 
     # test docs
     doc1 = Dataset.fake_command.__doc__
@@ -365,6 +368,15 @@ def test_eval_results():
     assert_in("TestUtil's fake command", doc1)
     assert_in("Parameters", doc1)
     assert_in("It's a number", doc1)
+
+    from datalad.utils import swallow_logs
+
+    # test eval_results is able to determine the call, a method of which it is
+    # decorating:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        Dataset('/does/not/matter').fake_command(3)
+        cml.assert_logged("Determined class of decorated function: {}"
+                          "".format(Test_Utils().__class__), level='DEBUG')
 
     # test results:
     result = Test_Utils().__call__(2)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -349,7 +349,14 @@ class Test_Utils(Interface):
 
 def test_eval_results():
 
-    result = Dataset('/does/not/matter').fake_command(3)
+    from datalad.utils import swallow_logs
+    import logging
+    # test eval_results is able to determine the call, a method of which it is
+    # decorating:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        Dataset('/does/not/matter').fake_command(3)
+        cml.assert_logged("Determined class of decorated function: {}"
+                          "".format(Test_Utils().__class__), level='DEBUG')
 
     # test docs
     doc1 = Dataset.fake_command.__doc__
@@ -359,36 +366,34 @@ def test_eval_results():
     assert_in("Parameters", doc1)
     assert_in("It's a number", doc1)
 
-    # # test results:
-    # result = Test_Utils().__call__(2)
-    # assert_equal(result, [0, 1])
-    # result = Dataset('/does/not/matter').fake_command(3)
-    # assert_equal(result, [0, 1, 2])
-    # # test signature:
-    # from inspect import getargspec
-    # assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])
-    # assert_equal(getargspec(Test_Utils.__call__)[0], ['number', 'dataset'])
-    #
-    # from datalad.utils import swallow_logs
-    # import logging
-    # # test _eval_arguments:
-    # with swallow_logs(new_level=logging.WARNING) as cml:
-    #     Dataset('/does/not/matter').fake_command(3, _eval_arg1="blubb")
-    #     assert_in("_eval_arg1: blubb", cml.out)
-    #     assert_in("_eval_arg2: default2", cml.out)
-    # # without anything keep defaults
-    # with swallow_logs(new_level=logging.WARNING) as cml:
-    #     Dataset('/does/not/matter').fake_command(3)
-    #     assert_in("_eval_arg1: default1", cml.out)
-    #     assert_in("_eval_arg2: default2", cml.out)
-    # # same for version not bound to Dataset:
-    # with swallow_logs(new_level=logging.WARNING) as cml:
-    #     Test_Utils().__call__(3, _eval_arg1="blubb")
-    #     assert_in("_eval_arg1: blubb", cml.out)
-    #     assert_in("_eval_arg2: default2", cml.out)
-    # # without anything keep defaults
-    # with swallow_logs(new_level=logging.WARNING) as cml:
-    #     Test_Utils().__call__(3)
-    #     assert_in("_eval_arg1: default1", cml.out)
-    #     assert_in("_eval_arg2: default2", cml.out)
+    # test results:
+    result = Test_Utils().__call__(2)
+    assert_equal(result, [0, 1])
+    result = Dataset('/does/not/matter').fake_command(3)
+    assert_equal(result, [0, 1, 2])
+    # test signature:
+    from inspect import getargspec
+    assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])
+    assert_equal(getargspec(Test_Utils.__call__)[0], ['number', 'dataset'])
+
+    # test _eval_arguments:
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        Dataset('/does/not/matter').fake_command(3, _eval_arg1="blubb")
+        assert_in("_eval_arg1: blubb", cml.out)
+        assert_in("_eval_arg2: default2", cml.out)
+    # without anything keep defaults
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        Dataset('/does/not/matter').fake_command(3)
+        assert_in("_eval_arg1: default1", cml.out)
+        assert_in("_eval_arg2: default2", cml.out)
+    # same for version not bound to Dataset:
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        Test_Utils().__call__(3, _eval_arg1="blubb")
+        assert_in("_eval_arg1: blubb", cml.out)
+        assert_in("_eval_arg2: default2", cml.out)
+    # without anything keep defaults
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        Test_Utils().__call__(3)
+        assert_in("_eval_arg1: default1", cml.out)
+        assert_in("_eval_arg2: default2", cml.out)
 

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -314,52 +314,59 @@ def test_filter_unmodified(path):
         {d: sorted(p) for d, p in filter_unmodified(spec, ds, orig_base_commit).items()})
 
 
+from ..base import Interface
+from datalad.distribution.dataset import datasetmethod
+from datalad.interface.utils import eval_results
+
+class Test_Utils(Interface):
+
+    @staticmethod
+    @datasetmethod(name='fake_command')
+    @eval_results
+    def __call__(number, dataset=None):
+
+        for i in range(number):
+            yield i
+
+
 def test_eval_results():
 
-    from ..base import Interface
-    from datalad.distribution.dataset import datasetmethod
-    from datalad.interface.utils import eval_results
     from inspect import getargspec
 
-    class FakeCommand(Interface):
 
-        @staticmethod
-        @datasetmethod(name='fake_command')
-        @eval_results
-        def __call__(number, dataset=None):
+    result = Dataset('/does/not/matter').fake_command(3)
+    # result = Test_Utils().__call__(2)
 
-            for i in range(number):
-                yield i
 
     # test results:
-    result = FakeCommand().__call__(2)
-    assert_equal(result, [0, 1])
-    result = Dataset('/does/not/matter').fake_command(3)
-    assert_equal(result, [0, 1, 2])
-    # test signature:
-    assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])
-    assert_equal(getargspec(FakeCommand.__call__)[0], ['number', 'dataset'])
-
-    from datalad.utils import swallow_logs
-    import logging
-    # test _eval_arguments:
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        Dataset('/does/not/matter').fake_command(3, _eval_arg1="blubb")
-        assert_in("_eval_arg1: blubb", cml.out)
-        assert_in("_eval_arg2: default2", cml.out)
-    # without anything keep defaults
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        Dataset('/does/not/matter').fake_command(3)
-        assert_in("_eval_arg1: default1", cml.out)
-        assert_in("_eval_arg2: default2", cml.out)
-    # same for version not bound to Dataset:
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        FakeCommand().__call__(3, _eval_arg1="blubb")
-        assert_in("_eval_arg1: blubb", cml.out)
-        assert_in("_eval_arg2: default2", cml.out)
-    # without anything keep defaults
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        FakeCommand().__call__(3)
-        assert_in("_eval_arg1: default1", cml.out)
-        assert_in("_eval_arg2: default2", cml.out)
+    # result = Test_Utils().__call__(2)
+    # assert_equal(result, [0, 1])
+    # result = Dataset('/does/not/matter').fake_command(3)
+    # assert_equal(result, [0, 1, 2])
+    # # test signature:
+    # assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])
+    # assert_equal(getargspec(Test_Utils.__call__)[0], ['number', 'dataset'])
+    #
+    # from datalad.utils import swallow_logs
+    # import logging
+    # # test _eval_arguments:
+    # with swallow_logs(new_level=logging.WARNING) as cml:
+    #     Dataset('/does/not/matter').fake_command(3, _eval_arg1="blubb")
+    #     assert_in("_eval_arg1: blubb", cml.out)
+    #     assert_in("_eval_arg2: default2", cml.out)
+    # # without anything keep defaults
+    # with swallow_logs(new_level=logging.WARNING) as cml:
+    #     Dataset('/does/not/matter').fake_command(3)
+    #     assert_in("_eval_arg1: default1", cml.out)
+    #     assert_in("_eval_arg2: default2", cml.out)
+    # # same for version not bound to Dataset:
+    # with swallow_logs(new_level=logging.WARNING) as cml:
+    #     Test_Utils().__call__(3, _eval_arg1="blubb")
+    #     assert_in("_eval_arg1: blubb", cml.out)
+    #     assert_in("_eval_arg2: default2", cml.out)
+    # # without anything keep defaults
+    # with swallow_logs(new_level=logging.WARNING) as cml:
+    #     Test_Utils().__call__(3)
+    #     assert_in("_eval_arg1: default1", cml.out)
+    #     assert_in("_eval_arg2: default2", cml.out)
 

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -6,32 +6,44 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Test dirty dataset handling
+"""Test interface.utils
 
 """
 
-__docformat__ = 'restructuredtext'
-
 import os
+import logging
 from os.path import join as opj
 from os.path import relpath
 from nose.tools import assert_raises, assert_equal
 from datalad.tests.utils import with_tempfile, assert_not_equal
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import ok_
-from datalad.interface.utils import handle_dirty_dataset
-from datalad.interface.utils import get_paths_by_dataset
-from datalad.interface.utils import save_dataset_hierarchy
-from datalad.interface.utils import get_dataset_directories
-from datalad.interface.utils import filter_unmodified
-from datalad.interface.save import Save
+from datalad.utils import swallow_logs
 from datalad.distribution.dataset import Dataset
+from datalad.distribution.dataset import datasetmethod
+from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.utils import _install_subds_inplace
-from datalad.api import save
+from datalad.support.param import Parameter
+from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import EnsureNone
 
+from ..base import Interface
+from ..utils import eval_results
+from ..utils import build_doc
+from ..utils import handle_dirty_dataset
+from ..utils import get_paths_by_dataset
+from ..utils import save_dataset_hierarchy
+from ..utils import get_dataset_directories
+from ..utils import filter_unmodified
+from ..save import Save
+
+
+__docformat__ = 'restructuredtext'
+lgr = logging.getLogger('datalad.interface.tests.test_utils')
 _dirty_modes = ('fail', 'ignore', 'save-before')
 
 
@@ -314,17 +326,8 @@ def test_filter_unmodified(path):
         {d: sorted(p) for d, p in filter_unmodified(spec, ds, orig_base_commit).items()})
 
 
-from ..base import Interface
-from datalad.distribution.dataset import datasetmethod, EnsureDataset
-from datalad.interface.utils import eval_results, build_doc
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureNone
-from datalad.support.param import Parameter
-
-from ..utils import build_doc_as_class_decorator
-
-
-@build_doc_as_class_decorator
+# Note: class name needs to match module's name
+@build_doc
 class Test_Utils(Interface):
     """TestUtil's fake command"""
 
@@ -343,36 +346,37 @@ class Test_Utils(Interface):
     @staticmethod
     @datasetmethod(name='fake_command')
     @eval_results
-    #@build_doc
     def __call__(number, dataset=None):
 
         for i in range(number):
             yield i
 
 
-def test_eval_results():
-
-    import logging
-
-    lgr = logging.getLogger('datalad.interface.tests.test_utils')
-    lgr.warning("START TEST")
-
-
-
-    #Test_Utils().__call__(1)
-    #Test_Utils().__call__(1)
-    #Test_Utils().__call__(1)
-    #Test_Utils().__call__(1)
+def test_eval_results_plus_build_doc():
 
     # test docs
+
+    # docstring was build already:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        Test_Utils().__call__(1)
+        assert_not_in("Building doc for", cml.out)
+    # docstring accessible both ways:
     doc1 = Dataset.fake_command.__doc__
     doc2 = Test_Utils().__call__.__doc__
+
+    # docstring was built from Test_Util's definition:
     assert_equal(doc1, doc2)
     assert_in("TestUtil's fake command", doc1)
     assert_in("Parameters", doc1)
     assert_in("It's a number", doc1)
 
-    from datalad.utils import swallow_logs
+    # docstring also contains eval_result's parameters:
+    assert_in("_eval_arg1", doc1)
+    assert_in("_eval_arg2", doc1)
+    assert_in("default1", doc1)
+    assert_in("default2", doc1)
+    assert_in("first parameter", doc1)
+    assert_in("second parameter", doc1)
 
     # test eval_results is able to determine the call, a method of which it is
     # decorating:
@@ -386,28 +390,29 @@ def test_eval_results():
     assert_equal(result, [0, 1])
     result = Dataset('/does/not/matter').fake_command(3)
     assert_equal(result, [0, 1, 2])
+
     # test signature:
     from inspect import getargspec
     assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])
     assert_equal(getargspec(Test_Utils.__call__)[0], ['number', 'dataset'])
 
     # test _eval_arguments:
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         Dataset('/does/not/matter').fake_command(3, _eval_arg1="blubb")
         assert_in("_eval_arg1: blubb", cml.out)
         assert_in("_eval_arg2: default2", cml.out)
     # without anything keep defaults
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         Dataset('/does/not/matter').fake_command(3)
         assert_in("_eval_arg1: default1", cml.out)
         assert_in("_eval_arg2: default2", cml.out)
     # same for version not bound to Dataset:
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         Test_Utils().__call__(3, _eval_arg1="blubb")
         assert_in("_eval_arg1: blubb", cml.out)
         assert_in("_eval_arg2: default2", cml.out)
     # without anything keep defaults
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         Test_Utils().__call__(3)
         assert_in("_eval_arg1: default1", cml.out)
         assert_in("_eval_arg2: default2", cml.out)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -766,7 +766,7 @@ def filter_unmodified(content_by_ds, refds, since):
 
 import wrapt
 
-def eval_results(switch):
+def eval_results(func):
     """Decorator providing functionality to evaluate return values of datalad
     commands
     """
@@ -774,17 +774,33 @@ def eval_results(switch):
 
     @wrapt.decorator
     def new_func(wrapped, instance, args, kwargs):
-        # rudimentary wrapper to harvest generators
-        if switch():
-            lgr.debug("switch ON")
-        else:
-            lgr.debug("switch OFF")
-        results = wrapped(*args, **kwargs)
-        if isgenerator(results):
-            return list(results)
-        else:
-            return results
-    return new_func
+
+        def ext_func(*_args, **_kwargs):
+            _eval_arg1 = _kwargs.pop('_eval_arg1', "default1")
+            _eval_arg2 = _kwargs.pop('_eval_arg2', "default2")
+
+            # use additional arguments to do stuff:
+            lgr.warning("_eval_arg1: %s", _eval_arg1)
+            lgr.warning("_eval_arg2: %s", _eval_arg2)
+
+            # rudimentary wrapper to harvest generators
+            results = wrapped(*_args, **_kwargs)
+            if isgenerator(results):
+                return list(results)
+            else:
+                return results
+        return ext_func(*args, **kwargs)
+
+    return new_func(func)
 
 
-
+# @wrapt.decorator
+# def build_doc(wrapped, instance, args, kwargs):
+#
+#     lgr.warning("wrapped: %s", wrapped)
+#     lgr.warning("instance: %s", instance)
+#     lgr.warning("args: %s", args)
+#     lgr.warning("kwargs: %s", kwargs)
+#     lgr.warning("wrapped.__module__: %s", wrapped.__module__)
+#
+#     return wrapped(*args, **kwargs)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -763,17 +763,28 @@ def filter_unmodified(content_by_ds, refds, since):
                         or any(m.startswith(_with_sep(p)) for p in paths_refds))]
     return keep
 
+
 import wrapt
-@wrapt.decorator
-def eval_results(wrapped, instance, args, kwargs):
+
+def eval_results(switch):
     """Decorator providing functionality to evaluate return values of datalad
     commands
     """
     from inspect import isgenerator
 
-    # rudimentary wrapper to harvest generators
-    results = wrapped(*args, **kwargs)
-    if isgenerator(results):
-        return list(results)
-    else:
-        return results
+    @wrapt.decorator
+    def new_func(wrapped, instance, args, kwargs):
+        # rudimentary wrapper to harvest generators
+        if switch():
+            lgr.debug("switch ON")
+        else:
+            lgr.debug("switch OFF")
+        results = wrapped(*args, **kwargs)
+        if isgenerator(results):
+            return list(results)
+        else:
+            return results
+    return new_func
+
+
+

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -33,6 +33,7 @@ from datalad.utils import get_trace
 from datalad.utils import walk
 from datalad.utils import get_dataset_root
 from datalad.utils import swallow_logs
+from datalad.utils import better_wraps
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.distribution.dataset import Dataset
@@ -761,3 +762,21 @@ def filter_unmodified(content_by_ds, refds, since):
                         # or a modified path under a given directory
                         or any(m.startswith(_with_sep(p)) for p in paths_refds))]
     return keep
+
+
+def eval_results(func):
+    """Decorator providing functionality to evaluate return values of datalad
+    commands
+    """
+    from inspect import isgenerator
+
+    @better_wraps(func)
+    def new_func(*args, **kwargs):
+        # rudimentary wrapper to harvest generators
+        results = func(*args, **kwargs)
+        if isgenerator(results):
+            return list(results)
+        else:
+            return results
+
+    return new_func

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -857,7 +857,6 @@ def build_doc(func):
     # the future.
     # TODO: Almost, but doesn't work entirely as intended
 
-
     @wrapt.decorator
     def builder(wrapped, instance, args, kwargs):
 
@@ -871,7 +870,7 @@ def build_doc(func):
             # restrictions on when and how to use eval_results as well as on how
             # to name a command's module and class. As of now, we are inline
             # with these requirements as far as I'm aware.
-            mod = sys.modules[func.__module__]
+            mod = sys.modules[wrapped.__module__]
             if PY2:
                 # we rely on:
                 # - decorated function is method of a subclass of Interface
@@ -886,11 +885,11 @@ def build_doc(func):
                     [i for i in mod.__dict__
                      if type(mod.__dict__[i]) == type and
                      issubclass(mod.__dict__[i], Interface) and
-                     i.lower() == func.__module__.split('.')[-1]]
+                     i.lower() == wrapped.__module__.split('.')[-1]]
                 assert(len(command_class_names) == 1)
                 command_class_name = command_class_names[0]
             else:
-                command_class_name = func.__qualname__.split('.')[-2]
+                command_class_name = wrapped.__qualname__.split('.')[-2]
             _func_class = mod.__dict__[command_class_name]
             lgr.debug("Determined class of decorated function: %s", _func_class)
 
@@ -918,3 +917,29 @@ def build_doc(func):
 
     # and return the now-empty wrapper:
     return builder(func)
+
+
+def build_doc_as_class_decorator(func):
+
+    lgr.warning("Class decorator ...")
+    lgr.warning("wrapped: %s", func)
+    lgr.warning("wrapped.__call__: %s", func.__call__)
+    lgr.warning("wrapped.__call__.__doc__: %s", func.__call__.__doc__)
+
+
+    lgr.warning("Building doc ...")
+
+    spec = getattr(func, '_params_', dict())
+    update_docstring_with_parameters(func.__call__, # wrapped?
+                                     spec,
+                prefix=alter_interface_docs_for_api(func.__doc__),
+                suffix=alter_interface_docs_for_api(
+                    func.__call__.__doc__)
+            )
+
+
+
+
+
+    # return original
+    return func

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -763,20 +763,17 @@ def filter_unmodified(content_by_ds, refds, since):
                         or any(m.startswith(_with_sep(p)) for p in paths_refds))]
     return keep
 
-
-def eval_results(func):
+import wrapt
+@wrapt.decorator
+def eval_results(wrapped, instance, args, kwargs):
     """Decorator providing functionality to evaluate return values of datalad
     commands
     """
     from inspect import isgenerator
 
-    @better_wraps(func)
-    def new_func(*args, **kwargs):
-        # rudimentary wrapper to harvest generators
-        results = func(*args, **kwargs)
-        if isgenerator(results):
-            return list(results)
-        else:
-            return results
-
-    return new_func
+    # rudimentary wrapper to harvest generators
+    results = wrapped(*args, **kwargs)
+    if isgenerator(results):
+        return list(results)
+    else:
+        return results

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -47,6 +47,7 @@ from ..utils import _path_
 from ..utils import get_timestamp_suffix
 from ..utils import get_trace
 from ..utils import get_dataset_root
+from ..utils import better_wraps
 
 from ..support.annexrepo import AnnexRepo
 
@@ -70,6 +71,38 @@ def test_get_func_kwargs_doc():
     def some_func(arg1, kwarg1=None, kwarg2="bu"):
         return
     eq_(get_func_kwargs_doc(some_func), ['arg1', 'kwarg1', 'kwarg2'])
+
+
+def test_better_wraps():
+    from functools import wraps
+    from inspect import getargspec
+
+    def wraps_decorator(func):
+        @wraps(func)
+        def new_func(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return new_func
+
+    def better_decorator(func):
+        @better_wraps(func)
+        def new_func(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return new_func
+
+    @wraps_decorator
+    def function1(a, b, c):
+        return "function1"
+
+    @better_decorator
+    def function2(a, b, c):
+        return "function2"
+
+    eq_("function1", function1(1, 2, 3))
+    eq_(getargspec(function1)[0], [])
+    eq_("function2", function2(1, 2, 3))
+    eq_(getargspec(function2)[0], ['a', 'b', 'c'])
 
 
 @with_tempfile(mkdir=True)
@@ -214,6 +247,7 @@ def test_md5sum_archive(d):
     # just a smoke (encoding/decoding) test for md5sum
     _ = md5sum(opj(d, '1.tar.gz'))
 
+
 def test_updated():
     d = {}
     eq_(updated(d, {1: 2}), {1: 2})
@@ -232,6 +266,7 @@ def test_updated():
 
 def test_get_local_file_url_windows():
     raise SkipTest("TODO")
+
 
 @assert_cwd_unchanged
 def test_getpwd_basic():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -555,7 +555,7 @@ def optional_args(decorator):
 
         Calls decorator with decorator(f, `*args`, `**kwargs`)"""
 
-    @wraps(decorator)
+    @better_wraps(decorator)
     def wrapper(*args, **kwargs):
         def dec(f):
             return decorator(f, *args, **kwargs)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -21,6 +21,7 @@ import tempfile
 import platform
 import gc
 import glob
+import wrapt
 
 from contextlib import contextmanager
 from functools import wraps
@@ -525,10 +526,25 @@ def saved_generator(gen):
 #
 # Decorators
 #
+def better_wraps(to_be_wrapped):
+    """Decorator to replace `functools.wraps`
+
+    This is based on `wrapt` instead of `functools` and in opposition to `wraps`
+    preserves the correct signature of the decorated function.
+    It is written with the intention to replace the use of `wraps` without any
+    need to rewrite the actual decorators.
+    """
+
+    @wrapt.decorator(adapter=to_be_wrapped)
+    def intermediator(to_be_wrapper, instance, args, kwargs):
+        return to_be_wrapper(*args, **kwargs)
+
+    return intermediator
+
 
 # Borrowed from pandas
 # Copyright: 2011-2014, Lambda Foundry, Inc. and PyData Development Team
-# Licese: BSD-3
+# License: BSD-3
 def optional_args(decorator):
     """allows a decorator to take optional positional and keyword arguments.
         Assumes that taking a single, callable, positional argument means that


### PR DESCRIPTION
DON'T MERGE

This is preparing the evaluation of return values using a decorator and related stuff by developing the basic mechanisms. It will be integrated in PR #1350 

- [x] first, make use of the replacement for `functools.wraps` in order to allow for additional decorators for our commands
- [x] provide a rudimentary decorator for dealing with return values
- [x] solve python 3 issues
- [x] enhance `eval_results` to be able to receive its own arguments
- [x] additional decorator to build the docstrings right there instead of during import of `datalad.api`
- [ ] RF to use build_doc everywhere and remove that part from `datalad.api._generate_api`