### PR TITLE
RF+NF: Dataset.get_subdatasets() -> standalone `subdatasets`

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -89,7 +89,7 @@ def _generate_func_api():
             # TODO: BEGIN to be removed, when @build_doc is applied everywhere
             spec = getattr(intf, '_params_', dict())
             api_name = get_api_name(intfspec)
-            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'get', 'clone'):
+            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'get', 'clone', 'subdatasets'):
                 # FIXME no longer using an interface class instance
                 # convert the parameter SPEC into a docstring for the function
                 update_docstring_with_parameters(

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -282,10 +282,6 @@ def main(args=None):
     # to possibly be passed into PBS scheduled call
     args_ = args or sys.argv
 
-    # configure rendering of return values
-    datalad.cfg.overrides['datalad.api.result-renderer'] = \
-        cmdlineargs.common_output_format
-
     # enable overrides
     datalad.cfg.reload()
 

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -211,10 +211,10 @@ class Add(Interface):
             for subds_path in [d for d in toadd
                                if GitRepo.is_valid_repo(d) and
                                d != ds_path and
-                               d not in ds.get_subdatasets(
+                               d not in ds.subdatasets(
                                    recursive=False,
-                                   absolute=True,
-                                   fulfilled=True)]:
+                                   fulfilled=True,
+                                   result_xfm='paths')]:
                 # TODO add check that the subds has a commit, and refuse
                 # to operate on it otherwise, or we would get a bastard
                 # submodule that cripples git operations

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -16,6 +16,7 @@ import logging
 
 from collections import OrderedDict
 from os.path import join as opj, basename
+from os.path import relpath
 
 from datalad.utils import assure_list
 from datalad.dochelpers import exc_str
@@ -162,18 +163,18 @@ class AddSibling(Interface):
         repos[ds_basename] = {'repo': ds.repo}
 
         if recursive:
-            for subds_name in ds.get_subdatasets(recursive=True):
-                subds_path = opj(ds.path, subds_name)
-                subds = Dataset(subds_path)
+            for subds in ds.subdatasets(recursive=True, result_xfm='datasets'):
                 lgr.debug("Adding sub-dataset %s for adding a sibling",
-                          subds_path)
+                          subds.path)
                 if not subds.is_installed():
                     lgr.info("Skipping adding sibling for %s since it "
                              "is not installed", subds)
                     continue
