### PR TITLE
RF+ENH+BF: attempts to fix up for recent git-annex changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     # will be used in the matrix, where neither other variable is used
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
+    - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=
     - NOSE_OPTS=-s
     # Special settings/helper for combined coverage from special remotes execution
@@ -51,7 +52,10 @@ matrix:
     - DATALAD_API_ALWAYSRENDER=1
     - DATALAD_TESTS_PROTOCOLREMOTE=1
     - DATALAD_TESTS_DATALADREMOTE=1
-    - DATALAD_LOG_OUTPUTS=1
+    - DATALAD_LOG_CMD_CWD=1
+    - DATALAD_LOG_CMD_OUTPUTS=1
+    - DATALAD_LOG_CMD_ENV=1
+    - DATALAD_LOG_CMD_STDIN=1
     - DATALAD_TESTS_UI_BACKEND=console
   - python: 2.7
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,11 +357,23 @@ Refer datalad/config.py for information on how to add these environment variable
 
 - *DATALAD_LOG_LEVEL*: 
   Used for control the verbosity of logs printed to stdout while running datalad commands/debugging
-- *DATALAD_LOG_OUTPUTS*: 
+- *DATALAD_LOG_CMD_OUTPUTS*:
   Used to control either both stdout and stderr of external commands execution are logged in detail (at DEBUG level)
+- *DATALAD_LOG_CMD_ENV*:
+  If contains a digit (e.g. 1), would log entire environment passed into
+  the Runner.run's popen call.  Otherwise could be a comma separated list
+  of environment variables to log
+- *DATALAD_LOG_CMD_STDIN*:
+  Either to log stdin for the command
+- *DATALAD_LOG_CMD_CWD*:
+  Either to log cwd where command to be executed
+- *DATALAD_LOG_PID*
+  To instruct datalad to log PID of the process
+- *DATALAD_LOG_TARGET*
+  Where to log: `stderr` (default), `stdout`, or another filename
 - *DATALAD_LOG_TIMESTAMP*:
   Used to add timestamp to datalad logs
-- *DATALAD_LOG_TRACEBACK*: 
+- *DATALAD_LOG_TRACEBACK*:
   Runs TraceBack function with collide set to True, if this flag is set to 'collide'.
   This replaces any common prefix between current traceback log and previous invocation with "..."
 - *DATALAD_EXC_STR_TBLIMIT*: 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -125,7 +125,7 @@ def teardown_package():
     lgr.debug("Printing versioning information collected so far")
     from datalad.support.external_versions import external_versions as ev
     # request versioning for few others which we do not check at runtime
-    for m in ('git',):
+    for m in ('git', 'system-ssh'):
         try:  # Let's make sure to not blow up when we are almost done
             ev[m]
         except Exception:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -504,8 +504,10 @@ class Runner(object):
         if isinstance(self.protocol, NullProtocol):
             lgr.log(level, msg, *args, **kwargs)
         else:
+            if args:
+                msg = msg % args
             lgr.log(level, "{%s} %s" % (
-                self.protocol.__class__.__name__, msg % args)
+                self.protocol.__class__.__name__, msg)
             )
 
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -26,6 +26,7 @@ from six import PY3, PY2
 from six import string_types, binary_type
 from os.path import abspath, isabs
 
+from .consts import GIT_SSH_COMMAND
 from .dochelpers import exc_str
 from .support.exceptions import CommandError
 from .support.protocol import NullProtocol, DryRunProtocol, \
@@ -573,7 +574,7 @@ class GitRunner(Runner):
                     lgr.debug("Updated %s to %s" % (varstring, git_env[varstring]))
 
         if 'GIT_SSH_COMMAND' not in git_env:
-            git_env['GIT_SSH_COMMAND'] = 'datalad sshrun'
+            git_env['GIT_SSH_COMMAND'] = GIT_SSH_COMMAND
 
         return git_env
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -21,6 +21,7 @@ import shlex
 import atexit
 import functools
 
