### PR TITLE
BF(workaround): provide a decorator for LZMAFile call to do dir() first

### DIFF
--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -59,14 +59,19 @@ def dump2fileobj(obj, fileobj):
         codecs.getwriter('utf-8')(fileobj),
         **json_dump_kwargs)
 
+def LZMAFile(*args, **kwargs):
+    """A little decorator to overcome a bug in lzma
+
+    A unique to yoh and some others bug with pyliblzma
+    calling dir() helps to avoid AttributeError __exit__
+    see https://bugs.launchpad.net/pyliblzma/+bug/1219296
+	"""
+    lzmafile = lzma.LZMAFile(*args, **kwargs)
+    dir(lzmafile)
+	return lzmafile
 
 def dump2xzstream(obj, fname):
-    # A unique to yoh and some others bug with pyliblzma
-    # calling dir() helps to avoid AttributeError __exit__
-    # see https://bugs.launchpad.net/pyliblzma/+bug/1219296
-    lzmafile = lzma.LZMAFile(fname, mode='w')
-    dir(lzmafile)
-    with lzmafile as f:
+	with LZMAFile(fname, mode='w') as f:
         jwriter = codecs.getwriter('utf-8')(f)
         for o in obj:
             jsondump(o, jwriter, **compressed_json_dump_kwargs)
@@ -74,7 +79,7 @@ def dump2xzstream(obj, fname):
 
 
 def load_xzstream(fname):
-    with lzma.LZMAFile(fname, mode='r') as f:
+    with LZMAFile(fname, mode='r') as f:
         for line in f:
             yield loads(line)
 

--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -65,13 +65,13 @@ def LZMAFile(*args, **kwargs):
     A unique to yoh and some others bug with pyliblzma
     calling dir() helps to avoid AttributeError __exit__
     see https://bugs.launchpad.net/pyliblzma/+bug/1219296
-	"""
+    """
     lzmafile = lzma.LZMAFile(*args, **kwargs)
     dir(lzmafile)
-	return lzmafile
+    return lzmafile
 
 def dump2xzstream(obj, fname):
-	with LZMAFile(fname, mode='w') as f:
+    with LZMAFile(fname, mode='w') as f:
         jwriter = codecs.getwriter('utf-8')(f)
         for o in obj:
             jsondump(o, jwriter, **compressed_json_dump_kwargs)

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -26,6 +26,7 @@ from ..support.annexrepo import AnnexRepo
 from .utils import with_tempfile
 from .utils import SkipTest
 from .utils import chpwd
+from datalad.support.json_py import LZMAFile
 
 try:
     import h5py
@@ -200,11 +201,11 @@ def test_proxying_lzma_LZMAFile():
     import lzma
 
     def generate_dat(f):
-        with lzma.LZMAFile(f, "w") as f:
+        with LZMAFile(f, "w") as f:
             f.write("123".encode('utf-8'))
 
     def verify_dat(f, mode="r"):
-        with lzma.LZMAFile(f, mode) as f:
+        with LZMAFile(f, mode) as f:
             eq_(f.read().decode('utf-8'), "123")
 
     yield _test_proxying_open, generate_dat, verify_dat


### PR DESCRIPTION
This pull request fixes #1975 
