### PR TITLE
Some minor improvements of the plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ bet we will fix some bugs and make a world even a better place.
 
 ### Enhancements and new features
 
-?
+- `export_tarball` plugin has been generalized to `export_archive` and can now also
+  generate ZIP archives.
 
 
 # 0.9.1 (Oct 01, 2017) -- "DATALAD!"(JBTM)

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -252,6 +252,13 @@ class Plugin(Interface):
                 check_installed=len(arg_defaults) != len(plugin_args),
                 purpose='handover to plugin')
 
+        # final test whether the call is complete
+        missing_args = [k for k in plugin_args[:-len(arg_defaults)]
+                        if k not in supported_args]
+        if missing_args:
+            raise TypeError('Missing value(s) for plugin argument(s): {}'.format(
+                missing_args))
+
         # call as a generator
         for res in plugin_call(**supported_args):
             if not res:

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -96,18 +96,18 @@ class Plugin(Interface):
 
     To run a specific plugin, provide the plugin name as an argument::
 
-      datalad plugin export_tarball
+      datalad plugin export_archive
 
     A plugin may come with its own documentation which can be displayed upon
     request::
 
-      datalad plugin export_tarball -H
+      datalad plugin export_archive -H
 
     If a plugin supports (optional) arguments, they can be passed to the plugin
     as key=value pairs with the name and the respective value of an argument,
     e.g.::
 
-      datalad plugin export_tarball output=myfile
+      datalad plugin export_archive filename=myfile
 
     Any number of arguments can be given. Only arguments with names supported
     by the respective plugin are passed to the plugin. If unsupported arguments

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -236,7 +236,8 @@ class Plugin(Interface):
         plugin_args = plugin_argspec[0]
         arg_defaults = plugin_argspec[3]
         supported_args = {k: v for k, v in kwargs.items() if k in plugin_args}
-        if len(supported_args) < len(kwargs):
+        excluded_args = user_supplied_args.difference(supported_args.keys())
+        if excluded_args:
             lgr.warning("Ignoring plugin argument(s) %s, not supported by plugin %s",
                         list(set(kwargs.keys()).difference(supported_args.keys())),
                         plugin)

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -236,10 +236,10 @@ class Plugin(Interface):
         plugin_args = plugin_argspec[0]
         arg_defaults = plugin_argspec[3]
         supported_args = {k: v for k, v in kwargs.items() if k in plugin_args}
-        excluded_args = user_supplied_args.difference(supported_args.keys())
-        if excluded_args:
-            lgr.warning('ignoring plugin argument(s) %s, not supported by plugin',
-                        excluded_args)
+        if len(supported_args) < len(kwargs):
+            lgr.warning("Ignoring plugin argument(s) %s, not supported by plugin %s",
+                        list(set(kwargs.keys()).difference(supported_args.keys())),
+                        plugin)
         # always overwrite the dataset arg if one is needed
         if 'dataset' in plugin_args:
             supported_args['dataset'] = require_dataset(

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -214,20 +214,27 @@ class Plugin(Interface):
                 user_supplied_args.add(argname)
         plugin_call = _load_plugin(plugins[plugin]['file'])
 
+        # check the plugin signature
+        plugin_argspec = inspect.getargspec(plugin_call)
+
         if showpluginhelp:
             # we don't need special docs for the cmdline, standard python ones
             # should be comprehensible enough
             ui.message(
-                dedent_docstring(plugin_call.__doc__)
-                if plugin_call.__doc__
-                else 'This plugin has no documentation')
+                'Usage: {}{}\n\n{}'.format(
+                    plugin,
+                    inspect.formatargspec(*plugin_argspec),
+                    dedent_docstring(plugin_call.__doc__)
+                    if plugin_call.__doc__
+                    else 'This plugin has no documentation'))
             return
 
         #
         # argument preprocessing
         #
