### PR TITLE
BF: publish if only updates to git-annex, do not puke if remote is ignored by annex

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -239,6 +239,13 @@ class Dataset(object):
                 self._cfg = self.repo.config
         return self._cfg
 
+    def is_remote_annex_ignored(self, remote):
+        """Return True if remote is explicitly ignored"""
+        return self.config.getbool(
+            'remote.{}'.format(remote), 'annex-ignore',
+            default=False
+        )
+
     def get_subdatasets(self, pattern=None, fulfilled=None, absolute=False,
                         recursive=False, recursion_limit=None, edges=False):
         # TODO wipe this function out completely once we are comfortable

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -239,13 +239,6 @@ class Dataset(object):
                 self._cfg = self.repo.config
         return self._cfg
 
-    def is_remote_annex_ignored(self, remote):
-        """Return True if remote is explicitly ignored"""
-        return self.config.getbool(
-            'remote.{}'.format(remote), 'annex-ignore',
-            default=False
-        )
-
     def get_subdatasets(self, pattern=None, fulfilled=None, absolute=False,
                         recursive=False, recursion_limit=None, edges=False):
         # TODO wipe this function out completely once we are comfortable

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -69,13 +69,13 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     is_annex_repo = isinstance(ds.repo, AnnexRepo)
 
     def _publish_data():
-        if ds.is_remote_annex_ignored(remote):
+        if ds.repo.is_remote_annex_ignored(remote):
             return [], []  # Cannot publish any data
         try:
             remote_wanted = ds.repo.get_preferred_content('wanted', remote)
         except CommandError as exc:
             if "cannot determine uuid" in str(exc):
-                if not ds.is_remote_annex_ignored(remote):
+                if not ds.repo.is_remote_annex_ignored(remote):
                     lgr.warning(
                         "Annex failed to determine UUID, skipping publishing data for now: %s",
                         exc_str(exc)
@@ -181,7 +181,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     #     if annex_uuid is None:
     #         # most probably not yet 'known' and might require some annex
     knew_remote_uuid = None
-    if is_annex_repo and not ds.is_remote_annex_ignored(remote):
+    if is_annex_repo and not ds.repo.is_remote_annex_ignored(remote):
         try:
             ds.repo.get_preferred_content('wanted', remote)  # could be just checking config.remote.uuid
             knew_remote_uuid = True

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -289,7 +289,8 @@ class Siblings(Interface):
             **dict(
                 res,
                 path=path,
-                with_annex='+' if 'annex-uuid' in res else '-',
+                with_annex='+' if 'annex-uuid' in res \
+                    else ('-' if res.get('annex-ignore', None) else '?'),
                 spec=spec)))
 
 
