### PR TITLE
Fix bytes object path issue with pandas #1948

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -180,7 +180,7 @@ class AutomagicIO(object):
         # For now, as long as it is a symlink pointing to under .git/annex
         if exists(path):
             return True
-        return lexists(path) and 'annex/objects' in realpath(path)
+        return lexists(path) and 'annex/objects' in str(realpath(path))
 
     def _dataset_auto_get(self, filepath):
         """Verify that filepath is under annex, and if so and not present - get it"""

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1809,7 +1809,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     # since it is not true for submodules, whose '.git' is a
                     # symlink and being resolved to some
                     # '.git/modules/.../annex/objects'
-                    out.append(exists(target_path) and 'annex/objects' in target_path)
+                    out.append(exists(target_path) and 'annex/objects' in str(target_path))
                 else:
                     out.append(False)
             return out
@@ -1850,7 +1850,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 # '.git/modules/.../annex/objects'
                 out.append(
                     islink(filepath)
-                    and 'annex/objects' in realpath(filepath)  # realpath OK
+                    and 'annex/objects' in str(realpath(filepath))  # realpath OK
                 )
             return out
 
@@ -2685,7 +2685,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     self.commit(msg, options, _datalad_msg=_datalad_msg,
                                 careless=careless, files=files, proxy=True)
                 else:
-                    raise 
+                    raise
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, force=False, **kwargs):


### PR DESCRIPTION
This pull request fixes #1948

This pull request proposes converting path names to strings prior to checking if 'annex/objects` is in path.