### PR TITLE
TST: Add a test for publishing recursively with absent subdatasets

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -588,9 +588,12 @@ class Publish(Interface):
             else:
                 # this is a dataset
                 if ap.get('state', None) == 'absent':
-                    ap['status'] = 'impossible'
-                    ap['message'] = 'subdataset is not installed'
-                    yield ap
+                    if ap.get('raw_input', False):
+                        # if this was requested, it is a problem, otherwise it can
+                        # be ignored
+                        ap['status'] = 'impossible'
+                        ap['message'] = 'subdataset is not installed'
+                        yield ap
                     continue
                 # if this is a dataset, get the remote info for itself
                 remote_info_result = _get_remote_info(

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -467,6 +467,7 @@ def test_gh1426(origin_path, target_path):
     eq_(origin.repo.get_hexsha(), target.get_hexsha())
 
 
+@skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -488,9 +488,12 @@ def test_publish_gh1691(origin, src_path, dst_path):
         'ssh://localhost:' + dst_path,
         name='target', recursive=True)
 
-    # publish recursively:
+    # publish recursively, which silently ignores non-installed datasets
     results = source.publish(to='target', recursive=True)
-    # Note: ATM we get an IncompleteResultsError!
     assert_result_count(results, 1)
     assert_result_count(results, 1, status='ok', type='dataset', path=source.path)
+
+    # if however, a non-installed subdataset is requsted explicitly, it'll fail
+    results = source.publish(path='subm 1', to='target', on_failure='ignore')
+    assert_result_count(results, 1, status='impossible', type='dataset', action='publish')
 


### PR DESCRIPTION
Demonstrating #1691, and the fix.