### PR TITLE
BF: Don't extract an empty string from datalad.repo.version

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -197,6 +197,13 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         if version is None:
             version = self.config.get("datalad.repo.version", None)
+            # we might get an empty string here
+            # TODO: if we use obtain() instead, we get an error complaining
+            # '' cannot be converted to int (via Constraint as defined for
+            # "datalad.repo.version" in common_cfg
+            # => Allow conversion to result in None?
+            if not version:
+                version = None
 
         if fix_it:
             self._init(version=version, description=description)

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -38,7 +38,7 @@ if on_windows:
                    "if direct mode is forced by OS anyway.")
 
 repo_version = cfg.get("datalad.repo.version", None)
-if repo_version is not None and int(repo_version) >= 6:
+if repo_version and int(repo_version) >= 6:
     raise SkipTest("Can't test direct mode switch, "
                    "if repository version 6 or later is enforced.")
 


### PR DESCRIPTION
Fixes Travis build using `DATALAD_REPO_VERSION=`.

We need a more general solution as stated in the comment (see diff), but a quickfix might be more important right now to not obfuscate other failures.

edit Closes #1835 