### PR TITLE
Change testing for direct mode and V6 to exclusion lists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
   matrix:
     - DATALAD_REPO_DIRECT=1
     - DATALAD_REPO_DIRECT=
+    - DATALAD_REPO_VERSION=6
+    - DATALAD_REPO_VERSION=
 
 # Disabled since old folks don't want to change workflows of submitting through central authority
 #    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,11 +117,6 @@ matrix:
     env:
     - TMPDIR="/tmp/nfsmount"
     - _DATALAD_NONPR_ONLY=1
-  - python: 2.7
-    # test modules that should not fail in direct mode now:
-    env:
-    - TESTS_TO_PERFORM="datalad/tests datalad/support"
-    - DATALAD_REPO_DIRECT=1
 
   allow_failures:
   # Test under NFS mount  (full, only in master)
@@ -129,8 +124,6 @@ matrix:
     env:
     - TMPDIR="/tmp/nfsmount"
     - _DATALAD_NONPR_ONLY=1
-  # For now, don't fail entirely when direct mode fails
-  - env: DATALAD_REPO_DIRECT=1
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test functioning of the datalad main cmdline utility """
 
+from datalad.tests.utils import skip_direct_mode
 import re
 import sys
 from six.moves import StringIO
@@ -150,6 +151,7 @@ def test_incorrect_options():
     yield check_incorrect_option, ('--dbg',), err_insufficient
     yield check_incorrect_option, tuple(), err_insufficient
 
+@skip_direct_mode
 def test_script_shims():
     runner = Runner()
     for script in [

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -152,7 +152,7 @@ def test_incorrect_options():
     yield check_incorrect_option, ('--dbg',), err_insufficient
     yield check_incorrect_option, tuple(), err_insufficient
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_script_shims():
     runner = Runner()

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test functioning of the datalad main cmdline utility """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import re
 import sys