-        # check the plugin signature and filter out all unsupported args
-        plugin_args, _, _, arg_defaults = inspect.getargspec(plugin_call)
+        # filter out all unsupported args
+        plugin_args = plugin_argspec[0]
+        arg_defaults = plugin_argspec[3]
         supported_args = {k: v for k, v in kwargs.items() if k in plugin_args}
         excluded_args = user_supplied_args.difference(supported_args.keys())
         if excluded_args:

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -13,7 +13,7 @@ __docformat__ = 'restructuredtext'
 
 # PLUGIN API
 def dlplugin(dataset, filename=None, archivetype='tar', compression='gz',
-             on_failure='error'):
+             on_file_error='error'):
     """Export the content of a dataset as a TAR/ZIP archive.
 
     Parameters
@@ -26,7 +26,7 @@ def dlplugin(dataset, filename=None, archivetype='tar', compression='gz',
       Type of archive to generate.
     compression : {'', 'gz', 'bz2')
       Compression method to use. 'bz2' is not supported for ZIP archives.
-    on_failure : {'error', 'continue', 'ignore'}, optional
+    on_file_error : {'error', 'continue', 'ignore'}, optional
       By default, any issue accessing a file in the dataset while adding
       it to the TAR archive will result in an error and the plugin is
       aborted. Setting this to 'continue' will issue warnings instead
@@ -110,10 +110,12 @@ def dlplugin(dataset, filename=None, archivetype='tar', compression='gz',
                     arcname=aname,
                     **(tar_args if archivetype == 'tar' else {}))
             except OSError as e:
-                if on_failure in('ignore', 'continue'):
-                    (lgr.warning if on_failure == 'continue' else lgr.debug)(
+                if on_file_error in('ignore', 'continue'):
+                    (lgr.warning if on_file_error == 'continue' else lgr.debug)(
                         'Skipped %s: %s',
                         fpath, exc_str(e))
+                else:
+                    raise e
 
     if not isabs(filename):
         filename = opj(os.getcwd(), filename)

--- a/datalad/plugin/tests/export_archive.py
+++ b/datalad/plugin/tests/export_archive.py
@@ -7,7 +7,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Test tarball exporter"""
+"""Test archive exporter"""
 
 import os
 import time
@@ -42,32 +42,32 @@ def test_failure(path):
     # unknown pluginer
     assert_raises(ValueError, ds.plugin, 'nah')
     # non-existing dataset
-    assert_raises(ValueError, plugin, 'export_tarball', Dataset('nowhere'))
+    assert_raises(ValueError, plugin, 'export_archive', Dataset('nowhere'))
 
 
 @with_tree(_dataset_template)
-def test_tarball(path):
+def test_archive(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
     ds.add('.')
     committed_date = ds.repo.get_committed_date()
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
     with chpwd(path):
-        res = list(ds.plugin('export_tarball'))
+        res = list(ds.plugin('export_archive'))
         assert_status('ok', res)
         assert_result_count(res, 1)
         assert(isabs(res[0]['path']))
     assert_true(os.path.exists(default_outname))
     custom_outname = opj(path, 'myexport.tar.gz')
     # feed in without extension
-    ds.plugin('export_tarball', output=custom_outname[:-7])
+    ds.plugin('export_archive', output=custom_outname[:-7])
     assert_true(os.path.exists(custom_outname))
     custom1_md5 = md5sum(custom_outname)
-    # encodes the original tarball filename -> different checksum, despit
+    # encodes the original archive filename -> different checksum, despit
     # same content
     assert_not_equal(md5sum(default_outname), custom1_md5)
     # should really sleep so if they stop using time.time - we know
     time.sleep(1.1)
-    ds.plugin('export_tarball', output=custom_outname)
+    ds.plugin('export_archive', output=custom_outname)
     # should not encode mtime, so should be identical
     assert_equal(md5sum(custom_outname), custom1_md5)
 

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -90,6 +90,12 @@ def test_archive(path):
     check_contents(custom_outname, 'myexport')
 
     # now loose some content
+    if ds.repo.is_direct_mode():
+        # in direct mode the add() aove commited directly to the annex/direct/master
+        # branch, hence drop will have no effect (notneeded)
+        # this might be undesired behavior (or not), but this is not the place to test
+        # for it
+        return
     ds.drop('file_up', check=False)
     assert_raises(IOError, ds.plugin, 'export_archive', filename=opj(path, 'my'))
     ds.plugin('export_archive', filename=opj(path, 'partial'), missing_content='ignore')

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -89,10 +89,16 @@ def test_archive(path):
     check_contents(default_outname, 'datalad_%s' % ds.id)
     check_contents(custom_outname, 'myexport')
 
+    # now loose some content
+    ds.drop('file_up', check=False)
+    assert_raises(OSError, ds.plugin, 'export_archive', filename='my')
+    ds.plugin('export_archive', filename='partial', on_file_error='ignore')
+    assert_true(os.path.exists('partial.tar.gz'))
+
 
 @with_tree(_dataset_template)
 def test_zip_archive(path):
-    ds = Dataset(opj(path, 'ds')).create(force=True)
+    ds = Dataset(opj(path, 'ds')).create(force=True, no_annex=True)
     ds.add('.')
     with chpwd(path):
         ds.plugin('export_archive', filename='my', archivetype='zip')

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -59,7 +59,7 @@ def test_archive(path):
     assert_true(os.path.exists(default_outname))
     custom_outname = opj(path, 'myexport.tar.gz')
     # feed in without extension
-    ds.plugin('export_archive', output=custom_outname[:-7])
+    ds.plugin('export_archive', filename=custom_outname[:-7])
     assert_true(os.path.exists(custom_outname))
     custom1_md5 = md5sum(custom_outname)
     # encodes the original archive filename -> different checksum, despit
@@ -67,7 +67,7 @@ def test_archive(path):
     assert_not_equal(md5sum(default_outname), custom1_md5)
     # should really sleep so if they stop using time.time - we know
     time.sleep(1.1)
-    ds.plugin('export_archive', output=custom_outname)
+    ds.plugin('export_archive', filename=custom_outname)
     # should not encode mtime, so should be identical
     assert_equal(md5sum(custom_outname), custom1_md5)
 
@@ -88,3 +88,16 @@ def test_archive(path):
             assert_equal(nfiles, 4)
     check_contents(default_outname, 'datalad_%s' % ds.id)
     check_contents(custom_outname, 'myexport')
+
+
+@with_tree(_dataset_template)
+def test_zip_archive(path):
+    ds = Dataset(opj(path, 'ds')).create(force=True)
+    ds.add('.')
+    with chpwd(path):
+        ds.plugin('export_archive', filename='my', archivetype='zip')
+        assert_true(os.path.exists('my.zip'))
+        custom1_md5 = md5sum('my.zip')
+        time.sleep(1.1)
+        ds.plugin('export_archive', filename='my', archivetype='zip')
+        assert_equal(md5sum('my.zip'), custom1_md5)

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -91,8 +91,8 @@ def test_archive(path):
 
     # now loose some content
     ds.drop('file_up', check=False)
-    assert_raises(OSError, ds.plugin, 'export_archive', filename=opj(path, 'my'))
-    ds.plugin('export_archive', filename=opj(path, 'partial'), on_file_error='ignore')
+    assert_raises(IOError, ds.plugin, 'export_archive', filename=opj(path, 'my'))
+    ds.plugin('export_archive', filename=opj(path, 'partial'), missing_content='ignore')
     assert_true(os.path.exists(opj(path, 'partial.tar.gz')))
 
 

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -91,9 +91,9 @@ def test_archive(path):
 
     # now loose some content
     ds.drop('file_up', check=False)
-    assert_raises(OSError, ds.plugin, 'export_archive', filename='my')
-    ds.plugin('export_archive', filename='partial', on_file_error='ignore')
-    assert_true(os.path.exists('partial.tar.gz'))
+    assert_raises(OSError, ds.plugin, 'export_archive', filename=opj(path, 'my'))
+    ds.plugin('export_archive', filename=opj(path, 'partial'), on_file_error='ignore')
+    assert_true(os.path.exists(opj(path, 'partial.tar.gz')))
 
 
 @with_tree(_dataset_template)

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -87,10 +87,10 @@ def test_plugin_call(path, dspath):
                     fake_dummy_spec['nodocs']['file']))
         with swallow_outputs() as cmo:
             plugin(['dummy'], showpluginhelp=True)
