### PR TITLE
ENH: Improve wtf plugin with essential bits stolen from PyMVPA

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -151,12 +151,6 @@ def teardown_package():
 
     lgr.debug("Printing versioning information collected so far")
     from datalad.support.external_versions import external_versions as ev
-    # request versioning for few others which we do not check at runtime
-    for m in ('git', 'system-ssh'):
-        try:  # Let's make sure to not blow up when we are almost done
-            ev[m]
-        except Exception:
-            pass
     print(ev.dumps(query=True))
 
 lgr.log(5, "Done importing main __init__")

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -100,7 +100,7 @@ Metadata
                            _t2s(pl.mac_ver()),
                            _t2s(pl.win32_ver())]).rstrip()))),
         env='\n'.join(
-            '{}: {}'.format(k, v) for k, v in os.environ.iteritems()
+            '{}: {}'.format(k, v) for k, v in os.environ.items()
             if k.startswith('PYTHON') or k.startswith('GIT') or k.startswith('DATALAD')),
         dataset='' if not ds else dataset_template.format(
             basic='\n'.join(

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -35,6 +35,7 @@ def dlplugin(dataset=None):
         cfg = ds.config
     from datalad.ui import ui
     from datalad.api import metadata
+    from datalad.support.external_versions import external_versions
     import os
     import platform as pl
 
@@ -60,6 +61,9 @@ Environment
 ===========
 {env}
 {dataset}
+Externals
+=========
+{externals}
 Configuration
 =============
 {cfg}
@@ -83,7 +87,6 @@ Metadata
             result_filter=lambda x: x['action'] == 'metadata')
     if ds_meta:
         ds_meta = ds_meta['metadata']
-
     ui.message(report_template.format(
         system='\n'.join(
             '{}: {}'.format(*i) for i in (
@@ -109,6 +112,7 @@ Metadata
                 '{}: {}'.format(k, v) for k, v in ds_meta)
             if ds_meta else '[no metadata]'
         ),
+        externals=external_versions.dumps(preamble=None, indent='', query=True),
         cfg='\n'.join(
             '{}: {}'.format(
                 k,

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -113,6 +113,18 @@ class ExternalVersions(object):
         'cmd:system-git': _get_system_git_version,
         'cmd:system-ssh': _get_system_ssh_version,
     }
+    INTERESTING = (
+        'appdirs',
+        'boto',
+        'iso8601',
+        'git', 'gitdb',
+        'humanize',
+        'msgpack',
+        'patool',
+        'requests',
+        'scrapy', 'six',
+        'wrapt',
+    )
 
     def __init__(self):
         self._versions = {}
@@ -126,6 +138,14 @@ class ExternalVersions(object):
             if hasattr(value, attr):
                 version = getattr(value, attr)
                 break
+
+        # try pkg_resources
+        if version is None and hasattr(value, '__name__'):
+            try:
+                import pkg_resources
+                version = pkg_resources.get_distribution(value.__name__).version
+            except Exception:
+                pass
 
         # assume that value is the version
         if version is None:
@@ -198,7 +218,7 @@ class ExternalVersions(object):
         """Return dictionary (copy) of versions"""
         return self._versions.copy()
 
-    def dumps(self, indent=False, preamble="Versions:", query=False):
+    def dumps(self, indent=None, preamble="Versions:", query=False):
         """Return listing of versions as a string
 
         Parameters
@@ -213,13 +233,16 @@ class ExternalVersions(object):
           get those which weren't queried for yet
         """
         if query:
-            [self[k] for k in self.CUSTOM]
+            [self[k] for k in tuple(self.CUSTOM) + self.INTERESTING]
         if indent and (indent is True):
             indent = ' '
         items = ["%s=%s" % (k, self._versions[k]) for k in sorted(self._versions)]
-        out = "%s" % preamble
-        if indent:
-            out += (linesep + indent).join([''] + items) + linesep
+        out = "%s" % preamble if preamble else ''
+        if indent is not None:
+            if preamble:
+                preamble += linesep
+            indent = ' ' if indent is True else str(indent)
+            out += (linesep + indent).join(items) + linesep
         else:
             out += " " + ' '.join(items)
         return out

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -199,3 +199,8 @@ def test_system_ssh_version():
                 return "", s
         with patch('datalad.support.external_versions._runner', _runner()):
             assert_equal(ev['cmd:system-ssh'], v)
+
+
+def test_humanize():
+    # doesn't provide __version__
+    assert ExternalVersions()['humanize']


### PR DESCRIPTION
This pull request proposes to make the `wtf` plugin more informative

Demo

```
% datalad plugin wtf
System
======
OS          : posix Linux 4.8.0-2-amd64 #1 SMP Debian 4.8.11-1 (2016-12-02)
Distribution: debian/buster/sid

Environment
===========
GIT_EDITOR: vim
GIT_PYTHON_GIT_EXECUTABLE: /usr/lib/git-annex.linux/git
PYTHONPATH: /home/mih/hacking/datalad/git

Dataset information
===================
path: /tmp/audio
repo: AnnexRepo

Metadata
--------
[no metadata]

Configuration
=============
alias.co: checkout
alias.glog: log --pretty=format:'%h %ad %s (%an)' --date=short --graph
alias.st: status
alias.wdiff: diff --color-words
alias.wshow: show --color-words
annex.backends: MD5E
annex.uuid: b76c4724-c271-437f-afa7-24e5369970fa
annex.version: 5
color.diff: auto
color.status: true
core.bare: false
core.editor: vim
core.filemode: true
core.logallrefupdates: true
core.repositoryformatversion: 0
datalad.dataset.id: 26fa0f8e-a5b7-11e7-a0d7-f0d5bf7b5561
datalad.log.timestamp: false
datalad.metadata.nativetype: audio
diff.ignoresubmodule: true
hub.oauthtoken: <HIDDEN>
hub.username: <HIDDEN>
push.default: simple
url.git@github.com:.insteadof: github:
user.email: <HIDDEN>
user.name: <HIDDEN>
```