### PR TITLE
WiP: Borrow pieces from NumPy to run the tests without needing entire numpy for that purpose

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -41,3 +41,4 @@ authors if you are to use corresponding parts.
    - [BlueImp-MD5](https://github.com/blueimp/JavaScript-MD5) - MIT License - Copyright (c) 2016-
    - [QUnit](https://qunitjs.com/) - MIT License - Copyright (c)
    - [Sinon-QUnit Plugin](http://sinonjs.org/qunit/) - BSD License - Copyright (c) 2010-2011
+   - [NumPy Testing](http://numpy.org) - BSD license - Copyright (c) 2005- NumPy Developers <numpy-dev@numpy.org>

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -56,33 +56,9 @@ atexit.register(lgr.log, 5, "Exiting")
 
 from .version import __version__
 
-# Class allows us to save the results of the tests in runTests - see runTests
-# method docstring for details
-import nose
-class NumpyTestProgram(nose.core.TestProgram):
-    def runTests(self):
-        """Run Tests. Returns true on success, false on failure, and
-        sets self.success to the same value.
-
-        Because nose currently discards the test result object, but we need
-        to return it to the user, override TestProgram.runTests to retain
-        the result
-        """
-        if self.testRunner is None:
-            self.testRunner = nose.core.TextTestRunner(stream=self.config.stream,
-                                                       verbosity=self.config.verbosity,
-                                                       config=self.config)
-        plug_runner = self.config.plugins.prepareTestRunner(self.testRunner)
-        if plug_runner is not None:
-            self.testRunner = plug_runner
-        self.result = self.testRunner.run(self.test)
-        self.success = self.result.wasSuccessful()
-        return self.success
-
 def test(verbose=False, nocapture=False, pdb=False, stop=False):
     """A helper to run datalad's tests.  Requires nose
     """
-    import nose
     argv = ['datalad']
     # could make it 'smarter' but decided to be explicit so later we could
     # easily migrate to another runner without changing any API here
@@ -94,8 +70,8 @@ def test(verbose=False, nocapture=False, pdb=False, stop=False):
         argv.append('--pdb')
     if stop:
         argv.append('--stop')
-    #return nose.main('datalad', argv=argv, exit=False)
-    NumpyTestProgram(argv=argv, exit=False)
+    from datalad.support.third.nosetester import NoseTester
+    NoseTester('datalad').test(extra_argv=argv)
 
 test.__test__ = False
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -56,10 +56,11 @@ atexit.register(lgr.log, 5, "Exiting")
 
 from .version import __version__
 
-def test(verbose=False, nocapture=False, pdb=False, stop=False):
+
+def test(module='datalad', verbose=False, nocapture=False, pdb=False, stop=False):
     """A helper to run datalad's tests.  Requires nose
     """
-    argv = ['datalad']
+    argv = [] #module]
     # could make it 'smarter' but decided to be explicit so later we could
     # easily migrate to another runner without changing any API here
     if verbose:
@@ -71,8 +72,8 @@ def test(verbose=False, nocapture=False, pdb=False, stop=False):
     if stop:
         argv.append('--stop')
     from datalad.support.third.nosetester import NoseTester
-    tester = NoseTester('datalad')
-    tester.package_name = 'datalad'  # butt plug
+    tester = NoseTester(module)
+    tester.package_name = module.split('.', 1)[0]
     tester.test(extra_argv=argv)
 
 test.__test__ = False

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -71,7 +71,9 @@ def test(verbose=False, nocapture=False, pdb=False, stop=False):
     if stop:
         argv.append('--stop')
     from datalad.support.third.nosetester import NoseTester
-    NoseTester('datalad').test(extra_argv=argv)
+    tester = NoseTester('datalad')
+    tester.package_name = 'datalad'  # butt plug
+    tester.test(extra_argv=argv)
 
 test.__test__ = False
 

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -15,16 +15,39 @@ __docformat__ = 'restructuredtext'
 import datalad
 from .base import Interface
 from datalad.interface.base import build_doc
+from ..support.param import Parameter
 
 
 @build_doc
 class Test(Interface):
     """Run internal DataLad (unit)tests.
 
-    This can be used to verify correct operation on the system
+    This can be used to verify correct operation on the system.
+    It is just a thin wrapper around a call to nose, so number of 
+    exposed options is minimal
     """
     # XXX prevent common args from being added to the docstring
     _no_eval_results = True
+
+    _params_ = dict(
+        verbose=Parameter(
+            args=("-v", "--verbose"),
+            action="store_true",
+            doc="be verbose - list test names"),
+        nocapture=Parameter(
+            args=("-s", "--nocapture"),
+            action="store_true",
+            doc="do not capture stdout"),
+        pdb=Parameter(
+            args=("--pdb",),
+            action="store_true",
+            doc="drop into debugger on failures or errors"),
+        stop=Parameter(
+            args=("-x", "--stop"),
+            action="store_true",
+            doc="stop running tests after the first error or failure")
+    )
+
     @staticmethod
-    def __call__():
-        datalad.test()
+    def __call__(verbose=False, nocapture=False, pdb=False, stop=False):
+        datalad.test(verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -45,9 +45,13 @@ class Test(Interface):
         stop=Parameter(
             args=("-x", "--stop"),
             action="store_true",
-            doc="stop running tests after the first error or failure")
+            doc="stop running tests after the first error or failure"),
+        module=Parameter(
+            args=("module",),
+            nargs="?",
+            doc="be verbose - list test names"),
     )
 
     @staticmethod
-    def __call__(verbose=False, nocapture=False, pdb=False, stop=False):
-        datalad.test(verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)
+    def __call__(module='datalad', verbose=False, nocapture=False, pdb=False, stop=False):
+        datalad.test(module=module, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/support/third/noseclasses.py
+++ b/datalad/support/third/noseclasses.py
@@ -10,14 +10,13 @@ import os
 import doctest
 import inspect
 
-import numpy
 import nose
 from nose.plugins import doctests as npd
 from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
 from nose.plugins.base import Plugin
 from nose.util import src
 from .nosetester import get_package_name
-from .utils import KnownFailureException, KnownFailureTest
+#from .utils import KnownFailureException, KnownFailureTest
 
 
 # Some of the classes in this module begin with 'Numpy' to clearly distinguish
@@ -145,8 +144,6 @@ class NumpyDocTestCase(npd.DocTestCase):
                                      checker=checker)
 
 
-print_state = numpy.get_printoptions()
-
 class NumpyDoctest(npd.Doctest):
     name = 'numpydoctest'   # call nosetests with --with-numpydoctest
     score = 1000  # load late, after doctest builtin
@@ -215,10 +212,11 @@ class NumpyDoctest(npd.Doctest):
         #
         # Note: __file__ allows the doctest in NoseTester to run
         # without producing an error
-        test.globs = {'__builtins__':__builtins__,
+        test.globs = {#'__builtins__':__builtins__,
                       '__file__':'__main__',
                       '__name__':'__main__',
-                      'np':numpy}
+                      #'np':numpy
+        }
         # add appropriate scipy import for SciPy tests
         if 'scipy' in pkg_name:
             p = pkg_name.split('.')
@@ -257,7 +255,8 @@ class NumpyDoctest(npd.Doctest):
     # Add an afterContext method to nose.plugins.doctests.Doctest in order
     # to restore print options to the original state after each doctest
     def afterContext(self):
-        numpy.set_printoptions(**print_state)
+        # numpy.set_printoptions(**print_state)
+        pass
 
     # Ignore NumPy-specific build files that shouldn't be searched for tests
     def wantFile(self, file):
@@ -288,33 +287,33 @@ class Unplugger(object):
                                   if p.name != self.to_unplug]
 
 
-class KnownFailurePlugin(ErrorClassPlugin):
-    '''Plugin that installs a KNOWNFAIL error class for the
-    KnownFailureClass exception.  When KnownFailure is raised,
-    the exception will be logged in the knownfail attribute of the
-    result, 'K' or 'KNOWNFAIL' (verbose) will be output, and the
-    exception will not be counted as an error or failure.'''
-    enabled = True
-    knownfail = ErrorClass(KnownFailureException,
-                           label='KNOWNFAIL',
-                           isfailure=False)
-
-    def options(self, parser, env=os.environ):
-        env_opt = 'NOSE_WITHOUT_KNOWNFAIL'
-        parser.add_option('--no-knownfail', action='store_true',
-                          dest='noKnownFail', default=env.get(env_opt, False),
-                          help='Disable special handling of KnownFailure '
-                               'exceptions')
-
-    def configure(self, options, conf):
-        if not self.can_configure:
-            return
-        self.conf = conf
-        disable = getattr(options, 'noKnownFail', False)
-        if disable:
-            self.enabled = False
-
-KnownFailure = KnownFailurePlugin   # backwards compat
+# class KnownFailurePlugin(ErrorClassPlugin):
+#     '''Plugin that installs a KNOWNFAIL error class for the
+#     KnownFailureClass exception.  When KnownFailure is raised,
+#     the exception will be logged in the knownfail attribute of the
+#     result, 'K' or 'KNOWNFAIL' (verbose) will be output, and the
+#     exception will not be counted as an error or failure.'''
+#     enabled = True
+#     knownfail = ErrorClass(KnownFailureException,
+#                            label='KNOWNFAIL',
+#                            isfailure=False)
+#
+#     def options(self, parser, env=os.environ):
+#         env_opt = 'NOSE_WITHOUT_KNOWNFAIL'
+#         parser.add_option('--no-knownfail', action='store_true',
+#                           dest='noKnownFail', default=env.get(env_opt, False),
+#                           help='Disable special handling of KnownFailure '
+#                                'exceptions')
+#
+#     def configure(self, options, conf):
+#         if not self.can_configure:
+#             return
+#         self.conf = conf
+#         disable = getattr(options, 'noKnownFail', False)
+#         if disable:
+#             self.enabled = False
+#
+# KnownFailure = KnownFailurePlugin   # backwards compat
 
 
 # Class allows us to save the results of the tests in runTests - see runTests


### PR DESCRIPTION
I have failed to pick out exactly how to invoke bloody nose.run so it works also outside of the code base, so decided to just copy those pieces into our code base and trim connections to NumPy so we could just still use their runner for now.
Needed so we could test 'as installed' datalad without needing numpy

might abandon it altogether so do not merge

note that anyways - `datalad test` doesn't work if datalad is built using nuitka for execution as a standalone (`--exe` mode) since nose would not be able to find datalad module