### PR TITLE
RF: SSHRI should not provide string form with escaped characters

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -99,11 +99,7 @@ def _create_dataset_sibling(
 
     # construct a would-be ssh url based on the current dataset's path
     ssh_url.path = remoteds_path
-    # .git/config seems to not like all the escapes since they aren't needed
-    # XXX yoh broke consistency with this escape argument present only in SSHRI
-    #     but here it could be a simple URL as tests show
-    ds_sshurl = ssh_url.as_str(escape=False) \
-        if isinstance(ssh_url, SSHRI) else ssh_url.as_str()
+    ds_sshurl = ssh_url.as_str()
     # configure dataset's git-access urls
     ds_target_url = target_url.replace('%RELNAME', ds_name) \
         if target_url else ds_sshurl

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -773,3 +773,18 @@ def test_install_consistent_state(src, dest, dest2, dest3):
     check_consistent_installation(dest3_ds)
 
     # TODO: makes a nice use-case for an update operation
+
+
+from datalad.tests.utils import skip_ssh
+
+@skip_ssh
+@with_tempfile
+@with_tempfile
+def test_install_subds_with_space(opath, tpath):
+    ds = create(opath)
+    ds.create('sub ds')
+    # works even now, boring
+    # install(tpath, source=opath, recursive=True)
+    # do via ssh!
+    install(tpath, source="localhost:" + opath, recursive=True)
+    assert Dataset(opj(tpath, 'sub ds')).is_installed()

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -320,11 +320,7 @@ def _get_flexible_source_candidates(src, base_url=None):
             base_suffix = ''
         ri.path = normpath(opj(base_path, src, base_suffix))
 
-    # TODO:  fix up for all this ssh special handling of RI!  Clearly
-    #        some urlencoding should be happening for some but not for sshri
-    #        So best probably to make it not escape by default and see what
-    #        breaks ;)
-    src = str(ri) if not isinstance(ri, SSHRI) else ri.as_str(escape=False)
+    src = str(ri)
 
     candidates.append(src)
     if isinstance(ri, URL):

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -32,6 +32,7 @@ from datalad.support.exceptions import InstallFailedError
 from datalad.support.network import DataLadRI
 from datalad.support.network import URL
 from datalad.support.network import RI
+from datalad.support.network import SSHRI
 from datalad.support.network import PathRI
 from datalad.dochelpers import exc_str
 from datalad.utils import swallow_logs
@@ -319,7 +320,11 @@ def _get_flexible_source_candidates(src, base_url=None):
             base_suffix = ''
         ri.path = normpath(opj(base_path, src, base_suffix))
 
-    src = str(ri)
+    # TODO:  fix up for all this ssh special handling of RI!  Clearly
+    #        some urlencoding should be happening for some but not for sshri
+    #        So best probably to make it not escape by default and see what
+    #        breaks ;)
+    src = str(ri) if not isinstance(ri, SSHRI) else ri.as_str(escape=False)
 
     candidates.append(src)
     if isinstance(ri, URL):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -713,7 +713,7 @@ class SSHRI(RI, RegexBasedURLMixin):
         # escape path so we have direct representation of the path to work with
         fields['path'] = unescape_ssh_path(fields['path'])
 
-    def as_str(self, escape=True):
+    def as_str(self, escape=False):
         fields = self.fields  # copy so we could escape symbols
         url_fmt = '{hostname}'
         if fields['username']:

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -326,7 +326,7 @@ def _test_url_quote_path(cls, clskwargs, target_url):
 
 
 def test_url_quote_path():
-    yield _test_url_quote_path, SSHRI, {}, r'example.com:/\ \"' + r"\'\;a\&b\&cd\ \`\|\ "
+    yield _test_url_quote_path, SSHRI, {}, r'example.com:/ "' + r"';a&b&cd `| "
     yield _test_url_quote_path, URL, {'scheme': "http"}, 'http://example.com/%20%22%27%3Ba%26b%26cd%20%60%7C%20'
     yield _test_url_quote_path, PathRI, {}, r'/ "' + r"';a&b&cd `| "  # nothing is done to file:implicit
 


### PR DESCRIPTION
Should address #1459 

Also with this I am confessing that I have "downgraded" the version of git-annex-standalone as we ship from NeuroDebian (now it is at a revision right before it broke for us).  So travis should get all happy

I have uploaded the most recent broken version to neurodebian -devel so we could "play" with it