+from collections import OrderedDict
 from six import PY3, PY2
 from six import string_types, binary_type
 from os.path import abspath, isabs
@@ -57,7 +58,8 @@ class Runner(object):
     able to record calls and allows for dry runs.
     """
 
-    __slots__ = ['commands', 'dry', 'cwd', 'env', 'protocol', '_log_outputs']
+    __slots__ = ['commands', 'dry', 'cwd', 'env', 'protocol',
+                 '_log_opts']
 
     def __init__(self, cwd=None, env=None, protocol=None, log_outputs=None):
         """
@@ -96,7 +98,11 @@ class Runner(object):
                 atexit.register(functools.partial(protocol.write_to_file, filename))
 
         self.protocol = protocol
-        self._log_outputs = log_outputs  # we don't know yet either we need ot log every output or not
+        # Various options for logging
+        self._log_opts = {}
+        # we don't know yet either we need ot log every output or not
+        if log_outputs is not None:
+            self._log_opts['outputs'] = log_outputs
 
     def __call__(self, cmd, *args, **kwargs):
         """Convenience method
@@ -129,17 +135,55 @@ class Runner(object):
             raise TypeError("Argument 'command' is neither a string, "
                             "nor a list nor a callable.")
 
-    @property
-    def log_outputs(self):
-        if self._log_outputs is None:
+    def _opt_env_adapter(v):
+        """If value is a string, split by ,"""
+        if v:
+            if v.isdigit():
+                log_env = bool(int(v))
+            else:
+                log_env = v.split(',')
+            return log_env
+        else:
+            return False
+
+    _LOG_OPTS_ADAPTERS = OrderedDict([
+        ('outputs', None),
+        ('cwd', None),
+        ('env', _opt_env_adapter),
+        ('stdin', None),
+    ])
+
+    def _get_log_setting(self, opt, default=False):
+        try:
+            return self._log_opts[opt]
+        except KeyError:
             try:
                 from . import cfg
-                self._log_outputs = \
-                    cfg.getbool('datalad.log', 'outputs', default=False)
             except ImportError:
-                # could be too early, then DON'T log!
-                return True
-        return self._log_outputs
+                return default
+            adapter = self._LOG_OPTS_ADAPTERS.get(opt, None)
+            self._log_opts[opt] = \
+                (cfg.getbool if not adapter else cfg.get_value)(
+                    'datalad.log.cmd', opt, default=default)
+            if adapter:
+                self._log_opts[opt] = adapter(self._log_opts[opt])
+            return self._log_opts[opt]
+
+    @property
+    def log_outputs(self):
+        return self._get_log_setting('outputs')
+
+    @property
+    def log_cwd(self):
+        return self._get_log_setting('cwd')
+
+    @property
+    def log_stdin(self):
+        return self._get_log_setting('stdin')
+
+    @property
+    def log_env(self):
+        return self._get_log_setting('env')
 
     # Two helpers to encapsulate formatting/output
     def _log_out(self, line):
@@ -318,6 +362,8 @@ class Runner(object):
         outputstream = subprocess.PIPE if log_stdout else sys.stdout
         errstream = subprocess.PIPE if log_stderr else sys.stderr
 
+        popen_env = env or self.env
+
         # TODO: if outputstream is sys.stdout and that one is set to StringIO
         #       we have to "shim" it with something providing fileno().
         # This happens when we do not swallow outputs, while allowing nosetest's
@@ -326,7 +372,23 @@ class Runner(object):
         # to overcome this problem.
         # For now necessary test code should be wrapped into swallow_outputs cm
         # to avoid the problem
-        self.log("Running: %s\ncwd: %s. stdin=%r" % (cmd, cwd or self.cwd, stdin))
+        log_msgs = ["Running: %s"]
+        log_args = [cmd]
+        if self.log_cwd:
+            log_msgs += ['cwd=%r']
+            log_args += [cwd or self.cwd]
+        if self.log_stdin:
+            log_msgs += ['stdin=%r']
+            log_args += [stdin]
+        log_env = self.log_env
+        if log_env and popen_env:
+            log_msgs += ["env=%r"]
+            log_args.append(
+                popen_env if log_env is True
+                else {k: popen_env[k] for k in log_env if k in popen_env}
+            )
+        log_msg = '\n'.join(log_msgs)
+        self.log(log_msg, *log_args)
 
         if self.protocol.do_execute_ext_commands:
 
@@ -344,7 +406,7 @@ class Runner(object):
                                         stderr=errstream,
                                         shell=shell,
                                         cwd=cwd or self.cwd,
-                                        env=env or self.env,
+                                        env=popen_env,
                                         stdin=stdin)
 
             except Exception as e:
@@ -432,16 +494,19 @@ class Runner(object):
                     [str(f), "args=%s" % str(args), "kwargs=%s" % str(kwargs)],
                     None)
 
-    def log(self, msg, level=logging.DEBUG):
+    def log(self, msg, *args, **kwargs):
         """log helper
 
         Logs at DEBUG-level by default and adds "Protocol:"-prefix in order to
         log the used protocol.
         """
+        level = kwargs.pop('level', logging.DEBUG)
         if isinstance(self.protocol, NullProtocol):
-            lgr.log(level, msg)
+            lgr.log(level, msg, *args, **kwargs)
         else:
-            lgr.log(level, "{%s} %s" % (self.protocol.__class__.__name__, msg))
+            lgr.log(level, "{%s} %s" % (
+                self.protocol.__class__.__name__, msg % args)
+            )
 
 
 class GitRunner(Runner):

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -326,7 +326,7 @@ class Runner(object):
         # to overcome this problem.
         # For now necessary test code should be wrapped into swallow_outputs cm
         # to avoid the problem
-        self.log("Running: %s\ncwd: %s" % (cmd, cwd or self.cwd))
+        self.log("Running: %s\ncwd: %s. stdin=%r" % (cmd, cwd or self.cwd, stdin))
 
         if self.protocol.do_execute_ext_commands:
 

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -51,3 +51,7 @@ WEB_HTML_DIR = join(DATALAD_GIT_DIR, 'web')
 
 # Format to use for time stamps
 TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S%z"
+
+# We use custom ssh runner while interacting with git
+#GIT_SSH_COMMAND = "/tmp/sshrun"  # was a little shell script to help troubleshooting
+GIT_SSH_COMMAND = "datalad sshrun"

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -315,7 +315,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 ['-c', 'remote.{0}.annex-ssh-options={1}{2}'
                        ''.format(remote_name,
                                  (cfg_string_old + " ") if cfg_string_old else "",
-                                 cfg_string)]
+                                 cfg_string
+                                 )]
 
     @property
     def dirty(self):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -72,6 +72,24 @@ def _get_system_git_version():
     return __get_git_version(_runner)
 
 
+def _get_system_ssh_version():
+    """Return version of ssh available system-wide
+
+    Annex prior 20170302 was using bundled version, but now would use system one
+    if installed
+    """
+    try:
+        out, err = _runner.run('ssh -V'.split())
+        # apparently spits out to err but I wouldn't trust it blindly
+        if err.startswith('OpenSSH'):
+            out = err
+        assert out.startswith('OpenSSH')  # that is the only one we care about atm
+        return out.split(' ', 1)[0].rstrip(',.').split('_')[1]
+    except CommandError as exc:
+        lgr.warn("Could not determine version of ssh available: %s", exc_str(exc))
+        return None
+
+
 class ExternalVersions(object):
     """Helper to figure out/use versions of the externals (modules, cmdline tools, etc).
 
