### PR TITLE
`remove` does not commit the removal of a 2nd file in a sequence

### DIFF
--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -520,3 +520,13 @@ def test_drop_nocrash_absent_subds(path):
     ok_clean_git(parent.path)
     with chpwd(path):
         assert_status('notneeded', drop('.', recursive=True))
+
+
+@with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
+def test_remove_more_than_one(path):
+    ds = Dataset(path).create(force=True)
+    ds.add('.')
+    ok_clean_git(path)
+    # ensure #1912 stays resolved
+    ds.remove(['one', 'two'], check=False)
+    ok_clean_git(path)


### PR DESCRIPTION
#### What is the problem?
`datalad remove a b` will remove a and b from the file system, but will only commit the removal of a and not b -- left as staged for deletion.