### PR TITLE
NF: `plugin` command

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -27,14 +27,14 @@ def _generate_func_api():
     from .interface.base import get_interface_groups
     from .interface.base import get_api_name
     from .interface.base import alter_interface_docs_for_api
-    from .interface.base import merge_allargs2kwargs
+    from .interface.base import get_allargs_as_kwargs
 
     def _kwargs_to_namespace(call, args, kwargs):
         """
         Given a __call__, args and kwargs passed, prepare a cmdlineargs-like
         thing
         """
-        kwargs_ = merge_allargs2kwargs(call, args, kwargs)
+        kwargs_ = get_allargs_as_kwargs(call, args, kwargs)
         # Get all arguments removing those possible ones used internally and
         # which shouldn't be exposed outside anyways
         [kwargs_.pop(k) for k in kwargs_ if k.startswith('_')]

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -142,6 +142,33 @@ def setup_parser(
         of the command; 'continue' works like 'ignore', but an error causes a
         non-zero exit code; 'stop' halts on first failure and yields non-zero exit
         code. A failure is any result with status 'impossible' or 'error'.""")
+    parser.add_argument(
+        '--run-before', dest='common_run_before',
+        nargs='+',
+        action='append',
+        metavar='PLUGINSPEC',
+        help="""DataLad plugin to run after the command. PLUGINSPEC is a list
+        comprised of a plugin name plus optional `key=value` pairs with arguments
+        for the plugin call (see `plugin` command documentation for details).
+        This option can be given more than once to run multiple plugins
+        in the order in which they were given."""),
+    parser.add_argument(
+        '--run-after', dest='common_run_after',
+        nargs='+',
+        action='append',
+        metavar='PLUGINSPEC',
+        help="""DataLad plugin to run after the command. PLUGINSPEC is a list
+        comprised of a plugin name plus optional `key=value` pairs with arguments
+        for the plugin call (see `plugin` command documentation for details).
+        This option can be given more than once to run multiple plugins
+        in the order in which they were given."""),
+    parser.add_argument(
+        '--cmd', dest='_', action='store_true',
+        help="""syntactical helper that can be used to end the list of global
+        command line options before the subcommand label. Options like
+        --run-before can take an arbitray number of arguments and may require
+        to be followed by a single --cmd in order to enable identification
+        of the subcommand.""")
 
     # yoh: atm we only dump to console.  Might adopt the same separation later on
     #      and for consistency will call it --verbose-level as well for now

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -151,17 +151,17 @@ def setup_parser(
         comprised of a plugin name plus optional `key=value` pairs with arguments
         for the plugin call (see `plugin` command documentation for details).
         This option can be given more than once to run multiple plugins
-        in the order in which they were given."""),
+        in the order in which they were given.
+        For running plugins that require a --dataset argument it is important
+        to provide the respective dataset as the --dataset argument of the main
+        command, if it is not in the list of plugin arguments."""),
     parser.add_argument(
         '--run-after', dest='common_run_after',
         nargs='+',
         action='append',
         metavar='PLUGINSPEC',
-        help="""DataLad plugin to run after the command. PLUGINSPEC is a list
-        comprised of a plugin name plus optional `key=value` pairs with arguments
-        for the plugin call (see `plugin` command documentation for details).
-        This option can be given more than once to run multiple plugins
-        in the order in which they were given."""),
+        help="""Like --run-before, but plugins are executed after the main command
+        has finished."""),
     parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -38,7 +38,7 @@ from datalad.interface.results import success_status_map
 from datalad.interface.results import results_from_annex_noinfo
 from datalad.interface.utils import discover_dataset_trace_to_targets
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.save import Save
 from datalad.distribution.utils import _fixup_submodule_dotgit_setup
 from datalad.support.constraints import EnsureStr

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -17,7 +17,7 @@ from os.path import exists
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.interface.common_opts import location_description
 # from datalad.interface.common_opts import git_opts

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -20,7 +20,7 @@ from os.path import join as opj
 from datalad.interface.base import Interface
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_init_opts

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -218,7 +218,8 @@ class Create(Interface):
             unavailable_path_msg=None,
             # if we have a dataset given that actually exists, we want to
             # fail if the requested path is not in it
-            nondataset_path_status='error' if dataset and dataset.is_installed() else '',
+            nondataset_path_status='error' \
+                if isinstance(dataset, Dataset) and dataset.is_installed() else '',
             on_failure='ignore')
         path = None
         for r in annotated_paths:
@@ -263,7 +264,7 @@ class Create(Interface):
 
         # important to use the given Dataset object to avoid spurious ID
         # changes with not-yet-materialized Datasets
-        tbds = dataset if dataset is not None and dataset.path == path['path'] \
+        tbds = dataset if isinstance(dataset, Dataset) and dataset.path == path['path'] \
             else Dataset(path['path'])
 
         # don't create in non-empty directory without `force`:
@@ -329,7 +330,7 @@ class Create(Interface):
         # the next only makes sense if we saved the created dataset,
         # otherwise we have no committed state to be registered
         # in the parent
-        if save and dataset is not None and dataset.path != tbds.path:
+        if save and isinstance(dataset, Dataset) and dataset.path != tbds.path:
             # we created a dataset in another dataset
             # -> make submodule
             for r in dataset.add(

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -70,6 +70,9 @@ class Create(Interface):
     However, the result will not be a full dataset, and, consequently,
     not all features are supported (e.g. a description).
 
+    DataLad plugins can be executed on a newly created dataset via the
+    `--with-plugins` option to perform further customizations.
+
     || REFLOW >>
     To create a local version of a remote dataset use the
     :func:`~datalad.api.install` command instead.

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -27,7 +27,6 @@ from datalad.interface.common_opts import annex_init_opts
 from datalad.interface.common_opts import location_description
 from datalad.interface.common_opts import nosave_opt
 from datalad.interface.common_opts import shared_access_opt
-from datalad.interface.common_opts import with_plugin_opt
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureKeyChoice
@@ -69,9 +68,6 @@ class Create(Interface):
     Plain Git repositories can be created via the [PY: `no_annex` PY][CMD: --no-annex CMD] flag.
     However, the result will not be a full dataset, and, consequently,
     not all features are supported (e.g. a description).
-
-    DataLad plugins can be executed on a newly created dataset via the
-    `--with-plugins` option to perform further customizations.
 
     || REFLOW >>
     To create a local version of a remote dataset use the
@@ -153,7 +149,6 @@ class Create(Interface):
             can be given multiple times CMD]"""),
         # TODO could move into cfg_access/permissions plugin
         shared_access=shared_access_opt,
-        with_plugin=with_plugin_opt,
         git_opts=git_opts,
         annex_opts=annex_opts,
         annex_init_opts=annex_init_opts,
@@ -174,7 +169,6 @@ class Create(Interface):
             native_metadata_type=None,
             shared_access=None,
             git_opts=None,
-            with_plugin=None,
             annex_opts=None,
             annex_init_opts=None):
 
@@ -344,17 +338,6 @@ class Create(Interface):
 
         path.update({'status': 'ok'})
         yield path
-
-        for pluginspec in with_plugin if with_plugin else []:
-            for r in tbds.plugin(
-                    pluginspec,
-                    return_type='generator'):
-                # ensure proper reporting
-                if dataset:
-                    r['refds'] = dataset
-                else:
-                    r.pop('refds', None)
-                yield r
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -30,7 +30,8 @@ from datalad.distribution.dataset import EnsureDataset, Dataset, \
     datasetmethod, require_dataset
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
+from datalad.interface.utils import eval_results
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import as_common_datasrc
 from datalad.interface.common_opts import publish_by_default
@@ -39,8 +40,6 @@ from datalad.interface.common_opts import inherit_opt
 from datalad.interface.common_opts import annex_wanted_opt
 from datalad.interface.common_opts import annex_group_opt
 from datalad.interface.common_opts import annex_groupwanted_opt
-from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
 from datalad.support.constraints import EnsureChoice

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -29,7 +29,7 @@ from datalad.support.constraints import EnsureStr, EnsureNone
 from datalad.support.constraints import EnsureChoice
 from datalad.support.exceptions import MissingExternalDependency
 from ..interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.distribution.dataset import EnsureDataset, datasetmethod, \
     require_dataset, Dataset
 from datalad.distribution.siblings import Siblings

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -26,7 +26,7 @@ from datalad.support.constraints import EnsureStr, EnsureNone, EnsureInt
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 
 lgr = logging.getLogger('datalad.distribution.tests')
 

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -37,7 +37,7 @@ from datalad.interface.results import success_status_map
 from datalad.interface.results import results_from_annex_noinfo
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 
 lgr = logging.getLogger('datalad.distribution.drop')
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -21,7 +21,7 @@ from datalad.interface.base import Interface
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.annotate_paths import annotated2content_by_ds
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.interface.results import results_from_paths
 from datalad.interface.results import annexjson2result

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -30,7 +30,7 @@ from datalad.interface.results import get_status_dict
 from datalad.interface.results import YieldDatasets
 from datalad.interface.results import is_result_matching_pathsource_argument
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureStr
 from datalad.support.exceptions import InsufficientArgumentsError

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -17,7 +17,7 @@ from os.path import curdir
 from os.path import sep as dirsep
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.utils import filter_unmodified
 from datalad.interface.common_opts import annex_copy_opts, recursion_flag, \
     recursion_limit, git_opts, annex_opts

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -32,7 +32,7 @@ from datalad.interface.common_opts import if_dirty_opt
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.utils import path_is_under
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.interface.save import Save
 from datalad.distribution.drop import _drop_files

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -18,7 +18,7 @@ from os.path import relpath
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureStr

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -23,7 +23,7 @@ from git import GitConfigParser
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureStr

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -266,8 +266,10 @@ def test_create_withplugin(path):
     assert(not lexists(ds.path))
     # now for reals...
     ds = create(
-        path,
-        with_plugin=[['add_readme', 'filename=with hole.txt']])
+        # needs to identify the dataset, otherwise post-proc
+        # plugin doesn't no what to run on
+        dataset=path,
+        run_after=[['add_readme', 'filename=with hole.txt']])
     ok_clean_git(path)
     # README wil lend up in annex by default
     # TODO implement `nice_dataset` plugin to give sensible

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -11,6 +11,7 @@
 
 import os
 from os.path import join as opj