@@ -92,6 +110,7 @@ class ExternalVersions(object):
         'cmd:annex': _get_annex_version,
         'cmd:git': _get_git_version,
         'cmd:system-git': _get_system_git_version,
+        'cmd:system-ssh': _get_system_ssh_version,
     }
 
     def __init__(self):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -42,6 +42,7 @@ from git.objects.blob import Blob
 
 from datalad import ssh_manager
 from datalad.cmd import Runner, GitRunner
+from datalad.consts import GIT_SSH_COMMAND
 from datalad.dochelpers import exc_str
 from datalad.config import ConfigManager
 from datalad.utils import assure_list
@@ -384,6 +385,9 @@ class GitRepo(RepoInterface):
     overridden accidentally by AnnexRepo.
     """
 
+    # We use our sshrun helper
+    GIT_SSH_ENV = {'GIT_SSH_COMMAND': GIT_SSH_COMMAND}
+
     # Just a non-functional example:
     # must be implemented, since abstract in RepoInterface:
     def sth_like_file_has_content(self):
@@ -597,7 +601,7 @@ class GitRepo(RepoInterface):
             ssh_manager.get_connection(url).open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
-            env = {'GIT_SSH_COMMAND': "datalad sshrun"}
+            env = GitRepo.GIT_SSH_ENV
         else:
             env = None
         ntries = 5  # 3 is not enough for robust workaround
@@ -1392,8 +1396,7 @@ class GitRepo(RepoInterface):
                 ssh_manager.get_connection(fetch_url).open()
                 # TODO: with git <= 2.3 keep old mechanism:
                 #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
-                with rm.repo.git.custom_environment(
-                        GIT_SSH_COMMAND="datalad sshrun"):
+                with rm.repo.git.custom_environment(**GitRepo.GIT_SSH_ENV):
                     fi_list += rm.fetch(refspec=refspec, progress=progress, **kwargs)
                     # TODO: progress +kwargs
             else:
@@ -1435,8 +1438,7 @@ class GitRepo(RepoInterface):
             ssh_manager.get_connection(fetch_url).open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with remote.repo.git.custom_environment(GIT_SSH="wrapper_script"):
-            with remote.repo.git.custom_environment(
-                    GIT_SSH_COMMAND="datalad sshrun"):
+            with remote.repo.git.custom_environment(**GitRepo.GIT_SSH_ENV):
                 return remote.pull(refspec=refspec, progress=progress, **kwargs)
                 # TODO: progress +kwargs
         else:
@@ -1518,8 +1520,7 @@ class GitRepo(RepoInterface):
                 ssh_manager.get_connection(push_url).open()
                 # TODO: with git <= 2.3 keep old mechanism:
                 #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
-                with rm.repo.git.custom_environment(
-                        GIT_SSH_COMMAND="datalad sshrun"):
+                with rm.repo.git.custom_environment(**GitRepo.GIT_SSH_ENV):
                     pi_list += rm.push(refspec=refspec, progress=progress, **kwargs)
                     # TODO: progress +kwargs
             else:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -165,7 +165,7 @@ class SSHConnection(object):
         cmd = ["ssh", "-O", "check"] + self._ctrl_options + [self.sshri.as_str()]
         lgr.debug("Checking %s by calling %s" % (self, cmd))
         try:
-            out, err = self.runner.run(cmd)
+            out, err = self.runner.run(cmd, stdin=open('/dev/null'))
             res = True
         except CommandError as e:
             if e.code != 255:
@@ -273,7 +273,9 @@ class SSHConnection(object):
         try:
             annex_install_dir = self(
                 # use sh -e to be able to fail at each stage of the process
-                "sh -e -c 'dirname $(readlink -f $(which git-annex-shell))'")[0].strip()
+                "sh -e -c 'dirname $(readlink -f $(which git-annex-shell))'"
+                , stdin=open('/dev/null')
+            )[0].strip()
         except CommandError as e:
             lgr.debug('Failed to locate remote git-annex installation: %s',
                       exc_str(e))

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -99,6 +99,7 @@ class SSHConnection(object):
 
         # essential properties of the remote system
         self._remote_props = {}
+        self._opened_by_us = False
 
     def __call__(self, cmd, stdin=None, log_output=True):
         """Executes a command on the remote.
