### PR TITLE
BF: consult also type_src before deciding that by default type is the dataset

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -707,7 +707,7 @@ class Publish(Interface):
                 yield ap
                 continue
             remote_info_result = None
-            if ap.get('type', 'dataset') != 'dataset':
+            if ap.get('type', ap.get('type_src', 'dataset')) != 'dataset':
                 # for everything that is not a dataset get the remote info
                 # for the parent
                 parentds = ap.get('parentds', None)


### PR DESCRIPTION
I must confess that this is a semi-blind fix since I do not really know the purpose
of type_src here, which is used only in few spots in the code.  But I saw that the
record had type_src file, and made sense to be used here

Quick review/blessing/critic would be appreciated @mih 
Closes #1813