### PR TITLE
Various little improvements of `siblings`

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -111,11 +111,12 @@ def setup_parser(
     parser.add_argument(
         '--output-format', dest='common_output_format',
         default='default',
-        metavar="{default,json,tailored,'<template>'",
+        metavar="{default,json,json_pp,tailored,'<template>'",
         help="""select format for returned command results. 'default' give one line
         per result reporting action, status, path and an optional message;
         'json' renders a JSON object with all properties for each result (one per 
-        line); 'tailored' enables a command-specific rendering style that is typically
+        line); 'json_pp' pretty-prints JSON spanning multiple lines; 'tailored'
+        enables a command-specific rendering style that is typically
         tailored to human consumption (no result output otherwise),
         '<template>' reports any value(s) of any result properties in any format
         indicated by the template (e.g. '{path}', compare with JSON

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""High-level interface for adding a sibling to a dataset
+"""[obsolete: use `siblings add`]
 """
 
 __docformat__ = 'restructuredtext'
@@ -60,7 +60,7 @@ def _check_deps(repo, deps):
 
 
 class AddSibling(Interface):
-    """Add a sibling to a dataset.
+    """THIS COMMAND IS OBSOLETE: Use `siblings add`.
 
     """
 

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -19,7 +19,7 @@ from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.utils import build_doc
 from datalad.interface.results import get_status_dict
-from datalad.interface.common_opts import dataset_description
+from datalad.interface.common_opts import location_description
 # from datalad.interface.common_opts import git_opts
 # from datalad.interface.common_opts import git_clone_opts
 # from datalad.interface.common_opts import annex_opts
@@ -97,7 +97,7 @@ class Clone(Interface):
             doc="""path to clone into.  If no `path` is provided a
             destination path will be derived from a source URL
             similar to :command:`git clone`"""),
-        description=dataset_description,
+        description=location_description,
         reckless=reckless_opt,
         alt_sources=Parameter(
             args=('--alternative-sources',),

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -24,7 +24,7 @@ from datalad.interface.utils import build_doc
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_init_opts
-from datalad.interface.common_opts import dataset_description
+from datalad.interface.common_opts import location_description
 from datalad.interface.common_opts import nosave_opt
 from datalad.interface.common_opts import shared_access_opt
 from datalad.support.constraints import EnsureStr
@@ -111,7 +111,7 @@ class Create(Interface):
             args=("-f", "--force",),
             doc="""enforce creation of a dataset in a non-empty directory""",
             action='store_true'),
-        description=dataset_description,
+        description=location_description,
         no_annex=Parameter(
             args=("--no-annex",),
             doc="""if set, a plain Git repository will be created without any

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -32,7 +32,7 @@ from datalad.interface.common_opts import recursion_flag
 # from datalad.interface.common_opts import git_opts
 # from datalad.interface.common_opts import annex_opts
 # from datalad.interface.common_opts import annex_get_opts
-from datalad.interface.common_opts import dataset_description
+from datalad.interface.common_opts import location_description
 from datalad.interface.common_opts import jobs_opt
 from datalad.interface.common_opts import reckless_opt
 from datalad.interface.common_opts import verbose
@@ -366,7 +366,7 @@ class Get(Interface):
             doc="""whether to obtain data for all file handles. If disabled, `get`
             operations are limited to dataset handles.[CMD:  This option prevents data
             for file handles from being obtained CMD]"""),
-        description=dataset_description,
+        description=location_description,
         reckless=reckless_opt,
         # git_opts=git_opts,
         # annex_opts=annex_opts,

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -18,7 +18,7 @@ from os.path import relpath
 from datalad.interface.base import Interface
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
-from datalad.interface.common_opts import dataset_description
+from datalad.interface.common_opts import location_description
 from datalad.interface.common_opts import jobs_opt
 # from datalad.interface.common_opts import git_opts
 # from datalad.interface.common_opts import git_clone_opts
@@ -127,7 +127,7 @@ class Install(Interface):
             args=("-g", "--get-data",),
             doc="""if given, obtain all data content too""",
             action="store_true"),
-        description=dataset_description,
+        description=location_description,
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         save=nosave_opt,

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -403,8 +403,8 @@ def _query_remotes(
                 ainfo['description'] = r.get('description', None)
                 annex_info[uuid] = ainfo
     known_remotes = ds.repo.get_remotes()
-    # treat the local repo as any other remote using 'HERE' as a label
-    remotes = [name] if name else ['HERE'] + known_remotes
+    # treat the local repo as any other remote using 'here' as a label
+    remotes = [name] if name else ['here'] + known_remotes
     for remote in remotes:
         info = get_status_dict(
             action='query-sibling',
@@ -412,7 +412,7 @@ def _query_remotes(
             type='sibling',
             name=remote,
             **res_kwargs)
-        if remote != 'HERE' and remote not in known_remotes:
+        if remote != 'here' and remote not in known_remotes:
             info['status'] = 'error'
             info['message'] = 'unknown sibling name'
             yield info
@@ -420,7 +420,7 @@ def _query_remotes(
         # now pull everything we know out of the config
         # simply because it is cheap and we don't have to go through
         # tons of API layers to be able to work with it
-        if remote == 'HERE':
+        if remote == 'here':
             # special case: this repo
             # aim to provide info using the same keys as for remotes
             # (see below)

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -387,7 +387,11 @@ def _query_remotes(
         # pull repo info from annex
         # TODO maybe we should make this step optional to save the call
         # in some cases. Would need an additional flag...
-        raw_info = ds.repo.repo_info(fast=True)
+        try:
+            # need to do in safety net because of gh-1560
+            raw_info = ds.repo.repo_info(fast=True)
+        except CommandError:
+            raw_info = {}
         available_space = raw_info.get('available local disk space', None)
         for trust in ('trusted', 'semitrusted', 'untrusted'):
             ri = raw_info.get('{} repositories'.format(trust), [])

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -79,7 +79,8 @@ class Siblings(Interface):
         Absolute path of the dataset
 
     "url"
-        At minimum a "fetch" URL, possibly also a "pushurl"
+        For regular siblings at minimum a "fetch" URL, possibly also a
+        "pushurl"
 
     Additionally, any further configuration will also be reported using
     a key that matches that in the Git configuration.

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -10,7 +10,9 @@
 """
 
 from os.path import join as opj, basename
-from datalad.api import install, siblings
+from datalad.api import create
+from datalad.api import install
+from datalad.api import siblings
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 
@@ -173,3 +175,20 @@ def test_siblings(origin, repo_path):
             ok_(pushurl.endswith(basename(repo.path)))
         eq_(url, r['url'])
         eq_(pushurl, r['pushurl'])
+
+
+@with_tempfile(mkdir=True)
+def test_here(path):
+    # few smoke tests regarding the 'HERE' sibling
+    ds = create(path)
+    res = ds.siblings(
+        'query',
+        on_failure='ignore')
+    assert_status('ok', res)
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, name='HERE')
+    here = res[0]
+    eq_(ds.repo.uuid, here['annex-uuid'])
+    assert_in('annex-description', here)
+    assert_in('annex-bare', here)
+    assert_in('available_local_disk_space', here)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -179,14 +179,14 @@ def test_siblings(origin, repo_path):
 
 @with_tempfile(mkdir=True)
 def test_here(path):
-    # few smoke tests regarding the 'HERE' sibling
+    # few smoke tests regarding the 'here' sibling
     ds = create(path)
     res = ds.siblings(
         'query',
         on_failure='ignore')
     assert_status('ok', res)
     assert_result_count(res, 1)
-    assert_result_count(res, 1, name='HERE')
+    assert_result_count(res, 1, name='here')
     here = res[0]
     eq_(ds.repo.uuid, here['annex-uuid'])
     assert_in('annex-description', here)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -192,3 +192,15 @@ def test_here(path):
     assert_in('annex-description', here)
     assert_in('annex-bare', here)
     assert_in('available_local_disk_space', here)
+
+    # set a description
+    res = ds.siblings(
+        'configure',
+        name='here',
+        description='very special',
+        on_failure='ignore')
+    assert_status('ok', res)
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, name='here')
+    here = res[0]
+    eq_('very special', here['annex-description'])

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -55,7 +55,8 @@ def test_siblings(origin, repo_path):
         name="test-remote",
         url=httpurl1,
         publish_depends=['r1', 'r2'],
