### PR TITLE
Cannot change annex description

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -654,6 +654,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         there shouldn't be a need to 'init' again.
 
         """
+        # MIH: this function is required for re-initing repos. The logic
+        # in the contructor is rather convoluted and doesn't acknowledge
+        # the case of a perfectly healthy annex that just needs a new
+        # description
+        # will keep leading underscore in the name for know, but this is
+        # not private
         # TODO: provide git and git-annex options.
         # TODO: Document (or implement respectively) behaviour in special cases
         # like direct mode (if it's different), not existing paths, etc.

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1726,3 +1726,12 @@ def test_AnnexRepo_metadata(path):
     ar.set_metadata(playfile, add={'novel': 'best'})
     eq_(['best'], ar.get_metadata(playfile)[playfile]['novel'])
 
+
+@with_tempfile(mkdir=True)
+def test_change_description(path):
+    # prelude
+    ar = AnnexRepo(path, create=True, description='some')
+    eq_(ar.get_description(), 'some')
+    # try change it
+    ar = AnnexRepo(path, create=False, init=True, description='someother')
+    eq_(ar.get_description(), 'someother')

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1734,4 +1734,8 @@ def test_change_description(path):
     eq_(ar.get_description(), 'some')
     # try change it
     ar = AnnexRepo(path, create=False, init=True, description='someother')
+    # this doesn't cut the mustard, still old
+    eq_(ar.get_description(), 'some')
+    # need to resort to "internal" helper
+    ar._init(description='someother')
     eq_(ar.get_description(), 'someother')


### PR DESCRIPTION
When I have an existing annex there seems to be no way to get its description changed.

````
>>> r=AnnexRepo('.')
>>> r.get_description()
'some'
>>> r=AnnexRepo('.', init=True, description='someother')
>>> r.get_description()
'some'
````

Calling `git annex init someother` in the cmdline has the desired effect, of course.
