### PR TITLE
ENH: create --text-to-git to establish .gitattributes so that text file to git

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -141,6 +141,16 @@ class Add(Interface):
             as it inflates dataset sizes and impacts flexibility of data
             transport. If not specified - it will be up to git-annex to
             decide, possibly on .gitattributes options."""),
+        to_annex=Parameter(
+            args=("--to-annex",),
+            action='store_false',
+            dest='to_git',
+            doc="""flag whether to force adding data to Annex, instead of
+        git.  It might be that .gitattributes instructs for a file to be
+        added to git, but for some particular files it is desired to be
+        added to annex (e.g. sensitive files etc).
+        If not specified - it will be up to git-annex to
+        decide, possibly on .gitattributes options."""),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         # TODO not functional anymore
@@ -178,7 +188,6 @@ class Add(Interface):
             annex_opts=None,
             annex_add_opts=None,
             jobs=None):
-
         # parameter constraints:
         if not path:
             raise InsufficientArgumentsError(

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -306,7 +306,7 @@ class Create(Interface):
                 git_attributes_file = opj(tbds.path, '.gitattributes')
                 with open(git_attributes_file, 'a') as f:
                     f.write('* annex.largefiles=(not(mimetype=text/*))\n')
-                tbrepo.add(git_attributes_file, git=True)
+                tbrepo.add([git_attributes_file], git=True)
                 tbrepo.commit(
                     "Instructed annex to add text files to git",
                     _datalad_msg=True,

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -118,6 +118,14 @@ class Create(Interface):
             doc="""if set, a plain Git repository will be created without any
             annex""",
             action='store_true'),
+        text_to_git=Parameter(
+            args=("--text-to-git",),
+            doc="""if set, all text files in the future would be added to Git,
+            not annex. Achieved by adding an entry to .gitattributes file. See
+            http://git-annex.branchable.com/tips/largefiles/ and `no_annex`
+            DataLad plugin to establish even more detailed control over which
+            files are added to git and which to annex.""",
+            action='store_true'),
         save=nosave_opt,
         # TODO could move into cfg_annex plugin
         annex_version=Parameter(
@@ -169,7 +177,9 @@ class Create(Interface):
             shared_access=None,
             git_opts=None,
             annex_opts=None,
-            annex_init_opts=None):
+            annex_init_opts=None,
+            text_to_git=None
+    ):
 
         # two major cases
         # 1. we got a `dataset` -> we either want to create it (path is None),
@@ -289,7 +299,9 @@ class Create(Interface):
                 description=description,
                 git_opts=git_opts,
                 annex_opts=annex_opts,
-                annex_init_opts=annex_init_opts)
+                annex_init_opts=annex_init_opts,
+                text_to_git=text_to_git
+            )
 
         if native_metadata_type is not None:
             if not isinstance(native_metadata_type, list):
@@ -312,6 +324,8 @@ class Create(Interface):
         with open(opj(tbds.path, '.datalad', '.gitattributes'), 'a') as gitattr:
             # TODO this will need adjusting, when annex'ed aggregate meta data
             # comes around
+            gitattr.write('# Text files (according to file --mime-type) are added directly to git.\n')
+            gitattr.write('# See http://git-annex.branchable.com/tips/largefiles/ for more info.\n')
             gitattr.write('** annex.largefiles=nothing\n')
 
         # save everything, we need to do this now and cannot merge with the

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -309,6 +309,7 @@ def test_add_subdataset(path, other):
 @with_tree(tree={
     'file.txt': 'some text',
     'empty': '',
+    'file2.txt': 'some text to go to annex',
     '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
 )
 def test_add_mimetypes(path):
@@ -321,7 +322,11 @@ def test_add_mimetypes(path):
     ds.repo.commit('added attributes to git explicitly')
     # now test that those files will go into git/annex correspondingly
     __not_tested__ = ds.add(['file.txt', 'empty'])
-    ok_clean_git(path)
+    ok_clean_git(path, untracked=['file2.txt'])
     # Empty one considered to be  application/octet-stream  i.e. non-text
     ok_file_under_git(path, 'empty', annexed=True)
     ok_file_under_git(path, 'file.txt', annexed=False)
+
+    # But we should be able to force adding file to annex when desired
+    ds.add('file2.txt', to_git=False)
+    ok_file_under_git(path, 'file2.txt', annexed=True)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -282,8 +282,8 @@ def test_create_withplugin(path):
 
 
 @with_tempfile(mkdir=True)
-def test_create_text_to_git(path):
-    ds = create(path, text_to_git=True)
+def test_create_text_no_annex(path):
+    ds = create(path, text_no_annex=True)
     ok_clean_git(path)
     import re
     ok_file_has_content(

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -16,9 +16,11 @@ from os.path import lexists
 from ..dataset import Dataset
 from datalad.api import create
 from datalad.utils import chpwd
+from datalad.utils import _path_
 from datalad.cmd import Runner
 
 from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import create_tree
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_
 from datalad.tests.utils import assert_not_in
@@ -29,6 +31,8 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tree
+from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import ok_file_under_git
 
 
 _dataset_hierarchy_template = {
@@ -275,3 +279,29 @@ def test_create_withplugin(path):
     # TODO implement `nice_dataset` plugin to give sensible
     # default and avoid that
     assert(lexists(opj(ds.path, 'with hole.txt')))
+
+
+@with_tempfile(mkdir=True)
+def test_create_text_to_git(path):
+    ds = create(path, text_to_git=True)
+    ok_clean_git(path)
+    import re
+    ok_file_has_content(
+        _path_(path, '.gitattributes'),
+        content='\* annex\.largefiles=\(not\(mimetype=text/\*\)\)',
+        re_=True,
+        match=False,
+        flags=re.MULTILINE
+    )
+    # and check that it is really committing text files to git and binaries
+    # to annex
+    create_tree(path,
+        {
+            't': 'some text',
+            'b': ''  # empty file is not considered to be a text file
+                     # should we adjust the rule to consider only non empty files?
+        }
+    )
+    ds.add(['t', 'b'])
+    ok_file_under_git(path, 't', annexed=False)
+    ok_file_under_git(path, 'b', annexed=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -108,7 +108,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                  direct=None, backend=None, always_commit=True, create=True,
                  init=False, batch_size=None, version=None, description=None,
                  git_opts=None, annex_opts=None, annex_init_opts=None,
-                 repo=None, text_to_git=None):
+                 repo=None):
         """Creates representation of git-annex repository at `path`.
 
         AnnexRepo is initialized by giving a path to the annex.
