### PR TITLE
BF: use swallow_output in 2 failing spots whenever nosetests ran without -s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
     - TESTS_TO_PERFORM=
-    - NOSE_OPTS=
+    - NOSE_OPTS=-s
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
   matrix:
@@ -34,6 +34,8 @@ matrix:
     env:
     - _DATALAD_UPSTREAM_GITPYTHON=1
     - _DATALAD_NONPR_ONLY=1
+    # Just so we test if we did not screw up running under nose without -s as well
+    - NOSE_OPTS=
   - python: 2.7
     # By default no logs will be output. This one is to test with log output at INFO level
     env:
@@ -43,7 +45,6 @@ matrix:
   - python: 2.7
     # By default no logs will be output. This one is to test with low level but dumped to /dev/null
     env:
-    - NOSE_OPTS=-s
     - DATALAD_LOG_LEVEL=2
     - DATALAD_LOG_TARGET=/dev/null
     - DATALAD_LOG_TRACEBACK=collide  # just a smoke test for now

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
     - TESTS_TO_PERFORM=
+    - NOSE_OPTS=
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
   matrix:
@@ -42,6 +43,7 @@ matrix:
   - python: 2.7
     # By default no logs will be output. This one is to test with low level but dumped to /dev/null
     env:
+    - NOSE_OPTS=-s
     - DATALAD_LOG_LEVEL=2
     - DATALAD_LOG_TARGET=/dev/null
     - DATALAD_LOG_TRACEBACK=collide  # just a smoke test for now
@@ -146,7 +148,7 @@ script:
   # Verify that setup.py build doesn't puke
   - python setup.py build
   # Run tests
-  - PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO $TESTS_TO_PERFORM 
+  - PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` $NOSE_OPTS -v --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO $TESTS_TO_PERFORM
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD $NOSE_WRAPPER make -C docs html doctest
   # Run javascript tests

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -312,6 +312,14 @@ class Runner(object):
         outputstream = subprocess.PIPE if log_stdout else sys.stdout
         errstream = subprocess.PIPE if log_stderr else sys.stderr
 
+        # TODO: if outputstream is sys.stdout and that one is set to StringIO
+        #       we have to "shim" it with something providing fileno().
+        # This happens when we do not swallow outputs, while allowing nosetest's
+        # StringIO to be provided as stdout, crashing the Popen requiring
+        # fileno().  In out swallow_outputs, we just use temporary files
+        # to overcome this problem.
+        # For now necessary test code should be wrapped into swallow_outputs cm
+        # to avoid the problem
         self.log("Running: %s\ncwd: %s" % (cmd, cwd or self.cwd))
 
         if self.protocol.do_execute_ext_commands:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1022,11 +1022,19 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     try:
         # Note: For some reason, it hangs if log_stdout/err True
         # TODO: Figure out what's going on
-        ar._run_annex_command('sync',
-                              expect_stderr=True,
-                              log_stdout=False,
-                              log_stderr=False,
-                              expect_fail=True)
+        #  yoh: I think it is because of what is "TODOed" within cmd.py --
+        #       trying to log/obtain both through PIPE could lead to lock
+        #       downs.
+        # here we use our swallow_logs to overcome a problem of running under
+        # nosetests without -s, when nose then tries to swallow stdout by
+        # mocking it with StringIO, which is not fully compatible with Popen
+        # which needs its .fileno()
+        with swallow_outputs():
+            ar._run_annex_command('sync',
+                                  expect_stderr=True,
+                                  log_stdout=False,
+                                  log_stderr=False,
+                                  expect_fail=True)
     # sync should return exit code 1, since it can not merge
     # doesn't matter for the purpose of this test
     except CommandError as e:
@@ -1048,13 +1056,12 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
 
     # sync with the new remote:
     try:
-        # Note: For some reason, it hangs if log_stdout/err True
-        # TODO: Figure out what's going on
-        ar._run_annex_command('sync', annex_options=['ssh-remote-2'],
-                              expect_stderr=True,
-                              log_stdout=False,
-                              log_stderr=False,
-                              expect_fail=True)
+        with swallow_outputs():
+            ar._run_annex_command('sync', annex_options=['ssh-remote-2'],
+                                  expect_stderr=True,
+                                  log_stdout=False,
+                                  log_stderr=False,
+                                  expect_fail=True)
     # sync should return exit code 1, since it can not merge
     # doesn't matter for the purpose of this test
     except CommandError as e:

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -18,6 +18,7 @@ from .. import __main__, __version__
 from ..auto import AutomagicIO
 
 from datalad.tests.utils import skip_ssh
+from datalad.tests.utils import swallow_outputs
 from datalad.cmdline.main import main
 
 @patch('sys.stdout', new_callable=StringIO)
@@ -46,6 +47,12 @@ def test_main_run_a_script(stdout, mock_activate):
 @skip_ssh
 def test_exit_code():
     # will relay actual exit code on CommandError
+    cmd = ['sshrun', 'localhost', 'exit 42']
     with assert_raises(SystemExit) as cme:
-        main(['sshrun', 'localhost', 'exit 42'])
+        if isinstance(sys.stdout, StringIO):  # running nosetests without -s
+            with swallow_outputs():  # need to give smth with .fileno ;)
+                main(cmd)
+        else:
+            # to test both scenarios
+            main(cmd)
     assert_equal(cme.exception.code, 42)


### PR DESCRIPTION
I test to run nosetests without -s nowadays, and it seems (this PR tests run will show ;-) ) to work but few tests required workaround.