@@ -615,15 +616,29 @@ def _query_remotes(
             if annex_description is not None:
                 info['annex-description'] = annex_description
         if get_annex_info and isinstance(ds.repo, AnnexRepo):
-            if not ds.is_remote_annex_ignored(remote):
-                for prop in ('wanted', 'required', 'group'):
-                    var = ds.repo.get_preferred_content(
-                        prop, '.' if remote == 'here' else remote)
-                    if var:
-                        info['annex-{}'.format(prop)] = var
-                groupwanted = ds.repo.get_groupwanted(remote)
-                if groupwanted:
-                    info['annex-groupwanted'] = groupwanted
+            if not ds.repo.is_remote_annex_ignored(remote):
+                try:
+                    for prop in ('wanted', 'required', 'group'):
+                        var = ds.repo.get_preferred_content(
+                            prop, '.' if remote == 'here' else remote)
+                        if var:
+                            info['annex-{}'.format(prop)] = var
+                    groupwanted = ds.repo.get_groupwanted(remote)
+                    if groupwanted:
+                        info['annex-groupwanted'] = groupwanted
+                except CommandError as exc:
+                    if 'cannot determine uuid' in str(exc):
+                        # not an annex (or no connection), would be marked as
+                        #  annex-ignore
+                        msg = "Failed to determine if %s carries annex." % remote
+                        ds.repo.config.reload()
+                        if ds.repo.is_remote_annex_ignored(remote):
+                            msg += " Remote was marked by annex as annex-ignore.  " \
+                                   "Edit .git/config to reset if you think that was done by mistake due to absent connection etc"
+                        lgr.warning(msg)
+                        info['annex-ignore'] = True
+                    else:
+                        raise
             else:
                 info['annex-ignore'] = True
 

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -615,14 +615,17 @@ def _query_remotes(
             if annex_description is not None:
                 info['annex-description'] = annex_description
         if get_annex_info and isinstance(ds.repo, AnnexRepo):
-            for prop in ('wanted', 'required', 'group'):
-                var = ds.repo.get_preferred_content(
-                    prop, '.' if remote == 'here' else remote)
-                if var:
-                    info['annex-{}'.format(prop)] = var
-            groupwanted = ds.repo.get_groupwanted(remote)
-            if groupwanted:
-                info['annex-groupwanted'] = groupwanted
+            if not ds.is_remote_annex_ignored(remote):
+                for prop in ('wanted', 'required', 'group'):
+                    var = ds.repo.get_preferred_content(
+                        prop, '.' if remote == 'here' else remote)
+                    if var:
+                        info['annex-{}'.format(prop)] = var
+                groupwanted = ds.repo.get_groupwanted(remote)
+                if groupwanted:
+                    info['annex-groupwanted'] = groupwanted
+            else:
+                info['annex-ignore'] = True
 
         info['status'] = 'ok'
         yield info

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -338,6 +338,14 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
     eq_({sub1.path, sub2.path},
         set(result_paths))
 
+    # if we publish again -- nothing to be published
+    eq_(source.publish(to="target"), ([], []))
+    # if we drop a file and publish again -- dataset should be published
+    # since git-annex branch was updated
+    source.drop('test-annex.dat')
+    eq_(source.publish(to="target"), ([source], []))
+    eq_(source.publish(to="target"), ([], []))  # and empty again if we try again
+
 
 @skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import with_tempfile, assert_in, \
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_result_count
+from datalad.tests.utils import neq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import create_tree
@@ -133,14 +134,18 @@ def test_publish_simple(origin, src_path, dst_path):
 
 
 @with_testrepos('submodule_annex', flavors=['local'])
+@with_tempfile
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
+def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
+    # we will be publishing back to origin, so to not alter testrepo
+    # we will first clone it
+    origin = install(origin_path, source=pristine_origin, recursive=True)
     # prepare src
-    source = install(src_path, source=origin, recursive=True)
+    source = install(src_path, source=origin_path, recursive=True)
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
@@ -194,6 +199,19 @@ def test_publish_recursive(origin, src_path, dst_path, sub1_pub, sub2_pub):
         list(sub2.get_branch_commits("master")))
     eq_(list(sub2_target.get_branch_commits("git-annex")),
         list(sub2.get_branch_commits("git-annex")))
+
+    # we are tracking origin but origin has different git-annex, since we
+    # cloned from it, so it is not aware of our git-annex
+    neq_(list(origin.repo.get_branch_commits("git-annex")),
+         list(source.repo.get_branch_commits("git-annex")))
+    # So if we first publish to it recursively, we would update
+    # all sub-datasets since git-annex branch would need to be pushed
+    res_ = publish(dataset=source, recursive=True)
+    eq_(set(r.path for r in res_[0]),
+        set(opj(*([source.path] + x)) for x in ([], ['subm 1'], ['subm 2'])))
+    # and now should carry the same state for git-annex
+    eq_(list(origin.repo.get_branch_commits("git-annex")),
+        list(source.repo.get_branch_commits("git-annex")))
 
     # test for publishing with  --since.  By default since no changes, nothing pushed
     res_ = publish(dataset=source, recursive=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -868,6 +868,13 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         return self._annex_custom_command([], ["git", "annex", "dead", name])
 
+    def is_remote_annex_ignored(self, remote):
+        """Return True if remote is explicitly ignored"""
+        return self.config.getbool(
+            'remote.{}'.format(remote), 'annex-ignore',
+            default=False
+        )
+
     def is_special_annex_remote(self, remote, check_if_known=True):
         """Return either remote is a special annex remote
 


### PR DESCRIPTION

Closes #1667 -- had to fix up some assumptions in the test.  Before publish would not publish anything if there were changes only in git-annex, e.g. you just installed the dataset .  But that means you got updates to git-annex and for consistency, or to share possibly info about files you also got, publish should push git-annex branch even if there were no other changes

Closes #1669 -- caught exception and issued a descriptive warning