### PR TITLE
BF+ENH: allow for submodules to have numeric or bool names

### DIFF
--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -65,7 +65,11 @@ def _parse_gitmodules(dspath):
     parser = GitConfigParser(gitmodule_path)
     mods = {}
     for sec in parser.sections():
-        modpath = parser.get_value(sec, 'path', default=0)
+        try:
+            modpath = parser.get(sec, 'path')
+        except Exception:
+            lgr.debug("Failed to get '%s.path', skipping section", sec)
+            continue
         if not modpath or not sec.startswith('submodule '):
             continue
         modpath = normpath(opj(dspath, modpath))

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -208,7 +208,7 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
     assert_result_count(subdss, len(subdss), state='absent')
     # this also means, subdatasets to be listed as not fulfilled:
     eq_(set(ds.subdatasets(recursive=True, fulfilled=False, result_xfm='relpaths')),
-        {'subm 1', 'subm 2'})
+        {'subm 1', '2'})
 
 
 @with_testrepos(flavors=['local'])

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -307,7 +307,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
     source = install(src_path, source=origin, recursive=True)
 
     sub1 = Dataset(opj(src_path, "subm 1"))
-    sub2 = Dataset(opj(src_path, "subm 2"))
+    sub2 = Dataset(opj(src_path, "2"))
 
     for flat in False, True:
         target_path_ = target_dir_tpl = target_path + "-" + str(flat)
@@ -328,7 +328,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
                 ui=True)
 
         # raise if git repos were not created
-        for suffix in [sep + 'subm 1', sep + 'subm 2', '']:
+        for suffix in [sep + 'subm 1', sep + '2', '']:
             target_dir = opj(target_path_, 'prefix' if flat else "").rstrip(os.path.sep) + suffix
             # raise if git repos were not created
             GitRepo(target_dir, create=False)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -257,7 +257,7 @@ def test_get_recurse_subdatasets(src, path):
 
     # ask for the two subdatasets specifically. This will obtain them,
     # but not any content of any files in them
-    subds1, subds2 = ds.get(['subm 1', 'subm 2'], get_data=False,
+    subds1, subds2 = ds.get(['subm 1', '2'], get_data=False,
                             description="youcouldnotmakethisup",
                             result_xfm='datasets')
     for d in (subds1, subds2):
@@ -333,7 +333,7 @@ def test_get_greedy_recurse_subdatasets(src, path):
         result_xfm='datasets', return_type='item-or-list')
 
     # GIMME EVERYTHING
-    ds.get(['subm 1', 'subm 2'])
+    ds.get(['subm 1', '2'])
 
     # We got all content in the subdatasets
     subds1, subds2 = ds.subdatasets(result_xfm='datasets')

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -343,7 +343,7 @@ def test_install_recursive(src, path_nr, path_r):
             "Unintentionally installed: %s" % (sub,))
     # this also means, subdatasets to be listed as not fulfilled:
     eq_(set(ds.subdatasets(recursive=True, fulfilled=False, result_xfm='relpaths')),
-        {'subm 1', 'subm 2'})
+        {'subm 1', '2'})
 
     # now recursively:
     # don't filter implicit results so we can inspect them
@@ -361,7 +361,7 @@ def test_install_recursive(src, path_nr, path_r):
     # (Note: Until we provide proper (singleton) instances for Datasets,
     # need to check for their paths)
     assert_in(opj(top_ds.path, 'subm 1'), [i.path for i in ds_list])
-    assert_in(opj(top_ds.path, 'subm 2'), [i.path for i in ds_list])
+    assert_in(opj(top_ds.path, '2'), [i.path for i in ds_list])
 
     eq_(len(top_ds.subdatasets(recursive=True)), 2)
 
@@ -591,22 +591,22 @@ def test_install_list(path, top_path):
     assert_not_in('annex.hardlink', ds.config)
     ok_(ds.is_installed())
     sub1 = Dataset(opj(top_path, 'subm 1'))