+from os.path import lexists
 
 from ..dataset import Dataset
 from datalad.api import create
@@ -254,3 +255,21 @@ def test_saving_prior(topdir):
     # is committed -- ds2 is already known to git and it just pukes with a bit
     # confusing    'ds2' already exists in the index
     assert_in('ds2', ds1.subdatasets(result_xfm='relpaths'))
+
+
+@with_tempfile(mkdir=True)
+def test_create_withplugin(path):
+    # first without
+    ds = create(path)
+    assert(not lexists(opj(ds.path, 'README.rst')))
+    ds.remove()
+    assert(not lexists(ds.path))
+    # now for reals...
+    ds = create(
+        path,
+        with_plugin=[['add_readme', 'filename=with hole.txt']])
+    ok_clean_git(path)
+    # README wil lend up in annex by default
+    # TODO implement `nice_dataset` plugin to give sensible
+    # default and avoid that
+    assert(lexists(opj(ds.path, 'with hole.txt')))

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -30,7 +30,7 @@ from datalad.interface.common_opts import if_dirty_opt
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.utils import path_is_under
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.results import get_status_dict
 from datalad.utils import rmtree

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -18,7 +18,7 @@ from os.path import lexists, join as opj
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -41,7 +41,7 @@ _group_dataset = (
          'create-sibling-github'),
         ('datalad.interface.unlock', 'Unlock', 'unlock'),
         ('datalad.interface.save', 'Save', 'save'),
-        ('datalad.export', 'Export', 'export'),
+        ('datalad.plugin', 'Plugin', 'plugin'),
     ])
 
 _group_metadata = (

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -28,7 +28,7 @@ from os.path import dirname
 from os.path import normpath
 
 from .base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from .common_opts import allow_dirty
 from ..consts import ARCHIVES_SPECIAL_REMOTE
 from ..support.param import Parameter

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -25,7 +25,7 @@ from os.path import sep as dirsep
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureBool

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -24,11 +24,22 @@ from collections import OrderedDict
 from ..ui import ui
 from ..dochelpers import exc_str
 
+from datalad.interface.common_opts import eval_params
+from datalad.interface.common_opts import eval_defaults
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.utils import with_pathsep as _with_sep
 from datalad.support.constraints import EnsureKeyChoice
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import resolve_path
+
+
+default_logchannels = {
+    '': 'debug',
+    'ok': 'debug',
+    'notneeded': 'debug',
+    'impossible': 'warning',
+    'error': 'error',
+}
 
 
 def get_api_name(intfspec):
@@ -242,6 +253,60 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     # assign the amended docs
     func.__doc__ = doc
     return func
+
+
+def build_doc(cls, **kwargs):
+    """Decorator to build docstrings for datalad commands
+
+    It's intended to decorate the class, the __call__-method of which is the
+    actual command. It expects that __call__-method to be decorated by
+    eval_results.
+
+    Parameters
+    ----------
+    cls: Interface
+      class defining a datalad command
+    """
+
+    # Note, that this is a class decorator, which is executed only once when the
+    # class is imported. It builds the docstring for the class' __call__ method
+    # and returns the original class.
+    #
+    # This is because a decorator for the actual function would not be able to
+    # behave like this. To build the docstring we need to access the attribute
+    # _params of the class. From within a function decorator we cannot do this
+    # during import time, since the class is being built in this very moment and
+    # is not yet available in the module. And if we do it from within the part
+    # of a function decorator, that is executed when the function is called, we
+    # would need to actually call the command once in order to build this
+    # docstring.
+
+    lgr.debug("Building doc for {}".format(cls))
+
+    cls_doc = cls.__doc__
+    if hasattr(cls, '_docs_'):
+        # expand docs
+        cls_doc = cls_doc.format(**cls._docs_)
+
+    call_doc = None
+    # suffix for update_docstring_with_parameters:
+    if cls.__call__.__doc__:
+        call_doc = cls.__call__.__doc__
+
+    # build standard doc and insert eval_doc
+    spec = getattr(cls, '_params_', dict())
+    # get docs for eval_results parameters:
+    spec.update(eval_params)
+
+    update_docstring_with_parameters(
+        cls.__call__, spec,
+        prefix=alter_interface_docs_for_api(cls_doc),
+        suffix=alter_interface_docs_for_api(call_doc),
+        add_args=eval_defaults if not hasattr(cls, '_no_eval_results') else None
+    )
+
+    # return original
+    return cls
 
 
 class Interface(object):

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -548,8 +548,13 @@ class Interface(object):
         return content_by_ds, unavailable_paths
 
 
-def merge_allargs2kwargs(call, args, kwargs):
-    """Generate a kwargs dict from a call signature and *args, **kwargs"""
+def get_allargs_as_kwargs(call, args, kwargs):
+    """Generate a kwargs dict from a call signature and *args, **kwargs
+
+    Basically resolving the argnames for all positional arguments, and
+    resolvin the defaults for all kwargs that are not given in a kwargs
+    dict
+    """
     from inspect import getargspec
     argspec = getargspec(call)
     defaults = argspec.defaults
@@ -564,5 +569,8 @@ def merge_allargs2kwargs(call, args, kwargs):
             kwargs_[k] = v
     # update with provided kwarg args
     kwargs_.update(kwargs)
-    assert (nargs == len(kwargs_))
+    # XXX we cannot assert the following, because our own highlevel
+    # API commands support more kwargs than what is discoverable
+    # from their signature...
+    #assert (nargs == len(kwargs_))
     return kwargs_

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -27,7 +27,7 @@ from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 
 from logging import getLogger
 lgr = getLogger('datalad.api.clean')

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -13,6 +13,7 @@
 __docformat__ = 'restructuredtext'
 
 from appdirs import AppDirs
+from os.path import join as opj
 from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureInt
 
@@ -67,6 +68,20 @@ definitions = {
                'text': 'Where should datalad cache files?'}),
         'destination': 'global',
         'default': dirs.user_cache_dir,
