### PR TITLE
Drop --global from the git config check

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -329,7 +329,7 @@ def check_git_configured():
 
     Raises
     ------
-    RuntimeError  if any of those two ariables are not set
+    RuntimeError if any of those two variables are not set
     """
 
     check_runner = GitRunner()

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -341,7 +341,7 @@ def check_git_configured():
                       exc_str(exc))
             raise RuntimeError(
                 "You must configure git first (set both user.name and "
-                "user.email) settings before using DataLad."
+                "user.email) before using DataLad."
             )
 
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -335,7 +335,7 @@ def check_git_configured():
     check_runner = GitRunner()
     for c in 'user.name', 'user.email':
         try:
-            check_runner.run(['git', 'config', '--global', c])
+            check_runner.run(['git', 'config', c])
         except CommandError as exc:
             lgr.debug("Failed to verify that git is configured: %s",
                       exc_str(exc))


### PR DESCRIPTION
The first two commits are typo fixes for `check_git_configured`.

The last commit prevents datalad from throwing an error when
user.name/user.email are set in a config file other than ~/.gitconfig.

### Changes
- [x] This change is complete
