### PR TITLE
BF: also guard listing of ssh sockets for OSError

### DIFF
--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -390,9 +390,19 @@ class SSHManager(object):
 
         from os import listdir
         from os.path import isdir
-        self._prev_connections = [opj(self.socket_dir, p)
-                                  for p in listdir(self.socket_dir)
-                                  if not isdir(opj(self.socket_dir, p))]
+        try:
+            self._prev_connections = [opj(self.socket_dir, p)
+                                      for p in listdir(self.socket_dir)
+                                      if not isdir(opj(self.socket_dir, p))]
+        except OSError as exc:
+            self._prev_connections = []
+            lgr.warning(
+                "Failed to list %s for existing sockets. "
+                "Most likely future communications would be impaired or fail. "
+                "Original exception: %s",
+                self._socket_dir, exc_str(exc)
+            )
+
         lgr.log(5,
                 "Found %d previous connections",
                 len(self._prev_connections))


### PR DESCRIPTION
happens e.g. if sockets became owned by root due to evil sudo.
That caused travis runs to fail, e.g.
https://travis-ci.org/datalad/datalad/jobs/315021004

- [x] This change is complete