-        on_failure='ignore')
+        on_failure='ignore',
+        result_renderer=None)
     assert_status('error', res)
     assert_in('unknown sibling(s) specified as publication dependency',
               res[0]['message'])
@@ -65,7 +66,8 @@ def test_siblings(origin, repo_path):
     res = siblings('configure',
                    dataset=source, name="test-remote",
                    url=httpurl1,
-                   result_xfm='paths')
+                   result_xfm='paths',
+                   result_renderer=None)
 
     eq_(res, [source.path])
     assert_in("test-remote", source.repo.get_remotes())
@@ -74,26 +76,31 @@ def test_siblings(origin, repo_path):
 
     # reconfiguring doesn't change anything
     siblings('configure', dataset=source, name="test-remote",
-             url=httpurl1)
+             url=httpurl1,
+             result_renderer=None)
     assert_in("test-remote", source.repo.get_remotes())
     eq_(httpurl1,
         source.repo.get_remote_url("test-remote"))
     # re-adding doesn't work
     res = siblings('add', dataset=source, name="test-remote",
-                   url=httpurl1, on_failure='ignore')
+                   url=httpurl1, on_failure='ignore',
+                   result_renderer=None)
     assert_status('error', res)
     # only after removal
-    res = siblings('remove', dataset=source, name="test-remote")
+    res = siblings('remove', dataset=source, name="test-remote",
+                   result_renderer=None)
     assert_status('ok', res)
     assert_not_in("test-remote", source.repo.get_remotes())
     res = siblings('add', dataset=source, name="test-remote",
-                   url=httpurl1, on_failure='ignore')
+                   url=httpurl1, on_failure='ignore',
+                   result_renderer=None)
     assert_status('ok', res)
 
     # add to another remote automagically taking it from the url
     # and being in the dataset directory
     with chpwd(source.path):
