### PR TITLE
Use @build_doc decorator for all commands

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -80,7 +80,7 @@ def _generate_func_api():
                     'add_archive_content', 'aggregate_metadata',
                     'crawl_init', 'crawl', 'create_sibling',
                     'create_sibling_github', 'create_test_dataset',
-                    'download_url', 'export', 'ls', 'move', 'publish',
+                    'export', 'ls', 'move', 'publish',
                     'search', 'sshrun', 'test'):
                 # FIXME no longer using an interface class instance
                 # convert the parameter SPEC into a docstring for the function

--- a/datalad/api.py
+++ b/datalad/api.py
@@ -72,27 +72,9 @@ def _generate_func_api():
             # turn the interface spec into an instance
             mod = import_module(intfspec[0], package='datalad')
             intf = getattr(mod, intfspec[1])
-
-            # TODO: BEGIN to be removed, when @build_doc is applied everywhere
-            spec = getattr(intf, '_params_', dict())
             api_name = get_api_name(intfspec)
-            if api_name in (
-                    'add_archive_content', 'aggregate_metadata',
-                    'crawl_init', 'crawl', 'create_sibling',
-                    'create_sibling_github', 'create_test_dataset',
-                    'export', 'ls', 'move', 'publish',
-                    'search', 'sshrun', 'test'):
-                # FIXME no longer using an interface class instance
-                # convert the parameter SPEC into a docstring for the function
-                update_docstring_with_parameters(
-                    intf.__call__, spec,
-                    prefix=alter_interface_docs_for_api(
-                        intf.__doc__),
-                    suffix=alter_interface_docs_for_api(
-                        intf.__call__.__doc__)
-                )
-                # TODO: END to be removed, when @build_doc is applied everywhere
             globals()[api_name] = intf.__call__
+
 
 # Invoke above helper
 _generate_func_api()

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -29,6 +29,7 @@ from datalad.distribution.add_sibling import _check_deps
 from datalad.distribution.dataset import EnsureDataset, Dataset, \
     datasetmethod, require_dataset
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import as_common_datasrc
 from datalad.interface.common_opts import publish_by_default
