### PR TITLE
ENH: screencasts - generate .cmd.md file to be cut/pasted into description + possible to modify terminal size for "big" recording

### DIFF
--- a/docs/casts/basic_search.sh
+++ b/docs/casts/basic_search.sh
@@ -1,0 +1,33 @@
+full_title="Demo of basic datasets meta-data search using DataLad"
+#run "set -eu  # Fail early if any error happens"
+
+say "DataLad allows to aggregate dataset-level meta-data, i.e. data describing the dataset (description, authors, etc), from a variety of formats (see http://docs.datalad.org/en/latest/metadata.html for more info)."
+say 'In this example we will start from a point where someone who has not used datalad before decided to find datasets which related to "raiders" (after "Raiders of the Lost Ark" movie) and neuroimaging.'
+say 'As you will see below, upon the very first invocation of "datalad search" command, DataLad will need first to acquire aggregated meta-data for our collection of datasets available at http://datasets.datalad.org and for that it will install that top level super-dataset (a pure git repository) under ~/datalad:'
+( sleep 4; type yes; key Return; ) &
+run "datalad search raiders neuroimaging"
+
+say '"search" searches within current dataset (unless -d option is used), and if it is outside of any it would offer to search within the ~/datalad we have just installed'
+( sleep 4; type yes; key Return; ) &
+run "datalad search raiders neuroimaging"
+
+say "To avoid interactive question, you can specify to search within that dataset by using -d /// . And now let's specialize the search to not only list the dataset location, but also report the fields where match was found.  This time let's search for datasets with Haxby among the authors"
+run "datalad search -d /// -s author -R haxby"
+say "For convenience let's switch to that directory, and now all result paths to datasets (not yet installed) would be relative to current directory"
+run "cd ~/datalad"
+run "datalad search -s author -R haxby"
+
+say "Instead of listing all matching fields, you could specify which fields to report using -r option (using * would list all of them)"
+run "datalad search -s author -r name -r author Haxby"
+
+say "Enough of searching!  Let's actually get all those interesting datasets (for now without all the data) we found."
+say "We could easily do that by passing those reported path as arguments to datalad install command"
+run "datalad search -s author haxby | xargs datalad install"
+say "and explore what we have got"
+run "datalad ls -Lr . | grep -v 'not installed'"
+run "cat openfmri/ds000105/dataset_description.json"
+say "and get data we are interested in, e.g. all the anatomicals within those installed BIDS datasets"
+run "datalad get -J4 openfmri/ds000*/sub-*/anat"
+run "datalad ls -Lr . | grep -v 'not installed'"
+
+say "Now it is your turn to find some interesting datasets for yourself!"

--- a/tools/cast2asciinema
+++ b/tools/cast2asciinema
@@ -12,7 +12,17 @@ title="$(echo $(basename $1) | sed -e 's/.sh$//')"
 xdt="xdotool search --classname xterm windowactivate"
 
 # make sure the target xterm is up and running
-xterm -geometry 80x24 -e bash &
+# Sizes
+# "big"
+#width=120
+#height=36
+# "small"
+width=120
+height=36
+text_width=$(($width - 8))
+
+geometry=${width}x${height}
+xterm -geometry $geometry -e bash &
 xterm_pid=$!
 sleep 1
 $xdt --sync sleep 0.5
@@ -47,7 +57,7 @@ function execute () {
 }
 function say()
 {
-	type "$(printf "#\n# $1" | fmt -w 72 --prefix '# ')"
+	type "$(printf "#\n# $1" | fmt -w ${text_width} --prefix '# ')"
 	key Return
 	sleep 3
 }
@@ -101,5 +111,9 @@ while test -d "/proc/$asciinema_pid"; do sleep 1; echo "wait for asciinema"; don
 kill $xterm_pid
 
 # adjust title if was specified
-full_title=${full_title:-$title}
+full_title="${full_title:-$title} [$geometry]"
 sed -i -e "s/^\( *.command.\): \".*/\1: \"$full_title\",/" "$title.json"
+
+# Pre-create description with the list of commands annotated in .md
+echo -e "## List of the commands (with timing after #) executed in the asciinema:\n" > "$title.cmds.md"
+sed -e 's,\(^.*[^ ]\)\( *#.*\)$,**\1** \2\n,g' "$title.cmds" >> "$title.cmds.md"

--- a/tools/cast2asciinema
+++ b/tools/cast2asciinema
@@ -13,12 +13,12 @@ xdt="xdotool search --classname xterm windowactivate"
 
 # make sure the target xterm is up and running
 # Sizes
+# "small"
+width=80
+height=24
 # "big"
 #width=120
 #height=36
-# "small"
-width=120
-height=36
 text_width=$(($width - 8))
 
 geometry=${width}x${height}

--- a/tools/cast2asciinema
+++ b/tools/cast2asciinema
@@ -117,3 +117,6 @@ sed -i -e "s/^\( *.command.\): \".*/\1: \"$full_title\",/" "$title.json"
 # Pre-create description with the list of commands annotated in .md
 echo -e "## List of the commands (with timing after #) executed in the asciinema:\n" > "$title.cmds.md"
 sed -e 's,\(^.*[^ ]\)\( *#.*\)$,**\1** \2\n,g' "$title.cmds" >> "$title.cmds.md"
