### PR TITLE
Python API docs need more accurate type description

### DIFF
--- a/datalad/support/param.py
+++ b/datalad/support/param.py
@@ -98,8 +98,14 @@ class Parameter(object):
         if sdoc is not None:
             if sdoc[0] == '(' and sdoc[-1] == ')':
                 sdoc = sdoc[1:-1]
-            if self.cmd_kwargs.get('nargs', None) == '*' \
-                    or self.cmd_kwargs.get('action', None) == 'append':
+            nargs = self.cmd_kwargs.get('nargs', '')
+            if isinstance(nargs, int):
+                sdoc = '{}-item sequence of {}'.format(nargs, sdoc)
+            elif nargs == '+':
+                sdoc = 'non-empty sequence of {}'.format(sdoc)
+            elif nargs == '*':
+                sdoc = 'sequence of {}'.format(sdoc)
+            if self.cmd_kwargs.get('action', None) == 'append':
                 sdoc = 'list of {}'.format(sdoc)
             paramsdoc += " : %s" % sdoc
             if has_default:


### PR DESCRIPTION
For example we have to incorporate the implications of `action`, or `nargs` settings in `Parameter`. Example:

````
purge=Parameter(
        args=('--purge',),
        nargs='+',
        metavar='KEY',
        doc="""any metadata item with a key matching an entry in the given
        list is removed from the metadata.""",
        constraints=EnsureStr() | EnsureNone()),
 ````

which in itself is correct for the commandline API leads to this Python API docstring excerpt:

````
purge : str or None, optional
  any metadata item with a key matching an entry in the given list is
  removed from the metadata. Constraints: value must be a string, or
  value must be `None`. [Default: None]
````

So the dtype description is accurate for a single list item, but the list itself is nowhere mentioned, just in the custom text.

We need to check situations like `nargs='+'` (or with an int), as well as `action='append'. I am sure there are more.