### PR TITLE
RF+BF: save -- revive all_changes to die properly, and -a -> -u, all_changes -> all_updated

### DIFF
--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -574,7 +574,7 @@ def _save_installed_datasets(ds, installed_datasets):
         ds.save(
             files=paths + ['.gitmodules'],
             message='[DATALAD] ' + msg,
-            all_changes=False,
+            all_updated=False,
             recursive=False)
     except ValueError as e:
         if "did not match any file(s) known to git" in str(e):

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -157,7 +157,7 @@ def test_create_subdataset_hierarchy_from_top(path):
     subsubds = subds.create('subsub', force=True)
     ok_(subsubds.is_installed())
     ok_(subsubds.repo.dirty)
-    ds.save(recursive=True, all_changes=True)
+    ds.save(recursive=True, all_updated=True)
     ok_clean_git(ds.path)
     ok_(ds.id != subds.id != subsubds.id)
 
@@ -173,7 +173,7 @@ def test_nested_create(path):
     os.makedirs(opj(ds.path, 'lvl1', 'empty'))
     with open(opj(lvl2path, 'file'), 'w') as f:
         f.write('some')
-    ok_(ds.save(all_changes=True))
+    ok_(ds.save(all_updated=True))
     # later create subdataset in a fresh dir
     subds1 = ds.create(opj('lvl1', 'subds'))
     ok_clean_git(ds.path)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -51,7 +51,7 @@ def _make_dataset_hierarchy(path):
     with open(opj(origin_sub3.path, 'file_in_annex.txt'), "w") as f:
         f.write('content3')
     origin_sub4 = origin_sub3.create('sub4')
-    origin.save(recursive=True, all_changes=True)
+    origin.save(recursive=True, all_updated=True)
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
 
@@ -172,7 +172,7 @@ def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
     origin = Dataset(o_path).create(force=True)
-    origin.save("Initial", all_changes=True)
+    origin.save("Initial", all_updated=True)
 
     ds = install(c_path, source=o_path)
 
@@ -320,7 +320,7 @@ def test_get_mixed_hierarchy(src, path):
         f.write('content')
     origin.add('file_in_git.txt', to_git=True)
     origin_sub.add('file_in_annex.txt')
-    origin.save(all_changes=True)
+    origin.save(all_updated=True)
 
     # now, install that thing:
     ds, subds = install(path, source=src, recursive=True)
