### PR TITLE
PR#1485 reborn against master, plus more fixes

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -77,7 +77,7 @@ def _generate_func_api():
             # TODO: BEGIN to be removed, when @build_doc is applied everywhere
             spec = getattr(intf, '_params_', dict())
             api_name = get_api_name(intfspec)
-            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'get', 'clone', 'subdatasets', 'install', 'add'):
+            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'remove', 'get', 'clone', 'subdatasets', 'install', 'add'):
                 # FIXME no longer using an interface class instance
                 # convert the parameter SPEC into a docstring for the function
                 update_docstring_with_parameters(

--- a/datalad/api.py
+++ b/datalad/api.py
@@ -77,7 +77,7 @@ def _generate_func_api():
             # TODO: BEGIN to be removed, when @build_doc is applied everywhere
             spec = getattr(intf, '_params_', dict())
             api_name = get_api_name(intfspec)
-            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'get', 'clone', 'subdatasets', 'install'):
+            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'get', 'clone', 'subdatasets', 'install', 'add'):
                 # FIXME no longer using an interface class instance
                 # convert the parameter SPEC into a docstring for the function
                 update_docstring_with_parameters(

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -108,13 +108,16 @@ def setup_parser(
         variables in the process environment.""")
     parser.add_argument(
         '--output-format', dest='common_output_format',
-        choices=['default', 'json', 'tailored'],
         default='default',
+        metavar="{default,json,tailored,'<template>'",
         help="""select format for returned command results. 'default' give one line
         per result reporting action, status, path and an optional message;
         'json' renders a JSON object with all properties for each result (one per 
         line); 'tailored' enables a command-specific rendering style that is typically
-        tailored to human consumption (no result output otherwise).""")
+        tailored to human consumption (no result output otherwise),
+        '<template>' reports any value(s) of any result properties in any format
+        indicated by the template (e.g. '{path}', compare with JSON
+        output for all key-value choices).""")
     parser.add_argument(
         '--report-status', dest='common_report_status',
         choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -168,12 +168,8 @@ class initiate_dataset(object):
             # place hack from 'add-to-super' times here
             sds = ds.get_superdataset()
             if sds is not None:
-                # TODO this should use the `add` command and not this helper
-                from datalad.distribution.add import _install_subds_inplace
-                subdsrelpath = relpath(realpath(ds.path), realpath(sds.path))  # realpath OK
-                lgr.debug("Adding %s as a subdataset to %s", subdsrelpath, sds)
-                _install_subds_inplace(ds=sds, path=ds.path,
-                                       relativepath=subdsrelpath)
+                lgr.debug("Adding %s as a subdataset to %s", ds, sds)
+                sds.add(ds.path, save=False)
                 # this leaves the subdataset staged in the parent
             elif str(self.add_to_super) != 'auto':
                 raise ValueError(

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -26,8 +26,13 @@ from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_add_opts
 from datalad.interface.common_opts import jobs_opt
+from datalad.interface.results import get_status_dict
+from datalad.interface.results import results_from_paths
+from datalad.interface.results import annexjson2result
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import _discover_trace_to_known
+from datalad.interface.utils import eval_results
+from datalad.interface.utils import build_doc
 from datalad.distribution.utils import _fixup_submodule_dotgit_setup
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
@@ -35,6 +40,7 @@ from datalad.support.param import Parameter
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.exceptions import CommandError
 
 from .dataset import EnsureDataset
 from .dataset import datasetmethod
@@ -44,14 +50,6 @@ from .dataset import Dataset
 __docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.distribution.add')
-
-
-def _install_subds_inplace(ds, path, relativepath, name=None, url=None):
-    """Register an existing repository in the repo tree as a submodule"""
-    ds.repo.add_submodule(relativepath, url=url, name=name)
-    _fixup_submodule_dotgit_setup(ds, relativepath)
-    # return newly added submodule as a dataset
-    return Dataset(path)
 
 
 def _discover_subdatasets_recursively(top, trace, spec, recursion_limit):
@@ -78,6 +76,7 @@ def _discover_subdatasets_recursively(top, trace, spec, recursion_limit):
         _discover_subdatasets_recursively(path, trace, spec, recursion_limit)
 
 
+@build_doc
 class Add(Interface):
     """Add files/directories to an existing dataset.
 
@@ -148,6 +147,7 @@ class Add(Interface):
 
     @staticmethod
     @datasetmethod(name='add')
+    @eval_results
     def __call__(
             path=None,
             dataset=None,
@@ -172,9 +172,15 @@ class Add(Interface):
             path=path,
             dataset=dataset,
             recursive=False)
-        if unavailable_paths:
-            lgr.warning("ignoring non-existent path(s): %s",
-                        unavailable_paths)
+        refds_path = dataset.path if isinstance(dataset, Dataset) else dataset
+        common_report = dict(action='add', logger=lgr, refds=refds_path)
+        # we cannot possibly `add` these
+        for r in results_from_paths(
+                unavailable_paths, status='impossible',
+                message="path does not exist: %s",
+                **common_report):
+            yield r
+
         if recursive:
             # with --recursive for each input path traverse the directory
             # tree, when we find a dataset, add it to the spec, AND add it as
@@ -182,6 +188,7 @@ class Add(Interface):
             # MIH: wrap in list() to avoid exception, because dict size might
             # change, but we want to loop over all that are in at the start
             # only
+            # NOTE no results are generated in this loop, just discovery
             for d in list(content_by_ds.keys()):
                 for p in content_by_ds[d]:
                     _discover_subdatasets_recursively(
@@ -191,8 +198,9 @@ class Add(Interface):
                         recursion_limit)
 
         if not content_by_ds:
-            raise InsufficientArgumentsError(
-                "non-existing paths given to add")
+            # we should have complained about any inappropriate path argument
+            # above, so if nothing is left, we can simply exit
+            return
 
         if dataset:
             # remeber the datasets associated with actual inputs
@@ -209,7 +217,7 @@ class Add(Interface):
                 # saving any staged content in the final step
                 content_by_ds = {d: v for d, v in content_by_ds.items() if v}
 
-        results = []
+        save_needed = False
         # simple loop over datasets -- save happens later
         # start deep down
         for ds_path in sorted(content_by_ds, reverse=True):
@@ -228,24 +236,30 @@ class Add(Interface):
                 # to operate on it otherwise, or we would get a bastard
                 # submodule that cripples git operations
                 if not subds.repo.get_hexsha():
-                    # TODO generator: tuen into 'impossible' result
-                    lgr.warn('Ignoring subdataset %s with no commits', subds)
+                    yield get_status_dict(
+                        ds=subds, status='impossible',
+                        message='cannot add subdataset with no commits',
+                        **common_report)
                     continue
+                subds_relpath = relpath(subds_path, ds_path)
                 # make an attempt to configure a submodule source URL based on the
                 # discovered remote configuration
                 remote, branch = subds.repo.get_tracking_branch()
                 subds_url = subds.repo.get_remote_url(remote) if remote else None
-                _install_subds_inplace(
-                    ds=ds,
-                    path=subds_path,
-                    relativepath=relpath(subds_path, ds_path),
-                    url=subds_url)
+                # Register the repository in the repo tree as a submodule
+                try:
+                    ds.repo.add_submodule(subds_relpath, url=subds_url, name=None)
+                except CommandError as e:
+                    yield get_status_dict(
+                        ds=subds, status='error', message=e.stderr,
+                        **common_report)
+                    continue
+                _fixup_submodule_dotgit_setup(ds, subds_relpath)
+                # report added subdatasets -- `annex add` below won't do it
+                yield get_status_dict(ds=subds, status='ok', **common_report)
                 # make sure that .gitmodules is added to the list of files
                 toadd.append(opj(ds.path, '.gitmodules'))
-                # report added subdatasets -- add below won't do it
-                results.append({
-                    'success': True,
-                    'file': Dataset(subds_path)})
+                save_needed = save
             # make sure any last minute additions make it to the saving stage
             # XXX? should content_by_ds become OrderedDict so that possible
             # super here gets processed last?
@@ -255,40 +269,19 @@ class Add(Interface):
                 git=to_git if isinstance(ds.repo, AnnexRepo) else True,
                 commit=False)
             for a in added:
-                a['file'] = opj(ds_path, a['file'])
-            results.extend(added)
+                if a['file'] == '.gitmodules':
+                    # filter out .gitmodules, because this is only included for
+                    # technical reasons and has nothing to do with the actual content
+                    continue
+                yield annexjson2result(a, ds, type_='file', **common_report)
+                save_needed = save
 
-        if results and save:
-            # TODO GENERATOR
+        if save_needed:
             # new returns a generator and yields status dicts
             # pass through as embedded results
             # OPT: tries to save even unrelated stuff
-            list(save_dataset_hierarchy(
-                content_by_ds,
-                base=dataset.path if dataset and dataset.is_installed() else None,
-                message=message if message else '[DATALAD] added content'))
-
-        return results
-
-    @staticmethod
-    def result_renderer_cmdline(res, args):
-        from datalad.ui import ui
-        from os import linesep
-        if res is None:
-            res = []
-        if not isinstance(res, list):
-            res = [res]
-        if not len(res):
-            ui.message("Nothing was added{}".format(
-                       '' if args.recursive else
-                       " (consider --recursive if that is unexpected)"))
-            return
-
-        msg = linesep.join([
-            "{suc} {path}".format(
-                suc="Added" if item.get('success', False)
-                    else "Failed to add. (%s)" % item.get('note',
-                                                          'unknown reason'),
-                path=item.get('file'))
-            for item in res])
-        ui.message(msg)
+            for res in save_dataset_hierarchy(
+                    content_by_ds,
+                    base=dataset.path if dataset and dataset.is_installed() else None,
+                    message=message if message else '[DATALAD] added content'):
+                yield res

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -290,7 +290,13 @@ class Create(Interface):
         if save and dataset is not None and dataset.path != tbds.path:
             # we created a dataset in another dataset
             # -> make submodule
-            dataset.add(tbds.path, save=save, ds2super=True)
+            for r in dataset.add(
+                    tbds.path, save=save, ds2super=True,
+                    return_type='generator',
+                    result_filter=None,
+                    result_xfm=None,
+                    on_failure='ignore'):
+                yield r
 
         yield get_status_dict(
             action='create',

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -55,12 +55,12 @@ check_argument = Parameter(
 res_kwargs = dict(action='drop', logger=lgr)
 
 
-def _drop_files(ds, files, check):
+def _drop_files(ds, files, check, noannex_iserror=True):
     if not hasattr(ds.repo, 'drop'):
         msg = 'no annex in dataset'
         for f in files:
             yield get_status_dict(
-                status='impossible',
+                status='impossible' if noannex_iserror else 'notneeded',
                 path=f if isabs(f) else normpath(opj(ds.path, f)),
                 message=msg, **res_kwargs)
         return

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -15,12 +15,14 @@ __docformat__ = 'restructuredtext'
 import logging
 
 from os.path import join as opj
+from os.path import isabs
+from os.path import normpath
+
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone
 from datalad.distribution.dataset import Dataset, EnsureDataset, \
     datasetmethod
 from datalad.interface.base import Interface
-from datalad.interface.base import report_result_objects
 from datalad.interface.common_opts import if_dirty_opt
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
@@ -58,7 +60,9 @@ def _drop_files(ds, files, check):
         msg = 'no annex in dataset'
         for f in files:
             yield get_status_dict(
-                status='impossible', path=f, message=msg, **res_kwargs)
+                status='impossible',
+                path=f if isabs(f) else normpath(opj(ds.path, f)),
+                message=msg, **res_kwargs)
         return
 
     opts = ['--force'] if not check else []

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -467,11 +467,13 @@ class Get(Interface):
 
         # explore the unknown
         for path in sorted(unavailable_paths):
+            lgr.debug("Investigate non-existing path %s", path)
             # how close can we get?
             dspath = get_dataset_root(path)
             if dspath is None:
                 # nothing we can do for this path
                 continue
+            lgr.debug("Found containing dataset %s for path %s", dspath, path)
             ds = Dataset(dspath)
             # now actually obtain whatever is necessary to get to this path
             containing_ds = ds

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -594,6 +594,7 @@ class Get(Interface):
             for r in results_from_annex_noinfo(
                     ds, content, respath_by_status,
                     dir_fail_msg='could not get some content in %s %s',
+                    noinfo_dir_msg='nothing to get from %s',
                     noinfo_file_msg='%s is already present',
                     action='get',
                     logger=lgr,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -16,8 +16,6 @@ from os import curdir
 from os.path import isdir
 from os.path import join as opj
 from os.path import relpath
-from os.path import normpath
-from os.path import isabs
 
 from six.moves.urllib.parse import quote as urlquote
 
@@ -30,6 +28,8 @@ from datalad.interface.results import results_from_paths
 from datalad.interface.results import YieldDatasets
 from datalad.interface.results import annexjson2result
 from datalad.interface.results import count_results
+from datalad.interface.results import success_status_map
+from datalad.interface.results import results_from_annex_noinfo
 from datalad.interface.common_opts import recursion_flag
 # from datalad.interface.common_opts import git_opts
 # from datalad.interface.common_opts import annex_opts
@@ -565,12 +565,6 @@ class Get(Interface):
             # done already
             return
 
-        status_map = {
-            'ok': 'success',
-            'notneeded': 'success',
-            'impossible': 'failure',
-            'error': 'failure',
-        }
         # hand over to git-annex, get files content,
         # repo files in git as 'notneeded' to get
         for ds_path in sorted(content_by_ds.keys()):
@@ -592,55 +586,19 @@ class Get(Interface):
                     jobs=jobs):
                 res = annexjson2result(res, ds, type_='file', logger=lgr,
                                        refds=refds_path)
-                respath_by_status[status_map[res['status']]] = res['path']
+                success = success_status_map[res['status']]
+                respath_by_status[success] = \
+                    respath_by_status.get(success, []) + [res['path']]
                 yield res
-            # the following result reporting assume that low-level
-            # code causes some form of error (exception or result)
-            # to surface in case anything goes wrong in `annex get`
-            while content:
-                p = content.pop()
-                common_report = dict(
+
+            for r in results_from_annex_noinfo(
+                    ds, content, respath_by_status,
+                    dir_fail_msg='could not get some content in %s %s',
+                    noinfo_file_msg='%s is already present',
                     action='get',
-                    # any relpath is relative to the currently processed dataset
-                    # not the global reference dataset
-                    path=p if isabs(p) else normpath(opj(ds.path, p)),
                     logger=lgr,
-                    refds=refds_path)
-                if isdir(p):
-                    # `annex get` will never report on directories, but if a
-                    # directory was requested, we want to say something about
-                    # it in the results.  we are inside a single, existing
-                    # repo, hence all directories are already present, if not
-                    # we had an error
-                    # do we have any failures in a subdir of the requested dir?
-                    failure_results = [
-                        fp for fp in respath_by_status.get('failure', [])
-                        if fp.startswith(_with_sep(p))]
-                    if failure_results:
-                        # we were not able to obtain all content, let's label
-                        # this 'impossible' to get a warning-type report
-                        # after all we have the directory itself, but not
-                        # (some) of its content
-                        yield get_status_dict(
-                            status='impossible', type_='directory',
-                            message=('could not get some content in %s %s',
-                                     p, failure_results), **common_report)
-                    else:
-                        # otherwise cool
-                        yield get_status_dict(
-                            status='ok', type_='directory', **common_report)
-                    continue
-                elif not any(p in ps for ps in respath_by_status.values()):
-                    # not a directory, and we have had no word from `git annex`,
-                    # yet no exception, hence the file was most probably
-                    # already present, or is in Git -> not needed
-                    yield get_status_dict(
-                        status='notneeded', type_='file',
-                        message=('%s is already present', p), **common_report)
-                else:
-                    # not a case we want to report beyond what we got from
-                    # `git annex`
-                    pass
+                    refds=refds_path):
+                yield r
 
     @staticmethod
     def custom_result_summary_renderer(res):

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -123,7 +123,6 @@ def test_add_recursive(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
     subds = ds.create('dir', force=True)
-    ds.save("Submodule added.")
     ok_(subds.repo.dirty)
 
     # no subds without recursive:
@@ -143,6 +142,7 @@ def test_add_recursive(path):
         annexkey='MD5E-s9--3f0f870d18d6ba60a79d9463ff3827ea',
         status='ok')
     assert_in('testindir', Dataset(opj(path, 'dir')).repo.get_annexed_files())
+    ok_(subds.repo.dirty)
 
     added2 = ds.add('dir', to_git=True)
     # added to git, so parsed git output record
@@ -152,6 +152,7 @@ def test_add_recursive(path):
         message='non-large file; adding content to git repository',
         status='ok')
     assert_in('testindir2', Dataset(opj(path, 'dir')).repo.get_indexed_files())
+    ok_clean_git(ds.path)
 
     # We used to fail to add to pure git repository, but now it should all be
     # just fine

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -14,11 +14,8 @@ from os.path import join as opj
 
 from ..dataset import Dataset
 from datalad.api import create
-from datalad.api import uninstall
 from datalad.utils import chpwd
-from datalad.utils import rmtree
 from datalad.cmd import Runner
-from datalad.support.exceptions import CommandError
 
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import eq_
@@ -28,6 +25,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_equal
 from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tree
 
@@ -187,7 +185,11 @@ def test_nested_create(path):
     assert_raises(ValueError, ds.create, lvl2relpath)
     # even with force, as to do this properly complicated surgery would need to
     # take place
-    assert_raises(CommandError, ds.create, lvl2relpath, force=True)
+    assert_in_results(
+        ds.create(lvl2relpath, force=True,
+                  on_failure='ignore', result_xfm=None, result_filter=None,
+                  return_type='generator'),
+        status='error', action='add')
     # only way to make it work is to unannex the content upfront
     ds.repo._run_annex_command('unannex', annex_options=[opj(lvl2relpath, 'file')])
     # nothing to save, git-annex commits the unannex itself

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -279,10 +279,10 @@ def test_remove_file_handle_only(path):
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
-    # we add one file
-    assert_result_count(
-        subds.add('.'), 1,
-        action='add', status='ok')
+    # we add one file, but we get a response for the requested
+    # directory too
+    assert_result_count(subds.add('.'), 2,
+                        action='add', status='ok')
     # save all -> all clean
     ds.save(all_updated=True, recursive=True)
     ok_clean_git(subds.path)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -31,6 +31,7 @@ from datalad.tests.utils import SkipTest
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
@@ -279,7 +280,9 @@ def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
     # we add one file
-    eq_(len(subds.add('.')), 1)
+    assert_result_count(
+        subds.add('.'), 1,
+        action='add', status='ok')
     # save all -> all clean
     ds.save(all_updated=True, recursive=True)
     ok_clean_git(subds.path)

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -42,7 +42,7 @@ res_kwargs = dict(action='uninstall', logger=lgr)
 
 def _uninstall_dataset(ds, check, has_super):
     if check and ds.is_installed():
-        for r in _drop_files(ds, curdir, check=True):
+        for r in _drop_files(ds, curdir, check=True, noannex_iserror=False):
             yield r
     # TODO: uninstall of a subdataset that has a local URL
     #       (e.g. ./anything) implies cannot be undone, decide how, and

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -22,11 +22,9 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import DataLadRI
 from datalad.support.network import URL
 from datalad.support.network import RI
-from datalad.support.network import SSHRI
 from datalad.support.network import PathRI
 from datalad.utils import knows_annex
 
-from .dataset import Dataset
 
 lgr = logging.getLogger('datalad.distribution.utils')
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -320,6 +320,10 @@ class Interface(object):
             kwargs['return_type'] = 'generator'
             kwargs['result_xfm'] = None
             kwargs['result_renderer'] = args.common_output_format
+            if '{' in args.common_output_format:
+                # stupid hack, could and should become more powerful
+                kwargs['result_renderer'] = \
+                    lambda x, **kwargs: print(args.common_output_format.format(**x))
             if args.common_on_failure:
                 kwargs['on_failure'] = args.common_on_failure
             # compose filter function from to be invented cmdline options

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -323,7 +323,7 @@ class Interface(object):
             if '{' in args.common_output_format:
                 # stupid hack, could and should become more powerful
                 kwargs['result_renderer'] = \
-                    lambda x, **kwargs: print(args.common_output_format.format(**x))
+                    lambda x, **kwargs: ui.message(args.common_output_format.format(**x))
             if args.common_on_failure:
                 kwargs['on_failure'] = args.common_on_failure
             # compose filter function from to be invented cmdline options

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -18,7 +18,6 @@ lgr = logging.getLogger('datalad.interface.base')
 import sys
 import re
 import textwrap
-from os.path import curdir
 import inspect
 from collections import OrderedDict
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -314,7 +314,7 @@ class Interface(object):
         # let it run like generator so we can act on partial results quicker
         # TODO remove following condition test when transition is complete and
         # run indented code unconditionally
-        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Get', 'Clone', 'Subdatasets', 'Install'):
+        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Get', 'Clone', 'Subdatasets', 'Install', 'Add'):
             # set all common args explicitly  to override class defaults
             # that are tailored towards the the Python API
             kwargs['return_type'] = 'generator'

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -314,7 +314,7 @@ class Interface(object):
         # let it run like generator so we can act on partial results quicker
         # TODO remove following condition test when transition is complete and
         # run indented code unconditionally
-        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Get', 'Clone', 'Subdatasets', 'Install', 'Add'):
+        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Remove', 'Get', 'Clone', 'Subdatasets', 'Install', 'Add'):
             # set all common args explicitly  to override class defaults
             # that are tailored towards the the Python API
             kwargs['return_type'] = 'generator'

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -299,8 +299,7 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
     **kwargs
       Any further kwargs are included in the yielded result dictionary.
     """
-    while requested_paths:
-        p = requested_paths.pop()
+    for p in requested_paths:
         # any relpath is relative to the currently processed dataset
         # not the global reference dataset
         p = p if isabs(p) else normpath(opj(ds.path, p))

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -194,6 +194,8 @@ def annexjson2result(d, ds, **kwargs):
         res['action'] = d['command']
     if 'key' in d:
         res['annexkey'] = d['key']
+    if 'note' in d:
+        res['message'] = d['note']
     return res
 
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -14,15 +14,27 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
+from os.path import isdir
+from os.path import isabs
 from os.path import join as opj
 from os.path import relpath
 from os.path import abspath
+from os.path import normpath
 from datalad.utils import assure_list
+from datalad.utils import with_pathsep as _with_sep
 from datalad.distribution.dataset import Dataset
 
 
 lgr = logging.getLogger('datalad.interface.results')
 
+
+# which status is a success , which is failure
+success_status_map = {
+    'ok': 'success',
+    'notneeded': 'success',
+    'impossible': 'failure',
+    'error': 'failure',
+}
 
 def get_status_dict(action=None, ds=None, path=None, type_=None, logger=None,
                     refds=None, status=None, message=None, **kwargs):
@@ -194,7 +206,8 @@ def annexjson2result(d, ds, **kwargs):
         res['action'] = d['command']
     if 'key' in d:
         res['annexkey'] = d['key']
-    if 'note' in d:
+    # avoid meaningless standard message
+    if 'note' in d and d['note'] != 'checksum...':
         res['message'] = d['note']
     return res
 
@@ -248,3 +261,81 @@ def is_result_matching_pathsource_argument(res, **kwargs):
         return True
     else:
         False
+
+
+def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_msg, noinfo_file_msg, **kwargs):
+    """Helper to yield results based on what information git annex did no give us.
+
+    The helper assumes that the annex command returned without an error code,
+    and interprets which of the requested paths we have heard nothing about,
+    and assumes that git annex was happy with their current state.
+
+    Parameters
+    ==========
+    ds : Dataset
+      All results have to be concerning this single dataset (used to resolve
+      relpaths).
+    requested_paths : list
+      List of path arguments sent to `git annex`
+    respath_by_status : dict
+      Mapping of 'success' or 'failure' labels to lists of result paths
+      reported by `git annex`. Everything that is not in here, we assume
+      that `git annex` was happy about.
+    dir_fail_msg : str
+      Message template to inject into the result for a requested directory where
+      a failure was reported for some of its content. The template contains two
+      string placeholders that will be expanded with 1) the path of the
+      directory, and 2) the content failure paths for that directory
+    noinfo_file_msg : str
+      Message template to inject into the result for a requested file that `git
+      annex` was silent about. There must be one string placeholder that is
+      expanded with the path of that file.
+    **kwargs
+      Any further kwargs are included in the yielded result dictionary.
+    """
+    while requested_paths:
+        p = requested_paths.pop()
+        # any relpath is relative to the currently processed dataset
+        # not the global reference dataset
+        p = p if isabs(p) else normpath(opj(ds.path, p))
+        common_report = dict(path=p, **kwargs)
+        if isdir(p):
+            # `annex` will never report on directories, but if a
+            # directory was requested, we want to say something about
+            # it in the results.  we are inside a single, existing
+            # repo, hence all directories are already present, if not
+            # we had an error
+            # do we have any failures in a subdir of the requested dir?
+            failure_results = [
+                fp for fp in respath_by_status.get('failure', [])
+                if fp.startswith(_with_sep(p))]
+            if failure_results:
+                # we were not able to process all requested_paths, let's label
+                # this 'impossible' to get a warning-type report
+                # after all we have the directory itself, but not
+                # (some) of its requested_paths
+                yield get_status_dict(
+                    status='impossible', type_='directory',
+                    message=(dir_fail_msg, p, failure_results),
+                    **common_report)
+            else:
+                # otherwise cool, but how cool?
+                success_results = [
+                    fp for fp in respath_by_status.get('success', [])
+                    if fp.startswith(_with_sep(p))]
+                yield get_status_dict(
+                    status='ok' if success_results else 'notneeded',
+                    type_='directory', **common_report)
+            continue
+        elif not any(p in ps for ps in respath_by_status.values()):
+            # not a directory, and we have had no word from `git annex`,
+            # yet no exception, hence the file was most probably
+            # already in the desired state
+            yield get_status_dict(
+                status='notneeded', type_='file',
+                message=(noinfo_file_msg, p),
+                **common_report)
+        else:
+            # not a case we want to report beyond what we got from
+            # `git annex`
+            pass

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -36,6 +36,7 @@ success_status_map = {
     'error': 'failure',
 }
 
+
 def get_status_dict(action=None, ds=None, path=None, type_=None, logger=None,
                     refds=None, status=None, message=None, **kwargs):
     """Helper to create a result dictionary.

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -109,8 +109,8 @@ def test_recursive_save(path):
     ok_clean_git(ds.path)
     subsubds = subds.create('subsub')
     assert_equal(
-        ds.get_subdatasets(recursive=True, absolute=True, fulfilled=True),
-        [subsubds.path, subds.path])
+        ds.subdatasets(recursive=True, fulfilled=True, result_xfm='paths'),
+        [subds.path, subsubds.path])
     newfile_name = opj(subsubds.path, 'test')
     with open(newfile_name, 'w') as f:
         f.write('some')

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -27,7 +27,6 @@ from datalad.utils import swallow_logs
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import EnsureDataset
-from datalad.distribution.add import _install_subds_inplace
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -349,7 +349,7 @@ class Test_Utils(Interface):
         for i in range(number):
             # this dict will need to have the minimum info required by
             # eval_results
-            yield {'path': 'some', 'status': 'ok', 'somekey': i}
+            yield {'path': 'some', 'status': 'ok', 'somekey': i, 'action': 'off'}
 
 
 def test_eval_results_plus_build_doc():
@@ -419,7 +419,7 @@ def test_result_filter():
             Test_Utils().__call__(
                 4,
                 result_filter=filt)[-1],
-            {'path': 'some', 'status': 'ok', 'somekey': 2})
+            {'action': 'off', 'path': 'some', 'status': 'ok', 'somekey': 2})
 
     # test more sophisticated filters that actually get to see the
     # API call's kwargs

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -60,6 +60,8 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureCallable
 from datalad.support.param import Parameter
 
+from datalad.ui import ui
+
 from .base import Interface
 from .base import update_docstring_with_parameters
 from .base import alter_interface_docs_for_api
@@ -1039,7 +1041,7 @@ def eval_results(func):
                 ## output rendering
                 if result_renderer == 'default':
                     # TODO have a helper that can expand a result message
-                    print('{action}({status}): {path}{type}{msg}'.format(
+                    ui.message('{action}({status}): {path}{type}{msg}'.format(
                         action=res['action'],
                         status=res['status'],
                         path=relpath(res['path'],
@@ -1050,7 +1052,7 @@ def eval_results(func):
                             if isinstance(res['message'], tuple) else res['message'])
                         if 'message' in res else ''))
                 elif result_renderer == 'json':
-                    print(json.dumps(
+                    ui.message(json.dumps(
                         {k: v for k, v in res.items()
                          if k not in ('message', 'logger')},
                         sort_keys=True))
@@ -1069,7 +1071,7 @@ def eval_results(func):
                     sum(sum(s.values()) for s in action_summary.values()) > 1:
                 # give a summary in default mode, when there was more than one
                 # action performed
-                print("Action summary:\n  {}".format(
+                ui.message("action summary:\n  {}".format(
                     '\n  '.join('{} ({})'.format(
                         act,
                         ', '.join('{}: {}'.format(status, action_summary[act][status])

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -1039,11 +1039,12 @@ def eval_results(func):
                 ## output rendering
                 if result_renderer == 'default':
                     # TODO have a helper that can expand a result message
-                    print('{action}({status}): {path}{msg}'.format(
+                    print('{action}({status}): {path}{type}{msg}'.format(
                         action=res['action'],
                         status=res['status'],
                         path=relpath(res['path'],
                                      res['refds']) if res.get('refds', None) else res['path'],
+                        type=' ({})'.format(res['type']) if 'type' in res else '',
                         msg=' [{}]'.format(
                             res['message'][0] % res['message'][1:]
                             if isinstance(res['message'], tuple) else res['message'])

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -1065,7 +1065,10 @@ def eval_results(func):
                         continue
                 yield res
 
-            if result_renderer == 'default' and action_summary:
+            if result_renderer == 'default' and action_summary and \
+                    sum(sum(s.values()) for s in action_summary.values()) > 1:
+                # give a summary in default mode, when there was more than one
+                # action performed
                 print("Action summary:\n  {}".format(
                     '\n  '.join('{} ({})'.format(
                         act,

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -39,8 +39,6 @@ from datalad.utils import assure_list
 from datalad.utils import get_trace
 from datalad.utils import walk
 from datalad.utils import get_dataset_root
-from datalad.utils import swallow_logs
-from datalad.utils import better_wraps
 from datalad.utils import unique
 from datalad.support.exceptions import CommandError
 from datalad.support.gitrepo import GitRepo
@@ -54,7 +52,6 @@ from datalad import cfg as dlcfg
 from datalad.dochelpers import exc_str
 
 from datalad.support.constraints import Constraint
-from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureCallable

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -633,5 +633,7 @@ def test_get_dataset_root(path):
         eq_(get_dataset_root(abspath(os.curdir)), abspath(os.curdir))
         # subdirs are no issue
         eq_(get_dataset_root(subdir), os.curdir)
+        # even more subdirs are no issue
+        eq_(get_dataset_root(opj(subdir, subdir)), os.curdir)
         # non-dir paths are no issue
         eq_(get_dataset_root(fname), os.curdir)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -36,6 +36,7 @@ from os.path import isdir
 from os.path import relpath
 from os.path import stat
 from os.path import dirname
+from os.path import split as psplit
 
 
 from six import text_type, binary_type, string_types
@@ -1187,11 +1188,16 @@ def get_dataset_root(path):
     suffix = os.sep + opj('.git', 'objects')
     if not isdir(path):
         path = dirname(path)
-    while not exists(path + suffix):
-        path = opj(path, os.pardir)
-        if not exists(path):
-            return None
-    return normpath(path)
+    apath = abspath(path)
+    # while we can still go up
+    while psplit(apath)[1]:
+        if exists(path + suffix):
+            return path
+        # new test path in the format we got it
+        path = normpath(opj(path, os.pardir))
+        # no luck, next round
+        apath = abspath(path)
+    return None
 
 
 lgr.log(5, "Done importing datalad.utils")


### PR DESCRIPTION
- [x] Give summary according to #1476
- [x] converted `add` to a new-style command
- [ ] figure out what to do with the `ValueError` thrown by `Interface._prep()` if non-dataset paths are given. This should rather turn into an "error" result to get a result for each input argument.
- [x] make `add` talk about all non-actions like `get`. For example: currently a `datalad add .` in a clean dataset gives no result whatsoever
- [x] be able to `add` and `save` things that are already staged #1413 
- [x] calling `drop` in pure-git repo during recursive uninstall is no longer an issue #1493 
- [x] can install `uninstalled/uninstalledsub/sub` again #1492