### PR TITLE
BF: towards fixing v6 (and may be direct mode)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,6 @@ matrix:
     - DATALAD_REPO_VERSION=6
     - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
     - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-
   - python: 2.7
     # test whether known direct mode failures still fail
     env:
@@ -141,6 +140,18 @@ matrix:
     env:
     - TMPDIR="/tmp/nfsmount"
     - _DATALAD_NONPR_ONLY=1
+  # test whether known v6 failures still fail
+  - env:
+    - DATALAD_TESTS_SSH=1
+    - DATALAD_REPO_VERSION=6
+    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
+    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
+  # test whether known direct mode failures still fail
+  - env:
+    - DATALAD_TESTS_SSH=1
+    - DATALAD_REPO_DIRECT=yes
+    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
+    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,17 @@ matrix:
     env:
     - TMPDIR="/tmp/nfsmount"
     - _DATALAD_NONPR_ONLY=1
+  - python: 2.7
+    # test whether known v6 failures still fail
+    - DATALAD_REPO_VERSION=6
+    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
+    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
+
+  - python: 2.7
+    # test whether known direct mode failures still fail
+    - DATALAD_REPO_DIRECT=yes
+    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
+    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 
   allow_failures:
   # Test under NFS mount  (full, only in master)

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,12 +121,14 @@ matrix:
     - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     # test whether known v6 failures still fail
+    env:
     - DATALAD_REPO_VERSION=6
     - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
     - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 
   - python: 2.7
     # test whether known direct mode failures still fail
+    env:
     - DATALAD_REPO_DIRECT=yes
     - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
     - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - COVERAGE=coverage
   matrix:
     - DATALAD_REPO_DIRECT=yes
-    - DATALAD_REPO_DIRECT=no
     - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,7 @@ matrix:
   - python: 2.7
     # test whether known v6 failures still fail
     env:
+    - DATALAD_TESTS_SSH=1
     - DATALAD_REPO_VERSION=6
     - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
     - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
@@ -129,6 +130,7 @@ matrix:
   - python: 2.7
     # test whether known direct mode failures still fail
     env:
+    - DATALAD_TESTS_SSH=1
     - DATALAD_REPO_DIRECT=yes
     - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
     - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
   matrix:
-    - DATALAD_REPO_DIRECT=1
-    - DATALAD_REPO_DIRECT=
+    - DATALAD_REPO_DIRECT=yes
+    - DATALAD_REPO_DIRECT=no
     - DATALAD_REPO_VERSION=6
-    - DATALAD_REPO_VERSION=
+    - DATALAD_REPO_VERSION=5
 
 # Disabled since old folks don't want to change workflows of submitting through central authority
 #    - secure: "k2rHdTBjUU3pUUASqfRr7kHaaSmNKLLAR2f66A0fFSulih4CXxwLrR3g8/HP9m+jMve8mAYEiPSI7dT7cCm3WMA/piyLh2wKCGgzDD9oLjtvPAioR8dgLpzbgjxV/Vq6fwwPMlvbqqa+MmAImnAoSufEmI7zVQHCq11Hd5nd6Es="

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -154,8 +154,8 @@ def test_incorrect_options():
     yield check_incorrect_option, ('--dbg',), err_insufficient
     yield check_incorrect_option, tuple(), err_insufficient
 