@@ -253,6 +254,7 @@ def _create_dataset_sibling(
     return remoteds_path
 
 
+@build_doc
 class CreateSibling(Interface):
     """Create a dataset sibling on a UNIX-like SSH-accessible machine
 
@@ -274,6 +276,8 @@ class CreateSibling(Interface):
     mechanism is provided to produce a flat list of datasets (see
     --target-dir).
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         # TODO: Figure out, whether (and when) to use `sshurl` as push url

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -29,6 +29,7 @@ from datalad.support.constraints import EnsureStr, EnsureNone
 from datalad.support.constraints import EnsureChoice
 from datalad.support.exceptions import MissingExternalDependency
 from ..interface.base import Interface
+from datalad.interface.utils import build_doc
 from datalad.distribution.dataset import EnsureDataset, datasetmethod, \
     require_dataset, Dataset
 from datalad.distribution.siblings import Siblings
@@ -189,6 +190,7 @@ def _make_github_repo(gh, entity, reponame, existing, access_protocol, dryrun):
 template_fx = lambda x: re.sub(r'\s+', '_', re.sub(r'[/\\]+', '-', x))
 
 
+@build_doc
 class CreateSiblingGithub(Interface):
     """Create dataset sibling on Github.
 
@@ -211,6 +213,8 @@ class CreateSiblingGithub(Interface):
     interface (https://github.com/sociomantic/git-hub) by running:
     :kbd:`git hub setup`.
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         dataset=Parameter(

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -26,6 +26,7 @@ from datalad.support.constraints import EnsureStr, EnsureNone, EnsureInt
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 
 lgr = logging.getLogger('datalad.distribution.tests')
 
@@ -123,9 +124,12 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
         )
 
 
+@build_doc
 class CreateTestDataset(Interface):
     """Create test (meta-)dataset.
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         path=Parameter(

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -17,6 +17,7 @@ from os.path import curdir
 from os.path import sep as dirsep
 
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 from datalad.interface.utils import filter_unmodified
 from datalad.interface.common_opts import annex_copy_opts, recursion_flag, \
     recursion_limit, git_opts, annex_opts
@@ -279,6 +280,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     return published, skipped
 
 
+@build_doc
 class Publish(Interface):
     """Publish a dataset to a known :term:`sibling`.
 
@@ -307,6 +309,8 @@ class Publish(Interface):
       Git repositories, or git-annex special remotes (if their support data
       upload).
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
     # TODO: Figure out, how to tell about tracking branch/upstream
     #      (and the respective remote)
     #      - it is used, when no destination is given

--- a/datalad/export/__init__.py
+++ b/datalad/export/__init__.py
@@ -25,6 +25,7 @@ from datalad.distribution.dataset import require_dataset
 from datalad.dochelpers import exc_str
 
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 
 lgr = logging.getLogger('datalad.export')
 
@@ -36,9 +37,12 @@ def _get_exporter_names():
             if not e.endswith('__init__.py')]
 
 
+@build_doc
 class Export(Interface):
     """Export a dataset to another representation
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         dataset=Parameter(

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -28,6 +28,7 @@ from os.path import dirname
 from os.path import normpath
 
 from .base import Interface
+from datalad.interface.utils import build_doc
 from .common_opts import allow_dirty
 from ..consts import ARCHIVES_SPECIAL_REMOTE
 from ..support.param import Parameter
@@ -57,6 +58,7 @@ _KEY_OPT_NOTE = "Note that it will be of no effect if %s is given" % _KEY_OPT
 # all but by default to print only the one associated with this given action
 
 
+@build_doc
 class AddArchiveContent(Interface):
     """Add content of an archive under git annex control.
 
@@ -69,6 +71,8 @@ class AddArchiveContent(Interface):
         annex-repo$ datalad add-archive-content my_big_tarball.tar.gz
 
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
     _params_ = dict(
         delete=Parameter(
             args=("-d", "--delete"),

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -193,7 +193,8 @@ def is_api_arg(arg):
     return arg != 'self' and not arg.startswith('_')
 
 
-def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
+def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
+                                     add_args=None):
     """Generate a useful docstring from a parameter spec
 
     Amends any existing docstring of a callable with a textual
@@ -204,7 +205,11 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
     # get the signature
     ndefaults = 0
     args, varargs, varkw, defaults = getargspec(func)
-    if not defaults is None:
+    if add_args:
+        add_argnames = sorted(add_args.keys())
+        args.extend(add_argnames)
+        defaults = defaults + tuple(add_args[k] for k in add_argnames)
+    if defaults is not None:
         ndefaults = len(defaults)
     # start documentation with what the callable brings with it
     doc = prefix if prefix else u''
@@ -223,7 +228,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None):
             # somewhat OK
             defaults_idx = ndefaults - len(args) + i
             if defaults_idx >= 0:
-                if not param.constraints is None:
+                if param.constraints is not None:
                     param.constraints(defaults[defaults_idx])
             orig_docs = param._doc
             param._doc = alter_interface_docs_for_api(param._doc)

--- a/datalad/interface/crawl.py
+++ b/datalad/interface/crawl.py
@@ -13,6 +13,7 @@ __docformat__ = 'restructuredtext'
 
 from os.path import exists
 from .base import Interface
+from datalad.interface.utils import build_doc
 
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone
@@ -26,6 +27,7 @@ lgr = getLogger('datalad.api.crawl')
 from .. import cfg
 
 
+@build_doc
 class Crawl(Interface):
     """Crawl online resource to create or update a dataset.
 
@@ -33,6 +35,8 @@ class Crawl(Interface):
 
       $ datalad crawl  # within a dataset having .datalad/crawl/crawl.cfg
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
     _params_ = dict(
         # Dry run is untested and largely probably not working in this implementation
         # so let's not expose it for now at all

--- a/datalad/interface/crawl_init.py
+++ b/datalad/interface/crawl_init.py
@@ -12,6 +12,7 @@ __docformat__ = 'restructuredtext'
 
 from os.path import curdir
 from .base import Interface
+from datalad.interface.utils import build_doc
 from collections import OrderedDict
 from datalad.distribution.dataset import Dataset
 
@@ -26,6 +27,7 @@ lgr = getLogger('datalad.api.crawl_init')
 CRAWLER_PIPELINE_SECTION = 'crawl:pipeline'
 
 
+@build_doc
 class CrawlInit(Interface):
     """Initialize crawling configuration
 
@@ -41,6 +43,8 @@ class CrawlInit(Interface):
         --template fcptable \
         dataset=Baltimore tarballs=True
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         template=Parameter(

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -19,6 +19,7 @@ __docformat__ = 'restructuredtext'
 from os.path import isdir, curdir
 
 from .base import Interface
+from datalad.interface.utils import build_doc
 from ..ui import ui
 from ..utils import assure_list_from_str
 from ..dochelpers import exc_str
@@ -29,6 +30,7 @@ from logging import getLogger
 lgr = getLogger('datalad.api.download-url')
 
 
+@build_doc
 class DownloadURL(Interface):
     """Download content
 
@@ -40,6 +42,8 @@ class DownloadURL(Interface):
 
       $ datalad download http://example.com/file.dat s3://bucket/file2.dat
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         urls=Parameter(

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -26,6 +26,7 @@ from six.moves.urllib.error import HTTPError
 from ..cmdline.helpers import get_repo_instance
 from ..utils import auto_repr
 from .base import Interface
+from datalad.interface.utils import build_doc
 from ..ui import ui
 from ..utils import swallow_logs
 from ..consts import METADATA_DIR
@@ -47,6 +48,7 @@ from logging import getLogger
 lgr = getLogger('datalad.api.ls')
 
 
+@build_doc
 class Ls(Interface):
     """List summary information about URLs and dataset(s)
 
@@ -58,6 +60,8 @@ class Ls(Interface):
       $ datalad ls s3://openfmri/tarballs/ds202  # to list S3 bucket
       $ datalad ls                               # to list current dataset
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     # TODO: during big RF refactor this one away since it must not be instance's
     # attribute.  For now introduced to make `datalad ls` be relatively usable

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -14,13 +14,17 @@ __docformat__ = 'restructuredtext'
 
 import datalad
 from .base import Interface
+from datalad.interface.utils import build_doc
 
 
+@build_doc
 class Test(Interface):
     """Run internal DataLad (unit)tests.
 
     This can be used to verify correct operation on the system
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
     @staticmethod
     def __call__():
         datalad.test()

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 import os
 from os.path import join as opj, exists, relpath, dirname
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import if_dirty_opt
@@ -38,6 +39,7 @@ def _store_json(ds, path, meta):
     ds.repo.add(fname, git=True)
 
 
+@build_doc
 class AggregateMetaData(Interface):
     """Aggregate meta data of a dataset for later query.
 
@@ -52,6 +54,8 @@ class AggregateMetaData(Interface):
     List
       Any datasets where (updated) aggregated meta data was saved.
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         dataset=Parameter(

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -23,6 +23,7 @@ from six import iteritems
 from six import reraise
 from six import PY3
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     require_dataset
@@ -41,6 +42,7 @@ from datalad.support import ansi_colors
 from datalad.ui import ui
 
 
+@build_doc
 class Search(Interface):
     """Search within available in datasets' meta data
 
@@ -52,6 +54,8 @@ class Search(Interface):
         fields which were requested by `report` option
 
     """
+    # XXX prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         dataset=Parameter(

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -21,12 +21,14 @@ import sys
 
 from datalad.support.param import Parameter
 from datalad.interface.base import Interface
+from datalad.interface.utils import build_doc
 
 from datalad import ssh_manager
 
 lgr = logging.getLogger('datalad.sshrun')
 
 
+@build_doc
 class SSHRun(Interface):
     """Run command on remote machines via SSH.
 
@@ -35,6 +37,8 @@ class SSHRun(Interface):
     connection management. Its primary use case is to be used with Git
     as 'core.sshCommand' or via "GIT_SSH_COMMAND".
     """
+    # prevent common args from being added to the docstring
+    _no_eval_results = True
 
     _params_ = dict(
         login=Parameter(


### PR DESCRIPTION
This fixes a number of issues

- [x] documentation for commands that specified 'Returns' was absent from the HTML docs, due to a formatting error
- [x] defaults for common args where no validated against their constraints
- [x] code duplication for arg docstring rendering removed