### PR TITLE
BF: report impossible if target repo does not exist during publish

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -461,10 +461,10 @@ def _get_remote_info(ds_path, ds_remote_info, to, missing):
     """Returns None if desired info was obtained, or a tuple (status, message)
     if not"""
     ds = Dataset(ds_path)
-	if ds.repo is None:
-		# There is no repository, nothing could be done
-		return ('impossible',
-		        'No repository found for %s' % ds)
+    if ds.repo is None:
+        # There is no repository, nothing could be done
+        return ('impossible',
+                'No repository found for %s' % ds)
     if to is None:
         # we need an upstream remote, if there's none given. We could
         # wait for git push to complain, but we need to explicitly

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -461,6 +461,10 @@ def _get_remote_info(ds_path, ds_remote_info, to, missing):
     """Returns None if desired info was obtained, or a tuple (status, message)
     if not"""
     ds = Dataset(ds_path)
+	if ds.repo is None:
+		# There is no repository, nothing could be done
+		return ('impossible',
+		        'No repository found for %s' % ds)
     if to is None:
         # we need an upstream remote, if there's none given. We could
         # wait for git push to complain, but we need to explicitly
@@ -497,7 +501,7 @@ def _get_remote_info(ds_path, ds_remote_info, to, missing):
         if missing == 'skip':
             ds_remote_info[ds_path] = None
             return ('notneeded',
-                    ("Unkown target sibling '%s', skipping publication", to))
+                    ("Unknown target sibling '%s', skipping publication", to))
         elif missing == 'inherit':
             superds = ds.get_superdataset()
             if not superds:


### PR DESCRIPTION
Quick&Dirty fix:
In my case it was a submodule which we do not even probably want to publish -- its url points to a github repository (but may be we would?), and it was not locally installed (I believe):

mridefacer in http://datasets.datalad.org/?dir=/labs/gobbini/famface/data  (also subject to not yet finished fix in #1675

ideally we need to decide on what we are doing with "such" submodules
- if their url is some remote, but they are present locally -- should we publish them? (probably so)
   IIRC: `git clone` first tries to find those submodules based on supermodule url, not the url in .submodules. This way also more guarantee that this published clone would have what is needed/referenced