@@ -150,12 +150,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         description: str, optional
           short description that humans can use to identify the
           repository/location, e.g. "Precious data on my laptop"
-        text_to_git: bool, optional
-          If True, add `* annex.largefiles=(not(mimetype=text/*))` to 
-          .gitattributes thus making annex by default add all text files to git
-          while the rest to annex. See  http://git-annex.branchable.com/tips/largefiles/
-          for more detailed control over which files would be added to git or annex
-          upon `git annex add` or `datalad add` commands 
         """
         if self.git_annex_version is None:
             self._check_git_annex_version()
@@ -257,14 +251,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         if backend:
             self.set_default_backend(backend, persistent=True)
 
-        if text_to_git:
-            git_attributes_file = _path_(self.path, '.gitattributes')
-            with open(git_attributes_file, 'a') as f:
-                f.write('* annex.largefiles=(not(mimetype=text/*))\n')
-            self.add(git_attributes_file, git=True)
-            self.commit("Instructed annex to add text files to git",
-                        _datalad_msg=True,
-                        files=[git_attributes_file])
 
     def set_default_backend(self, backend, persistent=True, commit=True):
         """Set default backend

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -108,7 +108,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                  direct=None, backend=None, always_commit=True, create=True,
                  init=False, batch_size=None, version=None, description=None,
                  git_opts=None, annex_opts=None, annex_init_opts=None,
-                 repo=None):
+                 repo=None, text_to_git=None):
         """Creates representation of git-annex repository at `path`.
 
         AnnexRepo is initialized by giving a path to the annex.
@@ -150,6 +150,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         description: str, optional
           short description that humans can use to identify the
           repository/location, e.g. "Precious data on my laptop"
+        text_to_git: bool, optional
+          If True, add `* annex.largefiles=(not(mimetype=text/*))` to 
+          .gitattributes thus making annex by default add all text files to git
+          while the rest to annex. See  http://git-annex.branchable.com/tips/largefiles/
+          for more detailed control over which files would be added to git or annex
+          upon `git annex add` or `datalad add` commands 
         """
         if self.git_annex_version is None:
             self._check_git_annex_version()
@@ -250,6 +256,15 @@ class AnnexRepo(GitRepo, RepoInterface):
         # the annex, in case there are annexed files already?
         if backend:
             self.set_default_backend(backend, persistent=True)
+
+        if text_to_git:
+            git_attributes_file = _path_(self.path, '.gitattributes')
+            with open(git_attributes_file, 'a') as f:
+                f.write('* annex.largefiles=(not(mimetype=text/*))\n')
+            self.add(git_attributes_file, git=True)
+            self.commit("Instructed annex to add text files to git",
+                        _datalad_msg=True,
+                        files=[git_attributes_file])
 
     def set_default_backend(self, backend, persistent=True, commit=True):
         """Set default backend


### PR DESCRIPTION
It became a frequent practice for me to create such a .gitattributes file nearly for many datasets
I was creating locally for practice etc.  Even though there is `no_annex` plugin, it is not really visible (now it will be in `create --help`) and ATM lacks even option for such mode. 
And once again -- I think extensibility of plugins is great but most common operations should have clear and concise options available