### PR TITLE
ENH: boxcom cast + create-sibling-github

### DIFF
--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -17,6 +17,7 @@ from nose.tools import assert_raises, assert_in, assert_true, assert_false, \
     assert_not_in, assert_equal
 from nose import SkipTest
 
+from ..create_sibling_github import get_repo_url
 
 try:
     import github as gh
@@ -59,3 +60,16 @@ def test_dont_trip_over_missing_subds(path):
     assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting', existing='reconfigure')
     # return happy emptiness when all is skipped
     assert_equal(ds1.create_sibling_github('bogus', recursive=True, github_login='disabledloginfortesting', existing='skip'), [])
+
+
+def test_get_repo_url():
+    from collections import namedtuple
+    FakeRepo = namedtuple('FakeRepo', ('clone_url', 'ssh_url'))
+    https_url1 = 'https://github.com/user1/repo'
+    ssh_ri1 = 'git@github.com/user1/repo1'
+    repo1 = FakeRepo(https_url1, ssh_ri1)
+
+    assert_equal(get_repo_url(repo1, 'ssh', None), ssh_ri1)
+    assert_equal(get_repo_url(repo1, 'ssh', 'user2'), ssh_ri1)  # no support for changing
+    assert_equal(get_repo_url(repo1, 'https', None), https_url1)
+    assert_equal(get_repo_url(repo1, 'https', 'user2'), 'https://user2@github.com/user1/repo')

--- a/docs/casts/boxcom.sh
+++ b/docs/casts/boxcom.sh
@@ -8,8 +8,9 @@ run "cd demo"
 run "datalad run dd if=/dev/urandom of=big.dat bs=1M count=1"
 
 say "Next we configure box.com as a remote storage location, using a git-annex command."
-say "Git-annex requires the login credentials to be given as environment variables. This demo uses a script that hides the real credentials and give some fake output to illustrate the basic idea"
+say "Git-annex requires the login credentials to be given as environment variables WEBDAV_USERNAME and WEBDAV_PASSWORD. This demo uses a script that hides the real credentials"
 run ". ~/box.com_work.sh"
+
 say "Now for the actual box.com configuration."
 say "Key argument is the access URL: 'team/project_one' is where the data will be stored in the box.com account."
 run "git annex initremote box.com type=webdav url=https://dav.box.com/dav/team/project_one chunk=50mb encryption=none"


### PR DESCRIPTION
- boxcom cast -- just let ppl know what variables to defined
- create-sibling-github -- if login provided, then use it while defining github credential name, so to support multiple logins;  also include it within https urls to avoid reentry later (not yet sure about all this but at least it allowed me to use it and try with different accounts)