@@ -359,7 +359,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     origin_subsub = origin_sub.create('subsub')
     with open(opj(origin_subsub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
-    origin.save(recursive=True, all_changes=True)
+    origin.save(recursive=True, all_updated=True)
 
     ds = install(path, source=src)
     eq_(len(ds.get_subdatasets(fulfilled=True)), 0)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -79,7 +79,7 @@ def test_clean_subds_removal(path):
     assert(not exists(subds1.path))
     # and now again, but this time remove something that is not installed
     ds.create('three')
-    ds.save(all_changes=True)
+    ds.save(all_updated=True)
     eq_(sorted(ds.get_subdatasets()), ['three', 'two'])
     ds.uninstall('two')
     ok_clean_git(ds.path)
@@ -274,7 +274,7 @@ def test_uninstall_recursive(path):
     # we add one file
     eq_(len(subds.add('.')), 1)
     # save all -> all clean
-    ds.save(all_changes=True, recursive=True)
+    ds.save(all_updated=True, recursive=True)
     ok_clean_git(subds.path)
     ok_clean_git(ds.path)
     # now uninstall in subdataset through superdataset
@@ -304,7 +304,7 @@ def test_uninstall_recursive(path):
 def test_remove_dataset_hierarchy(path):
     ds = Dataset(path).create()
     ds.create('deep')
-    ds.save(all_changes=True)
+    ds.save(all_updated=True)
     ok_clean_git(ds.path)
     # fail on missing --recursive because subdataset is present
     assert_raises(ValueError, ds.remove)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -87,7 +87,7 @@ def test_update_simple(origin, src_path, dst_path):
     # and now test recursive update with merging in differences
     create_tree(opj(source.path, 'subm 2'), {'load.dat': 'heavy'})
     source.save(message="saving changes within subm2",
-                recursive=True, all_changes=True)
+                recursive=True, all_updated=True)
     dest.update(merge=True, recursive=True)
     # and now we can get new file
     dest.get('subm 2/load.dat')

--- a/datalad/export/tests/test_tarball.py
+++ b/datalad/export/tests/test_tarball.py
@@ -46,7 +46,7 @@ def test_failure(path):
 @with_tree(_dataset_template)
 def test_tarball(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
-    ds.save(all_changes=True)
+    ds.save(all_updated=True)
     committed_date = ds.repo.get_committed_date()
     with chpwd(path):
         _mod, tarball1 = ds.export('tarball')

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -110,6 +110,11 @@ class Save(Interface):
         message=save_message_opt,
         all_changes=Parameter(
             args=("-a", "--all-changes"),
+            doc="""save all changes (even to not yet added files) of all components
+            in datasets that contain any of the given paths [DEPRECATED!].""",
+            action="store_true"),
+        all_updated=Parameter(
+            args=("-u", "--all-updated"),
             doc="""save changes of all known components in datasets that contain
             any of the given paths.""",
             action="store_true"),
@@ -126,8 +131,16 @@ class Save(Interface):
     @staticmethod
     @datasetmethod(name='save')
     def __call__(message=None, files=None, dataset=None,
-                 all_changes=False, version_tag=None,
-                 recursive=False, recursion_limit=None, super_datasets=False):
+                 all_updated=False, all_changes=None, version_tag=None,
+                 recursive=False, recursion_limit=None, super_datasets=False
+                 ):
+        if all_changes is not None:
+            from datalad.support.exceptions import DeprecatedError
+            raise DeprecatedError(
+                new="all_updated option where fits and/or datalad add",
+                version="0.5.0",
+                msg="RF: all_changes option passed to the save"
+            )
         if not dataset and not files:
             # we got nothing at all -> save what is staged in the repo in "this" directory?
             # we verify that there is an actual repo next
@@ -144,9 +157,9 @@ class Save(Interface):
             lgr.warning("ignoring non-existent path(s): %s",
                         unavailable_paths)
         # here we know all datasets associated with any inputs
-        # so we can expand "all_changes" right here to avoid confusion
+        # so we can expand "all_updated" right here to avoid confusion
         # wrt to "super" and "intermediate" datasets discovered later on
-        if all_changes:
+        if all_updated:
             # and we do this by replacing any given paths with the respective
             # datasets' base path
             for ds in content_by_ds:

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -17,8 +17,10 @@ from datalad.utils import chpwd
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import DeprecatedError
 from datalad.tests.utils import ok_, assert_false, assert_true, assert_not_equal
 from datalad.api import save
+from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import ok_clean_git
@@ -37,21 +39,25 @@ def test_save(path):
     ds.repo.add("new_file.tst", git=True)
     ok_(ds.repo.dirty)
 
-    ds.save("add a new file", all_changes=False)
+    # no all_changes any longer
+    with assert_raises(DeprecatedError):
+        ds.save("add a new file", all_changes=True)
+
+    ds.save("add a new file", all_updated=False)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     with open(opj(path, "new_file.tst"), "w") as f:
         f.write("modify")
 
     ok_(ds.repo.dirty)
-    ds.save("modified new_file.tst", all_changes=True)
+    ds.save("modified new_file.tst", all_updated=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # save works without ds and files given in the PWD
     with open(opj(path, "new_file.tst"), "w") as f:
         f.write("rapunzel")
     with chpwd(path):
-        save("love rapunzel", all_changes=True)
+        save("love rapunzel", all_updated=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # and also without `-a` when things are staged
@@ -59,7 +65,7 @@ def test_save(path):
         f.write("exotic")
     ds.repo.add("new_file.tst", git=True)
     with chpwd(path):
-        save("love marsians", all_changes=False)
+        save("love marsians", all_updated=False)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
 
@@ -86,7 +92,7 @@ def test_save(path):
     # uncommited .datalad (probably caused within create)
     ok_(ds.repo.dirty)
     # ensure modified subds is committed
-    ds.save(all_changes=True)
+    ds.save(all_updated=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
 
@@ -106,7 +112,7 @@ def test_recursive_save(path):
     with open(newfile_name, 'w') as f:
         f.write('some')
     # saves the status change of the subdataset due to the subsubdataset addition
-    assert_equal(ds.save(all_changes=True), [ds])
+    assert_equal(ds.save(all_updated=True), [ds])
 
     # make the new file known to its dataset
     # with #1141 this would be
@@ -116,10 +122,10 @@ def test_recursive_save(path):
     # but remains dirty because of the untracked file down below
     assert ds.repo.dirty
     # auto-add will save nothing deep down without recursive
-    assert_equal(ds.save(all_changes=True), [])
+    assert_equal(ds.save(all_updated=True), [])
     assert ds.repo.dirty
     # with recursive pick up the change in subsubds
-    assert_equal(ds.save(all_changes=True, recursive=True), [subsubds, subds, ds])
+    assert_equal(ds.save(all_updated=True, recursive=True), [subsubds, subds, ds])
     # modify content in subsub and try saving
     testfname = newfile_name
     subsubds.unlock(testfname)
@@ -129,19 +135,19 @@ def test_recursive_save(path):
     # no auto_add
     assert_false(ds.save())
     # no recursive
-    assert_false(ds.save(all_changes=True))
+    assert_false(ds.save(all_updated=True))
     # an explicit target saves only the corresponding dataset
     assert_equal(save(files=[testfname]), [subsubds])
     # plain recursive without any files given will save the beast
     assert_equal(ds.save(recursive=True), [subds, ds])
     # there is nothing else to save
-    assert_false(ds.save(all_changes=True, recursive=True))
+    assert_false(ds.save(all_updated=True, recursive=True))
     # one more time and check that all datasets in the hierarchy get updated
     states = [d.repo.get_hexsha() for d in (ds, subds, subsubds)]
     testfname = opj('sub', 'subsub', 'saveme2')
     with open(opj(ds.path, testfname), 'w') as f:
         f.write('I am in here!')
-    assert_true(ds.save(all_changes=True, recursive=True))
+    assert_true(ds.save(all_updated=True, recursive=True))
     newstates = [d.repo.get_hexsha() for d in (ds, subds, subsubds)]
     for old, new in zip(states, newstates):
         assert_not_equal(old, new)
@@ -161,7 +167,7 @@ def test_recursive_save(path):
     ok_clean_git(subds.repo, untracked=['testnew'],
                  index_modified=['subsub'], head_modified=['testadded'])
     subsubds.save(message="savingtestmessage", super_datasets=True,
-                  all_changes=True)
+                  all_updated=True)
     ok_clean_git(subsubds.repo)
     # but its super should have got only the subsub saved
     # not the file we created

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -281,7 +281,7 @@ def test_filter_unmodified(path):
     # dataset does not have the recent change saved
     assert_equal({}, filter_unmodified(spec, ds, orig_base_commit))
 
-    ds.save(all_changes=True)
+    ds.save(all_updated=True)
 
     modspec, unavail = Save._prep('.', ds, recursive=True)
     # arg sorting is not affected

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -86,7 +86,7 @@ def handle_dirty_dataset(ds, mode, msg=None):
         if not ds.is_installed():
             raise RuntimeError('dataset {} is not yet installed'.format(ds))
         from datalad.interface.save import Save
-        Save.__call__(dataset=ds, message=msg, all_changes=True)
+        Save.__call__(dataset=ds, message=msg, all_updated=True)
     else:
         raise ValueError("unknown if-dirty mode '{}'".format(mode))
 

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -172,7 +172,7 @@ def test_aggregation(path):
     assert_true(success)
 
     # save the toplevel dataset only (see below)
-    ds.save('with aggregated meta data', all_changes=True)
+    ds.save('with aggregated meta data', all_updated=True)
 
     # now clone the beast to simulate a new user installing an empty dataset
     clone = install(opj(path, 'clone'), source=ds.path)

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -75,7 +75,7 @@ class DeprecatedError(RuntimeError):
     def __str__(self):
         s = self.msg if self.msg else ''
         if self.version:
-            s += " Deprecated since version %s." % self.version
+            s += (" is deprecated" if s else "Deprecated") + " since version %s." % self.version
         if self.new:
             s += " Use %s instead." % self.new
         return s

--- a/docs/examples/3rdparty_analysis_workflow.sh
+++ b/docs/examples/3rdparty_analysis_workflow.sh
@@ -236,7 +236,7 @@ bash code/run_analysis.sh
 # Once Alice is satisfied with her modifications she can save the new state.
 #%
 # -a make datalad auto-detect modifications
-datalad save -a -m "Alice always helps"
+datalad save -u -m "Alice always helps"
 
 #%
 # Full circle
@@ -251,7 +251,7 @@ datalad save -a -m "Alice always helps"
 
 HOME="$BOBS_HOME"
 cd ~/myanalysis
-datalad add-sibling alice "$ALICES_HOME/bobs_analysis"
+datalad add-sibling -s alice "$ALICES_HOME/bobs_analysis"
 
 #%
 # Once registered, Bob can update his dataset based on Alice's version, and merge
@@ -279,7 +279,7 @@ datalad get result.txt
 #%
 
 # this generated sibling for the dataset and all subdatasets
-datalad create-sibling --recursive "$SERVER_URL" public
+datalad create-sibling --recursive -s public "$SERVER_URL"
 
 #%
 # Once the remote sibling is created and registered under the name "public",


### PR DESCRIPTION
BF: demo script which was apparently broken for a while   see #1374 

- fail if `save -a` is used since its behavior has changed to fulfill the promise of the least surprise
  - get proper deprecation error with description instead of just behaving differently now

```
$> datalad save -a                                                                                                                
[ERROR  ] RF: all_changes option passed to the save is deprecated since version 0.5.0. Use all_updated  option where fits and/or datalad add instead. [save.py:__call__:142] (DeprecatedError) 
```
- I know that `save -a` is somewhat consistent with `git commit -a` but
  -  we might want to revive `-a` operation at some point, then it would be all kosher without confusion and tears
  - it is `git add -u` to add updated files into the index so we will be consistent with it instead ;)