@@ -118,18 +119,24 @@ class SSHConnection(object):
           stdout, stderr of the command run.
         """
 
+        # TODO:  do not do all those checks for every invocation!!
+        # TODO: check for annex location once, check for open socket once
+        #       and provide roll back if fails to run and was not explicitly
+        #       checked first
         if not self.is_open():
             if not self.open():
                 raise RuntimeError(
                     'Cannot open SSH connection to {}'.format(
                         self.sshri))
-            # locate annex and set the bundled vs. system Git machinery in motion
+
+        # locate annex and set the bundled vs. system Git machinery in motion
         remote_annex_installdir = self.get_annex_installdir()
         if remote_annex_installdir:
             # make sure to use the bundled git version if any exists
             cmd = '{}; {}'.format(
                 'export "PATH={}:$PATH"'.format(remote_annex_installdir),
                 cmd)
+
         # build SSH call, feed remote command as a single last argument
         # whatever it contains will go to the remote machine for execution
         # we cannot perform any sort of escaping, because it will limit
@@ -138,10 +145,11 @@ class SSHConnection(object):
         ssh_cmd += [self.sshri.as_str()] \
             + [cmd]
 
-        if log_output:
-            kwargs = dict(log_stdout=True, log_stderr=True, log_online=False)
-        else:
-            kwargs = dict(log_stdout=False, log_stderr=False, log_online=True)
+        kwargs = dict(
+            log_stdout=log_output, log_stderr=log_output,
+            log_online=not log_output
+        )
+
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True
         return self.runner.run(
@@ -159,7 +167,11 @@ class SSHConnection(object):
 
     def is_open(self):
         if not exists(self.ctrl_path):
-            lgr.log(5, "Not opening %s since %s exists" % (self, self.ctrl_path))
+            lgr.log(
+                5,
+                "Not opening %s for checking since %s does not exist",
+                self, self.ctrl_path
+            )
             return False
         # check whether controlmaster is still running:
         cmd = ["ssh", "-O", "check"] + self._ctrl_options + [self.sshri.as_str()]
@@ -188,7 +200,6 @@ class SSHConnection(object):
         bool
           Whether SSH reports success opening the connection
         """
