### PR TITLE
BF+RF: little annoying things around `drop` improved

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -339,9 +339,13 @@ def main(args=None):
                 # behave as if the command ran directly, importantly pass
                 # exit code as is
                 if exc.stdout:
-                    os.write(1, exc.stdout)
+                    os.write(1, exc.stdout.encode()) \
+                        if hasattr(exc.stdout, 'encode')  \
+                        else os.write(1, exc.stdout)
                 if exc.stderr:
-                    os.write(2, exc.stderr)
+                    os.write(2, exc.stderr.encode()) \
+                        if hasattr(exc.stderr, 'encode')  \
+                        else os.write(2, exc.stderr)
                 sys.exit(exc.code)
             except Exception as exc:
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))

--- a/datalad/crawler/pipelines/tests/test_openfmri_collection.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri_collection.py
@@ -70,7 +70,8 @@ def test_openfmri_superdataset_pipeline1(ind, topurl, outd):
 
     # TODO: replace below command with the one listing subdatasets
     subdatasets = ['ds000001', 'ds000002']
-    eq_(Dataset(outd).get_subdatasets(fulfilled=True), subdatasets)
+    eq_(Dataset(outd).subdatasets(fulfilled=True, result_xfm='relpaths'),
+        subdatasets)
 
     # Check that crawling configuration was created for every one of those
     for sub in subdatasets:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -78,9 +78,7 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     assert_true(annex.file_has_content(fn_extracted))
 
     annex.rm_url(fn_extracted, file_url)
-    with swallow_logs(new_level=logging.WARN) as cm:
-        assert_raises(RuntimeError, annex.drop, fn_extracted)
-        in_("git-annex: drop: 1 failed", cm.out)
+    assert_false(annex.drop(fn_extracted)['success'])
 
     annex.add_url_to_file(fn_extracted, file_url)
     annex.drop(fn_extracted)

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -208,7 +208,13 @@ class Add(Interface):
             # remember the datasets associated with actual inputs
             input_ds = list(content_by_ds.keys())
             # forge chain from base dataset to any leaf dataset
-            _discover_trace_to_known(dataset.path, [], content_by_ds)
+            _discover_trace_to_known(
+                # from here
+                dataset.path,
+                # to any dataset we are aware of
+                list(content_by_ds.keys()),
+                [],
+                content_by_ds)
             if ds2super:
                 # now check all dataset entries corresponding to the original
                 # input to see if they contain their own paths and remove them

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -308,7 +308,7 @@ class Add(Interface):
                     ds, toadd, respath_by_status,
                     dir_fail_msg='could not add some content in %s %s',
                     noinfo_dir_msg='nothing to add from %s',
-                    noinfo_file_msg='%s is already included in the dataset',
+                    noinfo_file_msg='already included in the dataset',
                     action='add',
                     logger=lgr,
                     refds=refds_path):

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -32,7 +32,7 @@ from datalad.interface.results import annexjson2result
 from datalad.interface.results import success_status_map
 from datalad.interface.results import results_from_annex_noinfo
 from datalad.interface.utils import save_dataset_hierarchy
-from datalad.interface.utils import _discover_trace_to_known
+from datalad.interface.utils import discover_dataset_trace_to_targets
 from datalad.interface.utils import eval_results
 from datalad.interface.utils import build_doc
 from datalad.distribution.utils import _fixup_submodule_dotgit_setup
@@ -208,7 +208,7 @@ class Add(Interface):
             # remember the datasets associated with actual inputs
             input_ds = list(content_by_ds.keys())
             # forge chain from base dataset to any leaf dataset
-            _discover_trace_to_known(
+            discover_dataset_trace_to_targets(
                 # from here
                 dataset.path,
                 # to any dataset we are aware of

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -240,6 +240,8 @@ class Dataset(object):
 
     def get_subdatasets(self, pattern=None, fulfilled=None, absolute=False,
                         recursive=False, recursion_limit=None, edges=False):
+        # TODO wipe this function out completely once we are comfortable
+        # with it. Internally we don't need or use it anymore.
         import inspect
         lgr.warning('%s still uses Dataset.get_subdatasets(). RF to use `subdatasets` command', inspect.stack()[1][3])
         from datalad.api import subdatasets

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -86,7 +86,7 @@ def _drop_files(ds, files, check, noannex_iserror=True, **kwargs):
             ds, files, respath_by_status,
             dir_fail_msg='could not drop some content in %s %s',
             noinfo_dir_msg='nothing to drop from %s',
-            noinfo_file_msg="%s has no annex'ed content",
+            noinfo_file_msg="no annex'ed content",
             **kwargs):
         yield r
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -260,6 +260,7 @@ def _install_necessary_subdatasets(
                 status='error', logger=lgr, refds=refds_path,
                 message=("Installation of subdatasets %s failed with exception: %s",
                          subdataset['path'], exc_str(e)))
+            return
 
         cur_par_ds = cur_subds
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -597,7 +597,7 @@ class Get(Interface):
                     ds, content, respath_by_status,
                     dir_fail_msg='could not get some content in %s %s',
                     noinfo_dir_msg='nothing to get from %s',
-                    noinfo_file_msg='%s is already present',
+                    noinfo_file_msg='already present',
                     action='get',
                     logger=lgr,
                     refds=refds_path):

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -229,6 +229,7 @@ class Install(Interface):
                         on_failure='ignore',
                         return_type='generator',
                         result_xfm=None,
