### PR TITLE
Towards a resolution of #1650 (run a command and capture its impact)

### DIFF
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -66,6 +66,7 @@ _group_misc = (
         ('datalad.interface.add_archive_content', 'AddArchiveContent',
          'add-archive-content'),
         ('datalad.interface.download_url', 'DownloadURL', 'download-url'),
+        ('datalad.interface.run', 'Run', 'run'),
     ])
 
 _group_plumbing = (

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -18,8 +18,6 @@ import re
 from argparse import REMAINDER
 from os.path import join as opj
 from os.path import curdir
-from os.path import pardir
-from os.path import relpath
 from os.path import normpath
 
 from datalad.cmd import Runner
@@ -31,19 +29,14 @@ from datalad.interface.results import get_status_dict
 from datalad.interface.common_opts import save_message_opt
 
 from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureChoice
 from datalad.support.exceptions import CommandError
-from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.param import Parameter
 
-from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
 from datalad.utils import get_dataset_root
-from datalad.utils import getpwd
 from datalad.tests.utils import ok_clean_git
 
 lgr = logging.getLogger('datalad.interface.run')

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -1,0 +1,176 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Run log arbitrary comands and track how they modify a dataset"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import json
+
+from argparse import REMAINDER
+from os.path import join as opj
+from os.path import curdir
+from os.path import pardir
+from os.path import relpath
+
+from datalad.cmd import Runner
+
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
+
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import EnsureChoice
+from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.param import Parameter
+
+from datalad.distribution.dataset import Dataset
+from datalad.distribution.dataset import require_dataset
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import datasetmethod
+
+from datalad.utils import get_dataset_root
+from datalad.utils import getpwd
+from datalad.tests.utils import ok_clean_git
+
+lgr = logging.getLogger('datalad.interface.run')
+
+
+@build_doc
+class Run(Interface):
+    """Run and explain
+    """
+    _params_ = dict(
+        cmd=Parameter(
+            args=("cmd",),
+            nargs=REMAINDER,
+            metavar='SHELL COMMAND',
+            doc="command for execution"),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to query.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the input and/or the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        # TODO
+        # --list-commands
+        #   go through the history and report any recorded command. this info
+        #   could be used to unlock the associated output files for a rerun
+        # --rerun #
+        #   rerun command # from the list of recorded commands using the info/cmd
+        #   on record
+        # --message
+        #   prepend default message and replace default short summary
+    )
+
+    # TODO running a command outside a dataset should be supported, but it will prevent
+    # a reliable rerun, and we do not want to record absolute CWD paths...
+
+    @staticmethod
+    @datasetmethod(name='run')
+    @eval_results
+    def __call__(
+            # it is optional, because `rerun` can get a recorded one
+            cmd=None,
+            dataset=None):
+        if not dataset:
+            # act on the whole dataset if nothing else was specified
+            dataset = get_dataset_root(curdir)
+        ds = require_dataset(
+            dataset, check_installed=True,
+            purpose='tracking outcomes of a command')
+        # not needed ATM
+        #refds_path = ds.path
+        lgr.debug('tracking command output underneath %s', ds)
+        try:
+            # base assumption is that the animal smells superb
+            ok_clean_git(ds.path)
+        except AssertionError:
+            yield get_status_dict(
+                'run',
+                ds=ds,
+                status='impossible',
+                message='unsaved modifications present, cannot detect changes by command')
+            return
+
+        if not cmd:
+            # TODO here we would need to recover a cmd when a rerun is attempted
+            return
+
+        # anticipate quoted compound shell commands
+        cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd
+
+        # TODO do our best to guess which files to unlock based on the command string
+        #      in many cases this will be impossible (but see --rerun). however,
+        #      generating new data (common case) will be just fine already
+
+        # we have a clean dataset, let's run things
+        cmd_exitcode = None
+        runner = Runner()
+        try:
+            print(cmd)
+            lgr.info("== Command start (output follows) =====")
+            runner.run(
+                cmd,
+                # immediate output
+                log_online=True,
+                # not yet sure what we should do with the command output
+                # IMHO `run` itself should be very silent and let the command talk
+                log_stdout=False,
+                log_stderr=False,
+                expect_stderr=True,
+                expect_fail=True,
+                # TODO stdin
+            )
+        except CommandError as e:
+            # strip our own info from the exception. The original command output
+            # went to stdout/err -- we just have to exitcode in the same way
+            cmd_exitcode = e.code
+        lgr.info("== Command exit (modification check follows) =====")
+
+        # TODO what if a command did not alter the dataset? Record nothing? Empty commit?
+
+        # TODO ammend commit message with `run` info:
+        # - cwd if inside the dataset
+        # - the command itself
+        run_info = {
+            'command': cmd,
+        }
+        rel_pwd = relpath(getpwd(), start=ds.path)
+        if not rel_pwd.startswith(pardir):
+            # only when inside the dataset to not leak information
+            run_info['pwd'] = rel_pwd
+
+        # compose commit message
+        cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
+        cmd_shorty = '{}{}'.format(
+            cmd_shorty[:40],
+            '...' if len(cmd_shorty) > 40 else '')
+        msg = '[DATALAD RUNCMD] {}\n\n{}'.format(
+            cmd_shorty,
+            # YAML might be a better choice...
+            json.dumps(run_info, indent=1))
+
+        #for r in ds.save(all_changes=True, recursive=True):
+        for r in ds.add('.', recursive=True, message=msg):
+            # TODO make `add` look for modifications like `save` to spare us the flood
+            # of useless 'got nothing new here messages'
+            if r.get('status', None) == 'notneeded':
+                # the user didn't trigger this action, hence it makes very little sense
+                # to raise awareness that something did not happen
+                continue
+            yield r
+
+        if cmd_exitcode:
+            # finally raise due to the original command error
+            raise CommandError(code=cmd_exitcode)

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -81,7 +81,9 @@ class Run(Interface):
             doc="""specify the dataset to record the command results in,
             or to rerun a recorded command from (see --rerun).  If
             no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory""",
+            based on the current working directory. If a dataset is given,
+            the command will be executed in the root directory of this
+            dataset.""",
             constraints=EnsureDataset() | EnsureNone()),
         message=save_message_opt,
         rerun=Parameter(
@@ -196,11 +198,8 @@ class Run(Interface):
                     yield r
         else:
             # not a rerun, figure out where we are running
-            pwd = getpwd()
-            rel_pwd = relpath(pwd, start=ds.path)
-            if rel_pwd.startswith(pardir):
-                lgr.warning('Process working directory not inside the dataset, command run may not be reproducible.')
-                rel_pwd = None
+            pwd = ds.path
+            rel_pwd = curdir
 
         # anticipate quoted compound shell commands
         cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -81,14 +81,9 @@ def test_basics(path, nodspath):
 
     # run outside the dataset, should still work but with limitations
     with chpwd(nodspath):
-        with swallow_logs(new_level=logging.WARNING) as cml:
-            res = ds.run(['touch', opj(ds.path, 'empty2')], message='TEST')
-            assert_status('ok', res)
-            # we have been warned
-            cml.assert_logged(".*not inside.*", level="WARNING")
-            commit_msg = ds.repo.repo.head.commit.message
-            # crude test that PWD wasn't recorded
-            assert_not_in('"pwd": ', commit_msg)
+        res = ds.run(['touch', 'empty2'], message='TEST')
+        assert_status('ok', res)
+        assert_result_count(res, 1, action='add', path=opj(ds.path, 'empty2'), type='file')
 
 
 @skip_if_on_windows

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -1,0 +1,44 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""test command datalad save
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import os
+from os.path import join as opj
+from datalad.utils import chpwd
+
+from datalad.interface.results import is_ok_dataset
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.tests.utils import ok_
+from datalad.api import run
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import with_testrepos
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import create_tree
+from datalad.tests.utils import assert_equal
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_result_values_equal
+
+
+@with_tempfile(mkdir=True)
+def test_invalid_call(path):
+    with chpwd(path):
+        # no dataset, no luck
+        assert_raises(NoDatasetArgumentFound, run, 'doesntmatter')
+        # dirty dataset
+        ds = Dataset(path).create()
+        create_tree(ds.path, {'this': 'dirty'})
+        assert_status('impossible', run('doesntmatter', on_failure='ignore'))

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -29,7 +29,6 @@ from datalad.tests.utils import eq_
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import skip_if_on_windows
 
@@ -60,7 +59,7 @@ def test_basics(path, nodspath):
         with assert_raises(CommandError) as cme:
             ds.run('7i3amhmuch9invalid')
             # let's not speculate that the exit code is always 127
-            ok(cme.code > 0)
+            ok_(cme.code > 0)
         eq_(last_state, ds.repo.get_hexsha())
         # now one that must work
         res = ds.run('touch empty', message='TEST')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -6,31 +6,32 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""test command datalad save
+"""test command datalad run
 
 """
 
 __docformat__ = 'restructuredtext'
 
-import os
+import logging
 from os.path import join as opj
 from datalad.utils import chpwd
 
-from datalad.interface.results import is_ok_dataset
 from datalad.distribution.dataset import Dataset
-from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import CommandError
 from datalad.tests.utils import ok_
 from datalad.api import run
 from datalad.tests.utils import assert_raises
-from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import create_tree
-from datalad.tests.utils import assert_equal
+from datalad.tests.utils import eq_
 from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_result_count
+from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import assert_result_values_equal
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import skip_if_on_windows
 
 
 @with_tempfile(mkdir=True)
@@ -42,3 +43,49 @@ def test_invalid_call(path):
         ds = Dataset(path).create()
         create_tree(ds.path, {'this': 'dirty'})
         assert_status('impossible', run('doesntmatter', on_failure='ignore'))
+
+
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_basics(path, nodspath):
+    ds = Dataset(path).create()
+    last_state = ds.repo.get_hexsha()
+    # run inside the dataset
+    with chpwd(path):
+        # runs nothing, does nothing
+        assert_result_count(ds.run(), 0)
+        eq_(last_state, ds.repo.get_hexsha())
+        # provoke command failure
+        with assert_raises(CommandError) as cme:
+            ds.run('7i3amhmuch9invalid')
+            # let's not speculate that the exit code is always 127
+            ok(cme.code > 0)
+        eq_(last_state, ds.repo.get_hexsha())
+        # now one that must work
+        res = ds.run('touch empty', message='TEST')
+        ok_clean_git(ds.path)
+        assert_result_count(res, 2)
+        # TODO 'state' is still untracked!!!
+        assert_result_count(res, 1, action='add', path=opj(ds.path, 'empty'), type='file')
+        assert_result_count(res, 1, action='save', path=ds.path)
+        commit_msg = ds.repo.repo.head.commit.message
+        ok_(commit_msg.startswith('[DATALAD RUNCMD] TEST'))
+        # crude test that we have a record for the PWD
+        assert_in('"pwd": "."', commit_msg)
+        last_state = ds.repo.get_hexsha()
+        # now run a command that will not alter the dataset
+        res = ds.run('touch empty', message='NOOP_TEST')
+        assert_status('notneeded', res)
+        eq_(last_state, ds.repo.get_hexsha())
+
+    # run outside the dataset, should still work but with limitations
+    with chpwd(nodspath):
+        with swallow_logs(new_level=logging.WARNING) as cml:
+            res = ds.run(['touch', opj(ds.path, 'empty2')], message='TEST')
+            assert_status('ok', res)
+            # we have been warned
+            cml.assert_logged(".*not inside.*", level="WARNING")
+            commit_msg = ds.repo.repo.head.commit.message
+            # crude test that PWD wasn't recorded
+            assert_not_in('"pwd": ', commit_msg)

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -58,6 +58,7 @@ Miscellaneous commands
    generated/man/datalad-crawl-init
    generated/man/datalad-download-url
    generated/man/datalad-ls
+   generated/man/datalad-run
    generated/man/datalad-test
 
 Plumbing commands


### PR DESCRIPTION
- [x] basic implementation of `run` with auto-commit, and recording of command, PWD, and exit code
- [x] basic tests, 100% coverage
- [x] waiting for #1733 

This PR does not implement support for command that do in-place modification of dataset files. This is waiting for a resolution of #1424.

Ping #1650
