### PR TITLE
ENH: automagicio - proxy also isfile

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -77,6 +77,7 @@ class AutomagicIO(object):
         self._builtin_open = __builtin__.open
         self._io_open = io.open
         self._builtin_exists = os.path.exists
+        self._builtin_isfile = os.path.isfile
         if h5py:
             self._h5py_File = h5py.File
         else:
@@ -179,6 +180,11 @@ class AutomagicIO(object):
             return True
         return lexists(path) and 'annex/objects' in realpath(path)
 
+    def _proxy_isfile(self, path):
+        return self._proxy_open_name_mode(
+            'os.path.isfile', self._builtin_isfile, path
+        )
+
     def _dataset_auto_get(self, filepath):
         """Verify that filepath is under annex, and if so and not present - get it"""
 
@@ -236,6 +242,7 @@ class AutomagicIO(object):
         __builtin__.open = self._proxy_open
         io.open = self._proxy_io_open
         os.path.exists = self._proxy_exists
+        os.path.isfile = self._proxy_isfile
         if h5py:
             h5py.File = self._proxy_h5py_File
         if lzma:
@@ -254,6 +261,7 @@ class AutomagicIO(object):
         if lzma:
             lzma.LZMAFile = self._lzma_LZMAFile
         os.path.exists = self._builtin_exists
+        os.path.isfile = self._builtin_isfile
         self._active = False
 
     def __del__(self):

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -134,6 +134,9 @@ def _test_proxying_open(generate_load, verify_load, repo):
         assert_false(annex2.file_has_content(fpath2_2))
         verify_load(fpath2_2)
         assert_true(annex2.file_has_content(fpath2_2))
+        annex2.drop(fpath2_2)
+        assert_false(annex2.file_has_content(fpath2_2))
+        assert_true(os.path.isfile(fpath2_2))
 
     # if we override stdout with something not supporting fileno, like tornado
     # does which ruins using get under IPython


### PR DESCRIPTION
This pull request fixes #2011 

### Changes
- [x] This change is complete

quite neat:
```shell
$> python -m datalad /usr/bin/fsleyes ~/datalad/openfmri/ds000002/sub-05/anat/sub-05_inplaneT2.nii.gz
[INFO   ] Activating DataLad's AutoMagicIO 
[INFO   ] Running code of /usr/bin/fsleyes 
[INFO   ] File /home/yoh/datalad/openfmri/ds000002/sub-05/anat/sub-05_inplaneT2.nii.gz has no content -- retrieving 
19:23:24: Debug: ScreenToClient cannot work when toplevel window is not shown                                   
19:23:24: Debug: ScreenToClient cannot work when toplevel window is not shown                                   
19:23:24: Debug: ScreenToClient cannot work when toplevel window is not shown
...
python -m datalad /usr/bin/fsleyes   6.40s user 1.62s system 71% cpu 11.146 total
```