@@ -152,6 +153,7 @@ def test_incorrect_options():
     yield check_incorrect_option, tuple(), err_insufficient
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_script_shims():
     runner = Runner()
     for script in [

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 from os import listdir
 from os.path import join as opj, exists, lexists, basename
 from collections import OrderedDict
@@ -49,6 +50,7 @@ def test_annexificator_no_git_if_dirty(outdir):
 
 @with_tempfile(mkdir=True)
 @with_tempfile()
+@skip_direct_mode
 def test_initiate_dataset(path, path2):
     dataset_path = opj(path, 'test')
     datas = list(initiate_dataset('template', 'testdataset', path=dataset_path)())
@@ -166,6 +168,7 @@ def _test_annex_file(mode, topdir, topurl, outdir):
     assert_equal(output[0]['datalad_stats'], ActivityStats(files=1, add_git=1))
 
 
+@skip_direct_mode
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
         yield _test_annex_file, mode
@@ -213,6 +216,7 @@ def _test_add_archive_content_tar(direct, repo_path):
         assert_false(annex.repo.dirty)
 
 
+@skip_direct_mode
 def test_add_archive_content_tar():
     for direct in (True, False):
         yield _test_add_archive_content_tar, direct
@@ -222,6 +226,7 @@ def test_add_archive_content_tar():
 @with_tempfile(mkdir=True)
 @with_tree(tree={'file': 'load'})
 @serve_path_via_http
+@skip_direct_mode
 def test_add_dir_file(repo_path, p, topurl):
     # test whenever file becomes a directory and then back a file.  Should all work!
     annex = Annexificator(path=repo_path, auto_finalize=False)

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -51,7 +51,7 @@ def test_annexificator_no_git_if_dirty(outdir):
 
 @with_tempfile(mkdir=True)
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_initiate_dataset(path, path2):
     dataset_path = opj(path, 'test')
     datas = list(initiate_dataset('template', 'testdataset', path=dataset_path)())
@@ -169,7 +169,7 @@ def _test_annex_file(mode, topdir, topurl, outdir):
     assert_equal(output[0]['datalad_stats'], ActivityStats(files=1, add_git=1))
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
@@ -218,7 +218,7 @@ def _test_add_archive_content_tar(direct, repo_path):
         assert_false(annex.repo.dirty)
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_add_archive_content_tar():
     for direct in (True, False):
@@ -229,7 +229,7 @@ def test_add_archive_content_tar():
 @with_tempfile(mkdir=True)
 @with_tree(tree={'file': 'load'})
 @serve_path_via_http
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_add_dir_file(repo_path, p, topurl):
     # test whenever file becomes a directory and then back a file.  Should all work!
     annex = Annexificator(path=repo_path, auto_finalize=False)

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from os import listdir
 from os.path import join as opj, exists, lexists, basename
@@ -169,6 +170,7 @@ def _test_annex_file(mode, topdir, topurl, outdir):
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
         yield _test_annex_file, mode
@@ -217,6 +219,7 @@ def _test_add_archive_content_tar(direct, repo_path):
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_add_archive_content_tar():
     for direct in (True, False):
         yield _test_add_archive_content_tar, direct

--- a/datalad/crawler/pipelines/tests/test_balsa.py
+++ b/datalad/crawler/pipelines/tests/test_balsa.py
@@ -126,7 +126,7 @@ TEST_TREE1 = {
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_balsa_extract_meta(ind, topurl, outd, clonedir):
     list(initiate_dataset(
@@ -201,7 +201,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     list(initiate_dataset(
@@ -310,7 +310,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     list(initiate_dataset(

--- a/datalad/crawler/pipelines/tests/test_balsa.py
+++ b/datalad/crawler/pipelines/tests/test_balsa.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
 from ..balsa import pipeline as ofpipeline, superdataset_pipeline
@@ -126,6 +127,7 @@ TEST_TREE1 = {
 @with_tempfile
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_balsa_extract_meta(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -200,6 +202,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @with_tempfile
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -308,6 +311,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @with_tempfile
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",

--- a/datalad/crawler/pipelines/tests/test_balsa.py
+++ b/datalad/crawler/pipelines/tests/test_balsa.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
 from ..balsa import pipeline as ofpipeline, superdataset_pipeline
 import os
@@ -124,6 +125,7 @@ TEST_TREE1 = {
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
+@skip_direct_mode
 def test_balsa_extract_meta(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -197,6 +199,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
+@skip_direct_mode
 def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -304,6 +307,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
+@skip_direct_mode
 def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from .utils import _test_smoke_pipelines
 from ..crcns import pipeline, superdataset_pipeline
@@ -17,6 +18,7 @@ from datalad.tests.utils import ok_startswith
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -17,7 +17,7 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import ok_startswith
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 from .utils import _test_smoke_pipelines
 from ..crcns import pipeline, superdataset_pipeline
 from ..crcns import get_metadata
@@ -15,6 +16,7 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import ok_startswith
 
 
+@skip_direct_mode
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from os.path import exists
 from requests.exceptions import InvalidURL
@@ -31,6 +32,7 @@ from ..fcptable import pipeline, superdataset_pipeline
 TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 from os.path import exists
 from requests.exceptions import InvalidURL
 
@@ -29,6 +30,7 @@ from ..fcptable import pipeline, superdataset_pipeline
 
 TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
+@skip_direct_mode
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -31,7 +31,7 @@ from ..fcptable import pipeline, superdataset_pipeline
 
 TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -206,7 +206,7 @@ _versioned_files = """
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     index_html = opj(ind, 'ds666', 'index.html')
@@ -437,7 +437,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 )
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_openfmri_pipeline2(ind, topurl, outd):
     # no versioned files -- should still work! ;)

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import os
 from glob import glob
@@ -206,6 +207,7 @@ _versioned_files = """
 @with_tempfile
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     index_html = opj(ind, 'ds666', 'index.html')
 
@@ -436,6 +438,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 @serve_path_via_http
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_openfmri_pipeline2(ind, topurl, outd):
     # no versioned files -- should still work! ;)
 

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from glob import glob
 from os.path import join as opj
@@ -204,6 +205,7 @@ _versioned_files = """
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
+@skip_direct_mode
 def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     index_html = opj(ind, 'ds666', 'index.html')
 
@@ -433,6 +435,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 )
 @serve_path_via_http
 @with_tempfile
+@skip_direct_mode
 def test_openfmri_pipeline2(ind, topurl, outd):
     # no versioned files -- should still work! ;)
 

--- a/datalad/crawler/pipelines/tests/test_openfmri_collection.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri_collection.py
@@ -54,7 +54,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 )
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_openfmri_superdataset_pipeline1(ind, topurl, outd):
 
     list(initiate_dataset(

--- a/datalad/crawler/pipelines/tests/test_openfmri_collection.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri_collection.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from glob import glob
 from os.path import join as opj, exists
@@ -53,6 +54,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 )
 @serve_path_via_http
 @with_tempfile
+@skip_direct_mode
 def test_openfmri_superdataset_pipeline1(ind, topurl, outd):
 
     list(initiate_dataset(

--- a/datalad/crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad/crawler/pipelines/tests/test_simple_with_archives.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from os.path import join as opj
 
@@ -31,6 +32,7 @@ lgr = getLogger('datalad.crawl.tests')
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ["random_url"]
 
@@ -42,6 +44,7 @@ from .test_balsa import TEST_TREE1
 @serve_path_via_http
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_simple1(ind, topurl, outd):
 
     list(initiate_dataset(
@@ -78,6 +81,7 @@ def test_simple1(ind, topurl, outd):
 @serve_path_via_http
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_crawl_autoaddtext(ind, topurl, outd):
     ds = create(outd, text_no_annex=True)
     with chpwd(outd):  # TODO -- dataset argument

--- a/datalad/crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad/crawler/pipelines/tests/test_simple_with_archives.py
@@ -31,7 +31,7 @@ from logging import getLogger
 lgr = getLogger('datalad.crawl.tests')
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ["random_url"]
@@ -43,7 +43,7 @@ from .test_balsa import TEST_TREE1
 @with_tree(tree=TEST_TREE1, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_simple1(ind, topurl, outd):
 
@@ -80,7 +80,7 @@ def test_simple1(ind, topurl, outd):
 }, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_crawl_autoaddtext(ind, topurl, outd):
     ds = create(outd, text_no_annex=True)

--- a/datalad/crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad/crawler/pipelines/tests/test_simple_with_archives.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 from os.path import join as opj
 
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
@@ -29,6 +30,7 @@ from logging import getLogger
 lgr = getLogger('datalad.crawl.tests')
 
 
+@skip_direct_mode
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ["random_url"]
 
@@ -39,6 +41,7 @@ from .test_balsa import TEST_TREE1
 @with_tree(tree=TEST_TREE1, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
+@skip_direct_mode
 def test_simple1(ind, topurl, outd):
 
     list(initiate_dataset(
@@ -74,6 +77,7 @@ def test_simple1(ind, topurl, outd):
 }, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
+@skip_direct_mode
 def test_crawl_autoaddtext(ind, topurl, outd):
     ds = create(outd, text_no_annex=True)
     with chpwd(outd):  # TODO -- dataset argument

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for customremotes archives providing dl+archive URLs handling"""
 
+from datalad.tests.utils import skip_direct_mode
 from ..archives import ArchiveAnnexCustomRemote
 from ..base import AnnexExchangeProtocol
 from ...support.annexrepo import AnnexRepo
@@ -119,6 +120,7 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
 @with_tree(
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
+@skip_direct_mode
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)
@@ -151,6 +153,7 @@ def test_get_git_environ_adjusted():
     assert_equal(sys_env["PWD"], os.environ.get("PWD"))
 
 
+@skip_direct_mode
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
     if not on_windows:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for customremotes archives providing dl+archive URLs handling"""
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from ..archives import ArchiveAnnexCustomRemote
 from ..base import AnnexExchangeProtocol
@@ -121,6 +122,7 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)
@@ -154,6 +156,7 @@ def test_get_git_environ_adjusted():
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
     if not on_windows:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -121,7 +121,7 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
 @with_tree(
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
@@ -155,7 +155,7 @@ def test_get_git_environ_adjusted():
     assert_equal(sys_env["PWD"], os.environ.get("PWD"))
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for the base of our custom remotes"""
 
+from datalad.tests.utils import skip_direct_mode
 from os.path import isabs
 
 from datalad.tests.utils import with_tree
@@ -17,6 +18,7 @@ from ..base import AnnexCustomRemote
 
 
 @with_tree(tree={'file.dat': ''})
+@skip_direct_mode
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)
     repo.add('file.dat')

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -18,7 +18,7 @@ from ..base import AnnexCustomRemote
 
 
 @with_tree(tree={'file.dat': ''})
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)
     repo.add('file.dat')

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import logging
 from os.path import join as opj
 
@@ -116,6 +117,7 @@ def test_add_files(path):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_add_recursive(path):
     # make simple hierarchy
     parent = Dataset(path).create()
@@ -147,6 +149,7 @@ def test_add_recursive(path):
 
 
 @with_tree(**tree_arg)
+@skip_direct_mode
 def test_add_dirty_tree(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
@@ -303,6 +306,7 @@ def test_add_source(path, url, ds_dir):
 
 @with_tree(**tree_arg)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_add_subdataset(path, other):
     subds = create(opj(path, 'dir'), force=True)
     ds = create(path, force=True)
@@ -339,6 +343,7 @@ def test_add_subdataset(path, other):
     'file2.txt': 'some text to go to annex',
     '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
 )
+@skip_direct_mode
 def test_add_mimetypes(path):
     # XXX apparently there is symlinks dereferencing going on while deducing repo
     #    type there!!!! so can't use following invocation  -- TODO separately

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -117,7 +117,7 @@ def test_add_files(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_add_recursive(path):
     # make simple hierarchy
     parent = Dataset(path).create()
@@ -149,7 +149,7 @@ def test_add_recursive(path):
 
 
 @with_tree(**tree_arg)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_add_dirty_tree(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
@@ -306,7 +306,7 @@ def test_add_source(path, url, ds_dir):
 
 @with_tree(**tree_arg)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_add_subdataset(path, other):
     subds = create(opj(path, 'dir'), force=True)
     ds = create(path, force=True)
@@ -343,7 +343,7 @@ def test_add_subdataset(path, other):
     'file2.txt': 'some text to go to annex',
     '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
 )
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_add_mimetypes(path):
     # XXX apparently there is symlinks dereferencing going on while deducing repo
     #    type there!!!! so can't use following invocation  -- TODO separately

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -217,7 +217,7 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_clone_into_dataset(source, top_path):
 
     ds = create(top_path)

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -10,6 +10,7 @@
 """
 
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from os.path import join as opj
 from os.path import isdir
@@ -121,6 +122,7 @@ def test_clone_datasets_root(tdir):
 
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_clone_simple_local(src, path):
     origin = Dataset(path)
 
@@ -163,6 +165,7 @@ def test_clone_simple_local(src, path):
 
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
+@skip_v6  #FIXME
 def test_clone_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
         ds = clone(url, result_xfm='datasets', return_type='item-or-list')

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -10,6 +10,7 @@
 """
 
 
+from datalad.tests.utils import skip_direct_mode
 from os.path import join as opj
 from os.path import isdir
 from os.path import exists
@@ -213,6 +214,7 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
+@skip_direct_mode
 def test_clone_into_dataset(source, top_path):
 
     ds = create(top_path)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -137,7 +137,7 @@ def test_create(path):
 
 
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_create_sub(path):
 
     ds = Dataset(path)
@@ -175,8 +175,8 @@ def test_create_sub(path):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode
-@skip_direct_mode
+@skip_direct_mode  #FIXME
+@skip_direct_mode  #FIXME
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto
     # an existing directory tree
@@ -205,7 +205,7 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_nested_create(path):
     # to document some more organic usage pattern
@@ -296,7 +296,7 @@ def test_create_withplugin(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_create_text_no_annex(path):
     ds = create(path, text_no_annex=True)
     ok_clean_git(path)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj
 from os.path import lexists
@@ -135,6 +136,7 @@ def test_create(path):
 
 
 @with_tempfile
+@skip_direct_mode
 def test_create_sub(path):
 
     ds = Dataset(path)
@@ -172,6 +174,8 @@ def test_create_sub(path):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
+@skip_direct_mode
+@skip_direct_mode
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto
     # an existing directory tree
@@ -200,6 +204,7 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 
 @with_tempfile
+@skip_direct_mode
 def test_nested_create(path):
     # to document some more organic usage pattern
     ds = Dataset(path).create()
@@ -289,6 +294,7 @@ def test_create_withplugin(path):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_create_text_no_annex(path):
     ds = create(path, text_no_annex=True)
     ok_clean_git(path)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj
@@ -205,6 +206,7 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_nested_create(path):
     # to document some more organic usage pattern
     ds = Dataset(path).create()

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import os
 from os import chmod
@@ -371,6 +372,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 @with_tempfile(mkdir=True)
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
     source = install(src_path, source=origin, recursive=True)
@@ -535,6 +537,7 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_target_ssh_inherit():
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os import chmod
 import stat
@@ -298,6 +299,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
+@skip_direct_mode
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
@@ -368,6 +370,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
+@skip_direct_mode
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
     source = install(src_path, source=origin, recursive=True)
@@ -430,6 +433,7 @@ def test_failon_no_permissions(src_path, target_path):
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile
+@skip_direct_mode
 def test_replace_and_relative_sshpath(src_path, dst_path):
     # We need to come up with the path relative to our current home directory
     # https://github.com/datalad/datalad/issues/1653
@@ -530,6 +534,7 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
         assert_false(target_sub.repo.file_has_content('sub.dat'))
 
 
+@skip_direct_mode
 def test_target_ssh_inherit():
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -300,7 +300,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
@@ -371,7 +371,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
@@ -435,7 +435,7 @@ def test_failon_no_permissions(src_path, target_path):
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_replace_and_relative_sshpath(src_path, dst_path):
     # We need to come up with the path relative to our current home directory
     # https://github.com/datalad/datalad/issues/1653
@@ -536,7 +536,7 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
         assert_false(target_sub.repo.file_has_content('sub.dat'))
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_target_ssh_inherit():
     # TODO: waits for resolution on

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -8,6 +8,7 @@
 """Test create testdataset helpers
 
 """
+from datalad.tests.utils import skip_direct_mode
 from glob import glob
 from os.path import join as opj
 
@@ -36,6 +37,7 @@ def test_parse_spec():
     eq_(_parse_spec(''), [])
 
 
+@skip_direct_mode
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -47,6 +49,7 @@ def test_create_test_dataset():
         ok_(len(glob(opj(ds, 'file*'))))
 
 
+@skip_direct_mode
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -57,6 +60,7 @@ def test_create_1test_dataset():
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
     with swallow_logs(), chpwd(topdir), swallow_outputs():
@@ -68,6 +72,7 @@ def test_new_relpath(topdir):
 
 
 @with_tempfile()
+@skip_direct_mode
 def test_hierarchy(topdir):
     # GH 1178
     from datalad.api import create_test_dataset

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -37,7 +37,7 @@ def test_parse_spec():
     eq_(_parse_spec(''), [])
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -49,7 +49,7 @@ def test_create_test_dataset():
         ok_(len(glob(opj(ds, 'file*'))))
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -60,7 +60,7 @@ def test_create_1test_dataset():
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
     with swallow_logs(), chpwd(topdir), swallow_outputs():
@@ -72,7 +72,7 @@ def test_new_relpath(topdir):
 
 
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_hierarchy(topdir):
     # GH 1178
     from datalad.api import create_test_dataset

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -325,6 +325,7 @@ def test_get_recurse_subdatasets(src, path):
 
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
+@skip_v6
 def test_get_greedy_recurse_subdatasets(src, path):
 
     ds = install(

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -10,6 +10,7 @@
 """
 
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from os import curdir
 from os.path import join as opj, basename
@@ -247,6 +248,7 @@ def test_get_recurse_dirs(o_path, c_path):
 @slow  # 15.1496s
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_get_recurse_subdatasets(src, path):
 
     ds = install(
@@ -401,6 +403,7 @@ def test_get_mixed_hierarchy(src, path):
 
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_autoresolve_multiple_datasets(src, path):
     with chpwd(path):
         ds1 = install(

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -10,6 +10,7 @@
 """
 
 
+from datalad.tests.utils import skip_direct_mode
 from os import curdir
 from os.path import join as opj, basename
 from glob import glob
@@ -94,6 +95,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(content="doesntmatter")
+@skip_direct_mode
 def test_get_invalid_call(path, file_outside):
 
     # no argument at all:
@@ -156,6 +158,7 @@ def test_get_single_file(path):
                  'file4.txt': 'whatever 4'})
 @serve_path_via_http
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_get_multiple_files(path, url, ds_dir):
     from os import listdir
     from datalad.support.network import RI
@@ -203,6 +206,7 @@ def test_get_multiple_files(path, url, ds_dir):
                                 'file4.txt': 'something'
                             }}})
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
@@ -367,6 +371,7 @@ def test_get_install_missing_subdataset(src, path):
 #                  'subds': {'file_in_annex.txt': 'content'}})
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_get_mixed_hierarchy(src, path):
 
     origin = Dataset(src).create(no_annex=True)
@@ -414,6 +419,7 @@ def test_autoresolve_multiple_datasets(src, path):
 @slow  # 20 sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_get_autoresolve_recurse_subdatasets(src, path):
 
     origin = Dataset(src).create()
@@ -441,6 +447,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
 @slow  # 92sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_recurse_existing(src, path):
     origin_ds = _make_dataset_hierarchy(src)
 
@@ -483,6 +490,7 @@ def test_recurse_existing(src, path):
 @slow  # 33sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_get_in_unavailable_subdataset(src, path):
     _make_dataset_hierarchy(src)
     root = install(

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -96,7 +96,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(content="doesntmatter")
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_invalid_call(path, file_outside):
 
     # no argument at all:
@@ -159,7 +159,7 @@ def test_get_single_file(path):
                  'file4.txt': 'whatever 4'})
 @serve_path_via_http
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_multiple_files(path, url, ds_dir):
     from os import listdir
     from datalad.support.network import RI
@@ -207,7 +207,7 @@ def test_get_multiple_files(path, url, ds_dir):
                                 'file4.txt': 'something'
                             }}})
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
@@ -373,7 +373,7 @@ def test_get_install_missing_subdataset(src, path):
 #                  'subds': {'file_in_annex.txt': 'content'}})
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_mixed_hierarchy(src, path):
 
     origin = Dataset(src).create(no_annex=True)
@@ -422,7 +422,7 @@ def test_autoresolve_multiple_datasets(src, path):
 @slow  # 20 sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_autoresolve_recurse_subdatasets(src, path):
 
     origin = Dataset(src).create()
@@ -450,7 +450,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
 @slow  # 92sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_recurse_existing(src, path):
     origin_ds = _make_dataset_hierarchy(src)
 
@@ -493,7 +493,7 @@ def test_recurse_existing(src, path):
 @slow  # 33sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_in_unavailable_subdataset(src, path):
     _make_dataset_hierarchy(src)
     root = install(

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import logging
 import os
 
@@ -399,6 +400,7 @@ def test_install_recursive_with_data(src, path):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
+@skip_direct_mode
 def test_install_into_dataset(source, top_path):
 
     ds = create(top_path)
@@ -440,6 +442,7 @@ def test_install_into_dataset(source, top_path):
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tempfile
+@skip_direct_mode
 def test_failed_install_multiple(top_path):
     ds = create(top_path)
 
@@ -497,6 +500,7 @@ def test_install_known_subdataset(src, path):
 @slow  # 46.3650s
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_implicit_install(src, dst):
 
     origin_top = create(src)
@@ -613,6 +617,7 @@ def test_reckless(path, top_path):
                            }
                  })
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
@@ -726,6 +731,7 @@ def test_install_skip_failed_recursive(src, path):
                            }
                  })
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_install_noautoget_data(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
@@ -756,6 +762,7 @@ def test_install_source_relpath(src, dest):
 @with_tempfile
 @with_tempfile
 @with_tempfile
+@skip_direct_mode
 def test_install_consistent_state(src, dest, dest2, dest3):
     # if we install a dataset, where sub-dataset "went ahead" in that branch,
     # while super-dataset was not yet updated (e.g. we installed super before)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -409,7 +409,7 @@ def test_install_recursive_with_data(src, path):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_install_into_dataset(source, top_path):
 
     ds = create(top_path)
@@ -451,7 +451,7 @@ def test_install_into_dataset(source, top_path):
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_failed_install_multiple(top_path):
     ds = create(top_path)
 
@@ -510,7 +510,7 @@ def test_install_known_subdataset(src, path):
 @slow  # 46.3650s
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_implicit_install(src, dst):
 
     origin_top = create(src)
@@ -627,7 +627,7 @@ def test_reckless(path, top_path):
                            }
                  })
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
@@ -742,7 +742,7 @@ def test_install_skip_failed_recursive(src, path):
                            }
                  })
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_install_noautoget_data(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
@@ -773,7 +773,7 @@ def test_install_source_relpath(src, dest):
 @with_tempfile
 @with_tempfile
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_install_consistent_state(src, dest, dest2, dest3):
     # if we install a dataset, where sub-dataset "went ahead" in that branch,
     # while super-dataset was not yet updated (e.g. we installed super before)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import logging
 import os
@@ -222,6 +223,7 @@ def test_install_datasets_root(tdir):
 
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_install_simple_local(src, path):
     origin = Dataset(path)
 
@@ -261,6 +263,7 @@ def test_install_simple_local(src, path):
 
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
+@skip_v6  #FIXME
 def test_install_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
         ds = install(source=url)
@@ -274,6 +277,7 @@ def test_install_dataset_from_just_source(url, path):
 
 @with_testrepos(flavors=['local'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_install_dataset_from_instance(src, dst):
     origin = Dataset(src)
     clone = install(source=origin, path=dst)
@@ -288,6 +292,8 @@ def test_install_dataset_from_instance(src, dst):
 
 @with_testrepos(flavors=['network'])
 @with_tempfile
+@skip_v6  #FIXME
+@skip_v6  #FIXME
 def test_install_dataset_from_just_source_via_path(url, path):
     # for remote urls only, the source could be given to `path`
     # to allows for simplistic cmdline calls
@@ -327,6 +333,7 @@ def test_install_dataladri(src, topurl, path):
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_install_recursive(src, path_nr, path_r):
     # first install non-recursive:
     ds = install(path_nr, source=src, recursive=False)
@@ -370,6 +377,8 @@ def test_install_recursive(src, path_nr, path_r):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
+@skip_v6  #FIXME
 def test_install_recursive_with_data(src, path):
 
     # now again; with data:
@@ -468,6 +477,7 @@ def test_failed_install_multiple(top_path):
 
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_install_known_subdataset(src, path):
 
     # get the superdataset:
@@ -618,6 +628,7 @@ def test_reckless(path, top_path):
                  })
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import logging
 import os
@@ -100,6 +101,7 @@ def test_smth_about_not_supported(p1, p2):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -166,6 +168,7 @@ def test_publish_simple(origin, src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
     # we will be publishing back to origin, so to not alter testrepo
@@ -320,6 +323,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 @with_tempfile(mkdir=True)
 @with_tempfile
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
 
     # prepare src
@@ -413,6 +417,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 @with_tempfile()
 @with_tempfile()
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_publish_depends(
         origin,
         src_path,
@@ -521,6 +526,7 @@ def test_gh1426(origin_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_publish_gh1691(origin, src_path, dst_path):
 
     # prepare src; no subdatasets installed, but mount points present

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -100,7 +100,7 @@ def test_smth_about_not_supported(p1, p2):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_publish_simple(origin, src_path, dst_path):
 
@@ -167,7 +167,7 @@ def test_publish_simple(origin, src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
@@ -322,7 +322,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
 
@@ -416,7 +416,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 @with_tempfile()
 @with_tempfile()
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_publish_depends(
         origin,
@@ -497,7 +497,7 @@ def test_publish_depends(
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_gh1426(origin_path, target_path):
     # set up a pair of repos, one the published copy of the other
     origin = create(origin_path)
@@ -558,7 +558,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 @with_tree(tree={'1': '123'})
 @with_tempfile(mkdir=True)
 @serve_path_via_http
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
@@ -575,7 +575,7 @@ def test_publish_target_url(src, desttop, desturl):
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_gh1763(src, target1, target2):
     # this test is very similar to test_publish_depends, but more
     # comprehensible, and directly tests issue 1763

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import logging
 import os
 from os.path import join as opj
@@ -98,6 +99,7 @@ def test_smth_about_not_supported(p1, p2):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -163,6 +165,7 @@ def test_publish_simple(origin, src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
     # we will be publishing back to origin, so to not alter testrepo
@@ -316,6 +319,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile
+@skip_direct_mode
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
 
     # prepare src
@@ -408,6 +412,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 @with_tempfile()
 @with_tempfile()
 @with_tempfile()
+@skip_direct_mode
 def test_publish_depends(
         origin,
         src_path,
@@ -487,6 +492,7 @@ def test_publish_depends(
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_gh1426(origin_path, target_path):
     # set up a pair of repos, one the published copy of the other
     origin = create(origin_path)
@@ -546,6 +552,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 @with_tree(tree={'1': '123'})
 @with_tempfile(mkdir=True)
 @serve_path_via_http
+@skip_direct_mode
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
@@ -562,6 +569,7 @@ def test_publish_target_url(src, desttop, desturl):
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
+@skip_direct_mode
 def test_gh1763(src, target1, target2):
     # this test is very similar to test_publish_depends, but more
     # comprehensible, and directly tests issue 1763

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -7,6 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test subdataset command"""
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj
 from os.path import relpath
@@ -23,6 +24,7 @@ from datalad.tests.utils import assert_status
 
 
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
+@skip_direct_mode
 def test_get_subdatasets(path):
     ds = Dataset(path)
     eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -24,7 +24,7 @@ from datalad.tests.utils import assert_status
 
 
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_subdatasets(path):
     ds = Dataset(path)
     eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj, split as psplit
 from os.path import exists, lexists
@@ -70,6 +71,7 @@ def test_uninstall_uninstalled(path):
 
 
 @with_tempfile()
+@skip_direct_mode
 def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
@@ -219,6 +221,7 @@ def test_uninstall_subdataset(src, dst):
             'keep': 'keep1', 'kill': 'kill1'}},
     'keep': 'keep2',
     'kill': 'kill2'})
+@skip_direct_mode
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
     subds = ds.create('deep', force=True)
@@ -268,6 +271,7 @@ def test_uninstall_dataset(path):
 
 
 @with_tree({'one': 'test', 'two': 'test'})
+@skip_direct_mode
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
     ds.add(os.curdir)
@@ -289,6 +293,7 @@ def test_remove_file_handle_only(path):
 
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
+@skip_direct_mode
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
@@ -349,6 +354,7 @@ def test_remove_dataset_hierarchy(path):
 
 
 @with_tempfile()
+@skip_direct_mode
 def test_careless_subdataset_uninstall(path):
     # nested datasets
     ds = Dataset(path).create()
@@ -367,6 +373,7 @@ def test_careless_subdataset_uninstall(path):
 
 
 @with_tempfile()
+@skip_direct_mode
 def test_kill(path):
     # nested datasets with load
     ds = Dataset(path).create()
@@ -440,6 +447,7 @@ def test_remove_recursive_2(tdir):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_failon_nodrop(path):
     # test to make sure that we do not wipe out data when checks are enabled
     # despite the general error behavior mode

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj, split as psplit
@@ -178,6 +179,7 @@ def test_uninstall_git_file(path):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_uninstall_subdataset(src, dst):
 
     ds = install(dst, source=src, recursive=True)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -72,7 +72,7 @@ def test_uninstall_uninstalled(path):
 
 
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
@@ -223,7 +223,7 @@ def test_uninstall_subdataset(src, dst):
             'keep': 'keep1', 'kill': 'kill1'}},
     'keep': 'keep2',
     'kill': 'kill2'})
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
     subds = ds.create('deep', force=True)
@@ -273,7 +273,7 @@ def test_uninstall_dataset(path):
 
 
 @with_tree({'one': 'test', 'two': 'test'})
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
     ds.add(os.curdir)
@@ -295,7 +295,7 @@ def test_remove_file_handle_only(path):
 
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
@@ -356,7 +356,7 @@ def test_remove_dataset_hierarchy(path):
 
 
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_careless_subdataset_uninstall(path):
     # nested datasets
     ds = Dataset(path).create()
@@ -375,7 +375,7 @@ def test_careless_subdataset_uninstall(path):
 
 
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_kill(path):
     # nested datasets with load
     ds = Dataset(path).create()
@@ -449,7 +449,7 @@ def test_remove_recursive_2(tdir):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_failon_nodrop(path):
     # test to make sure that we do not wipe out data when checks are enabled
     # despite the general error behavior mode

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -36,7 +36,7 @@ from datalad.tests.utils import assert_in_results
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_update_simple(origin, src_path, dst_path):
 
@@ -127,7 +127,7 @@ def test_update_git_smoke(src_path, dst_path):
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_update_fetch_all(src, remote_1, remote_2):
     rmt1 = AnnexRepo.clone(src, remote_1)
     rmt2 = AnnexRepo.clone(src, remote_2)
@@ -186,7 +186,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
@@ -243,7 +243,7 @@ def test_newthings_coming_down(originpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_update_volatile_subds(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -292,7 +292,7 @@ def test_update_volatile_subds(originpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_reobtain_data(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj, exists
 from ..dataset import Dataset
@@ -34,6 +35,7 @@ from datalad.tests.utils import assert_in_results
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -123,6 +125,7 @@ def test_update_git_smoke(src_path, dst_path):
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_update_fetch_all(src, remote_1, remote_2):
     rmt1 = AnnexRepo.clone(src, remote_1)
     rmt2 = AnnexRepo.clone(src, remote_2)
@@ -181,6 +184,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
@@ -237,6 +241,7 @@ def test_newthings_coming_down(originpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_update_volatile_subds(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -285,6 +290,7 @@ def test_update_volatile_subds(originpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_reobtain_data(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,6 +9,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj, exists
@@ -36,6 +37,7 @@ from datalad.tests.utils import assert_in_results
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -122,6 +122,12 @@ definitions = {
                'title': 'Skips SSH tests if this flag is **not** set'}),
         'type': EnsureBool(),
     },
+    'datalad.tests.skipknownfailures': {
+        'ui': ('yesno', {
+               'title': 'Skips tests that are known to currently fail'}),
+        'type': EnsureBool(),
+        'default': 'yes',
+    },
     'datalad.tests.temp.dir': {
         'ui': ('question', {
                'title': 'Create a temporary directory at location specified by this flag. It is used by tests to create a temporary git directory while testing git annex archives etc'}),

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 import logging
 import os
@@ -73,6 +74,7 @@ treeargs = dict(
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     chpwd(repo_path)
@@ -165,6 +167,7 @@ tree4uargs = dict(
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_add_archive_content(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -302,6 +305,8 @@ def test_add_archive_content(path_orig, url, repo_path):
 @with_tempfile(mkdir=True)
 @skip_direct_mode
 @skip_direct_mode
+@skip_v6  #FIXME
+@skip_v6  #FIXME
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -326,6 +331,7 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     repo = AnnexRepo(repo_path, create=True, direct=direct)

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad.tests.utils import skip_direct_mode
 import logging
 import os
 from os import unlink
@@ -71,6 +72,7 @@ treeargs = dict(
 @with_tree(**treeargs)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     chpwd(repo_path)
@@ -162,6 +164,7 @@ tree4uargs = dict(
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_add_archive_content(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -297,6 +300,8 @@ def test_add_archive_content(path_orig, url, repo_path):
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
+@skip_direct_mode
+@skip_direct_mode
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -320,6 +325,7 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
+@skip_direct_mode
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     repo = AnnexRepo(repo_path, create=True, direct=direct)

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -73,7 +73,7 @@ treeargs = dict(
 @with_tree(**treeargs)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
@@ -166,7 +166,7 @@ tree4uargs = dict(
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_add_archive_content(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
@@ -303,8 +303,8 @@ def test_add_archive_content(path_orig, url, repo_path):
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@skip_direct_mode
-@skip_direct_mode
+@skip_direct_mode  #FIXME
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 @skip_v6  #FIXME
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
@@ -330,7 +330,7 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -76,7 +76,7 @@ def test_invalid_call(path):
 
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
@@ -220,7 +220,7 @@ def test_annotate_paths(dspath, nodspath):
 
 
 @with_tree(demo_hierarchy['b'])
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_get_modified_subpaths(path):
     ds = Dataset(path).create(force=True)
     suba = ds.create('ba', force=True)
@@ -325,7 +325,7 @@ def test_get_modified_subpaths(path):
 
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -10,6 +10,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 from copy import deepcopy
 
 from os.path import join as opj
@@ -75,6 +76,7 @@ def test_invalid_call(path):
 
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
@@ -218,6 +220,7 @@ def test_annotate_paths(dspath, nodspath):
 
 
 @with_tree(demo_hierarchy['b'])
+@skip_direct_mode
 def test_get_modified_subpaths(path):
     ds = Dataset(path).create(force=True)
     suba = ds.create('ba', force=True)
@@ -322,6 +325,7 @@ def test_get_modified_subpaths(path):
 
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)

--- a/datalad/interface/tests/test_crawl_init.py
+++ b/datalad/interface/tests/test_crawl_init.py
@@ -37,7 +37,7 @@ def _test_crawl_init(args, template, template_func, save, target_value, tmpdir):
             ok_clean_git(tmpdir, annex=isinstance(ds.repo, AnnexRepo))
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_crawl_init():
     yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', False, \
@@ -57,7 +57,7 @@ def _test_crawl_init_error(args, template, template_func, target_value, tmpdir):
             assert_raises(target_value, crawl_init, args=args, template=template, template_func=template_func)
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_crawl_init_error():
     yield _test_crawl_init_error, 'tmpdir', None, None, ValueError
@@ -79,7 +79,7 @@ def _test_crawl_init_error_patch(return_value, exc, exc_msg, d):
             cm.assert_called_with('openfmri', None, return_only=True, kwargs=OrderedDict([('dataset', 'Baltimore')]))
 
 
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_crawl_init_error_patch():
     yield _test_crawl_init_error_patch, [], ValueError, "returned pipeline is empty"

--- a/datalad/interface/tests/test_crawl_init.py
+++ b/datalad/interface/tests/test_crawl_init.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
+from datalad.tests.utils import skip_direct_mode
 from nose.tools import eq_, assert_raises, assert_in
 from mock import patch
 from ...api import crawl_init
@@ -35,6 +36,7 @@ def _test_crawl_init(args, template, template_func, save, target_value, tmpdir):
             ok_clean_git(tmpdir, annex=isinstance(ds.repo, AnnexRepo))
 
 
+@skip_direct_mode
 def test_crawl_init():
     yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', False, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
@@ -53,6 +55,7 @@ def _test_crawl_init_error(args, template, template_func, target_value, tmpdir):
             assert_raises(target_value, crawl_init, args=args, template=template, template_func=template_func)
 
 
+@skip_direct_mode
 def test_crawl_init_error():
     yield _test_crawl_init_error, 'tmpdir', None, None, ValueError
     yield _test_crawl_init_error, ['dataset=Baltimore', 'pie=True'], 'openfmri', None, RuntimeError
@@ -73,6 +76,7 @@ def _test_crawl_init_error_patch(return_value, exc, exc_msg, d):
             cm.assert_called_with('openfmri', None, return_only=True, kwargs=OrderedDict([('dataset', 'Baltimore')]))
 
 
+@skip_direct_mode
 def test_crawl_init_error_patch():
     yield _test_crawl_init_error_patch, [], ValueError, "returned pipeline is empty"
     yield _test_crawl_init_error_patch, {1: 2}, ValueError, "pipeline should be represented as a list. Got: {1: 2}"

--- a/datalad/interface/tests/test_crawl_init.py
+++ b/datalad/interface/tests/test_crawl_init.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from nose.tools import eq_, assert_raises, assert_in
 from mock import patch
@@ -37,6 +38,7 @@ def _test_crawl_init(args, template, template_func, save, target_value, tmpdir):
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_crawl_init():
     yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', False, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
@@ -56,6 +58,7 @@ def _test_crawl_init_error(args, template, template_func, target_value, tmpdir):
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_crawl_init_error():
     yield _test_crawl_init_error, 'tmpdir', None, None, ValueError
     yield _test_crawl_init_error, ['dataset=Baltimore', 'pie=True'], 'openfmri', None, RuntimeError
@@ -77,6 +80,7 @@ def _test_crawl_init_error_patch(return_value, exc, exc_msg, d):
 
 
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_crawl_init_error_patch():
     yield _test_crawl_init_error_patch, [], ValueError, "returned pipeline is empty"
     yield _test_crawl_init_error_patch, {1: 2}, ValueError, "pipeline should be represented as a list. Got: {1: 2}"

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad.tests.utils import skip_v6
 from datalad.tests.utils import skip_direct_mode
 from os.path import join as opj
 from datalad.utils import chpwd
@@ -44,6 +45,7 @@ def test_magic_number():
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_diff(path, norepo):
     with chpwd(norepo):
         assert_status('impossible', diff(on_failure='ignore'))
@@ -143,6 +145,7 @@ def test_diff(path, norepo):
 
 @with_tempfile(mkdir=True)
 @skip_direct_mode
+@skip_v6  #FIXME
 def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -144,7 +144,7 @@ def test_diff(path, norepo):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 @skip_v6  #FIXME
 def test_diff_recursive(path):
     ds = Dataset(path).create()

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad.tests.utils import skip_direct_mode
 from os.path import join as opj
 from datalad.utils import chpwd
 
@@ -141,6 +142,7 @@ def test_diff(path, norepo):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad.tests.utils import skip_direct_mode
 import logging
 from os.path import join as opj
 from datalad.utils import chpwd
@@ -88,6 +89,7 @@ def test_basics(path, nodspath):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_rerun(path, nodspath):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -89,7 +89,7 @@ def test_basics(path, nodspath):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_rerun(path, nodspath):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -36,7 +36,7 @@ from datalad.tests.utils import assert_result_values_equal
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_save(path):
 
     ds = Dataset(path)
@@ -112,7 +112,7 @@ def test_save(path):
 
 
 @with_tempfile()
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_recursive_save(path):
     ds = Dataset(path).create()
     # nothing to save
@@ -261,7 +261,7 @@ def test_recursive_save(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_subdataset_save(path):
     parent = Dataset(path).create()
     sub = parent.create('sub')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj
 from datalad.utils import chpwd
@@ -35,6 +36,7 @@ from datalad.tests.utils import assert_result_values_equal
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
+@skip_direct_mode
 def test_save(path):
 
     ds = Dataset(path)
@@ -110,6 +112,7 @@ def test_save(path):
 
 
 @with_tempfile()
+@skip_direct_mode
 def test_recursive_save(path):
     ds = Dataset(path).create()
     # nothing to save
@@ -258,6 +261,7 @@ def test_recursive_save(path):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_subdataset_save(path):
     parent = Dataset(path).create()
     sub = parent.create('sub')

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -10,6 +10,7 @@
 
 """
 
+from datalad.tests.utils import skip_direct_mode
 import os
 import logging
 from os.path import join as opj
@@ -133,6 +134,7 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 
 @slow  # 74.4509s
 @with_tree(demo_hierarchy)
+@skip_direct_mode
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -134,7 +134,7 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 
 @slow  # 74.4509s
 @with_tree(demo_hierarchy)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)

--- a/datalad/metadata/tests/test_manipulation.py
+++ b/datalad/metadata/tests/test_manipulation.py
@@ -214,7 +214,7 @@ def test_basic_dsmeta(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_mod_hierarchy(path):
     base = Dataset(path).create()
     sub = base.create('sub')

--- a/datalad/metadata/tests/test_manipulation.py
+++ b/datalad/metadata/tests/test_manipulation.py
@@ -10,6 +10,7 @@
 """Test meta data manipulation"""
 
 
+from datalad.tests.utils import skip_direct_mode
 import os
 from os.path import join as opj
 from os.path import exists
@@ -213,6 +214,7 @@ def test_basic_dsmeta(path):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_mod_hierarchy(path):
     base = Dataset(path).create()
     sub = base.create('sub')

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -10,6 +10,7 @@
 """Test plugin interface mechanics"""
 
 
+from datalad.tests.utils import skip_direct_mode
 import logging
 from os.path import join as opj
 from os.path import exists
@@ -212,6 +213,7 @@ def test_wtf(path):
 
 
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_no_annex(path):
     ds = create(path)
     ok_clean_git(ds.path)

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -213,7 +213,7 @@ def test_wtf(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_no_annex(path):
     ds = create(path)
     ok_clean_git(ds.path)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,6 +10,7 @@
 
 """
 
+from datalad.tests.utils import skip_v6
 import logging
 from functools import partial
 import os
@@ -233,6 +234,7 @@ def test_AnnexRepo_annex_proxy(src, annex_path):
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
+@skip_v6  #FIXME
 def test_AnnexRepo_get_file_key(src, annex_path):
 
     ar = AnnexRepo.clone(src, annex_path)
@@ -260,6 +262,7 @@ def test_AnnexRepo_get_file_key(src, annex_path):
 
 
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_AnnexRepo_get_outofspace(annex_path):
     ar = AnnexRepo(annex_path, create=True)
 
@@ -278,6 +281,7 @@ def test_AnnexRepo_get_outofspace(annex_path):
 
 
 @with_testrepos('basic_annex', flavors=['local'])
+@skip_v6  #FIXME
 def test_AnnexRepo_get_remote_na(path):
     ar = AnnexRepo(path)
 
@@ -295,6 +299,7 @@ def test_AnnexRepo_get_remote_na(path):
 @with_batch_direct
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
+@skip_v6  #FIXME
 def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     ar = AnnexRepo.clone(src, annex_path, direct=direct)
     testfiles = ["test-annex.dat", "test.dat"]
@@ -593,6 +598,7 @@ def test_AnnexRepo_backend_option(path, url):
 
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
+@skip_v6  #FIXME
 def test_AnnexRepo_get_file_backend(src, dst):
     #init local test-annex before cloning:
     AnnexRepo(src)
@@ -715,6 +721,7 @@ def test_AnnexRepo_commit(path):
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])
+@skip_v6  #FIXME
 def test_AnnexRepo_add_to_annex(path):
 
     # Note: Some test repos appears to not be initialized.
@@ -768,6 +775,7 @@ def test_AnnexRepo_add_to_annex(path):
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])
+@skip_v6  #FIXME
 def test_AnnexRepo_add_to_git(path):
 
     # Note: Some test repos appears to not be initialized.
@@ -807,6 +815,7 @@ def test_AnnexRepo_add_to_git(path):
 @ignore_nose_capturing_stdout
 @with_testrepos('.*annex.*', flavors=['local', 'network'])
 @with_tempfile
+@skip_v6  #FIXME
 def test_AnnexRepo_get(src, dst):
 
     annex = AnnexRepo.clone(src, dst)
@@ -881,6 +890,7 @@ def _test_AnnexRepo_get_contentlocation(batch, path, work_dir_outside):
             os.path.realpath(opj(annex.path, key_location)))
 
 
+@skip_v6  #FIXME
 def test_AnnexRepo_get_contentlocation():
     for batch in (False, True):
         yield _test_AnnexRepo_get_contentlocation, batch
@@ -1150,6 +1160,7 @@ def test_repo_version(path1, path2, path3):
 
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
+@skip_v6  #FIXME
 def test_annex_copy_to(origin, clone):
     repo = AnnexRepo(origin, create=False)
     remote = AnnexRepo.clone(origin, clone, create=True)
@@ -1222,6 +1233,7 @@ def test_annex_copy_to(origin, clone):
 
 @with_testrepos('.*annex.*', flavors=['local', 'network'])
 @with_tempfile
+@skip_v6  #FIXME
 def test_annex_drop(src, dst):
     ar = AnnexRepo.clone(src, dst)
     testfile = 'test-annex.dat'
@@ -1550,6 +1562,7 @@ def test_AnnexRepo_flyweight(path1, path2):
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
 @with_tempfile
+@skip_v6  #FIXME
 def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
 
     reporeal = realpath(repo)
@@ -1584,6 +1597,7 @@ def test_AnnexRepo_update_submodule():
     raise SkipTest("TODO")
 
 
+@skip_v6  #FIXME
 def test_AnnexRepo_get_submodules():
     raise SkipTest("TODO")
 
@@ -2092,6 +2106,7 @@ def test_change_description(path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
+@skip_v6  #FIXME
 def test_AnnexRepo_get_corresponding_branch(path):
 
     ar = AnnexRepo(path)
@@ -2111,6 +2126,7 @@ def test_AnnexRepo_get_corresponding_branch(path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
+@skip_v6  #FIXME
 def test_AnnexRepo_get_tracking_branch(path):
 
     ar = AnnexRepo(path)

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -37,7 +37,8 @@ if on_windows:
     raise SkipTest("Can't test direct mode switch, "
                    "if direct mode is forced by OS anyway.")
 
-if cfg.obtain("datalad.repo.version") >= 6:
+repo_version = cfg.get("datalad.repo.version", None)
+if repo_version is not None and int(repo_version) >= 6:
     raise SkipTest("Can't test direct mode switch, "
                    "if repository version 6 or later is enforced.")
 

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -17,6 +17,7 @@ import logging
 # Please do ignore possible unused marking.
 # This is used via Dataset class:
 import datalad.api
+from datalad import cfg
 
 from nose.tools import ok_
 from mock import patch
@@ -36,12 +37,15 @@ if on_windows:
     raise SkipTest("Can't test direct mode switch, "
                    "if direct mode is forced by OS anyway.")
 
+if cfg.obtain("datalad.repo.version") >= 6:
+    raise SkipTest("Can't test direct mode switch, "
+                   "if repository version 6 or later is enforced.")
+
 
 @with_tempfile
 @with_tempfile
 @with_tempfile
 @with_tempfile
-@skip_v6
 def test_direct_cfg(path1, path2, path3, path4):
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
         # create annex repo in direct mode:
@@ -77,7 +81,6 @@ def test_direct_cfg(path1, path2, path3, path4):
 
 
 @with_tempfile
-@skip_v6
 def test_direct_create(path):
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
         ds = Dataset(path).create()
@@ -91,7 +94,6 @@ def test_direct_create(path):
 @skip_if_no_network
 @with_testrepos('basic_annex', flavors=['network'])
 @with_tempfile
-@skip_v6
 def test_direct_install(url, path):
 
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -41,7 +41,7 @@ if on_windows:
 @with_tempfile
 @with_tempfile
 @with_tempfile
-@skip_v6  #FIXME
+@skip_v6
 def test_direct_cfg(path1, path2, path3, path4):
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
         # create annex repo in direct mode:
@@ -77,7 +77,7 @@ def test_direct_cfg(path1, path2, path3, path4):
 
 
 @with_tempfile
-@skip_v6  #FIXME
+@skip_v6
 def test_direct_create(path):
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
         ds = Dataset(path).create()
@@ -91,6 +91,7 @@ def test_direct_create(path):
 @skip_if_no_network
 @with_testrepos('basic_annex', flavors=['network'])
 @with_tempfile
+@skip_v6
 def test_direct_install(url, path):
 
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -11,6 +11,7 @@
 """
 
 
+from datalad.tests.utils import skip_v6
 import logging
 
 # Please do ignore possible unused marking.
@@ -40,6 +41,7 @@ if on_windows:
 @with_tempfile
 @with_tempfile
 @with_tempfile
+@skip_v6  #FIXME
 def test_direct_cfg(path1, path2, path3, path4):
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
         # create annex repo in direct mode:
@@ -75,6 +77,7 @@ def test_direct_cfg(path1, path2, path3, path4):
 
 
 @with_tempfile
+@skip_v6  #FIXME
 def test_direct_create(path):
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
         ds = Dataset(path).create()

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from datalad.tests.utils import skip_direct_mode
 import git
 import os
 
@@ -54,6 +55,7 @@ def test_clone(src, tempdir):
 
 @usecase
 @with_tempfile(mkdir=True)
+@skip_direct_mode
 def test_make_studyforrest_mockup(path):
     # smoke test
     make_studyforrest_mockup(path)

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -55,7 +55,7 @@ def test_clone(src, tempdir):
 
 @usecase
 @with_tempfile(mkdir=True)
-@skip_direct_mode
+@skip_direct_mode  #FIXME
 def test_make_studyforrest_mockup(path):
     # smoke test
     make_studyforrest_mockup(path)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -852,13 +852,16 @@ def skip_ssh(func):
 def skip_v6(func):
     """Skips tests if datalad is configured to use v6 mode
     (DATALAD_REPO_VERSION=6)
+
+    Skipping can be overridden by disabling 'datalad.tests.skipknownfailures'.
     """
     @wraps(func)
     def newfunc(*args, **kwargs):
         from datalad import cfg
         version = cfg.get("datalad.repo.version", None)
         if version is not None and version == '6':
-            raise SkipTest("TODO: Currently disabled in V6")
+            if cfg.obtain("datalad.tests.skipknownfailures"):
+                raise SkipTest("TODO: Currently disabled in V6")
         return func(*args, **kwargs)
     return newfunc
 
@@ -866,13 +869,16 @@ def skip_v6(func):
 def skip_direct_mode(func):
     """Skips tests if datalad is configured to use direct mode
     (set DATALAD_REPO_DIRECT)
+
+    Skipping can be overridden by disabling 'datalad.tests.skipknownfailures'.
     """
     @wraps(func)
     def newfunc(*args, **kwargs):
         from datalad import cfg
         direct = cfg.get("datalad.repo.direct", None)
         if direct is not None:
-            raise SkipTest("TODO: Currently disabled in direct mode")
+            if cfg.obtain("datalad.tests.skipknownfailures"):
+                raise SkipTest("TODO: Currently disabled in direct mode")
         return func(*args, **kwargs)
     return newfunc
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -841,9 +841,38 @@ def skip_ssh(func):
     def newfunc(*args, **kwargs):
         if on_windows:
             raise SkipTest("SSH currently not available on windows.")
-        test_ssh = os.environ.get('DATALAD_TESTS_SSH', '').lower()
+        from datalad import cfg
+        test_ssh = cfg.get("datalad.tests.ssh", None)
         if test_ssh in ('', '0', 'false', 'no'):
             raise SkipTest("Run this test by setting DATALAD_TESTS_SSH")
+        return func(*args, **kwargs)
+    return newfunc
+
+
+def skip_v6(func):
+    """Skips tests if datalad is configured to use v6 mode
+    (DATALAD_REPO_VERSION=6)
+    """
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        from datalad import cfg
+        version = cfg.get("datalad.repo.version", None)
+        if version is not None and version == '6':
+            raise SkipTest("TODO: Currently disabled in V6")
+        return func(*args, **kwargs)
+    return newfunc
+
+
+def skip_direct_mode(func):
+    """Skips tests if datalad is configured to use direct mode
+    (set DATALAD_REPO_DIRECT)
+    """
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        from datalad import cfg
+        direct = cfg.get("datalad.repo.direct", None)
+        if direct is not None:
+            raise SkipTest("TODO: Currently disabled in direct mode")
         return func(*args, **kwargs)
     return newfunc
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -842,7 +842,7 @@ def skip_ssh(func):
         if on_windows:
             raise SkipTest("SSH currently not available on windows.")
         from datalad import cfg
-        test_ssh = cfg.get("datalad.tests.ssh", None)
+        test_ssh = cfg.get("datalad.tests.ssh", '')
         if test_ssh in ('', '0', 'false', 'no'):
             raise SkipTest("Run this test by setting DATALAD_TESTS_SSH")
         return func(*args, **kwargs)


### PR DESCRIPTION
Closes #1562 

Approach changed to use decorators `skip_direct_mode` and `skip_v6` for tests currently failing with those builds. In addition there's a comment `# FIXME` for all of them.

- [x] create initial lists to represent status quo
- [x] mark concerned tests with decorators which are raising `SkipTest`
- [x] properly set up Travis to make use of the above for DM as well as V6