### PR TITLE
WIP: RF: lazy loading *Repo.repo

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -181,11 +181,6 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # check for possible SSH URLs of the remotes in order to set up
         # shared connections:
-
-
-        # TODO: This uses `repo` via GitRepo.get_Remotes:
-        # Contradicts lazy loading of repo, if we use it in the constructor!
-
         for r in self.get_remotes():
             for url in [self.get_remote_url(r),
                         self.get_remote_url(r, push=True)]:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -181,6 +181,11 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # check for possible SSH URLs of the remotes in order to set up
         # shared connections:
+
+
+        # TODO: This uses `repo` via GitRepo.get_Remotes:
+        # Contradicts lazy loading of repo, if we use it in the constructor!
+
         for r in self.get_remotes():
             for url in [self.get_remote_url(r),
                         self.get_remote_url(r, push=True)]:
@@ -787,6 +792,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # changed, we also need to override _flyweight_invalid and explicitly
         # pass allow_noninitialized=False!
 
+        # TODO: Again, this isn't true, since it doesn't respect a .git file:
         initialized_annex = GitRepo.is_valid_repo(path) and \
             exists(opj(path, '.git', 'annex'))
         if allow_noninitialized:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1170,6 +1170,12 @@ class GitRepo(RepoInterface):
         remotes : list of str
           List of names of the remotes
         """
+
+        # TODO: read directly from config and spare instantiation of gitpy.Repo
+        # since we need it in AnnexRepo constructor. Furthermore gitpy does it
+        # the same way and the use of a Repo instance seems to have no reason
+        # other than a nice object oriented look.
+
         if with_refs_only:
             # older versions of GitPython might not tolerate remotes without
             # any references at all, so we need to catch

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1171,11 +1171,8 @@ class GitRepo(RepoInterface):
           List of names of the remotes
         """
 
-        # TODO: read directly from config and spare instantiation of gitpy.Repo
-        # since we need it in AnnexRepo constructor. Furthermore gitpy does it
-        # the same way and the use of a Repo instance seems to have no reason
-        # other than a nice object oriented look.
-
+        # Note: This still uses GitPython and therefore might cause a gitpy.Repo
+        # instance to be created.
         if with_refs_only:
             # older versions of GitPython might not tolerate remotes without
             # any references at all, so we need to catch
@@ -1188,8 +1185,17 @@ class GitRepo(RepoInterface):
                     if "not have any references" not in str(exc):
                         # was some other reason
                         raise
-        else:
-            remotes = [remote.name for remote in self.repo.remotes]
+
+        # Note: read directly from config and spare instantiation of gitpy.Repo
+        # since we need this in AnnexRepo constructor. Furthermore gitpy does it
+        # pretty much the same way and the use of a Repo instance seems to have
+        # no reason other than a nice object oriented look.
+        from datalad.utils import unique
+
+        self.config.reload()
+        remotes = unique([x[7:] for x in self.config.sections()
+                          if x.startswith("remote.")])
+
         if with_urls_only:
             remotes = [
                 r for r in remotes

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -518,7 +518,8 @@ class GitRepo(RepoInterface):
         self._repo = repo
         self._cfg = None
 
-        if create and not GitRepo.is_valid_repo(path):
+        _valid_repo = GitRepo.is_valid_repo(path)
+        if create and not _valid_repo:
             if repo is not None:
                 # `repo` passed with `create`, which doesn't make sense
                 raise TypeError("argument 'repo' must not be used with 'create'")
@@ -545,11 +546,7 @@ class GitRepo(RepoInterface):
 
             if not exists(path):
                 raise NoSuchPathError(path)
-
-            # TODO: GitRepo.is_valid_repo() checks for .git/objects instead
-            # This probably needs to change, so we can use it here.
-            # Note, that a submodule might have just a .git file!
-            if not exists(opj(path, '.git')):
+            if not _valid_repo:
                 raise InvalidGitRepositoryError(path)
 
         # inject git options into GitPython's git call wrapper:
@@ -713,7 +710,7 @@ class GitRepo(RepoInterface):
     @classmethod
     def is_valid_repo(cls, path):
         """Returns if a given path points to a git repository"""
-        return exists(opj(path, '.git', 'objects'))
+        return exists(opj(path, '.git'))
 
     @property
     def config(self):


### PR DESCRIPTION
- don't instantiate `git.Repo` if we don't need it. Thus, making creation of *`Repo` instances cheaper
- fix *`Repo.is_valid_repo` to respect .git files
- make *`Repo.get_remotes()` not using `git.Repo` by default (needed in `AnnexRepo` constructor and therefore this change is required to not intantiate `git.Repo` immediatly