-                repos[ds_basename + '/' + subds_name] = {
+                # MIH why not simply absolute paths?
+                repos[ds_basename + '/' + relpath(subds.path, start=ds.path)] = {
                     #                repos[subds_name] = {
-                    'repo': GitRepo(subds_path, create=False)
+                    # MIH this next line is strange, why not subds.repo? why GitRepo?
+                    'repo': GitRepo(subds.path, create=False)
                 }
 
         # Note: This is copied from create_sibling

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -16,6 +16,7 @@ import logging
 import re
 
 from os.path import join as opj
+from os.path import relpath
 from datalad import cfg
 
 from datalad.interface.common_opts import recursion_flag, recursion_limit
@@ -302,16 +303,15 @@ class CreateSiblingGithub(Interface):
         # dataset instance and mountpoint relative to the top
         toprocess = [(ds, '')]
         if recursive:
-            for d in ds.get_subdatasets(
+            for sub in ds.subdatasets(
                     fulfilled=None,  # we want to report on missing dataset in here
-                    absolute=False,
                     recursive=recursive,
-                    recursion_limit=recursion_limit):
-                sub = Dataset(opj(ds.path, d))
+                    recursion_limit=recursion_limit,
+                    result_xfm='datasets'):
                 if not sub.is_installed():
                     lgr.info('Ignoring unavailable subdataset %s', sub)
                     continue
-                toprocess.append((sub, d))
+                toprocess.append((sub, relpath(sub.path, start=ds.path)))
 
         # check for existing remote configuration
         filtered = []

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -126,8 +126,8 @@ class Remove(Interface):
             if not toppath:
                 nonexistent_paths.append(p)
                 continue
-            if p in Dataset(toppath).get_subdatasets(
-                    recursive=False, absolute=True):
+            if p in Dataset(toppath).subdatasets(
+                    recursive=False, result_xfm='paths'):
                 # this is a known subdataset that needs to be removed
                 pl = content_by_ds.get(p, [])
                 pl.append(p)

--- a/datalad/distribution/rewrite_urls.py
+++ b/datalad/distribution/rewrite_urls.py
@@ -81,9 +81,9 @@ class RewriteURLs(Interface):
 
         repos_to_update = [ds.repo]
         if recursive:
-            repos_to_update += [GitRepo(opj(ds.path, sub_path))
-                                for sub_path in
-                                ds.get_subdatasets(recursive=True)]
+            repos_to_update += \
+                [d.repo
+                 for d in ds.subdatasets(recursive=True, result_xfm='datasets')]
 
         for dataset_repo in repos_to_update:
             parser = get_module_parser(dataset_repo)

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -1,0 +1,219 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Plumbing command for reporting subdatasets"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import re
+from os.path import join as opj
+from os.path import normpath
+
+from git import GitConfigParser
+
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.utils import build_doc
+from datalad.interface.results import get_status_dict
+from datalad.support.constraints import EnsureBool
+from datalad.support.constraints import EnsureNone
+from datalad.support.param import Parameter
+from datalad.interface.common_opts import recursion_flag
+from datalad.interface.common_opts import recursion_limit
+from datalad.distribution.dataset import require_dataset
+from datalad.cmd import GitRunner
+from datalad.support.gitrepo import GitRepo
+
+from .dataset import Dataset
+from .dataset import EnsureDataset
+from .dataset import datasetmethod
+
+lgr = logging.getLogger('datalad.distribution.subdatasets')
+
+
+submodule_full_props = re.compile(r'([0-9a-f]+) (.*) \((.*)\)$')
+submodule_nodescribe_props = re.compile(r'([0-9a-f]+) (.*)$')
+
+status_map = {
+    ' ': 'clean',
+    '+': 'modified',
+    '-': 'absent',
+    'U': 'conflict',
+}
+
+
+def _parse_gitmodules(dspath):
+    gitmodule_path = opj(dspath, ".gitmodules")
+    parser = GitConfigParser(gitmodule_path)
+    mods = {}
+    for sec in parser.sections():
+        modpath = parser.get_value(sec, 'path', default=0)
+        if not modpath or not sec.startswith('submodule '):
+            continue
+        modpath = normpath(opj(dspath, modpath))
+        modprops = {opt: parser.get_value(sec, opt)
+                    for opt in parser.options(sec)
+                    if not (opt.startswith('__') or opt == 'path')}
+        modprops['name'] = sec[11:-1]
+        mods[modpath] = modprops
+    return mods
+
+
+def _parse_git_submodules(dspath):
+    """All known ones with some properties"""
+    modinfo = _parse_gitmodules(dspath)
+
+    # need to go rogue  and cannot use proper helper in GitRepo
+    # as they also pull in all of GitPython's magic
+    stdout, stderr = GitRunner(cwd=dspath).run(
+        # this will not work in direct mode, need better way #1422
+        ['git', 'submodule'],
+        log_stderr=False,
+        log_stdout=True,
+        log_online=False,
+        expect_stderr=False,
+        shell=False,
+        expect_fail=False)
+
+    for line in stdout.split('\n'):
+        if not line:
+            continue
+        sm = {}
+        sm['state'] = status_map[line[0]]
+        props = submodule_full_props.match(line[1:])
+        if props:
+            sm['reccommit'] = props.group(1)
+            sm['path'] = opj(dspath, props.group(2))
+            sm['describe'] = props.group(3)
+        else:
+            props = submodule_nodescribe_props.match(line[1:])
+            sm['reccommit'] = props.group(1)
+            sm['path'] = opj(dspath, props.group(2))
+        sm.update(modinfo.get(sm['path'], {}))
+        yield sm
+
+
+@build_doc
+class Subdatasets(Interface):
+    """Report subdatasets and their properties.
+
+    The following properties are reported (if possible) for each matching
+    subdataset record.
+
+    "describe"
+        Output of `git describe` for the subdataset
+
+    "name"
+        Name of the subdataset in the parent (often identical with the
+        relative path in the parent dataset)
+
+    "path"
+        Absolute path to the subdataset
+
+    "parentpath"
+        Absolute path to the parent dataset
+
+    "reccommit"
+        SHA1 of the subdataset commit recorded in the parent dataset
+
+    "state"
+        Condition of the subdataset: 'clean', 'modified', 'absent', 'conflict'
+        as reported by `git submodule`
+
+    "url"
+        URL of the subdataset recorded in the parent
+
+    """
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to update.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the input and/or the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        fulfilled=Parameter(
+            args=("--fulfilled",),
+            doc="""if given, must be a boolean flag indicating whether
+            to report either only locally present or absent datasets.
+            By default subdatasets are reported regardless of their
+            status""",
+            constraints=EnsureBool() | EnsureNone()),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+        bottomup=Parameter(
+            args=("--bottomup",),
+            action="store_true",
+            doc="""whether to report subdatasets in bottom-up order along
+            each branch in the dataset tree, and not top-down."""))
+
+    @staticmethod
+    @datasetmethod(name='subdatasets')
+    @eval_results
+    def __call__(
+            dataset=None,
+            fulfilled=None,
+            recursive=False,
+            recursion_limit=None,
+            bottomup=False):
+        dataset = require_dataset(
+            dataset, check_installed=False, purpose='subdataset reporting')
+        refds_path = dataset.path
+
+        # return as quickly as possible
+        if isinstance(recursion_limit, int) and (recursion_limit <= 0):
+            return
+
+        for r in _get_submodules(
+                dataset.path, fulfilled, recursive, recursion_limit,
+                bottomup):
+            # without the refds_path cannot be rendered/converted relative
+            # in the eval_results decorator
+            r['refds'] = refds_path
+            yield r
+
+
+# internal helper that needs all switches, simply to avoid going through
+# the main command interface with all its decorators again
+def _get_submodules(dspath, fulfilled, recursive, recursion_limit,
+                    bottomup):
+    if not GitRepo.is_valid_repo(dspath):
+        return
+    # put in giant for-loop to be able to yield results before completion
+    for sm in _parse_git_submodules(dspath):
+        subdsres = get_status_dict(
+            'subdataset',
+            status='ok',
+            type_='dataset',
+            logger=lgr)
+        subdsres.update(sm)
+        subdsres['parentpath'] = dspath
+        if not bottomup and \
+                (fulfilled is None or
+                 GitRepo.is_valid_repo(sm['path']) == fulfilled):
+            yield subdsres
+
+        # expand list with child submodules. keep all paths relative to parent
+        # and convert jointly at the end
+        if recursive and \
+                (recursion_limit in (None, 'existing') or
+                 (isinstance(recursion_limit, int) and
+                  recursion_limit > 1)):
+            for r in _get_submodules(
+                    sm['path'],
+                    fulfilled, recursive,
+                    (recursion_limit - 1)
+                    if isinstance(recursion_limit, int)
+                    else recursion_limit,
+                    bottomup):
+                yield r
+        if bottomup and \
+                (fulfilled is None or
+                 GitRepo.is_valid_repo(sm['path']) == fulfilled):
+            yield subdsres

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -74,7 +74,7 @@ def _parse_git_submodules(dspath):
     # as they also pull in all of GitPython's magic
     stdout, stderr = GitRunner(cwd=dspath).run(
         # this will not work in direct mode, need better way #1422
-        ['git', 'submodule'],
+        ['git', '--work-tree=.', 'submodule'],
         log_stderr=False,
         log_stdout=True,
         log_online=False,

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -98,44 +98,6 @@ def test_register_sibling(remote, path):
     # TODO: Validation!
 
 
-@with_testrepos('.*nested_submodule.*', flavors=['local'])
-def test_get_subdatasets(path):
-    ds = Dataset(path)
-    eq_(ds.get_subdatasets(), ['sub dataset1'])
-    eq_(ds.get_subdatasets(edges=True), [(os.curdir, 'sub dataset1')])
-    eq_(ds.get_subdatasets(recursive=True),
-        [
-            'sub dataset1/sub sub dataset1/subm 1',
-            'sub dataset1/sub sub dataset1/subm 2',
-            'sub dataset1/sub sub dataset1',
-            'sub dataset1/subm 1',
-            'sub dataset1/subm 2',
-            'sub dataset1'
-        ])
-    eq_(ds.get_subdatasets(recursive=True, edges=True),
-        [
-            ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1'),
-            ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 2'),
-            ('sub dataset1', 'sub dataset1/sub sub dataset1'),
-            ('sub dataset1', 'sub dataset1/subm 1'),
-            ('sub dataset1', 'sub dataset1/subm 2'),
-            (os.curdir, 'sub dataset1'),
-        ])
-    eq_(ds.get_subdatasets(recursive=True, recursion_limit=0),
-        [])
-    eq_(ds.get_subdatasets(recursive=True, recursion_limit=1),
-        ['sub dataset1'])
-    eq_(ds.get_subdatasets(recursive=True, recursion_limit=2),
-        [
-            'sub dataset1/sub sub dataset1',
-            'sub dataset1/subm 1',
-            'sub dataset1/subm 2',
-            'sub dataset1',
-        ])
-
-    # TODO:  More Flavors!
-
-
 # TODO: There's something wrong with the nested testrepo!
 # Fear mongering detected!
 @with_testrepos('submodule_annex')
@@ -208,10 +170,10 @@ def test_subdatasets(path):
     # from scratch
     ds = Dataset(path)
     assert_false(ds.is_installed())
-    eq_(ds.get_subdatasets(), [])
+    eq_(ds.subdatasets(), [])
     ds = ds.create()
     assert_true(ds.is_installed())
-    eq_(ds.get_subdatasets(), [])
+    eq_(ds.subdatasets(), [])
     # create some file and commit it
     open(os.path.join(ds.path, 'test'), 'w').write('some')
     ds.add(path='test')
@@ -227,18 +189,15 @@ def test_subdatasets(path):
     eq_(subds.get_superdataset(), ds)
     eq_(subds.get_superdataset(topmost=True), ds)
 
-    subdss = ds.get_subdatasets()
+    subdss = ds.subdatasets()
     eq_(len(subdss), 1)
-    eq_(os.path.join(path, subdss[0]), subds.path)
-    eq_(subds.path, ds.get_subdatasets(absolute=True)[0])
-    eq_(subdss, ds.get_subdatasets(recursive=True))
-    eq_(subdss, ds.get_subdatasets(fulfilled=True))
-    # don't have that right now
-    assert_raises(NotImplementedError, ds.get_subdatasets, pattern='sub*')
+    eq_(subds.path, ds.subdatasets(result_xfm='paths')[0])
+    eq_(subdss, ds.subdatasets(recursive=True))
+    eq_(subdss, ds.subdatasets(fulfilled=True))
     ds.save("with subds", version_tag=2)
     ds.recall_state(1)
     assert_true(ds.is_installed())
-    eq_(ds.get_subdatasets(), [])
+    eq_(ds.subdatasets(), [])
 
     # very nested subdataset to test topmost
     subsubds = subds.install(_path_('d1/subds'), source=path)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -277,7 +277,7 @@ def test_get_greedy_recurse_subdatasets(src, path):
     ds.get(['subm 1', 'subm 2'])
 
     # We got all content in the subdatasets
-    subds1, subds2 = [Dataset(d) for d in ds.get_subdatasets(absolute=True)]
+    subds1, subds2 = ds.subdatasets(result_xfm='datasets')
     ok_(ds.repo.file_has_content('test-annex.dat') is False)
     ok_(subds1.repo.file_has_content('test-annex.dat') is True)
     ok_(subds2.repo.file_has_content('test-annex.dat') is True)
@@ -289,7 +289,7 @@ def test_get_install_missing_subdataset(src, path):
 
     ds = install(path=path, source=src)
     ds.create(force=True)  # force, to cause dataset initialization
-    subs = [Dataset(s_path) for s_path in ds.get_subdatasets(absolute=True)]
+    subs = ds.subdatasets(result_xfm='datasets')
     ok_(all([not sub.is_installed() for sub in subs]))
 
     # we don't install anything, if no explicitly given path points into a
@@ -362,10 +362,10 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     origin.save(recursive=True, all_updated=True)
 
     ds = install(path, source=src)
-    eq_(len(ds.get_subdatasets(fulfilled=True)), 0)
+    eq_(len(ds.subdatasets(fulfilled=True)), 0)
 
     results = get(opj(ds.path, 'sub'), recursive=True, result_xfm='datasets')
-    eq_(len(ds.get_subdatasets(fulfilled=True, recursive=True)), 2)
+    eq_(len(ds.subdatasets(fulfilled=True, recursive=True)), 2)
     subsub = Dataset(opj(ds.path, 'sub', 'subsub'))
     ok_(subsub.is_installed())
     assert_in(subsub, results)

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -1,0 +1,84 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test subdataset command"""
+
+import os
+from os.path import join as opj
+from os.path import relpath
+
+from ..dataset import Dataset
+from datalad.api import subdatasets
+
+from nose.tools import eq_
+from datalad.tests.utils import with_testrepos
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_status
+
+
+@with_testrepos('.*nested_submodule.*', flavors=['clone'])
+def test_get_subdatasets(path):
+    ds = Dataset(path)
+    eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [
+        'sub dataset1'
+    ])
+    ds.get('sub dataset1')
+    eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [
+        'sub dataset1/sub sub dataset1',
+        'sub dataset1/subm 1',
+        'sub dataset1/subm 2',
+    ])
+    # obtain key subdataset, so all leave subdatasets are discoverable
+    ds.get(opj('sub dataset1', 'sub sub dataset1'))
+    eq_(ds.subdatasets(result_xfm='relpaths'), ['sub dataset1'])
+    eq_([(r['parentpath'], r['path']) for r in ds.subdatasets()],
+        [(path, opj(path, 'sub dataset1'))])
+    eq_(subdatasets(ds, recursive=True, result_xfm='relpaths'), [
+        'sub dataset1',
+        'sub dataset1/sub sub dataset1',
+        'sub dataset1/sub sub dataset1/subm 1',
+        'sub dataset1/sub sub dataset1/subm 2',
+        'sub dataset1/subm 1',
+        'sub dataset1/subm 2',
+    ])
+    eq_(subdatasets(ds, recursive=True, bottomup=True, result_xfm='relpaths'), [
+        'sub dataset1/sub sub dataset1/subm 1',
+        'sub dataset1/sub sub dataset1/subm 2',
+        'sub dataset1/sub sub dataset1',
+        'sub dataset1/subm 1',
+        'sub dataset1/subm 2',
+        'sub dataset1',
+    ])
+    eq_(subdatasets(ds, recursive=True, fulfilled=True, result_xfm='relpaths'), [
+        'sub dataset1',
+        'sub dataset1/sub sub dataset1',
+    ])
+    eq_([(relpath(r['parentpath'], start=ds.path), relpath(r['path'], start=ds.path))
+         for r in ds.subdatasets(recursive=True)], [
+        (os.curdir, 'sub dataset1'),
+        ('sub dataset1', 'sub dataset1/sub sub dataset1'),
+        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1'),
+        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 2'),
+        ('sub dataset1', 'sub dataset1/subm 1'),
+        ('sub dataset1', 'sub dataset1/subm 2'),
+    ])
+    eq_(subdatasets(ds, recursive=True, recursion_limit=0),
+        [])
+    eq_(ds.subdatasets(recursive=True, recursion_limit=1, result_xfm='relpaths'),
+        ['sub dataset1'])
+    eq_(ds.subdatasets(recursive=True, recursion_limit=2, result_xfm='relpaths'),
+        [
+        'sub dataset1',
+        'sub dataset1/sub sub dataset1',
+        'sub dataset1/subm 1',
+        'sub dataset1/subm 2',
+    ])
+    res = ds.subdatasets(recursive=True)
+    assert_status('ok', res)
+    for r in res:
+        for prop in ('url', 'state', 'reccommit', 'name'):
+            assert_in(prop, r)

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -48,7 +48,7 @@ def _uninstall_dataset(ds, check, has_super):
     #       (e.g. ./anything) implies cannot be undone, decide how, and
     #       if to check for that
     # TODO check that the relevant branched are pushed to a remote
-    if ds.get_subdatasets(fulfilled=True):
+    if ds.subdatasets(fulfilled=True):
         yield get_status_dict(
             status='error',
             ds=ds,

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -142,7 +142,7 @@ def _install_subds_from_flexible_source(
     # submodule already was installed and all is good?
 
     # do fancy update
-    if sm_path in ds.get_subdatasets(absolute=False, recursive=False):
+    if sm_path in ds.subdatasets(recursive=False, result_xfm='relpaths'):
         lgr.debug("Update cloned subdataset {0} in parent".format(subds))
         # TODO: move all of that into update_submodule ??
         # TODO: direct mode ramifications?

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -155,7 +155,7 @@ def _split_out_parameters(initdoc):
 
 
 __re_params = re.compile('(?:\n\S.*?)+$')
-__re_spliter1 = re.compile('(?:\n|\A)(?=\S)')
+__re_spliter1 = re.compile('\n(?=\S)')
 __re_spliter2 = re.compile('[\n:]')
 
 

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -76,4 +76,5 @@ _group_plumbing = (
         ('datalad.distribution.create_test_dataset', 'CreateTestDataset',
          'create-test-dataset'),
         ('datalad.support.sshrun', 'SSHRun', 'sshrun'),
+        ('datalad.distribution.subdatasets', 'Subdatasets', 'subdatasets'),
     ])

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -313,7 +313,7 @@ class Interface(object):
         # let it run like generator so we can act on partial results quicker
         # TODO remove following condition test when transition is complete and
         # run indented code unconditionally
-        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Get', 'Clone'):
+        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Get', 'Clone', 'Subdatasets'):
             # set all common args explicitly  to override class defaults
             # that are tailored towards the the Python API
             kwargs['return_type'] = 'generator'

--- a/datalad/interface/crawl.py
+++ b/datalad/interface/crawl.py
@@ -146,7 +146,7 @@ class Crawl(Interface):
                 # Note: we could collect all datasets to be crawled here or pass recursive=True
                 # into the subdatasets' crawl.  We will collect all of them here so we might later
                 # also introduce automatic commits when super-dataset got successfully updated
-                subdatasets = Dataset(os.curdir).get_subdatasets(recursive=recursive)
+                subdatasets = Dataset(os.curdir).subdatasets(recursive=recursive, result_xfm='relpaths')
 
                 lgr.info("Crawling %d subdatasets", len(subdatasets))
                 output = [output]

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -114,7 +114,7 @@ def annexjson2result(d, ds, **kwargs):
         res['path'] = opj(ds.path, d['file'])
     if 'action' in d:
         res['action'] = d['command']
-    if 'annexkey' in d:
+    if 'key' in d:
         res['annexkey'] = d['key']
     return res
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -112,7 +112,7 @@ def annexjson2result(d, ds, **kwargs):
     # git annex (or its wrapper) is not always homogeneous
     if 'file' in d:
         res['path'] = opj(ds.path, d['file'])
-    if 'action' in d:
+    if 'command' in d:
         res['action'] = d['command']
     if 'key' in d:
         res['annexkey'] = d['key']

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -15,6 +15,7 @@ __docformat__ = 'restructuredtext'
 import logging
 
 from os.path import join as opj
+from os.path import relpath
 from datalad.utils import assure_list
 from datalad.distribution.dataset import Dataset
 
@@ -79,6 +80,13 @@ class YieldDatasets(ResultXFM):
             lgr.debug('rejected by return value configuration: %s', res)
 
 
+class YieldRelativePaths(ResultXFM):
+    def __call__(self, res):
+        refpath = res.get('refds', None)
+        if refpath:
+            return relpath(res['path'], start=refpath)
+
+
 class YieldField(ResultXFM):
     def __init__(self, field):
         self.field = field
@@ -93,6 +101,7 @@ class YieldField(ResultXFM):
 known_result_xfms = {
     'datasets': YieldDatasets(),
     'paths': YieldField('path'),
+    'relpaths': YieldRelativePaths(),
 }
 
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -108,9 +108,14 @@ known_result_xfms = {
 def annexjson2result(d, ds, **kwargs):
     res = get_status_dict(**kwargs)
     res['status'] = 'ok' if d.get('success', False) is True else 'error'
-    res['path'] = opj(ds.path, d['file'])
-    res['action'] = d['command']
-    res['annexkey'] = d['key']
+    # we cannot rely on any of these to be available as the feed from
+    # git annex (or its wrapper) is not always homogeneous
+    if 'file' in d:
+        res['path'] = opj(ds.path, d['file'])
+    if 'action' in d:
+        res['action'] = d['command']
+    if 'annexkey' in d:
+        res['annexkey'] = d['key']
     return res
 
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -106,6 +106,7 @@ known_result_xfms = {
 
 
 def annexjson2result(d, ds, **kwargs):
+    lgr.debug('received JSON result from annex: %s', d)
     res = get_status_dict(**kwargs)
     res['status'] = 'ok' if d.get('success', False) is True else 'error'
     # we cannot rely on any of these to be available as the feed from

--- a/datalad/interface/tests/test_crawl.py
+++ b/datalad/interface/tests/test_crawl.py
@@ -61,7 +61,7 @@ def test_crawl_api_chdir(run_pipeline_, load_pipeline_from_config_, chpwd_):
            [], [], [], [], Exception("crawling failed")
        ]
 )
-@patch('datalad.distribution.dataset.Dataset.get_subdatasets',  # return_value=['path1', 'path2'])
+@patch('datalad.distribution.dataset.Dataset.subdatasets',  # return_value=['path1', 'path2'])
     side_effect=[
         ['path1', 'path1/path1_1', 'path2', 'path_to_fail'],
         # ATM we will not recursively crawl within sub-datasets

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -93,12 +93,13 @@ class AggregateMetaData(Interface):
         # if you want to modify the behavior of get_subdataset() make sure
         # there is a way to return the subdatasets DEPTH FIRST!
         ds_meta = {}
-        for subds_path in ds.get_subdatasets(
+        for subds in ds.subdatasets(
                 fulfilled=True,
-                absolute=False,
                 recursive=recursive,
-                recursion_limit=recursion_limit):
-            subds = Dataset(opj(ds.path, subds_path))
+                recursion_limit=recursion_limit,
+                bottomup=True,
+                result_xfm='datasets'):
+            subds_relpath = relpath(subds.path, start=ds.path)
             if subds.id is None:
                 # nothing to worry about, any meta data from below this will be
                 # injected upstairs
@@ -121,7 +122,7 @@ class AggregateMetaData(Interface):
             # Phase 2: store everything that is in the look up and belongs into
             #          this dataset
             #
-            _dump_submeta(subds, ds_meta, subds_path, save, modified_ds)
+            _dump_submeta(subds, ds_meta, subds_relpath, save, modified_ds)
             # save state of modified dataset, all we modified has been staged
             # already
             # we need to save before extracting to full metadata for upstairs
@@ -131,7 +132,7 @@ class AggregateMetaData(Interface):
             # Phase 3: obtain all aggregated meta data from this dataset, and
             #          keep in lookup to escalate it upstairs
             #
-            ds_meta[subds_path] = get_metadata(
+            ds_meta[subds_relpath] = get_metadata(
                 subds,
                 guess_type=False,
                 ignore_subdatasets=False,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1513,6 +1513,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         json_objects = (json.loads(line)
                         for line in out.splitlines() if line.startswith('{'))
+        # protect against progress leakage
+        json_objects = [j for j in json_objects if not 'byte-progress' in j]
         return json_objects
 
     # TODO: reconsider having any magic at all and maybe just return a list/dict always

--- a/docs/examples/3rdparty_analysis_workflow.sh
+++ b/docs/examples/3rdparty_analysis_workflow.sh
@@ -259,7 +259,7 @@ datalad add-sibling -s alice "$ALICES_HOME/bobs_analysis"
 # here changes with his own.
 #%
 
-datalad update alice --merge
+datalad update -s alice --merge
 
 #%
 # He can, once again, use the ``get`` command to obtain the latest version

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -70,3 +70,4 @@ Plumbing commands
    generated/man/datalad-clone
    generated/man/datalad-create-test-dataset
    generated/man/datalad-sshrun
+   generated/man/datalad-subdatasets

--- a/tools/testing/run_doc_examples
+++ b/tools/testing/run_doc_examples
@@ -19,5 +19,6 @@ export DATALAD_TESTS_RUNCMDLINE=1
 export PS4=+
 grep -l DATALAD_TESTS_RUNCMDLINE docs/examples/* 2>/dev/null \
 | while read t; do
-    bash "$t"
+    echo "RUNNING $t"
+    bash -x "$t"
 done


### PR DESCRIPTION
In response to #1411

This implementation is a lot faster, as it completely avoids instantiation of repositories, but wraps `git submodule` instead. Moreover, it exposes more information in a more directly accessible way.

It uses the new command API, so all transformation and filter mechanisms can be applied based on arbitrary subdataset properties.

The old `Dataset.get_subdatasets()` is left in place, as it is still used a lot in the tests. All occurrences in the actual code base are RF'ed. Use in test triggers a warning identifying the caller to
streamline further RF.

The new `subdatasets` command as advertised as a plumbing command in the docs.

Tests in `test_subdatasets.py` have been extended to near 100% coverage, only one safeguard line is missing.

TODO:

- [x] make it work in direct mode #1422 
- [x] figure out how crawler should behave without broken `get_subdataset` behavior #1412 
- [x]  base branch still needs to fixes from https://github.com/mih/datalad/pull/18