### PR TITLE
OPT: delay full tree traversal in sort_paths_into_subdatasets for the use case of adding a new subds

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -228,6 +228,8 @@ class Add(Interface):
                     'success': True,
                     'file': Dataset(subds_path)})
             # make sure any last minute additions make it to the saving stage
+            # XXX? should content_by_ds become OrderedDict so that possible
+            # super here gets processed last?
             content_by_ds[ds_path] = toadd
             added = ds.repo.add(
                 toadd,
@@ -238,6 +240,7 @@ class Add(Interface):
             results.extend(added)
 
         if results and save:
+            # OPT: tries to save even unrelated stuff
             save_dataset_hierarchy(
                 content_by_ds,
                 base=dataset.path if dataset and dataset.is_installed() else None,

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -309,7 +309,7 @@ class Dataset(object):
           None is return if there is not repository instance yet. For an
           existing repository with no subdatasets an empty list is returned.
         """
-
+        # OPT TODO: make it a generator for a possible early termination?
         if isinstance(recursion_limit, int) and (recursion_limit <= 0):
             return []
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -33,6 +33,7 @@ from datalad.utils import get_trace
 from datalad.utils import walk
 from datalad.utils import get_dataset_root
 from datalad.utils import swallow_logs
+from datalad.utils import unique
 from datalad.support.exceptions import CommandError
 from datalad.support.gitrepo import GitRepo
 from datalad.support.gitrepo import GitCommandError
@@ -169,14 +170,33 @@ def sort_paths_into_subdatasets(superds_path, target_subs, spec):
     # of all datasets in a completely independent fashion
     # (except for order of processing)
 
+    subds = Dataset(superds_path)
+
     # get all existing subdataset as candidate nodes of the graph
     # that needs to be built and checked
-    subds_graph = Dataset(superds_path).get_subdatasets(
-        absolute=True, recursive=True, edges=True, fulfilled=True)
-    if not subds_graph:
+    # OPT TODO:  this is the expensive one!  e.g we might have a big
+    #       hierarchy of datasets and interested in analyzing only a single
+    #       target_subds -- now it gets the entire hierarchy first (EXPENSIVE)
+    #       to look/check just one... bleh... and then even better -- would continue
+    #       out of the loop if that dataset is already known
+    #       Moreover possibly causing entire recursive traversal of sub-datasets
+    #       multiple times if operating from some higher level super and sorted
+    #       target_subds in multiple subs
+    # Delay expensive operation
+    subds_graph = None
+    # so we first get immediate children, delaying even check for being fulfilled
+    subdss = subds.get_subdatasets(absolute=True, recursive=False, fulfilled=None)
+    if not subdss:
         # no subdatasets, nothing to sort
         return
     for t in target_subs:
+        if t in subdss and Dataset(t).is_installed():  # yoh guesses is_installed is as good or better than fulfilled
+            # immediate known kiddo
+            continue
+        if subds_graph is None:
+            subds_graph = subds.get_subdatasets(
+                absolute=True, recursive=True, edges=True, fulfilled=True)
+
         trace = get_trace(
             subds_graph,
             superds_path,
@@ -203,7 +223,7 @@ def sort_paths_into_subdatasets(superds_path, target_subs, spec):
             spec[d] = keep_paths
     # tidy up -- deduplicate
     for c in spec:
-        spec[c] = list(set(spec[c]))
+        spec[c] = unique(spec[c])
 
 
 def save_dataset_hierarchy(
@@ -239,7 +259,9 @@ def save_dataset_hierarchy(
     if base:
         # just a convenience...
         dpaths = assure_list(dpaths)
-        dpaths.append(base.path if isinstance(base, Dataset) else base)
+        base_path = base.path if isinstance(base, Dataset) else base
+        if base_path not in dpaths:
+            dpaths.append(base_path)
     # sort all datasets under their potential superdatasets
     # start from the top to get all subdatasets down the line
     # and collate them into as few superdatasets as possible
@@ -652,7 +674,7 @@ def get_dataset_directories(top, ignore_datalad=True):
 # this one here seems more leightweight and less convoluted
 def _discover_trace_to_known(path, trace, spec):
     # this beast walks the directory tree from a given `path` until
-    # it discoveres a known dataset (i.e. recorded in the spec)
+    # it discovers a known dataset (i.e. recorded in the spec)
     # if it finds one, it commits any accummulated trace of visited
     # datasets on this edge to the spec
     valid_repo = GitRepo.is_valid_repo(path)
@@ -664,9 +686,12 @@ def _discover_trace_to_known(path, trace, spec):
                 spec[p] = list(set(spec.get(p, []) + [trace[i + 1]]))
             # this edge is not done, we need to try to reach any downstream
             # dataset
+    # OPT TODO? listdir might be large and we could have only few items
+    #  in spec -- so why not to traverse only those in spec which have
+    #  leading dir path???
     for p in listdir(path):
         if valid_repo and p == '.git':
-            # ignore gitdir to steed things up
+            # ignore gitdir to speed things up
             continue
         p = opj(path, p)
         if not isdir(p):


### PR DESCRIPTION
There seems to be even more points to optimize but decided first to check this one

@mih -- feel free to discard (i.e. not merge) and just adjust code accordingly in the ultimate return values RF to avoid conflicts

Possibly closes #1388 

so here is timing before
```shell
$> time bash -c 's=NEW6; datalad create $s; datalad add -d . $s'
[INFO   ] Creating a new annex repo at /mnt/btrfs/datasets-quicksub/datalad/crawl/openfmri/NEW6 
Created dataset at /mnt/btrfs/datasets-quicksub/datalad/crawl/openfmri/NEW6.                                                           
Added <Dataset path=/mnt/btrfs/datasets-quicksub/datalad/crawl/openfmri/NEW6>                                                          
bash -c 's=NEW6; datalad create $s; datalad add -d . $s'  7.18s user 3.66s system 78% cpu 13.883 total
```
and here is after
```shell
$> time bash -c 's=NEW7; datalad create $s; datalad add -d . $s'
[INFO   ] Creating a new annex repo at /mnt/btrfs/datasets-quicksub/datalad/crawl/openfmri/NEW7 
Created dataset at /mnt/btrfs/datasets-quicksub/datalad/crawl/openfmri/NEW7.                                                           
Added <Dataset path=/mnt/btrfs/datasets-quicksub/datalad/crawl/openfmri/NEW7>
bash -c 's=NEW7; datalad create $s; datalad add -d . $s'  2.55s user 1.19s system 86% cpu 4.342 total
```

NB this comparison was done on a "warmed up" filesystem where I already traversed those submodules multiple times.  I expect difference to be even greater on a "fresh" one

since our tests battery doesn't involve any such large hierarchies, it might be likely that this would make them only slower for an additional logic and get_subdatasets.  There might be a better way

Also note other `OPT` comments where I thought that current logic could be improved to avoid unnecessary for common use-cases delays

Ideally, it should be possible to make that   `get_subdatasets + get_trace` tandem into something a bit smarter thing which would build up the "graph" based on queried paths, and not all at once.  Also it should be reused/grown from within `save_dataset_hierarchy` which calls that `sort_paths_into_subdatasets` for every subds, since there might be a hierarchy