+                        result_filter=None,
                         **common_kwargs):
                     # no post-processing of the installed content on disk
                     # should be necessary here, all done by code further
@@ -258,6 +259,7 @@ class Install(Interface):
                         on_failure='ignore',
                         return_type='generator',
                         result_xfm=None,
+                        result_filter=None,
                         **common_kwargs):
                     # no post-processing of get'ed content on disk should be
                     # necessary here, this is the responsibility of `get`

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -29,7 +29,7 @@ from datalad.interface.common_opts import recursion_flag
 from datalad.interface.utils import handle_dirty_datasets
 from datalad.interface.utils import path_is_under
 from datalad.interface.utils import save_dataset_hierarchy
-from datalad.interface.utils import _discover_trace_to_known
+from datalad.interface.utils import discover_dataset_trace_to_targets
 from datalad.interface.utils import eval_results
 from datalad.interface.utils import build_doc
 from datalad.interface.results import get_status_dict
@@ -193,7 +193,7 @@ class Remove(Interface):
         if dataset and dataset.is_installed():
             # forge chain from base dataset to any leaf dataset
             # in order to save state changes all the way up
-            _discover_trace_to_known(
+            discover_dataset_trace_to_targets(
                 # from here
                 dataset.path,
                 # to any of

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -193,7 +193,13 @@ class Remove(Interface):
         if dataset and dataset.is_installed():
             # forge chain from base dataset to any leaf dataset
             # in order to save state changes all the way up
-            _discover_trace_to_known(dataset.path, [], content_by_ds)
+            _discover_trace_to_known(
+                # from here
+                dataset.path,
+                # to any of
+                list(content_by_ds.keys()),
+                [],
+                content_by_ds)
 
         for r in save_dataset_hierarchy(
                 # pass list of datasets to save that excludes known

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -42,7 +42,6 @@ from datalad.distribution.uninstall import _uninstall_dataset
 
 
 lgr = logging.getLogger('datalad.distribution.remove')
-res_kwargs = dict(action='remove', logger=lgr)
 
 
 @build_doc
@@ -96,6 +95,7 @@ class Remove(Interface):
             recursive=False,
             check=True,
             if_dirty='save-before'):
+        res_kwargs = dict(action='remove', logger=lgr)
         if dataset:
             dataset = require_dataset(
                 dataset, check_installed=False, purpose='removal')
@@ -112,6 +112,8 @@ class Remove(Interface):
             path=path,
             dataset=dataset,
             recursive=recursive)
+        refds_path = dataset.path if isinstance(dataset, Dataset) else dataset
+        res_kwargs['refds'] = refds_path
         if path_is_under(content_by_ds):
             # behave like `rm` and refuse to remove where we are
             raise ValueError(
@@ -152,7 +154,8 @@ class Remove(Interface):
                 superds = ds.get_superdataset(
                     datalad_only=False,
                     topmost=False)
-                for r in _uninstall_dataset(ds, check=check, has_super=False):
+                for r in _uninstall_dataset(ds, check=check, has_super=False,
+                                            **res_kwargs):
                     yield r
                 if not superds:
                     continue

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -117,7 +117,7 @@ def test_create_sub(path):
     ok_clean_git(subds.path, annex=True)
 
     # subdataset is known to superdataset:
-    assert_in("some/what/deeper", ds.get_subdatasets())
+    assert_in("some/what/deeper", ds.subdatasets(result_xfm='relpaths'))
     # and was committed:
     ok_clean_git(ds.path)
 
@@ -131,14 +131,14 @@ def test_create_sub(path):
     ok_clean_git(subds2.path, annex=True)
 
     # unknown to superdataset:
-    assert_not_in("someother", ds.get_subdatasets())
+    assert_not_in("someother", ds.subdatasets(result_xfm='relpaths'))
 
     # 3. create sub via super:
     subds3 = ds.create("third", no_annex=True)
     ok_(isinstance(subds3, Dataset))
     ok_(subds3.is_installed())
     ok_clean_git(subds3.path, annex=False)
-    assert_in("third", ds.get_subdatasets())
+    assert_in("third", ds.subdatasets(result_xfm='relpaths'))
 
 
 @with_tree(tree=_dataset_hierarchy_template)
@@ -176,7 +176,7 @@ def test_nested_create(path):
     # later create subdataset in a fresh dir
     subds1 = ds.create(opj('lvl1', 'subds'))
     ok_clean_git(ds.path)
-    eq_(ds.get_subdatasets(), [opj('lvl1', 'subds')])
+    eq_(ds.subdatasets(result_xfm='relpaths'), [opj('lvl1', 'subds')])
     # later create subdataset in an existing empty dir
     subds2 = ds.create(opj('lvl1', 'empty'))
     ok_clean_git(ds.path)
@@ -200,7 +200,7 @@ def test_nested_create(path):
     # XXX even force doesn't help, because (I assume) GitPython doesn't update
     # its representation of the Git index properly
     ds.create(lvl2relpath, force=True)
-    assert_in(lvl2relpath, ds.get_subdatasets())
+    assert_in(lvl2relpath, ds.subdatasets(result_xfm='relpaths'))
 
 
 # Imported from #1016
@@ -220,4 +220,4 @@ def test_saving_prior(topdir):
     # ds1, and then the whole procedure actually crashes since because ds2/file1.txt
     # is committed -- ds2 is already known to git and it just pukes with a bit
     # confusing    'ds2' already exists in the index
-    assert_in('ds2', ds1.get_subdatasets())
+    assert_in('ds2', ds1.subdatasets(result_xfm='relpaths'))

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -43,9 +43,9 @@ def test_dont_trip_over_missing_subds(path):
         source=ds2.path, path='subds2',
         result_xfm='datasets', return_type='item-or-list')
     assert_true(subds2.is_installed())
-    assert_in('subds2', ds1.get_subdatasets())
+    assert_in('subds2', ds1.subdatasets(result_xfm='relpaths'))
     subds2.uninstall()
-    assert_in('subds2', ds1.get_subdatasets())
+    assert_in('subds2', ds1.subdatasets(result_xfm='relpaths'))
     assert_false(subds2.is_installed())
     # see if it wants to talk to github (and fail), or if it trips over something
     # before

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -341,10 +341,10 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
     source = install(src_path, source=origin, recursive=True)
-    eq_(len(source.get_subdatasets()), 2)
+    eq_(len(source.subdatasets()), 2)
     # get a new subdataset and make sure it is committed in the super
     source.create('brandnew')
-    eq_(len(source.get_subdatasets()), 3)
+    eq_(len(source.subdatasets()), 3)
     ok_clean_git(source.path)
 
     # and now we create a sibling for the new subdataset only

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -149,6 +149,18 @@ def test_uninstall_git_file(path):
     if not hasattr(ds.repo, 'drop'):
         # nothing can be dropped in a plain GitRepo
         assert_status('impossible', ds.drop(path='INFO.txt', on_failure='ignore'))
+    else:
+        # drop file in Git in an annex repo
+        # we could argue that it also should be impossible, but we simply
+        # turn the fact that annex said nothing at all into a result
+        # XXX maybe we actually want to make the 'impossible' result above
+        # also into 'notneeded'... it is less about education that about "can we
+        # we get the content back?", and for a file in Git we can
+        res = ds.drop(path='INFO.txt')
+        assert_result_count(
+            res, 1,
+            status='notneeded',
+            message=("%s has no annex'ed content", opj(ds.path, 'INFO.txt')))
 
     res = ds.uninstall(path="INFO.txt", on_failure='ignore')
     assert_status('error', res)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -146,21 +146,15 @@ def test_uninstall_git_file(path):
     ok_(exists(opj(path, 'INFO.txt')))
     ok_file_under_git(ds.repo.path, 'INFO.txt')
 
-    if not hasattr(ds.repo, 'drop'):
-        # nothing can be dropped in a plain GitRepo
-        assert_status('impossible', ds.drop(path='INFO.txt', on_failure='ignore'))
-    else:
-        # drop file in Git in an annex repo
-        # we could argue that it also should be impossible, but we simply
-        # turn the fact that annex said nothing at all into a result
-        # XXX maybe we actually want to make the 'impossible' result above
-        # also into 'notneeded'... it is less about education that about "can we
-        # we get the content back?", and for a file in Git we can
-        res = ds.drop(path='INFO.txt')
-        assert_result_count(
-            res, 1,
-            status='notneeded',
-            message=("%s has no annex'ed content", opj(ds.path, 'INFO.txt')))
+    # drop file in Git in an annex repo
+    # regardless of the type of repo this is 'notneeded'...
+    # it is less about education that about "can we
+    # we get the content back?", and for a file in Git we can
+    assert_result_count(
+        ds.drop(path='INFO.txt'),
+        1,
+        status='notneeded',
+        message="no annex'ed content")
 
     res = ds.uninstall(path="INFO.txt", on_failure='ignore')
     assert_status('error', res)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -70,7 +70,7 @@ def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
     subds2 = ds.create('two')
-    eq_(sorted(ds.get_subdatasets()), ['one', 'two'])
+    eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['one', 'two'])
     ok_clean_git(ds.path)
     # now kill one
     res = ds.remove(
@@ -80,23 +80,23 @@ def test_clean_subds_removal(path):
     ok_(not subds1.is_installed())
     ok_clean_git(ds.path)
     # two must remain
-    eq_(ds.get_subdatasets(), ['two'])
+    eq_(ds.subdatasets(result_xfm='relpaths'), ['two'])
     # one is gone
     assert(not exists(subds1.path))
     # and now again, but this time remove something that is not installed
     ds.create('three')
     ds.save(all_updated=True)
-    eq_(sorted(ds.get_subdatasets()), ['three', 'two'])
+    eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['three', 'two'])
     ds.uninstall('two')
     ok_clean_git(ds.path)
