### PR TITLE
`metadata` command 

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -522,17 +522,18 @@ def _configure_remote(
                         message='cannot configure as a common data source, '
                                 'URL protocol is not http or https',
                         **result_props)
-            for prop, var in (('wanted', annex_wanted),
-                              ('required', annex_required),
-                              ('group', annex_group)):
-                if var:
-                    ds.repo.set_preferred_content(prop, var, name)
-            if annex_groupwanted:
-                ds.repo.set_groupwanted(annex_group, annex_groupwanted)
-
     #
     # place configure steps that also work for 'here' below
     #
+    if isinstance(ds.repo, AnnexRepo):
+        for prop, var in (('wanted', annex_wanted),
+                          ('required', annex_required),
+                          ('group', annex_group)):
+            if var is not None:
+                ds.repo.set_preferred_content(prop, var, '.' if name =='here' else name)
+        if annex_groupwanted:
+            ds.repo.set_groupwanted(annex_group, annex_groupwanted)
+
     if description:
         if not isinstance(ds.repo, AnnexRepo):
             result_props['status'] = 'impossible'
@@ -615,7 +616,8 @@ def _query_remotes(
                 info['annex-description'] = annex_description
         if get_annex_info and isinstance(ds.repo, AnnexRepo):
             for prop in ('wanted', 'required', 'group'):
-                var = ds.repo.get_preferred_content(prop, remote)
+                var = ds.repo.get_preferred_content(
+                    prop, '.' if remote == 'here' else remote)
                 if var:
                     info['annex-{}'.format(prop)] = var
             groupwanted = ds.repo.get_groupwanted(remote)

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -49,6 +49,8 @@ _group_metadata = (
     [
         ('datalad.metadata.search', 'Search',
          'search', 'search'),
+        ('datalad.metadata.metadata', 'Metadata',
+         'metadata'),
         ('datalad.metadata.aggregate', 'AggregateMetaData',
          'aggregate-metadata', 'aggregate_metadata'),
     ])

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -478,14 +478,6 @@ class AnnotatePaths(Interface):
                     if 'refds' in r and not r['refds']:
                         # avoid cruft
                         del r['refds']
-                    if r.get('state', None) == 'absent':
-                        # not there (yet)
-                        message = unavailable_path_msg \
-                            if unavailable_path_msg else None
-                        if message and '%s' in message:
-                            message = (message, path)
-                        r['message'] = message
-                        r['status'] = unavailable_path_status
                     yield r
             return
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -250,9 +250,8 @@ class Metadata(Interface):
             content = [ap for ap in content_by_ds[ds_path]
                        if ap.get('type', None) != 'dataset' or ap['path'] == ds_path]
             ds = Dataset(ds_path)
-            if not isinstance(ds.repo, AnnexRepo):
+            if not dataset_global and not isinstance(ds.repo, AnnexRepo):
                 # report on all explicitly requested paths only
-                # TODO adjust when dataset-global metadata is supported
                 for ap in [c for c in content if ap.get('raw_input', False)]:
                     yield dict(
                         ap,

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -99,17 +99,78 @@ def _get_key(k):
 
 @build_doc
 class Metadata(Interface):
-    """Metadata manipulation for datasets and their components
+    """Metadata manipulation for files and whole datasets
 
-    The field names are limited to alphanumerics (and [_-.]),
-    and are case insensitive
+    Two types of metadata are supported:
 
-    # TODO
-    Mention that a tag is just an entry in the 'tag' field and
-    -a or -i without values is equivalent to adding a tag.
+    1. metadata describing a dataset as a whole (dataset-global), and
 
-    --remove without a value is equivalent to purging the entire
-    entry of the key
+    2. metadata for individual files in a dataset.
+
+    Both types can be accessed and modified with this command.
+    Note, however, that this only refers to Datalad's native metadata,
+    and not to any other metadata that is possibly stored in files of a
+    dataset.
+
+    Datalad's native metadata capability is primarily targeting data
+    description via arbitrary tags and other (brief) key-value attributes
+    (with possibly multiple values for a single key).
+
+    Metadata key names are limited to alphanumerics (and [_-.]). Moreover,
+    all key names are converted to lower case.
+
+
+    *Dataset (global) metadata*
+
+    Metadata describing a dataset as a whole is stored in JSON format
+    in the dataset at .datalad/metadata/dataset.json. The amount of
+    metadata that can be stored is not limited by Datalad. However,
+    it should be kept brief as this information is stored in the Git
+    history of the dataset, and access or modification requires to
+    read the entire file.
+
+    Arbitrary metadata keys can be used. However, Datalad reserves the
+    keys 'tag' and 'definition' for its own use. The can still be
+    manipulated without any restrictions like any other metadata items,
+    but doing so can impact Datalad's metadata-related functionality,
+    handle with care.
+
+    The 'tag' key is used to store a list of (unique) tags.
+
+    The 'definition' key is used to store key-value mappings that define
+    metadata keys used elsewhere in the metadata. Using the feature is
+    optional (see --define-key). It can be useful in the context of
+    data discovery needs, where metadata keys can be precisely defined
+    by linking them to specific ontology terms.
+
+
+    *File metadata*
+
+    Metadata storage for individual files is provided by git-annex, and
+    generally the same rules as for dataset-global metadata apply.
+    However, there is just one reserved key name: 'tag'.
+
+    Again, the amount of metadata is not limited, but metadata is stored
+    in git-annex' internal data structures in the Git repository of a
+    dataset. Large amounts of metadata can slow its performance.
+
+
+    || CMDLINE >>
+    *Output rendering*
+
+    By default, a short summary of the metadata for each dataset
+    (component) is rendered::
+
+      <path> (<type>): -|<keys> [<tags>]
+
+    where <path> is the path of the respective component, <type> a label
+    for the type of dataset components metadata is presented for. Non-existant
+    metadata is indicated by a dash, otherwise a comma-separated list of
+    metadata keys (except for 'tag'), is followed by a list of tags, if there
+    are any.
+
+
+    << CMDLINE ||
     """
     # make the custom renderer the default, path reporting isn't the top
     # priority here

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1,0 +1,316 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Set and query metadata of datasets and their components"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import re
+from os.path import relpath
+from os.path import join as opj
+
+from datalad.interface.annotate_paths import AnnotatePaths
+from datalad.interface.annotate_paths import annotated2content_by_ds
+from datalad.interface.base import Interface
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import eval_results
+from datalad.interface.utils import build_doc
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureStr
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.param import Parameter
+from datalad.interface.common_opts import recursion_flag
+from datalad.interface.common_opts import recursion_limit
+from datalad.distribution.dataset import Dataset
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import datasetmethod
+
+lgr = logging.getLogger('datalad.metadata.metadata')
+
+valid_key = re.compile(r'^[0-9a-z._-]+$')
+
+
+def _parse_argspec(args):
+    """Little helper to get cmdline and python args into a uniform
+    shape
+
+    Returns
+    -------
+    tags, mapping
+      A list of tags, and a dict with a mapping of given metadatakeys
+      and their associates metadata values
+    """
+    tags = []
+    mapping = {}
+    if not args:
+        return tags, mapping
+    if not isinstance(args, (dict, list, tuple)):
+        raise ValueError(
+            'invalid metadata specification, must be a dict or sequence')
+
+    asdict = isinstance(args, dict)
+    for k in args.items() if isinstance(args, dict) else args:
+        v = None
+        if asdict:
+            # simple, came in from a dict
+            k, v = k
+            if v:
+                mapping[_get_key(k)] = v
+            else:
+                tags.append(k)
+        elif isinstance(k, list):
+            # list of lists, came from cmdline
+            if len(k) == 1:
+                tags.append(k[0])
+            elif len(k) > 1:
+                mapping[_get_key(k[0])] = k[1:]
+            else:
+                raise ValueError(
+                    'invalid metadata specification, something weird')
+        else:
+            tags.append(k)
+    return tags, mapping
+
+
+def _get_key(k):
+    # annex has caseinsensitive, good enough
+    k = k.lower()
+    # validate keys against annex constraints
+    if not valid_key.match(k):
+        raise ValueError(
+            'invalid metadata key "{}", must match pattern {}'.format(
+                k, valid_key.pattern))
+    return k
+
+
+@build_doc
+class Metadata(Interface):
+    """Metadata manipulation for datasets and their components
+
+    The field names are limited to alphanumerics (and [_-.]),
+    and are case insensitive
+
+    # TODO
+    Mention that a tag is just an entry in the 'tag' field and
+    -a or -i without values is equivalent to adding a tag.
+
+    --remove without a value is equivalent to purging the entire
+    entry of the key
+    """
+    # make the custom renderer the default, path reporting isn't the top
+    # priority here
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""""",
+            constraints=EnsureDataset() | EnsureNone()),
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="path(s) to set/get metadata",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
+        add=Parameter(
+            args=('-a', '--add',),
+            nargs='+',
+            action='append',
+            metavar=('KEY', 'VAL'),
+            doc="""
+          The values of matching keys in the given dict appended to
+          any possibly existing values. The metadata keys need not
+          necessarily exist before.""",
+            constraints=EnsureStr() | EnsureNone()),
+        init=Parameter(
+            args=('-i', '--init',),
+            nargs='+',
+            action='append',
+            metavar=('KEY', 'VAL'),
+            doc="""
+          Metadata items for the keys in the given dict are set
+          to the respective values, if the key is not yet present
+          in a file's metadata.""",
+            constraints=EnsureStr() | EnsureNone()),
+        remove=Parameter(
+            args=('--remove',),
+            nargs='+',
+            action='append',
+            metavar=('KEY', 'VAL'),
+            doc="""
+          Values in the given dict are removed from the metadata items
+          matching the respective key, if they exist in a file's metadata.
+          Non-existing values, or keys do not lead to failure.""",
+            constraints=EnsureStr() | EnsureNone()),
+        reset=Parameter(
+            args=('--reset',),
+            nargs='+',
+            action='append',
+            metavar=('KEY', 'VAL'),
+            doc="""
+          Metadata items matching keys in the given dict are (re)set
+          to the respective values.""",
+            constraints=EnsureStr() | EnsureNone()),
+        # TODO --defprefix
+        dataset_global=Parameter(
+            args=('-g', '--dataset-global'),
+            action='store_true',
+            doc="""Whether to perform metadata query or modification
+            on the global dataset metadata, or on individual dataset
+            components. For example, without this switch setting
+            metadata using the root path of a dataset, will set the
+            given metadata for all files in a dataset, whereas with
+            this flag only the metadata record of the dataset itself
+            will be altered."""),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit)
+
+    @staticmethod
+    @datasetmethod(name='metadata')
+    @eval_results
+    def __call__(
+            path=None,
+            dataset=None,
+            add=None,
+            init=None,
+            remove=None,
+            reset=None,
+            dataset_global=False,
+            recursive=False,
+            recursion_limit=None):
+        # bring metadataset setter args in shape first
+        untag, remove = _parse_argspec(remove)
+        purge, reset = _parse_argspec(reset)
+        tag_add, add = _parse_argspec(add)
+        tag_init, init = _parse_argspec(init)
+        # merge all potential sources of tag specifications
+        all_untag = remove.get('tag', []) + untag
+        if all_untag:
+            remove['tag'] = all_untag
+        all_addtag = add.get('tag', []) + tag_add
+        if all_addtag:
+            add['tag'] = all_addtag
+        all_inittag = init.get('tag', []) + tag_init
+        if all_inittag:
+            init['tag'] = all_inittag
+
+        lgr.debug("Will 'init' metadata items: %s", init)
+        lgr.debug("Will 'add' metadata items: %s", add)
+        lgr.debug("Will 'remove' metadata items: %s", remove)
+        lgr.debug("Will 'reset' metadata items: %s", reset)
+        lgr.debug("Will 'purge' metadata items: %s", purge)
+
+        refds_path = Interface.get_refds_path(dataset)
+        res_kwargs = dict(action='metadata', logger=lgr, refds=refds_path)
+
+        to_process = []
+        for ap in AnnotatePaths.__call__(
+                dataset=refds_path,
+                path=path,
+                recursive=recursive,
+                recursion_limit=recursion_limit,
+                action='metadata',
+                unavailable_path_status='error',
+                nondataset_path_status='error',
+                force_subds_discovery=False,
+                return_type='generator',
+                on_failure='ignore'):
+            if ap.get('status', None):
+                # this is done
+                yield ap
+                continue
+            if ap.get('type', None) == 'dataset':
+                if ap.get('state', None) == 'absent':
+                    # just discovered via recursion, but not relevant here
+                    continue
+                if GitRepo.is_valid_repo(ap['path']):
+                    ap['process_content'] = True
+            to_process.append(ap)
+
+        content_by_ds, ds_props, completed, nondataset_paths = \
+            annotated2content_by_ds(
+                to_process,
+                refds_path=refds_path,
+                path_only=False)
+        assert(not completed)
+
+        # iterate over all datasets, order doesn't matter
+        for ds_path in content_by_ds:
+            # ignore submodule entries
+            content = [ap for ap in content_by_ds[ds_path]
+                       if ap.get('type', None) != 'dataset' or ap['path'] == ds_path]
+            ds = Dataset(ds_path)
+            if not isinstance(ds.repo, AnnexRepo):
+                # report on all explicitly requested paths only
+                # TODO adjust when dataset-global metadata is supported
+                for ap in [c for c in content if ap.get('raw_input', False)]:
+                    yield dict(
+                        ap,
+                        status='impossible',
+                        message=(
+                            'non-annex dataset %s has no file metadata support', ds),
+                        **res_kwargs)
+                continue
+            ds_paths = [p['path'] for p in content]
+            if reset or purge or add or init or remove:
+                mod_paths = []
+                for mp in ds.repo.set_metadata(
+                        ds_paths,
+                        reset=reset,
+                        add=add,
+                        init=init,
+                        remove=remove,
+                        purge=purge,
+                        # we always go recursive
+                        # TODO is that a good thing? But how to otherwise distinuish
+                        # this kind of recursive from the one across datasets in
+                        # the API?
+                        recursive=True):
+                    if mp.get('success', False):
+                        mod_paths.append(mp['file'])
+                    else:
+                        yield get_status_dict(
+                            status='error',
+                            message='setting metadata failed',
+                            path=opj(ds.path, mp[0]),
+                            type='file',
+                            **res_kwargs)
+                # query the actually modified paths only
+                ds_paths = mod_paths
+
+            # and lastly, query -- even if we set before -- there could
+            # be side-effect from multiple set paths on an individual
+            # path, hence we need to query to get the final result
+            for file, meta in ds.repo.get_metadata(ds_paths):
+                r = get_status_dict(
+                    status='ok',
+                    path=opj(ds.path, file),
+                    type='file',
+                    metadata=meta,
+                    **res_kwargs)
+                yield r
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        from datalad.ui import ui
+        if res['status'] != 'ok' or not res.get('action', None) == 'metadata':
+            # logging complained about this already
+            return
+        # list the path, available metadata keys, and tags
+        path = relpath(res['path'],
+                       res['refds']) if res.get('refds', None) else res['path']
+        meta = res.get('metadata', {})
+        ui.message('{path}:{spacer}{meta}{tags}'.format(
+            path=path,
+            spacer=' ' if len([m for m in meta if m != 'tag']) else '',
+            meta=','.join(k for k in sorted(meta.keys()) if not k == 'tag'),
+            tags='' if 'tag' not in meta else ' [{}]'.format(
+                 ','.join(meta['tag']))))

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -125,39 +125,41 @@ class Metadata(Interface):
             nargs='+',
             action='append',
             metavar=('KEY', 'VAL'),