+
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_script_shims():
     runner = Runner()
     for script in [

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -155,7 +155,6 @@ def test_incorrect_options():
     yield check_incorrect_option, tuple(), err_insufficient
 
 
-@known_failure_direct_mode  #FIXME
 def test_script_shims():
     runner = Runner()
     for script in [

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -8,8 +8,10 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test functioning of the datalad main cmdline utility """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import re
 import sys
 from six.moves import StringIO
@@ -152,8 +154,8 @@ def test_incorrect_options():
     yield check_incorrect_option, ('--dbg',), err_insufficient
     yield check_incorrect_option, tuple(), err_insufficient
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_script_shims():
     runner = Runner()
     for script in [

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -7,8 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from os import listdir
 from os.path import join as opj, exists, lexists, basename
 from collections import OrderedDict
@@ -51,7 +53,7 @@ def test_annexificator_no_git_if_dirty(outdir):
 
 @with_tempfile(mkdir=True)
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_initiate_dataset(path, path2):
     dataset_path = opj(path, 'test')
     datas = list(initiate_dataset('template', 'testdataset', path=dataset_path)())
@@ -169,8 +171,8 @@ def _test_annex_file(mode, topdir, topurl, outdir):
     assert_equal(output[0]['datalad_stats'], ActivityStats(files=1, add_git=1))
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
         yield _test_annex_file, mode
@@ -218,8 +220,8 @@ def _test_add_archive_content_tar(direct, repo_path):
         assert_false(annex.repo.dirty)
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_add_archive_content_tar():
     for direct in (True, False):
         yield _test_add_archive_content_tar, direct
@@ -229,7 +231,7 @@ def test_add_archive_content_tar():
 @with_tempfile(mkdir=True)
 @with_tree(tree={'file': 'load'})
 @serve_path_via_http
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_add_dir_file(repo_path, p, topurl):
     # test whenever file becomes a directory and then back a file.  Should all work!
     annex = Annexificator(path=repo_path, auto_finalize=False)

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -172,10 +172,9 @@ def _test_annex_file(mode, topdir, topurl, outdir):
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
-        yield _test_annex_file, mode
+        yield known_failure_v6(_test_annex_file), mode  #FIXME
 
 
 @assert_cwd_unchanged()  # we are passing annex, not chpwd
@@ -221,7 +220,6 @@ def _test_add_archive_content_tar(direct, repo_path):
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_add_archive_content_tar():
     for direct in (True, False):
         yield _test_add_archive_content_tar, direct

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -171,10 +171,12 @@ def _test_annex_file(mode, topdir, topurl, outdir):
     assert_equal(output[0]['datalad_stats'], ActivityStats(files=1, add_git=1))
 
 
-@known_failure_direct_mode  #FIXME
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
-        yield known_failure_v6(_test_annex_file), mode  #FIXME
+        if mode in ('full', 'fast'):
+            yield known_failure_direct_mode(known_failure_v6(_test_annex_file)), mode  #FIXME
+        else:
+            yield known_failure_v6(_test_annex_file), mode  #FIXME
 
 
 @assert_cwd_unchanged()  # we are passing annex, not chpwd
@@ -219,8 +221,10 @@ def _test_add_archive_content_tar(direct, repo_path):
         assert_false(annex.repo.dirty)
 
 
-@known_failure_direct_mode  #FIXME
 def test_add_archive_content_tar():
+    #FIXME: This doesn't really make sense:
+    # 1. We have a dedicated direct mode test build
+    # 2. On a FS where direct mode is enforced, we can't switch
     for direct in (True, False):
         yield _test_add_archive_content_tar, direct
 

--- a/datalad/crawler/pipelines/tests/test_balsa.py
+++ b/datalad/crawler/pipelines/tests/test_balsa.py
@@ -7,8 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
 from ..balsa import pipeline as ofpipeline, superdataset_pipeline
 import os
@@ -126,8 +128,8 @@ TEST_TREE1 = {
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_balsa_extract_meta(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -201,8 +203,8 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -310,8 +312,8 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -7,9 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_v6
-from datalad.tests.utils import known_failure_direct_mode
-
 
 from .utils import _test_smoke_pipelines
 from ..crcns import pipeline, superdataset_pipeline
@@ -19,7 +16,6 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import ok_startswith
 
 
-@known_failure_direct_mode  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -20,7 +20,6 @@ from datalad.tests.utils import ok_startswith
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -7,8 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from .utils import _test_smoke_pipelines
 from ..crcns import pipeline, superdataset_pipeline
 from ..crcns import get_metadata
@@ -17,8 +19,8 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import ok_startswith
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus', "bogusgroup"]
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -7,8 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from os.path import exists
 from requests.exceptions import InvalidURL
 
@@ -31,8 +33,8 @@ from ..fcptable import pipeline, superdataset_pipeline
 
 TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -7,9 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_v6
-from datalad.tests.utils import known_failure_direct_mode
-
 
 from os.path import exists
 from requests.exceptions import InvalidURL
@@ -33,7 +30,7 @@ from ..fcptable import pipeline, superdataset_pipeline
 
 TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
-@known_failure_direct_mode  #FIXME
+
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_fcptable.py
+++ b/datalad/crawler/pipelines/tests/test_fcptable.py
@@ -34,7 +34,6 @@ from ..fcptable import pipeline, superdataset_pipeline
 TOPURL = "http://fcon_1000.projects.nitrc.org/fcpClassic/FcpTable.html"
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ['bogus']
     yield _test_smoke_pipelines, superdataset_pipeline, []

--- a/datalad/crawler/pipelines/tests/test_openfmri.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri.py
@@ -7,8 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import os
 from glob import glob
 from os.path import join as opj
@@ -206,8 +208,8 @@ _versioned_files = """
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     index_html = opj(ind, 'ds666', 'index.html')
 
@@ -437,8 +439,8 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 )
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_openfmri_pipeline2(ind, topurl, outd):
     # no versioned files -- should still work! ;)
 

--- a/datalad/crawler/pipelines/tests/test_openfmri_collection.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri_collection.py
@@ -7,7 +7,8 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import os
 from glob import glob
 from os.path import join as opj, exists
@@ -54,7 +55,7 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 )
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_openfmri_superdataset_pipeline1(ind, topurl, outd):
 
     list(initiate_dataset(

--- a/datalad/crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad/crawler/pipelines/tests/test_simple_with_archives.py
@@ -7,8 +7,10 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from os.path import join as opj
 
 from datalad.crawler.pipelines.tests.utils import _test_smoke_pipelines
@@ -31,8 +33,8 @@ from logging import getLogger
 lgr = getLogger('datalad.crawl.tests')
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ["random_url"]
 
@@ -43,8 +45,8 @@ from .test_balsa import TEST_TREE1
 @with_tree(tree=TEST_TREE1, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_simple1(ind, topurl, outd):
 
     list(initiate_dataset(
@@ -80,8 +82,8 @@ def test_simple1(ind, topurl, outd):
 }, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_crawl_autoaddtext(ind, topurl, outd):
     ds = create(outd, text_no_annex=True)
     with chpwd(outd):  # TODO -- dataset argument

--- a/datalad/crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad/crawler/pipelines/tests/test_simple_with_archives.py
@@ -34,7 +34,6 @@ lgr = getLogger('datalad.crawl.tests')
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ["random_url"]
 
@@ -46,7 +45,6 @@ from .test_balsa import TEST_TREE1
 @serve_path_via_http
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_simple1(ind, topurl, outd):
 
     list(initiate_dataset(
@@ -83,7 +81,6 @@ def test_simple1(ind, topurl, outd):
 @serve_path_via_http
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_crawl_autoaddtext(ind, topurl, outd):
     ds = create(outd, text_no_annex=True)
     with chpwd(outd):  # TODO -- dataset argument

--- a/datalad/crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad/crawler/pipelines/tests/test_simple_with_archives.py
@@ -7,7 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 
@@ -33,7 +32,6 @@ from logging import getLogger
 lgr = getLogger('datalad.crawl.tests')
 
 
-@known_failure_direct_mode  #FIXME
 def test_smoke_pipelines():
     yield _test_smoke_pipelines, pipeline, ["random_url"]
 

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -124,7 +124,6 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)
@@ -158,7 +157,6 @@ def test_get_git_environ_adjusted():
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
     if not on_windows:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -156,7 +156,6 @@ def test_get_git_environ_adjusted():
     assert_equal(sys_env["PWD"], os.environ.get("PWD"))
 
 
-@known_failure_direct_mode  #FIXME
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
     if not on_windows:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -8,8 +8,10 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for customremotes archives providing dl+archive URLs handling"""
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from ..archives import ArchiveAnnexCustomRemote
 from ..base import AnnexExchangeProtocol
 from ...support.annexrepo import AnnexRepo
@@ -121,8 +123,8 @@ def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
 @with_tree(
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)
@@ -155,8 +157,8 @@ def test_get_git_environ_adjusted():
     assert_equal(sys_env["PWD"], os.environ.get("PWD"))
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_basic_scenario():
     yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
     if not on_windows:

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -8,7 +8,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for the base of our custom remotes"""
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 from os.path import isabs
 
 from datalad.tests.utils import with_tree
@@ -18,7 +19,7 @@ from ..base import AnnexCustomRemote
 
 
 @with_tree(tree={'file.dat': ''})
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)
     repo.add('file.dat')

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -9,7 +9,8 @@
 
 """
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import logging
 from os.path import join as opj
 
@@ -117,7 +118,7 @@ def test_add_files(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_add_recursive(path):
     # make simple hierarchy
     parent = Dataset(path).create()
@@ -149,7 +150,7 @@ def test_add_recursive(path):
 
 
 @with_tree(**tree_arg)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_add_dirty_tree(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
@@ -306,7 +307,7 @@ def test_add_source(path, url, ds_dir):
 
 @with_tree(**tree_arg)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_add_subdataset(path, other):
     subds = create(opj(path, 'dir'), force=True)
     ds = create(path, force=True)
@@ -343,7 +344,7 @@ def test_add_subdataset(path, other):
     'file2.txt': 'some text to go to annex',
     '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
 )
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_add_mimetypes(path):
     # XXX apparently there is symlinks dereferencing going on while deducing repo
     #    type there!!!! so can't use following invocation  -- TODO separately

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -10,8 +10,10 @@
 """
 
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from os.path import join as opj
 from os.path import isdir
 from os.path import exists
@@ -122,7 +124,7 @@ def test_clone_datasets_root(tdir):
 
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_clone_simple_local(src, path):
     origin = Dataset(path)
 
@@ -165,7 +167,7 @@ def test_clone_simple_local(src, path):
 
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_clone_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
         ds = clone(url, result_xfm='datasets', return_type='item-or-list')
@@ -217,7 +219,7 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_clone_into_dataset(source, top_path):
 
     ds = create(top_path)

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -219,7 +219,6 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_clone_into_dataset(source, top_path):
 
     ds = create(top_path)

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -122,9 +122,9 @@ def test_clone_datasets_root(tdir):
         assert_status('error', res)
 
 
+@known_failure_v6  #FIXME
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_clone_simple_local(src, path):
     origin = Dataset(path)
 
@@ -165,9 +165,9 @@ def test_clone_simple_local(src, path):
         eq_(uuid_before, ds.repo.uuid)
 
 
+@known_failure_v6  #FIXME
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_clone_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
         ds = clone(url, result_xfm='datasets', return_type='item-or-list')

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -9,8 +9,10 @@
 
 """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import os
 from os.path import join as opj
 from os.path import lexists
@@ -137,7 +139,7 @@ def test_create(path):
 
 
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_sub(path):
 
     ds = Dataset(path)
@@ -175,8 +177,7 @@ def test_create_sub(path):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode  #FIXME
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto
     # an existing directory tree
@@ -205,8 +206,8 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_nested_create(path):
     # to document some more organic usage pattern
     ds = Dataset(path).create()
@@ -296,7 +297,7 @@ def test_create_withplugin(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_text_no_annex(path):
     ds = create(path, text_no_annex=True)
     ok_clean_git(path)

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -9,8 +9,10 @@
 
 """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import os
 from os import chmod
 import stat
@@ -300,7 +302,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
@@ -371,8 +373,8 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
     source = install(src_path, source=origin, recursive=True)
@@ -435,7 +437,7 @@ def test_failon_no_permissions(src_path, target_path):
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_replace_and_relative_sshpath(src_path, dst_path):
     # We need to come up with the path relative to our current home directory
     # https://github.com/datalad/datalad/issues/1653
@@ -536,8 +538,8 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
         assert_false(target_sub.repo.file_has_content('sub.dat'))
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_target_ssh_inherit():
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -538,10 +538,9 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
         assert_false(target_sub.repo.file_has_content('sub.dat'))
 
 
-@known_failure_direct_mode  #FIXME
 def test_target_ssh_inherit():
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274
     #yield _test_target_ssh_inherit, None      # no wanted etc
     #yield _test_target_ssh_inherit, 'manual'  # manual -- no load should be annex copied
-    yield _test_target_ssh_inherit, 'backup'  # backup -- all data files
+    yield known_failure_direct_mode(_test_target_ssh_inherit), 'backup'  # backup -- all data files  #FIXME

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -539,7 +539,6 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_target_ssh_inherit():
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -60,8 +60,8 @@ def test_create_1test_dataset():
     ok_clean_git(dss[0], annex=False)
 
 
-@with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
     with swallow_logs(), chpwd(topdir), swallow_outputs():
@@ -72,8 +72,8 @@ def test_new_relpath(topdir):
         ok_clean_git(ds, annex=False)
 
 
-@with_tempfile()
 @known_failure_direct_mode  #FIXME
+@with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178
     from datalad.api import create_test_dataset

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -8,7 +8,7 @@
 """Test create testdataset helpers
 
 """
-from datalad.tests.utils import known_failure_direct_mode
+from datalad.tests.utils import skip_direct_mode
 
 from glob import glob
 from os.path import join as opj
@@ -38,7 +38,8 @@ def test_parse_spec():
     eq_(_parse_spec(''), [])
 
 
-@known_failure_direct_mode  #FIXME
+# Note: This randomly fails in direct mode due to gh-issue #1852
+@skip_direct_mode  #FIXME
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -50,7 +51,8 @@ def test_create_test_dataset():
         ok_(len(glob(opj(ds, 'file*'))))
 
 
-@known_failure_direct_mode  #FIXME
+# Note: This randomly fails in direct mode due to gh-issue #1852
+@skip_direct_mode  #FIXME
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -60,7 +62,8 @@ def test_create_1test_dataset():
     ok_clean_git(dss[0], annex=False)
 
 
-@known_failure_direct_mode  #FIXME
+# Note: This randomly fails in direct mode due to gh-issue #1852
+@skip_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
@@ -72,7 +75,8 @@ def test_new_relpath(topdir):
         ok_clean_git(ds, annex=False)
 
 
-@known_failure_direct_mode  #FIXME
+# Note: This randomly fails in direct mode due to gh-issue #1852
+@skip_direct_mode  #FIXME
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -8,7 +8,8 @@
 """Test create testdataset helpers
 
 """
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 from glob import glob
 from os.path import join as opj
 
@@ -37,7 +38,7 @@ def test_parse_spec():
     eq_(_parse_spec(''), [])
 
 
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -49,7 +50,7 @@ def test_create_test_dataset():
         ok_(len(glob(opj(ds, 'file*'))))
 
 
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -60,7 +61,7 @@ def test_create_1test_dataset():
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
     with swallow_logs(), chpwd(topdir), swallow_outputs():
@@ -72,7 +73,7 @@ def test_new_relpath(topdir):
 
 
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_hierarchy(topdir):
     # GH 1178
     from datalad.api import create_test_dataset

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -12,7 +12,6 @@
 
 from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
-from datalad.tests.utils import skip_v6
 
 from os import curdir
 from os.path import join as opj, basename
@@ -327,7 +326,6 @@ def test_get_recurse_subdatasets(src, path):
 
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
-@skip_v6
 def test_get_greedy_recurse_subdatasets(src, path):
 
     ds = install(

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -10,8 +10,10 @@
 """
 
 
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+
 from os import curdir
 from os.path import join as opj, basename
 from glob import glob
@@ -96,7 +98,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(content="doesntmatter")
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_invalid_call(path, file_outside):
 
     # no argument at all:
@@ -159,7 +161,7 @@ def test_get_single_file(path):
                  'file4.txt': 'whatever 4'})
 @serve_path_via_http
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_multiple_files(path, url, ds_dir):
     from os import listdir
     from datalad.support.network import RI
@@ -207,7 +209,7 @@ def test_get_multiple_files(path, url, ds_dir):
                                 'file4.txt': 'something'
                             }}})
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
@@ -248,7 +250,7 @@ def test_get_recurse_dirs(o_path, c_path):
 @slow  # 15.1496s
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_get_recurse_subdatasets(src, path):
 
     ds = install(
@@ -374,7 +376,7 @@ def test_get_install_missing_subdataset(src, path):
 #                  'subds': {'file_in_annex.txt': 'content'}})
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_mixed_hierarchy(src, path):
 
     origin = Dataset(src).create(no_annex=True)
@@ -404,7 +406,7 @@ def test_get_mixed_hierarchy(src, path):
 
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_autoresolve_multiple_datasets(src, path):
     with chpwd(path):
         ds1 = install(
@@ -423,7 +425,7 @@ def test_autoresolve_multiple_datasets(src, path):
 @slow  # 20 sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_autoresolve_recurse_subdatasets(src, path):
 
     origin = Dataset(src).create()
@@ -451,7 +453,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
 @slow  # 92sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_recurse_existing(src, path):
     origin_ds = _make_dataset_hierarchy(src)
 
@@ -494,7 +496,7 @@ def test_recurse_existing(src, path):
 @slow  # 33sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_in_unavailable_subdataset(src, path):
     _make_dataset_hierarchy(src)
     root = install(

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -406,7 +406,6 @@ def test_get_mixed_hierarchy(src, path):
 
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_autoresolve_multiple_datasets(src, path):
     with chpwd(path):
         ds1 = install(

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -223,9 +223,9 @@ def test_install_datasets_root(tdir):
             assert_in("already exists and not empty", str(cme))
 
 
+@known_failure_v6  #FIXME
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_install_simple_local(src, path):
     origin = Dataset(path)
 
@@ -263,9 +263,9 @@ def test_install_simple_local(src, path):
         eq_(uuid_before, ds.repo.uuid)
 
 
+@known_failure_v6  #FIXME
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_install_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
         ds = install(source=url)
@@ -277,9 +277,9 @@ def test_install_dataset_from_just_source(url, path):
     assert_in('INFO.txt', ds.repo.get_indexed_files())
 
 
+@known_failure_v6  #FIXME
 @with_testrepos(flavors=['local'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_install_dataset_from_instance(src, dst):
     origin = Dataset(src)
     clone = install(source=origin, path=dst)
@@ -334,7 +334,6 @@ def test_install_dataladri(src, topurl, path):
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_install_recursive(src, path_nr, path_r):
     # first install non-recursive:
     ds = install(path_nr, source=src, recursive=False)
@@ -378,7 +377,6 @@ def test_install_recursive(src, path_nr, path_r):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_install_recursive_with_data(src, path):
 
     # now again; with data:
@@ -477,7 +475,6 @@ def test_failed_install_multiple(top_path):
 
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_install_known_subdataset(src, path):
 
     # get the superdataset:
@@ -628,7 +625,6 @@ def test_reckless(path, top_path):
                  })
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -400,9 +400,13 @@ def test_install_recursive_with_data(src, path):
             ok_(all(subds.repo.file_has_content(subds.repo.get_annexed_files())))
 
 
-@known_failure_direct_mode  #FIXME
+# @known_failure_direct_mode  #FIXME:
+# If we use all testrepos, we get a mixed hierarchy. Therefore ok_clean_git
+# fails if we are in direct mode and run into a plain git beneath an annex, due
+# to currently impossible recursion of `AnnexRepo._submodules_dirty_direct_mode`
+
 @slow  # 88.0869s  because of going through multiple test repos, ~8sec each time
-@with_testrepos(flavors=['local'])
+@with_testrepos('.*annex.*', flavors=['local'])
 # 'local-url', 'network'
 # TODO: Somehow annex gets confused while initializing installed ds, whose
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,8 +9,10 @@
 
 """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import logging
 import os
 
@@ -223,7 +225,7 @@ def test_install_datasets_root(tdir):
 
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_simple_local(src, path):
     origin = Dataset(path)
 
@@ -263,7 +265,7 @@ def test_install_simple_local(src, path):
 
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_dataset_from_just_source(url, path):
     with chpwd(path, mkdir=True):
         ds = install(source=url)
@@ -277,7 +279,7 @@ def test_install_dataset_from_just_source(url, path):
 
 @with_testrepos(flavors=['local'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_dataset_from_instance(src, dst):
     origin = Dataset(src)
     clone = install(source=origin, path=dst)
@@ -292,8 +294,7 @@ def test_install_dataset_from_instance(src, dst):
 
 @with_testrepos(flavors=['network'])
 @with_tempfile
-@skip_v6  #FIXME
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_dataset_from_just_source_via_path(url, path):
     # for remote urls only, the source could be given to `path`
     # to allows for simplistic cmdline calls
@@ -333,7 +334,7 @@ def test_install_dataladri(src, topurl, path):
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_recursive(src, path_nr, path_r):
     # first install non-recursive:
     ds = install(path_nr, source=src, recursive=False)
@@ -377,8 +378,7 @@ def test_install_recursive(src, path_nr, path_r):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_recursive_with_data(src, path):
 
     # now again; with data:
@@ -409,7 +409,7 @@ def test_install_recursive_with_data(src, path):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_install_into_dataset(source, top_path):
 
     ds = create(top_path)
@@ -451,7 +451,7 @@ def test_install_into_dataset(source, top_path):
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_failed_install_multiple(top_path):
     ds = create(top_path)
 
@@ -477,7 +477,7 @@ def test_failed_install_multiple(top_path):
 
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_install_known_subdataset(src, path):
 
     # get the superdataset:
@@ -510,7 +510,7 @@ def test_install_known_subdataset(src, path):
 @slow  # 46.3650s
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_implicit_install(src, dst):
 
     origin_top = create(src)
@@ -627,8 +627,8 @@ def test_reckless(path, top_path):
                            }
                  })
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
@@ -742,7 +742,7 @@ def test_install_skip_failed_recursive(src, path):
                            }
                  })
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_install_noautoget_data(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
@@ -773,7 +773,7 @@ def test_install_source_relpath(src, dest):
 @with_tempfile
 @with_tempfile
 @with_tempfile
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_install_consistent_state(src, dest, dest2, dest3):
     # if we install a dataset, where sub-dataset "went ahead" in that branch,
     # while super-dataset was not yet updated (e.g. we installed super before)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -400,6 +400,7 @@ def test_install_recursive_with_data(src, path):
             ok_(all(subds.repo.file_has_content(subds.repo.get_annexed_files())))
 
 
+@known_failure_direct_mode  #FIXME
 @slow  # 88.0869s  because of going through multiple test repos, ~8sec each time
 @with_testrepos(flavors=['local'])
 # 'local-url', 'network'
@@ -407,7 +408,6 @@ def test_install_recursive_with_data(src, path):
 # .git/config show a submodule url "file:///aaa/bbb%20b/..."
 # this is delivered by with_testrepos as the url to clone
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_install_into_dataset(source, top_path):
 
     ds = create(top_path)
@@ -738,7 +738,6 @@ def test_install_skip_failed_recursive(src, path):
                            }
                  })
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_install_noautoget_data(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -9,8 +9,10 @@
 
 """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import logging
 import os
 from os.path import join as opj
@@ -101,8 +103,8 @@ def test_smth_about_not_supported(p1, p2):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -227,8 +229,8 @@ def test_publish_plain_git(origin, src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
     # we will be publishing back to origin, so to not alter testrepo
@@ -395,8 +397,8 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
 
     # prepare src
@@ -489,8 +491,8 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 @with_tempfile()
 @with_tempfile()
 @with_tempfile()
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_publish_depends(
         origin,
         src_path,
@@ -570,7 +572,7 @@ def test_publish_depends(
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_gh1426(origin_path, target_path):
     # set up a pair of repos, one the published copy of the other
     origin = create(origin_path)
@@ -599,7 +601,7 @@ def test_gh1426(origin_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_publish_gh1691(origin, src_path, dst_path):
 
     # prepare src; no subdatasets installed, but mount points present
@@ -631,7 +633,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 @with_tree(tree={'1': '123'})
 @with_tempfile(mkdir=True)
 @serve_path_via_http
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
@@ -648,7 +650,7 @@ def test_publish_target_url(src, desttop, desturl):
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_gh1763(src, target1, target2):
     # this test is very similar to test_publish_depends, but more
     # comprehensible, and directly tests issue 1763

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -116,7 +116,6 @@ def test_siblings(origin, repo_path):
     eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
 
-
     # no longer a use case, I would need additional convincing that
     # this is anyhow useful other then tripple checking other peoples
     # errors. for an actual check use 'query'
@@ -187,7 +186,17 @@ def test_siblings(origin, repo_path):
         pushurl = repo.get_remote_url("test-remote-2", push=True)
         ok_(url.startswith(httpurl1))
         ok_(pushurl.startswith(sshurl))
-        if repo != source.repo:
+        # FIXME: next condition used to compare the *Repo objects instead of
+        # there paths. Due to missing annex-init in
+        # datalad/tests/utils.py:clone_url this might not be the same, since
+        # `source` actually is an annex, but after flavor 'clone' in
+        # `with_testrepos` and then `install` any trace of an annex might be
+        # gone in v5 (branch 'master' only), while in direct mode it still is
+        # considered an annex. `repo` is forced to be a `GitRepo`, so we might
+        # compare two objects of different classes while they actually are
+        # pointing to the same repository.
+        # See github issue #1854
+        if repo.path != source.repo.path:
             ok_(url.endswith('/' + basename(repo.path)))
             ok_(pushurl.endswith(basename(repo.path)))
         eq_(url, r['url'])

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -7,7 +7,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test subdataset command"""
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import os
 from os.path import join as opj
 from os.path import relpath
@@ -25,7 +26,7 @@ from datalad.tests.utils import assert_status
 
 
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_subdatasets(path):
     ds = Dataset(path)
     eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [
@@ -166,7 +167,7 @@ def test_get_subdatasets(path):
         [])
 
 
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 @with_tempfile
 def test_get_subdatasets_types(path):
     from datalad.api import create

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -26,7 +26,6 @@ from datalad.tests.utils import assert_status
 
 
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
-@known_failure_direct_mode  #FIXME
 def test_get_subdatasets(path):
     ds = Dataset(path)
     eq_(subdatasets(ds, recursive=True, fulfilled=False, result_xfm='relpaths'), [

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -180,6 +180,7 @@ def test_uninstall_git_file(path):
     eq_(res, ['INFO.txt'])
 
 
+@known_failure_v6  #FIXME  Note: Failure seems to somehow be depend on PY2/PY3
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -180,7 +180,6 @@ def test_uninstall_git_file(path):
     eq_(res, ['INFO.txt'])
 
 
-@known_failure_v6  # FIXME: git files end up in annex, therefore drop result is different
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -181,7 +181,6 @@ def test_uninstall_git_file(path):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_uninstall_subdataset(src, dst):
 
     ds = install(dst, source=src, recursive=True)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -148,6 +148,7 @@ def test_uninstall_annex_file(path):
     ok_(not exists(opj(path, 'test-annex.dat')))
 
 
+@known_failure_v6  # FIXME: git files end up in annex, therefore drop result is different
 @with_testrepos('.*basic.*', flavors=['clone'])
 def test_uninstall_git_file(path):
     ds = Dataset(path)
@@ -179,6 +180,7 @@ def test_uninstall_git_file(path):
     eq_(res, ['INFO.txt'])
 
 
+@known_failure_v6  # FIXME: git files end up in annex, therefore drop result is different
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,8 +9,10 @@
 
 """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import os
 from os.path import join as opj, split as psplit
 from os.path import exists, lexists
@@ -72,7 +74,7 @@ def test_uninstall_uninstalled(path):
 
 
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
@@ -179,7 +181,7 @@ def test_uninstall_git_file(path):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_uninstall_subdataset(src, dst):
 
     ds = install(dst, source=src, recursive=True)
@@ -223,7 +225,7 @@ def test_uninstall_subdataset(src, dst):
             'keep': 'keep1', 'kill': 'kill1'}},
     'keep': 'keep2',
     'kill': 'kill2'})
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
     subds = ds.create('deep', force=True)
@@ -273,7 +275,7 @@ def test_uninstall_dataset(path):
 
 
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
     ds.add(os.curdir)
@@ -303,7 +305,7 @@ def test_remove_file_handle_only(path):
 
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
@@ -364,7 +366,7 @@ def test_remove_dataset_hierarchy(path):
 
 
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_careless_subdataset_uninstall(path):
     # nested datasets
     ds = Dataset(path).create()
@@ -383,7 +385,7 @@ def test_careless_subdataset_uninstall(path):
 
 
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_kill(path):
     # nested datasets with load
     ds = Dataset(path).create()
@@ -457,7 +459,7 @@ def test_remove_recursive_2(tdir):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_failon_nodrop(path):
     # test to make sure that we do not wipe out data when checks are enabled
     # despite the general error behavior mode

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,8 +9,10 @@
 
 """
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import os
 from os.path import join as opj, exists
 from ..dataset import Dataset
@@ -36,8 +38,8 @@ from datalad.tests.utils import assert_in_results
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -127,7 +129,7 @@ def test_update_git_smoke(src_path, dst_path):
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_update_fetch_all(src, remote_1, remote_2):
     rmt1 = AnnexRepo.clone(src, remote_1)
     rmt2 = AnnexRepo.clone(src, remote_2)
@@ -186,7 +188,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
@@ -243,7 +245,7 @@ def test_newthings_coming_down(originpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_update_volatile_subds(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -292,7 +294,7 @@ def test_update_volatile_subds(originpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_reobtain_data(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -16,6 +16,8 @@ from appdirs import AppDirs
 from os.path import join as opj
 from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureInt
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureChoice
 
 dirs = AppDirs("datalad", "datalad.org")
 
@@ -126,13 +128,13 @@ definitions = {
         'ui': ('yesno', {
                'title': 'Skips tests that are known to currently fail'}),
         'type': EnsureBool(),
-        'default': 'yes',
+        'default': True,
     },
     'datalad.tests.knownfailures.probe': {
         'ui': ('yesno', {
                'title': 'Probes tests that are known to fail on whether or not they are actually still failing'}),
         'type': EnsureBool(),
-        'default': 'no',
+        'default': False,
     },
     'datalad.tests.temp.dir': {
         'ui': ('question', {
@@ -206,11 +208,13 @@ definitions = {
                'title': 'Direct Mode for git-annex repositories',
                'text': 'Set this flag to create annex repositories in direct mode by default'}),
         'type': EnsureBool(),
+        'default': False,
     },
     'datalad.repo.version': {
         'ui': ('question', {
                'title': 'git-annex repository version',
                'text': 'Specifies the repository version for git-annex to be used by default'}),
         'type': EnsureInt(),
+        'default': 5,
     },
 }

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -122,11 +122,17 @@ definitions = {
                'title': 'Skips SSH tests if this flag is **not** set'}),
         'type': EnsureBool(),
     },
-    'datalad.tests.skipknownfailures': {
+    'datalad.tests.knownfailures.skip': {
         'ui': ('yesno', {
                'title': 'Skips tests that are known to currently fail'}),
         'type': EnsureBool(),
         'default': 'yes',
+    },
+    'datalad.tests.knownfailures.probe': {
+        'ui': ('yesno', {
+               'title': 'Probes tests that are known to fail on whether or not they are actually still failing'}),
+        'type': EnsureBool(),
+        'default': 'no',
     },
     'datalad.tests.temp.dir': {
         'ui': ('question', {

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -161,6 +161,8 @@ tree4uargs = dict(
 )
 
 
+@known_failure_v6   # FIXME
+#  apparently fails only sometimes in PY3, but in a way that's common in V6
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree1args)
 @serve_path_via_http()

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -12,8 +12,10 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 import logging
 import os
 from os import unlink
@@ -73,8 +75,8 @@ treeargs = dict(
 @with_tree(**treeargs)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     chpwd(repo_path)
@@ -166,8 +168,8 @@ tree4uargs = dict(
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_add_archive_content(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -303,10 +305,8 @@ def test_add_archive_content(path_orig, url, repo_path):
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -330,8 +330,8 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     repo = AnnexRepo(repo_path, create=True, direct=direct)

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 
@@ -76,7 +75,6 @@ treeargs = dict(
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     chpwd(repo_path)
@@ -169,7 +167,6 @@ tree4uargs = dict(
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_add_archive_content(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -306,7 +303,6 @@ def test_add_archive_content(path_orig, url, repo_path):
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -331,7 +327,6 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     repo = AnnexRepo(repo_path, create=True, direct=direct)

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -161,7 +161,6 @@ tree4uargs = dict(
 )
 
 
-@known_failure_v6  # FIXME: git files make repo unexpectedly dirty
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree1args)
 @serve_path_via_http()

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -12,7 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_direct_mode
+from datalad.tests.utils import known_failure_v6
 
 
 import logging
@@ -161,6 +161,7 @@ tree4uargs = dict(
 )
 
 
+@known_failure_v6  # FIXME: git files make repo unexpectedly dirty
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree1args)
 @serve_path_via_http()

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -74,7 +74,6 @@ treeargs = dict(
 @with_tree(**treeargs)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     chpwd(repo_path)
@@ -166,7 +165,6 @@ tree4uargs = dict(
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_archive_content(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -302,7 +300,6 @@ def test_add_archive_content(path_orig, url, repo_path):
 @with_tree(**tree1args)
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     orig_pwd = getpwd()
@@ -326,7 +323,6 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
-@known_failure_direct_mode  #FIXME
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM
     repo = AnnexRepo(repo_path, create=True, direct=direct)

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -10,7 +10,8 @@
 
 """
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 from copy import deepcopy
 
 from os.path import join as opj
@@ -76,7 +77,7 @@ def test_invalid_call(path):
 
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
@@ -220,7 +221,7 @@ def test_annotate_paths(dspath, nodspath):
 
 
 @with_tree(demo_hierarchy['b'])
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_get_modified_subpaths(path):
     ds = Dataset(path).create(force=True)
     suba = ds.create('ba', force=True)
@@ -325,7 +326,7 @@ def test_get_modified_subpaths(path):
 
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)

--- a/datalad/interface/tests/test_crawl_init.py
+++ b/datalad/interface/tests/test_crawl_init.py
@@ -40,7 +40,6 @@ def _test_crawl_init(args, template, template_func, save, target_value, tmpdir):
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_crawl_init():
     yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', False, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
@@ -48,7 +47,8 @@ def test_crawl_init():
           '[crawl:pipeline]\ntemplate = openfmri\n_dataset = ds000001\n\n'
     yield _test_crawl_init, ['dataset=ds000001', 'versioned_urls=True'], 'openfmri', None, False, \
           '[crawl:pipeline]\ntemplate = openfmri\n_dataset = ds000001\n_versioned_urls = True\n\n'
-    yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', True, \
+    #FIXME:
+    yield known_failure_v6(_test_crawl_init), None, 'openfmri', 'superdataset_pipeline', True, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
 
 
@@ -60,7 +60,6 @@ def _test_crawl_init_error(args, template, template_func, target_value, tmpdir):
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_crawl_init_error():
     yield _test_crawl_init_error, 'tmpdir', None, None, ValueError
     yield _test_crawl_init_error, ['dataset=Baltimore', 'pie=True'], 'openfmri', None, RuntimeError
@@ -82,7 +81,6 @@ def _test_crawl_init_error_patch(return_value, exc, exc_msg, d):
 
 
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_crawl_init_error_patch():
     yield _test_crawl_init_error_patch, [], ValueError, "returned pipeline is empty"
     yield _test_crawl_init_error_patch, {1: 2}, ValueError, "pipeline should be represented as a list. Got: {1: 2}"

--- a/datalad/interface/tests/test_crawl_init.py
+++ b/datalad/interface/tests/test_crawl_init.py
@@ -39,7 +39,6 @@ def _test_crawl_init(args, template, template_func, save, target_value, tmpdir):
             ok_clean_git(tmpdir, annex=isinstance(ds.repo, AnnexRepo))
 
 
-@known_failure_direct_mode  #FIXME
 def test_crawl_init():
     yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', False, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
@@ -59,7 +58,6 @@ def _test_crawl_init_error(args, template, template_func, target_value, tmpdir):
             assert_raises(target_value, crawl_init, args=args, template=template, template_func=template_func)
 
 
-@known_failure_direct_mode  #FIXME
 def test_crawl_init_error():
     yield _test_crawl_init_error, 'tmpdir', None, None, ValueError
     yield _test_crawl_init_error, ['dataset=Baltimore', 'pie=True'], 'openfmri', None, RuntimeError
@@ -80,7 +78,6 @@ def _test_crawl_init_error_patch(return_value, exc, exc_msg, d):
             cm.assert_called_with('openfmri', None, return_only=True, kwargs=OrderedDict([('dataset', 'Baltimore')]))
 
 
-@known_failure_direct_mode  #FIXME
 def test_crawl_init_error_patch():
     yield _test_crawl_init_error_patch, [], ValueError, "returned pipeline is empty"
     yield _test_crawl_init_error_patch, {1: 2}, ValueError, "pipeline should be represented as a list. Got: {1: 2}"

--- a/datalad/interface/tests/test_crawl_init.py
+++ b/datalad/interface/tests/test_crawl_init.py
@@ -8,8 +8,10 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from nose.tools import eq_, assert_raises, assert_in
 from mock import patch
 from ...api import crawl_init
@@ -37,8 +39,8 @@ def _test_crawl_init(args, template, template_func, save, target_value, tmpdir):
             ok_clean_git(tmpdir, annex=isinstance(ds.repo, AnnexRepo))
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_crawl_init():
     yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', False, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
@@ -57,8 +59,8 @@ def _test_crawl_init_error(args, template, template_func, target_value, tmpdir):
             assert_raises(target_value, crawl_init, args=args, template=template, template_func=template_func)
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_crawl_init_error():
     yield _test_crawl_init_error, 'tmpdir', None, None, ValueError
     yield _test_crawl_init_error, ['dataset=Baltimore', 'pie=True'], 'openfmri', None, RuntimeError
@@ -79,8 +81,8 @@ def _test_crawl_init_error_patch(return_value, exc, exc_msg, d):
             cm.assert_called_with('openfmri', None, return_only=True, kwargs=OrderedDict([('dataset', 'Baltimore')]))
 
 
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_crawl_init_error_patch():
     yield _test_crawl_init_error_patch, [], ValueError, "returned pipeline is empty"
     yield _test_crawl_init_error_patch, {1: 2}, ValueError, "pipeline should be represented as a list. Got: {1: 2}"

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -12,8 +12,10 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
+
+
 from os.path import join as opj
 from datalad.utils import chpwd
 
@@ -45,7 +47,7 @@ def test_magic_number():
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_diff(path, norepo):
     with chpwd(norepo):
         assert_status('impossible', diff(on_failure='ignore'))
@@ -144,8 +146,8 @@ def test_diff(path, norepo):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
-@skip_v6  #FIXME
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -147,7 +147,6 @@ def test_diff(path, norepo):
 
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -12,7 +12,8 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import logging
 from os.path import join as opj
 from datalad.utils import chpwd
@@ -89,7 +90,7 @@ def test_basics(path, nodspath):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_rerun(path, nodspath):
     ds = Dataset(path).create()
     sub = ds.create('sub')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -12,7 +12,8 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import os
 from os.path import join as opj
 from datalad.utils import chpwd
@@ -36,7 +37,7 @@ from datalad.tests.utils import assert_result_values_equal
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_save(path):
 
     ds = Dataset(path)
@@ -112,7 +113,7 @@ def test_save(path):
 
 
 @with_tempfile()
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_recursive_save(path):
     ds = Dataset(path).create()
     # nothing to save
@@ -261,7 +262,7 @@ def test_recursive_save(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_subdataset_save(path):
     parent = Dataset(path).create()
     sub = parent.create('sub')

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -10,7 +10,8 @@
 
 """
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import os
 import logging
 from os.path import join as opj
@@ -134,7 +135,7 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 
 @slow  # 74.4509s
 @with_tree(demo_hierarchy)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)

--- a/datalad/metadata/tests/test_manipulation.py
+++ b/datalad/metadata/tests/test_manipulation.py
@@ -10,7 +10,8 @@
 """Test meta data manipulation"""
 
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import os
 from os.path import join as opj
 from os.path import exists
@@ -214,7 +215,7 @@ def test_basic_dsmeta(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_mod_hierarchy(path):
     base = Dataset(path).create()
     sub = base.create('sub')

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -10,7 +10,8 @@
 """Test plugin interface mechanics"""
 
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import logging
 from os.path import join as opj
 from os.path import exists
@@ -213,7 +214,7 @@ def test_wtf(path):
 
 
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_no_annex(path):
     ds = create(path)
     ok_clean_git(ds.path)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1673,15 +1673,28 @@ class AnnexRepo(GitRepo, RepoInterface):
         options = options[:] if options else []
 
         if self.is_direct_mode():
+
+            # TODO:
+            # If anything there should be a CommandNotAvailableError now:
             lgr.debug("'%s' is in direct mode, "
                       "'annex unlock' not available", self)
             lgr.warning("In direct mode there is no 'unlock'. However if "
                         "the file's content is present, it is kind of "
                         "unlocked. Therefore just checking whether this is "
                         "the case.")
+            # TODO/FIXME:
+            # Note: the following isn't exactly nice, if `files` is a dir.
+            # For a "correct" result we would need to report all files within
+            # potential dir(s) in `files`, that are annexed and have content.
+            # Also note, that even now files in git might be reported "unlocked",
+            # since they have content. This might be a confusing result.
+            # On the other hand, this is solved on the level of Dataset.unlock
+            # by annotating those paths 'notneeded' beforehand.
             return [f for f in files if self.file_has_content(f)]
 
         else:
+
+            # TODO: catch and parse output if failed (missing content ...)
             std_out, std_err = \
                 self._run_annex_command('unlock', annex_options=files + options)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1905,7 +1905,6 @@ class GitRepo(RepoInterface):
     def deinit_submodule(self, path, **kwargs):
         """Deinit a submodule
 
-
         Parameters
         ----------
         path: str
@@ -1914,9 +1913,9 @@ class GitRepo(RepoInterface):
             see `__init__`
         """
 
-        kwargs = updated(kwargs, {'insert_kwargs_after': 'deinit'})
-        self._gitpy_custom_call('submodule', ['deinit', path],
-                                cmd_options=kwargs)
+        self._git_custom_command(path,
+                                 ['git', 'submodule', 'deinit'] +
+                                 to_options(**kwargs))
         # TODO: return value
 
     def update_submodule(self, path, mode='checkout', init=False):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -745,8 +745,12 @@ class GitRepo(RepoInterface):
         only_remote: bool, optional
             Check only remote (no local branches) for having git-annex branch
         """
-        return any((b.endswith('/git-annex') for b in self.get_remote_branches())) or \
-            ((not only_remote) and any((b == 'git-annex' for b in self.get_branches())))
+        return any((b.endswith('/git-annex') or
+                    'annex/direct' in b
+                    for b in self.get_remote_branches())) or \
+            ((not only_remote) and
+             any((b == 'git-annex' or 'annex/direct' in b
+                  for b in self.get_branches())))
 
     @classmethod
     def get_toppath(cls, path, follow_up=True, git_options=None):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -836,8 +836,10 @@ def test_AnnexRepo_add_unexpected_direct_mode(path):
                           regex=False)
 
 
+
 @ignore_nose_capturing_stdout
-@with_testrepos('.*annex.*', flavors=['local', 'network'])
+@with_testrepos('.*annex.*', flavors=['local'])
+# TODO: flavor 'network' has wrong content for test-annex.dat!
 @with_tempfile
 @skip_v6  #FIXME
 def test_AnnexRepo_get(src, dst):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,7 +10,8 @@
 
 """
 
-from datalad.tests.utils import skip_v6
+from datalad.tests.utils import known_failure_v6
+
 import logging
 from functools import partial
 import os
@@ -235,7 +236,7 @@ def test_AnnexRepo_annex_proxy(src, annex_path):
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_file_key(src, annex_path):
 
     ar = AnnexRepo.clone(src, annex_path)
@@ -263,7 +264,7 @@ def test_AnnexRepo_get_file_key(src, annex_path):
 
 
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_outofspace(annex_path):
     ar = AnnexRepo(annex_path, create=True)
 
@@ -282,7 +283,7 @@ def test_AnnexRepo_get_outofspace(annex_path):
 
 
 @with_testrepos('basic_annex', flavors=['local'])
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_remote_na(path):
     ar = AnnexRepo(path)
 
@@ -300,7 +301,7 @@ def test_AnnexRepo_get_remote_na(path):
 @with_batch_direct
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     ar = AnnexRepo.clone(src, annex_path, direct=direct)
     testfiles = ["test-annex.dat", "test.dat"]
@@ -599,7 +600,7 @@ def test_AnnexRepo_backend_option(path, url):
 
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_file_backend(src, dst):
     #init local test-annex before cloning:
     AnnexRepo(src)
@@ -722,7 +723,7 @@ def test_AnnexRepo_commit(path):
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_add_to_annex(path):
 
     # Note: Some test repos appears to not be initialized.
@@ -776,7 +777,7 @@ def test_AnnexRepo_add_to_annex(path):
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_add_to_git(path):
 
     # Note: Some test repos appears to not be initialized.
@@ -841,7 +842,7 @@ def test_AnnexRepo_add_unexpected_direct_mode(path):
 @with_testrepos('.*annex.*', flavors=['local'])
 # TODO: flavor 'network' has wrong content for test-annex.dat!
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get(src, dst):
 
     annex = AnnexRepo.clone(src, dst)
@@ -916,7 +917,7 @@ def _test_AnnexRepo_get_contentlocation(batch, path, work_dir_outside):
             os.path.realpath(opj(annex.path, key_location)))
 
 
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_contentlocation():
     for batch in (False, True):
         yield _test_AnnexRepo_get_contentlocation, batch
@@ -1186,7 +1187,7 @@ def test_repo_version(path1, path2, path3):
 
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_annex_copy_to(origin, clone):
     repo = AnnexRepo(origin, create=False)
     remote = AnnexRepo.clone(origin, clone, create=True)
@@ -1259,7 +1260,7 @@ def test_annex_copy_to(origin, clone):
 
 @with_testrepos('.*annex.*', flavors=['local', 'network'])
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_annex_drop(src, dst):
     ar = AnnexRepo.clone(src, dst)
     testfile = 'test-annex.dat'
@@ -1588,7 +1589,7 @@ def test_AnnexRepo_flyweight(path1, path2):
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
 @with_tempfile
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
 
     reporeal = realpath(repo)
@@ -1623,7 +1624,7 @@ def test_AnnexRepo_update_submodule():
     raise SkipTest("TODO")
 
 
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_submodules():
     raise SkipTest("TODO")
 
@@ -2132,7 +2133,7 @@ def test_change_description(path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_corresponding_branch(path):
 
     ar = AnnexRepo(path)
@@ -2152,7 +2153,7 @@ def test_AnnexRepo_get_corresponding_branch(path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
-@skip_v6  #FIXME
+@known_failure_v6  #FIXME
 def test_AnnexRepo_get_tracking_branch(path):
 
     ar = AnnexRepo(path)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -242,13 +242,13 @@ def test_AnnexRepo_get_file_key(src, annex_path):
     # test-annex.dat should return the correct key:
     eq_(
         ar.get_file_key("test-annex.dat"),
-        'SHA256E-s4--181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b.dat')
+        'SHA256E-s28--2795fb26981c5a687b9bf44930cc220029223f472cea0f0b17274f4473181e7b.dat')
 
     # and should take a list with an empty string as result, if a file wasn't
     # in annex:
     eq_(
         ar.get_file_key(["filenotpresent.wtf", "test-annex.dat"]),
-        ['', 'SHA256E-s4--181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b.dat']
+        ['', 'SHA256E-s28--2795fb26981c5a687b9bf44930cc220029223f472cea0f0b17274f4473181e7b.dat']
     )
 
     # test.dat is actually in git
@@ -826,7 +826,7 @@ def test_AnnexRepo_get(src, dst):
     with swallow_outputs():
         annex.get(testfile)
     ok_(annex.file_has_content("test-annex.dat"))
-    ok_file_has_content(testfile_abs, '123', strip=True)
+    ok_file_has_content(testfile_abs, "content to be annex-addurl'd", strip=True)
 
     called = []
     # for some reason yoh failed mock to properly just call original func
@@ -851,7 +851,7 @@ def test_AnnexRepo_get(src, dst):
             swallow_outputs():
         annex.get(testfile, jobs=5)
     eq_(called, ['find', 'get'])
-    ok_file_has_content(testfile_abs, '123', strip=True)
+    ok_file_has_content(testfile_abs, "content to be annex-addurl'd", strip=True)
 
 
 # TODO:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -678,8 +678,14 @@ def test_AnnexRepo_always_commit(path):
     eq_(num_commits, 4)
 
 
-@with_testrepos('basic_annex', flavors=['clone'])
-def test_AnnexRepo_on_uninited_annex(path):
+@with_testrepos('basic_annex', flavors=['local'])
+@with_tempfile
+def test_AnnexRepo_on_uninited_annex(origin, path):
+    # "Manually" clone to avoid initialization:
+    from datalad.cmd import Runner
+    runner = Runner()
+    _ = runner(["git", "clone", origin, path], expect_stderr=True)
+
     assert_false(exists(opj(path, '.git', 'annex'))) # must not be there for this test to be valid
     annex = AnnexRepo(path, create=False, init=False)  # so we can initialize without
     # and still can get our things

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -236,7 +236,6 @@ def test_AnnexRepo_annex_proxy(src, annex_path):
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_file_key(src, annex_path):
 
     ar = AnnexRepo.clone(src, annex_path)
@@ -264,7 +263,6 @@ def test_AnnexRepo_get_file_key(src, annex_path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_outofspace(annex_path):
     ar = AnnexRepo(annex_path, create=True)
 
@@ -283,7 +281,6 @@ def test_AnnexRepo_get_outofspace(annex_path):
 
 
 @with_testrepos('basic_annex', flavors=['local'])
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_remote_na(path):
     ar = AnnexRepo(path)
 
@@ -301,7 +298,6 @@ def test_AnnexRepo_get_remote_na(path):
 @with_batch_direct
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     ar = AnnexRepo.clone(src, annex_path, direct=direct)
     testfiles = ["test-annex.dat", "test.dat"]
@@ -600,7 +596,6 @@ def test_AnnexRepo_backend_option(path, url):
 
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_file_backend(src, dst):
     #init local test-annex before cloning:
     AnnexRepo(src)
@@ -842,7 +837,6 @@ def test_AnnexRepo_add_unexpected_direct_mode(path):
 @with_testrepos('.*annex.*', flavors=['local'])
 # TODO: flavor 'network' has wrong content for test-annex.dat!
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get(src, dst):
 
     annex = AnnexRepo.clone(src, dst)
@@ -917,7 +911,6 @@ def _test_AnnexRepo_get_contentlocation(batch, path, work_dir_outside):
             os.path.realpath(opj(annex.path, key_location)))
 
 
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_contentlocation():
     for batch in (False, True):
         yield _test_AnnexRepo_get_contentlocation, batch
@@ -1187,7 +1180,6 @@ def test_repo_version(path1, path2, path3):
 
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_annex_copy_to(origin, clone):
     repo = AnnexRepo(origin, create=False)
     remote = AnnexRepo.clone(origin, clone, create=True)
@@ -1258,9 +1250,10 @@ def test_annex_copy_to(origin, clone):
     eq_(cme.exception.failed, ['nonex1', 'nonex2'])
 
 
-@with_testrepos('.*annex.*', flavors=['local', 'network'])
+
+@with_testrepos('.*annex.*', flavors=['local'])
+# TODO: flavor 'network' has wrong content for test-annex.dat!
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_annex_drop(src, dst):
     ar = AnnexRepo.clone(src, dst)
     testfile = 'test-annex.dat'
@@ -1589,7 +1582,6 @@ def test_AnnexRepo_flyweight(path1, path2):
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
 
     reporeal = realpath(repo)
@@ -2133,7 +2125,6 @@ def test_change_description(path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_corresponding_branch(path):
 
     ar = AnnexRepo(path)
@@ -2153,7 +2144,6 @@ def test_AnnexRepo_get_corresponding_branch(path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_tracking_branch(path):
 
     ar = AnnexRepo(path)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -419,7 +419,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     eq_([u'origin/' + clone.get_active_branch(), u'origin/new_branch'],
         [commit.name for commit in fetched])
 
-    ok_clean_git(clone.path)
+    ok_clean_git(clone.path, annex=False)
     assert_in("origin/new_branch", clone.get_remote_branches())
     assert_in(filename, clone.get_files("origin/new_branch"))
     assert_false(exists(opj(clone_path, filename)))  # not checked out

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -41,7 +41,7 @@ except ImportError:
 # some additional testing, e.g. non-context manager style of invocation
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_proxying_open_testrepobased(repo):
-    TEST_CONTENT = "123\n"
+    TEST_CONTENT = "content to be annex-addurl'd"
     fname = 'test-annex.dat'
     fpath = opj(repo, fname)
     assert_raises(IOError, open, fpath)

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -11,7 +11,7 @@
 """
 
 
-from datalad.tests.utils import skip_v6
+
 import logging
 
 # Please do ignore possible unused marking.

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -7,7 +7,8 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
+
 import git
 import os
 
@@ -55,7 +56,7 @@ def test_clone(src, tempdir):
 
 @usecase
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_make_studyforrest_mockup(path):
     # smoke test
     make_studyforrest_mockup(path)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -11,6 +11,8 @@
 
 """
 
+from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import known_failure_direct_mode
 import inspect
 import os
 import shutil

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -70,6 +70,7 @@ from .utils import assert_not_in
 from .utils import assert_raises
 from .utils import ok_startswith
 from .utils import skip_if_no_module
+from .utils import probe_known_failure, skip_known_failure, known_failure, known_failure_v6, known_failure_direct_mode
 
 
 def test_get_func_kwargs_doc():
@@ -678,3 +679,134 @@ def test_safe_print():
     with patch.object(__builtin__, 'print', _print):
         safe_print("bua")
     assert_equal(called[0], 2)
+
+
+def test_probe_known_failure():
+
+    # Note: we can't test the switch "datalad.tests.knownfailures.probe"
+    # directly, since it was evaluated in the decorator already. So we need
+    # to have different assertions in this test based on config and have it
+    # tested across builds, which use different settings for that switch.
+
+    @probe_known_failure
+    def not_failing():
+        pass
+
+    @probe_known_failure
+    def failing():
+        raise AssertionError("Failed")
+
+    from datalad import cfg
+    switch = cfg.obtain("datalad.tests.knownfailures.probe")
+
+    if switch:
+        # if probing is enabled the failing is considered to be expected and
+        # therefore the decorated function doesn't actually fail:
+        failing()
+        # in opposition a function that doesn't fail raises an AssertionError:
+        assert_raises(AssertionError, not_failing)
+    else:
+        # if probing is disabled it should just fail/pass as is:
+        assert_raises(AssertionError, failing)
+        not_failing()
+
+
+def test_skip_known_failure():
+
+    # Note: we can't test the switch "datalad.tests.knownfailures.skip"
+    # directly, since it was evaluated in the decorator already. So we need
+    # to have different assertions in this test based on config and have it
+    # tested across builds, which use different settings for that switch.
+
+    @skip_known_failure
+    def failing():
+        raise AssertionError("Failed")
+
+    from datalad import cfg
+    switch = cfg.obtain("datalad.tests.knownfailures.skip")
+
+    if switch:
+        # if skipping is enabled, we shouldn't see the exception:
+        failing()
+    else:
+        # if it's disabled, failing() is executed and therefore exception
+        # is raised:
+        assert_raises(AssertionError, failing)
+
+
+def test_known_failure():
+
+    @known_failure
+    def failing():
+        raise AssertionError("Failed")
+
+    from datalad import cfg
+
+    skip = cfg.obtain("datalad.tests.knownfailures.skip")
+    probe = cfg.obtain("datalad.tests.knownfailures.probe")
+
+    if skip:
+        # skipping takes precedence over probing
+        failing()
+    elif probe:
+        # if we probe a known failure it's okay to fail:
+        failing()
+    else:
+        # not skipping and not probing results in the original failure:
+        assert_raises(AssertionError, failing)
+
+
+def test_known_failure_v6():
+
+    @known_failure_v6
+    def failing():
+        raise AssertionError("Failed")
+
+    from datalad import cfg
+
+    v6 = cfg.obtain("datalad.repo.version") == 6
+    skip = cfg.obtain("datalad.tests.knownfailures.skip")
+    probe = cfg.obtain("datalad.tests.knownfailures.probe")
+
+    if v6:
+        if skip:
+            # skipping takes precedence over probing
+            failing()
+        elif probe:
+            # if we probe a known failure it's okay to fail:
+            failing()
+        else:
+            # not skipping and not probing results in the original failure:
+            assert_raises(AssertionError, failing)
+
+    else:
+        # behaves as if it wasn't decorated at all, no matter what
+        assert_raises(AssertionError, failing)
+
+
+def test_known_failure_direct_mode():
+
+    @known_failure_direct_mode
+    def failing():
+        raise AssertionError("Failed")
+
+    from datalad import cfg
+
+    direct = cfg.obtain("datalad.repo.direct")
+    skip = cfg.obtain("datalad.tests.knownfailures.skip")
+    probe = cfg.obtain("datalad.tests.knownfailures.probe")
+
+    if direct:
+        if skip:
+            # skipping takes precedence over probing
+            failing()
+        elif probe:
+            # if we probe a known failure it's okay to fail:
+            failing()
+        else:
+            # not skipping and not probing results in the original failure:
+            assert_raises(AssertionError, failing)
+
+    else:
+        # behaves as if it wasn't decorated at all, no matter what
+        assert_raises(AssertionError, failing)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -963,7 +963,7 @@ def skip_v6(func):
     from datalad import cfg
     version = cfg.obtain("datalad.repo.version")
 
-    @skip_if(version == 6)
+    @skip_if(version == 6, msg="Skip test in v6 test run")
     @wraps(func)
     def newfunc(*args, **kwargs):
         return func(*args, **kwargs)
@@ -977,7 +977,8 @@ def skip_direct_mode(func):
 
     from datalad import cfg
 
-    @skip_if(cfg.obtain("datalad.repo.direct"))
+    @skip_if(cfg.obtain("datalad.repo.direct"),
+             msg="Skip test in direct mode test run")
     @wraps(func)
     def newfunc(*args, **kwargs):
         return func(*args, **kwargs)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -634,6 +634,8 @@ def clone_url(url):
     runner = Runner()
     tdir = tempfile.mkdtemp(**get_tempfile_kwargs({}, prefix='clone_url'))
     _ = runner(["git", "clone", url, tdir], expect_stderr=True)
+    if GitRepo(tdir).is_with_annex():
+        AnnexRepo(tdir, init=True)
     _TEMP_PATHS_CLONES.add(tdir)
     return tdir
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -860,8 +860,19 @@ def skip_v6(func):
         from datalad import cfg
         version = cfg.get("datalad.repo.version", None)
         if version is not None and version == '6':
-            if cfg.obtain("datalad.tests.skipknownfailures"):
+            if cfg.obtain("datalad.tests.knownfailures.skip"):
                 raise SkipTest("TODO: Currently disabled in V6")
+            if cfg.obtain("datalad.tests.knownfailures.probe"):
+                func_failed = False
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    # we expected it to fail; all good
+                    func_failed = True
+                finally:
+                    if not func_failed:
+                        raise AssertionError("Test was marked as a known failure "
+                                             "but didn't fail")
         return func(*args, **kwargs)
     return newfunc
 
@@ -879,6 +890,18 @@ def skip_direct_mode(func):
         if direct is not None:
             if cfg.obtain("datalad.tests.skipknownfailures"):
                 raise SkipTest("TODO: Currently disabled in direct mode")
+            if cfg.obtain("datalad.tests.knownfailures.probe"):
+                func_failed = False
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    # we expected it to fail; all good
+                    func_failed = True
+                finally:
+                    if not func_failed:
+                        raise AssertionError("Test was marked as a known failure "
+                                             "but didn't fail")
+
         return func(*args, **kwargs)
     return newfunc
 

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -172,9 +172,7 @@ class SubmoduleDataset(BasicAnnexTestRepo):
             '', ['git', 'submodule', 'update', '--init', '--recursive'], **kw)
         # init annex in subdatasets
         for s in ('subm 1', 'subm 2'):
-            self.repo._git_custom_command(
-                '', ['git', 'annex', 'init'],
-                cwd=opj(self.path, s), expect_stderr=True)
+            AnnexRepo(opj(self.path, s), init=True)
 
 
 class NestedDataset(BasicAnnexTestRepo):
@@ -201,9 +199,7 @@ class NestedDataset(BasicAnnexTestRepo):
             cwd=self.path, **kw)
         # init all annexes
         for s in ('', 'sub dataset1', opj('sub dataset1', 'sub sub dataset1')):
-            self.repo._git_custom_command(
-                '', ['git', 'annex', 'init'],
-                cwd=opj(self.path, s), expect_stderr=True)
+            AnnexRepo(opj(self.path, s), init=True)
 
 
 class InnerSubmodule(object):

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -24,8 +24,21 @@ from ..utils import swallow_logs
 
 from ..version import __version__
 from . import _TEMP_PATHS_GENERATED
-
+from .utils import get_tempfile_kwargs
 from datalad.customremotes.base import init_datalad_remote
+
+
+# we need a local file, that is supposed to be treated as a remote file via
+# file-scheme URL
+remote_file_fd, remote_file_path = \
+    tempfile.mkstemp(**get_tempfile_kwargs({}, prefix='testrepo'))
+# to be removed upon teardown
+_TEMP_PATHS_GENERATED.append(remote_file_path)
+with open(remote_file_path, "w") as f:
+    f.write("content to be annex-addurl'd")
+# OS-level descriptor needs to be closed!
+os.close(remote_file_fd)
+
 
 @add_metaclass(ABCMeta)
 class TestRepo(object):
@@ -34,7 +47,6 @@ class TestRepo(object):
 
     def __init__(self, path=None, puke_if_exists=True):
         if not path:
-            from .utils import get_tempfile_kwargs
             path = tempfile.mktemp(**get_tempfile_kwargs({}, prefix='testrepo'))
             # to be removed upon teardown
             _TEMP_PATHS_GENERATED.append(path)
@@ -96,9 +108,14 @@ class BasicAnnexTestRepo(TestRepo):
         self.repo.commit("Adding a basic INFO file and rudimentary load file for annex testing")
         # even this doesn't work on bloody Windows
         from .utils import on_windows
-        fileurl = get_local_file_url(opj(self.path, 'test.dat')) \
-                  if not on_windows \
-                  else "https://raw.githubusercontent.com/datalad/testrepo--basic--r1/master/test.dat"
+        fileurl = get_local_file_url(remote_file_path)
+        # Note:
+        # The line above used to be conditional:
+        # if not on_windows \
+        # else "https://raw.githubusercontent.com/datalad/testrepo--basic--r1/master/test.dat"
+        # This self-reference-ish construction (pointing to 'test.dat'
+        # and therefore have the same content in git and annex) is outdated and
+        # causes trouble especially in annex V6 repos.
         self.repo.add_url_to_file("test-annex.dat", fileurl)
         self.repo.commit("Adding a rudimentary git-annex load file")
         self.repo.drop("test-annex.dat")  # since available from URL


### PR DESCRIPTION
- [x] set up test repos differently to not artificially complicate things for v6 builds (at least partially done):  annexed file in test repo now has different content to not collide with a file under git
- [x] ~fix remote testrepo on github, which is invalid now (see above)~
Can't be done. We can not have a simple annex on github. More complex setup with additional storage elsewhere doesn't serve the needs for a basic testrepo. To be done separatly; see #1826 
- [x] new decorators to be able to distinguish whether we want to skip a test in v6/DM build because it needs fixing or because it doesn't make sense in that mode
- [x] decorators to allow to either skip or not skip known failures
- [x] decorators to allow to probe whether or not a known failure is still failing as suggested in PR #1789
- [x] actually make use of those decorators
- [x] add Travis builds to use the functionality
- [x] don't use empty env vars to define Travis' matrix
- [x] add defaults to `datalad.repo.direct` and `datalad.repo.version`
- [x] make sure the defaults above don't conflict with annex-enforced direct mode
- [x] ~make known failure decorators work with generator tests (apparently only first `yield` is considered or sth like this)~
Won't easily work that way. Probably need to decorate the failing `yield`'s instead as already done in `datalad/interface/tests/test_crawl_init.py`.
- [x] improve and enhance implementation of `datalad unlock`, the errors of which came to attention after solving #1854; Note: Not to be enitrely done in this PR, due to #1860

**Summary regarding changes to known failure decorators:**
There are several decorators in `tests/utils.py` now:
 - `skip_v6` and `skip_direct_mode` for skipping the decorated tests in those builds, since those tests might make no sense (like testing direct mode switches in v6 build, which isn't possible)
 - `known_failure`, `known_failure_v6` and `known_failure_direct_mode` to mark tests, that are are known to fail (always/in v6 build/in DM build) and need some fixing

Behavior of the latter can be tuned via `datalad.tests.knownfailures.skip` (default: True) and `datalad.tests.knownfailures.probe` (default: False). Skipping takes precedence over probing. If not skipped and not probed those tests will yield the actual failure. If not skipped but probed those tests will pass if they still fail and vice versa. This is used in the new Travis builds to see, whether some of them were (may be implicitly) fixed but still marked as known to fail.

**New Travis builds**
There are two new builds probing the known failures in v6 and direct mode. That way we automatically get a hint on what might have been (implicitly) fixed. However, those builds are allowed to fail, since a failure means, that a test actually passed but was marked "known to fail". So it's no harm to master and shouldn't prevent anything from being merged. Furthermore there are some weird tests, that don't always fail, which in return might lead to a failing probing. This hopefully will become better once some basic issues (like the testrepo mess) are fixed.