### PR TITLE
Limit recursive install on a per-subdataset basis

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -264,6 +264,11 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
     for sub in ds.subdatasets(
             return_type='generator', result_renderer='disabled'):
         subds = Dataset(sub['path'])
+        if sub.get('gitmodule_datalad-recursiveinstall', '') == 'skip':
+            lgr.debug(
+                "subdataset %s is configured to be skipped on recursive installation",
+                sub['path'])
+            continue
         if start is not None and not subds.path.startswith(_with_sep(start)):
             # this one we can ignore, not underneath the start path
             continue

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -33,6 +33,7 @@ from datalad.support.gitrepo import InvalidGitRepositoryError
 from datalad.support.exceptions import CommandError
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
+from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import require_dataset
 from datalad.cmd import GitRunner
 from datalad.support.gitrepo import GitRepo
@@ -345,6 +346,9 @@ def _get_submodules(dspath, fulfilled, recursive, recursion_limit,
                     val)
                 # also add to the info we just read above
                 sm['gitmodule_{}'.format(prop)] = val
+            Dataset(dspath).add(
+                '.gitmodules', to_git=True,
+                message='[DATALAD] modified subdataset properties')
 
         #common = commonprefix((with_pathsep(subds), with_pathsep(path)))
         #if common.endswith(sep) and common == with_pathsep(subds):

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -162,11 +162,22 @@ class Subdatasets(Interface):
     "gitmodule_<label>"
         Any additional configuration property on record.
 
-    Performance note: Requesting `bottomup` reporting order, or a particular
-    numerical `recursion_limit` implies an internal switch to an alternative
-    query implementation for recursive query that is more flexible, but also
-    notably slower (performs one call to Git per dataset versus a single call
-    for all combined).
+    Performance note: Property modification, requesting `bottomup` reporting
+    order, or a particular numerical `recursion_limit` implies an internal
+    switch to an alternative query implementation for recursive query that is
+    more flexible, but also notably slower (performs one call to Git per
+    dataset versus a single call for all combined).
+
+    The following properties for subdatasets are recognized by DataLad
+    (without the 'gitmodule_' prefix that is used in the query results):
+
+    "datalad-recursiveinstall"
+        If set to 'skip', the respective subdataset is skipped when DataLad
+        is recursively installing its superdataset. However, the subdataset
+        remains installable when explicitly requested, and no other features
+        are impaired.
+
+
 
     """
     _params_ = dict(

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -50,6 +50,7 @@ lgr = logging.getLogger('datalad.distribution.subdatasets')
 
 submodule_full_props = re.compile(r'([0-9a-f]+) (.*) \((.*)\)$')
 submodule_nodescribe_props = re.compile(r'([0-9a-f]+) (.*)$')
+valid_key = re.compile(r'^[A-Za-z][-A-Za-z0-9]*$')
 
 status_map = {
     ' ': 'clean',
@@ -214,7 +215,9 @@ class Subdatasets(Interface):
             nargs=2,
             action='append',
             doc="""Name and value of one or more subdataset properties to
-            be set in the parent dataset's .gitmodules file. The value can be
+            be set in the parent dataset's .gitmodules file. The property name
+            is case-insensitive, must start with a letter, and consist only
+            of alphanumeric characters. The value can be
             a Python format() template string wrapped in '<>' (e.g.
             '<{gitmodule_name}>').
             Supported keywords are any item reported in the result properties
@@ -258,6 +261,12 @@ class Subdatasets(Interface):
         if isinstance(recursion_limit, int) and (recursion_limit <= 0):
             return
 