-    sub2 = Dataset(opj(top_path, 'subm 2'))
+    sub2 = Dataset(opj(top_path, '2'))
     ok_(not sub1.is_installed())
     ok_(not sub2.is_installed())
 
     # fails, when `source` is passed:
     assert_raises(ValueError, ds.install,
-                  path=['subm 1', 'subm 2'],
+                  path=['subm 1', '2'],
                   source='something')
 
     # now should work:
-    result = ds.install(path=['subm 1', 'subm 2'], result_xfm='paths')
+    result = ds.install(path=['subm 1', '2'], result_xfm='paths')
     ok_(sub1.is_installed())
     ok_(sub2.is_installed())
     eq_(set(result), {sub1.path, sub2.path})
     # and if we request it again via get, result should be empty
-    get_result = ds.get(path=['subm 1', 'subm 2'], get_data=False)
+    get_result = ds.get(path=['subm 1', '2'], get_data=False)
     assert_status('notneeded', get_result)
 
 
@@ -674,7 +674,7 @@ def test_install_skip_list_arguments(src, path, path_outside):
 
     # install a list with valid and invalid items:
     result = ds.install(
-        path=['subm 1', 'not_existing', path_outside, 'subm 2'],
+        path=['subm 1', 'not_existing', path_outside, '2'],
         get_data=False,
         on_failure='ignore', result_xfm=None, return_type='list')
     # good and bad results together
@@ -686,7 +686,7 @@ def test_install_skip_list_arguments(src, path, path_outside):
                          (path_outside, "path not associated with any dataset")]:
         assert_result_count(
             result, 1, status='impossible', message=msg, path=skipped)
-    for sub in [Dataset(opj(path, 'subm 1')), Dataset(opj(path, 'subm 2'))]:
+    for sub in [Dataset(opj(path, 'subm 1')), Dataset(opj(path, '2'))]:
         assert_result_count(
             result, 1, status='ok',
             message=('Installed subdataset in order to get %s', sub.path))
@@ -708,7 +708,7 @@ def test_install_skip_failed_recursive(src, path):
     # install top level:
     ds = install(path, source=src)
     sub1 = Dataset(opj(path, 'subm 1'))
-    sub2 = Dataset(opj(path, 'subm 2'))
+    sub2 = Dataset(opj(path, '2'))
     # sabotage recursive installation of 'subm 1' by polluting the target:
     with open(opj(path, 'subm 1', 'blocking.txt'), "w") as f:
         f.write("sdfdsf")

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -720,7 +720,8 @@ def test_install_skip_failed_recursive(src, path):
         # toplevel dataset was in the house already
         assert_result_count(
             result, 0, path=ds.path, type='dataset')
