### PR TITLE
WiP NF XNAT/NITRC-IR support

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -343,7 +343,9 @@ def main(args=None):
                 # behave as if the command ran directly, importantly pass
                 # exit code as is
                 if exc.msg:
-                    os.write(2, exc.msg.encode() if isinstance(exc.msg, text_type) else exc.msg)
+                    os.write(
+                        2,
+                        (exc.msg.encode() if isinstance(exc.msg, text_type) else exc.msg).rstrip() + "\n")
                 if exc.stdout:
                     os.write(1, exc.stdout.encode()) \
                         if hasattr(exc.stdout, 'encode')  \

--- a/datalad/crawler/dbs/base.py
+++ b/datalad/crawler/dbs/base.py
@@ -198,6 +198,8 @@ class FileStatusesBaseDB(object):
         # TODO: make use of URL -- we should validate that url is among those associated
         #  with the file
         old_status = self.get(fpath)
+        if old_status is None:
+            return True
         if status.filename and not old_status.filename:
             old_status.filename = basename(fpath)
         return old_status != status

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -37,6 +37,7 @@ from ...utils import rmtree, updated
 from ...utils import lmtime
 from ...utils import find_files
 from ...utils import auto_repr
+from ...utils import check_free_space
 from ...utils import getpwd
 from ...utils import try_multiple
 from ...tests.utils import put_file_under_git
@@ -50,6 +51,7 @@ from ...support.annexrepo import AnnexRepo
 from ...support.stats import ActivityStats
 from ...support.versions import get_versions
 from ...support.exceptions import AnnexBatchCommandError
+from ...support.exceptions import OutOfSpaceError
 from ...support.external_versions import external_versions
 from ...support.network import get_url_straight_filename, get_url_disposition_filename
 
@@ -517,6 +519,10 @@ class Annexificator(object):
                 lgr.info("Need to download %s from %s. No progress indication will be reported"
                          % (naturalsize(url_status.size), url))
             try:
+                if url_status and url_status.size:
+                    # Get amount of freespace on the drive, and fail early if
+                    # we have no sufficient storage
+                    check_free_space(fpath, url_status.size)
                 out_json = try_multiple(
                     6, AnnexBatchCommandError, 3,  # up to 3**5=243 sec sleep
                     _call,

--- a/datalad/crawler/pipelines/fcptable.py
+++ b/datalad/crawler/pipelines/fcptable.py
@@ -182,4 +182,7 @@ def pipeline(dataset):
         ],
         annex.switch_branch('master'),
         annex.finalize(cleanup=True),
+        # TODO:  if we want to aggregate with info for data from NITRC XNAT, we should
+        # match 'label' for each subject which is "Site_subjid".  subjid you can
+        # get from this dataset by globing I guess
     ]

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -46,7 +46,7 @@ TOPURL = "https://openfmri.org/dataset/"
 # define a pipeline factory function accepting necessary keyword arguments
 # Should have no strictly positional arguments
 def superdataset_pipeline(url=TOPURL, **kwargs):