-    eq_(sorted(ds.get_subdatasets()), ['three', 'two'])
+    eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['three', 'two'])
     ok_(not subds2.is_installed())
     assert(exists(subds2.path))
     res = ds.remove('two', result_xfm='datasets')
     ok_clean_git(ds.path)
     # subds1 got uninstalled, and ds got the removal of subds1 saved
     eq_(res, [subds2, ds])
-    eq_(ds.get_subdatasets(), ['three'])
+    eq_(ds.subdatasets(result_xfm='relpaths'), ['three'])
     #import pdb; pdb.set_trace()
     assert(not exists(subds2.path))
 
@@ -180,37 +180,35 @@ def test_uninstall_subdataset(src, dst):
 
     ds = install(dst, source=src, recursive=True)
     ok_(ds.is_installed())
-    known_subdss = ds.get_subdatasets()
-    for subds_path in ds.get_subdatasets():
-        subds = Dataset(opj(ds.path, subds_path))
+    known_subdss = ds.subdatasets(result_xfm='datasets')
+    for subds in ds.subdatasets(result_xfm='datasets'):
         ok_(subds.is_installed())
 
         annexed_files = subds.repo.get_annexed_files()
         subds.repo.get(annexed_files)
 
         # drop data of subds:
-        res = ds.drop(path=subds_path, result_xfm='paths')
+        res = ds.drop(path=subds.path, result_xfm='paths')
 
         ok_(all([opj(subds.path, f) in res for f in annexed_files]))
         ok_(all([not i for i in subds.repo.file_has_content(annexed_files)]))
         # subdataset is still known
