### PR TITLE
BF: to get master testable again

### DIFF
--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -15,6 +15,7 @@ from ....dochelpers import exc_str
 from ....tests.utils import assert_true, assert_raises, assert_false
 from ....tests.utils import SkipTest
 from ....tests.utils import with_tempfile, skip_if_no_network, use_cassette
+from ....tests.utils import skip_if_url_is_not_available
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
 from datalad.crawler.pipelines.fcptable import *
 from datalad.crawler.pipeline import run_pipeline
@@ -26,6 +27,7 @@ lgr = getLogger('datalad.crawl.tests')
 
 from ..fcptable import pipeline, superdataset_pipeline
 
+TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']
@@ -36,7 +38,6 @@ def test_smoke_pipelines():
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 def _test_dataset(dataset, error, create, skip, tmpdir):
-    TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
     with chpwd(tmpdir):
 
@@ -78,6 +79,7 @@ def _test_dataset(dataset, error, create, skip, tmpdir):
 
 
 def test_dataset():
+    skip_if_url_is_not_available(TOPURL, regex='service provider outage')
     yield _test_dataset, 'Baltimore', None, False, False
     yield _test_dataset, 'AnnArbor_b', None, False, False
     yield _test_dataset, 'Ontario', None, False, False

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -81,6 +81,19 @@ def skip_if_scrapy_without_selector():
             % getattr(scrapy, '__version__'))
 
 
+def skip_if_url_is_not_available(url, regex=None):
+    # verify that dataset is available
+    from datalad.downloaders.providers import Providers
+    from datalad.downloaders.base import DownloadError
+    providers = Providers.from_config_files()
+    try:
+        content = providers.fetch(url)
+        if regex and re.search(regex, content):
+            raise SkipTest("%s matched %r -- skipping the test" % (url, regex))
+    except DownloadError:
+        raise SkipTest("%s failed to download" % url)
+
+
 def create_tree_archive(path, name, load, overwrite=False, archives_leading_dir=True):
     """Given an archive `name`, create under `path` with specified `load` tree
     """

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ requires.update({
     ],
     'devel-utils': [
         'nose-timer',
-        'line-profiler',
+        # disable for now, as it pulls in ipython 6, which is PY3 only
+        #'line-profiler',
         # necessary for accessing SecretStorage keyring (system wide Gnome
         # keyring)  but not installable on travis, IIRC since it needs connectivity
         # to the dbus whenever installed or smth like that, thus disabled here


### PR DESCRIPTION
- [x] disable `line-profiler` in setup.py to avoid pulling ipython 6.x not compatible with python < 3.4

