### PR TITLE
BF: do not blow if percent-progress is not provided by annex

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3430,7 +3430,7 @@ class ProcessAnnexProgressIndicators(object):
             # if we fail to parse, just return this precious thing for
             # possibly further processing
             return line
-
+        target_size = None
         if 'command' in j and 'key' in j:
             # might be the finish line message
             j_download_id = (j['command'], j['key'])
@@ -3446,8 +3446,8 @@ class ProcessAnnexProgressIndicators(object):
                         size_j = self.expected[j['key']]
                     except:
                         size_j = None
-                    size = size_j or AnnexRepo.get_size_from_key(j['key'])
-                    self.total_pbar.update(size, increment=True)
+                    target_size = size_j or AnnexRepo.get_size_from_key(j['key'])
+                    self.total_pbar.update(target_size, increment=True)
             else:
                 self._failed += 1
 
@@ -3475,7 +3475,8 @@ class ProcessAnnexProgressIndicators(object):
             return line
 
         def get_size_from_perc_complete(count, perc):
-            return int(math.ceil(int(count) / (float(perc) / 100.)))
+            return int(math.ceil(int(count) / (float(perc) / 100.))) \
+                if perc else 0
 
         # so we have a progress indicator, let's dead with it
         action = j['action']
@@ -3490,12 +3491,14 @@ class ProcessAnnexProgressIndicators(object):
             # for now deduce from key or approx from '%'
             # TODO: unittest etc to check when we have a relaxed
             # URL without any size known in advance
-            target_size = \
-                AnnexRepo.get_size_from_key(action.get('key')) or \
-                get_size_from_perc_complete(
-                    j['byte-progress'],
-                    j['percent-progress'].rstrip('%')
-                )
+            if not target_size:
+                target_size = \
+                    AnnexRepo.get_size_from_key(action.get('key')) or \
+                    get_size_from_perc_complete(
+                        j['byte-progress'],
+                        j.get('percent-progress', '').rstrip('%')
+                    ) or \
+                    0
             w, h = ui_utils.get_terminal_size()
             w = w or 80  # default to 80
             title = str(download_item)


### PR DESCRIPTION
Also just reuse one if already known from previous logic

The issue was that git annex does not report in json the percent progress
if key did not have size known (eg for a fast url or youtube video).
Next git-annex version (to be tested) should report one from the file size