-
         if self.is_open():
             return
 
@@ -214,19 +225,25 @@ class SSHConnection(object):
                 "Failed to run cmd %s. Exit code=%s\nstdout: %s\nstderr: %s",
                 cmd, exit_code, stdout, stderr
             )
+        else:
+            self._opened_by_us = True
         return ret
 
     def close(self):
         """Closes the connection.
         """
-
+        if not self._opened_by_us:
+            lgr.debug("Not closing %s since was not opened by itself", self)
+            return
         # stop controlmaster:
         cmd = ["ssh", "-O", "stop"] + self._ctrl_options + [self.sshri.as_str()]
         lgr.debug("Closing %s by calling %s", self, cmd)
         try:
             self.runner.run(cmd, expect_stderr=True, expect_fail=True)
         except CommandError as e:
+            lgr.debug("Failed to run close command")
             if exists(self.ctrl_path):
+                lgr.debug("Removing existing control path %s", self.ctrl_path)
                 # socket need to go in any case
                 remove(self.ctrl_path)
             if e.code != 255:
@@ -334,6 +351,9 @@ class SSHManager(object):
         self._prev_connections = [opj(self.socket_dir, p)
                                   for p in listdir(self.socket_dir)
                                   if not isdir(opj(self.socket_dir, p))]