-        assert_status('error', [result[0]])
+        # subm 1 should fail to install. [1] since comes after '2' submodule
+        assert_in_results(result, status='error', path=sub1.path)
         assert_in_results(result, status='ok', path=sub2.path)
 
         cml.assert_logged(

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -237,12 +237,12 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # prepare src
     source = install(src_path, source=origin.path, recursive=True)
     # we will be trying to push into this later on, need to give permissions...
-    origin_sub2 = Dataset(opj(origin_path, 'subm 2'))
+    origin_sub2 = Dataset(opj(origin_path, '2'))
     origin_sub2.config.set(
         'receive.denyCurrentBranch', 'updateInstead', where='local')
     ## TODO this manual fixup is needed due to gh-1548 -- needs proper solution
     #os.remove(opj(origin_sub2.path, '.git'))
-    #os.rename(opj(origin_path, '.git', 'modules', 'subm 2'), opj(origin_sub2.path, '.git'))
+    #os.rename(opj(origin_path, '.git', 'modules', '2'), opj(origin_sub2.path, '.git'))
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
@@ -265,7 +265,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # we will be testing presence of the file content, so let's make it progress
     sub2_target.config.set('receive.denyCurrentBranch', 'updateInstead', where='local')
     sub1 = GitRepo(opj(src_path, 'subm 1'), create=False)
-    sub2 = GitRepo(opj(src_path, 'subm 2'), create=False)
+    sub2 = GitRepo(opj(src_path, '2'), create=False)
     sub1.add_remote("target", sub1_pub)
     sub2.add_remote("target", sub2_pub)
 
@@ -403,7 +403,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
     sub2_target = AnnexRepo(sub2_pub, create=True)
     sub2_target.checkout("TMP", ["-b"])
     sub1 = GitRepo(opj(src_path, 'subm 1'), create=False)
-    sub2 = GitRepo(opj(src_path, 'subm 2'), create=False)
+    sub2 = GitRepo(opj(src_path, '2'), create=False)
     sub1.add_remote("target", sub1_pub)
     sub2.add_remote("target", sub2_pub)
 

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -33,9 +33,9 @@ def test_get_subdatasets(path):
     ])
     ds.get('sub dataset1')
     eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [
+        'sub dataset1/2',
         'sub dataset1/sub sub dataset1',
         'sub dataset1/subm 1',
-        'sub dataset1/2',
     ])
     # obtain key subdataset, so all leave subdatasets are discoverable
     ds.get(opj('sub dataset1', 'sub sub dataset1'))
