### PR TITLE
ENH: make cloning INFO message more lean (move report of # of candidates to debug)

### DIFF
--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -223,12 +223,12 @@ class Clone(Interface):
         # combine all given sources (incl. alternatives), maintain order
         for s in [source] + assure_list(alt_sources):
             candidate_sources.extend(_get_flexible_source_candidates(s))
-        lgr.info("Cloning dataset from '%s' (trying %i location candidate(s)) to '%s'",
-                 source, len(candidate_sources), dest_path)
-        for source_ in candidate_sources:
+        lgr.info("Cloning %s to '%s'",
+                 source, dest_path)
+        for isource_, source_ in enumerate(candidate_sources):
             try:
-                lgr.debug("Attempting to clone dataset from '%s' to '%s'",
-                          source_, dest_path)
+                lgr.debug("Attempting to clone %s (%d out of %d candidates) to '%s'",
+                          source_, isource_ + 1, len(candidate_sources), dest_path)
                 GitRepo.clone(path=dest_path, url=source_, create=True)
                 break  # do not bother with other sources if succeeded
             except GitCommandError as e:


### PR DESCRIPTION
example:
```shell
[INFO   ] Cloning http://datasets.datalad.org/labs/haxby to '/tmp/haxby' 
[DEBUG  ] Attempting to clone http://datasets.datalad.org/labs/haxby (1 out of 2 candidates) to '/tmp/haxby' 
[DEBUG  ] Git clone from http://datasets.datalad.org/labs/haxby to /tmp/haxby 
[DEBUG  ] Failed to clone from URL: http://datasets.datalad.org/labs/haxby (Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)
  cmdline: /usr/lib/git-annex.linux/git clone -v http://datasets.datalad.org/labs/haxby /tmp/haxby
  stderr: 'Cloning into '/tmp/haxby'...
fatal: repository 'http://datasets.datalad.org/labs/haxby/' not found
' [cmd.py:wait:291]) 
[DEBUG  ] Attempting to clone http://datasets.datalad.org/labs/haxby/.git (2 out of 2 candidates) to '/tmp/haxby' 

```