### PR TITLE
BF+ENH: *Repo.add(updates=False), do not call git annex add without files upon save

### DIFF
--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -162,6 +162,8 @@ class Save(Interface):
         if all_updated:
             # and we do this by replacing any given paths with the respective
             # datasets' base path
+            # XXX this implies no "boundary" possibly imposed by specified paths!
+            #  see our use-case spreadsheet -- TODO
             for ds in content_by_ds:
                 content_by_ds[ds] = [ds]
 

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -69,10 +69,12 @@ def test_dirty(path):
     ds.create()
     orig_state = ds.repo.get_hexsha()
     _check_all_clean(ds, orig_state)
-    # tainted: untracked
-    with open(opj(ds.path, 'something'), 'w') as f:
+    # tainted: untracked -- no automagic save
+    somefile = opj(ds.path, 'something')
+    with open(somefile, 'w') as f:
         f.write('some')
-    orig_state = _check_auto_save(ds, orig_state)
+    assert_raises(AssertionError, _check_auto_save, ds, orig_state)
+    os.unlink(somefile)
     # tainted: staged
     with open(opj(ds.path, 'staged'), 'w') as f:
         f.write('some')

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -33,6 +33,7 @@ from datalad.utils import get_trace
 from datalad.utils import walk
 from datalad.utils import get_dataset_root
 from datalad.utils import swallow_logs
+from datalad.utils import unique
 from datalad.support.exceptions import CommandError
 from datalad.support.gitrepo import GitRepo
 from datalad.support.gitrepo import GitCommandError
@@ -322,13 +323,31 @@ def save_dataset(
         if isinstance(ds.repo, AnnexRepo):
             # to make this work without calling `git add` in addition,
             # this needs git-annex v6.20161210 (see #1027)
-            ds.repo.add(tostage, commit=False)
+
+            # !!! We must not call it with the entire path to the dataset
+            # since that would also add (annex) untracked files. IMHO operating
+            # slowly is still better than operating incorrectly (re above
+            # comment states that acting upon untracked is expensive). I see no
+            # other way imho (yoh) until something like 'annex add --update' exists
+            # (dropped joey a question via email).  Note that those which were
+            # already staged not needed to be added
+            # First we need to fish out from tostage the path of ds itself
+            # and get its updates
+            if ds.path in tostage:
+                tostage.pop(tostage.index(ds.path))
+                updated_listing = ds.repo.add(tostage, updates=True, dry_run=True, commit=False)
+                tostage.extend([x['file'] for x in updated_listing])
+                tostage = unique(tostage)  # remove duplicates if any
+            if tostage:
+                ds.repo.add(tostage, commit=False)
+            else:
+                lgr.log(3, "Not calling annex add since no files found to be modified")
         else:
             # --update will ignore any untracked files, sadly git-annex add
-            # above does not
+            # above does not "natively"
             # will complain about vanished files though, filter them here, but
             # keep them for a later commit call
-            ds.repo.add(tostage, git_options=['--update'], commit=False)
+            ds.repo.add(tostage, updates=True, commit=False)
 
     _datalad_msg = False
     if not message:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -751,7 +751,9 @@ class GitRepo(RepoInterface):
         return msg + '\n\nFiles:\n' + '\n'.join(files)
 
     @normalize_paths
-    def add(self, files, commit=False, msg=None, git=True, git_options=None, _datalad_msg=False):
+    def add(self, files, commit=False, msg=None, git=True,
+            updates=False,
+            git_options=None, _datalad_msg=False):
         """Adds file(s) to the repository.
 
         Parameters
@@ -773,13 +775,16 @@ class GitRepo(RepoInterface):
 
         files = _remove_empty_items(files)
         out = []
+        git_options = assure_list(git_options)
+        if updates:
+            git_options += ['--update']
 
-        if files:
+        if files or updates:
             try:
                 # without --verbose git 2.9.3  add does not return anything
                 add_out = self._git_custom_command(
                     files,
-                    ['git', 'add'] + assure_list(git_options) + ['--verbose']
+                    ['git', 'add'] + git_options + ['--verbose']
                 )
                 # get all the entries
                 out = self._process_git_get_output(*add_out)
@@ -806,7 +811,7 @@ class GitRepo(RepoInterface):
                 raise
 
         else:
-            lgr.warning("add was called with empty file list.")
+            lgr.warning("add was called with empty file list and no updates.")
 
         if commit:
             if msg is None:


### PR DESCRIPTION
I saw no other way but to ask 'git add -u --dry-run' for what files to be added before calling 'git annex add' which should not called without specific files path, since it would just add everything, which lead to #1419.  IMHO we better operate slower but correctly.

This is my 2nd attempt (see https://github.com/datalad/datalad/compare/master...yarikoptic:bf-save-u if interested, but that one was 'shortsighted' although I have spent probably half a day on it learning intricacies of the save), and I did try to keep it minimal.  While at it I have fixed the tests which still hoped to get stuff automagically added.  I guess we are to introduce '-a' option back sooner than later ;-)

But while analyzing the 'save', I was converging on an idea that we might not need/want '-u' since we will not be able to provide consistent interface.  Please see the newly added 'save' spreadsheet in the API Use-cases convergence google doc.  E.g. SUC6.  So I am starting to wonder if we should just always save all staged and non-staged (but tracked) changes?

Unlikely I will be up whenever the tests fail, so if you could contribute to fixing them -- would be most welcome!
Closes #1419

FTR  Joey agreed that having 'annex add -u' is sensible thus there is http://git-annex.branchable.com/todo/annex_add___40__-u__124__--update__41___mode/ now  but probably will not happen right away, thus this solution might still be sensible for now