### PR TITLE
BF: make multiple invocations for get/copy if too many files listed

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -52,6 +52,8 @@ from datalad.utils import on_windows
 from datalad.utils import swallow_logs
 from datalad.utils import assure_list
 from datalad.utils import _path_
+from datalad.utils import generate_chunks
+from datalad.utils import CMD_MAX_ARG
 from datalad.cmd import GitRunner
 
 # imports from same module:
@@ -1251,9 +1253,15 @@ class AnnexRepo(GitRepo, RepoInterface):
         # TODO: provide more meaningful message (possibly aggregating 'note'
         #  from annex failed ones
         with cm:
+            # TODO: reproduce DK's bug on OSX, and either switch to
+            #  --batch mode (I don't think we have --progress support in long
+            #  alive batch processes ATM),
+            #
             results = self._run_annex_command_json(
                 'get',
-                args=options + fetch_files,
+                args=options,
+                # TODO: eventually make use of --batch mode
+                files=fetch_files,
                 jobs=jobs,
                 expected_entries=expected_downloads)
         results_list = list(results)
@@ -2121,7 +2129,9 @@ class AnnexRepo(GitRepo, RepoInterface):
             assert(remotes[self.WEB_UUID]['description'] == 'web')
         return remotes
 
-    def _run_annex_command_json(self, command, args=None, jobs=None,
+    def _run_annex_command_json(self, command, args=None,
+                                jobs=None,
+                                files=[],
                                 expected_entries=None, **kwargs):
         """Run an annex command with --json and load output results into a tuple of dicts
 
@@ -2149,10 +2159,23 @@ class AnnexRepo(GitRepo, RepoInterface):
                 annex_options += ['-J%d' % jobs]
             if args:
                 annex_options += args
-            out, err = self._run_annex_command(
-                command,
-                annex_options=annex_options,
-                **kwargs)
+
+            # TODO: RF to use --batch where possible instead of splitting
+            # into multiple invocations
+            if not files:
+                file_chunks = [[]]
+            else:
+                maxl = max(map(len, files))
+                chunk_size = CMD_MAX_ARG // maxl
+                file_chunks = generate_chunks(files, chunk_size)
+            out, err = "", ""
+            for file_chunk in file_chunks:
+                out_, err_ = self._run_annex_command(
+                    command,
+                    annex_options=annex_options + file_chunk,
+                    **kwargs)
+                out += out_
+                err += err_
         except CommandError as e:
             # Note: A call might result in several 'failures', that can be or
             # cannot be handled here. Detection of something, we can deal with,
@@ -2844,7 +2867,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         with cm:
             results = self._run_annex_command_json(
                 'copy',
-                args=annex_options + copy_files,
+                args=annex_options,
+                files=copy_files,
                 jobs=jobs,
                 expected_entries=expected_copys
                 #log_stdout=True, log_stderr=not log_online,
@@ -3197,8 +3221,6 @@ class BatchedAnnex(object):
         Parameters
         ----------
         cmds : str or tuple or list of (str or tuple)
-        output_proc : callable
-          To provide handling
 
         Returns
         -------

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -48,6 +48,7 @@ from ..utils import get_timestamp_suffix
 from ..utils import get_trace
 from ..utils import get_dataset_root
 from ..utils import better_wraps
+from ..utils import generate_chunks
 
 from ..support.annexrepo import AnnexRepo
 
@@ -372,6 +373,18 @@ def test_assure_bool():
         for v in values:
             eq_(assure_bool(v), t)
     assert_raises(ValueError, assure_bool, "unknown")
+
+
+def test_generate_chunks():
+    ok_generator(generate_chunks([1], 1))
+    eq_(list(generate_chunks([1], 1)), [[1]])
+    eq_(list(generate_chunks([1], 2)), [[1]])
+    eq_(list(generate_chunks([1, 2, 3], 2)), [[1, 2], [3]])
+    # type is preserved
+    eq_(list(generate_chunks((1, 2, 3), 2)), [(1, 2), (3,)])
+    # no hangers
+    eq_(list(generate_chunks((1, 2, 3, 4), 2)), [(1, 2), (3, 4)])
+    assert_raises(AssertionError, list, generate_chunks([1], 0))
 
 
 def test_any_re_search():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -66,6 +66,12 @@ except:  # pragma: no cover
     on_debian_wheezy = False
     linux_distribution_name = linux_distribution_release = None
 
+# Maximal length of cmdline string
+# Did not find anything in Python which could tell at run time and
+# probably   getconf ARG_MAX   might not be available
+# The last one would be the most conservative/Windows
+CMD_MAX_ARG = 2097152 if on_linux else 262144 if on_osx else 32767
+
 #
 # Little helpers
 #
@@ -522,6 +528,15 @@ def unique(seq, key=None):
         # should be just as fine
         return [x for x in seq if not (key(x) in seen or seen_add(key(x)))]
 
+
+def generate_chunks(container, size):
+    """Given a container, generate chunks from it with size up to `size`
+    """
+    # There could be a "smarter" solution but I think this would suffice
+    assert size > 0,  "Size should be non-0 positive"
+    while container:
+        yield container[:size]
+        container = container[size:]
 
 #
 # Generators helpers


### PR DESCRIPTION
Ideally we should just use --batch mode for get, but it is N/A for copy ATM, so decided to implement this "do in groups of files" for get/copy

Closes #1683 