### PR TITLE
ENH(TST): setup a fake HOME for running tests without being affected by user config

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -330,12 +330,18 @@ def check_git_configured():
     Raises
     ------
     RuntimeError  if any of those two ariables are not set
+
+    Returns
+    -------
+    dict with user.name and user.email entries
     """
 
     check_runner = GitRunner()
+    vals = {}
     for c in 'user.name', 'user.email':
         try:
-            check_runner.run(['git', 'config', '--global', c])
+            v, err = check_runner.run(['git', 'config', '--global', c])
+            vals[c] = v.rstrip('\n')
         except CommandError as exc:
             lgr.debug("Failed to verify that git is configured: %s",
                       exc_str(exc))
@@ -343,6 +349,7 @@ def check_git_configured():
                 "You must configure git first (set both user.name and "
                 "user.email) settings before using DataLad."
             )
+    return vals
 
 
 def _remove_empty_items(list_):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -411,11 +411,15 @@ class SSHManager(object):
         """
         # parse url:
         from datalad.support.network import RI, is_ssh
-        if ':' not in url and '/' not in url:
-            # it is just a hostname
-            lgr.debug("Assuming %r is just a hostname for ssh connection", url)
-            url += ':'
-        sshri = RI(url) if not isinstance(url, RI) else url
+        if isinstance(url, RI):
+            sshri = url
+        else:
+            if ':' not in url and '/' not in url:
+                # it is just a hostname
+                lgr.debug("Assuming %r is just a hostname for ssh connection",
+                          url)
+                url += ':'
+            sshri = RI(url)
 
         if not is_ssh(sshri):
             raise ValueError("Unsupported SSH URL: '{0}', use "

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -411,6 +411,10 @@ class SSHManager(object):
         """
         # parse url:
         from datalad.support.network import RI, is_ssh
+        if ':' not in url and '/' not in url:
+            # it is just a hostname
+            lgr.debug("Assuming %r is just a hostname for ssh connection", url)
+            url += ':'
         sshri = RI(url) if not isinstance(url, RI) else url
 
         if not is_ssh(sshri):

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -44,7 +44,15 @@ def test_ssh_get_connection():
 
     # fail on malformed URls (meaning: our fancy URL parser can't correctly
     # deal with them):
-    assert_raises(ValueError, manager.get_connection, 'localhost')
+    #assert_raises(ValueError, manager.get_connection, 'localhost')
+    # we now allow those simple specifications of host to get_connection
+    c2 = manager.get_connection('localhost')
+    assert_is_instance(c2, SSHConnection)
+
+    # but should fail if it looks like something else
+    assert_raises(ValueError, manager.get_connection, 'localhost/')
+    assert_raises(ValueError, manager.get_connection, ':localhost')
+
     # we can do what urlparse cannot
     # assert_raises(ValueError, manager.get_connection, 'someone@localhost')
     # next one is considered a proper url by urlparse (netloc:'',

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -73,10 +73,12 @@ def test_ssh_open_close(tfile1):
     ok_(exists(path))
 
     # use connection to execute remote command:
-    out, err = c1('ls -a')
+    local_home = os.path.expanduser('~')
+    # we list explicitly local HOME since we override it in module_setup
+    out, err = c1('ls -a %r' % local_home)
     remote_ls = [entry for entry in out.splitlines()
                  if entry != '.' and entry != '..']
-    local_ls = os.listdir(os.path.expanduser('~'))
+    local_ls = os.listdir(local_home)
     eq_(set(remote_ls), set(local_ls))
 
     # now test for arguments containing spaces and other pleasant symbols

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -13,6 +13,7 @@ from .utils import (
     with_tree,
 
     assert_raises,
+    assert_equal,
 )
 
 
@@ -32,3 +33,15 @@ def test_not_under_git(path):
             require_dataset,
             None, check_installed=True, purpose='test'
         )
+
+
+def test_git_config_fixture():
+    # in the setup_package we setup a new HOME with custom config
+    from datalad.support.gitrepo import check_git_configured
+    assert_equal(
+        check_git_configured(),
+        {
+            'user.name': 'DataLad Tester',
+            'user.email': 'test@example.com'
+         }
+    )


### PR DESCRIPTION
Got tired from needing to setup some fake HOME just to test datalad on a new box (well -- docker, buildd, etc).  Also IIRC it was desired to avoid side-effects of user configs.  So here we have it now -- only user name and email are known, the rest is tabula rasa.

### Changes
- [x] This change is complete

Please have a look @datalad/developers