-            eq_(cmo.out.rstrip(), "mydocstring")
+            eq_(cmo.out.rstrip(), "Usage: dummy(dataset, noval, withval='test')\n\nmydocstring")
         with swallow_outputs() as cmo:
             plugin(['nodocs'], showpluginhelp=True)
-            eq_(cmo.out.rstrip(), "This plugin has no documentation")
+            eq_(cmo.out.rstrip(), "Usage: nodocs()\n\nThis plugin has no documentation")
         # loading fails, no docs
         assert_raises(ValueError, plugin, ['broken'], showpluginhelp=True)
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -37,7 +37,7 @@ broken_plugin = """garbage"""
 
 nodocs_plugin = """\
 def dlplugin():
-    pass
+    yield
 """
 
 # functioning plugin dummy
@@ -111,7 +111,7 @@ def test_plugin_call(path, dspath):
             res = list(plugin(['dummy', 'noval=one', 'obscure=some']))
             assert_status('ok', res)
             cml.assert_logged(
-                msg=".*ignoring plugin argument\\(s\\).*obscure.*, not supported by plugin.*",
+                msg=".*Ignoring plugin argument\\(s\\).*obscure.*, not supported by plugin.*",
                 regex=True, level='WARNING')
         # fails on missing positional arg
         assert_raises(TypeError, plugin, ['dummy'])

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -91,7 +91,7 @@ with DataLad.
    :toctree: generated
 
    add_readme
-   export_tarball
+   export_archive
    no_annex
    wtf
 


### PR DESCRIPTION
### Changes
- [x] `export_tarball` has docs
- [x] `export_tarball can generate tarballs from incomplete datasets
- [x] show signature of any plugin, even when there are no real docs
- [x] `export_tarball` -> `export_archive` for TAR and ZIP archives, both compressed or uncompressed

Note that this is a prerequisite for #1942