### PR TITLE
Add missing dependency on 'duecredit'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ requires = {
         'vcrpy',
     ],
     'metadata': [
+        'duecredit',
         'simplejson',
         'whoosh',
         'pyld', # should be either <0.8 or >= 0.8.2. dunno how to specify for pip


### PR DESCRIPTION
The `aggregate-metadata` command did not work for me until I installed the `duecredit` package. Hopefully this is the right place to put the dependency in.

### Changes
- [x] This change is complete
- [ ] This is in progress

Please have a look @datalad/developers
