### PR TITLE
ENH: crash fi git config is not yet setup with name/email

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -96,6 +96,10 @@ def setup_package():
     if 'GIT_HOME' in os.environ:
         os.environ['HOME'] = os.environ['GIT_HOME']
 
+    # For now we will just verify that it is ready to run the tests
+    from datalad.support.gitrepo import check_git_configured
+    check_git_configured()
+
     # To overcome pybuild by default defining http{,s}_proxy we would need
     # to define them to e.g. empty value so it wouldn't bother touching them.
     # But then haskell libraries do not digest empty value nicely, so we just

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1203,3 +1203,16 @@ def test_get_git_attributes(path):
     # ATM we do not do any translation of values, so if it is just a tag, it
     # would be what git returns -- "set"
     eq_(gr.get_git_attributes(), {'tag': 'set', 'sec.key': 'val'})
+
+
+@with_tempfile(mkdir=True)
+def test_check_git_configured(newhome):
+    try:
+        old = GitRepo._config_checked
+        GitRepo._config_checked = False
+        with patch.dict('os.environ', {'HOME': newhome}):
+            # clear clear home
+            assert_raises(RuntimeError, GitRepo, newhome, create=True)
+        # But then if we
+    finally:
+        GitRepo._config_checked = old


### PR DESCRIPTION
Otherwise we could get dozens of tests failing due to incorrect
operations etc, so better to crash as early as needed, e.g.
while instantiating the first GitRepo

I managed to run "datalad test" in a fresh'ish docker image - ended up with FAILED (SKIP=66, errors=60, failures=20) ;-)