### PR TITLE
Datalad -> DataLad

### DIFF
--- a/datalad/distribution/__init__.py
+++ b/datalad/distribution/__init__.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Datalad distribution components: dataset, metadata handling, ...
+"""DataLad distribution components: dataset, metadata handling, ...
 
 """
 

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -88,7 +88,7 @@ class Clone(Interface):
         source=Parameter(
             args=("source",),
             metavar='SOURCE',
-            doc="""URL, Datalad resource identifier, local path or instance of
+            doc="""URL, DataLad resource identifier, local path or instance of
             dataset to be cloned""",
             constraints=EnsureStr() | EnsureNone()),
         path=Parameter(

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -155,7 +155,7 @@ class Create(Interface):
             action='append',
             constraints=EnsureStr() | EnsureNone(),
             doc="""Metadata type label. Must match the name of the respective
-            parser implementation in Datalad (e.g. "bids").[CMD:  This option
+            parser implementation in DataLad (e.g. "bids").[CMD:  This option
             can be given multiple times CMD]"""),
         # TODO could move into cfg_access/permissions plugin
         shared_access=shared_access_opt,

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -108,11 +108,11 @@ class Metadata(Interface):
     2. metadata for individual files in a dataset.
 
     Both types can be accessed and modified with this command.
-    Note, however, that this only refers to Datalad's native metadata,
+    Note, however, that this only refers to DataLad's native metadata,
     and not to any other metadata that is possibly stored in files of a
     dataset.
 
-    Datalad's native metadata capability is primarily targeting data
+    DataLad's native metadata capability is primarily targeting data
     description via arbitrary tags and other (brief) key-value attributes
     (with possibly multiple values for a single key).
 
@@ -124,15 +124,15 @@ class Metadata(Interface):
 
     Metadata describing a dataset as a whole is stored in JSON format
     in the dataset at .datalad/metadata/dataset.json. The amount of
-    metadata that can be stored is not limited by Datalad. However,
+    metadata that can be stored is not limited by DataLad. However,
     it should be kept brief as this information is stored in the Git
     history of the dataset, and access or modification requires to
     read the entire file.
 
-    Arbitrary metadata keys can be used. However, Datalad reserves the
+    Arbitrary metadata keys can be used. However, DataLad reserves the
     keys 'tag' and 'definition' for its own use. The can still be
     manipulated without any restrictions like any other metadata items,
-    but doing so can impact Datalad's metadata-related functionality,
+    but doing so can impact DataLad's metadata-related functionality,
     handle with care.
 
     The 'tag' key is used to store a list of (unique) tags.

--- a/datalad/resources/website/index.html
+++ b/datalad/resources/website/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>Datalad Repository</title>
+        <title>DataLad Repository</title>
         <link rel="icon" type="image/png" sizes="16x16" href=".git/datalad/web/assets/images/favicon-16x16.png?v=1">
         <link rel="shortcut icon" href=".git/datalad/web/assets/images/favicon.ico?v=1">
         <link rel="stylesheet" type="text/css" href=".git/datalad/web/assets/css/jquery.dataTables-1.10.12.css">

--- a/datalad/resources/website/tests/test.html
+++ b/datalad/resources/website/tests/test.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
-    <title>Datalad WebUI Test</title>
+    <title>DataLad WebUI Test</title>
     <link rel="stylesheet" href="qunit/qunit-2.0.1.css">
   </head>
   <body>

--- a/docs/datalad-metadata.rst
+++ b/docs/datalad-metadata.rst
@@ -6,7 +6,7 @@ datalad metadata
 This is a documentation on datalad's approach to metadata. Especially on how
 the metadata representation currently looks like.
 
-Datalad uses RDF to represent metadata. However, this kind of representation is
+DataLad uses RDF to represent metadata. However, this kind of representation is
 required by datalad within collections only. A dataset may or may not contain
 metadata, which is prepared that way. A collection's metadata about a dataset
 can be imported from any location (within or not within the dataset itself) and

--- a/docs/examples/3rdparty_analysis_workflow.sh
+++ b/docs/examples/3rdparty_analysis_workflow.sh
@@ -79,7 +79,7 @@ datalad ls -r -L .
 # require 3rd-party data. Upon completion of the above command, Bob has now
 # access to the entire dataset content, and precise current version of that
 # dataset got linked to his ``myanalysis``.  However, no data was actually
-# downloaded (yet). Datalad datasets primarily contain information on a
+# downloaded (yet). DataLad datasets primarily contain information on a
 # dataset's content and where to obtain it, hence the installation above was
 # done rather quickly, and will still be relatively lean even for a dataset
 # that contains several hundred GBs of data.
@@ -95,7 +95,7 @@ datalad get src/forrest_structural/sub-01/anat/sub-01_T1w.nii.gz
 
 #%
 # Although we originally installed the dataset from Github, the actual data is
-# hosted elsewhere. Datalad supports multiple redundant data providers per each
+# hosted elsewhere. DataLad supports multiple redundant data providers per each
 # file in a dataset, and will transparently attempt to obtain data from an
 # alternative location if a particular data provider is not available.
 #
@@ -103,7 +103,7 @@ datalad get src/forrest_structural/sub-01/anat/sub-01_T1w.nii.gz
 # analysis scripts in the same dataset repository as the input data. Managing
 # input data, analysis code, and results the same version control system
 # creates a precise record of what version of code and input data was used to
-# create which particular results. Datalad datasets are regular Git_
+# create which particular results. DataLad datasets are regular Git_
 # repositories and therefore provide the same powerful source code management
 # features, as any other Git_ repository, and make them available for data too.
 #
@@ -195,7 +195,7 @@ cd bobs_analysis
 #%
 
 #%
-# With the script Bob created, Alice can obtain all required data content. Datalad
+# With the script Bob created, Alice can obtain all required data content. DataLad
 # knows that necessary file is available in Bob's version of the dataset on the
 # same machine, so it won't even attempt to download it from its original location.
 #%
@@ -223,7 +223,7 @@ bash code/run_analysis.sh || true
 
 #%
 # However, when she performs actions that attempt to modify data files managed by
-# datalad she will get an error. Datalad, by default, prevents modification of
+# datalad she will get an error. DataLad, by default, prevents modification of
 # data files. If modification is desired (as in this case), datalad can *unlock*
 # individual files, or the entire dataset. Afterwards modifications are
 # possible.
@@ -274,7 +274,7 @@ datalad get result.txt
 
 # Lastly, let's assume that Bob completed his analysis and he is ready to share
 # the results with the world, or a remote collaborator. One way to make
-# datasets available, is to upload them to a webserver via SSH. Datalad
+# datasets available, is to upload them to a webserver via SSH. DataLad
 # supports this by creating a :term:`sibling` for the dataset on the server,
 # to which the dataset can by published (repeatedly).
 #%
@@ -290,7 +290,7 @@ datalad create-sibling --recursive -s public "$SERVER_URL"
 datalad publish -r --to public .
 
 #%
-# This command can be repeated as often as desired. Datalad checks the state
+# This command can be repeated as often as desired. DataLad checks the state
 # of both the local and the remote sibling and transmits the changes.
 #%
 

--- a/docs/source/acknowledgements.rst
+++ b/docs/source/acknowledgements.rst
@@ -1,14 +1,14 @@
 Acknowledgments
 ***************
 
-Datalad development is being performed as part of a US-German collaboration in
+DataLad development is being performed as part of a US-German collaboration in
 computational neuroscience (CRCNS) project "DataGit: converging catalogues,
 warehouses, and deployment logistics into a federated 'data distribution'"
 (Halchenko_/Hanke_), co-funded by the US National Science Foundation (`NSF
 1429999`_) and the German Federal Ministry of Education and Research (`BMBF
 01GQ1411`_).
 
-Datalad is built atop the git-annex_ software that is being developed and
+DataLad is built atop the git-annex_ software that is being developed and
 maintained by `Joey Hess`_.
 
 .. _Halchenko: http://haxbylab.dartmouth.edu/ppl/yarik.html

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -18,7 +18,7 @@ well.
 Datasets
 ========
 
-A Datalad :term:`dataset` is a Git repository that may or may not have a data
+A DataLad :term:`dataset` is a Git repository that may or may not have a data
 :term:`annex` that is used to manage data referenced in a dataset. In practice,
 most DataLad datasets will come with an annex.
 
@@ -58,12 +58,12 @@ live on different servers all around the world.
 API principles
 ==============
 
-You can use Datalad's ``install`` command to download datasets. The command accepts
+You can use DataLad's ``install`` command to download datasets. The command accepts
 URLs of different protocols (``http``, ``ssh``) as an argument. Nevertheless, the easiest way
 to obtain a first dataset is downloading the canonical :term:`superdataset` from
 http://datasets.datalad.org/ using a shortcut.
 
-Downloading Datalad's canonical superdataset
+Downloading DataLad's canonical superdataset
 --------------------------------------------
 
 DataLad's canonical :term:`superdataset` provides an automated collection of datasets
@@ -93,7 +93,7 @@ regular ``http`` or ``https`` protocol URLs. For example:
 
 Downloading datasets via ssh
 ----------------------------
-Datalad also supports SSH URLs, such as ``ssh://me@localhost/path``. 
+DataLad also supports SSH URLs, such as ``ssh://me@localhost/path``.
 
 ``datalad install ssh://me@localhost/path``
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,8 +75,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'datalad'
-copyright = u'2016, Datalad team'
-author = u'Datalad team'
+copyright = u'2016, DataLad team'
+author = u'DataLad team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -252,7 +252,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   (master_doc, 'datalad.tex', u'datalad Documentation',
-   u'Datalad team', 'manual'),
+   u'DataLad team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,7 +1,7 @@
 Configuration
 *************
 
-Datalad uses the same configuration mechanism and syntax as Git itself.
+DataLad uses the same configuration mechanism and syntax as Git itself.
 Consequently, datalad can be configured using the :command:`git config`
 command. Both a *global* user configuration (typically at
 :file:`~/.gitconfig`), and a *local* repository-specific configuration

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -10,7 +10,7 @@ Getting started
 Installation
 ============
 
-Unless system packages are available for your operating system (see below), Datalad 
+Unless system packages are available for your operating system (see below), DataLad
 can be installed via pip_ (**P**\ip **I**\nstalls **P**\ython). To automatically install 
 datalad and all its software dependencies type::
 
@@ -63,7 +63,7 @@ above. ``pip`` comes with Python distributions like anaconda_.
 First steps
 ===========
 
-Datalad can be queried for information about known datasets. Doing a first search 
+DataLad can be queried for information about known datasets. Doing a first search
 query, datalad automatically offers assistence to obtain a :term:`superdataset` first.
 The superdataset is a lightweight container that contains meta information about known datasets but does not contain actual data itself. 
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -13,7 +13,7 @@
 Glossary
 ********
 
-Datalad purposefully uses a terminology that is different from the one used by
+DataLad purposefully uses a terminology that is different from the one used by
 its technological foundations Git_ and git-annex_. This glossary provides
 definitions for terms used in the datalad documentation and API, and relates
 them to the corresponding Git_/git-annex_ concepts.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Datalad |---| data management and distribution suite: Documentation
+DataLad |---| data management and distribution suite: Documentation
 *******************************************************************
 
 .. toctree::

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -6,7 +6,7 @@ Meta data
 Overview
 ========
 
-Datalad has built-in, modular, and extensible support for meta data in various
+DataLad has built-in, modular, and extensible support for meta data in various
 formats. The core concept is that meta data is accessed via dedicated parsers
 in their native format, avoiding the need for mandatory conversion into a
 "standard" format. Via these parser datalad is capable of performing a certain
@@ -135,20 +135,20 @@ The following fields are supported:
 Brain Imaging Data Structure (BIDS)
 -----------------------------------
 
-Datalad has basic support for extraction of meta data from the `BIDS
+DataLad has basic support for extraction of meta data from the `BIDS
 <http://bids.neuroimaging.io>`_ ``dataset_description.json`` file.
 
 Friction-less data packages
 ---------------------------
 
-Datalad has basic support for extraction of meta data from `friction-less data
+DataLad has basic support for extraction of meta data from `friction-less data
 packages <http://specs.frictionlessdata.io/data-packages>`_
 (``datapackage.json``).  file.
 
 JSON-LD meta data format
 ------------------------
 
-Datalad uses JSON-LD_ as its primary meta data format. By default, the
+DataLad uses JSON-LD_ as its primary meta data format. By default, the
 following context (available from `here <schema.json>`_
 is used for any meta data item:
 

--- a/docs/source/related.rst
+++ b/docs/source/related.rst
@@ -2,7 +2,7 @@ Delineation from related solutions
 **********************************
 
 To our knowledge, there is no other effort with a scope as broad as DataLad's.
-Datalad aims to unify access to vast arrays of (scientific) data in a domain and
+DataLad aims to unify access to vast arrays of (scientific) data in a domain and
 data modality agnostic fashion with as few and universally available software
 dependencies as possible.
 
@@ -12,7 +12,7 @@ powerful, NSF-supported framework, but it requires non-trivial deployment and
 management procedures. As a representative of *data grid* technology, it is
 more suitable for an institutional deployment, as data access, authentication,
 permission management, and versioning are complex and not-feasible to be
-performed directly by researchers. Datalad on the other hand federates
+performed directly by researchers. DataLad on the other hand federates
 institutionally hosted data, but in addition enables individual researchers and
 small labs to contribute datasets to the federation with minimal cost and
 without the need for centralized coordination and permission management.
@@ -46,7 +46,7 @@ Data delivery/management middleware
 
 Even though there are projects to manage data directly with dVCS (e.g. Git),
 such as the `Rdatasets Git repository`_ this approach does not scale, for example
-to the amount of data typically observed in a scientific context. Datalad
+to the amount of data typically observed in a scientific context. DataLad
 uses git-annex_ to support managing large amounts of data with Git, while
 avoiding the scalability issues of putting data directly into Git repositories.
 
@@ -89,9 +89,9 @@ or git-annex commands directly, it is useful to appreciate that DataLad is
 build atop of very flexible and powerful tools.  Knowing basics of git and
 git-annex in addition to DataLad helps to not only make better use of
 DataLad but also to enable more advanced and more efficient data management
-scenarios. Datalad makes use of lower-level configuration and data structures
-as much as possible. Consequently, it is possible to manipulate Datalad
-datasets with low-level tools if needed. Moreover, Datalad datasets are
+scenarios. DataLad makes use of lower-level configuration and data structures
+as much as possible. Consequently, it is possible to manipulate DataLad
+datasets with low-level tools if needed. Moreover, DataLad datasets are
 compatible with tools and services designed to work with plain Git repositories,
 such as the popular GitHub_ service.
 

--- a/tools/screencast_bash.rc
+++ b/tools/screencast_bash.rc
@@ -51,7 +51,7 @@ if ! hash datalad; then
 fi
 
 # Basic git setup
-git config --global user.name "Datalad Demo"
+git config --global user.name "DataLad Demo"
 git config --global user.email demo@datalad.org
 
 # pager by default is not helpful in demo


### PR DESCRIPTION
This /only/ changes strings and leaves the classname DataladAnnexCustomRemote untouched.

This does not take care of 'datalad' -> 'DataLad', as that will be much more
difficult to sift through (between all the commands and URLs).