### PR TITLE
Completes basic data consumer functionality on Windows

### DIFF
--- a/datalad/ui/utils.py
+++ b/datalad/ui/utils.py
@@ -8,20 +8,43 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Various utils oriented to UI"""
 
-import fcntl
-import termios
+from datalad.utils import on_windows
 import struct
 
 
 # origin http://stackoverflow.com/a/3010495/1265472
 def get_terminal_size():
     """Return current terminal size"""
-    try:
-        h, w, hp, wp = struct.unpack(
-            'HHHH',
-            fcntl.ioctl(0, termios.TIOCGWINSZ,
-            struct.pack('HHHH', 0, 0, 0, 0))
-        )
-        return w, h
-    except:
-        return None, None
+    if on_windows:
+        try:
+            from ctypes import windll, create_string_buffer
+
+            # stdin handle is -10
+            # stdout handle is -11
+            # stderr handle is -12
+
+            h = windll.kernel32.GetStdHandle(-12)
+            csbi = create_string_buffer(22)
+            res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
+        except:
+            return None, None
+        if res:
+            (bufx, bufy, curx, cury, wattr,
+             left, top, right, bottom, maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+            sizex = right - left + 1
+            sizey = bottom - top + 1
+            return sizex, sizey
+        else:
+            return None, None
+    else:
+        import fcntl
+        import termios
+        try:
+            h, w, hp, wp = struct.unpack(
+                'HHHH',
+                fcntl.ioctl(0, termios.TIOCGWINSZ,
+                            struct.pack('HHHH', 0, 0, 0, 0))
+            )
+            return w, h
+        except:
+            return None, None

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -316,11 +316,14 @@ def rmtemp(f, *args, **kwargs):
         if os.path.isdir(f):
             rmtree(f, *args, **kwargs)
         else:
-            for i in range(10):
+            # on windows boxes there is evidence for a latency of
+            # more than a second until a file is considered no
+            # longer "in-use"
+            for i in range(50):
                 try:
                     os.unlink(f)
-                except OSError as e:
-                    if i < 9:
+                except (OSError, WindowsError) as e:
+                    if i < 49:
                         sleep(0.1)
                         continue
                     else:


### PR DESCRIPTION
Copied straight from the "terminal" of greatness:

````
D:\>datalad install ///
[INFO] Cloning dataset from 'http://datasets.datalad.org/' (trying 2 location candidate(s)) to 'D:\datasets.datalad.org'
install(ok): D:\datasets.datalad.org (dataset)

D:\>cd datasets.datalad.org

D:\datasets.datalad.org>datalad get openfmri\ds000001\sub-06\anat\sub-06_inplaneT2.nii.gz
[INFO] Cloning dataset from 'http://datasets.datalad.org/openfmri/.git' (trying 1 location candidate(s)) to 'D:\datasets.datalad.org\openfmri'
install(ok): D:\datasets.datalad.org\openfmri (dataset) [Installed subdataset in order to get D:\datasets.datalad.org\openfmri\ds000001\sub-06\anat\sub-06_inpla
neT2.nii.gz]
[INFO] Cloning dataset from 'http://datasets.datalad.org/openfmri/ds000001/.git' (trying 1 location candidate(s)) to 'D:\datasets.datalad.org\openfmri\ds000001'

install(ok): D:\datasets.datalad.org\openfmri\ds000001 (dataset) [Installed subdataset in order to get D:\datasets.datalad.org\openfmri\ds000001\sub-06\anat\sub
-06_inplaneT2.nii.gz]
Total:   0%|                                                                                                                        | 0.00/679K [00:00<?, ?B/s]
Total:  39%|###########################################6                                                                     | 262K/679K [00:01<00:02, 142KB/s]
Total:  68%|############################################################################3                                    | 459K/679K [00:02<00:01, 175KB/s]
Total: 100%|#################################################################################################################| 679K/679K [00:02<00:00, 223KB/s]
Total (1 ok out of 1)100%|###################################################################################################| 679K/679K [00:02<00:00, 223KB/s]
get(ok): D:\datasets.datalad.org\openfmri\ds000001\sub-06/anat/sub-06_inplaneT2.nii.gz (file)
get(notneeded): D:\datasets.datalad.org\openfmri\ds000001\sub-06\anat\sub-06_inplaneT2.nii.gz (file) [already present]
action summary:
  get (notneeded: 1, ok: 1)
  install (ok: 2)

D:\datasets.datalad.org>cd ..

D:\>datalad remove datasets.datalad.org -r
drop(ok): D:\datasets.datalad.org\openfmri\ds000001\sub-06/anat/sub-06_inplaneT2.nii.gz (file) [checking http://openneuro.s3.amazonaws.com/ds000001/ds000001_R1.
1.0/uncompressed/sub006/anatomy/inplane001.nii.gz?versionId=null...]
drop(ok): D:\datasets.datalad.org\openfmri\ds000001 (directory)
uninstall(ok): D:\datasets.datalad.org\openfmri\ds000001 (dataset)
drop(notneeded): D:\datasets.datalad.org\openfmri [no annex'ed content]
uninstall(ok): D:\datasets.datalad.org\openfmri (dataset)
drop(notneeded): D:\datasets.datalad.org [no annex'ed content]
remove(ok): D:\datasets.datalad.org (dataset)
action summary:
  drop (notneeded: 2, ok: 2)
  remove (ok: 1)
  uninstall (ok: 2)

D:\>
```` 