### PR TITLE
BF: Proper clone failure report due to insufficient permissions

### DIFF
--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -102,6 +102,7 @@ class Clone(Interface):
         reckless=reckless_opt,
         alt_sources=Parameter(
             args=('--alternative-sources',),
+            dest='alt_sources',
             metavar='SOURCE',
             nargs='+',
             doc="""Alternative sources to be tried if a dataset cannot

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -10,6 +10,7 @@
 
 
 import logging
+import re
 from os import listdir
 from os.path import relpath
 from os.path import pardir
@@ -236,6 +237,15 @@ class Clone(Interface):
                     lgr.debug("Wiping out unsuccessful clone attempt at: %s",
                               dest_path)
                     rmtree(dest_path)
+                if 'could not create work tree' in e.stderr.lower():
+                    # this cannot be fixed by trying another URL
+                    yield get_status_dict(
+                        status='error',
+                        message=re.match(r".*fatal: (.*)\n",
+                                         e.stderr,
+                                         flags=re.MULTILINE | re.DOTALL).group(1),
+                        **status_kwargs)
+                    return
 
         if not destination_dataset.is_installed():
             yield get_status_dict(

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import use_cassette
 from datalad.tests.utils import skip_if_no_network
+from datalad.tests.utils import skip_if_on_windows
 
 from ..dataset import Dataset
 
@@ -309,3 +310,13 @@ def test_clone_isnt_a_smartass(origin_path, path):
     assert clonedsub.path.startswith(path)
     # no subdataset relation
     eq_(cloned.subdatasets(), [])
+
+
+@skip_if_on_windows
+def test_clone_report_permission_issue():
+    with chpwd('/'):
+        res = clone('///', result_xfm=None, return_type='list', on_failure='ignore')
+        assert_status('error', res)
+        assert_result_count(
+            res, 1, status='error',
+            message="could not create work tree dir '/datasets.datalad.org': Permission denied")


### PR DESCRIPTION
Fixes:

- [x] #1618 
- [x] Broken argspec of `clone` cmdline parser