+        lgr.log(5,
+                "Found %d previous connections",
+                len(self._prev_connections))
 
     @property
     def socket_dir(self):

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -56,6 +56,14 @@ class SSHRun(Interface):
     @staticmethod
     def __call__(login, cmd, port=None, no_stdin=False):
         lgr.debug("sshrun invoked: %r %r %r %r", login, cmd, port, no_stdin)
+        # Perspective workarounds for git-annex invocation, see
+        # https://github.com/datalad/datalad/issues/1456#issuecomment-292641319
+        
+        # if cmd.startswith("'") and cmd.endswith("'"):
+        #     cmd = cmd[1:-1]
+        # tripequote = """'"'"'"""
+        # if tripequote in cmd:
+        #     cmd = cmd.replace(tripequote, "'")
         sshurl = 'ssh://{}{}'.format(
             login,
             ':{}'.format(port) if port else '')

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -24,6 +24,8 @@ from datalad.interface.base import Interface
 
 from datalad import ssh_manager
 
+lgr = logging.getLogger('datalad.sshrun')
+
 
 class SSHRun(Interface):
     """Run command on remote machines via SSH.
@@ -53,9 +55,7 @@ class SSHRun(Interface):
 
     @staticmethod
     def __call__(login, cmd, port=None, no_stdin=False):
-        # when heavy debugging if needed
-        #with open('/tmp/log', 'a') as f:
-        #    f.write("call: %s %s %s %s\n" % (login, cmd, port, no_stdin))
+        lgr.debug("sshrun invoked: %r %r %r %r", login, cmd, port, no_stdin)
         sshurl = 'ssh://{}{}'.format(
             login,
             ':{}'.format(port) if port else '')

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -29,7 +29,7 @@ class SSHRun(Interface):
     """Run command on remote machines via SSH.
 
     This is a replacement for a small part of the functionality of SSH.
