### PR TITLE
Advanced magic in `crawl` test, need exorcist ;-)

### DIFF
--- a/datalad/interface/crawl.py
+++ b/datalad/interface/crawl.py
@@ -147,6 +147,8 @@ class Crawl(Interface):
                 # into the subdatasets' crawl.  We will collect all of them here so we might later
                 # also introduce automatic commits when super-dataset got successfully updated
                 subdatasets = Dataset(os.curdir).get_subdatasets(recursive=recursive)
+                if len(subdatasets):
+                    assert Dataset(os.curdir).is_installed()
 
                 lgr.info("Crawling %d subdatasets", len(subdatasets))
                 output = [output]


### PR DESCRIPTION
I am trying to debug a test failure in the crawler for the new `subdataset` command. It "fails" because it doesn't return subdatasets for a Dataset that is an empty directory (hence not installed). However, the old Dataset.get_subdatasets() happily reports the presence of subdatasets. Here is the situation using the old code:
````
> /home/mih/hacking/datalad/git/datalad/interface/crawl.py(150)__call__()
-> subdatasets = Dataset(os.curdir).get_subdatasets(recursive=recursive)
(Pdb) ds=Dataset(os.curdir)
(Pdb) ds.path
'/tmp/datalad_temp_test_crawl_api_recursiveVTk5BI'
(Pdb) Dataset(os.curdir).get_subdatasets(recursive=recursive)
['path1', 'path1/path1_1', 'path2', 'path_to_fail']
(Pdb) import os
(Pdb) os.listdir(ds.path)
[]
````

So the beast is not there, yet it has subdatasets. I assume that is GitPython still remembering things it should have forgotton. The new code, doesn't use GitPython functionality, so it returns an empty list -- as also the old code should have done IMHO.

Somehow, not sure how to tackle this.

In any case, the new code is in #1423 