### PR TITLE
Support obscure file/key names in S3 buckets

### DIFF
--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -154,10 +154,7 @@ class S3Downloader(BaseDownloader):
         # magical check, which would fail if someone had % followed by two digits
         filepath = rec.path.lstrip('/')
         if re.search('%[0-9a-fA-F]{2}', filepath):
-            lgr.debug(
-                "URL decoding S3 URL filepath portion to be a simple key",
-                filepath
-            )
+            lgr.debug("URL unquoting S3 URL filepath %s", filepath)
             filepath = urlunquote(filepath)
         # TODO: needs replacement to assure_ since it doesn't
         # deal with non key=value

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -93,3 +93,15 @@ def test_reuse_session(tempfile, mocked_auth):
 
     Providers.reset_default_providers()  # necessary to avoid side-effects from having a vcr'ed connection
     # leaking through default provider's bucket, e.g. breaking test_mtime if ran after this one
+
+
+def test_parse_url():
+    from ..s3 import S3Downloader
+    f = S3Downloader._parse_url
+    b1 = "s3://bucket.name/file/path?revision=123"
+    assert_equal(f(b1, bucket_only=True), 'bucket.name')
+    assert_equal(f(b1), ('bucket.name', 'file/path', {'revision': '123'}))
+    assert_equal(f("s3://b/f name"), ('b', 'f name', {}))
+    assert_equal(f("s3://b/f%20name"), ('b', 'f name', {}))
+    assert_equal(f("s3://b/f%2Bname"), ('b', 'f+name', {}))
+    assert_equal(f("s3://b/f%2bname?r=%20"), ('b', 'f+name', {'r': '%20'}))

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -139,6 +139,10 @@ class VersionedFilesPool(object):
 def get_key_url(e, schema='http', versioned=True):
     """Generate an s3:// or http:// url given a key
     """
+    # TODO: here we would need to encode the name since urlquote actually
+    # can't do that on its own... but then we should get a copy of the thing
+    # so we could still do the .format....
+    # ... = e.name.encode('utf-8')  # unicode isn't advised in URLs
     e.name_urlquoted = urlquote(e.name)
     if schema == 'http':
         fmt = "http://{e.bucket.name}.s3.amazonaws.com/{e.name_urlquoted}"

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -278,8 +278,9 @@ def gen_bucket_test2_obscurenames_versioned():
     # http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
     files("f 1", load="")
     files("f [1][2]")
-    files(u"юникод")
-    files(u"юни/код")
+    # Need to grow up for this .... TODO
+    #files(u"юникод")
+    #files(u"юни/код")
     # all fancy ones at once
     files("f!-_.*'( )")
     # the super-fancy which aren't guaranteed to be good idea (as well as [] above)

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -1,4 +1,4 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8  -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -24,8 +24,8 @@ import logging
 import datalad.log  # Just to have lgr setup happen this one used a script
 lgr = logging.getLogger('datalad.s3')
 
-from ..dochelpers import exc_str
-from .exceptions import DownloadError, AccessDeniedError
+from datalad.dochelpers import exc_str
+from datalad.support.exceptions import DownloadError, AccessDeniedError
 
 from six.moves.urllib.request import urlopen, Request
 from six.moves.urllib.parse import urlparse, urlunparse
@@ -52,7 +52,7 @@ def _get_bucket_connection(credential):
     # with different resources. Thus for now just making an option which
     # one to use
     # do full shebang with entering credentials
-    from ..downloaders.credentials import AWS_S3
+    from datalad.downloaders.credentials import AWS_S3
     credential = AWS_S3(credential, None)
     if not credential.is_known:
         credential.enter_new()
@@ -260,6 +260,30 @@ def gen_bucket_test1_dirs():
     files("d1/file1.txt")
     # and then delete it and place it back
     files("d1", load="smth")
+
+
+def gen_bucket_test2_obscurenames_versioned():
+    # in principle bucket name could also contain ., but boto doesn't digest it
+    # well
+    bucket_name = 'datalad-test2-obscurenames-versioned'
+    bucket = gen_test_bucket(bucket_name)
+    bucket.configure_versioning(True)
+
+    # Enable web access to that bucket to everyone
+    bucket.configure_website('index.html')
+    set_bucket_public_access_policy(bucket)
+
+    files = VersionedFilesPool(bucket)
+
+    # http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+    files("f 1", load="")
+    files("f [1][2]")
+    files(u"юникод")
+    files(u"юни/код")
+    # all fancy ones at once
+    files("f!-_.*'( )")
+    # the super-fancy which aren't guaranteed to be good idea (as well as [] above)
+    files("f &$=@:+,?;")
 
 
 def get_versioned_url(url, guarantee_versioned=False, return_all=False, verify=False,


### PR DESCRIPTION
This pull request fixes #1999

TODO which I've not yet accomplished - unicode filenames in s3. Decided to postpone for now
This pull request proposes to do automagic decision to url unquote path component if any %XX is found in it.  This would allow to be smart about quoted urls (like we are passing back and worth with annex) and straight url given as a string to download-url.  i don't think conflict is likely

### Changes
- [x] This change is complete - running on the bucket which caused all the turmoil now

Please have a look @datalad/developers
