### PR TITLE
AutomagicIO issues under PY3

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -134,7 +134,10 @@ class AutomagicIO(object):
                         lgr.debug("No name/file was given, avoiding proxying")
                         raise _EarlyExit
                     file = kwargs.get(filearg)
-
+                if isinstance(file, int):
+                    lgr.debug(
+                        "Skipping operation on %i, already a file descriptor", file)
+                    raise _EarlyExit
                 mode = 'r'
                 if len(args) > 1:
                     mode = args[1]


### PR DESCRIPTION
FTR: Tests under PY3 are now flooded with:

```
[WARNING] Failed proxying open with (3, 'rb', -1), {}: lstat: illegal type for path parameter [posixpath.py:lexists:171] 
[WARNING] Failed proxying open with (5, 'rb', -1), {}: lstat: illegal type for path parameter [posixpath.py:lexists:171] 
[WARNING] Failed proxying open with (3, 'rb', -1), {}: lstat: illegal type for path parameter [posixpath.py:lexists:171] 
```
but there is no functional impairment. Haven't looked into it, but it smells like we are doing something wrong.