+    },
+    'datalad.locations.system-plugins': {
+        'ui': ('question', {
+               'title': 'System plugin directory',
+               'text': 'Where should datalad search for system plugins?'}),
+        'destination': 'global',
+        'default': opj(dirs.site_config_dir, 'plugins'),
+    },
+    'datalad.locations.user-plugins': {
+        'ui': ('question', {
+               'title': 'User plugin directory',
+               'text': 'Where should datalad search for user plugins?'}),
+        'destination': 'global',
+        'default': opj(dirs.user_config_dir, 'plugins'),
     },
     'datalad.exc.str.tblimit': {
         'ui': ('question', {

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -215,3 +215,16 @@ missing_sibling_opt = Parameter(
     By default it would fail the run ('fail' setting).  With 'inherit' a
     'create-sibling' with '--inherit-settings' will be used to create sibling
     on the remote. With 'skip' - it simply will be skipped.""")
+
+with_plugin_opt = Parameter(
+    args=('--with-plugin',),
+    nargs='*',
+    action='append',
+    metavar='PLUGINSPEC',
+    doc="""DataLad plugin to run in addition. PLUGINSPEC is a list
+    comprised of a plugin name plus optional `key=value` pairs with arguments
+    for the plugin call (see `plugin` command documentation for details).
+    [PY: PLUGINSPECs must be wrapped in list where each item configures
+    one plugin call. Plugins are called in the order defined by this list.
+    PY][CMD: This option can be given more than once to run multiple plugins
+    in the order in which they are given. CMD]""")

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -284,14 +284,13 @@ eval_params = dict(
         with arguments for the plugin call (see `plugin` command documentation
         for details).
         PLUGINSPECs must be wrapped in list where each item configures
-        one plugin call. Plugins are called in the order defined by this list."""),
+        one plugin call. Plugins are called in the order defined by this list.
+        For running plugins that require a `dataset` argument it is important
+        to provide the respective dataset as the `dataset` argument of the main
+        command, if it is not in the list of plugin arguments."""),
     run_after=Parameter(
-        doc="""DataLad plugin to run after the command. PLUGINSPEC is a list
-        comprised of a plugin name plus optional 2-tuples of key-value pairs
-        with arguments for the plugin call (see `plugin` command documentation
-        for details).
-        PLUGINSPECs must be wrapped in list where each item configures
-        one plugin call. Plugins are called in the order defined by this list."""),
+        doc="""Like `run_before`, but plugins are executed after the main command
+        has finished."""),
 )
 
 eval_defaults = dict(

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -278,11 +278,28 @@ eval_params = dict(
         that carries the result dictionaries of the failures in its `failed`
         attribute.""",
         constraints=EnsureChoice('ignore', 'continue', 'stop')),
+    run_before=Parameter(
+        doc="""DataLad plugin to run before the command. PLUGINSPEC is a list
+        comprised of a plugin name plus optional 2-tuples of key-value pairs
+        with arguments for the plugin call (see `plugin` command documentation
+        for details).
+        PLUGINSPECs must be wrapped in list where each item configures
+        one plugin call. Plugins are called in the order defined by this list."""),
+    run_after=Parameter(
+        doc="""DataLad plugin to run after the command. PLUGINSPEC is a list
+        comprised of a plugin name plus optional 2-tuples of key-value pairs
+        with arguments for the plugin call (see `plugin` command documentation
+        for details).
+        PLUGINSPECs must be wrapped in list where each item configures
+        one plugin call. Plugins are called in the order defined by this list."""),
 )
+
 eval_defaults = dict(
     return_type='list',
     result_filter=None,
     result_renderer=None,
     result_xfm=None,
     on_failure='continue',
+    run_before=None,
+    run_after=None,
 )

--- a/datalad/interface/crawl.py
+++ b/datalad/interface/crawl.py
@@ -13,7 +13,7 @@ __docformat__ = 'restructuredtext'
 
 from os.path import exists
 from .base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone

--- a/datalad/interface/crawl_init.py
+++ b/datalad/interface/crawl_init.py
@@ -12,7 +12,7 @@ __docformat__ = 'restructuredtext'
 
 from os.path import curdir
 from .base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from collections import OrderedDict
 from datalad.distribution.dataset import Dataset
 

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -22,7 +22,7 @@ from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.annotate_paths import annotated2content_by_ds
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureChoice

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -19,7 +19,7 @@ __docformat__ = 'restructuredtext'
 from os.path import isdir, curdir
 
 from .base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from ..ui import ui
 from ..utils import assure_list_from_str
 from ..dochelpers import exc_str

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -26,7 +26,7 @@ from six.moves.urllib.error import HTTPError
 from ..cmdline.helpers import get_repo_instance
 from ..utils import auto_repr
 from .base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from ..ui import ui
 from ..utils import swallow_logs
 from ..consts import METADATA_DIR

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -34,7 +34,7 @@ from datalad.interface.common_opts import super_datasets_flag
 from datalad.interface.common_opts import save_message_opt
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.utils import get_tree_roots
 from datalad.interface.utils import discover_dataset_trace_to_targets
 

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import datalad
 from .base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 
 
 @build_doc

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -35,7 +35,7 @@ from datalad.support.constraints import EnsureKeyChoice
 
 from ..base import Interface
 from ..utils import eval_results
-from ..utils import build_doc
+from datalad.interface.base import build_doc
 from ..utils import handle_dirty_dataset
 from ..utils import get_paths_by_dataset
 from ..utils import filter_unmodified

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -26,7 +26,7 @@ from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.annotate_paths import annotated2content_by_ds
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -547,7 +547,6 @@ def eval_results(func):
 
     @wrapt.decorator
     def eval_func(wrapped, instance, args, kwargs):
-
         # determine class, the __call__ method of which we are decorating:
         # Ben: Note, that this is a bit dirty in PY2 and imposes restrictions on
         # when and how to use eval_results as well as on how to name a command's
@@ -576,120 +575,60 @@ def eval_results(func):
         _func_class = mod.__dict__[command_class_name]
         lgr.debug("Determined class of decorated function: %s", _func_class)
 
+        # retrieve common options from kwargs, and fall back on the command
+        # class attributes, or general defaults if needed
         common_params = {
             p_name: kwargs.pop(
                 p_name,
                 getattr(_func_class, p_name, eval_defaults[p_name]))
             for p_name in eval_params}
+        # short cuts and configured setup for common options
+        on_failure = common_params['on_failure']
+        return_type = common_params['return_type']
+        # resolve string labels for transformers too
+        result_xfm = common_params['result_xfm']
+        if result_xfm in known_result_xfms:
+            result_xfm = known_result_xfms[result_xfm]
         result_renderer = common_params['result_renderer']
+        # TODO remove this conditional branch entirely, done outside
+        if not result_renderer:
+            result_renderer = dlcfg.get('datalad.api.result-renderer', None)
+        # wrap the filter into a helper to be able to pass additional arguments
+        # if the filter supports it, but at the same time keep the required interface
+        # as minimal as possible. Also do this here, in order to avoid this test
+        # to be performed for each return value
+        result_filter = common_params['result_filter']
+        _result_filter = result_filter
+        if result_filter:
+            if isinstance(result_filter, Constraint):
+                _result_filter = result_filter.__call__
+            if (PY2 and inspect.getargspec(_result_filter).keywords) or \
+                    (not PY2 and inspect.getfullargspec(_result_filter).varkw):
+                # we need to produce a dict with argname/argvalue pairs for all args
+                # incl. defaults and args given as positionals
+                fullkwargs_ = merge_allargs2kwargs(wrapped, args, kwargs)
 
+                def _result_filter(res):
+                    return result_filter(res, **fullkwargs_)
+
+        # this internal helper function actually drives the command
+        # generator-style, it may generate an exception if desired,
+        # on incomplete results
         def generator_func(*_args, **_kwargs):
-            # obtain results
-            results = wrapped(*_args, **_kwargs)
             # flag whether to raise an exception
-            # TODO actually compose a meaningful exception
             incomplete_results = []
-            # inspect and render
-            result_filter = common_params['result_filter']
-            # wrap the filter into a helper to be able to pass additional arguments
-            # if the filter supports it, but at the same time keep the required interface
-            # as minimal as possible. Also do this here, in order to avoid this test
-            # to be performed for each return value
-            _result_filter = result_filter
-            if result_filter:
-                if isinstance(result_filter, Constraint):
-                    _result_filter = result_filter.__call__
-                if (PY2 and inspect.getargspec(_result_filter).keywords) or \
-                        (not PY2 and inspect.getfullargspec(_result_filter).varkw):
-                    # we need to produce a dict with argname/argvalue pairs for all args
-                    # incl. defaults and args given as positionals
-                    fullkwargs_ = merge_allargs2kwargs(wrapped, _args, _kwargs)
-
-                    def _result_filter(res):
-                        return result_filter(res, **fullkwargs_)
-            result_renderer = common_params['result_renderer']
-            result_xfm = common_params['result_xfm']
-            if result_xfm in known_result_xfms:
-                result_xfm = known_result_xfms[result_xfm]
-            on_failure = common_params['on_failure']
-            if not result_renderer:
-                result_renderer = dlcfg.get('datalad.api.result-renderer', None)
             # track what actions were performed how many times
             action_summary = {}
-            for res in results:
-                actsum = action_summary.get(res['action'], {})
-                if res['status']:
-                    actsum[res['status']] = actsum.get(res['status'], 0) + 1
-                    action_summary[res['action']] = actsum
-                ## log message, if a logger was given
-                # remove logger instance from results, as it is no longer useful
-                # after logging was done, it isn't serializable, and generally
-                # pollutes the output
-                res_lgr = res.pop('logger', None)
-                if isinstance(res_lgr, logging.Logger):
-                    # didn't get a particular log function, go with default
-                    res_lgr = getattr(res_lgr, default_logchannels[res['status']])
-                if res_lgr and 'message' in res:
-                    msg = res['message']
-                    msgargs = None
-                    if isinstance(msg, tuple):
-                        msgargs = msg[1:]
-                        msg = msg[0]
-                    if 'path' in res:
-                        msg = '{} [{}({})]'.format(
-                            msg, res['action'], res['path'])
-                    if msgargs:
-                        # support string expansion of logging to avoid runtime cost
-                        res_lgr(msg, *msgargs)
-                    else:
-                        res_lgr(msg)
-                ## error handling
-                # looks for error status, and report at the end via
-                # an exception
-                if on_failure in ('continue', 'stop') \
-                        and res['status'] in ('impossible', 'error'):
-                    incomplete_results.append(res)
-                    if on_failure == 'stop':
-                        # first fail -> that's it
-                        # raise will happen after the loop
-                        break
-                if _result_filter:
-                    try:
-                        if not _result_filter(res):
-                            raise ValueError('excluded by filter')
-                    except ValueError as e:
-                        lgr.debug('not reporting result (%s)', exc_str(e))
-                        continue
-                ## output rendering
-                if result_renderer == 'default':
-                    # TODO have a helper that can expand a result message
-                    ui.message('{action}({status}): {path}{type}{msg}'.format(
-                        action=res['action'],
-                        status=res['status'],
-                        path=relpath(res['path'],
-                                     res['refds']) if res.get('refds', None) else res['path'],
-                        type=' ({})'.format(res['type']) if 'type' in res else '',
-                        msg=' [{}]'.format(
-                            res['message'][0] % res['message'][1:]
-                            if isinstance(res['message'], tuple) else res['message'])
-                        if 'message' in res else ''))
-                elif result_renderer in ('json', 'json_pp'):
-                    ui.message(json.dumps(
-                        {k: v for k, v in res.items()
-                         if k not in ('message', 'logger')},
-                        sort_keys=True,
-                        indent=2 if result_renderer.endswith('_pp') else None))
-                elif result_renderer == 'tailored':
-                    if hasattr(_func_class, 'custom_result_renderer'):
-                        _func_class.custom_result_renderer(res, **_kwargs)
-                elif hasattr(result_renderer, '__call__'):
-                    result_renderer(res, **_kwargs)
-                if result_xfm:
-                    res = result_xfm(res)
-                    if res is None:
-                        continue
-                yield res
 
+            # process main results
+            for r in _process_results(
+                    wrapped(*_args, **_kwargs),
+                    _func_class, action_summary,
+                    on_failure, incomplete_results,
+                    result_renderer, result_xfm, _result_filter, **_kwargs):
+                yield r
+
+            # result summary before a potential exception
             if result_renderer == 'default' and action_summary and \
                     sum(sum(s.values()) for s in action_summary.values()) > 1:
                 # give a summary in default mode, when there was more than one
@@ -702,25 +641,28 @@ def eval_results(func):
                                 for act in sorted(action_summary))))
 
             if incomplete_results:
-                # stupid catch all message <- tailor TODO
                 raise IncompleteResultsError(
                     failed=incomplete_results,
                     msg="Command did not complete successfully")
 
-        if common_params['return_type'] == 'generator':
+        if return_type == 'generator':
+            # hand over the generator
             return generator_func(*args, **kwargs)
         else:
             @wrapt.decorator
             def return_func(wrapped_, instance_, args_, kwargs_):
                 results = wrapped_(*args_, **kwargs_)
                 if inspect.isgenerator(results):
+                    # unwind generator if there is one, this actually runs
+                    # any processing
                     results = list(results)
                 # render summaries
-                if not common_params['result_xfm'] and result_renderer == 'tailored':
+                # TODO why not do that with action summary in the generator?
+                if not result_xfm and result_renderer == 'tailored':
                     # cannot render transformed results
                     if hasattr(_func_class, 'custom_result_summary_renderer'):
                         _func_class.custom_result_summary_renderer(results)
-                if common_params['return_type'] == 'item-or-list' and \
+                if return_type == 'item-or-list' and \
                         len(results) < 2:
                     return results[0] if results else None
                 else:
@@ -729,3 +671,86 @@ def eval_results(func):
             return return_func(generator_func)(*args, **kwargs)
 
     return eval_func(func)
+
+
+def _process_results(
+        results, cmd_class,
+        action_summary, on_failure, incomplete_results,
+        result_renderer, result_xfm, result_filter, **kwargs):
+    # private helper pf @eval_results
+    # loop over results generated from some source and handle each
+    # of them according to the requested behavior (logging, rendering, ...)
+    for res in results:
+        actsum = action_summary.get(res['action'], {})
+        if res['status']:
+            actsum[res['status']] = actsum.get(res['status'], 0) + 1
+            action_summary[res['action']] = actsum
+        ## log message, if a logger was given
+        # remove logger instance from results, as it is no longer useful
+        # after logging was done, it isn't serializable, and generally
+        # pollutes the output
+        res_lgr = res.pop('logger', None)
+        if isinstance(res_lgr, logging.Logger):
+            # didn't get a particular log function, go with default
+            res_lgr = getattr(res_lgr, default_logchannels[res['status']])
+        if res_lgr and 'message' in res:
+            msg = res['message']
+            msgargs = None
+            if isinstance(msg, tuple):
+                msgargs = msg[1:]
+                msg = msg[0]
+            if 'path' in res:
+                msg = '{} [{}({})]'.format(
+                    msg, res['action'], res['path'])
+            if msgargs:
+                # support string expansion of logging to avoid runtime cost
+                res_lgr(msg, *msgargs)
+            else:
+                res_lgr(msg)
+        ## error handling
+        # looks for error status, and report at the end via
+        # an exception
+        if on_failure in ('continue', 'stop') \
+                and res['status'] in ('impossible', 'error'):
+            incomplete_results.append(res)
+            if on_failure == 'stop':
+                # first fail -> that's it
+                # raise will happen after the loop
+                break
+        if result_filter:
+            try:
+                if not result_filter(res):
+                    raise ValueError('excluded by filter')
+            except ValueError as e:
+                lgr.debug('not reporting result (%s)', exc_str(e))
+                continue
+        ## output rendering
+        # TODO RF this in a simple callable that gets passed into this function
+        if result_renderer == 'default':
+            # TODO have a helper that can expand a result message
+            ui.message('{action}({status}): {path}{type}{msg}'.format(
+                action=res['action'],
+                status=res['status'],
+                path=relpath(res['path'],
+                             res['refds']) if res.get('refds', None) else res['path'],
+                type=' ({})'.format(res['type']) if 'type' in res else '',
+                msg=' [{}]'.format(
+                    res['message'][0] % res['message'][1:]
+                    if isinstance(res['message'], tuple) else res['message'])
+                if 'message' in res else ''))
+        elif result_renderer in ('json', 'json_pp'):
+            ui.message(json.dumps(
+                {k: v for k, v in res.items()
+                 if k not in ('message', 'logger')},
+                sort_keys=True,
+                indent=2 if result_renderer.endswith('_pp') else None))
+        elif result_renderer == 'tailored':
+            if hasattr(cmd_class, 'custom_result_renderer'):
+                cmd_class.custom_result_renderer(res, **kwargs)
+        elif hasattr(result_renderer, '__call__'):
+            result_renderer(res, **kwargs)
+        if result_xfm:
+            res = result_xfm(res)
+            if res is None:
+                continue
+        yield res

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 import os
 from os.path import join as opj, exists, relpath, dirname
 from datalad.interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import if_dirty_opt

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -26,7 +26,7 @@ from datalad.interface.base import Interface
 from datalad.interface.save import Save
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureStr
 from datalad.support.gitrepo import GitRepo

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -23,7 +23,7 @@ from six import iteritems
 from six import reraise
 from six import PY3
 from datalad.interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     require_dataset

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -28,6 +28,7 @@ from datalad.distribution.dataset import require_dataset
 from datalad.dochelpers import exc_str
 
 from datalad.interface.base import Interface
+from datalad.interface.base import dedent_docstring
 from datalad.interface.utils import build_doc
 from datalad.interface.utils import eval_results
 from datalad.ui import ui
@@ -249,7 +250,7 @@ class Plugin(Interface):
             # we don't need special docs for the cmdline, standard python ones
             # should be comprehensible enough
             ui.message(
-                plugin_call.__doc__
+                dedent_docstring(plugin_call.__doc__)
                 if plugin_call.__doc__
                 else 'This plugin has no documentation')
             return

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -204,7 +204,9 @@ class Plugin(Interface):
     def __call__(plugin=None, dataset=None, showpluginhelp=False, showplugininfo=False, **kwargs):
         plugins = _get_plugins()
         if not plugin:
+            max_name_len = max(len(k) for k in plugins.keys())
             for plname, plinfo in sorted(plugins.items(), key=lambda x: x[0]):
+                spacer = ' ' * (max_name_len - len(plname))
                 synopsis = None
                 try:
                     with open(plinfo['file']) as plf:
@@ -213,12 +215,14 @@ class Plugin(Interface):
                                 synopsis = line[17:].strip()
                                 break
                 except Exception as e:
-                    ui.message('{} [BROKEN] {}'.format(plname, exc_str(e)))
+                    ui.message('{}{} [BROKEN] {}'.format(
+                        plname, spacer, exc_str(e)))
                     continue
                 if synopsis:
-                    msg = '{} -- {}'.format(plname, synopsis)
+                    msg = '{}{} - {}'.format(
+                        plname, spacer, synopsis)
                 else:
-                    msg = '{} [no synopsis]'.format(plname)
+                    msg = '{}{} [no synopsis]'.format(plname, spacer)
                 if showplugininfo:
                     msg = '{} ({})'.format(msg, plinfo['file'])
                 ui.message(msg)

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -29,7 +29,7 @@ from datalad.dochelpers import exc_str
 
 from datalad.interface.base import Interface
 from datalad.interface.base import dedent_docstring
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 from datalad.interface.utils import eval_results
 from datalad.ui import ui
 

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -53,15 +53,9 @@ class Plugin(Interface):
             constraints=EnsureDataset() | EnsureNone()),
         plugin=Parameter(
             args=("plugin",),
-            choices=_get_plugin_names(),
+            nargs='?',
             doc="""label of the type or format the dataset shall be exported
             to."""),
