### PR TITLE
BF(?): do not write index explicitly in precommit

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -878,10 +878,15 @@ class GitRepo(RepoInterface):
     def precommit(self):
         """Perform pre-commit maintenance tasks
         """
-
-        if self.repo is not None and exists(opj(self.path, '.git')):  # don't try to write otherwise:
-            # flush possibly cached in GitPython changes to index:
-            self.repo.index.write()
+        # All GitPython commands should take care about flushing index
+        # whenever they modify it, so we would not care to do anything
+        # if self.repo is not None and exists(opj(self.path, '.git')):  # don't try to write otherwise:
+        #     # flush possibly cached in GitPython changes to index:
+        #     # if self.repo.git:
+        #     #     sys.stderr.write("CLEARING\n")
+        #     #     self.repo.git.clear_cache()
+        #     self.repo.index.write()
+        pass
 
     @staticmethod
     def _get_prefixed_commit_msg(msg):


### PR DESCRIPTION
to see if this would be legit (no tests broken) and possibly help to resolve the locking issue.

the point is -- we might not need to write index at that point. moreover it might be OPT since now this call makes GitPython  first read index if it wasn't read before and then write it (if I got it right)