-    In addition to SSH alaon, this command can make use ofdatalad's SSH
+    In addition to SSH alone, this command can make use of datalad's SSH
     connection management. Its primary use case is to be used with Git
     as 'core.sshCommand' or via "GIT_SSH_COMMAND".
     """
@@ -44,14 +44,26 @@ class SSHRun(Interface):
         port=Parameter(
             args=("-p", '--port'),
             doc="port to connect to on the remote host"),
+        no_stdin=Parameter(
+            args=("-n",),
+            action="store_true",
+            dest="no_stdin",
+            doc="Redirect stdin from /dev/null"),
     )
 
     @staticmethod
-    def __call__(login, cmd, port=None):
+    def __call__(login, cmd, port=None, no_stdin=False):
+        # when heavy debugging if needed
+        #with open('/tmp/log', 'a') as f:
+        #    f.write("call: %s %s %s %s\n" % (login, cmd, port, no_stdin))
         sshurl = 'ssh://{}{}'.format(
             login,
             ':{}'.format(port) if port else '')
         ssh = ssh_manager.get_connection(sshurl)
-        out, err = ssh(cmd, stdin=sys.stdin, log_output=False)
+        # TODO: /dev/null on windows ;)  or may be could be just None?
+        out, err = ssh(
+            cmd,
+            stdin=open('/dev/null', 'r') if no_stdin else sys.stdin,
+            log_output=False)
         os.write(1, out.encode('UTF-8'))
         os.write(2, err.encode('UTF-8'))

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1018,6 +1018,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     else:
         ok_(not exists(socket_1))
 
+    from datalad import lgr
+    lgr.debug("HERE")
     # remote interaction causes socket to be created:
     try:
         # Note: For some reason, it hangs if log_stdout/err True

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -183,3 +183,19 @@ def test_list_tuple():
 
     for v in thing_with_list_version, thing_with_tuple_version, '0.1', (0, 1), [0, 1]:
         yield _test_list_tuple, v
+
+
+def test_system_ssh_version():
+    ev = ExternalVersions()
+    assert ev['cmd:system-ssh']  # usually we have some available at boxes we test
+
+    for s, v in [
+        ('OpenSSH_7.4p1 Debian-6, OpenSSL 1.0.2k  26 Jan 2017', '7.4p1'),
+    ]:
+        ev = ExternalVersions()
+        # TODO: figure out leaner way
+        class _runner(object):
+            def run(self, cmd):
+                return "", s
+        with patch('datalad.support.external_versions._runner', _runner()):
+            assert_equal(ev['cmd:system-ssh'], v)

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -46,3 +46,10 @@ def test_no_stdin_swallow(fname):
     out, err = Runner().run(cmd + ['-n'], stdin=open(fname))
     assert_equal(out, '')
 
+
+@skip_ssh
+@with_tempfile(suffix="1 space", content="magic")
+def test_fancy_quotes(f):
+    cmd = ['datalad', 'sshrun', 'localhost', """'cat '"'"'%s'"'"''""" % f]
+    out, err = Runner().run(cmd)
+    assert_equal(out, 'magic')

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -1,0 +1,48 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import sys
+from six.moves import StringIO
+from nose.tools import assert_raises, assert_equal
+
+from datalad.cmd import Runner
+from datalad.cmdline.main import main
+
+from datalad.tests.utils import skip_ssh
+from datalad.tests.utils import swallow_outputs
+from datalad.tests.utils import with_tempfile
+
+
+@skip_ssh
+def test_exit_code():
+    # will relay actual exit code on CommandError
+    cmd = ['sshrun', 'localhost', 'exit 42']
+    with assert_raises(SystemExit) as cme:
+        if isinstance(sys.stdout, StringIO):  # running nosetests without -s
+            with swallow_outputs():  # need to give smth with .fileno ;)
+                main(cmd)
+        else:
+            # to test both scenarios
+            main(cmd)
+    assert_equal(cme.exception.code, 42)
+
+
+@skip_ssh
+@with_tempfile(content="123magic")
+def test_no_stdin_swallow(fname):
+    # will relay actual exit code on CommandError
+    cmd = ['datalad', 'sshrun', 'localhost', 'cat']
+
+    out, err = Runner().run(cmd, stdin=open(fname))
+    assert_equal(out.rstrip(), '123magic')
+
+    # test with -n switch now, which we could place even at the end
+    out, err = Runner().run(cmd + ['-n'], stdin=open(fname))
+    assert_equal(out, '')
+

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -17,9 +17,6 @@ from nose.tools import assert_raises, assert_equal
 from .. import __main__, __version__
 from ..auto import AutomagicIO
 
-from datalad.tests.utils import skip_ssh
-from datalad.tests.utils import swallow_outputs
-from datalad.cmdline.main import main
 
 @patch('sys.stdout', new_callable=StringIO)
 def test_main_help(stdout):
@@ -43,16 +40,3 @@ def test_main_run_a_script(stdout, mock_activate):
     assert_equal(stdout.getvalue().rstrip(), "Running the script")
     # And we have "activated"
     mock_activate.assert_called_once_with()
-
-@skip_ssh
-def test_exit_code():
-    # will relay actual exit code on CommandError
-    cmd = ['sshrun', 'localhost', 'exit 42']
-    with assert_raises(SystemExit) as cme:
-        if isinstance(sys.stdout, StringIO):  # running nosetests without -s
-            with swallow_outputs():  # need to give smth with .fileno ;)
-                main(cmd)
-        else:
-            # to test both scenarios
-            main(cmd)
-    assert_equal(cme.exception.code, 42)


### PR DESCRIPTION
- [x] for the goodness of it -- report system version of ssh
- [x] `sshrun` now supports `-n`
- [x] more and improved (more consistent vars) logging of CMD execution. By default now would not add a new line with cwd to each run.  Use DATALAD_LOG_CMD_CWD variable
- [x] do not close SSHConnection if it wasn't opened by it
- [x] fixes #1458 in not passing stdin upon initial invocation of ssh command to some other check orwhatnot
- [x] yet to make it work with recent annex ;-)