### PR TITLE
ENH: tqdm - use leave=True instead of explicit clean call to avoid spurious new lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
     - DATALAD_TESTS_PROTOCOLREMOTE=1
     - DATALAD_TESTS_DATALADREMOTE=1
     - DATALAD_LOG_OUTPUTS=1
+    - DATALAD_TESTS_UI_BACKEND=console
   - python: 2.7
     env:
     # to test operation under root since also would consider FS "crippled" due to

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -95,7 +95,8 @@ def setup_package():
     # Set to non-interactive UI
     from datalad.ui import ui
     _test_states['ui_backend'] = ui.backend
-    ui.set_backend('tests-noninteractive')
+    # obtain() since that one consults for the default value
+    ui.set_backend(cfg.obtain('datalad.tests.ui.backend'))
 
 
 def teardown_package():

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -297,7 +297,7 @@ class BaseDownloader(object):
             with open(temp_filepath, 'wb') as fp:
                 # TODO: url might be a bit too long for the beast.
                 # Consider to improve to make it animated as well, or shorten here
-                pbar = ui.get_progressbar(label=url, fill_text=filepath, maxval=target_size)
+                pbar = ui.get_progressbar(label=url, fill_text=filepath, total=target_size)
                 t0 = time.time()
                 downloader_session.download(fp, pbar, size=size)
                 downloaded_time = time.time() - t0
@@ -427,7 +427,7 @@ class BaseDownloader(object):
         # FETCH CONTENT
         try:
             # Consider to improve to make it animated as well, or shorten here
-            #pbar = ui.get_progressbar(label=url, fill_text=filepath, maxval=target_size)
+            #pbar = ui.get_progressbar(label=url, fill_text=filepath, total=target_size)
             content = downloader_session.download(size=size)
             #pbar.finish()
             downloaded_size = len(content)

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -118,6 +118,13 @@ definitions = {
         'ui': ('question', {
                'title': 'Specify the size of temporary file system to use as loop device for testing DATALAD_TESTS_TEMP_DIR creation'}),
     },
+    'datalad.tests.ui.backend': {
+        'ui': ('question', {
+            'title': 'Tests UI backend',
+            # XXX we could add choices...
+            'text': 'Which UI backend to use'}),
+        'default': 'tests-noninteractive',
+    },
     'datalad.tests.usecassette': {
         'ui': ('question', {
                'title': 'Specifies the location of the file to record network transactions by the VCR module. Currently used by when testing custom special remotes'}),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2457,7 +2457,7 @@ class ProcessAnnexProgressIndicators(object):
             from datalad.ui import ui
             total = sum(filter(bool, self.expected.values()))
             self.total_pbar = ui.get_progressbar(
-                label="Total", maxval=total)
+                label="Total", total=total)
             self.total_pbar.start()
 
     def _update_pbar(self, pbar, new_value):
@@ -2483,7 +2483,7 @@ class ProcessAnnexProgressIndicators(object):
             if j.get('success') in {True, 'true'}:
                 self._succeeded += 1
                 if pbar:
-                    self._update_pbar(pbar, pbar.maxval)
+                    self._update_pbar(pbar, pbar.total)
                 elif self.total_pbar:
                     # we didn't have a pbar for this download, so total should
                     # get it all at once
@@ -2502,13 +2502,13 @@ class ProcessAnnexProgressIndicators(object):
                                                   ansi_colors.RED)) \
                     if self._failed else ''
 
-                self.total_pbar._pbar.desc = \
+                self.total_pbar.set_desc(
                     "Total (%d ok%s out of %d)" % (
                         self._succeeded,
                         failed_str,
                         len(self.expected)
                         if self.expected
-                        else self._succeeded + self._failed)
+                        else self._succeeded + self._failed))
                 # seems to be of no effect to force it repaint
                 self.total_pbar.refresh()
 
@@ -2550,7 +2550,7 @@ class ProcessAnnexProgressIndicators(object):
                 half = title_len//2 - 2
                 title = '%s .. %s' % (title[:half], title[-half:])
             pbar = self.pbars[download_id] = ui.get_progressbar(
-                label=title, maxval=target_size)
+                label=title, total=target_size)
             pbar.start()
 
         self._update_pbar(

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1415,7 +1415,8 @@ def test_ProcessAnnexProgressIndicators():
     proc = ProcessAnnexProgressIndicators(expected={'key1': 100, 'key2': None})
     # when without any target downloads, there is no total_pbar
     assert(proc.total_pbar is not None)
-    eq_(proc.total_pbar._pbar.total, 100)  # as much as it knows at this point
+    eq_(proc.total_pbar.total, 100)  # as much as it knows at this point
+    eq_(proc.total_pbar.current, 0)
     # for regular lines -- should still just return them without side-effects
     for l in irrelevant_lines:
         with swallow_outputs() as cmo:
@@ -1432,7 +1433,12 @@ def test_ProcessAnnexProgressIndicators():
         eq_(proc(success_lines[0]), success_lines[0])
         eq_(proc.pbars, {})
         out = cmo.out
-    assert out  # just assert that something was output
+
+    from datalad.ui import ui
+    from datalad.ui.dialog import SilentConsoleLog
+
+    assert out \
+        if not isinstance(ui.ui, SilentConsoleLog) else not out
     assert proc.total_pbar is not None
     # and no side-effect of any kind in finish
     with swallow_outputs() as cmo:

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -18,6 +18,7 @@ lgr = getLogger('datalad.ui')
 lgr.log(5, "Starting importing ui")
 
 from .dialog import ConsoleLog, DialogUI, UnderAnnexUI
+from .dialog import SilentConsoleLog
 from .dialog import UnderTestsUI
 from ..utils import is_interactive
 
@@ -49,7 +50,7 @@ class _UI_Switcher(object):
             'dialog': DialogUI,
             'annex': UnderAnnexUI,
             'tests': UnderTestsUI,
-            'tests-noninteractive': ConsoleLog,
+            'tests-noninteractive': SilentConsoleLog,
         }[backend]()
         lgr.debug("UI set to %s" % self._ui)
         self._backend = backend

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -104,6 +104,15 @@ class ConsoleLog(object):
         return isinstance(self, InteractiveUI)
 
 