-            doc="""
-          The values of matching keys in the given dict appended to
-          any possibly existing values. The metadata keys need not
-          necessarily exist before.""",
+            doc="""metadata items to add. If only a key is given, a
+            corresponding tag is added. If a key-value mapping (multiple
+            values at once are supported) is given, the values are
+            added to the metadata item of that key.""",
             constraints=EnsureStr() | EnsureNone()),
         init=Parameter(
             args=('-i', '--init',),
             nargs='+',
             action='append',
             metavar=('KEY', 'VAL'),
-            doc="""
-          Metadata items for the keys in the given dict are set
-          to the respective values, if the key is not yet present
-          in a file's metadata.""",
+            doc="""like --add, but tags are only added if no tag was present
+            before. Likewise, values are only added to a metadata key, if that
+            key did not exist before.""",
             constraints=EnsureStr() | EnsureNone()),
         remove=Parameter(
             args=('--remove',),
             nargs='+',
             action='append',
             metavar=('KEY', 'VAL'),
-            doc="""
-          Values in the given dict are removed from the metadata items
-          matching the respective key, if they exist in a file's metadata.
-          Non-existing values, or keys do not lead to failure.""",
+            doc="""metadata values to remove. If only a key is given, a
+            corresponding tag is removed. If a key-value mapping (multiple
+            values at once are supported) is given, only those values are
+            removed from the metadata item of that key. If no values are left
+            after the removal, the entire item of that key is removed.""",
             constraints=EnsureStr() | EnsureNone()),
         reset=Parameter(
             args=('--reset',),
             nargs='+',
             action='append',
             metavar=('KEY', 'VAL'),
-            doc="""
-          Metadata items matching keys in the given dict are (re)set
-          to the respective values.""",
+            doc="""metadata items to remove. If only a key is given, a
+            corresponding metadata key with all its values is removed.
+            If a key-value mapping (multiple values at once are supported)
+            is given, any existing values for this key are replaced by the
+            given ones.""",
             constraints=EnsureStr() | EnsureNone()),
         # TODO --defprefix
         dataset_global=Parameter(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -436,6 +436,7 @@ class Metadata(Interface):
             path=path,
             type=' ({})'.format(res['type']) if 'type' in res else '',
             spacer=' ' if len([m for m in meta if m != 'tag']) else '',
-            meta=','.join(k for k in sorted(meta.keys()) if not k == 'tag'),
+            meta=','.join(k for k in sorted(meta.keys()) if not k == 'tag')
+                 if meta else ' -',
             tags='' if 'tag' not in meta else ' [{}]'.format(
                  ','.join(meta['tag']))))

