### PR TITLE
BF(workaround): use patched wrapt disabling its extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ script:
   # Verify that setup.py build doesn't puke
   - python setup.py build
   # Run tests
-  - PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` $NOSE_OPTS -v -A "$NOSE_SELECTION_OP(integration or usecase or slow)" --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO $TESTS_TO_PERFORM
+  - WRAPT_DISABLE_EXTENSIONS=1 PATH=$PWD/tools/coverage-bin:$PATH $NOSE_WRAPPER `which nosetests` $NOSE_OPTS -v -A "$NOSE_SELECTION_OP(integration or usecase or slow)" --with-doctest --doctest-tests --with-cov --cover-package datalad --logging-level=INFO $TESTS_TO_PERFORM
   # Generate documentation and run doctests
   # but do only when we do not have obnoxious logging turned on -- something screws up sphinx on travis
   - if [ ! "${DATALAD_LOG_LEVEL:-}" = 2 ]; then PYTHONPATH=$PWD $NOSE_WRAPPER make -C docs html doctest; fi

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -3,6 +3,6 @@
 # we need to figure out/complaint to pip folks
 # For now, until https://github.com/GrahamDumpleton/wrapt/issues/98 resolved
 # we should use our version which allows to disable extension(s)
-https://github.com/yarikoptic/wrapt@develop
+git+https://github.com/yarikoptic/wrapt@develop
 -e .[devel]
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,4 +1,8 @@
 # Theoretically we don't want -e here but ATM pip would puke if just .[full] is provided
 # Since we use requirements.txt ATM only for development IMHO it is ok but
 # we need to figure out/complaint to pip folks
+# For now, until https://github.com/GrahamDumpleton/wrapt/issues/98 resolved
+# we should use our version which allows to disable extension(s)
+https://github.com/yarikoptic/wrapt@develop
 -e .[devel]
+


### PR DESCRIPTION
We wouldn't be able to release like that (we could patch debian packages for wrapt but still -- that is not a solution) but at least meanwhile we could bring tests under control until https://github.com/GrahamDumpleton/wrapt/issues/98 is resolved