### PR TITLE
Misc RF+ENH for `save`

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -474,7 +474,7 @@ class Add(Interface):
         # more comprehensible
         for res in Save.__call__(
                 # hand-selected annotated paths
-                files=to_save,
+                path=to_save,
                 dataset=refds_path,
                 message=message if message else '[DATALAD] added content',
                 return_type='generator',

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -273,7 +273,7 @@ class Remove(Interface):
 
         for res in Save.__call__(
                 # TODO compose hand-selected annotated paths
-                files=to_save,
+                path=to_save,
                 # we might have removed the reference dataset by now, recheck
                 dataset=refds_path if GitRepo.is_valid_repo(refds_path) else None,
                 # TODO allow for custom message

--- a/datalad/interface/crawl_init.py
+++ b/datalad/interface/crawl_init.py
@@ -109,4 +109,4 @@ class CrawlInit(Interface):
             from datalad.api import save
             ds = Dataset(curdir)
             ds.repo.add(configfile, git=True)
-            ds.save("committing crawl config file", files=[configfile])
+            ds.save("committing crawl config file", path=configfile)

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -163,11 +163,11 @@ class Save(Interface):
             doc=""""specify the dataset to save. If a dataset is given, but
             no `files`, the entire dataset will be saved.""",
             constraints=EnsureDataset() | EnsureNone()),
-        files=Parameter(
-            args=("files",),
-            metavar='FILES',
-            doc="""list of files to consider. If given, only changes made
-            to those files are recorded in the new state.""",
+        path=Parameter(
+            args=("path",),
+            metavar='PATH',
+            doc="""path/name of the dataset component to save. If given, only
+            changes made to those components are recorded in the new state.""",
             nargs='*',
             constraints=EnsureStr() | EnsureNone()),
         message=save_message_opt,
@@ -194,8 +194,7 @@ class Save(Interface):
     @staticmethod
     @datasetmethod(name='save')
     @eval_results
-    # TODO files -> path
-    def __call__(message=None, files=None, dataset=None,
+    def __call__(message=None, path=None, dataset=None,
                  all_updated=True, all_changes=None, version_tag=None,
                  recursive=False, recursion_limit=None, super_datasets=False
                  ):
@@ -206,7 +205,7 @@ class Save(Interface):
                 version="0.5.0",
                 msg="RF: all_changes option passed to the save"
             )
-        if not dataset and not files:
+        if not dataset and not path:
             # we got nothing at all -> save what is staged in the repo in "this" directory?
             # we verify that there is an actual repo next
             dataset = abspath(curdir)
@@ -214,7 +213,7 @@ class Save(Interface):
 
         to_process = []
         for ap in AnnotatePaths.__call__(
-                path=files,
+                path=path,
                 dataset=refds_path,
                 recursive=recursive,
                 recursion_limit=recursion_limit,

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -168,7 +168,7 @@ def test_recursive_save(path):
     assert_status('notneeded', ds.save())
     # an explicit target saves only the corresponding dataset
     assert_result_values_equal(
-        save(files=[testfname]),
+        save(path=[testfname]),
         'path',
         [subsubds.path])
     # plain recursive without any files given will save the beast
@@ -214,7 +214,7 @@ def test_recursive_save(path):
                                      for d in (ds, subds, subsubds)]):
         assert_equal(old, new)
     # but now we are saving this untracked bit specifically
-    subsubds.save(message="savingtestmessage", files=['testnew2'],
+    subsubds.save(message="savingtestmessage", path=['testnew2'],
                   super_datasets=True)
     ok_clean_git(subsubds.repo)
     # but its super should have got only the subsub saved
@@ -240,7 +240,7 @@ def test_recursive_save(path):
     subsubds.save(message="saving new changes", all_updated=True)  # no super
     with chpwd(subds.path):
         # no explicit dataset is provided by path is provided
-        save(files=['subsub'], message='saving sub', super_datasets=True)
+        save(path=['subsub'], message='saving sub', super_datasets=True)
     # super should get it saved too
     assert_equal(next(ds.repo.get_branch_commits('master')).message.rstrip(),
                  'saving sub')
@@ -262,7 +262,7 @@ def test_subdataset_save(path):
 
     # `save sub` does not save the parent!!
     with chpwd(parent.path):
-        assert_status('notneeded', save(files=sub.path))
+        assert_status('notneeded', save(path=sub.path))
     ok_clean_git(parent.path, untracked=['untracked'], index_modified=['sub'])
     # `save -d .` saves the state change in the subdataset, but leaves any untracked
     # content alone
@@ -283,6 +283,6 @@ def test_subdataset_save(path):
             ['ok', 'notneeded'],
             # the key condition of this test is that no reference dataset is
             # given!
-            save(files='sub', super_datasets=True))
+            save(path='sub', super_datasets=True))
     # save super must not cause untracked content to be commited!
     ok_clean_git(parent.path, untracked=['untracked'])

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -147,14 +147,20 @@ def test_recursive_save(path):
     # at this point the entire tree is clean
     ok_clean_git(ds.path)
     states = [d.repo.get_hexsha() for d in (ds, subds, subsubds)]
