### PR TITLE
BF: detect git repo root by presence of .git alone

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1199,7 +1199,7 @@ def get_dataset_root(path):
     as the input argument. If no associated dataset exists, or the
     input path doesn't exist, None is returned.
     """
-    suffix = os.sep + opj('.git', 'objects')
+    suffix = os.sep + '.git'
     if not isdir(path):
         path = dirname(path)
     apath = abspath(path)


### PR DESCRIPTION
That is how it is done in other places throughout the code (we should
provide a helper), so no reason to make it special here and thuse
detect correctly root within submodules and workdirs which would have
just .git file or a symlink

Closes #1803