### PR TITLE
BF: use example.com based urls in tests

### DIFF
--- a/datalad/distribution/tests/test_add_sibling.py
+++ b/datalad/distribution/tests/test_add_sibling.py
@@ -24,11 +24,16 @@ from nose.tools import eq_, ok_
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_add_sibling(origin, repo_path):
+
+    sshurl = "ssh://push-remote.example.com"
+    httpurl1 = "http://remote1.example.com/location"
+    httpurl2 = "http://remote2.example.com/location"
+
     # insufficient arguments
     # we need a dataset to work at
     with chpwd(repo_path):  # not yet there
         assert_raises(InsufficientArgumentsError,
-                      add_sibling, url="http://some.remo.te/location")
+                      add_sibling, url=httpurl1)
 
     # prepare src
     source = install(repo_path, source=origin, recursive=True)[0]
@@ -42,73 +47,74 @@ def test_add_sibling(origin, repo_path):
         add_sibling,
         dataset=source,
         name="test-remote",
-        url="http://some.remo.te/location",
+        url=httpurl1,
         publish_depends=['r1', 'r2'],
         force=True)
     # prior config was changed by failed call above
     eq_(source.config.get(depvar, None), 'stupid')
 
     res = add_sibling(dataset=source, name="test-remote",
-                      url="http://some.remo.te/location",
+                      url=httpurl1,
                       force=True)
 
     eq_(res, [basename(source.path)])
     assert_in("test-remote", source.repo.get_remotes())
-    eq_("http://some.remo.te/location",
+    eq_(httpurl1,
         source.repo.get_remote_url("test-remote"))
 
     # doing it again doesn't do anything
     res = add_sibling(dataset=source, name="test-remote",
-                      url="http://some.remo.te/location")
+                      url=httpurl1)
     eq_(res, [])
     assert_in("test-remote", source.repo.get_remotes())
-    eq_("http://some.remo.te/location",
+    eq_(httpurl1,
         source.repo.get_remote_url("test-remote"))
 
     # add to another remote automagically taking it from the url
     # and being in the dataset directory
     with chpwd(source.path):
-        res = add_sibling("http://some.remo.te2/location")
+        res = add_sibling(httpurl2)
     eq_(res, [basename(source.path)])
-    assert_in("some.remo.te2", source.repo.get_remotes())
+    assert_in("remote2.example.com", source.repo.get_remotes())
 
     # fail with conflicting url:
     with assert_raises(RuntimeError) as cm:
         add_sibling(dataset=source, name="test-remote",
-                    url="http://some.remo.te/location/elsewhere")
+                    url=httpurl1 + "/elsewhere")
     assert_in("""'test-remote' already exists with conflicting settings""",
               str(cm.exception))
 
     # don't fail with conflicting url, when using force:
     res = add_sibling(dataset=source, name="test-remote",
-                      url="http://some.remo.te/location/elsewhere", force=True)
+                      url=httpurl1 + "/elsewhere", force=True)
     eq_(res, [basename(source.path)])
-    eq_("http://some.remo.te/location/elsewhere",
+    eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
 
     # add a push url without force fails, since in a way the fetch url is the
     # configured push url, too, in that case:
     with assert_raises(RuntimeError) as cm:
         add_sibling(dataset=source, name="test-remote",
-                    url="http://some.remo.te/location/elsewhere",
-                    pushurl="ssh://push.it", force=False)
+                    url=httpurl1 + "/elsewhere",
+                    pushurl=sshurl, force=False)
     assert_in("""'test-remote' already exists with conflicting settings""",
               str(cm.exception))
 
     # add push url (force):
     res = add_sibling(dataset=source, name="test-remote",
-                      url="http://some.remo.te/location/elsewhere",
-                      pushurl="ssh://push.it", force=True)
+                      url=httpurl1 + "/elsewhere",
+                      pushurl=sshurl, force=True)
     eq_(res, [basename(source.path)])
-    eq_("http://some.remo.te/location/elsewhere",
+    eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
-    eq_("ssh://push.it",
+    eq_(sshurl,
         source.repo.get_remote_url("test-remote", push=True))
 
     # recursively:
     res = add_sibling(dataset=source, name="test-remote",
-                      url="http://some.remo.te/location/%NAME",
-                      pushurl="ssh://push.it/%NAME", recursive=True,
+                      url=httpurl1 + "/%NAME",
+                      pushurl=sshurl + "/%NAME",
+                      recursive=True,
                       force=True)
 
     eq_(set(res), {basename(source.path),
@@ -120,15 +126,15 @@ def test_add_sibling(origin, repo_path):
         assert_in("test-remote", repo.get_remotes())
         url = repo.get_remote_url("test-remote")
         pushurl = repo.get_remote_url("test-remote", push=True)
-        ok_(url.startswith("http://some.remo.te/location/" + basename(source.path)))
+        ok_(url.startswith(httpurl1 + '/' + basename(source.path)))
         ok_(url.endswith(basename(repo.path)))
-        ok_(pushurl.startswith("ssh://push.it/" + basename(source.path)))
+        ok_(pushurl.startswith(sshurl + '/' + basename(source.path)))
         ok_(pushurl.endswith(basename(repo.path)))
 
     # recursively without template:
     res = add_sibling(dataset=source, name="test-remote-2",
-                      url="http://some.remo.te/location",
-                      pushurl="ssh://push.it/",
+                      url=httpurl1,
+                      pushurl=sshurl,
                       recursive=True,
                       force=True)
     eq_(set(res), {basename(source.path),
@@ -141,8 +147,8 @@ def test_add_sibling(origin, repo_path):
         assert_in("test-remote-2", repo.get_remotes())
         url = repo.get_remote_url("test-remote-2")
         pushurl = repo.get_remote_url("test-remote-2", push=True)
-        ok_(url.startswith("http://some.remo.te/location"))
-        ok_(pushurl.startswith("ssh://push.it/"))
+        ok_(url.startswith(httpurl1))
+        ok_(pushurl.startswith(sshurl))
         if repo != source.repo:
             ok_(url.endswith('/' + basename(repo.path)))
             ok_(pushurl.endswith(basename(repo.path)))


### PR DESCRIPTION
Saw
```
datalad.distribution.tests.test_add_sibling.test_add_sibling ... The authenticity of host 'push.it (151.80.116.111)' can't be established.
RSA key fingerprint is SHA256:216WuUohcUHLAXzVSUNM9LBIXc5pkITuxU2l6KMBufM.
Are you sure you want to continue connecting (yes/no)? 
```

which felt not right ;)