-    annex = Annexificator(no_annex=True, allow_dirty=True)
+    annex = Annexificator(no_annex=True, allow_dirty=False)
     lgr.info("Creating a pipeline with kwargs %s" % str(kwargs))
     return [
         crawl_url(url),

--- a/datalad/crawler/pipelines/tests/test_xnat.py
+++ b/datalad/crawler/pipelines/tests/test_xnat.py
@@ -92,7 +92,11 @@ def check_basic_xnat_interface(url, project, subjects):
 def test_basic_xnat_interface():
     for url, project, subjects in [
         ('https://www.nitrc.org/ir', 'fcon_1000', ['xnat_S00401', 'xnat_S00447']),
-        ('https://central.xnat.org', 'CENTRAL_OASIS_LONG', ['OAS2_0001', 'OAS2_0176'])
+        ('https://central.xnat.org', 'CENTRAL_OASIS_LONG', ['OAS2_0001', 'OAS2_0176']),
+    # Should have worked, since we do have authentication setup for hcp, but
+    # failed to authenticate.  need to recall what is differently done for the test
+    # since it downloads just fine using download-url
+    #   ('https://db.humanconnectome.org', 'HCP_Retest', ['103818', '149741']),
     ]:
         yield check_basic_xnat_interface, url, project, subjects
 

--- a/datalad/crawler/pipelines/tests/test_xnat.py
+++ b/datalad/crawler/pipelines/tests/test_xnat.py
@@ -1,0 +1,108 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import os
+from glob import glob
+from os.path import join as opj
+from os.path import exists
+from mock import patch
+
+from ...nodes.crawl_url import crawl_url
+from ...nodes.matches import *
+from ...pipeline import run_pipeline, FinishPipeline
+
+from ...nodes.misc import Sink, assign, range_node, interrupt_if
+from ...nodes.annex import Annexificator, initiate_dataset
+from ...pipeline import load_pipeline_from_module
+
+from ....support.stats import ActivityStats
+from ....support.gitrepo import GitRepo
+from ....support.annexrepo import AnnexRepo
+
+from ....api import clean
+from ....utils import chpwd
+from ....utils import find_files
+from ....utils import swallow_logs
+from ....tests.utils import with_tree
+from ....tests.utils import SkipTest
+from ....tests.utils import eq_, assert_not_equal, ok_, ok_startswith
+from ....tests.utils import assert_in, assert_is_generator
+from ....tests.utils import skip_if_no_module
+from ....tests.utils import with_tempfile
+from ....tests.utils import serve_path_via_http
+from ....tests.utils import skip_if_no_network
+from ....tests.utils import use_cassette
+from ....tests.utils import ok_file_has_content
+from ....tests.utils import ok_file_under_git
+
+from .. import openfmri
+from ..openfmri import pipeline as ofpipeline
+
+import logging
+from logging import getLogger
+lgr = getLogger('datalad.crawl.tests')
+
+
+#
+# Some helpers
+#
+
+from ..xnat import XNATServer
+
+
+def check_basic_xnat_interface(url, project, subjects):
+    nitrc = XNATServer(url)
+    projects = nitrc.get_projects()
+    # verify that we still have projects we want!
+
+    assert_in(project, projects)
+    subjects_ = nitrc.get_subjects(project)
+    assert len(subjects_)
+    experiments = nitrc.get_experiments(project, subjects[0])
+    # NOTE: assumption that there is only one experiment
+    files1 = nitrc.get_files(project, subjects[0], experiments.keys()[0])
+    assert files1
+
+    experiments = nitrc.get_experiments(project, subjects[1])
+    files2 = nitrc.get_files(project, subjects[1], experiments.keys()[0])
+    assert files2
+
+    ok_startswith(files1[0]['URI'], '/data')
+    gen = nitrc.get_all_files_for_project(project,
+                                          subjects=subjects,
+                                          experiments=[experiments.keys()[0]])
+    assert_is_generator(gen)
+    all_files = list(gen)
+    if len(experiments) == 1:
+        eq_(len(all_files), len(files1) + len(files2))
+    else:
+        # there should be more files due to multiple experiments which we didn't actually check
+        assert len(all_files) > len(files1) + len(files2)
+
+
+# THIS SOMEHOW CAUSES the test to not run!!! wtf? TODO
+#@skip_if_no_network
+@use_cassette('test_basic_xnat_interface')
+def test_basic_xnat_interface():
+    for url, project, subjects in [
+        ('https://www.nitrc.org/ir', 'fcon_1000', ['xnat_S00401', 'xnat_S00447']),
+        ('https://central.xnat.org', 'CENTRAL_OASIS_LONG', ['OAS2_0001', 'OAS2_0176'])
+    ]:
+        yield check_basic_xnat_interface, url, project, subjects
+
+
+# TODO: RF to provide a generic/reusable test for this
+@with_tempfile(mkdir=True)
+def _test_smoke_pipelines(d):
+    # Just to verify that we can correctly establish the pipelines
+    AnnexRepo(d, create=True)
+    with chpwd(d):
+        with swallow_logs():
+            for p in [pipeline('bogus'), collection_pipeline()]:
+                ok_(len(p) > 1)

--- a/datalad/crawler/pipelines/tests/test_xnat.py
+++ b/datalad/crawler/pipelines/tests/test_xnat.py
@@ -54,6 +54,7 @@ lgr = getLogger('datalad.crawl.tests')
 #
 
 from ..xnat import XNATServer
+from ..xnat import PROJECT_ACCESS_TYPES
 
 
 def check_basic_xnat_interface(url, project, subjects):
@@ -62,6 +63,14 @@ def check_basic_xnat_interface(url, project, subjects):
     # verify that we still have projects we want!
 
     assert_in(project, projects)
+    projects_public = nitrc.get_projects(limit='public')
+    import json
+    print json.dumps(projects_public, indent=2)
+    assert len(projects_public) < len(projects)
+    assert not set(projects_public).difference(projects)
+    eq_(set(projects),
+        set(nitrc.get_projects(limit=PROJECT_ACCESS_TYPES)))
+
     subjects_ = nitrc.get_subjects(project)
     assert len(subjects_)
     experiments = nitrc.get_experiments(project, subjects[0])
@@ -73,7 +82,7 @@ def check_basic_xnat_interface(url, project, subjects):
     files2 = nitrc.get_files(project, subjects[1], experiments.keys()[0])
     assert files2
 
-    ok_startswith(files1[0]['URI'], '/data')
+    ok_startswith(files1[0]['uri'], '/data')
     gen = nitrc.get_all_files_for_project(project,
                                           subjects=subjects,
                                           experiments=[experiments.keys()[0]])

--- a/datalad/crawler/pipelines/xnat.py
+++ b/datalad/crawler/pipelines/xnat.py
@@ -1,0 +1,159 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A pipeline for crawling XNAT servers/datasets (e.g. NITRC/ir)"""
+
+"""
+Notes:
+
+- xml entries for subject contain meta-data
+- in longitudinal studies there could be multiple ages for a subject... find where
+  it is
+
+    1  curl -I ftp://www.nitrc.org/fcon_1000/htdocs/AnnArbor_a.tar
+    2  man wget
+    3  wget
+    4  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08
+    5  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects
+    6  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects?format=csv
+    7  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/Taipei_sub43181?format=xml
+    8* curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/Taipei_sub431
+    9  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects?format=csv
+   10  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects
+   11  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments
+   12  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scans
+   13* curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments?
+   14  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830
+   15  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830?format=csv
+   16  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830?format=xml
+   17  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz
+   18  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz/resources
+   19  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz/resources?format=csv
+   20  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz/resources?format=csv
+   21  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans
+   22  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources
+   23  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files
+   24  curl -O http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files/scan_mprage_anonymized.nii.gz
+
+   28  curl -I http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files/scan_mprage_anonymized.nii.gz
+   29  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files?format=csv
+   30  curl http://www.nitrc.org/ir/data/projects
+   31  curl http://www.nitrc.org/ir/data/projects?format=csv
+   32  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects
+   33  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects | format_json
+   34  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments | format_json
+   35  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/scans
+   36  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/scans |format_json
+   37  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors
+   38  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors
+   39  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg
+   40  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg?format=xml
+   41  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg/resources
+   42  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg/resources/NIfTI/files
+   43  curl -O http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg/resources/NIfTI/files/seg.nii.gz
+   44  fslview seg.nii.gz
+   45  curl -u user:pass http://www.nitrc.org/ir/data/JSESSION
+   46  history
+   47  curl http://www.nitrc.org/ir/data/projects?format=csv
+"""
+
+import os
+import re
+import json
+from os.path import lexists
+
+# Import necessary nodes
+from ..nodes.crawl_url import crawl_url
+from ..nodes.matches import css_match, a_href_match
+from ..nodes.misc import assign
+from ..nodes.misc import sub
+from ..nodes.misc import switch
+from ..nodes.misc import func_to_node
+from ..nodes.misc import find_files
+from ..nodes.misc import skip_if
+from ..nodes.misc import debug
+from ..nodes.misc import fix_permissions
+from ..nodes.annex import Annexificator
+from ...support.s3 import get_versioned_url
+from ...utils import updated
+from ...consts import ARCHIVES_SPECIAL_REMOTE, DATALAD_SPECIAL_REMOTE
+from datalad.downloaders.providers import Providers
+
+# For S3 crawling
+from ..nodes.s3 import crawl_s3
+from .openfmri_s3 import pipeline as s3_pipeline
+from datalad.api import ls
+from datalad.dochelpers import exc_str
+
+# Possibly instantiate a logger if you would like to log
+# during pipeline creation
+from logging import getLogger
+lgr = getLogger("datalad.crawler.pipelines.openfmri")
+
+from datalad.tests.utils import eq_
+
+
+def list_to_dict(l, field):
+    return {r.pop(field): r for r in l}
+
+class XNATServer(object):
+    def __init__(self, topurl):
+        self.topurl = topurl
+        from datalad.downloaders.providers import Providers
+        providers = Providers.from_config_files()
+        self.downloader = providers.get_provider(topurl).get_downloader(topurl)
+
+    def __call__(self, query, format='json', fields_to_check={'totalRecords', 'Result'}):
+        query_url = "%s/%s" % (self.topurl, query)
+        if format:
+            query_url += "?format=%s" % format
+        out = self.downloader.fetch(query_url)
+        if format == 'json':
+            j = json.loads(out)
+            assert j.keys() == ['ResultSet']
+            j = j['ResultSet']
+            if fields_to_check:
+                eq_(set(j.keys()), fields_to_check)
+            return j['Result']
+        return out
+
+    def get_projects(self):
+        return list_to_dict(self('data/projects'), 'ID')
+
+    def get_subjects(self, project):
+        return list_to_dict(
+            self('data/projects/%(project)s/subjects' % locals()),
+            'ID'
+        )
+
+    def get_experiments(self, project, subject):
+        return list_to_dict(
+            # http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments?
+            self('data/projects/%(project)s/subjects/%(subject)s/experiments' % locals()),
+            'ID'
+        )
+
+    def get_files(self, project, subject, experiment):
+        files = []
+        for rec_type in ('scans', 'assessors'):
+            url = 'data/projects/%(project)s/subjects/%(subject)s/experiments/%(experiment)s/%(rec_type)s' % \
+                      locals()
+            recs = self(url)
+            files_ = []
+            for rec in recs:
+                files_.extend(self(url + '/%(ID)s/files' % rec, fields_to_check={'title', 'Result', 'Columns'}))
+            for f in files_:
+                f['rec_type'] = rec_type
+            files.extend(files_)
+        return files
+
+    def get_all_files_for_project(self, project, subjects=None, experiments=None):
+        for subject in (subjects or self.get_subjects(project)):
+            for experiment in (experiments or self.get_experiments(project, subject)):
+                for file_ in self.get_files(project, subject, experiment):
+                    yield file_

--- a/datalad/crawler/pipelines/xnat.py
+++ b/datalad/crawler/pipelines/xnat.py
@@ -14,52 +14,6 @@ Notes:
 - xml entries for subject contain meta-data
 - in longitudinal studies there could be multiple ages for a subject... find where
   it is
-
-    1  curl -I ftp://www.nitrc.org/fcon_1000/htdocs/AnnArbor_a.tar
-    2  man wget
-    3  wget
-    4  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08
-    5  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects
-    6  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects?format=csv
-    7  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/Taipei_sub43181?format=xml
-    8* curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/Taipei_sub431
-    9  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects?format=csv
-   10  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects
-   11  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments
-   12  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scans
-   13* curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments?
-   14  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830
-   15  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830?format=csv
-   16  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830?format=xml
-   17  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz
-   18  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz/resources
-   19  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiment/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz/resources?format=csv
-   20  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scan/SaintLouis_sub82830_func_rest.nii.gz/resources?format=csv
-   21  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans
-   22  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources
-   23  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files
-   24  curl -O http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files/scan_mprage_anonymized.nii.gz
-
-   28  curl -I http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files/scan_mprage_anonymized.nii.gz
-   29  curl http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments/SaintLouis_sub82830/scans/anat_mprage_anonymized/resources/BRIK/files?format=csv
-   30  curl http://www.nitrc.org/ir/data/projects
-   31  curl http://www.nitrc.org/ir/data/projects?format=csv
-   32  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects
-   33  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects | format_json
-   34  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments | format_json
-   35  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/scans
-   36  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/scans |format_json
-   37  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors
-   38  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors
-   39  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg
-   40  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg?format=xml
-   41  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg/resources
-   42  curl http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg/resources/NIfTI/files
-   43  curl -O http://www.nitrc.org/ir/data/projects/cs_schizbull08/subjects/BPDwoPsy_054/experiments/BPDwoPsy_054_MR/assessors/BPDwoPsy_054_MR_seg/resources/NIfTI/files/seg.nii.gz
-   44  fslview seg.nii.gz
-   45  curl -u user:pass http://www.nitrc.org/ir/data/JSESSION
-   46  history
-   47  curl http://www.nitrc.org/ir/data/projects?format=csv
 """
 
 import os
@@ -96,10 +50,37 @@ from logging import getLogger
 lgr = getLogger("datalad.crawler.pipelines.openfmri")
 
 from datalad.tests.utils import eq_
+from datalad.utils import assure_list
 
 
 def list_to_dict(l, field):
     return {r.pop(field): r for r in l}
+
+DEFAULT_RESULT_FIELDS = {'totalrecords', 'result'}
+PROJECT_ACCESS_TYPES = {'public', 'protected', 'private'}
+
+
+def lower_case_the_keys(d):
+    """Create a dict with keys being lower cased but with a check against collisions
+    
+    If d is a list of tuple, would recurse into its elements
+    """
+    if not isinstance(d, dict):
+        assert isinstance(d, (list, tuple))
+        return d.__class__(
+            lower_case_the_keys(x) for x in d
+        )
+    out = {}
+    for k, v in d.items():
+        kl = k.lower()
+        if kl in out:
+            raise ValueError(
+                "We already got key %s=%r, but trying to add =%r"
+                % (kl, out[kl], v)
+            )
+        out[kl] = v
+    return out
+
 
 class XNATServer(object):
     def __init__(self, topurl):
@@ -108,34 +89,66 @@ class XNATServer(object):
         providers = Providers.from_config_files()
         self.downloader = providers.get_provider(topurl).get_downloader(topurl)
 
-    def __call__(self, query, format='json', fields_to_check={'totalRecords', 'Result'}):
+    def __call__(self, query,
+                 format='json',
+                 options=None,
+                 fields_to_check=DEFAULT_RESULT_FIELDS):
         query_url = "%s/%s" % (self.topurl, query)
+        options = options or {}
         if format:
-            query_url += "?format=%s" % format
+            options['format'] = format
+        if options:
+            # TODO: use the helper we have
+            query_url += "?" + '&'.join(("%s=%s" % (o, v) for o, v in options.items()))
         out = self.downloader.fetch(query_url)
         if format == 'json':
             j = json.loads(out)
-            assert j.keys() == ['ResultSet']
-            j = j['ResultSet']
+            j = lower_case_the_keys(j)
+            assert j.keys() == ['resultset']
+            j = lower_case_the_keys(j['resultset'])
             if fields_to_check:
                 eq_(set(j.keys()), fields_to_check)
-            return j['Result']
+            return lower_case_the_keys(j['result'])
         return out
 
-    def get_projects(self):
-        return list_to_dict(self('data/projects'), 'ID')
+    def get_projects(self, limit=None):
+        """Get list of projects 
+        
+        Parameters
+        ----------
+        limit: {'public', 'protected', 'private', None} or list of thereoff
+           'private' -- projects you have no any access to. 'protected' -- you could
+           fetch description but not the data. None - would list all the projects
+        """
+        # accessible  option could limit to the projects I have access to
+        kw = {}
+        if limit:
+            kw['options'] = {"accessible": "true"} if limit else None
+            kw['fields_to_check'] = DEFAULT_RESULT_FIELDS | {'title', 'xdat_user_id'}
+        out = list_to_dict(self('data/projects', **kw), 'id')
+        if limit:
+            limit = assure_list(limit)
+            # double check that all the project_access thingies in the set which
+            # we know
+            assert all(p['project_access'] in PROJECT_ACCESS_TYPES
+                       for p in out.values())
+            out = {
+                pid: p for pid, p in out.items()
+                if p['project_access'] in limit
+            }
+        return out
 
     def get_subjects(self, project):
         return list_to_dict(
             self('data/projects/%(project)s/subjects' % locals()),
-            'ID'
+            'id'
         )
 
     def get_experiments(self, project, subject):
         return list_to_dict(
             # http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments?
             self('data/projects/%(project)s/subjects/%(subject)s/experiments' % locals()),
-            'ID'
+            'id'
         )
 
     def get_files(self, project, subject, experiment):
@@ -146,7 +159,7 @@ class XNATServer(object):
             recs = self(url)
             files_ = []
             for rec in recs:
-                files_.extend(self(url + '/%(ID)s/files' % rec, fields_to_check={'title', 'Result', 'Columns'}))
+                files_.extend(self(url + '/%(id)s/files' % rec, fields_to_check={'title', 'result', 'columns'}))
             for f in files_:
                 f['rec_type'] = rec_type
             files.extend(files_)

--- a/datalad/crawler/pipelines/xnat.py
+++ b/datalad/crawler/pipelines/xnat.py
@@ -230,6 +230,8 @@ def pipeline(url, dataset, project_access='public', subjects=None):
         out = xnat('data/projects/%s' % dataset,
                    return_plain=True
                    )
+        # for NITRC I need to get more!
+        # "http://nitrc_es.projects.nitrc.org/datalad/%s" % dataset
         items = out['items']
         assert len(items) == 1
         dataset_meta = items[0]['data_fields']

--- a/datalad/downloaders/configs/nitrc.cfg
+++ b/datalad/downloaders/configs/nitrc.cfg
@@ -24,7 +24,7 @@ html_form_failure_re = Invalid Password Or User Name
 
 # requires JSESSIONID= cookie for the session... ???
 [provider:nitrc-ir]
-url_re = https?://www.nitrc.org/ir/.*
+url_re = https?://www.nitrc.org/ir.*
 credential = nitrc
 authentication_type = http_auth
 http_auth_url = https://www.nitrc.org/ir/

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -319,7 +319,7 @@ class Interface(object):
                 'AddArchiveContent', 'AddSibling', 'AggregateMetaData',
                 'CrawlInit', 'Crawl', 'CreateSiblingGithub', 'CreateSibling',
                 'CreateTestDataset', 'DownloadURL', 'Export', 'Ls', 'Move',
-                'Publish', 'RewriteURLs', 'SSHRun'):
+                'Publish', 'RewriteURLs', 'SSHRun', 'Search'):
             # set all common args explicitly  to override class defaults
             # that are tailored towards the the Python API
             kwargs['return_type'] = 'generator'

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -94,8 +94,12 @@ class DownloadURL(Interface):
             # providers.get_provider(url).get_downloader(url).download(url, path=path)
             # for now -- via sugaring
             try:
-                downloaded_path = providers.download(url, path=path, overwrite=overwrite)
-                downloaded_paths.append(downloaded_path)
+                if path == '-':
+                    print(providers.fetch(url))
+                    # TODO: obtain also result headers and format appropriately
+                else:
+                    downloaded_path = providers.download(url, path=path, overwrite=overwrite)
+                    downloaded_paths.append(downloaded_path)
                 # ui.message("%s -> %s" % (url, downloaded_path))
             except Exception as e:
                 failed_urls.append(url)

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -209,11 +209,7 @@ class OutOfSpaceError(CommandError):
 
     def __init__(self, sizemore_msg=None, **kwargs):
         super(OutOfSpaceError, self).__init__(**kwargs)
-        self.sizemore_msg = sizemore_msg
-
-    def __str__(self):
-        super_str = super(OutOfSpaceError, self).__str__().rstrip(linesep + '.')
-        return "%s needs %s more" % (super_str, self.sizemore_msg)
+        self.msg = "%s needs %s more" % (self.msg or "free space", sizemore_msg)
 
 
 class RemoteNotAvailableError(CommandError):

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -48,6 +48,7 @@ from ..utils import get_timestamp_suffix
 from ..utils import get_trace
 from ..utils import get_dataset_root
 from ..utils import better_wraps