+@auto_repr
+class SilentConsoleLog(ConsoleLog):
+    """A ConsoleLog with a SilentProgressbar"""
+
+    def get_progressbar(self, *args, **kwargs):
+        from .progressbars import SilentProgressBar
+        return SilentProgressBar(*args, out=self.out, **kwargs)
+
+
 def getpass_echo(prompt='Password: ', stream=None):
     """Q&D workaround until we have proper 'centralized' UI -- just use getpass BUT enable echo
     """

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -67,12 +67,15 @@ try:
             if external_versions['tqdm'] < '4.10.0' \
             else dict(mininterval=0)
 
-        def __init__(self, label='', fill_text=None, maxval=None, unit='B', out=sys.stdout):
+        def __init__(self, label='', fill_text=None,
+                     maxval=None, unit='B', out=sys.stdout, leave=False):
             super(tqdmProgressBar, self).__init__(maxval=maxval)
             self._pbar_params = updated(
                 self._default_pbar_params,
                 dict(desc=label, unit=unit,
-                     unit_scale=True, total=maxval, file=out))
+                     unit_scale=True, total=maxval, file=out,
+                     leave=leave
+                     ))
             self._pbar = None
 
         def _create(self):
@@ -96,9 +99,23 @@ try:
             if hasattr(tqdm, 'refresh'):
                 self._pbar.refresh()
 
-        def finish(self):
-            self.clear()
-            # be tollerant to bugs in those
+        def finish(self, clear=False):
+            """
+
+            Parameters
+            ----------
+            clear : bool, optional
+              Explicitly clear the progress bar. Note that we are
+              creating them with leave=False so they should disappear on their
+              own and explicit clear call should not be necessary
+
+            Returns
+            -------
+
+            """
+            if clear:
+                self.clear()
+            # be tolerant to bugs in those
             try:
                 if self._pbar is not None:
                     self._pbar.close()

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -73,7 +73,8 @@ def test_question_choices():
 def _test_progress_bar(backend, len, increment):
     out = StringIO()
     fill_str = ('123456890' * (len//10))[:len]
-    pb = DialogUI(out).get_progressbar('label', fill_str, maxval=10, backend=backend)
+    pb = DialogUI(out).get_progressbar(
+        'label', fill_str, total=10, backend=backend)
     pb.start()
     # we can't increment 11 times
     for x in range(11):
@@ -82,14 +83,15 @@ def _test_progress_bar(backend, len, increment):
             pb.update(x if not increment else 1, increment=increment)
         out.flush()  # needed atm
         pstr = out.getvalue()
-        if backend not in ('annex-remote',):  # no str repr
+        if backend not in ('annex-remote', 'silent'):  # no str repr
             ok_startswith(pstr.lstrip('\r'), 'label:')
             assert_re_in(r'.*\b%d%%.*' % (10*x), pstr)
         if backend == 'progressbar':
             assert_in('ETA', pstr)
     pb.finish()
-    if backend not in ('annex-remote',):
-        ok_endswith(out.getvalue(), '\n')
+    if backend not in ('annex-remote', 'silent'):
+        # returns back and there is no spurious newline
+        ok_endswith(out.getvalue(), '\r')
 
 
 def test_progress_bar():


### PR DESCRIPTION
There is still seems to be some spurious new lines, but otherwise output
seems to behave better

Example:

before:

```
$> datalad install -g -J3 sub001/anatomy
[INFO   ] Getting 1 items of dataset <Dataset path=/tmp/raiders> ...
[INFO   ] Actually getting 10 files

1 installed item is available at
<Dataset path=/tmp/raiders>
```
after:
```
$> datalad install -g -J3 sub001/anatomy
[INFO   ] Getting 1 items of dataset <Dataset path=/tmp/raiders> ...
[INFO   ] Actually getting 10 files
1 installed item is available at
<Dataset path=/tmp/raiders>
```

TODO
- [x] just disable "interactive" progress bars by default while running tests, make them "optional" so we could still smoke test them.  This is to avoid destroying output such as names of the tests being printed out... and there is still some spurious newline in some cases which extends output 