@@ -44,19 +44,19 @@ def test_get_subdatasets(path):
         [(path, opj(path, 'sub dataset1'))])
     eq_(subdatasets(ds, recursive=True, result_xfm='relpaths'), [
         'sub dataset1',
-        'sub dataset1/sub sub dataset1',
-        'sub dataset1/sub sub dataset1/subm 1',
-        'sub dataset1/sub sub dataset1/2',
-        'sub dataset1/subm 1',
         'sub dataset1/2',
+        'sub dataset1/sub sub dataset1',
+        'sub dataset1/sub sub dataset1/2',
+        'sub dataset1/sub sub dataset1/subm 1',
+        'sub dataset1/subm 1',
     ])
     # uses slow, flexible query
     eq_(subdatasets(ds, recursive=True, bottomup=True, result_xfm='relpaths'), [
-        'sub dataset1/sub sub dataset1/subm 1',
+        'sub dataset1/2',
         'sub dataset1/sub sub dataset1/2',
+        'sub dataset1/sub sub dataset1/subm 1',
         'sub dataset1/sub sub dataset1',
         'sub dataset1/subm 1',
-        'sub dataset1/2',
         'sub dataset1',
     ])
     eq_(subdatasets(ds, recursive=True, fulfilled=True, result_xfm='relpaths'), [
@@ -66,11 +66,11 @@ def test_get_subdatasets(path):
     eq_([(relpath(r['parentds'], start=ds.path), relpath(r['path'], start=ds.path))
          for r in ds.subdatasets(recursive=True)], [
         (os.curdir, 'sub dataset1'),
-        ('sub dataset1', 'sub dataset1/sub sub dataset1'),
-        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1'),
-        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/2'),
-        ('sub dataset1', 'sub dataset1/subm 1'),
         ('sub dataset1', 'sub dataset1/2'),
+        ('sub dataset1', 'sub dataset1/sub sub dataset1'),
+        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/2'),
+        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1'),
+        ('sub dataset1', 'sub dataset1/subm 1'),
     ])
     # uses slow, flexible query
     eq_(subdatasets(ds, recursive=True, recursion_limit=0),
@@ -82,9 +82,9 @@ def test_get_subdatasets(path):
     eq_(ds.subdatasets(recursive=True, recursion_limit=2, result_xfm='relpaths'),
         [
         'sub dataset1',
+        'sub dataset1/2',
         'sub dataset1/sub sub dataset1',
         'sub dataset1/subm 1',
-        'sub dataset1/2',
     ])
     res = ds.subdatasets(recursive=True)
     assert_status('ok', res)

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -166,6 +166,7 @@ def test_get_subdatasets(path):
         [])
 
 
+@skip_direct_mode  #FIXME
 @with_tempfile
 def test_get_subdatasets_types(path):
     from datalad.api import create

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -35,7 +35,7 @@ def test_get_subdatasets(path):
     eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [
         'sub dataset1/sub sub dataset1',
         'sub dataset1/subm 1',
-        'sub dataset1/subm 2',
+        'sub dataset1/2',
     ])
     # obtain key subdataset, so all leave subdatasets are discoverable
     ds.get(opj('sub dataset1', 'sub sub dataset1'))
@@ -46,17 +46,17 @@ def test_get_subdatasets(path):
         'sub dataset1',
         'sub dataset1/sub sub dataset1',
         'sub dataset1/sub sub dataset1/subm 1',
-        'sub dataset1/sub sub dataset1/subm 2',
+        'sub dataset1/sub sub dataset1/2',
         'sub dataset1/subm 1',
-        'sub dataset1/subm 2',
+        'sub dataset1/2',
     ])
     # uses slow, flexible query
     eq_(subdatasets(ds, recursive=True, bottomup=True, result_xfm='relpaths'), [
         'sub dataset1/sub sub dataset1/subm 1',
-        'sub dataset1/sub sub dataset1/subm 2',
+        'sub dataset1/sub sub dataset1/2',
         'sub dataset1/sub sub dataset1',
         'sub dataset1/subm 1',
-        'sub dataset1/subm 2',
+        'sub dataset1/2',
         'sub dataset1',
     ])
     eq_(subdatasets(ds, recursive=True, fulfilled=True, result_xfm='relpaths'), [
@@ -68,9 +68,9 @@ def test_get_subdatasets(path):
         (os.curdir, 'sub dataset1'),
         ('sub dataset1', 'sub dataset1/sub sub dataset1'),
         ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 1'),
-        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/subm 2'),
+        ('sub dataset1/sub sub dataset1', 'sub dataset1/sub sub dataset1/2'),
         ('sub dataset1', 'sub dataset1/subm 1'),
-        ('sub dataset1', 'sub dataset1/subm 2'),
+        ('sub dataset1', 'sub dataset1/2'),
     ])
     # uses slow, flexible query
     eq_(subdatasets(ds, recursive=True, recursion_limit=0),
@@ -84,7 +84,7 @@ def test_get_subdatasets(path):
         'sub dataset1',
         'sub dataset1/sub sub dataset1',
         'sub dataset1/subm 1',
-        'sub dataset1/subm 2',
+        'sub dataset1/2',
     ])
     res = ds.subdatasets(recursive=True)
     assert_status('ok', res)

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -18,6 +18,7 @@ from datalad.api import subdatasets
 
 from nose.tools import eq_
 from datalad.tests.utils import with_testrepos
+from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_status
@@ -164,3 +165,12 @@ def test_get_subdatasets(path):
                        result_xfm='paths'),
         [])
 
+
+@with_tempfile
+def test_get_subdatasets_types(path):
+    from datalad.api import create
+    ds = create(path)
+    ds.create('1')
+    ds.create('true')
+    # no types casting should happen
+    eq_(ds.subdatasets(result_xfm='relpaths'), ['1', 'true'])

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -96,16 +96,16 @@ def test_update_simple(origin, src_path, dst_path):
         status='ok', type='dataset')
 
     # and now test recursive update with merging in differences