+        if set_property:
+            for k, v in set_property:
+                if valid_key.match(k) is None:
+                    raise ValueError(
+                        "key '%s' is invalid (alphanumeric plus '-' only, must start with a letter)",
+                        k)
         try:
             if not (bottomup or contains or set_property or delete_property or \
                     (recursive and recursion_limit is not None)):

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -198,7 +198,7 @@ class Subdatasets(Interface):
             each branch in the dataset tree, and not top-down."""),
         set_property=Parameter(
             args=('--set-property',),
-            metavar='VALUE',
+            metavar=('NAME', 'VALUE'),
             nargs=2,
             action='append',
             doc="""Name and value of one or more subdataset properties to

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -169,7 +169,7 @@ class Subdatasets(Interface):
     dataset versus a single call for all combined).
 
     The following properties for subdatasets are recognized by DataLad
-    (without the 'gitmodule_' prefix that is used in the query results):
+    (without the 'gitmodule\_' prefix that is used in the query results):
 
     "datalad-recursiveinstall"
         If set to 'skip', the respective subdataset is skipped when DataLad

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 
 from os.path import join as opj
 from os.path import basename
+from os.path import lexists
 
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import with_tempfile
@@ -21,10 +22,12 @@ from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import eq_
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_raises
+from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import create_tree
 
 from datalad.distribution.dataset import Dataset
 from datalad.api import annotate_paths
+from datalad.api import install
 from datalad.interface.annotate_paths import get_modified_subpaths
 from datalad.utils import chpwd
 
@@ -315,3 +318,47 @@ def test_get_modified_subpaths(path):
     assert_result_count(
         res, 1,
         type_src='dataset', path=suba.path)
+
+
+@with_tree(demo_hierarchy)
+@with_tempfile(mkdir=True)
+def test_recurseinto(dspath, dest):
+    # make fresh dataset hierarchy
+    ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
+    ds.add('.', recursive=True)
+    # label intermediate dataset as 'norecurseinto'
+    res = Dataset(opj(ds.path, 'b')).subdatasets(
+        contains='bb',
+        set_property=[('datalad-recursiveinstall', 'skip')])
+    assert_result_count(res, 1, path=opj(ds.path, 'b', 'bb'))
+    ds.add('b/', recursive=True)
+    ok_clean_git(ds.path)
+
+    # recursive install, should skip the entire bb branch
+    res = install(source=ds.path, path=dest, recursive=True,
+                  result_xfm=None, result_filter=None)
+    assert_result_count(res, 5)
+    assert_result_count(res, 5, type='dataset')
+    # we got the neighbor subdataset
+    assert_result_count(res, 1, type='dataset',
+                        path=opj(dest, 'b', 'ba'))
+    # we did not get the one we wanted to skip
+    assert_result_count(res, 0, type='dataset',
+                        path=opj(dest, 'b', 'bb'))
+    assert_not_in(
+        opj(dest, 'b', 'bb'),
+        Dataset(dest).subdatasets(fulfilled=True, result_xfm='paths'))
+    assert(not Dataset(opj(dest, 'b', 'bb')).is_installed())
+
+    # cleanup
+    Dataset(dest).remove(recursive=True)
+    assert(not lexists(dest))
+    # again but just clone the base, and then get content and grab 'bb'
+    # explicitly -- must get it installed
+    dest = install(source=ds.path, path=dest)
+    res = dest.get(['.', opj('b', 'bb')], get_data=False, recursive=True)
+    assert_result_count(res, 8)
+    assert_result_count(res, 8, type='dataset')
+    assert_result_count(res, 1, type='dataset',
+                        path=opj(dest.path, 'b', 'bb'))
+    assert(Dataset(opj(dest.path, 'b', 'bb')).is_installed())

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1325,7 +1325,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
             # if None -- leave it to annex to decide
             if git is not None:
-                if self.config.getint("annex", "version") == 6:
+                if 'annex.version' in self.config and \
+                        self.config.getint("annex", "version") == 6:
                     # Note: For now ugly workaround to prevent unexpected
                     # outcome when adding to git. See:
                     # <http://git-annex.branchable.com/bugs/mysterious_dependency_of_git_annex_status_output_of_the_added_file/>


### PR DESCRIPTION
Docs are in the diff.

Data dependency datasets in the studyforrest collection want to marked up with this, before they come on board.