### PR TITLE
Better support for special remotes (webdav in particular)

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -610,7 +610,7 @@ def _query_remotes(
             for remotecfg in [k for k in ds.config.keys()
                               if k.startswith('remote.{}.'.format(remote))]:
                 info[remotecfg[8 + len(remote):]] = ds.config[remotecfg]
-        if get_annex_info and 'annex-uuid' in info:
+        if get_annex_info and info.get('annex-uuid', None):
             ainfo = annex_info.get(info['annex-uuid'])
             annex_description = ainfo.get('description', None)
             if annex_description is not None:

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -742,9 +742,10 @@ def _enable_remote(
                     result_props,
                     status='impossible',
                     message="cannot determine remote host, credential lookup for webdav access is not possible, and not credentials were supplied")
-            cred = UserPassword('webdav-{}'.format(hostname))
+            cred = UserPassword('webdav:{}'.format(hostname))
             if not cred.is_known:
                 cred.enter_new(
+                    instructions="Enter credentials for authentication with WEBDAV server at {}".format(hostname),
                     user=os.environ.get('WEBDAV_USERNAME', None),
                     password=os.environ.get('WEBDAV_PASSWORD', None))
             creds = cred()

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -744,10 +744,18 @@ def _enable_remote(
                     message="cannot determine remote host, credential lookup for webdav access is not possible, and not credentials were supplied")
             cred = UserPassword('webdav:{}'.format(hostname))
             if not cred.is_known:
-                cred.enter_new(
-                    instructions="Enter credentials for authentication with WEBDAV server at {}".format(hostname),
-                    user=os.environ.get('WEBDAV_USERNAME', None),
-                    password=os.environ.get('WEBDAV_PASSWORD', None))
+                try:
+                    cred.enter_new(
+                        instructions="Enter credentials for authentication with WEBDAV server at {}".format(hostname),
+                        user=os.environ.get('WEBDAV_USERNAME', None),
+                        password=os.environ.get('WEBDAV_PASSWORD', None))
+                except KeyboardInterrupt:
+                    # user hit Ctrl-C
+                    yield dict(
+                        result_props,
+                        status='impossible',
+                        message="credentials are required for sibling access, abort")
+                    return
             creds = cred()
             # update the env with the two necessary variable
             # we need to pass a complete env because of #1776

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -180,7 +180,7 @@ def _get_flexible_source_candidates(src, base_url=None, alternate_suffix=True):
 
 def _handle_possible_annex_dataset(dataset, reckless, description=None):
     """If dataset "knows annex" -- annex init it, set into reckless etc
-    
+
     Provides additional tune up to a possibly an annex repo, e.g.
     "enables" reckless mode, sets up description
     """
@@ -205,6 +205,20 @@ def _handle_possible_annex_dataset(dataset, reckless, description=None):
         repo._init(description=description)
     if reckless:
         repo._run_annex_command('untrust', annex_options=['here'])
+    # go through list of special remotes and issue info message that
+    # some additional ones are present and were not auto-enabled
+    remote_names = repo.get_remotes(
+        with_urls_only=False,
+        exclude_special_remotes=False)
+    for k, v in repo.get_special_remotes().items():
+        sr_name = v.get('name', None)
+        if sr_name and sr_name not in remote_names:
+            # if it is not listed among the remotes, it wasn't enabled
+            lgr.info(
+                'access to dataset sibling "%s" not auto-enabled, enable with:\n\t\tdatalad siblings -d "%s" enable -s %s',
+                sr_name,
+                dataset.path,
+                sr_name)
 
 
 def _get_installationpath_from_url(url):

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -185,23 +185,26 @@ def _handle_possible_annex_dataset(dataset, reckless, description=None):
     "enables" reckless mode, sets up description
     """
     # in any case check whether we need to annex-init the installed thing:
-    if knows_annex(dataset.path):
-        # init annex when traces of a remote annex can be detected
-        if reckless:
-            lgr.debug(
-                "Instruct annex to hardlink content in %s from local "
-                "sources, if possible (reckless)", dataset.path)
-            dataset.config.add(
-                'annex.hardlink', 'true', where='local', reload=True)
-        lgr.debug("Initializing annex repo at %s", dataset.path)
-        # XXX this is rather convoluted, init does init, but cannot
-        # set a description without `create=True`
-        repo = AnnexRepo(dataset.path, init=True)
-        # so do manually see #1403
-        if description:
-            repo._init(description=description)
-        if reckless:
-            repo._run_annex_command('untrust', annex_options=['here'])
+    if not knows_annex(dataset.path):
+        # not for us
+        return
+
+    # init annex when traces of a remote annex can be detected
+    if reckless:
+        lgr.debug(
+            "Instruct annex to hardlink content in %s from local "
+            "sources, if possible (reckless)", dataset.path)
+        dataset.config.add(
+            'annex.hardlink', 'true', where='local', reload=True)
+    lgr.debug("Initializing annex repo at %s", dataset.path)
+    # XXX this is rather convoluted, init does init, but cannot
+    # set a description without `create=True`
+    repo = AnnexRepo(dataset.path, init=True)
+    # so do manually see #1403
+    if description:
+        repo._init(description=description)
+    if reckless:
+        repo._run_annex_command('untrust', annex_options=['here'])
 
 
 def _get_installationpath_from_url(url):

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -95,24 +95,30 @@ class Credential(object):
             lgr.warning("Failed to query keyring: %s" % exc_str(exc))
             return False
 
-    def _ask_field_value(self, f):
+    def _ask_field_value(self, f, instructions=None):
+        msg = instructions if instructions else \
+            ("You need to authenticate with %r credentials." % self.name +
+                  (" %s provides information on how to gain access"
+                   % self.url if self.url else ''))
+
         return ui.question(
             f,
-            title="You need to authenticate with %r credentials." % self.name +
-                  " %s provides information on how to gain access"
-                  % self.url if self.url else '',
+            title=msg,
             hidden=self._is_field_hidden(f))
 
-    def _ask_and_set(self, f):
-        v = self._ask_field_value(f)
+    def _ask_and_set(self, f, instructions=None):
+        v = self._ask_field_value(f, instructions=instructions)
         self.set(**{f: v})
         return v
 
-    def enter_new(self, **kwargs):
+    def enter_new(self, instructions=None, **kwargs):
         """Enter new values for the credential fields
 
         Parameters
         ----------
+        instructions : str, optional
+          If given, the auto-generated instructions based on a login-URL are
+          replaced by the given string
         **kwargs
           Any given key value pairs with non-None values are used to set the
           field `key` to the given value, without asking for user input
@@ -123,7 +129,7 @@ class Credential(object):
                 # use given value, don't ask
                 self.set(**{f: kwargs[f]})
             elif not self._is_field_optional(f):
-                self._ask_and_set(f)
+                self._ask_and_set(f, instructions=instructions)
 
     def __call__(self):
         """Obtain credentials from a keyring and if any is not known -- ask"""

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -194,6 +194,9 @@ class DialogUI(ConsoleLog, InteractiveUI):
             #     response = (raw_input if PY2 else input)()
             # else:
             response = (getpass.getpass if hidden else getpass_echo)(msg + ": ")
+            if '\x03' in response:
+                # Ctrl-C is part of the response -> clearly we should not pretend it's all good
+                raise KeyboardInterrupt
 
             if not response and default:
                 response = default

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -113,9 +113,10 @@ class SilentConsoleLog(ConsoleLog):
         return SilentProgressBar(*args, out=self.out, **kwargs)
 
 
-def getpass_echo(prompt='Password: ', stream=None):
+def getpass_echo(prompt='Password', stream=None):
     """Q&D workaround until we have proper 'centralized' UI -- just use getpass BUT enable echo
     """
+    prompt = '{}: '.format(prompt)
     if on_windows:
         # Can't do anything fancy yet, so just ask the one without echo
         return getpass.getpass(prompt=prompt, stream=stream)
@@ -167,6 +168,14 @@ class DialogUI(ConsoleLog, InteractiveUI):
                 if default is not None and x == default \
                 else x
 
+        def ask_repetition_match(msg):
+            response = getpass.getpass('{}: '.format(msg))
+            response_r = getpass.getpass('{} (repeat): '.format(msg))
+            if response != response_r:
+                return None
+            else:
+                return response
+
         if choices is not None:
             msg += "%s (choices: %s)" % (text, ', '.join(map(mark_default, choices)))
         elif default is not None:
@@ -193,8 +202,11 @@ class DialogUI(ConsoleLog, InteractiveUI):
             #     # and provide per-OS handling with stdin being override
             #     response = (raw_input if PY2 else input)()
             # else:
-            response = (getpass.getpass if hidden else getpass_echo)(msg + ": ")
-            if '\x03' in response:
+            response = (ask_repetition_match if hidden else getpass_echo)(msg)
+            if response is None:
+                self.error("input mismatch, please start over")
+                continue
+            elif '\x03' in response:
                 # Ctrl-C is part of the response -> clearly we should not pretend it's all good
                 raise KeyboardInterrupt
 

--- a/docs/casts/boxcom.sh
+++ b/docs/casts/boxcom.sh
@@ -1,0 +1,46 @@
+say "Many people that need to exchange data use cloud storage services."
+say "One of these services is 'box.com' -- they offer similar features as dropbox, but provide more storage for free (10GB at the moment)"
+say "Here is how DataLad can be configured to use box.com for data storage and exchange..."
+
+say "For the purpose of this demo, we'll set up a dataset that contains a 1MB file with some random binary data"
+run "datalad create demo"
+run "cd demo"
+run "datalad run dd if=/dev/urandom of=big.dat bs=1M count=1"
+
+say "Next we configure box.com as a remote storage location, using a git-annex command."
+say "Git-annex requires the login credentials to be given as environment variables. This demo uses a script that hides the real credentials and give some fake output to illustrate the basic idea"
+run ". ~/box.com_work.sh"
+say "Now for the actual box.com configuration."
+say "Key argument is the access URL: 'team/project_one' is where the data will be stored in the box.com account."
+run "git annex initremote box.com type=webdav url=https://dav.box.com/dav/team/project_one chunk=50mb encryption=none"
+say "The 'chunk' and 'encryption' arguments further tailor the setup. Files will be automatically split into chunks less than 50MB. This make synchronization faster, and allows for storing really large files. File can be encrypted before upload to prevent access without a secure key -- for this demo we opted to not use encryption"
+
+say "The next step is optional"
+say "We set up a (possibly private) GitHub repo to exchange/synchronize the dataset itself (but not its data). If you just want to have off-site data storage, but no collaboration with others, this is not needed"
+say "For this demo we opt to create the dataset at github.com/datalad/exchange-demo"
+run "datalad create-sibling-github --github-organization datalad --publish-depends box.com --access-protocol ssh exchange-demo"
+say "We configured DataLad to automatically copy data over to box.com when the dataset is published to GitHub, so we can achieve both in one step:"
+
+run "datalad publish --to github big.dat"
+run "git annex whereis"
+say "The data file was automatically copied to box.com"
+
+say "Now let's see how a collaborator could get access to the data(set)"
+say "Anyone with permission to access the dataset on GitHub can install it"
+run "cd ../"
+run "datalad install -s git@github.com:datalad/exchange-demo.git fromgh"
+
+say "DataLad has reported the presence of a storage sibling 'box.com'"
+say "Anyone with permission to access a box.com account that the original box.com folder has been shared with can get access to the stored content"
+run "datalad siblings -d ~/fromgh enable -s box.com"
+say "If DataLad does not yet know about a user's box.com account, the above command would have prompted the user to provide access credentials"
+
+say "Let's confirm that the newly installed dataset is only aware of the GitHub and box.com locations"
+run "cd fromgh"
+run "git remote -v"
+
+say "Now we can obtain the data file, without having to worry about where exactly it is hosted"
+run "datalad get big.dat"
+run "ls -sLh big.dat"
+
+say "Similar configurations are possible for any data storage solutions supported by git-annex. See https://git-annex.branchable.com/special_remotes for more info."


### PR DESCRIPTION
- [x] `AnnexRepo.get_special_remotes()`
- [x] add support for enabling remotes when annex itself will not do it. One case is the webdav special remotes that requires user and password to be supplied in addition -- we could get then from the cred store and supply them: `AnnexRepo.enable_special_remote()`
- [x] probably worth supporting this low-level functionality through the `siblings` command -- come up with a good concept
- [x] check that auto-enabling a special remote during install doesn't fail the entire process if the password is mistyped (or a wrong one is given due to #1779)
 Related issues
- [x] fixes #1775 
- [x] fixes #1779 
- [x] fixes #1780 
- [x] new `siblings enable` subcommand can enable webdav special remotes, either with credential entry or automatic when credentials are already known
- [x] https://asciinema.org/a/136015