### PR TITLE
BF: do not whine whenever removing a dataset which is not a subdataset

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -682,13 +682,13 @@ git update-server-info
 # DataLad
 #
 # (Re)generate meta-data for DataLad Web UI and possibly init new submodules
-dsdir={path}
-logfile=$dsdir/{WEB_META_LOG}/{log_filename}
+dsdir="{path}"
+logfile="$dsdir/{WEB_META_LOG}/{log_filename}"
 
 mkdir -p "$dsdir/{WEB_META_LOG}"  # assure logs directory exists
 
 ( which datalad > /dev/null \
-  && ( cd ..; GIT_DIR=$PWD/.git datalad ls -a --json file "$dsdir"; ) \
+  && ( cd ..; GIT_DIR="$PWD/.git" datalad ls -a --json file "$dsdir"; ) \
   || echo "E: no datalad found - skipping generation of indexes for web frontend"; \
 ) &> "$logfile"
 

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -72,7 +72,7 @@ def _test_correct_publish(target_path, rootds=False, flat=True):
 
     hook_path = _path_(target_path, '.git/hooks/post-update')
     ok_file_has_content(hook_path,
-                        '.*\ndsdir=%s\n.*' % target_path,
+                        '.*\ndsdir="%s"\n.*' % target_path,
                         re_=True,
                         flags=re.DOTALL)
     # correct ls_json command in hook content (path wrapped in "quotes)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -34,6 +34,7 @@ from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.utils import chpwd
+from datalad.utils import _path_
 from datalad.support.external_versions import external_versions
 from datalad.utils import swallow_logs
 
@@ -362,3 +363,14 @@ def test_remove_recreation(path):
     ds = create(path)
     ok_clean_git(ds.path)
     ok_(ds.is_installed())
+
+
+@with_tempfile()
+def test_remove_nowhining(path):
+    # when removing a dataset under a dataset (but not a subdataset)
+    # should not provide a meaningless message that something was not right
+    ds = create(path)
+    # just install/clone inside of it
+    subds_path = _path_(path, 'subds')
+    install(subds_path, source=path)
+    remove(subds_path)  # should remove just fine

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -397,24 +397,32 @@ class Remove(Interface):
                 # remove submodule reference
                 submodule = [sm for sm in superds.repo.repo.submodules
                              if sm.path == subds_relpath]
-                # there can only be one!
-                assert len(submodule) == 1, \
-                    "Found multiple subdatasets with registered path {}:" \
-                    "{}{}{}There should be only one." \
-                    "".format(subds_relpath, os.linesep,
-                              submodule, os.linesep)
-                submodule = submodule[0]
-                submodule.remove()
+                if submodule:
+                    # there can only be one!
+                    assert len(submodule) == 1, \
+                        "Found multiple subdatasets with registered path {}:" \
+                        "{}{}{}There should be only one." \
+                        "".format(subds_relpath, os.linesep,
+                                  submodule, os.linesep)
+                    submodule = submodule[0]
+                    submodule.remove()
+
+                    # need to save changes to .gitmodules later
+                    content_by_ds[superds.path] = \
+                        content_by_ds.get(superds.path, []) \
+                        + [opj(superds.path, '.gitmodules'),
+                           ds_path]
+                    ds2save.add(superds.path)
+                else:
+                    lgr.info(
+                        "This dataset was not found to be a subdataset of %s",
+                        superds
+                    )
+
                 if exists(ds_path):
                     # could be an empty dir in case an already uninstalled subdataset
                     # got removed
                     os.rmdir(ds_path)
-                # need to save changes to .gitmodules later
-                content_by_ds[superds.path] = \
-                    content_by_ds.get(superds.path, []) \
-                    + [opj(superds.path, '.gitmodules'),
-                       ds_path]
-                ds2save.add(superds.path)
             else:
                 if check and hasattr(ds.repo, 'drop'):
                     _drop_files(ds, paths, check=True)


### PR DESCRIPTION
did
```
datalad install --reckless -s raiders raiders-clone
```
so it wasn't added to that superdataset. but upon remove benign message made no sense:
```shell
$> datalad remove --nocheck raiders-clone             
[ERROR  ] Found multiple subdatasets with registered path raiders-clone:
| []
| There should be only one. [uninstall.py:__call__:405] (AssertionError) 
```
so I just made that logic conditional on being a subdataset