-        assert_in(subds_path, ds.get_subdatasets())
+        assert_in(subds.path, ds.subdatasets(result_xfm='paths'))
 
-    eq_(ds.get_subdatasets(), known_subdss)
+    eq_(ds.subdatasets(result_xfm='datasets'), known_subdss)
 
-    for subds_path in ds.get_subdatasets():
+    for subds in ds.subdatasets(result_xfm='datasets'):
         # uninstall subds itself:
         if os.environ.get('DATALAD_TESTS_DATALADREMOTE') \
                 and external_versions['git'] < '2.0.9':
             raise SkipTest(
                 "Known problem with GitPython. See "
                 "https://github.com/gitpython-developers/GitPython/pull/521")
-        res = ds.uninstall(path=subds_path, result_xfm='datasets')
-        subds = Dataset(opj(ds.path, subds_path))
+        res = ds.uninstall(path=subds.path, result_xfm='datasets')
         eq_(res[0], subds)
         ok_(not subds.is_installed())
         # just a deinit must not remove the subdataset registration
-        eq_(ds.get_subdatasets(), known_subdss)
+        eq_(ds.subdatasets(result_xfm='datasets'), known_subdss)
         # mountpoint of subdataset should still be there
         ok_(exists(subds.path))
 
@@ -345,7 +343,7 @@ def test_careless_subdataset_uninstall(path):
     ds = Dataset(path).create()
     subds1 = ds.create('deep1')
     ds.create('deep2')
-    eq_(sorted(ds.get_subdatasets()), ['deep1', 'deep2'])
+    eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1', 'deep2'])
     ok_clean_git(ds.path)
     # now we kill the sub without the parent knowing
     subds1.uninstall()
@@ -354,7 +352,7 @@ def test_careless_subdataset_uninstall(path):
     ok_(exists(subds1.path))
     ok_clean_git(ds.path)
     # parent still knows the sub
-    eq_(sorted(ds.get_subdatasets()), ['deep1', 'deep2'])
+    eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1', 'deep2'])
 
 
 @with_tempfile()
@@ -366,7 +364,7 @@ def test_kill(path):
         f.write("load")
     ds.add("file.dat")
     subds = ds.create('deep1')
