### PR TITLE
General config overrides mechanism and `-c` option for the cmdline

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -101,6 +101,11 @@ def setup_parser(
         parser.add_argument(
             '--idbg', action='store_true', dest='common_idebug',
             help="enter IPython debugger when uncaught exception happens")
+    parser.add_argument(
+        '-c', action='append', dest='cfg_overrides', metavar='KEY=VALUE',
+        help="""configuration variable setting. Overrides any configuration
+        read from a file, but is potentially overridden itself by configuration
+        variables in the process environment.""")
 
     # yoh: atm we only dump to console.  Might adopt the same separation later on
     #      and for consistency will call it --verbose-level as well for now
@@ -246,6 +251,12 @@ def main(args=None):
 
     # to possibly be passed into PBS scheduled call
     args_ = args or sys.argv
+
+    if cmdlineargs.cfg_overrides is not None:
+        overrides = dict([
+            (o.split('=')[0], '='.join(o.split('=')[1:]))
+            for o in cmdlineargs.cfg_overrides])
+        datalad.cfg.overrides.update(overrides)
 
     if cmdlineargs.change_path is not None:
         from .common_args import change_path as change_path_opt

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -126,7 +126,7 @@ def check_incorrect_option(opts, err_str):
     # checked to meet its constraints.
     # But sys.argv[0] actually isn't used by main at all. It simply doesn't
     # matter what's in there. The only thing important to pass here is `opts`.
-    stdout, stderr = run_main(opts, expect_stderr=True, exit_code=2)
+    stdout, stderr = run_main(('datalad',) + opts, expect_stderr=True, exit_code=2)
     out = stdout + stderr
     assert_in("usage: ", out)
     assert_re_in(err_str, out, match=False)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -179,6 +179,14 @@ def test_something(path, new_home):
         globalcfg.remove_section('datalad.unittest', where='global')
         ok_file_has_content(global_gitconfig, "")
 
+    cfg = ConfigManager(
+        Dataset(opj(path, 'ds')),
+        dataset_only=True,
+        overrides={'datalad.godgiven': True})
+    assert_equal(cfg.get('datalad.godgiven'), True)
+    # setter has no effect
+    cfg.set('datalad.godgiven', 'false')
+    assert_equal(cfg.get('datalad.godgiven'), True)
 
 @with_tree(tree={
     'ds': {
@@ -299,3 +307,12 @@ def test_from_env():
     # not in dataset-only mode
     cfg = ConfigManager(Dataset('nowhere'), dataset_only=True)
     assert_not_in('datalad.crazy.cfg', cfg)
+    # check env trumps override
+    cfg = ConfigManager()
+    assert_not_in('datalad.crazy.override', cfg)
+    cfg.overrides['datalad.crazy.override'] = 'fromoverride'
+    cfg.reload()
+    assert_equal(cfg['datalad.crazy.override'], 'fromoverride')
+    os.environ['DATALAD_CRAZY_OVERRIDE'] = 'fromenv'
+    cfg.reload()
+    assert_equal(cfg['datalad.crazy.override'], 'fromenv')


### PR DESCRIPTION
Addresses #958 

At present we have no simple way to test the few lines in `main.py`.