-        res = siblings('add', url=httpurl2)
+        res = siblings('add', url=httpurl2,
+                       result_renderer=None)
     assert_result_count(
         res, 1,
         name="remote2.example.com", type='sibling')
@@ -101,8 +108,9 @@ def test_siblings(origin, repo_path):
 
     # don't fail with conflicting url, when using force:
     res = siblings('configure',
-                    dataset=source, name="test-remote",
-                    url=httpurl1 + "/elsewhere")
+                   dataset=source, name="test-remote",
+                   url=httpurl1 + "/elsewhere",
+                   result_renderer=None)
     assert_status('ok', res)
     eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
@@ -132,7 +140,8 @@ def test_siblings(origin, repo_path):
     res = siblings('configure',
                    dataset=source, name="test-remote",
                    url=httpurl1 + "/elsewhere",
-                   pushurl=sshurl)
+                   pushurl=sshurl,
+                   result_renderer=None)
     assert_status('ok', res)
     eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
@@ -145,7 +154,8 @@ def test_siblings(origin, repo_path):
             dataset=source, name="test-remote",
             url=httpurl1 + "/%NAME",
             pushurl=sshurl + "/%NAME",
-            recursive=True):
+            recursive=True,
+            result_renderer=None):
         repo = GitRepo(r['path'], create=False)
         assert_in("test-remote", repo.get_remotes())
         url = repo.get_remote_url("test-remote")
@@ -163,7 +173,8 @@ def test_siblings(origin, repo_path):
             dataset=source, name="test-remote-2",
             url=httpurl1,
             pushurl=sshurl,
-            recursive=True):
+            recursive=True,
+            result_renderer=None):
         repo = GitRepo(r['path'], create=False)
         assert_in("test-remote-2", repo.get_remotes())
         url = repo.get_remote_url("test-remote-2")