-        output=Parameter(
-            args=('-o', '--output'),
-            doc="""output destination specification to be passes to the exporter.
-            The particular semantics of the option value depend on the actual
-            exporter. Typically, this will be a file name or a path to a
-            directory."""),
         showpluginhelp=Parameter(
             args=('-H', '--show-plugin-help',),
             dest='showpluginhelp',
@@ -71,7 +65,11 @@ class Plugin(Interface):
 
     @staticmethod
     @datasetmethod(name='plugin')
-    def __call__(plugin, dataset=None, showpluginhelp=False, output=None, **kwargs):
+    def __call__(plugin=None, dataset=None, showpluginhelp=False, **kwargs):
+        if plugin is None:
+            from datalad.ui import ui
+            ui.message('\n'.join(_get_plugin_names()))
+            return
         # get a handle on the relevant plugin module
         import datalad.plugin as plugin_mod
         try:
@@ -96,6 +94,8 @@ class Plugin(Interface):
 
     @staticmethod
     def result_renderer_cmdline(res, args):
+        if res is None:
+            return
         pluginmod, result = res
         if args.showpluginhelp:
             # the function that prints the help was returned as result

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -83,10 +83,8 @@ class Plugin(Interface):
 
          datalad.locations.user-plugins
 
-
     Identically named plugins in latter location replace those in locations
     searched before.
-
 
     *Using plugins*
 
@@ -126,62 +124,6 @@ class Plugin(Interface):
     dataset was given, and none was found in the current working directory,
     the plugin call will fail. A dataset argument can also be passed alongside
     all other plugin arguments without using --dataset.
-
-
-    *Writing plugins*
-
-    Plugins are written in Python. In order for DataLad to be able to find
-    them, plugins need to be placed in one of the supported locations described
-    above. Plugin file names have to have a '.py' extensions and must not start
-    with an underscore ('_').
-
-    Plugin source files must define a function named::
-
-      dlplugin
-
-    This function is executed as the plugin. It can have any number of
-    arguments (positional, or keyword arguments with defaults), or none at
-    all. All arguments, except ``dataset`` must expect any value to
-    be a string.
-
-    The plugin function must be self-contained, i.e. all needed imports
-    of definitions must be done within the body of the function.
-
-    The doc string of the plugin function is displayed when the plugin
-    documentation is requested. The first line in a plugin file that starts
-    with triple double-quotes will be used as the plugin short description
-    (this will typically be the docstring of the module file). This short
-    description is displayed as the plugin synopsis in the plugin overview
-    list.
-
-    Plugin functions must yield their results as generator. Results are DataLad
-    status dictionaries. There are no constraints on the number and nature of
-    result properties. However, conventions exists and must be followed for
-    compatibility with the result evaluation and rendering performed by
-    DataLad.
-
-    The following keys must exist:
-
-    "status"
-        {'ok', 'notneeded', 'impossible', 'error'}
-
-    "action"
-        label for the action performed by the plugin. In many cases this
-        could be the plugin's name.
-
-    The following keys should exists if possible:
-
-    "path"
-        absolute path to a result on the file system
-
-    "type"
-        label indicating the nature of a result (e.g. 'file', 'dataset',
-        'directory', etc.)
-
-    "message"
-        string message annotating the result, particularly important for
-        non-ok results. This can be a tuple with 'logging'-style string
-        expansion.
 
     """
     _params_ = dict(

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -268,10 +268,9 @@ class Plugin(Interface):
 
         # call as a generator
         for res in plugin_call(**{k: v for k, v in kwargs.items() if k in plugin_args}):
-            if dataset:
-                # enforce standard regardless of what plugin did
-                res['refds'] = dataset
-                if 'logger' not in res:
-                    # make sure we have a logger
-                    res['logger'] = lgr
+            # enforce standard regardless of what plugin did
+            res['refds'] = dataset
+            if 'logger' not in res:
+                # make sure we have a logger
+                res['logger'] = lgr
             yield res

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -307,7 +307,7 @@ class Plugin(Interface):
                 continue
             if dataset:
                 # enforce standard regardless of what plugin did
-                res['refds'] = dataset
+                res['refds'] = getattr(dataset, 'path', dataset)
             elif 'refds' in res:
                 # no base dataset, results must not have them either
                 del res['refds']

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -60,11 +60,11 @@ def _load_plugin(filepath):
         # any exception means full stop
         raise ValueError('plugin at {} is broken: {}'.format(
             filepath, exc_str(e)))
-    if not len(locals) or 'datalad_plugin' not in locals:
+    if not len(locals) or 'dlplugin' not in locals:
         raise ValueError(
-            "loading plugin '%s' did not yield a 'datalad_plugin' symbol, found: %s",
+            "loading plugin '%s' did not yield a 'dlplugin' symbol, found: %s",
             filepath, locals.keys() if len(locals) else None)
-    return locals['datalad_plugin']
+    return locals['dlplugin']
 
 
 @build_doc
@@ -138,7 +138,7 @@ class Plugin(Interface):
 
     Plugin source files must define a function named::
 
-      datalad_plugin
+      dlplugin
 
     This function is executed as the plugin. It can have any number of
     arguments (positional, or keyword arguments with defaults), or none at

--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -6,10 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-#PLUGINSYNOPSIS: add a README file to a dataset
-"""
-
-"""
+"""add a README file to a dataset"""
 
 __docformat__ = 'restructuredtext'
 
@@ -21,8 +18,8 @@ def dlplugin(dataset, filename='README.rst', existing='skip'):
     The README file is added to the dataset and the addition is saved
     in the dataset.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     dataset : Dataset
       dataset to add information to
     filename : str, optional

--- a/datalad/plugin/dlplugin_add_readme.py
+++ b/datalad/plugin/dlplugin_add_readme.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 
 
 # PLUGIN API
-def datalad_plugin(dataset, filename='README.rst', existing='skip'):
+def dlplugin(dataset, filename='README.rst', existing='skip'):
     """Add basic information about DataLad datasets to a README file
 
     The README file is added to the dataset and the addition is saved

--- a/datalad/plugin/dlplugin_add_readme.py
+++ b/datalad/plugin/dlplugin_add_readme.py
@@ -1,0 +1,78 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#PLUGINSYNOPSIS: add a README file to a dataset
+"""
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+
+# PLUGIN API
+def datalad_plugin(dataset, filename='README.rst', existing='skip'):
+    """Add basic information about DataLad datasets to a README file
+
+    The README file is added to the dataset and the addition is saved
+    in the dataset.
+
+    Parameter
+    ---------
+    dataset : Dataset
+      dataset to add information to
+    filename : str, optional
+      path of the README file within the dataset. Default: 'README.rst'
+    existing : {'skip', 'append', 'replace'}
+      how to react if a file with the target name already exists:
+      'skip': do nothing; 'append': append information to the existing
+      file; 'replace': replace the existing file with new content.
+      Default: 'skip'
+
+    """
+
+    from os.path import lexists
+    from os.path import join as opj
+
+    default_content="""\
+About this dataset
+==================
+
+This is a DataLad dataset{id}.
+
+For more information on DataLad and on how to work with its datasets,
+see the DataLad documentation at: http://docs.datalad.org
+""".format(
+        id=' (id: {})'.format(dataset.id) if dataset.id else '')
+    filename = opj(dataset.path, filename)
+    res_kwargs = dict(action='add_readme', path=filename)
+
+    if lexists(filename) and existing == 'skip':
+        yield dict(
+            res_kwargs,
+            status='notneeded',
+            message='file already exists, and not appending content')
+        return
+
+    # unlock, file could be annexed
+    # TODO yield
+    dataset.unlock(filename)
+
+    with open(filename, 'a' if existing == 'append' else 'w') as fp:
+        fp.write(default_content)
+        yield dict(
+            status='ok',
+            path=filename,
+            type='file',
+            action='add_readme')
+
+    for r in dataset.add(
+            filename,
+            message='[DATALAD] added README',
+            result_filter=None,
+            result_xfm=None):
+        yield r

--- a/datalad/plugin/dlplugin_add_readme.py
+++ b/datalad/plugin/dlplugin_add_readme.py
@@ -60,7 +60,8 @@ see the DataLad documentation at: http://docs.datalad.org
 
     # unlock, file could be annexed
     # TODO yield
-    dataset.unlock(filename)
+    if lexists(filename):
+        dataset.unlock(filename)
 
     with open(filename, 'a' if existing == 'append' else 'w') as fp:
         fp.write(default_content)

--- a/datalad/plugin/dlplugin_export_tarball.py
+++ b/datalad/plugin/dlplugin_export_tarball.py
@@ -26,7 +26,7 @@ lgr = logging.getLogger('datalad.plugin.tarball')
 
 
 # PLUGIN API
-def _datalad_plugin_call(dataset, output, argv=None):
+def datalad_plugin(dataset, output, argv=None):
     if argv:
         lgr.warn("tarball exporter ignores any additional options '{}'".format(
             argv))

--- a/datalad/plugin/dlplugin_export_tarball.py
+++ b/datalad/plugin/dlplugin_export_tarball.py
@@ -13,23 +13,18 @@
 
 __docformat__ = 'restructuredtext'
 
-import logging
-import tarfile
-import os
-
-from mock import patch
-from os.path import join as opj, dirname, normpath, isabs
-from datalad.support.annexrepo import AnnexRepo
-from datalad.utils import file_basename
-
-lgr = logging.getLogger('datalad.plugin.tarball')
-
 
 # PLUGIN API
-def datalad_plugin(dataset, output, argv=None):
-    if argv:
-        lgr.warn("tarball exporter ignores any additional options '{}'".format(
-            argv))
+def datalad_plugin(dataset, output=None):
+    import os
+    import tarfile
+    from mock import patch
+    from os.path import join as opj, dirname, normpath, isabs, abspath
+    from datalad.utils import file_basename
+    from datalad.support.annexrepo import AnnexRepo
+
+    import logging
+    lgr = logging.getLogger('datalad.plugin.tarball')
 
     repo = dataset.repo
     committed_date = repo.get_committed_date()
@@ -81,10 +76,9 @@ def datalad_plugin(dataset, output, argv=None):
                 recursive=False,
                 filter=_filter_tarinfo)
 
-    # I think it might better return "final" filename where stuff was saved
-    return output
-
-
-# PLUGIN API
-def _datalad_get_plugin_help():
-    return 'Just call it, and it will produce a tarball.'
+    yield dict(
+        status='ok',
+        path=abspath(output),
+        type='file',
+        action='export_tarball',
+        logger=lgr)

--- a/datalad/plugin/dlplugin_export_tarball.py
+++ b/datalad/plugin/dlplugin_export_tarball.py
@@ -6,6 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#PLUGINSYNOPSIS: export a dataset to a tarball
 """
 
 """

--- a/datalad/plugin/dlplugin_export_tarball.py
+++ b/datalad/plugin/dlplugin_export_tarball.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 
 
 # PLUGIN API
-def datalad_plugin(dataset, output=None):
+def dlplugin(dataset, output=None):
     import os
     import tarfile
     from mock import patch

--- a/datalad/plugin/dlplugin_wtf.py
+++ b/datalad/plugin/dlplugin_wtf.py
@@ -1,0 +1,84 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#PLUGINSYNOPSIS: provide information about this DataLad installation
+"""
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+
+# PLUGIN API
+def datalad_plugin(dataset=None):
+    """Generate a report about the DataLad installation and configuration
+
+    IMPORTANT: Sharing this report with untrusted parties (e.g. on the web)
+    should be done with care, as it may include identifying information, and/or
+    credentials or access tokens.
+
+    Parameters
+    ----------
+    dataset : Dataset, optional
+      If a dataset is given or found, information on this dataset is provided
+      (if it exists), and its active configuration is reported.
+    """
+    ds = dataset
+    if ds and not ds.is_installed():
+        # we don't deal with absent datasets
+        ds = None
+    if ds is None:
+        from datalad import cfg
+    else:
+        cfg = ds.config
+    from datalad.ui import ui
+    from datalad.api import metadata
+
+    report_template = """\
+{dataset}
+Configuration
+=============
+{cfg}
+
+"""
+
+    dataset_template = """\
+Dataset information
+===================
+{basic}
+
+Metadata
+--------
+{meta}
+
+"""
+    ds_meta = None
+    if ds and ds.is_installed():
+        print('DS', ds)
+        ds_meta = metadata(
+            dataset=ds, dataset_global=True, return_type='item-or-list',
+            result_filter=lambda x: x['action'] == 'metadata')
+    if ds_meta:
+        ds_meta = ds_meta['metadata']
+
+    ui.message(report_template.format(
+        dataset='' if not ds else dataset_template.format(
+            basic='\n'.join(
+                '{}: {}'.format(k, v) for k, v in (
+                    ('path', ds.path),
+                    ('repo', ds.repo.__class__.__name__ if ds.repo else '[NONE]'),
+                )),
+            meta='\n'.join(
+                '{}: {}'.format(k, v) for k, v in ds_meta)
+            if ds_meta else '[no metadata]'
+        ),
+        cfg='\n'.join(
+            '{}: {}'.format(k, '<HIDDEN>' if k.startswith('user.') or 'token' in k else v)
+            for k, v in sorted(cfg.items(), key=lambda x: x[0])),
+    ))
+    yield

--- a/datalad/plugin/dlplugin_wtf.py
+++ b/datalad/plugin/dlplugin_wtf.py
@@ -59,7 +59,6 @@ Metadata
 """
     ds_meta = None
     if ds and ds.is_installed():
-        print('DS', ds)
         ds_meta = metadata(
             dataset=ds, dataset_global=True, return_type='item-or-list',
             result_filter=lambda x: x['action'] == 'metadata')

--- a/datalad/plugin/dlplugin_wtf.py
+++ b/datalad/plugin/dlplugin_wtf.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 
 
 # PLUGIN API
-def datalad_plugin(dataset=None):
+def dlplugin(dataset=None):
     """Generate a report about the DataLad installation and configuration
 
     IMPORTANT: Sharing this report with untrusted parties (e.g. on the web)

--- a/datalad/plugin/export_tarball.py
+++ b/datalad/plugin/export_tarball.py
@@ -16,7 +16,7 @@ def dlplugin(dataset, output=None):
     import os
     import tarfile
     from mock import patch
-    from os.path import join as opj, dirname, normpath, isabs, abspath
+    from os.path import join as opj, dirname, normpath, isabs
     from datalad.utils import file_basename
     from datalad.support.annexrepo import AnnexRepo
 
@@ -73,9 +73,12 @@ def dlplugin(dataset, output=None):
                 recursive=False,
                 filter=_filter_tarinfo)
 
