### PR TITLE
ENH: Don't fail on fetch if a (special) remote doesn't provide an URL

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1484,10 +1484,16 @@ class GitRepo(RepoInterface):
 
         fi_list = []
         for rm in remotes_to_fetch:
-            fetch_url = \
-                rm.config_reader.get('fetchurl'
-                                     if rm.config_reader.has_option('fetchurl')
-                                     else 'url')
+            from six.moves.configparser import NoOptionError
+            try:
+                fetch_url = \
+                    rm.config_reader.get('fetchurl'
+                                         if rm.config_reader.has_option('fetchurl')
+                                         else 'url')
+            except NoOptionError:
+                lgr.debug("Remote %s has no URL", rm)
+                return []
+
             if is_ssh(fetch_url):
                 ssh_manager.get_connection(fetch_url).open()
                 # TODO: with git <= 2.3 keep old mechanism:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1484,13 +1484,11 @@ class GitRepo(RepoInterface):
 
         fi_list = []
         for rm in remotes_to_fetch:
-            from six.moves.configparser import NoOptionError
-            try:
-                fetch_url = \
-                    rm.config_reader.get('fetchurl'
-                                         if rm.config_reader.has_option('fetchurl')
-                                         else 'url')
-            except NoOptionError:
+            fetch_url = \
+                self.config.get('remote.%s.fetchurl' % rm.name,
+                                self.config.get('remote.%s.url' % rm.name,
+                                                None))
+            if fetch_url is None:
                 lgr.debug("Remote %s has no URL", rm)
                 return []
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -424,6 +424,16 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     assert_in(filename, clone.get_files("origin/new_branch"))
     assert_false(exists(opj(clone_path, filename)))  # not checked out
 
+    # create a remote without an URL:
+    origin.add_remote('not-available', 'git://example.com/not/existing')
+    origin.config.unset('remote.not-available.url', where='local')
+
+    # fetch without provided URL
+    fetched = origin.fetch('not-available')
+    # nothing was done, nothing returned:
+    eq_([], fetched)
+
+
 
 @skip_ssh
 @with_testrepos('.*basic.*', flavors=['local'])


### PR DESCRIPTION
Annex special remotes may have no URL. Don't fail when trying to fetch from such remotes. Just do nothing and log on debug level.