--- a/datalad/metadata/tests/test_manipulation.py
+++ b/datalad/metadata/tests/test_manipulation.py
@@ -1,0 +1,156 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test meta data manipulation"""
+
+
+from os.path import join as opj
+
+from datalad.api import metadata
+from datalad.distribution.dataset import Dataset
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
+
+from datalad.utils import chpwd
+
+from datalad.tests.utils import create_tree
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import assert_result_count
+from datalad.tests.utils import eq_
+from datalad.tests.utils import ok_clean_git
+
+
+@with_tempfile(mkdir=True)
+def test_basic(path):
+    with chpwd(path):
+        # no repo -> error
+        assert_status('error', metadata(on_failure='ignore'))
+        # some repo, no error on query of pwd
+        GitRepo('.', create=True)
+        eq_([], metadata())
+        # impossible when making explicit query
+        assert_status('impossible', metadata('.', on_failure='ignore'))
+        # fine with annex
+        AnnexRepo('.', create=True)
+        eq_([], metadata())
+        eq_([], metadata('.'))
+
+    # create playing field
+    create_tree(path, {'somefile': 'content', 'dir': {'deepfile': 'othercontent'}})
+    ds = Dataset(path)
+    ds.add('.')
+    ok_clean_git(path)
+    # full query -> 2 files
+    res = ds.metadata()
+    assert_result_count(res, 2)
+    assert_result_count(res, 2, type='file', metadata={})
+
+    #
+    # tags: just a special case of a metadata key without a value
+    #
+    # tag one file
+    target_file = opj('dir', 'deepfile')
+    # needs a sequence or dict
+    assert_raises(ValueError, ds.metadata, target_file, add='mytag')
+    # like this
+    res = ds.metadata(target_file, add=['mytag'])
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, type='file', path=opj(ds.path, target_file),
+        metadata={'tag': ['mytag']})
+    # now init tag for all files that don't have one yet
+    res = ds.metadata(init=['rest'])
+    assert_result_count(res, 2)
+    # from before
+    assert_result_count(
+        res, 1, type='file', path=opj(ds.path, target_file),
+        metadata={'tag': ['mytag']})
+    # and the other one
+    assert_result_count(
+        res, 1, type='file', path=opj(ds.path, 'somefile'),
+        metadata={'tag': ['rest']})
+    # add two more different tags
+    res = ds.metadata(add=['other1', 'other2', 'other3'])
+    assert_result_count(res, 2)
+    for r in res:
+        assert_in('other1', r['metadata']['tag'])
+        assert_in('other2', r['metadata']['tag'])
+        assert_in('other3', r['metadata']['tag'])
+
+    # now remove two specifics tag from all files that exists in all files
+    res = ds.metadata(remove=['other1', 'other3'])
+    assert_result_count(res, 2)
+    for r in res:
+        assert_not_in('other1', r['metadata']['tag'])
+        assert_in('other2', r['metadata']['tag'])
+
+    # and now one that only exists in one file
+    res = ds.metadata(remove=['rest'])
+    # we still get 2 results, because we still touch all files
+    assert_result_count(res, 2)
+    # however there is no modification to files that don't have the tag
+    assert_result_count(
+        res, 1, type='file', path=opj(ds.path, 'somefile'),
+        metadata={'tag': ['other2']})
+    assert_result_count(
+        res, 1, type='file', path=opj(ds.path, target_file),
+        metadata={'tag': ['mytag', 'other2']})
+
+    # and finally kill the tags
+    res = ds.metadata(target_file, reset=['tag'])
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, type='file', metadata={},
+                        path=opj(ds.path, target_file))
+    # no change to the other one
+    assert_result_count(
+        ds.metadata('somefile'), 1,
+        type='file', path=opj(ds.path, 'somefile'),
+        metadata={'tag': ['other2']})
+    # kill all tags everywhere
+    res = ds.metadata(reset=['tag'])
+    assert_result_count(res, 2)
+    assert_result_count(res, 2, type='file', metadata={})
+
+    #
+    # key: value mapping
+    #
+    res = ds.metadata('somefile', add=dict(new=('v1', 'v2')))
+    assert_result_count(res, 1, metadata={'new': ['v1', 'v2']})
+    # same as this, which exits to support the way things come
+    # in from the cmdline
+    res = ds.metadata(target_file, add=[['new', 'v1', 'v2']])
+    assert_result_count(res, 1, metadata={'new': ['v1', 'v2']})
+    # other file got the exact same metadata now
+    assert_result_count(
+        ds.metadata(), 2, metadata={'new': ['v1', 'v2']})
+    # reset with just a key removes the entire mapping
+    res = ds.metadata(target_file, reset=['new'])
+    assert_result_count(res, 1, metadata={})
+    # reset with a mapping, overrides the old one
+    res = ds.metadata('somefile', reset=dict(new='george', more='yeah'))
+    assert_result_count(res, 1, metadata=dict(new=['george'], more=['yeah']))
+    # remove single value from mapping, last value to go removes the key
+    res = ds.metadata('somefile', remove=dict(more='yeah'))
+    assert_result_count(res, 1, metadata=dict(new=['george']))
+    # and finally init keys
+    res = ds.metadata(init=dict(new=['two', 'three'], super='fresh'))
+    assert_result_count(res, 2)
+    assert_result_count(
+        res, 1, path=opj(ds.path, target_file),
+        # order of values is not maintained
+        metadata=dict(new=['three', 'two'], super=['fresh']))
+    assert_result_count(
+        res, 1, path=opj(ds.path, 'somefile'),
+        # order of values is not maintained
+        metadata=dict(new=['george'], super=['fresh']))
+

--- a/datalad/metadata/tests/test_manipulation.py
+++ b/datalad/metadata/tests/test_manipulation.py
@@ -181,7 +181,7 @@ def test_basic_dsmeta(path):
     eq_(res[0]['metadata']['readme'], ['long', 'short'])
     # supply key definitions, no need for dataset_global
     res = ds.metadata(define_key=dict(mykey='truth'))
-    eq_(res[0]['metadata']['definition'], {'mykey': 'truth'})
+    eq_(res[0]['metadata']['definition'], {'mykey': u'truth'})
     # re-supply different key definitions -> error
     res = ds.metadata(define_key=dict(mykey='lie'), on_failure='ignore')
     assert_result_count(
@@ -191,12 +191,12 @@ def test_basic_dsmeta(path):
     res = ds.metadata(define_key=dict(otherkey='altfact'))
     assert_dict_equal(
         res[0]['metadata']['definition'],
-        {'mykey': 'truth', 'otherkey': 'altfact'})
+        {'mykey': u'truth', 'otherkey': 'altfact'})
     # 'definition' is a regular key, we can remove items
     res = ds.metadata(remove=dict(definition=['mykey']), dataset_global=True)
     assert_dict_equal(
         res[0]['metadata']['definition'],
-        {'otherkey': 'altfact'})
+        {'otherkey': u'altfact'})
     res = ds.metadata(remove=dict(definition=['otherkey']), dataset_global=True)
     # when there are no items left, the key vanishes too
     assert('definition' not in res[0]['metadata'])

--- a/datalad/metadata/tests/test_manipulation.py
+++ b/datalad/metadata/tests/test_manipulation.py
@@ -165,56 +165,49 @@ def test_basic_dsmeta(path):
     # ensure clean slate
     assert_result_count(ds.metadata(), 0)
     # init
-    res = ds.metadata(init=['tag1', 'tag2'], dataset_global=True,
-                      return_type='item-or-list')
-    eq_(res['metadata']['tag'], ['tag1', 'tag2'])
+    res = ds.metadata(init=['tag1', 'tag2'], dataset_global=True)
+    eq_(res[0]['metadata']['tag'], ['tag1', 'tag2'])
     # init again does nothing
-    res = ds.metadata(init=['tag3'], dataset_global=True,
-                      return_type='item-or-list')
-    eq_(res['metadata']['tag'], ['tag1', 'tag2'])
+    res = ds.metadata(init=['tag3'], dataset_global=True)
+    eq_(res[0]['metadata']['tag'], ['tag1', 'tag2'])
     # reset whole key
     res = ds.metadata(reset=['tag'], dataset_global=True)
     assert_result_count(ds.metadata(), 0)
     # add something arbitrary
     res = ds.metadata(add=dict(dtype=['heavy'], readme=['short', 'long']),
-                      dataset_global=True, return_type='item-or-list')
-    eq_(res['metadata']['dtype'], ['heavy'])
+                      dataset_global=True)
+    eq_(res[0]['metadata']['dtype'], ['heavy'])
     # sorted!
-    eq_(res['metadata']['readme'], ['long', 'short'])
+    eq_(res[0]['metadata']['readme'], ['long', 'short'])
     # supply key definitions, no need for dataset_global
-    res = ds.metadata(define_key=dict(mykey='truth'),
-                      return_type='item-or-list')
-    eq_(res['metadata']['definition'], {'mykey': 'truth'})
+    res = ds.metadata(define_key=dict(mykey='truth'))
+    eq_(res[0]['metadata']['definition'], {'mykey': 'truth'})
     # re-supply different key definitions -> error
     res = ds.metadata(define_key=dict(mykey='lie'), on_failure='ignore')
     assert_result_count(
         res, 1, status='error',
         message=("conflicting definition for key '%s': '%s' != '%s'",
                  "mykey", "lie", "truth"))
-    res = ds.metadata(define_key=dict(otherkey='altfact'),
-                      return_type='item-or-list')
+    res = ds.metadata(define_key=dict(otherkey='altfact'))
     assert_dict_equal(
-        res['metadata']['definition'],
+        res[0]['metadata']['definition'],
         {'mykey': 'truth', 'otherkey': 'altfact'})
     # 'definition' is a regular key, we can remove items
-    res = ds.metadata(remove=dict(definition=['mykey']), dataset_global=True,
-                      return_type='item-or-list')
+    res = ds.metadata(remove=dict(definition=['mykey']), dataset_global=True)
     assert_dict_equal(
-        res['metadata']['definition'],
+        res[0]['metadata']['definition'],
         {'otherkey': 'altfact'})
-    res = ds.metadata(remove=dict(definition=['otherkey']), dataset_global=True,
-                      return_type='item-or-list')
+    res = ds.metadata(remove=dict(definition=['otherkey']), dataset_global=True)
     # when there are no items left, the key vanishes too
-    assert('definition' not in res['metadata'])
+    assert('definition' not in res[0]['metadata'])
     # we still have metadata, so there is a DB file
-    assert(res['metadata'])
+    assert(res[0]['metadata'])
     db_path = opj(ds.path, '.datalad', 'metadata', 'dataset.json')
     assert(exists(db_path))
     ok_clean_git(ds.path)
     # but if we remove it, the file is gone
-    res = ds.metadata(reset=['readme', 'dtype'], dataset_global=True,
-                      return_type='item-or-list')
-    eq_(res['metadata'], {})
+    res = ds.metadata(reset=['readme', 'dtype'], dataset_global=True)
+    eq_(res[0]['metadata'], {})
     assert(not exists(db_path))
     ok_clean_git(ds.path)
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1998,61 +1998,61 @@ def test_AnnexRepo_metadata(path):
     # fugue
     # doesn't do anything if there is nothing to do
     ar.set_metadata('up.dat')
-    eq_({}, ar.get_metadata(None))
-    eq_({}, ar.get_metadata(''))
-    eq_({}, ar.get_metadata([]))
-    eq_({'up.dat': {}}, ar.get_metadata('up.dat'))
+    eq_([], list(ar.get_metadata(None)))
+    eq_([], list(ar.get_metadata('')))
+    eq_([], list(ar.get_metadata([])))
+    eq_({'up.dat': {}}, dict(ar.get_metadata('up.dat')))
     # basic invocation
-    eq_(None, ar.set_metadata(
+    eq_(1, len(list(ar.set_metadata(
         'up.dat',
         reset={'mike': 'awesome'},
         add={'tag': 'awesome'},
         remove={'tag': 'awesome'},  # cancels prev, just to use it
         init={'virgin': 'true'},
-        purge=['nothere']))
+        purge=['nothere']))))
     # no timestamps by default
-    md = ar.get_metadata('up.dat')
+    md = dict(ar.get_metadata('up.dat'))
     deq_({'up.dat': {
         'virgin': ['true'],
         'mike': ['awesome']}},
         md)
     # matching timestamp entries for all keys
-    md_ts = ar.get_metadata('up.dat', timestamps=True)
+    md_ts = dict(ar.get_metadata('up.dat', timestamps=True))
     for k in md['up.dat']:
         assert_in('{}-lastchanged'.format(k), md_ts['up.dat'])
     assert_in('lastchanged', md_ts['up.dat'])
     # recursive needs a flag
-    assert_raises(CommandError, ar.set_metadata, '.', purge=['virgin'])
-    ar.set_metadata('.', purge=['virgin'], recursive=True)
+    assert_raises(CommandError, list, ar.set_metadata('.', purge=['virgin']))
+    list(ar.set_metadata('.', purge=['virgin'], recursive=True))
     deq_({'up.dat': {
         'mike': ['awesome']}},
-        ar.get_metadata('up.dat'))
+        dict(ar.get_metadata('up.dat')))
     # Use trickier tags (spaces, =)
-    ar.set_metadata('.', reset={'tag': 'one and= '}, purge=['mike'], recursive=True)
+    list(ar.set_metadata('.', reset={'tag': 'one and= '}, purge=['mike'], recursive=True))
     playfile = opj('d o"w n', 'd o w n.dat')
     target = {
         'up.dat': {
             'tag': ['one and= ']},
         playfile: {
             'tag': ['one and= ']}}
-    deq_(target, ar.get_metadata('.'))
+    deq_(target, dict(ar.get_metadata('.')))
     # incremental work like a set
-    ar.set_metadata(playfile, add={'tag': 'one and= '})
-    deq_(target, ar.get_metadata('.'))
-    ar.set_metadata(playfile, add={'tag': ' two'})
+    list(ar.set_metadata(playfile, add={'tag': 'one and= '}))
+    deq_(target, dict(ar.get_metadata('.')))
+    list(ar.set_metadata(playfile, add={'tag': ' two'}))
     # returned values are sorted
-    eq_([' two', 'one and= '], ar.get_metadata(playfile)[playfile]['tag'])
+    eq_([' two', 'one and= '], dict(ar.get_metadata(playfile))[playfile]['tag'])
     # init honor prior values
-    ar.set_metadata(playfile, init={'tag': 'three'})
-    eq_([' two', 'one and= '], ar.get_metadata(playfile)[playfile]['tag'])
-    ar.set_metadata(playfile, remove={'tag': ' two'})
-    deq_(target, ar.get_metadata('.'))
+    list(ar.set_metadata(playfile, init={'tag': 'three'}))
+    eq_([' two', 'one and= '], dict(ar.get_metadata(playfile))[playfile]['tag'])
+    list(ar.set_metadata(playfile, remove={'tag': ' two'}))
+    deq_(target, dict(ar.get_metadata('.')))
     # remove non-existing doesn't error and doesn't change anything
-    ar.set_metadata(playfile, remove={'ether': 'best'})
-    deq_(target, ar.get_metadata('.'))
+    list(ar.set_metadata(playfile, remove={'ether': 'best'}))
+    deq_(target, dict(ar.get_metadata('.')))
     # add works without prior existence
-    ar.set_metadata(playfile, add={'novel': 'best'})
-    eq_(['best'], ar.get_metadata(playfile)[playfile]['novel'])
+    list(ar.set_metadata(playfile, add={'novel': 'best'}))
+    eq_(['best'], dict(ar.get_metadata(playfile))[playfile]['novel'])
 
 
 @with_tempfile(mkdir=True)

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -43,6 +43,7 @@ Meta data handling
    :maxdepth: 1
 
    generated/man/datalad-search
+   generated/man/datalad-metadata
    generated/man/datalad-aggregate-metadata
 
 Miscellaneous commands


### PR DESCRIPTION
On the way to 1st class preferred content management we need a frontend for git annex' metadata (tagging). Here is comes. While being add it I also implemented native support for dataset-level metadata:

Changes:

- [x] make `AnnexRepo` getter/setter generators
- [x] draft of a highlevel command to channel all of git-annex' file based metadata support
- [x] uniform support for dataset-level metadata via the same interface and semantics as for file-level metadata
- [x] dataset-level metadata is stored in JSON format (optimized for diffability) directly in Git
- [x] support for key definitions: while this is not the same as linked data, it represents a minimalistic compromise between precise semantics, and compact representation with minimal performance impact
- [x] somewhat useful custom result renderer for metadata
- [x] usual multi-dataset handling

More details are in the docstring of the command.

Possible TODOs (not necessarily in this PR):

- [ ] add `--import-from` option that uses a selected metadata parser (from the existing set that we have) to extract metadata from a supported format and imports it into our own dataset-level metadata. This should be easy to implement by building a corresponding value for the `init` arg of this command from the parser results, hence only amending existing metadata. Actually the edit strategy could be selected as `init`, `add`, or `reset`.