-    eq_(sorted(ds.get_subdatasets()), ['deep1'])
+    eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1'])
     ok_clean_git(ds.path)
 
     # and we fail to remove since content can't be dropped

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -80,7 +80,9 @@ def test_update_simple(origin, src_path, dst_path):
     # smoke-test if recursive update doesn't fail if submodule is removed
     # and that we can run it from within a dataset without providing it
     # explicitly
-    assert_status('ok', dest.remove('subm 1'))
+    assert_result_count(
+        dest.remove('subm 1'), 1,
+        status='ok', action='remove', path=opj(dest.path, 'subm 1'))
     with chpwd(dest.path):
         assert_result_count(
             update(recursive=True), 2,

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -246,17 +246,17 @@ def test_update_volatile_subds(originpath, destpath):
     osm1 = origin.create(sname)
     assert_result_count(ds.update(), 1, status='ok', type='dataset')
     # nothing without a merge, no inappropriate magic
-    assert_not_in(sname, ds.get_subdatasets())
+    assert_not_in(sname, ds.subdatasets(result_xfm='relpaths'))
     assert_result_count(ds.update(merge=True), 1, status='ok', type='dataset')
     # known, and placeholder exists
-    assert_in(sname, ds.get_subdatasets())
+    assert_in(sname, ds.subdatasets(result_xfm='relpaths'))
     ok_(exists(opj(ds.path, sname)))
 
     # remove from origin
     origin.remove(sname)
     assert_result_count(ds.update(merge=True), 1, status='ok', type='dataset')
     # gone locally, wasn't checked out
-    assert_not_in(sname, ds.get_subdatasets())
+    assert_not_in(sname, ds.subdatasets(result_xfm='relpaths'))
     assert_false(exists(opj(ds.path, sname)))
 
     # re-introduce at origin
@@ -270,12 +270,12 @@ def test_update_volatile_subds(originpath, destpath):
 
     # now remove just-installed subdataset from origin again
     origin.remove(sname, check=False)
-    assert_not_in(sname, origin.get_subdatasets())
-    assert_in(sname, ds.get_subdatasets())
+    assert_not_in(sname, origin.subdatasets(result_xfm='relpaths'))
+    assert_in(sname, ds.subdatasets(result_xfm='relpaths'))
     # merge should disconnect the installed subdataset, but leave the actual
     # ex-subdataset alone
     assert_result_count(ds.update(merge=True), 1, type='dataset')
-    assert_not_in(sname, ds.get_subdatasets())
+    assert_not_in(sname, ds.subdatasets(result_xfm='relpaths'))
     ok_file_has_content(opj(ds.path, sname, 'load.dat'), 'heavy')
     ok_(Dataset(opj(ds.path, sname)).is_installed())
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -175,6 +175,11 @@ known_result_xfms = {
     'relpaths': YieldRelativePaths(),
 }
 
+translate_annex_notes = {
+    '(Use --force to override this check, or adjust numcopies.)':
+        'configured minimum number of copies not found',
+}
+
 
 def annexjson2result(d, ds, **kwargs):
     """Helper to convert an annex JSON result to a datalad result dict
@@ -207,9 +212,11 @@ def annexjson2result(d, ds, **kwargs):
         res['action'] = d['command']
     if 'key' in d:
         res['annexkey'] = d['key']
-    # avoid meaningless standard message
-    if 'note' in d and d['note'] != 'checksum...':
-        res['message'] = d['note']
+    # avoid meaningless standard messages
+    if 'note' in d and (
+            d['note'] != 'checksum...' and
+            not d['note'].startswith('checking file')):
+        res['message'] = translate_annex_notes.get(d['note'], d['note'])
     return res
 
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -300,9 +300,8 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
       `git annex` was silent about (incl. any content). There must be one string
       placeholder that is expanded with the path of that directory.
     noinfo_file_msg : str
-      Message template to inject into the result for a requested file that `git
-      annex` was silent about. There must be one string placeholder that is
-      expanded with the path of that file.
+      Message to inject into the result for a requested file that `git
+      annex` was silent about.
     **kwargs
       Any further kwargs are included in the yielded result dictionary.
     """
@@ -349,5 +348,5 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
             # already in the desired state
             yield get_status_dict(
                 status='notneeded', type_='file',
-                message=(noinfo_file_msg, p),
+                message=noinfo_file_msg,
                 **common_report)

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -131,6 +131,10 @@ class Save(Interface):
         if all_updated:
             # and we do this by replacing any given paths with the respective
             # datasets' base path
+            # MIH: this is wrong, it makes the desired use case indistinguishable
+            # from an explicit "save everything underneath the dataset root"
+            # remember that we have to call `git add` inside the technical reasons
+            # and here we need to avoid that somehow -- yet not like this (see #1419)
             for ds in content_by_ds:
                 content_by_ds[ds] = [ds]
 

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -285,10 +285,10 @@ def test_add_archive_content(path_orig, url, repo_path):
     # verify that we can't drop a file if archive key was dropped and online archive was removed or changed size! ;)
     repo.get(key_1tar, options=['--key'])
     unlink(opj(path_orig, '1.tar.gz'))
-    with swallow_logs(new_level=logging.ERROR) as cml:
-        assert_raises(CommandError, repo.drop, key_1tar, options=['--key'])
-        assert exists(opj(repo.path, repo.get_contentlocation(key_1tar)))
-        assert_in('Could only verify the existence of 0 out of 1 necessary copies', cml.out)
+    res = repo.drop(key_1tar, options=['--key'])
+    assert_equal(res['success'], False)
+    assert_equal(res['note'], '(Use --force to override this check, or adjust numcopies.)')
+    assert exists(opj(repo.path, repo.get_contentlocation(key_1tar)))
 
 
 @assert_cwd_unchanged(ok_to_chdir=True)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -99,7 +99,7 @@ def test_dirty(path):
     _check_all_clean(subds, subds.repo.get_hexsha())
     ok_clean_git(ds.path)
     # subdataset must be added as a submodule!
-    assert_equal(ds.get_subdatasets(), ['subds'])
+    assert_equal(ds.subdatasets(result_xfm='relpaths'), ['subds'])
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -695,15 +695,17 @@ def _discover_trace_to_known(path, trace, spec):
                 spec[p] = list(set(spec.get(p, []) + [trace[i + 1]]))
             # this edge is not done, we need to try to reach any downstream
             # dataset
-    # OPT TODO? listdir might be large and we could have only few items
-    #  in spec -- so why not to traverse only those in spec which have
-    #  leading dir path???
     for p in listdir(path):
         if valid_repo and p == '.git':
             # ignore gitdir to speed things up
             continue
         p = opj(path, p)
         if not isdir(p):
+            continue
+        if all(t != p and not t.startswith(_with_sep(p)) for t in spec):
+            # OPT listdir might be large and we could have only few items
+            # in spec -- so traverse only those in spec which have
+            # leading dir path
             continue
         _discover_trace_to_known(p, trace, spec)
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -681,7 +681,31 @@ def get_dataset_directories(top, ignore_datalad=True):
 # processed ones and a base
 # let it simmer for a while and RF to use one or the other
 # this one here seems more leightweight and less convoluted
-def _discover_trace_to_known(basepath, targetpaths, current_trace, spec):
+def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace, spec):
+    """Discover the edges and nodes in a dataset tree to given target paths
+
+    Parameters
+    ----------
+    basepath : path
+      Path to a start or top-level dataset. Really has to be a path to a
+      dataset!
+    targetpaths : list(path)
+      Any non-zero number of path that are termination points for the
+      search algorithm. Can be paths to datasets, directories, or files
+      (and any combination thereof).
+    current_trace : list
+      For a top-level call this should probably always be `[]`
+    spec : dict
+      `content_by_ds`-style dictionary that will receive information about the
+      discovered datasets. Specifically, for each discovered dataset there
+      will be in item with its path under the key (path) of the respective
+      superdataset.
+
+    Returns
+    -------
+    None
+      Function calls itself recursively and populates `spec` in-place.
+    """
     # this beast walks the directory tree from a given `basepath` until
     # it discovers any of the given `targetpaths`
     # if it finds one, it commits any accummulated trace of visited
