### PR TITLE
BF: crawler needed to use now "options" instead of "git_options" apparently

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -1315,7 +1315,7 @@ class Annexificator(object):
             stats = data.get('datalad_stats', None)
             if self.repo.dirty:  # or self.tracker.dirty # for dry run
                 lgr.info("Repository found dirty -- adding and committing")
-                _call(self.repo.add, '.', git_options=self.options)  # so everything is committed
+                _call(self.repo.add, '.', options=self.options)  # so everything is committed
 
                 stats_str = ('\n\n' + stats.as_str(mode='full')) if stats else ''
                 _call(self._commit, "%s%s" % (', '.join(self._states), stats_str), options=["-a"])

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1407,7 +1407,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         if git_options:
             # TODO: note that below we would use 'add with --dry-run
             # so passed here options might need to be passed into it??
-            lgr.warning("git_options not yet implemented. Ignored.")
+            lgr.warning("add: git_options not yet implemented. Ignored.")
 
         if annex_options:
             lgr.warning("annex_options not yet implemented. Ignored.")
@@ -2004,7 +2004,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
 
         if git_options:
-            lgr.warning("git_options not yet implemented. Ignored.")
+            lgr.warning("add_url_to_file: git_options not yet implemented. Ignored.")
 
         if annex_options:
             lgr.warning("annex_options not yet implemented. Ignored.")
@@ -2075,7 +2075,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
 
         if git_options:
-            lgr.warning("git_options not yet implemented. Ignored.")
+            lgr.warning("add_urls: git_options not yet implemented. Ignored.")
 
         if annex_options:
             lgr.warning("annex_options not yet implemented. Ignored.")

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -98,6 +98,29 @@ def skip_if_url_is_not_available(url, regex=None):
         raise SkipTest("%s failed to download" % url)
 
 
+# TODO: eventually we might want to make use of attr module
+class File(object):
+    """Helper for a file entry in the create_tree/@with_tree
+
+    It allows to define additional settings for entries
+    """
+    def __init__(self, name, executable=False):
+        """
+
+        Parameters
+        ----------
+        name : str
+          Name of the file
+        executable: bool, optional
+          Make it executable
+        """
+        self.name = name
+        self.executable = executable
+
+    def __str__(self):
+        return self.name
+
+
 def create_tree_archive(path, name, load, overwrite=False, archives_leading_dir=True):
     """Given an archive `name`, create under `path` with specified `load` tree
     """
@@ -131,7 +154,13 @@ def create_tree(path, tree, archives_leading_dir=True):
     if isinstance(tree, dict):
         tree = tree.items()
 
-    for name, load in tree:
+    for file_, load in tree:
+        if isinstance(file_, File):
+            executable = file_.executable
+            name = file_.name
+        else:
+            executable = False
+            name = file_
         full_name = opj(path, name)
         if isinstance(load, (tuple, list, dict)):
             if name.endswith('.tar.gz') or name.endswith('.tar') or name.endswith('.zip'):
@@ -146,6 +175,8 @@ def create_tree(path, tree, archives_leading_dir=True):
                 if PY2 and isinstance(load, text_type):
                     load = load.encode('utf-8')
                 f.write(load)
+        if executable:
+            os.chmod(full_name, os.stat(full_name).st_mode | stat.S_IEXEC)
 
 #
 # Addition "checkers"


### PR DESCRIPTION
`git_options` are ignored, `options` are respected... duplication and absent clarity in the interface.  Just patching up and adding a test