### PR TITLE
BF: there is no .message in python3 Exception. Just use str()

### DIFF
--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -39,6 +39,6 @@ def test_get_metadata():
         aa1_meta = get_metadata('aa-1')
         ok_startswith(aa1_meta, '<?xml')
     except AccessFailedError as e:
-        if e.message.startswith('Access to https://search.datacite.org') and \
-                e.message.endswith('has failed: status code 502'):
+        if str(e).startswith('Access to https://search.datacite.org') and \
+                str(e).endswith('has failed: status code 502'):
             raise SkipTest("Probably datacite.org blocked us once again")

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -768,11 +768,11 @@ def _enable_remote(
         if cred and cred.is_known:
             cred.delete()
         result_props['status'] = 'error'
-        result_props['message'] = e.message
+        result_props['message'] = str(e)
     except AccessFailedError as e:
         # some kind of connection issue
         result_props['status'] = 'error'
-        result_props['message'] = e.message
+        result_props['message'] = str(e)
     except Exception as e:
         # something unexpected
         raise e

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -961,8 +961,8 @@ def _ls_s3(loc, fast=False, recursive=False, all_=False, long_=False,
 
             try:
                 acl = e.get_acl()
-            except S3ResponseError as err:
-                acl = err.message
+            except S3ResponseError as e:
+                acl = str(e)
 
             content = ""
             if list_content:
@@ -982,7 +982,7 @@ def _ls_s3(loc, fast=False, recursive=False, all_=False, long_=False,
                         raise ValueError(list_content)
                     # content = "[S3: OK]"
                 except S3ResponseError as err:
-                    content = err.message
+                    content = str(err)
                 finally:
                     content = " " + content
             if long_:

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -158,7 +158,7 @@ class Run(Interface):
             except Exception as e:
                 yield dict(
                     err_info, status='error',
-                    message=('cannot re-run command, command specification is not valid JSON: %s', e.message))
+                    message=('cannot re-run command, command specification is not valid JSON: %s', str(e)))
                 return
             if 'cmd' not in runinfo:
                 yield dict(


### PR DESCRIPTION
Was initially noted in the failing travis run of https://github.com/datalad/datalad/pull/1949