### PR TITLE
OPT: shave off ~10sec from test_make_studyforrest_mockup runtime by running 2 loops instead of 3

### DIFF
--- a/datalad/tests/utils_testdatasets.py
+++ b/datalad/tests/utils_testdatasets.py
@@ -55,7 +55,7 @@ def make_studyforrest_mockup(path):
     # (just doing 3, actual status quo is just shy of 10)
     # and also the real goal -> meta analysis
     metaanalysis = public.create('metaanalysis', description="analysis of analyses")
-    for i in range(1,4):
+    for i in range(1, 3):
         ana = public.create('analysis{}'.format(i),
                             description='analysis{}'.format(i))
         ana.install(source=annot.path, path=opj('src', 'annot'), reckless=True)


### PR DESCRIPTION
actually I thought it would go down from 70 to newly measured 40 sec but apparently it is just around 10sec... still notable improvement especially since it is just a smoke test