### PR TITLE
BF(workaround): pyliblzma might throw AttributeError __exit__ unless dir first

### DIFF
--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -61,7 +61,12 @@ def dump2fileobj(obj, fileobj):
 
 
 def dump2xzstream(obj, fname):
-    with lzma.LZMAFile(fname, mode='w') as f:
+    # A unique to yoh and some others bug with pyliblzma
+    # calling dir() helps to avoid AttributeError __exit__
+    # see https://bugs.launchpad.net/pyliblzma/+bug/1219296
+    lzmafile = lzma.LZMAFile(fname, mode='w')
+    dir(lzmafile)
+    with lzmafile as f:
         jwriter = codecs.getwriter('utf-8')(f)
         for o in obj:
             jsondump(o, jwriter, **compressed_json_dump_kwargs)


### PR DESCRIPTION
This pull request fixes #1930
