### PR TITLE
Benchmark basic API commands (add, install, etc)

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
+    "branches": ["0.5.x", "master"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -18,10 +18,14 @@ from subprocess import call
 from datalad.api import add
 from datalad.api import create
 from datalad.api import create_test_dataset
+from datalad.api import Dataset
 from datalad.api import install
 from datalad.api import ls
+from datalad.api import remove
+from datalad.api import uninstall
 
 from datalad.utils import rmtree
+from datalad.utils import getpwd
 
 # Some tracking example -- may be we should track # of datasets.datalad.org
 #import gc
@@ -102,15 +106,32 @@ class SuperdatasetsOperationsSuite(SuprocBenchmarks):
 
     def setup_cache(self):
         # creating in CWD so things get removed when ASV is done
-        return create_test_dataset("testds1", spec='2/-3/-2', seed=0)[0]
+        ds_path = create_test_dataset("testds1", spec='2', seed=0)[0]
+        tarfile_path = opj(osp.dirname(ds_path), 'testds1.tar')
+        import tarfile
+        with tarfile.open(tarfile_path, "w") as tar:
+            # F.CK -- Python tarfile can't later extract those because key dirs are
+            # read-only.  For now just a workaround - make it all writeable
+            from datalad.utils import rotree
+            rotree('testds1', ro=False, chmod_files=False)
+            tar.add('testds1', recursive=True)
+        rmtree('testds1')
+
+        return tarfile_path
 
     def setup(self, orig_ds_path):
-        self.ds = install(orig_ds_path + '_clone',
-                          source=orig_ds_path,
-                          recursive=True)
-        # 0.5.x versions return a list of all installed datasets when recursive
-        if isinstance(self.ds, list):
-            self.ds = self.ds[0]
+        # self.ds = install(orig_ds_path + '_clone',
+        #                   source=orig_ds_path,
+        #                   recursive=True)
+        import tarfile
+        tempdir = osp.dirname(orig_ds_path)
+        with tarfile.open(orig_ds_path) as tar:
+            tar.extractall(tempdir)
+        self.ds = Dataset(opj(tempdir, 'testds1'))
+        sys.stderr.write("HERE: %s\n" % self.ds)
+        # # 0.5.x versions return a list of all installed datasets when recursive
+        # if isinstance(self.ds, list):
+        #     self.ds = self.ds[0]
 
     def teardown(self, orig_ds_path):
         rmtree(self.ds.path)
@@ -122,6 +143,10 @@ class SuperdatasetsOperationsSuite(SuprocBenchmarks):
         # somewhat duplicating setup but lazy to do different one for now
         assert install(self.ds.path + '_', source=self.ds.path, recursive=True)
 
+    # def time_installcopy(self, orig_ds_path):
+    #     import shutil
+    #     shutil.copytree(orig_ds_path, self.ds.path + '___')
+
     def time_createadd(self, orig_ds_path):
         assert self.ds.create('newsubds')
 
@@ -131,3 +156,10 @@ class SuperdatasetsOperationsSuite(SuprocBenchmarks):
 
     def time_ls(self, orig_ds_path):
         ls(self.ds.path)
+
+    # TODO: since doesn't really allow to uninstall top level ds... bleh ;)
+    #def time_uninstall(self, orig_ds_path):
+    #    uninstall(self.ds.path, recursive=True)
+
+    def time_remove(self, orig_ds_path):
+        remove(self.ds.path, recursive=True)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -10,12 +10,26 @@
 import os
 import sys
 import os.path as osp
-
+from os.path import join as opj
 import timeit
 
 from subprocess import call
 
-import time
+from datalad.api import add
+from datalad.api import create
+from datalad.api import create_test_dataset
+from datalad.api import install
+from datalad.api import ls
+
+from datalad.utils import rmtree
+
+# Some tracking example -- may be we should track # of datasets.datalad.org
+#import gc
+#def track_num_objects():
+#    return len(gc.get_objects())
+#track_num_objects.unit = "objects"
+
+
 class SuprocBenchmarks(object):
     # manually set a number since otherwise takes way too long!
     # see https://github.com/spacetelescope/asv/issues/497
@@ -24,7 +38,7 @@ class SuprocBenchmarks(object):
 
     # custom timer so we account for subprocess times
     timer = timeit.default_timer
-    pass
+
 
 class StartupSuite(SuprocBenchmarks):
     """
@@ -67,3 +81,53 @@ class RunnerSuite(SuprocBenchmarks):
 
     def time_echo_gitrunner(self):
         self.git_runner.run("echo")
+
+
+class CreateTestDatasetSuite(SuprocBenchmarks):
+    """
+    Benchmarks to test on create_test_dataset how fast we could generate datasets
+    """
+
+    def time_create_test_dataset1(self):
+        create_test_dataset(spec='1', seed=0)
+
+    def time_create_test_dataset2x2(self):
+        create_test_dataset(spec='2/2', seed=0)
+
+
+class SuperdatasetsOperationsSuite(SuprocBenchmarks):
+    """
+    Benchmarks on common operations on collections of datasets using datalad API
+    """
+
+    def setup_cache(self):
+        # creating in CWD so things get removed when ASV is done
+        return create_test_dataset("testds1", spec='2/-3/-2', seed=0)[0]
+
+    def setup(self, orig_ds_path):
+        self.ds = install(orig_ds_path + '_clone',
+                          source=orig_ds_path,
+                          recursive=True)
+        # 0.5.x versions return a list of all installed datasets when recursive
+        if isinstance(self.ds, list):
+            self.ds = self.ds[0]
+
+    def teardown(self, orig_ds_path):
+        rmtree(self.ds.path)
+        possibly_installed = self.ds.path + '_'
+        if osp.exists(possibly_installed):
+            rmtree(possibly_installed)
+
+    def time_installr(self, orig_ds_path):
+        # somewhat duplicating setup but lazy to do different one for now
+        assert install(self.ds.path + '_', source=self.ds.path, recursive=True)
+
+    def time_createadd(self, orig_ds_path):
+        assert self.ds.create('newsubds')
+
+    def time_createadd_to_dataset(self, orig_ds_path):
+        subds = create(opj(self.ds.path, 'newsubds'))
+        self.ds.add(subds.path)
+
+    def time_ls(self, orig_ds_path):
+        ls(self.ds.path)


### PR DESCRIPTION
Whatever I thought would be 20 minutes, resulted in hours of 
- #1512 "discovery", troubleshooting and for which here I just provided an ugly workaround here for benchmarks in question but should be properly fixed asap
- 2 commits pushed directly into master (6ca5392a1550c64c17e448527d74076586ff7455, 6ca5392a1550c64c17e448527d74076586ff7455) 

So now, you can do something like 
```shell
$> asv run --python=2.7 --dry-run --bench .*SuperdatasetsOperationsSuite.*   
· Creating environments                                                   
· Discovering benchmarks
·· Uninstalling from virtualenv-py2.7
·· Building for virtualenv-py2.7
·· Installing into virtualenv-py2.7..
· Running 10 total benchmarks (2 commits * 1 environments * 5 benchmarks)
[  0.00%] · For DataLad commit hash 6ca5392a:
[  0.00%] ·· Building for virtualenv-py2.7..
[  0.00%] ·· Benchmarking virtualenv-py2.7
[  0.00%] ··· Setting up /home/yoh/proj/datalad/datalad/benchmarks/benchmarks.py:114
[ 10.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_createadd                                                                      1.50s
[ 20.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_createadd_to_dataset                                                           1.79s
[ 30.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_installr                                                                       6.02s
[ 40.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_ls                                                                          141.71ms
[ 50.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_remove                                                                         6.16s
[ 50.00%] · For DataLad commit hash cdedf35d:
[ 50.00%] ·· Building for virtualenv-py2.7...
[ 50.00%] ·· Benchmarking virtualenv-py2.7
[ 50.00%] ··· Setting up /home/yoh/proj/datalad/datalad/benchmarks/benchmarks.py:114
[ 60.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_createadd                                                                      1.17s
[ 70.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_createadd_to_dataset                                                           1.54s
[ 80.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_installr                                                                       6.07s
[ 90.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_ls                                                                          146.31ms
[100.00%] ··· Running benchmarks.SuperdatasetsOperationsSuite.time_remove                                                                         6.12s
```

I also filed https://github.com/spacetelescope/asv/issues/513 which if resolved could help to see right away which commit is for which branch(es) among being tested.

- [ ] add latest release into the "branches" to be tested.  Then could be compared right away against latest release performance
- [x] run benchmarks on some dedicated for that purpose box. probably shouldn't use smaug 