### PR TITLE
TEMP: bring back bundled ssh to take preference to see if that is one of the breakage reasons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,10 @@ before_install:
 install:
   # Install standalone build of git-annex for the recent enough version
   - travis_retry sudo eatmydata apt-get install git-annex-standalone zip pandoc
+  # 11d3219985ec3f58c453a87e6614a5036fb925ae moved bundled ssh from bin/ to extra/ so it gets added at the end of the path
+  # and yoh suspects that it is the source of many if not all current breakage, so let's try to symlink them under bin
+  # and see if goes away
+  - sudo ln -s /usr/lib/git-annex.linux/extra/ssh* /usr/lib/git-annex.linux/bin/ 
   - travis_retry sudo eatmydata apt-get install shunit2
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"


### PR DESCRIPTION
@joeyh -- apparently upgrade from `6.20170307+gitg24ade8a25-1~ndall+1` to fresh `6.20170403+gitgdbe23d695-1~ndall+1` broke quite a few of our logic/tests as could be seen from e.g. travis runs of https://github.com/datalad/datalad/pull/1452 

so far I saw one change which triggered my attention on using system wide ssh (if present) instead of bundled one -- so this PR first tests if there would be effect if we revert back by providing symlinks to it under annex's bin/ .... yet to analyze other possibly related changes in behavior

edit 1: no -- it shouldn't be change of choice of ssh since that change 11d3219985ec3f58c453a87e6614a5036fb925ae was done on March 02 so we had it already in 6.20170307 so must be something else