### PR TITLE
RF: benchmarks -- shortened names and moved into separate modules

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["0.5.x", "master"], // for git
+    "branches": ["master", "0.5.x"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
@@ -94,7 +94,7 @@
 
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
-    // "benchmark_dir": "benchmarks",
+    "benchmark_dir": "benchmarks",
 
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -1,0 +1,22 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Helpers for benchmarks of DataLad"""
+
+import timeit
+
+
+class SuprocBenchmarks(object):
+    # manually set a number since otherwise takes way too long!
+    # see https://github.com/spacetelescope/asv/issues/497
+    #number = 3
+    # although seems to work ok with a timer which accounts for subprocesses
+
+    # custom timer so we account for subprocess times
+    timer = timeit.default_timer
+
+

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -1,0 +1,83 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Benchmarks for DataLad"""
+
+import os
+import sys
+import os.path as osp
+from os.path import join as opj
+import tarfile
+import timeit
+
+from subprocess import call
+
+from datalad.api import add
+from datalad.api import create
+from datalad.api import create_test_dataset
+from datalad.api import Dataset
+from datalad.api import install
+from datalad.api import ls
+from datalad.api import remove
+from datalad.api import uninstall
+
+from datalad.utils import rmtree
+from datalad.utils import getpwd
+
+# Some tracking example -- may be we should track # of datasets.datalad.org
+#import gc
+#def track_num_objects():
+#    return len(gc.get_objects())
+#track_num_objects.unit = "objects"
+
+
+from .common import SuprocBenchmarks
+
+
+class startup(SuprocBenchmarks):
+    """
+    Benchmarks for datalad commands startup
+    """
+
+    def setup(self):
+        # we need to prepare/adjust PATH to point to installed datalad
+        # We will base it on taking sys.executable
+        python_path = osp.dirname(sys.executable)
+        self.env = os.environ.copy()
+        self.env['PATH'] = '%s:%s' % (python_path, self.env.get('PATH', ''))
+
+    def time_help_np(self):
+        call(["datalad", "--help-np"], env=self.env)
+        
+    def time_import(self):
+        call([sys.executable, "-c", "import datalad"])
+
+    def time_import_api(self):
+        call([sys.executable, "-c", "import datalad.api"])
+
+
+class runner(SuprocBenchmarks):
+    """Some rudimentary tests to see if there is no major slowdowns from Runner
+    """
+
+    def setup(self):
+        from datalad.cmd import Runner
+        self.runner = Runner()
+        # older versions might not have it
+        try:
+            from datalad.cmd import GitRunner
+            self.git_runner = GitRunner()
+        except ImportError:
+            pass
+
+    def time_echo(self):
+        self.runner.run("echo")
+
+    def time_echo_gitrunner(self):
+        self.git_runner.run("echo")
+
+


### PR DESCRIPTION
Now published already at http://datalad.github.io/datalad/ -- I reran them completely, so old results are gone, and should be easier to navigate.  running for more commits now