### PR TITLE
TEMP: to see the effect of # of test repos to test on -- run only on 1

### DIFF
--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -675,7 +675,7 @@ def _get_testrepos_uris(regex, flavors):
 
 
 @optional_args
-def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
+def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=1):
     """Decorator to provide a local/remote test repository
 
     All tests under datalad/tests/testrepos are stored in two-level hierarchy,


### PR DESCRIPTION
Many tests seems to use @with_testrepos just as a helper to test core functionality
which does not really need to be tested across our current range of test repos.
So I wondered how long it would now take if we just test by default on 1?

I do not think that we actually should do it, but we might want to get through those
tests and
- make it run on a random 1 test repo
- provide way to seed rng

possible side-effects -- non-deterministic coverage.  We (me) already hurt ourselves
by disabling some tests in PRs which now makes coverage report not really useful. So if this
one also would have dramatic effect -- it would mean that some tests must not be tested
only on 1 sample dataset

PS1: one test will fail everywhere which tests that we are returning needed number of datasets... which we don't here -- the purpose is timing check