### PR TITLE
Some speed-up for get_paths_by_dataset

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -77,7 +77,7 @@ def _generate_func_api():
             # TODO: BEGIN to be removed, when @build_doc is applied everywhere
             spec = getattr(intf, '_params_', dict())
             api_name = get_api_name(intfspec)
-            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'get', 'clone', 'subdatasets', 'install'):
+            if api_name not in ('update', 'save', 'create', 'unlock', 'clean', 'drop', 'uninstall', 'remove', 'get', 'clone', 'subdatasets', 'install', 'add'):
                 # FIXME no longer using an interface class instance
                 # convert the parameter SPEC into a docstring for the function
                 update_docstring_with_parameters(

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -108,13 +108,16 @@ def setup_parser(
         variables in the process environment.""")
     parser.add_argument(
         '--output-format', dest='common_output_format',
-        choices=['default', 'json', 'tailored'],
         default='default',
+        metavar="{default,json,tailored,'<template>'",
         help="""select format for returned command results. 'default' give one line
         per result reporting action, status, path and an optional message;
         'json' renders a JSON object with all properties for each result (one per 
         line); 'tailored' enables a command-specific rendering style that is typically
-        tailored to human consumption (no result output otherwise).""")
+        tailored to human consumption (no result output otherwise),
+        '<template>' reports any value(s) of any result properties in any format
+        indicated by the template (e.g. '{path}', compare with JSON
+        output for all key-value choices).""")
     parser.add_argument(
         '--report-status', dest='common_report_status',
         choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -168,12 +168,8 @@ class initiate_dataset(object):
             # place hack from 'add-to-super' times here
             sds = ds.get_superdataset()
             if sds is not None:
-                # TODO this should use the `add` command and not this helper
-                from datalad.distribution.add import _install_subds_inplace
-                subdsrelpath = relpath(realpath(ds.path), realpath(sds.path))  # realpath OK
-                lgr.debug("Adding %s as a subdataset to %s", subdsrelpath, sds)
-                _install_subds_inplace(ds=sds, path=ds.path,
-                                       relativepath=subdsrelpath)
+                lgr.debug("Adding %s as a subdataset to %s", ds, sds)
+                sds.add(ds.path, save=False)
                 # this leaves the subdataset staged in the parent
             elif str(self.add_to_super) != 'auto':
                 raise ValueError(

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -290,7 +290,13 @@ class Create(Interface):
         if save and dataset is not None and dataset.path != tbds.path:
             # we created a dataset in another dataset
             # -> make submodule
-            dataset.add(tbds.path, save=save, ds2super=True)
+            for r in dataset.add(
+                    tbds.path, save=save, ds2super=True,
+                    return_type='generator',
+                    result_filter=None,
+                    result_xfm=None,
+                    on_failure='ignore'):
+                yield r
 
         yield get_status_dict(
             action='create',

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -16,8 +16,6 @@ from os import curdir
 from os.path import isdir
 from os.path import join as opj
 from os.path import relpath
-from os.path import normpath
-from os.path import isabs
 
 from six.moves.urllib.parse import quote as urlquote
 
@@ -30,6 +28,8 @@ from datalad.interface.results import results_from_paths
 from datalad.interface.results import YieldDatasets
 from datalad.interface.results import annexjson2result
 from datalad.interface.results import count_results
+from datalad.interface.results import success_status_map
+from datalad.interface.results import results_from_annex_noinfo
 from datalad.interface.common_opts import recursion_flag
 # from datalad.interface.common_opts import git_opts
 # from datalad.interface.common_opts import annex_opts
@@ -565,12 +565,6 @@ class Get(Interface):
             # done already
             return
 
-        status_map = {
-            'ok': 'success',
-            'notneeded': 'success',
-            'impossible': 'failure',
-            'error': 'failure',
-        }
         # hand over to git-annex, get files content,
         # repo files in git as 'notneeded' to get
         for ds_path in sorted(content_by_ds.keys()):
@@ -592,55 +586,20 @@ class Get(Interface):
                     jobs=jobs):
                 res = annexjson2result(res, ds, type_='file', logger=lgr,
                                        refds=refds_path)
-                respath_by_status[status_map[res['status']]] = res['path']
+                success = success_status_map[res['status']]
+                respath_by_status[success] = \
+                    respath_by_status.get(success, []) + [res['path']]
                 yield res
-            # the following result reporting assume that low-level
-            # code causes some form of error (exception or result)
-            # to surface in case anything goes wrong in `annex get`
-            while content:
-                p = content.pop()
-                common_report = dict(
+
+            for r in results_from_annex_noinfo(
+                    ds, content, respath_by_status,
+                    dir_fail_msg='could not get some content in %s %s',
+                    noinfo_dir_msg='nothing to get from %s',
+                    noinfo_file_msg='%s is already present',
                     action='get',
-                    # any relpath is relative to the currently processed dataset
-                    # not the global reference dataset
-                    path=p if isabs(p) else normpath(opj(ds.path, p)),
                     logger=lgr,
-                    refds=refds_path)
-                if isdir(p):
-                    # `annex get` will never report on directories, but if a
-                    # directory was requested, we want to say something about
-                    # it in the results.  we are inside a single, existing
-                    # repo, hence all directories are already present, if not
-                    # we had an error
-                    # do we have any failures in a subdir of the requested dir?
-                    failure_results = [
-                        fp for fp in respath_by_status.get('failure', [])
-                        if fp.startswith(_with_sep(p))]
-                    if failure_results:
-                        # we were not able to obtain all content, let's label
-                        # this 'impossible' to get a warning-type report
-                        # after all we have the directory itself, but not
-                        # (some) of its content
-                        yield get_status_dict(
-                            status='impossible', type_='directory',
-                            message=('could not get some content in %s %s',
-                                     p, failure_results), **common_report)
-                    else:
-                        # otherwise cool
-                        yield get_status_dict(
-                            status='ok', type_='directory', **common_report)
-                    continue
-                elif not any(p in ps for ps in respath_by_status.values()):
-                    # not a directory, and we have had no word from `git annex`,
-                    # yet no exception, hence the file was most probably
-                    # already present, or is in Git -> not needed
-                    yield get_status_dict(
-                        status='notneeded', type_='file',
-                        message=('%s is already present', p), **common_report)
-                else:
-                    # not a case we want to report beyond what we got from
-                    # `git annex`
-                    pass
+                    refds=refds_path):
+                yield r
 
     @staticmethod
     def custom_result_summary_renderer(res):

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -29,6 +29,8 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import SkipTest
@@ -45,14 +47,20 @@ def test_add_insufficient_args(path):
     # no `path`, no `source`:
     assert_raises(InsufficientArgumentsError, add, dataset=path)
     with chpwd(path):
-        with swallow_logs(new_level=logging.WARNING) as cml:
-            assert_raises(InsufficientArgumentsError, add, path="some")
-            assert_in('ignoring non-existent', cml.out)
-
-    ds = Dataset(path)
+        res = add(path="some", on_failure='ignore')
+        assert_status('impossible', res)
+    ds = Dataset(opj(path, 'ds'))
     ds.create()
-    assert_raises(InsufficientArgumentsError, ds.add,
-                  opj(pardir, 'path', 'outside'))
+    # non-existing path outside
+    assert_status('impossible', ds.add(opj(path, 'outside'), on_failure='ignore'))
+    # existing path outside
+    with open(opj(path, 'outside'), 'w') as f:
+        f.write('doesnt matter')
+    # should be
+    #assert_status('impossible', ds.add(opj(path, 'outside'), on_failure='ignore'))
+    # but actually is
+    # RF Interface._prep() in some way, not sure how yet
+    assert_raises(ValueError, ds.add, opj(path, 'outside'), on_failure='ignore')
 
 
 tree_arg = dict(tree={'test.txt': 'some',
@@ -115,7 +123,6 @@ def test_add_recursive(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
     subds = ds.create('dir', force=True)
-    ds.save("Submodule added.")
     ok_(subds.repo.dirty)
 
     # no subds without recursive:
@@ -129,17 +136,23 @@ def test_add_recursive(path):
     # for that effect ATM)
     added1 = ds.add(opj('dir', 'testindir'), jobs=2)
     # added to annex, so annex output record
-    eq_(added1, [{'file': opj(ds.path, 'dir', 'testindir'), 'command': 'add',
-                  'key': 'MD5E-s9--3f0f870d18d6ba60a79d9463ff3827ea',
-                  'success': True}])
+    assert_result_count(
+        added1, 1,
+        path=opj(ds.path, 'dir', 'testindir'), action='add',
+        annexkey='MD5E-s9--3f0f870d18d6ba60a79d9463ff3827ea',
+        status='ok')
     assert_in('testindir', Dataset(opj(path, 'dir')).repo.get_annexed_files())
+    ok_(subds.repo.dirty)
 
     added2 = ds.add('dir', to_git=True)
     # added to git, so parsed git output record
-    eq_(added2, [{'file': opj(ds.path, 'dir', 'testindir2'), 'command': u'add',
-                  'note': u'non-large file; adding content to git repository',
-                  'success': True}])
+    assert_result_count(
+        added2, 1,
+        path=opj(ds.path, 'dir', 'testindir2'), action='add',
+        message='non-large file; adding content to git repository',
+        status='ok')
     assert_in('testindir2', Dataset(opj(path, 'dir')).repo.get_indexed_files())
+    ok_clean_git(ds.path)
 
     # We used to fail to add to pure git repository, but now it should all be
     # just fine
@@ -147,14 +160,21 @@ def test_add_recursive(path):
     with open(opj(subds.path, 'somefile.txt'), "w") as f:
         f.write("bla bla")
     result = ds.add(opj('git-sub', 'somefile.txt'), to_git=False)
-    eq_(result, [{'file': opj(subds.path, 'somefile.txt'), 'success': True}])
+    # adds the file
+    assert_result_count(
+        result, 1,
+        action='add', path=opj(subds.path, 'somefile.txt'), status='ok')
+    # but also saves both datasets
+    assert_result_count(
+        result, 2,
+        action='save', status='ok', type='dataset')
 
 
 @with_tree(**tree_arg)
 def test_relpath_add(path):
     ds = Dataset(path).create(force=True)
     with chpwd(opj(path, 'dir')):
-        eq_(add('testindir')[0]['file'],
+        eq_(add('testindir')[0]['path'],
             opj(ds.path, 'dir', 'testindir'))
         # and now add all
         add('..')

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -14,11 +14,8 @@ from os.path import join as opj
 
 from ..dataset import Dataset
 from datalad.api import create
-from datalad.api import uninstall
 from datalad.utils import chpwd
-from datalad.utils import rmtree
 from datalad.cmd import Runner
-from datalad.support.exceptions import CommandError
 
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import eq_
@@ -28,6 +25,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_equal
 from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tree
 
@@ -187,7 +185,11 @@ def test_nested_create(path):
     assert_raises(ValueError, ds.create, lvl2relpath)
     # even with force, as to do this properly complicated surgery would need to
     # take place
-    assert_raises(CommandError, ds.create, lvl2relpath, force=True)
+    assert_in_results(
+        ds.create(lvl2relpath, force=True,
+                  on_failure='ignore', result_xfm=None, result_filter=None,
+                  return_type='generator'),
+        status='error', action='add')
     # only way to make it work is to unannex the content upfront
     ds.repo._run_annex_command('unannex', annex_options=[opj(lvl2relpath, 'file')])
     # nothing to save, git-annex commits the unannex itself

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -31,6 +31,7 @@ from datalad.tests.utils import SkipTest
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
@@ -278,8 +279,10 @@ def test_remove_file_handle_only(path):
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
-    # we add one file
-    eq_(len(subds.add('.')), 1)
+    # we add one file, but we get a response for the requested
+    # directory too
+    assert_result_count(subds.add('.'), 2,
+                        action='add', status='ok')
     # save all -> all clean
     ds.save(all_updated=True, recursive=True)
     ok_clean_git(subds.path)

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -22,11 +22,9 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import DataLadRI
 from datalad.support.network import URL
 from datalad.support.network import RI
-from datalad.support.network import SSHRI
 from datalad.support.network import PathRI
 from datalad.utils import knows_annex
 
-from .dataset import Dataset
 
 lgr = logging.getLogger('datalad.distribution.utils')
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -18,7 +18,6 @@ lgr = logging.getLogger('datalad.interface.base')
 import sys
 import re
 import textwrap
-from os.path import curdir
 import inspect
 from collections import OrderedDict
 
@@ -314,12 +313,16 @@ class Interface(object):
         # let it run like generator so we can act on partial results quicker
         # TODO remove following condition test when transition is complete and
         # run indented code unconditionally
-        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Get', 'Clone', 'Subdatasets', 'Install'):
+        if cls.__name__ in ('Update', 'Save', 'Create', 'Unlock', 'Clean', 'Drop', 'Uninstall', 'Remove', 'Get', 'Clone', 'Subdatasets', 'Install', 'Add'):
             # set all common args explicitly  to override class defaults
             # that are tailored towards the the Python API
             kwargs['return_type'] = 'generator'
             kwargs['result_xfm'] = None
             kwargs['result_renderer'] = args.common_output_format
+            if '{' in args.common_output_format:
+                # stupid hack, could and should become more powerful
+                kwargs['result_renderer'] = \
+                    lambda x, **kwargs: ui.message(args.common_output_format.format(**x))
             if args.common_on_failure:
                 kwargs['on_failure'] = args.common_on_failure
             # compose filter function from to be invented cmdline options

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -109,8 +109,8 @@ def test_recursive_save(path):
     ok_clean_git(ds.path)
     subsubds = subds.create('subsub')
     assert_equal(
-        ds.get_subdatasets(recursive=True, absolute=True, fulfilled=True),
-        [subsubds.path, subds.path])
+        ds.subdatasets(recursive=True, fulfilled=True, result_xfm='paths'),
+        [subds.path, subsubds.path])
     newfile_name = opj(subsubds.path, 'test')
     with open(newfile_name, 'w') as f:
         f.write('some')

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -28,7 +28,6 @@ from datalad.utils import swallow_logs
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import EnsureDataset
-from datalad.distribution.add import _install_subds_inplace
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
@@ -358,7 +357,7 @@ class Test_Utils(Interface):
         for i in range(number):
             # this dict will need to have the minimum info required by
             # eval_results
-            yield {'path': 'some', 'status': 'ok', 'somekey': i}
+            yield {'path': 'some', 'status': 'ok', 'somekey': i, 'action': 'off'}
 
 
 def test_eval_results_plus_build_doc():
@@ -428,7 +427,7 @@ def test_result_filter():
             Test_Utils().__call__(
                 4,
                 result_filter=filt)[-1],
-            {'path': 'some', 'status': 'ok', 'somekey': 2})
+            {'action': 'off', 'path': 'some', 'status': 'ok', 'somekey': 2})
 
     # test more sophisticated filters that actually get to see the
     # API call's kwargs

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -510,7 +510,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
     # paths that don't exist (yet)
     unavailable_paths = []
     nondataset_paths = []
-    for path in paths:
+    for path in unique(paths):
         if not lexists(path):
             # not there yet, impossible to say which ds it will actually
             # be in, if any
@@ -525,24 +525,53 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
             d = dirname(path)
             if not d:
                 d = curdir
-        # this could be `None` if there is no git repo
-        dspath = dir_lookup.get(d, get_dataset_root(d))
-        dir_lookup[d] = dspath
+
+        dspath = dir_lookup.get(d, None)
+        if dspath:
+            _ds_looked_up = True
+        else:
+            _ds_looked_up = False
+            # this could be `None` if there is no git repo
+            dspath = get_dataset_root(d)
+            dir_lookup[d] = dspath
+
         if not dspath:
             nondataset_paths.append(path)
             continue
+
+        if path in out.get(dspath, []):
+            # we already recorded this path in the output
+            # this can happen, whenever `path` is a subdataset, that was
+            # discovered via recursive processing of another path before
+            continue
+
         if isdir(path):
             ds = Dataset(dspath)
             # we need to doublecheck that this is not a subdataset mount
-            # point, in which case get_toppath() would point to the parent
-            smpath = ds.get_containing_subdataset(
-                path, recursion_limit=1).path
-            if smpath != dspath:
-                # fix entry
-                dir_lookup[d] = smpath
-                # submodule still needs to be obtained
-                unavailable_paths.append(path)
-                continue
+            # point, in which case get_dataset_root() would point to the parent.
+
+            if not _ds_looked_up:
+                # we didn't deal with it before
+
+                smpath = ds.get_containing_subdataset(
+                    path, recursion_limit=1).path
+                if smpath != dspath:
+                    # fix entry
+                    dir_lookup[d] = smpath
+                    # submodule still needs to be obtained
+                    unavailable_paths.append(path)
+                    continue
+            else:
+                # we figured out the dataset previously, so we can spare some
+                # effort by not calling ds.subdatasets or
+                # ds.get_containing_subdataset. Instead we just need
+                # get_dataset_root, which is cheaper
+                if dspath != get_dataset_root(dspath):
+                    # if the looked up path isn't the default value,
+                    # it's a 'fixed' entry for an unavailable dataset (see above)
+                    unavailable_paths.append(path)
+                    continue
+
             if recursive:
                 # make sure we get everything relevant in all _checked out_
                 # subdatasets, obtaining of previously unavailable subdataset
@@ -559,6 +588,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
                         out[subdspath] = out.get(
                             subdspath,
                             [subdspath] if sub_paths else [])
+
         out[dspath] = out.get(dspath, []) + [path]
     return out, unavailable_paths, nondataset_paths
 


### PR DESCRIPTION
Closes #1505 

In the light of #1506 it probably doesn't make sense to spend more time on this right now. Nevertheless some obvious waste of time is removed. Basically this reduces the calls to `subdatasets`. There is one little change in semantics: Before paths, that were in the input several times, were reported several times in the output. Since the output is a dict with the discovered datasets as key, this doesn't make sense to me. Changing this behavior seems to not break anything, so ...

Marked as WIP, while waiting for the tests ...