### PR TITLE
ENH+RF: _LOG_NAME, _LOG_NAMES, _LOG_NAMESRE to control what log entries to print

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -147,6 +147,18 @@ definitions = {
             'title': 'Used for control the verbosity of logs printed to '
                      'stdout while running datalad commands/debugging'}),
     },
+    'datalad.log.name': {
+        'ui': ('question', {
+            'title': 'Include name of the log target in the log line'}),
+    },
+    'datalad.log.names': {
+        'ui': ('question', {
+            'title': 'Which names (,-separated) to print log lines for'}),
+    },
+    'datalad.log.namesre': {
+        'ui': ('question', {
+            'title': 'Regular expression for which names to print log lines for'}),
+    },
     'datalad.log.outputs': {
         'ui': ('question', {
                'title': 'Used to control either both stdout and stderr of external commands execution are logged in detail (at DEBUG level)'}),

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -169,8 +169,9 @@ class LoggerHelper(object):
         self.logtarget = logtarget
         self.lgr = logging.getLogger(logtarget if logtarget is not None else name)
 
-    def _get_environ(self, var, default=None):
-        return os.environ.get(self.name.upper() + '_%s' % var.upper(), default)
+    def _get_config(self, var, default=None):
+        from datalad import cfg
+        return cfg.get(self.name.lower() + '.log.' + var, default)
 
     def set_level(self, level=None, default='INFO'):
         """Helper to set loglevel for an arbitrary logger
@@ -180,7 +181,7 @@ class LoggerHelper(object):
         """
         if level is None:
             # see if nothing in the environment
-            level = self._get_environ('LOG_LEVEL')
+            level = self._get_config('level')
         if level is None:
             level = default
 
@@ -216,7 +217,7 @@ class LoggerHelper(object):
         logging.Logger
         """
         # By default mimic previously talkative behavior
-        logtarget = self._get_environ('LOG_TARGET', logtarget or 'stderr')
+        logtarget = self._get_config('target', logtarget or 'stderr')
 
         # Allow for multiple handlers being specified, comma-separated
         if ',' in logtarget:
@@ -235,12 +236,33 @@ class LoggerHelper(object):
             use_color = False
             # I had decided not to guard this call and just raise exception to go
             # out happen that specified file location is not writable etc.
+
+        for names_filter in 'names', 'namesre':
+            names = self._get_config(names_filter, '')
+            if names:
+                import re
+                # add a filter which would catch those
+                class LogFilter(object):
+                    """A log filter to filter based on the log target name(s)"""
+                    def __init__(self, names):
+                        self.target_names = set(n for n in names.split(',')) \
+                            if names_filter == 'names' \
+                            else re.compile(names)
+                    if names_filter == 'names':
+                        def filter(self, record):
+                            return record.name in self.target_names
+                    else:
+                        def filter(self, record):
+                            return self.target_names.match(record.name)
+
+                loghandler.addFilter(LogFilter(names))
+
         # But now improve with colors and useful information such as time
         loghandler.setFormatter(
             ColorFormatter(use_color=use_color,
                            # TODO: config log.name, pid
-                           log_name=self._get_environ("LOG_NAME", False),
-                           log_pid=self._get_environ("LOG_PID", False),
+                           log_name=self._get_config("name", False),
+                           log_pid=self._get_config("pid", False),
                            ))
         #  logging.Formatter('%(asctime)-15s %(levelname)-6s %(message)s'))
         self.lgr.addHandler(loghandler)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -691,11 +691,11 @@ def swallow_outputs():
 
 
 @contextmanager
-def swallow_logs(new_level=None, file_=None):
+def swallow_logs(new_level=None, file_=None, name='datalad'):
     """Context manager to consume all logs.
 
     """
-    lgr = logging.getLogger("datalad")
+    lgr = logging.getLogger(name)
 
     # Keep old settings
     old_level = lgr.level
@@ -792,6 +792,8 @@ def swallow_logs(new_level=None, file_=None):
     # we want to log levelname so we could test against it
     swallow_handler.setFormatter(
         logging.Formatter('[%(levelname)s] %(message)s'))
+    # Inherit filters
+    swallow_handler.filters = sum([h.filters for h in old_handlers], [])
     lgr.handlers = [swallow_handler]
     if old_level < logging.DEBUG:  # so if HEAVYDEBUG etc -- show them!
         lgr.handlers += old_handlers


### PR DESCRIPTION
thought to do it for a while but never got to it... now need to troubleshoot that ssh connector business and do not want to scroll or grep through tons of logs to find relevant lines.. so it will be something like

```DATALAD_LOG_LEVEL=2 DATALAD_LOG_NAMESRE=.*ssh do_whatever ```

and only log lines from modules having anything to do with ssh should get printed ;)

