### PR TITLE
ENH(TST): use our domain (.datalad.org) instead of some random .somewhere for nonexisting url

### DIFF
--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -281,7 +281,7 @@ def test_notclone_known_subdataset(src, path):
 @with_tempfile(mkdir=True)
 def test_failed_clone(dspath):
     ds = create(dspath)
-    res = ds.clone("http://nonexistingreallyanything.somewhere/bla", "sub",
+    res = ds.clone("http://nonexistingreallyanything.datalad.org/bla", "sub",
                    on_failure='ignore')
     assert_status('error', res)
     assert_message('Failed to clone data from any candidate source URL: %s',

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -579,7 +579,7 @@ def test_failed_install(dspath):
     assert_raises(IncompleteResultsError,
                   ds.install,
                   "sub",
-                  source="http://nonexistingreallyanything.somewhere/bla")
+                  source="http://nonexistingreallyanything.datalad.org/bla")
 
 
 @with_testrepos('submodule_annex', flavors=['local'])


### PR DESCRIPTION
The issue is that comcast does provide "something" for those non-existing
domains.  git even manages to clone from them, just considers repo to be empty:

```
 $> /usr/lib/git-annex.linux/git clone -v http://nonexistingreallyanything.somewhere/bla /tmp/datalad_temp_test_failed_clonez8pXGR/sub
Cloning into /tmp/datalad_temp_test_failed_clonez8pXGR/sub...
warning: You appear to have cloned an empty repository.
```

So, using our own domain, we would have a better chance to have control
over the names WE do not actually have

This pull request fixes remaining parts of  #1908 
