### PR TITLE
No API function with an underscore in its name has a proper docstring in the Python API

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -77,10 +77,10 @@ def _generate_func_api():
             spec = getattr(intf, '_params_', dict())
             api_name = get_api_name(intfspec)
             if api_name in (
-                    'add-archive-content', 'aggregate-metadata',
-                    'crawl-init', 'crawl', 'create-sibling',
-                    'create-sibling-github', 'create-test-dataset',
-                    'download-url', 'export', 'ls', 'move', 'publish',
+                    'add_archive_content', 'aggregate_metadata',
+                    'crawl_init', 'crawl', 'create_sibling',
+                    'create_sibling_github', 'create_test_dataset',
+                    'download_url', 'export', 'ls', 'move', 'publish',
                     'search', 'sshrun', 'test'):
                 # FIXME no longer using an interface class instance
                 # convert the parameter SPEC into a docstring for the function


### PR DESCRIPTION
This is confounded with those functions not (yet) using the `@build_doc` decorator...