### PR TITLE
BF: Align behavior of `diff <path>` with `git status <path>`

### DIFF
--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -265,6 +265,8 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None):
             # in the subdataset (including staged ones). In such a case, we
             # must not provide a diff range, but only the source commit we want
             # to diff against
+            # XXX if this is changed, likely the same logic in diff needs
+            # changing too!
             diff_range = sub['revision_src']
 
         for r in get_modified_subpaths(

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -124,7 +124,7 @@ def test_diff(path, norepo):
         ds.diff(path='deep'), 1, state='untracked', path=opj(ds.path, 'deep'),
         type='directory')
     assert_result_count(
-        ds.diff(path=opj('deep', 'somewhere')), 1,
+        ds.diff(path='deep'), 1,
         state='untracked', path=opj(ds.path, 'deep'))
     # now we stage on of the two files in deep
     ds.add(opj('deep', 'down2'), to_git=True, save=False)
@@ -157,6 +157,11 @@ def test_diff_recursive(path):
 
     # now we add a file to just the parent
     create_tree(ds.path, {'onefile': 'tobeadded', 'sub': {'twofile': 'tobeadded'}})
+    res = ds.diff(recursive=True, report_untracked='all')
+    assert_result_count(res, 3)
+    assert_result_count(res, 1, action='diff', state='untracked', path=opj(ds.path, 'onefile'), type='file')
+    assert_result_count(res, 1, action='diff', state='modified', path=sub.path, type='dataset')
+    assert_result_count(res, 1, action='diff', state='untracked', path=opj(sub.path, 'twofile'), type='file')
     # save sub
     sub.add('.')
     # save sub in parent


### PR DESCRIPTION
Needed to make #1746 work in full.