-    # now we introduce new files all the way down
-    create_tree(subsubds.path, {"mike1": 'mike1'})
     # now we save recursively, nothing should happen
     res = ds.save(recursive=True)
     # we do not get any report from a subdataset, because we detect at the
     # very top that the entire tree is clean
     assert_result_count(res, 1)
     assert_result_count(res, 1, status='notneeded', action='save', path=ds.path)
+    # now we introduce new files all the way down
+    create_tree(subsubds.path, {"mike1": 'mike1'})
+    # because we cannot say from the top if there is anything to do down below,
+    # we have to traverse and we will get reports for all dataset, but there is
+    # nothing actually saved
+    res = ds.save(recursive=True)
+    assert_result_count(res, 3)
+    assert_status('notneeded', res)
     subsubds_indexed = subsubds.repo.get_indexed_files()
     assert_not_in('mike1', subsubds_indexed)
     assert_equal(states, [d.repo.get_hexsha() for d in (ds, subds, subsubds)])

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -29,6 +29,7 @@ from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import assert_equal
 from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_values_equal
 
@@ -149,7 +150,11 @@ def test_recursive_save(path):
     # now we introduce new files all the way down
     create_tree(subsubds.path, {"mike1": 'mike1'})
     # now we save recursively, nothing should happen
-    assert_status('notneeded', ds.save(recursive=True))
+    res = ds.save(recursive=True)
+    # we do not get any report from a subdataset, because we detect at the
+    # very top that the entire tree is clean
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, status='notneeded', action='save', path=ds.path)
     subsubds_indexed = subsubds.repo.get_indexed_files()
     assert_not_in('mike1', subsubds_indexed)
     assert_equal(states, [d.repo.get_hexsha() for d in (ds, subds, subsubds)])

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -147,7 +147,7 @@ def test_save_hierarchy(path):
         ok_(d.repo.dirty)
     # need to give file specifically, otherwise it will simply just preserve
     # staged changes
-    ds_bb.save(files=opj(ds_bbaa.path, 'file_bbaa'))
+    ds_bb.save(path=opj(ds_bbaa.path, 'file_bbaa'))
     # it has saved all changes in the subtrees spanned
     # by the given datasets, but nothing else
     for d in (ds_bb, ds_bba, ds_bbaa):
@@ -186,7 +186,7 @@ def test_save_hierarchy(path):
         # type {'path': dspath, 'process_content': True} for each dataset
         # in question, but here we want to test how this would most likely
         # by used from cmdline
-        files=[opj(p, '')
+        path=[opj(p, '')
                for p in (aa.path, ba.path, bb.path, c.path, ca.path, d.path)],
         super_datasets=True)
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -474,7 +474,7 @@ class Metadata(Interface):
         if not to_save:
             return
         for res in Save.__call__(
-                files=to_save,
+                path=to_save,
                 dataset=refds_path,
                 message='[DATALAD] dataset metadata update',
                 return_type='generator',

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -967,12 +967,15 @@ def assert_status(label, results):
     in this sequence.
     """
     label = assure_list(label)
-    for r in assure_list(results):
+    results = assure_list(results)
+    for i, r in enumerate(results):
         try:
             assert_in('status', r)
             assert_in(r['status'], label)
         except AssertionError:
-            raise AssertionError('Expected status {} not found in:\n{}'.format(
+            raise AssertionError('Test {}/{}: expected status {} not found in:\n{}'.format(
+                i + 1,
+                len(results),
                 label,
                 dumps(r, indent=1)))
 


### PR DESCRIPTION
- [x] demo test and fix for #1699 
- [x] rename `files` argument of `save` to `path` for consistency with any other command