@@ -183,7 +194,8 @@ def test_here(path):
     ds = create(path)
     res = ds.siblings(
         'query',
-        on_failure='ignore')
+        on_failure='ignore',
+        result_renderer=None)
     assert_status('ok', res)
     assert_result_count(res, 1)
     assert_result_count(res, 1, name='here')
@@ -198,7 +210,8 @@ def test_here(path):
         'configure',
         name='here',
         description='very special',
-        on_failure='ignore')
+        on_failure='ignore',
+        result_renderer=None)
     assert_status('ok', res)
     assert_result_count(res, 1)
     assert_result_count(res, 1, name='here')

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -17,10 +17,10 @@ from datalad.support.constraints import EnsureInt, EnsureNone, EnsureStr
 from datalad.support.constraints import EnsureChoice
 
 
-dataset_description = Parameter(
+location_description = Parameter(
     args=("-D", "--description",),
     constraints=EnsureStr() | EnsureNone(),
-    doc="""short description of newly installed dataset instances. Its primary
+    doc="""short description to use for a dataset location. Its primary
     purpose is to help humans to identify a dataset copy (e.g., "mike's dataset
     on lab server"). Note that when a dataset is published, this information
     becomes available on the remote side.""")

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -544,7 +544,7 @@ eval_params = dict(
         constraints=EnsureChoice(*list(known_result_xfms.keys())) | EnsureCallable()),
     result_renderer=Parameter(
         doc="""format of return value rendering on stdout""",
-        constraints=EnsureChoice('default', 'json', 'tailored') | EnsureNone()),
+        constraints=EnsureChoice('default', 'json', 'json_pp', 'tailored') | EnsureNone()),
     on_failure=Parameter(
         doc="""behavior to perform on failure: 'ignore' any failure is reported,
         but does not cause an exception; 'continue' if any failure occurs an
@@ -584,6 +584,7 @@ def eval_results(func):
     `result_renderer` keyword argument of each decorated command. Supported
     modes are: 'default' (one line per result with action, status, path,
     and an optional message); 'json' (one object per result, like git-annex),
+    'json_pp' (like 'json', but pretty-printed spanning multiple lines),
     'tailored' custom output formatting provided by each command
     class (if any).
 
@@ -741,11 +742,12 @@ def eval_results(func):
                             res['message'][0] % res['message'][1:]
                             if isinstance(res['message'], tuple) else res['message'])
                         if 'message' in res else ''))
-                elif result_renderer == 'json':
+                elif result_renderer in ('json', 'json_pp'):
                     ui.message(json.dumps(
                         {k: v for k, v in res.items()
                          if k not in ('message', 'logger')},
-                        sort_keys=True))
+                        sort_keys=True,
+                        indent=2 if result_renderer.endswith('_pp') else None))
                 elif result_renderer == 'tailored':
                     if hasattr(_func_class, 'custom_result_renderer'):
                         _func_class.custom_result_renderer(res, **_kwargs)


### PR DESCRIPTION
Log:

- [x] tiny convenience bits
- [x] report annex description for all remotes with annexes and UUIDs
- [x] enable modification of annex descriptions (fixes #1484)
- [x] ability to query the local repo for infos under the label `here` (uses the same keys as for a proper annex remote):
````
mih@meiner ...tasets.datalad.org/labs/haxby/raiders (git)-[master] % datalad --output-format json_pp siblings -s here
{
  "action": "query-sibling",
  "annex-bare": "false",
  "annex-description": "mih@meiner:/tmp/datasets.datalad.org/labs/haxby/raiders",
  "annex-uuid": "7203baa3-f472-4bca-b886-753e2a9da1df",
  "annex-version": "5",
  "available_local_disk_space": 23273848256,
  "name": "HERE",
  "path": "/tmp/datasets.datalad.org/labs/haxby/raiders",
  "refds": "/tmp/datasets.datalad.org/labs/haxby/raiders",
  "status": "ok",
  "type": "sibling"
}
````