+# Yarik goes crazy
+#  let's make used commands in the descriptions to point to our manpages
+sed -i -e 's,\(datalad.* \(update\|create\|crawl\|install\|add\|metadata\|ls\|save\)\( \|$\)\),[\1\](http://docs.datalad.org/en/latest/generated/man/datalad-\2.html),g' "$title.cmds.md"

--- a/tools/cast2asciinema
+++ b/tools/cast2asciinema
@@ -118,5 +118,7 @@ sed -i -e "s/^\( *.command.\): \".*/\1: \"$full_title\",/" "$title.json"
 echo -e "## List of the commands (with timing after #) executed in the asciinema:\n" > "$title.cmds.md"
 sed -e 's,\(^.*[^ ]\)\( *#.*\)$,**\1** \2\n,g' "$title.cmds" >> "$title.cmds.md"
 # Yarik goes crazy
-#  let's make used commands in the descriptions to point to our manpages
-sed -i -e 's,\(datalad.* \(update\|create\|crawl\|install\|add\|metadata\|ls\|save\)\( \|$\)\),[\1\](http://docs.datalad.org/en/latest/generated/man/datalad-\2.html),g' "$title.cmds.md"
+#  let's make used datalad commands in the descriptions to point to our manpages
+# collect all known commands (sorry -- we need datalad available)
+commands_re=$(datalad -h | sed -n -e '/^ *{/s/ *[{}]//gp' | sed -e 's/,/\\|/g' -e 's,^,\\(,g' -e 's,$,\\),g')
+sed -i -e 's,\(datalad.* \)'"${commands_re}"'\( \|$\)\),[\1\](http://docs.datalad.org/en/latest/generated/man/datalad-\2.html),g' "$title.cmds.md"

--- a/tools/cast2asciinema
+++ b/tools/cast2asciinema
@@ -82,6 +82,21 @@ function run_expfail () {
 	run "$1"
 }
 
+# Take .cmds file and make them into .md file with detected datalad commands
+# invocations accompanied with a [help] url
+
+function cmds2md() {
+    [ $# = 1 ] || exit 1  # one file at a time
+    infile="$1"
+    mdfile="$1.md"
+    echo -e "## List of the commands (with timing after #) executed in the asciinema:\n" >| "$mdfile"
+    sed -e 's,\(^.*[^ ]\)\( *#.*\)$,```\1``` \2\n,g' "$infile" >> "$mdfile"
+    # let's make used datalad commands in the descriptions to point to our manpages
+    # collect all known commands (sorry -- we need datalad available)
+    commands_re=$(datalad -h | sed -n -e '/^ *{/s/ *[{}]//gp' | sed -e 's/,/\\|/g' -e 's,^,\\(,g' -e 's,$,\\),g')
+    sed -i -e 's,\(\<datalad .*'"${commands_re}"'\( \|$\).*\),\1 [help](http://docs.datalad.org/en/latest/generated/man/datalad-\2.html),g' "$mdfile"
+}
+
 cmds_log="$title.cmds"
 rm -f "$cmds_log"
 echo "Recording to $(readlink -f "$title.json") with commands log in $cmds_log"
@@ -115,10 +130,6 @@ full_title="${full_title:-$title} [$geometry]"
 sed -i -e "s/^\( *.command.\): \".*/\1: \"$full_title\",/" "$title.json"
 
 # Pre-create description with the list of commands annotated in .md
-echo -e "## List of the commands (with timing after #) executed in the asciinema:\n" > "$title.cmds.md"
-sed -e 's,\(^.*[^ ]\)\( *#.*\)$,**\1** \2\n,g' "$title.cmds" >> "$title.cmds.md"
-# Yarik goes crazy
-#  let's make used datalad commands in the descriptions to point to our manpages
-# collect all known commands (sorry -- we need datalad available)
-commands_re=$(datalad -h | sed -n -e '/^ *{/s/ *[{}]//gp' | sed -e 's/,/\\|/g' -e 's,^,\\(,g' -e 's,$,\\),g')
-sed -i -e 's,\(datalad.* \)'"${commands_re}"'\( \|$\)\),[\1\](http://docs.datalad.org/en/latest/generated/man/datalad-\2.html),g' "$title.cmds.md"
+# ATM those cannot be uploaded automagically to the asciinema but the clip
+# description could be changed online, just cut/paste
+cmds2md "$title.cmds"


### PR DESCRIPTION
Here is an example of asciinema with the description containing the commands with links to the manpages help:  https://asciinema.org/a/vhCxdfvqqnNGDk6xQFdxwvOQh

now https://asciinema.org/~DataLad contains two asciinemas generated at two different resolutions. @aqw  do you think it would be possible easily to switch between two different asciinemas depending on desktop-vs-mobile rendering? ideally making it possible to choose one or another

edit: also now includes a basic search cast, rendered here: https://asciinema.org/a/134920 and which I will add in a second to datalad.org repo (Closes #1755)