+from ..utils import check_free_space
 
 from ..support.annexrepo import AnnexRepo
 
@@ -637,3 +638,19 @@ def test_get_dataset_root(path):
         eq_(get_dataset_root(opj(subdir, subdir)), os.curdir)
         # non-dir paths are no issue
         eq_(get_dataset_root(fname), os.curdir)
+
+
+@with_tempfile(mkdir=True)
+def test_check_free_space(topdir):
+    from datalad.support.exceptions import OutOfSpaceError
+    # We would be golden whenever we would this much of free space
+    abit = 1
+    lots = 1024**10  # 1000000.0 YB
+
+    targetpath = _path_(topdir, "some/subdir/file")
+    check_free_space(targetpath, 0)     # we have that much
+    check_free_space(targetpath, abit)  # we have that much
+
+    with assert_raises(OutOfSpaceError) as exc:
+        check_free_space(targetpath, lots)
+        ok_startswith(str(exc), "For %s of size " % targetpath)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -791,7 +791,6 @@ def skip_if_no_network(func=None):
 
     If not used as a decorator, and just a function, could be used at the module level
     """
-
     def check_and_raise():
         if os.environ.get('DATALAD_TESTS_NONETWORK'):
             raise SkipTest("Skipping since no network settings")
@@ -799,6 +798,7 @@ def skip_if_no_network(func=None):
     if func:
         @wraps(func)
         def newfunc(*args, **kwargs):
+            import pdb; pdb.set_trace()
             check_and_raise()
             return func(*args, **kwargs)
         # right away tag the test as a networked test

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -798,7 +798,6 @@ def skip_if_no_network(func=None):
     if func:
         @wraps(func)
         def newfunc(*args, **kwargs):
-            import pdb; pdb.set_trace()
             check_and_raise()
             return func(*args, **kwargs)
         # right away tag the test as a networked test


### PR DESCRIPTION
TODOs

- [ ] come up with a saner default for file names/paths
- [ ] figure out if when deciding to either create a subdataset, first crawl it to see if there is any file to be crawled.  Some datasets (on central.xnat) seems to be just empty, so kinda waste
- [ ] aggregate with information about datasets which is exposed from regular NITRC (there is TODO comment on that)
  - [ ] per file meta-data (whenever we get there)
- [ ] make it drop files by default (nothing to extract and we might be short of space kinda)
- [ ] provide extractor for the meta-data
- [ ] publish NITRC-IR superdataset (public datasets for now)
- [ ] publish CENTRAL.xnat superdataset

in the future (probably after ultimate db is done) -- also crawl 
- [ ] HCP
- [ ] private ones from central and NITRC which do not have any private info in the file names/meta-data (@chaselgrove)