### PR TITLE
ENH: Say "all matches" if # of returned hits < max_nresults

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -647,14 +647,17 @@ class Search(Interface):
             # disabled: unreliable estimate, often confusing
             #nhits = hits.estimated_min_length()
             # report query stats
+            nresults = len(hits)
             lgr.info('Query completed in {} sec.{}'.format(
                 hits.runtime,
                 ' Reporting {}.'.format(
                     'max. {} top {}'.format(
                         max_nresults,
                         single_or_plural('match', 'matches', max_nresults))
-                    if max_nresults > 0 else 'all matches')
-                if not hits.is_empty() else ''))
+                    if (max_nresults > 0 and nresults >= max_nresults) else 'all matches')
+                if not hits.is_empty()
+                else ' No matches.'
+            ))
 
             if not hits:
                 return


### PR DESCRIPTION
+ Explicit "No matches" if none

This pull request fixes #1898 

- [ ] It needs a test! But I could not find any test which triggers that code (via `python -m nose -s -v datalad/metadata/tests/ `) - is search command unittested to any degree (besides some example demo search invocation)?

Sample output:
```shell
$> datalad --output-format '{path}' search --max-nresults 3 *sub-xx*run-01*nii.gz 
[INFO   ] Query completed in 0.00225687026978 sec. No matches. 

$> datalad --output-format '{path}' search --max-nresults 3 *sub-0[12]*run-01*nii.gz 
[INFO   ] Query completed in 0.00272393226624 sec. Reporting all matches. 
/home/yoh/datalad/openfmri/ds000001/sub-01/func/sub-01_task-balloonanalogrisktask_run-01_bold.nii.gz
/home/yoh/datalad/openfmri/ds000001/sub-02/func/sub-02_task-balloonanalogrisktask_run-01_bold.nii.gz

$> datalad --output-format '{path}' search --max-nresults 3 *sub-0[123]*run-01*nii.gz 
[INFO   ] Query completed in 0.00285696983337 sec. Reporting max. 3 top matches. 
/home/yoh/datalad/openfmri/ds000001/sub-03/func/sub-03_task-balloonanalogrisktask_run-01_bold.nii.gz
/home/yoh/datalad/openfmri/ds000001/sub-01/func/sub-01_task-balloonanalogrisktask_run-01_bold.nii.gz
/home/yoh/datalad/openfmri/ds000001/sub-02/func/sub-02_task-balloonanalogrisktask_run-01_bold.nii.gz

$> datalad --output-format '{path}' search --max-nresults 3 *sub-0[1234]*run-01*nii.gz 
[INFO   ] Query completed in 0.00339889526367 sec. Reporting max. 3 top matches. 
/home/yoh/datalad/openfmri/ds000001/sub-04/func/sub-04_task-balloonanalogrisktask_run-01_bold.nii.gz
/home/yoh/datalad/openfmri/ds000001/sub-03/func/sub-03_task-balloonanalogrisktask_run-01_bold.nii.gz
/home/yoh/datalad/openfmri/ds000001/sub-01/func/sub-01_task-balloonanalogrisktask_run-01_bold.nii.gz
```

You can see that now the suffix is consistent and suggestive on either we got everything matched or not