-    create_tree(opj(source.path, 'subm 2'), {'load.dat': 'heavy'})
-    source.add(opj('subm 2', 'load.dat'),
+    create_tree(opj(source.path, '2'), {'load.dat': 'heavy'})
+    source.add(opj('2', 'load.dat'),
                message="saving changes within subm2",
                recursive=True)
     assert_result_count(
         dest.update(merge=True, recursive=True), 2,
         status='ok', type='dataset')
     # and now we can get new file
-    dest.get('subm 2/load.dat')
-    ok_file_has_content(opj(dest.path, 'subm 2', 'load.dat'), 'heavy')
+    dest.get('2/load.dat')
+    ok_file_has_content(opj(dest.path, '2', 'load.dat'), 'heavy')
 
 
 @with_tempfile

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -875,7 +875,7 @@ def test_get_tracking_branch(o_path, c_path):
 def test_submodule_deinit(path):
 
     top_repo = GitRepo(path, create=False)
-    eq_(['subm 1', '2'], [s.name for s in top_repo.get_submodules()])
+    eq_({'subm 1', '2'}, {s.name for s in top_repo.get_submodules()})
     # note: here init=True is ok, since we are using it just for testing
     with swallow_logs(new_level=logging.WARN) as cml:
         top_repo.update_submodule('subm 1', init=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -875,12 +875,12 @@ def test_get_tracking_branch(o_path, c_path):
 def test_submodule_deinit(path):
 
     top_repo = GitRepo(path, create=False)
-    eq_(['subm 1', 'subm 2'], [s.name for s in top_repo.get_submodules()])
+    eq_(['subm 1', '2'], [s.name for s in top_repo.get_submodules()])
     # note: here init=True is ok, since we are using it just for testing
     with swallow_logs(new_level=logging.WARN) as cml:
         top_repo.update_submodule('subm 1', init=True)
         assert_in('Do not use update_submodule with init=True', cml.out)
-    top_repo.update_submodule('subm 2', init=True)
+    top_repo.update_submodule('2', init=True)
     ok_(all([s.module_exists() for s in top_repo.get_submodules()]))
 
     # modify submodule:

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -148,13 +148,13 @@ class SubmoduleDataset(BasicAnnexTestRepo):
         self.repo._git_custom_command(
             '', ['git', 'submodule', 'add', annex.url, 'subm 1'], **kw)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', annex.url, 'subm 2'], **kw)
+            '', ['git', 'submodule', 'add', annex.url, '2'], **kw)
         self.repo._git_custom_command(
-            '', ['git', 'commit', '-m', 'Added subm 1 and subm 2.'], **kw)
+            '', ['git', 'commit', '-m', 'Added subm 1 and 2.'], **kw)
         self.repo._git_custom_command(
             '', ['git', 'submodule', 'update', '--init', '--recursive'], **kw)
         # init annex in subdatasets
-        for s in ('subm 1', 'subm 2'):
+        for s in ('subm 1', '2'):
             self.repo._git_custom_command(
                 '', ['git', 'annex', 'init'],
                 cwd=opj(self.path, s), expect_stderr=True)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -4,7 +4,5 @@
 # For now, until https://github.com/GrahamDumpleton/wrapt/issues/98 resolved
 # we should use fresh version allowing to disable extensions
 wrapt>=1.10.11
-# to test against my patched version of GitPython
-git+https://github.com/yarikoptic/GitPython@bf-useget
 -e .[devel]
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -4,5 +4,7 @@
 # For now, until https://github.com/GrahamDumpleton/wrapt/issues/98 resolved
 # we should use fresh version allowing to disable extensions
 wrapt>=1.10.11
+# to test against my patched version of GitPython
+git+https://github.com/yarikoptic/GitPython@bf-useget
 -e .[devel]
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
 requires = {
     'core': [
         'appdirs',
-        'GitPython>=2.1.0',
+        'GitPython>=2.1.6',
         'iso8601',
         'humanize',
         'mock>=1.0.1',  # mock is also used for auto.py, not only for testing


### PR DESCRIPTION
sits on top of #1801 

to test even more thoroughly.
- [x] requires a fix in GitPython (https://github.com/gitpython-developers/GitPython/issues/613). 
- [x] Fix is still pending upstream and thus pip/debian packages do not provide a fixed version yet.  Merged upstream, but needs more testing/release (done - release 2.1.6)