@@ -711,7 +735,7 @@ def _discover_trace_to_known(basepath, targetpaths, current_trace, spec):
             continue
         # we need to call this even for non-directories, to be able to match
         # file target paths
-        _discover_trace_to_known(p, targetpaths, current_trace, spec)
+        discover_dataset_trace_to_targets(p, targetpaths, current_trace, spec)
 
 
 def filter_unmodified(content_by_ds, refds, since):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -185,68 +185,62 @@ def get_tree_roots(paths):
     return roots
 
 
-def sort_paths_into_subdatasets(superds_path, target_subs, spec):
-    # XXX forge a chain: whenever some path needs to be pushed down
-    # put the receiving dataset as a components to process into the
-    # respective superdataset -- this will enable further processing
-    # of all datasets in a completely independent fashion
-    # (except for order of processing)
+def sort_paths_into_subdatasets(spec):
+    """Sort a `content_by_ds` dict to have paths match their closest subdataset
 
-    subds = Dataset(superds_path)
+    This function is cheap and performs no Dataset requests (e.g. subdatasets)
+    or any kind of file-system lookups. Consequently, the result is not
+    guaranteed to yield a true path-subdataset assignment. It only works with
+    the dataset paths included in `spec`. Use a helper like
+    `discover_dataset_trace_to_targets()` to prepopulate the `spec` with all
+    relevant datasets to ensure a result that matches the content in the
+    filesystem.
 
-    # get all existing subdataset as candidate nodes of the graph
-    # that needs to be built and checked
-    # OPT TODO:  this is the expensive one!  e.g we might have a big
-    #       hierarchy of datasets and interested in analyzing only a single
-    #       target_subds -- now it gets the entire hierarchy first (EXPENSIVE)
-    #       to look/check just one... bleh... and then even better -- would continue
-    #       out of the loop if that dataset is already known
-    #       Moreover possibly causing entire recursive traversal of sub-datasets
-    #       multiple times if operating from some higher level super and sorted
-    #       target_subds in multiple subs
-    # Delay expensive operation
-    subds_graph = None
-    # so we first get immediate children, delaying even check for being fulfilled
-    subdss = subds.subdatasets(recursive=False, fulfilled=None, result_xfm='paths')
-    if not subdss:
-        # no subdatasets, nothing to sort
-        return
-    for t in target_subs:
-        if t in subdss and GitRepo.is_valid_repo(t):  # fastest possible test for "installed?"
-            # immediate known kiddo
-            continue
-        if subds_graph is None:
-            subds_graph = [(r['parentpath'], r['path'])
-                           for r in Dataset(superds_path).subdatasets(
-                           recursive=True, fulfilled=True)]
+    Paths are sorted to be assigned to the dataset path key that is the
+    closest, but not identical match. Hence, if any path to a dataset
+    it contained in a `spec` value, it will not be re-assigned to its
+    "own" `spec`-key, but is assigned to its superdataset. However, see the
+    note below.
 
-        trace = get_trace(
-            subds_graph,
-            superds_path,
-            t)
-        if not trace:
-            # not connected, or identical
-            continue
-        tosort = [superds_path] + trace + [t]
-        # loop over all but the last one, simplifies logic below
-        for i, d in enumerate(tosort[:-1]):
-            paths = spec.get(d, [])
-            keep_paths = []
-            next_ds = tosort[i + 1]
-            next_dspaths = spec.get(next_ds, [])
-            comp = _with_sep(next_ds)
-            for p in assure_list(paths):
-                if p.startswith(comp):
-                    next_dspaths.append(p)
-                    # remember that we pushed the path into this dataset
-                    keep_paths.append(next_ds)
-                else:
-                    keep_paths.append(p)
-            spec[next_ds] = next_dspaths
-            spec[d] = keep_paths
-    # tidy up -- deduplicate
-    for c in spec:
-        spec[c] = unique(spec[c])
+    Note, no path is ever re-assigned upward in the hierarchy.
+
+    Parameters
+    ----------
+    spec : dict
+      content_by_ds style dict that will be sorted in-place.
+
+    Returns
+    -------
+    None
+    """
+    # paths to all known dataset, bottom-up
+    dspaths = [(p, _with_sep(p)) for p in sorted(spec.keys(), reverse=True)]
+    # loop over all dataset entries, top-down
+    for ds in sorted(spec):
+        # for each unique path recorded for this dataset check if it should
+        # move
+        paths = spec[ds]
+        filtered_paths = []
+        for path in unique(paths):
+            # check all other known dataset in bottom-up fashion
+            # for the first dataset that "contains" this path
+            moveto = None
+            for targetkey, targetpath in dspaths:
+                if targetkey == ds:
+                    # we reached the current dataset on out way up,
+                    # everything beyond here is already sorted
+                    break
+                if path.startswith(targetpath) and path != targetkey:
+                    # move path down
+                    moveto = targetkey
+                    # this was the longest match, done
+                    break
+            if moveto:
+                spec[moveto].append(path)
+            else:
+                filtered_paths.append(path)
+        # reassign what wasn't moved, deduplicated at the same time
+        spec[ds] = filtered_paths
 
 
 def save_dataset_hierarchy(
@@ -295,7 +289,15 @@ def save_dataset_hierarchy(
     # save the superdataset
     for superds_path in superdss:
         target_subs = superdss[superds_path]
-        sort_paths_into_subdatasets(superds_path, target_subs, info)
+        # populate `info` with intermediate datasets
+        discover_dataset_trace_to_targets(
+            # from here
+            superds_path,
+            # to all
+            target_subs,
+            [], info)
+        # and now assign all paths to the corresponding datasets
+        sort_paths_into_subdatasets(info)
     # iterate over all datasets, starting at the bottom
     for dpath in sorted(info.keys(), reverse=True):
         ds = Dataset(dpath)

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -392,6 +392,6 @@ def test_ignore_nondatasets(path):
         assert_equal(meta, _kill_time(get_metadata(ds)))
         # making it a submodule has no effect either
         ds.add(subpath)
-        assert_equal(len(ds.get_subdatasets()), n_subm + 1)
+        assert_equal(len(ds.subdatasets()), n_subm + 1)
         assert_equal(meta, _kill_time(get_metadata(ds)))
         n_subm += 1

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1810,6 +1810,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             commandline options for the git annex drop command
         jobs : int, optional
             how many jobs to run in parallel (passed to git-annex call)
+
+        Returns
+        -------
+        list(JSON objects)
+          'success' item in each object indicates failure/success per file
+          path.
         """
 
         # annex drop takes either files or options

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1796,7 +1796,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         return self.whereis(file_, output='full', batch=batch)[AnnexRepo.WEB_UUID]['urls']
 
     @normalize_paths
-    def drop(self, files, options=None, key=False):
+    def drop(self, files, options=None, key=False, jobs=None):
         """Drops the content of annexed files from this repository.
 
         Drops only if possible with respect to required minimal number of
@@ -1805,6 +1805,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         Parameters
         ----------
         files: list of str
+            paths to drop
+        options : list of str, optional
+            commandline options for the git annex drop command
+        jobs : int, optional
+            how many jobs to run in parallel (passed to git-annex call)
         """
 
         # annex drop takes either files or options
@@ -1818,25 +1823,28 @@ class AnnexRepo(GitRepo, RepoInterface):
             raise InsufficientArgumentsError("drop() requires at least to "
                                              "specify 'files' or 'options'")
 
-        options = options[:] if options else []
-        files = files[:] if files else []
+        options = assure_list(options)
+        files = assure_list(files)
 
-        output_lines = []
         if key:
             # we can't drop multiple in 1 line, and there is no --batch yet, so
             # one at a time
             options = options + ['--key']
-            for k in files:
-                std_out, std_err = \
-                    self._run_annex_command('drop', annex_options=options + [k])
-                output_lines.extend(std_out.splitlines())
+            res = [self._run_annex_command_json(
+                'drop',
+                args=options + [k],
+                jobs=jobs)
+                for k in files]
+            # `normalize_paths` ... magic, useful?
+            if len(files) == 1:
+                return res[0]
+            else:
+                return res
         else:
-            std_out, std_err = \
-                self._run_annex_command('drop', annex_options=options + files)
-            output_lines.extend(std_out.splitlines())
-
-        return [line.split()[1] for line in output_lines
-                if line.startswith('drop') and line.endswith('ok')]
+            return self._run_annex_command_json(
+                'drop',
+                args=options + files,
+                jobs=jobs)
 
     def drop_key(self, keys, options=None, batch=False):
         """Drops the content of annexed files from this repository referenced by keys

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -405,18 +405,10 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     eq_(len(l), 1)
 
     # now only 1 copy; drop should fail
-    try:
-        with swallow_logs() as cml:
-            ar.drop(testfile)
-            assert_in('ERROR', cml.out)
-            assert_in('drop: 1 failed', cml.out)
-    except CommandError as e:
-        eq_(e.code, 1)
-        assert_in('Could only verify the '
-                  'existence of 0 out of 1 necessary copies', e.stdout)
-        failed = True
-
-    ok_(failed)
+    res = ar.drop(testfile)
+    eq_(res['command'], 'drop')
+    eq_(res['success'], False)
+    assert_in('adjust numcopies', res['note'])
 
     # read the url using different method
     ar.add_url_to_file(testfile, testurl)
@@ -1219,8 +1211,10 @@ def test_annex_drop(src, dst):
     result = ar.drop([testfile])
     assert_false(ar.file_has_content(testfile))
     ok_(isinstance(result, list))
-    eq_(result[0], testfile)
     eq_(len(result), 1)
+    eq_(result[0]['command'], 'drop')
+    eq_(result[0]['success'], True)
+    eq_(result[0]['file'], testfile)
 
     ar.get(testfile)
 
@@ -1229,8 +1223,10 @@ def test_annex_drop(src, dst):
     result = ar.drop([testkey], key=True)
     assert_false(ar.file_has_content(testfile))
     ok_(isinstance(result, list))
-    eq_(result[0], testkey)
     eq_(len(result), 1)
+    eq_(result[0]['command'], 'drop')
+    eq_(result[0]['success'], True)
+    eq_(result[0]['key'], testkey)
 
     # insufficient arguments:
     assert_raises(TypeError, ar.drop)


### PR DESCRIPTION
TODO

- [x] RF `AnnexRepo.drop()` to give JSON output with more detailed info
- [x] RF `drop` to use this additional info to fix #1501 and with it #808 
- [x] fully discontinue internal use of `Dataset.get_subdatasets()` (became low-hanging fruit)
- [x] I AM SPEEEED! ![SPEED](http://clipground.com/images/recommended-speed-clipart-1.jpg)
- [x] major speed-up in `add`
- [x] major speed-up in `save`