+    if not isabs(output):
+        output = opj(os.getcwd(), output)
+
     yield dict(
         status='ok',
-        path=abspath(output),
+        path=output,
         type='file',
         action='export_tarball',
         logger=lgr)

--- a/datalad/plugin/export_tarball.py
+++ b/datalad/plugin/export_tarball.py
@@ -6,10 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-#PLUGINSYNOPSIS: export a dataset to a tarball
-"""
-
-"""
+"""export a dataset to a tarball"""
 
 __docformat__ = 'restructuredtext'
 

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -56,7 +56,7 @@ def dlplugin(dataset, pattern, ref_dir='.', makedirs='no'):
     from os.path import join as opj
     from os.path import isabs
     from os.path import exists
-    from os import makedirs
+    from os import makedirs as makedirsfx
     from datalad.distribution.dataset import require_dataset
     from datalad.support.annexrepo import AnnexRepo
     from datalad.support.constraints import EnsureBool
@@ -98,7 +98,7 @@ def dlplugin(dataset, pattern, ref_dir='.', makedirs='no'):
     gitattr_dir = opj(ds.path, ref_dir)
     if not exists(gitattr_dir):
         if makedirs:
-            makedirs(gitattr_dir)
+            makedirsfx(gitattr_dir)
         else:
             yield dict(
                 res_kwargs,

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -13,7 +13,7 @@ __docformat__ = 'restructuredtext'
 
 
 # PLUGIN API
-def dlplugin(dataset, pattern, ref_dir='.', makedirs=False):
+def dlplugin(dataset, pattern, ref_dir='.', makedirs='no'):
     # could be extended to accept actual largefile expressions
     """Configure a dataset to never put some content into the dataset's annex
 
@@ -59,8 +59,10 @@ def dlplugin(dataset, pattern, ref_dir='.', makedirs=False):
     from os import makedirs
     from datalad.distribution.dataset import require_dataset
     from datalad.support.annexrepo import AnnexRepo
+    from datalad.support.constraints import EnsureBool
     from datalad.utils import assure_list
 
+    makedirs = EnsureBool()(makedirs)
     pattern = assure_list(pattern)
     ds = require_dataset(dataset, check_installed=True,
                          purpose='no_annex configuration')

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -1,0 +1,119 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""configure which dataset parts to never put in the annex"""
+
+
+__docformat__ = 'restructuredtext'
+
+
+# PLUGIN API
+def dlplugin(dataset, pattern, ref_dir='.', makedirs=False):
+    # could be extended to accept actual largefile expressions
+    """Configure a dataset to never put some content into the dataset's annex
+
+    This can be useful in mixed datasets that also contain textual data, such
+    as source code, which can be efficiently and more conveniently managed
+    directly in Git.
+
+    Patterns generally look like this::
+
+      code/*
+
+    which would match all file in the code directory. In order to match all
+    files under ``code/``, including all its subdirectories use such a
+    pattern::
+
+      code/**
+
+    Note that the plugin works incrementally, hence any existing configuration
+    (e.g. from a previous plugin run) is amended, not replaced.
+
+    Parameters
+    ----------
+    dataset : Dataset
+      dataset to configure
+    pattern : list
+      list of path patterns. Any content whose path is matching any pattern
+      will not be annexed when added to a dataset, but instead will be
+      tracked directly in Git. Path pattern have to be relative to the
+      directory given by the `ref_dir` option. By default, patterns should
+      be relative to the root of the dataset.
+    ref_dir : str, optional
+      Relative path (within the dataset) to the directory that is to be
+      configured. All patterns are interpreted relative to this path,
+      and configuration is written to a ``.gitattributes`` file in this
+      directory.
+    makedirs : bool, optional
+      If set, any missing directories will be created in order to be able
+      to place a file into ``ref_dir``. Default: False.
+    """
+    from os.path import join as opj
+    from os.path import isabs
+    from os.path import exists
+    from os import makedirs
+    from datalad.distribution.dataset import require_dataset
+    from datalad.support.annexrepo import AnnexRepo
+    from datalad.utils import assure_list
+
+    pattern = assure_list(pattern)
+    ds = require_dataset(dataset, check_installed=True,
+                         purpose='no_annex configuration')
+
+    res_kwargs = dict(
+        path=ds.path,
+        type='dataset',
+        action='no_annex',
+    )
+
+    # all the ways we refused to cooperate
+    if not isinstance(ds.repo, AnnexRepo):
+        yield dict(
+            res_kwargs,
+            status='notneeded',
+            message='dataset has no annex')
+        return
+    if any(isabs(p) for p in pattern):
+        yield dict(
+            res_kwargs,
+            status='error',
+            message=('path pattern for `no_annex` configuration must be relative paths: %s',
+                     pattern))
+        return
+    if isabs(ref_dir):
+        yield dict(
+            res_kwargs,
+            status='error',
+            message=('`ref_dir` for `no_annex` configuration must be a relative path: %s',
+                     ref_dir))
+        return
+
+    gitattr_dir = opj(ds.path, ref_dir)
+    if not exists(gitattr_dir):
+        if makedirs:
+            makedirs(gitattr_dir)
+        else:
+            yield dict(
+                res_kwargs,
+                status='error',
+                message='target directory for `no_annex` does not exist (consider makedirs=True)')
+            return
+
+    gitattr_file = opj(gitattr_dir, '.gitattributes')
+    with open(gitattr_file, 'a') as fp:
+        for p in pattern:
+            fp.write('{} annex.largefiles=nothing'.format(p))
+        yield dict(res_kwargs, status='ok')
+
+    for r in dataset.add(
+            gitattr_file,
+            to_git=True,
+            message="[DATALAD] exclude paths from annex'ing",
+            result_filter=None,
+            result_xfm=None):
+        yield r

--- a/datalad/plugin/tarball.py
+++ b/datalad/plugin/tarball.py
@@ -21,11 +21,11 @@ from os.path import join as opj, dirname, normpath, isabs
 from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import file_basename
 
-lgr = logging.getLogger('datalad.export.tarball')
+lgr = logging.getLogger('datalad.plugin.tarball')
 
 
 # PLUGIN API
-def _datalad_export_plugin_call(dataset, output, argv=None):
+def _datalad_plugin_call(dataset, output, argv=None):
     if argv:
         lgr.warn("tarball exporter ignores any additional options '{}'".format(
             argv))

--- a/datalad/plugin/tarball.py
+++ b/datalad/plugin/tarball.py
@@ -85,5 +85,5 @@ def _datalad_plugin_call(dataset, output, argv=None):
 
 
 # PLUGIN API
-def _datalad_get_cmdline_help():
+def _datalad_get_plugin_help():
     return 'Just call it, and it will produce a tarball.'

--- a/datalad/plugin/tests/__init__.py
+++ b/datalad/plugin/tests/__init__.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Interfaces tests
+"""Plugin tests
 
 """
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -1,0 +1,148 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test plugin interface mechanics"""
+
+
+import logging
+from os.path import join as opj
+from mock import patch
+
+from datalad.api import plugin
+from datalad.api import create
+
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import swallow_outputs
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import chpwd
+from datalad.tests.utils import create_tree
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import eq_
+
+broken_plugin = """garbage"""
+
+nodocs_plugin = """\
+def datalad_plugin():
+    pass
+"""
+
+# functioning plugin dummy
+dummy_plugin = """\
+#PLUGINSYNOPSIS: real dummy
+
+def datalad_plugin(dataset, noval, withval='test'):
+    "mydocstring"
+    yield dict(
+        status='ok',
+        action='dummy',
+        args=dict(
+            dataset=dataset,
+            noval=noval,
+            withval=withval))
+"""
+
+
+@with_tempfile()
+@with_tempfile(mkdir=True)
+def test_plugin_call(path, dspath):
+    # make plugins
+    create_tree(
+        path,
+        {
+            'dlplugin_dummy.py': dummy_plugin,
+            'dlplugin_nodocs.py': nodocs_plugin,
+            'dlplugin_broken.py': broken_plugin,
+        })
+    fake_dummy_spec = {
+        'dummy': {'file': opj(path, 'dlplugin_dummy.py')},
+        'nodocs': {'file': opj(path, 'dlplugin_nodocs.py')},
+        'broken': {'file': opj(path, 'dlplugin_broken.py')},
+    }
+
+    with patch('datalad.plugin._get_plugins', return_value=fake_dummy_spec):
+        with swallow_outputs() as cmo:
+            plugin(showplugininfo=True)
+            # hyphen spacing depends on the longest plugin name!
+            # sorted
+            # summary list generation doesn't actually load plugins for speed,
+            # hence broken is not known to be broken here
+            eq_(cmo.out,
+                "broken [no synopsis] ({})\ndummy  - real dummy ({})\nnodocs [no synopsis] ({})\n".format(
+                    fake_dummy_spec['broken']['file'],
+                    fake_dummy_spec['dummy']['file'],
+                    fake_dummy_spec['nodocs']['file']))
+        with swallow_outputs() as cmo:
+            plugin(['dummy'], showpluginhelp=True)
+            eq_(cmo.out.rstrip(), "mydocstring")
+        with swallow_outputs() as cmo:
+            plugin(['nodocs'], showpluginhelp=True)
+            eq_(cmo.out.rstrip(), "This plugin has no documentation")
+        # loading fails, no docs
+        assert_raises(ValueError, plugin, ['broken'], showpluginhelp=True)
+
+    # assume this most obscure plugin name is not used
+    assert_raises(ValueError, plugin, '32sdfhvz984--^^')
+
+    # broken plugin argument, must match Python keyword arg
+    # specs
+    assert_raises(ValueError, plugin, ['dummy', '1245'])
+
+    with patch('datalad.plugin._get_plugins', return_value=fake_dummy_spec):
+        # does not trip over unsupported argument, they get filtered out, because
+        # we carry all kinds of stuff
+        with swallow_logs(new_level=logging.WARNING) as cml:
+            res = list(plugin(['dummy', 'noval=one', 'obscure=some']))
+            assert_status('ok', res)
+            cml.assert_logged(
+                msg="ignoring plugin argument(s) {'obscure'}, not supported by plugin",
+                regex=False, level='WARNING')
+        # fails on missing positional arg
+        assert_raises(TypeError, plugin, ['dummy'])
+        # positional and kwargs actually make it into the plugin
+        res = list(plugin(['dummy', 'noval=one', 'withval=two']))[0]
+        eq_('one', res['args']['noval'])
+        eq_('two', res['args']['withval'])
+        # kwarg defaults are preserved
+        res = list(plugin(['dummy', 'noval=one']))[0]
+        eq_('test', res['args']['withval'])
+        # repeated specification yields list input
+        res = list(plugin(['dummy', 'noval=one', 'noval=two']))[0]
+        eq_(['one', 'two'], res['args']['noval'])
+        # can do the same thing  while bypassing argument parsing for calls
+        # from within python, and even preserve native python dtypes
+        res = list(plugin(['dummy', ('noval', 1), ('noval', 'two')]))[0]
+        eq_([1, 'two'], res['args']['noval'])
+        # and we can further simplify in this case by passing lists right
+        # away
+        res = list(plugin(['dummy', ('noval', [1, 'two'])]))[0]
+        eq_([1, 'two'], res['args']['noval'])
+
+    # dataset arg handling
+    # run plugin that needs a dataset where there is none
+    with patch('datalad.plugin._get_plugins', return_value=fake_dummy_spec):
+        ds = None
+        with chpwd(dspath):
+            assert_raises(ValueError, plugin, ['dummy', 'noval=one'])
+            # create a dataset here, fixes the error
+            ds = create()
+            print(ds.path, dspath)
+            res = list(plugin(['dummy', 'noval=one']))[0]
+            # gives dataset instance
+            eq_(ds, res['args']['dataset'])
+        # no do again, giving the dataset path
+        # but careful, `dataset` is a proper argument
+        res = list(plugin(['dummy', 'noval=one'], dataset=dspath))[0]
+        eq_(ds, res['args']['dataset'])
+        # however, if passed alongside the plugins args it also works
+        res = list(plugin(['dummy', 'dataset={}'.format(dspath), 'noval=one']))[0]
+        eq_(ds, res['args']['dataset'])
+        # but if both are given, the proper args takes precedence
+        assert_raises(ValueError, plugin, ['dummy', 'dataset={}'.format(dspath), 'noval=one'],
+                      dataset='rubbish')

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -206,3 +206,23 @@ def test_wtf(path):
         assert_in('Configuration', cmo.out)
         assert_in('Dataset information', cmo.out)
         assert_in('path: {}'.format(ds.path), cmo.out)
+
+
+@with_tempfile(mkdir=True)
+def test_no_annex(path):
+    ds = create(path)
+    ok_clean_git(ds.path)
+    create_tree(
+        ds.path,
+        {'code': {
+            'inannex': 'content',
+            'notinannex': 'othercontent'}})
+    # add two files, pre and post configuration
+    ds.add(opj('code', 'inannex'))
+    plugin(['no_annex', 'pattern=code/**'], dataset=ds)
+    ds.add(opj('code', 'notinannex'))
+    ok_clean_git(ds.path)
+    # one is annex'ed, the other is not, despite no change in add call
+    # importantly, also .gitattribute is not annexed
+    eq_([opj('code', 'inannex')],
+        ds.repo.get_annexed_files())

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -101,8 +101,8 @@ def test_plugin_call(path, dspath):
             res = list(plugin(['dummy', 'noval=one', 'obscure=some']))
             assert_status('ok', res)
             cml.assert_logged(
-                msg="ignoring plugin argument(s) {'obscure'}, not supported by plugin",
-                regex=False, level='WARNING')
+                msg=".*ignoring plugin argument\\(s\\).*obscure.*, not supported by plugin.*",
+                regex=True, level='WARNING')
         # fails on missing positional arg
         assert_raises(TypeError, plugin, ['dummy'])
         # positional and kwargs actually make it into the plugin

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -31,7 +31,7 @@ from datalad.tests.utils import eq_
 broken_plugin = """garbage"""
 
 nodocs_plugin = """\
-def datalad_plugin():
+def dlplugin():
     pass
 """
 
@@ -39,7 +39,7 @@ def datalad_plugin():
 dummy_plugin = """\
 #PLUGINSYNOPSIS: real dummy
 
-def datalad_plugin(dataset, noval, withval='test'):
+def dlplugin(dataset, noval, withval='test'):
     "mydocstring"
     yield dict(
         status='ok',

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -39,8 +39,8 @@ def dlplugin():
 """
 
 # functioning plugin dummy
-dummy_plugin = """\
-#PLUGINSYNOPSIS: real dummy
+dummy_plugin = '''\
+"""real dummy"""
 
 def dlplugin(dataset, noval, withval='test'):
     "mydocstring"
@@ -51,7 +51,7 @@ def dlplugin(dataset, noval, withval='test'):
             dataset=dataset,
             noval=noval,
             withval=withval))
-"""
+'''
 
 
 @with_tempfile()

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -12,8 +12,10 @@
 
 import logging
 from os.path import join as opj
+from os.path import exists
 from mock import patch
 
+from datalad.config import ConfigManager
 from datalad.api import plugin
 from datalad.api import create
 
@@ -27,6 +29,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
+from datalad.tests.utils import ok_clean_git
 
 broken_plugin = """garbage"""
 
@@ -147,6 +150,41 @@ def test_plugin_call(path, dspath):
         # but if both are given, the proper args takes precedence
         assert_raises(ValueError, plugin, ['dummy', 'dataset={}'.format(dspath), 'noval=one'],
                       dataset='rubbish')
+
+
+# MIH: I failed to replace our config manager instance for this test run
+# in order to be able to configure a set of plugins to run prior and after
+# create. A test should not alter a users config, hence I am disabling this
+# for now, and hope somebody can fix it up
+#@with_tempfile(mkdir=True)
+#def test_plugin_config(path):
+#    with patch.dict('os.environ',
+#                    {'HOME': path, 'DATALAD_SNEAKY_ADDITION': 'ignore'}):
+#        with patch('datalad.cfg', ConfigManager()) as cfg:
+#            global_gitconfig = opj(path, '.gitconfig')
+#            assert(not exists(global_gitconfig))
+#            # swap out the actual config for this test
+#            assert_in('datalad.sneaky.addition', cfg)
+#            # now we configure a plugin to run before and twice after `create`
+#            cfg.add('datalad.create.run-before',
+#                    'add_readme filename=before.txt',
+#                    where='global')
+#            cfg.add('datalad.create.run-after',
+#                    'add_readme filename=after1.txt',
+#                    where='global')
+#            cfg.add('datalad.create.run-after',
+#                    'add_readme filename=after2.txt',
+#                    where='global')
+#            # force reload to pick up newly populated .gitconfig
+#            cfg.reload(force=True)
+#            assert_in('datalad.create.run-before', cfg)
+#            # and now we create a dataset and expect the two readme files
+#            # to be part of it
+#            ds = create(dataset=opj(path, 'ds'))
+#            ok_clean_git(ds.path)
+#            assert(exists(opj(ds.path, 'before.txt')))
+#            assert(exists(opj(ds.path, 'after1.txt')))
+#            assert(exists(opj(ds.path, 'after2.txt')))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/plugin/tests/test_tarball.py
+++ b/datalad/plugin/tests/test_tarball.py
@@ -55,7 +55,7 @@ def test_tarball(path):
         res = list(ds.plugin('export_tarball'))
         assert_status('ok', res)
         assert_result_count(res, 1)
-        assert_result_count(res, 1, path=default_outname)
+        assert(isabs(res[0]['path']))
     assert_true(os.path.exists(default_outname))
     custom_outname = opj(path, 'myexport.tar.gz')
     # feed in without extension

--- a/datalad/plugin/tests/test_tarball.py
+++ b/datalad/plugin/tests/test_tarball.py
@@ -24,6 +24,8 @@ from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_startswith
 from datalad.tests.utils import assert_true, assert_not_equal, assert_raises, \
     assert_false, assert_equal
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_result_count
 
 
 _dataset_template = {
@@ -40,7 +42,7 @@ def test_failure(path):
     # unknown pluginer
     assert_raises(ValueError, ds.plugin, 'nah')
     # non-existing dataset
-    assert_raises(ValueError, plugin, 'tarball', Dataset('nowhere'))
+    assert_raises(ValueError, plugin, 'export_tarball', Dataset('nowhere'))
 
 
 @with_tree(_dataset_template)
@@ -48,16 +50,16 @@ def test_tarball(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
     ds.add('.')
     committed_date = ds.repo.get_committed_date()
-    with chpwd(path):
-        _mod, tarball1 = ds.plugin('tarball')
-        assert(not isabs(tarball1))
-        tarball1 = opj(path, tarball1)
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
-    assert_equal(tarball1, default_outname)
+    with chpwd(path):
+        res = list(ds.plugin('export_tarball'))
+        assert_status('ok', res)
+        assert_result_count(res, 1)
+        assert_result_count(res, 1, path=default_outname)
     assert_true(os.path.exists(default_outname))
     custom_outname = opj(path, 'myexport.tar.gz')
     # feed in without extension
-    ds.plugin('tarball', output=custom_outname[:-7])
+    ds.plugin('export_tarball', output=custom_outname[:-7])
     assert_true(os.path.exists(custom_outname))
     custom1_md5 = md5sum(custom_outname)
     # encodes the original tarball filename -> different checksum, despit
@@ -65,7 +67,7 @@ def test_tarball(path):
     assert_not_equal(md5sum(default_outname), custom1_md5)
     # should really sleep so if they stop using time.time - we know
     time.sleep(1.1)
-    ds.plugin('tarball', output=custom_outname)
+    ds.plugin('export_tarball', output=custom_outname)
     # should not encode mtime, so should be identical
     assert_equal(md5sum(custom_outname), custom1_md5)
 

--- a/datalad/plugin/tests/test_tarball.py
+++ b/datalad/plugin/tests/test_tarball.py
@@ -16,7 +16,7 @@ from os.path import isabs
 import tarfile
 
 from datalad.api import Dataset
-from datalad.api import export
+from datalad.api import plugin
 from datalad.utils import chpwd
 from datalad.utils import md5sum
 
@@ -37,10 +37,10 @@ _dataset_template = {
 @with_tree(_dataset_template)
 def test_failure(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
-    # unknown exporter
-    assert_raises(ValueError, ds.export, 'nah')
+    # unknown pluginer
+    assert_raises(ValueError, ds.plugin, 'nah')
     # non-existing dataset
-    assert_raises(ValueError, export, 'tarball', Dataset('nowhere'))
+    assert_raises(ValueError, plugin, 'tarball', Dataset('nowhere'))
 
 
 @with_tree(_dataset_template)
@@ -49,7 +49,7 @@ def test_tarball(path):
     ds.add('.')
     committed_date = ds.repo.get_committed_date()
     with chpwd(path):
-        _mod, tarball1 = ds.export('tarball')
+        _mod, tarball1 = ds.plugin('tarball')
         assert(not isabs(tarball1))
         tarball1 = opj(path, tarball1)
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
@@ -57,7 +57,7 @@ def test_tarball(path):
     assert_true(os.path.exists(default_outname))
     custom_outname = opj(path, 'myexport.tar.gz')
     # feed in without extension
-    ds.export('tarball', output=custom_outname[:-7])
+    ds.plugin('tarball', output=custom_outname[:-7])
     assert_true(os.path.exists(custom_outname))
     custom1_md5 = md5sum(custom_outname)
     # encodes the original tarball filename -> different checksum, despit
@@ -65,7 +65,7 @@ def test_tarball(path):
     assert_not_equal(md5sum(default_outname), custom1_md5)
     # should really sleep so if they stop using time.time - we know
     time.sleep(1.1)
-    ds.export('tarball', output=custom_outname)
+    ds.plugin('tarball', output=custom_outname)
     # should not encode mtime, so should be identical
     assert_equal(md5sum(custom_outname), custom1_md5)
 

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -6,10 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-#PLUGINSYNOPSIS: provide information about this DataLad installation
-"""
-
-"""
+"""provide information about this DataLad installation"""
 
 __docformat__ = 'restructuredtext'
 

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -172,7 +172,9 @@ class EnsureBool(Constraint):
                 return False
             elif value in ('1', 'yes', 'on', 'enable', 'true'):
                 return True
-        raise ValueError("value must be converted to boolean")
+        raise ValueError(
+            "value '{}' must be convertible to boolean".format(
+                value))
 
     def long_description(self):
         return 'value must be convertible to type bool'

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -21,7 +21,7 @@ import sys
 
 from datalad.support.param import Parameter
 from datalad.interface.base import Interface
-from datalad.interface.utils import build_doc
+from datalad.interface.base import build_doc
 
 from datalad import ssh_manager
 

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -26,7 +26,7 @@ Dataset operations
    generated/man/datalad-create-sibling
    generated/man/datalad-create-sibling-github
    generated/man/datalad-drop
-   generated/man/datalad-export
+   generated/man/datalad-plugin
    generated/man/datalad-get
    generated/man/datalad-install
    generated/man/datalad-publish

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -1,0 +1,120 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_customization:
+
+********************************************
+Customization and extension of functionality
+********************************************
+
+DataLad provides numerous commands that cover many use cases. However, there will
+always be a demand for further customization at a particular site, or for an
+individual user. DataLad addresses this need by providing a generic plugin
+interface.
+
+First of all, DataLad plugins can be executed via the :ref:`man_datalad-plugin`
+command. This allows for executing arbitrary plugins (on particular dataset)
+at any point in time.
+
+In addition, DataLad can be configured to run any number of plugins prior or
+after particular commands. For example, it is possible to execute a plugin
+each time DataLad has created a dataset to configure it so that all files
+that are added to its ``code/`` subdirectory will always be managed directly
+with Git and not be put into the dataset's annex. In order to achieve this,
+adjust your Git configuration in the following way::
+
+  git config --global --add datalad.create.run-after 'no_annex pattern=code/**'
+
+This will cause DataLad to run the ``no_annex`` plugin to add the given pattern
+to the dataset's ``.gitattribute`` file, which in turn instructs git annex to
+send any matching files directly to Git. The same functionality is available
+for ad-hoc adjustments via the ``--run-after`` option supported by most
+commands.
+
+Analog to ``--run-after`` DataLad also supports ``--run-before`` to execute
+plugins prior a command.
+
+DataLad will discover plugins at three locations:
+
+1. official plugins that are part of the local DataLad installation
+
+2. system-wide plugins, provided by the local admin
+
+   The location where plugins need to be placed depends on the platform.
+   On GNU/Linux systems this will be ``/etc/xdg/datalad/plugins``, whereas
+   on Windows it will be ``C:\ProgramData\datalad.org\datalad\plugins``.
+
+   This default location can be overridden by setting the
+   ``datalad.locations.system-plugins`` configuration variable in the local or
+   global Git configuration.
+
+3. user-supplied plugins, customizable by each user
+
+   Again, the location will depend on the platform.  On GNU/Linux systems this
+   will be ``$HOME/.config/datalad/plugins``, whereas on Windows it will be
+   ``C:\Users\<username>\AppData\Local\datalad.org\datalad\plugins``.
+
+   This default location can be overridden by setting the
+   ``datalad.locations.user-plugins`` configuration variable in the local or
+   global Git configuration.
+
+Identically named plugins in latter location replace those in locations
+searched before. This can be used to alter the behavior of plugins provided
+with DataLad, and enables users to adjust a site-wide configuration.
+
+
+Writing own plugins
+===================
+
+Plugins are written in Python. In order for DataLad to be able to find
+them, plugins need to be placed in one of the supported locations described
+above. Plugin file names have to have a '.py' extensions and must not start
+with an underscore ('_').
+
+Plugin source files must define a function named::
+
+  dlplugin
+
+This function is executed as the plugin. It can have any number of
+arguments (positional, or keyword arguments with defaults), or none at
+all. All arguments, except ``dataset`` must expect any value to
+be a string.
+
+The plugin function must be self-contained, i.e. all needed imports
+of definitions must be done within the body of the function.
+
+The doc string of the plugin function is displayed when the plugin
+documentation is requested. The first line in a plugin file that starts
+with triple double-quotes will be used as the plugin short description
+(this will typically be the docstring of the module file). This short
+description is displayed as the plugin synopsis in the plugin overview
+list.
+
+Plugin functions must yield their results as a Python generator. Results are
+DataLad status dictionaries. There are no constraints on the number of results,
+or the number and nature of result properties. However, conventions exists and
+must be followed for compatibility with the result evaluation and rendering
+performed by DataLad.
+
+The following property keys must exist:
+
+"status"
+    {'ok', 'notneeded', 'impossible', 'error'}
+
+"action"
+    label for the action performed by the plugin. In many cases this
+    could be the plugin's name.
+
+The following keys should exists if possible:
+
+"path"
+    absolute path to a result on the file system
+
+"type"
+    label indicating the nature of a result (e.g. 'file', 'dataset',
+    'directory', etc.)
+
+"message"
+    string message annotating the result, particularly important for
+    non-ok results. This can be a tuple with 'logging'-style string
+    expansion.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Concepts and technologies
    basics
    usecases/index
    metadata
+   customization
    faq
    glossary
 

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -78,6 +78,21 @@ Miscellaneous commands
    api.crawl_init
    api.test
 
+Plugins
+-------
+
+DataLad can be customized by plugins. The following plugins are shipped
+with DataLad.
+
+.. currentmodule:: datalad.plugin
+.. autosummary::
+   :toctree: generated
+
+   add_readme
+   export_tarball
+   no_annex
+   wtf
+
 
 Support functionality
 =====================

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -28,7 +28,7 @@ Dataset operations
    api.create_sibling
    api.create_sibling_github
    api.drop
-   api.export
+   api.plugin
    api.get
    api.install
    api.publish


### PR DESCRIPTION
Provide complete plugin interface (more general than `export` ever was). The main purpose is to be able to quickly craft little helpers as simple Python functions and run them as standalone commands, without all the overhead of crafting a full-scale command with a nifty API.

Sufficient docs should be inside. This is a precondition for a resolution of:  #1612 #1462 

Here is a list of existing issues that could be addressed by a plugin: https://github.com/datalad/datalad/labels/do-as-plugin

- [x] Replaces the old `export` command (fixes #1039)
- [x] Old tarball exporter is now a plugin `export_tarball`.
- [x] New `add_readme` plugin.
- [x] allow for giving plugin arguments multiple times to build input argument lists
- [x] more or less comprehensive tests for the general plugin mechanics
- [x] minimal WTF plugin
- [x] demo of a `--with-plugin` option that has the potential to simplify our API a bit
- [x] RF basic decorators `build_doc` and `eval_results`
- [x] common option (as a pair `--run-before`, `--run-after`) to run plugins with any command. With this model we could give users the ability to do `autoadd_untracked`, `autosave_dirty`, `fail_if_dirty` if they want to roll this way, without us having to decide what is best for them, and without having to explode the API to cover all possible cases.
- [x] allow for configuration of plugins that shall always run pre/post of a particular command