### PR TITLE
BF: specify if to request pyliblzma solely on python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+import sys
 import platform
 from os.path import dirname
 from os.path import join as opj
@@ -52,11 +53,7 @@ if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
     keyring_requires = ['keyring<8.0']
 
 # lzma is included in python since 3.3
-req_lzma = []
-try:
-    import lzma
-except ImportError:
-    req_lzma = ['pyliblzma']
+req_lzma = ['pyliblzma'] if sys.version_info < (3, 3) else []
 
 
 requires = {


### PR DESCRIPTION
do not rely on current state of local affairs of having lzma to define it as a
requirement or not.  I had e.g. one installed globally.

Might fix remaining issues on linux buildbots with running tests.

On OSX need to figure out how to install liblzma-dev