### PR TITLE
Make publish -r --since= great again

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -484,8 +484,8 @@ class CreateSibling(Interface):
                 name)
 
         if since == '':
-            # default behavior - only updated since last update
-            # so we figure out what was the last update
+            # consider creating siblings only since the point of
+            # the last update
             # XXX here we assume one to one mapping of names from local branches
             # to the remote
             active_branch = ds.repo.get_active_branch()

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -701,7 +701,10 @@ class Publish(Interface):
                 nondataset_path_status='error',
                 modified=since,
                 return_type='generator',
-                on_failure='ignore'):
+                on_failure='ignore',
+                force_no_revision_change_discovery=False, # we cannot publish what was not committed
+                force_untracked_discovery=False  # since we cannot publish untracked
+        ):
             if ap.get('status', None):
                 # this is done
                 yield ap

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -707,7 +707,7 @@ class Publish(Interface):
                 yield ap
                 continue
             remote_info_result = None
-            if ap.get('type', 'dataset') != 'dataset':
+            if ap.get('type', ap.get('type_src', 'dataset')) != 'dataset':
                 # for everything that is not a dataset get the remote info
                 # for the parent
                 parentds = ap.get('parentds', None)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -352,7 +352,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # since published to origin -- destination should not get that file
     nok_(lexists(opj(sub2_target.path, 'file.dat')))
     res_ = publish(dataset=source, to='target', recursive=True)
-    assert_status(('ok', 'notneeded'), res)
+    assert_status(('ok', 'notneeded'), res_)
     assert_result_count(res_, 1, status='ok', path=sub2.path, type='dataset')
     assert_result_count(res_, 0, path=opj(sub2.path, 'file.dat'), type='file')
 
@@ -374,6 +374,19 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     ok_(sub2_target.file_has_content('file.dat'))
     assert_result_count(
         res_, 1, status='ok', path=opj(sub2.path, 'file.dat'))
+
+    # Let's save those present changes and publish while implying "since last
+    # merge point"
+    source.save(message="Changes in subm2")
+    # and test if it could deduce the remote/branch to push to
+    source.config.set('branch.master.remote', 'target', where='local')
+    with chpwd(source.path):
+        res_ = publish(since='', recursive=True)
+    # TODO: somehow test that there were no even attempt to diff within "subm 1"
+    # since if `--since=''` worked correctly, nothing has changed there and it
+    # should have not been even touched
+    assert_status(('ok', 'notneeded'), res_)
+    assert_result_count(res_, 1, status='ok', path=source.path, type='dataset')
 
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -166,7 +166,9 @@ def yield_recursive(ds, path, action, recursion_limit):
             yield subd_res
 
 
-def get_modified_subpaths(aps, refds, revision, recursion_limit=None):
+def get_modified_subpaths(aps, refds, revision, recursion_limit=None,
+                          report_no_revision_change=True,
+                          report_untracked='all'):
     """
     Parameters
     ----------
@@ -202,10 +204,10 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None):
             # we might want to consider putting 'untracked' here
             # maybe that is a little faster, not tested yet
             ignore_subdatasets='none',
-            # we want to see any individual untracked file, this simplifies further
+            # by default, we want to see any individual untracked file, this simplifies further
             # processing dramatically, but may require subsequent filtering
             # in order to avoid flooding user output with useless info
-            report_untracked='all',
+            report_untracked=report_untracked,
             # no recursion, we needs to update `revision` for every subdataset
             # before we can `diff`
             recursive=False,
@@ -216,6 +218,11 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None):
         if r['status'] in ('impossible', 'error'):
             # something unexpected, tell daddy
             yield r
+            continue
+        # if asked, and no change in revision -- skip
+        if not report_no_revision_change \
+                and (r.get('revision_src') or r.get('revision')) \
+                and (r.get('revision_src') == r.get('revision')):
             continue
         r['status'] = ''
         modified.append(r)
@@ -410,6 +417,20 @@ class AnnotatePaths(Interface):
             when they are not installed, or their mount point directory doesn't
             exist. Disabling saves on command run time, if this information is
             not needed."""),
+        force_untracked_discovery=Parameter(
+            args=("--no-untracked-discovery",),
+            action='store_false',
+            dest='force_untracked_discovery',
+            doc="""Flag to disable discovery of untracked changes.
+                Disabling saves on command run time, if this information is
+                not needed."""),
+        force_no_revision_change_discovery=Parameter(
+            args=("--revision-change-discovery",),
+            action='store_false',
+            dest='force_no_revision_change_discovery',
+            doc="""Flag to disable discovery of changes which were not yet committed.
+            Disabling saves on command run time, if this information is
+            not needed."""),
         modified=Parameter(
             args=("--modified",),
             nargs='?',
@@ -439,6 +460,8 @@ class AnnotatePaths(Interface):
             nondataset_path_status='error',
             force_parentds_discovery=True,
             force_subds_discovery=True,
+            force_no_revision_change_discovery=True,
+            force_untracked_discovery=True,
             modified=None):
         # upfront check for the fastest possible response
         if not path and dataset is None:
@@ -455,7 +478,6 @@ class AnnotatePaths(Interface):
 
         # everything in one big loop to be able too yield as fast a possible
         # without any precomputing for all paths
-
         refds_path = Interface.get_refds_path(dataset)
         if modified is not None and (refds_path is None or not GitRepo.is_valid_repo(refds_path)):
             raise ValueError(
@@ -534,6 +556,8 @@ class AnnotatePaths(Interface):
                 requested_paths if requested_paths else [refds_path],
                 refds=Dataset(refds_path),
                 revision=modified,
+                report_no_revision_change=force_no_revision_change_discovery,
+                report_untracked='all' if force_untracked_discovery else 'no',
                 recursion_limit=recursion_limit)
 
         # do not loop over unique(), this could be a list of dicts
@@ -709,6 +733,8 @@ class AnnotatePaths(Interface):
                         rec_paths,
                         refds=Dataset(refds_path),
                         revision=modified,
+                        report_no_revision_change=force_no_revision_change_discovery,
+                        report_untracked='all' if force_untracked_discovery else 'no',
                         recursion_limit=recursion_limit):
                     res = get_status_dict(**dict(r, **res_kwargs))
                     reported_paths[res['path']] = res


### PR DESCRIPTION
Yet another semi-blind fix on top of the previous tiny #1814 (since otherwise couldn't check) making it possible to just `publish -r --since=`.  The last commit is the trickiest since I think I violated some logic of tripple-annotating-and-diffing files whenever I do not care about files, but rather care about publishing changes to entire datasets.  I have changed to report that there is a diff if commits differ, which was the logic if no files were provided.  But the thing is that files were provided, since they were result of the first stage of annotating paths (why would we care about individual files when publishing full datasets?) and were passed below in the logic.

Another commit extended API of helpers and the interface to allow to not care about unstaged and not tracked files while annotating paths.  Made use of it in publish, since we can publish only what is committed (so why bother traversing into changes/untracked which aren't?).  Closes #1812  

Unfortunately only @mih could tell me where I violated anything, and now I am interested to see if tests pass.   I only know that `publish -r --since=` seems to work again.  I will give it a shot again after updating few datasets.

related closed whining: #1495