### PR TITLE
ls: Fix unicode output on Python 2; disable unicode for non-tty

### DIFF
--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -372,9 +372,6 @@ class LsFormatter(string.Formatter):
     else:
         BLUE = RED = GREEN = RESET = DATASET = u""
 
-    # http://stackoverflow.com/questions/9932406/unicodeencodeerror-only-when-running-as-a-cron-job
-    # reveals that Python uses ascii encoding when stdout is a pipe, so we shouldn't force it to be
-    # unicode then
     # TODO: we might want to just ignore and force utf8 while explicitly .encode()'ing output!
     # unicode versions which look better but which blow during tests etc
     # Those might be reset by the constructor

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -383,6 +383,8 @@ class LsFormatter(string.Formatter):
         super(LsFormatter, self).__init__(*args, **kwargs)
         if sys.stdout.encoding is None:
             lgr.debug("encoding not set, using safe alternatives")
+        elif not sys.stdout.isatty():
+            lgr.debug("stdout is not a tty, using safe alternatives")
         else:
             try:
                 u"✓".encode(sys.stdout.encoding)

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -375,23 +375,25 @@ class LsFormatter(string.Formatter):
     # TODO: we might want to just ignore and force utf8 while explicitly .encode()'ing output!
     # unicode versions which look better but which blow during tests etc
     # Those might be reset by the constructor
-    OK = u"✓"
-    NOK = u"✗"
-    NONE = u"✗"
+    OK = 'OK'   # u"✓"
+    NOK = 'X'  # u"✗"
+    NONE = '-'  # u"✗"
 
     def __init__(self, *args, **kwargs):
         super(LsFormatter, self).__init__(*args, **kwargs)
-        for setting_encoding in (sys.getdefaultencoding(),
-                                 sys.stdout.encoding):
+        if sys.stdout.encoding is None:
+            lgr.debug("encoding not set, using safe alternatives")
+        else:
             try:
-                u"✓".encode(setting_encoding)
+                u"✓".encode(sys.stdout.encoding)
             except UnicodeEncodeError:
-                lgr.debug("encoding %s found to not support unicode, resetting to safe alternatives", setting_encoding)
-                self.OK = 'OK'   # u"✓"
-                self.NOK = 'X'  # u"✗"
-                self.NONE = '-'  # u"✗"
-                break
-
+                lgr.debug("encoding %s does not support unicode, "
+                          "using safe alternatives",
+                          sys.stdout.encoding)
+            else:
+                self.OK = u"✓"
+                self.NOK = u"✗"
+                self.NONE = u"✗"
 
     def convert_field(self, value, conversion):
         #print("%r->%r" % (value, conversion))

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -276,13 +276,10 @@ def test_ls_noarg(toppath):
 
 
 def test_ls_formatter():
-    # we will use those unicode symbols only whenever both are supporting
-    # UTF-8
-    for sysenc, sysioenc, OK in (
-            ('ascii', 'ascii', 'OK'),
-            ('ascii', 'UTF-8', 'OK'),
-            ('UTF-8', 'ascii', 'OK'),
-            ('UTF-8', 'UTF-8', u"✓")):
+    # we will use unicode symbols only when sys.stdio supports UTF-8
+    for sysioenc, OK in [(None, "OK"),
+                         ('ascii', 'OK'),
+                         ('UTF-8', u"✓")]:
 
         # we cannot overload sys.stdout.encoding
         class fake_stdout(object):
@@ -290,10 +287,7 @@ def test_ls_formatter():
             def write(self, *args):
                 pass
 
-        with patch.object(sys, 'getdefaultencoding', return_value=sysenc), \
-            patch.object(sys, 'stdout', fake_stdout()):
+        with patch.object(sys, 'stdout', fake_stdout()):
             formatter = LsFormatter()
             assert_equal(formatter.OK, OK)
             assert_in(OK, formatter.convert_field(True, 'X'))
-
-

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -277,15 +277,19 @@ def test_ls_noarg(toppath):
 
 def test_ls_formatter():
     # we will use unicode symbols only when sys.stdio supports UTF-8
-    for sysioenc, OK in [(None, "OK"),
-                         ('ascii', 'OK'),
-                         ('UTF-8', u"✓")]:
+    for sysioenc, OK, tty in [(None, "OK", True),
+                              ('ascii', 'OK', True),
+                              ('UTF-8', u"✓", True),
+                              ('UTF-8', "OK", False)]:
 
         # we cannot overload sys.stdout.encoding
         class fake_stdout(object):
             encoding = sysioenc
             def write(self, *args):
                 pass
+
+            def isatty(self):
+                return tty
 
         with patch.object(sys, 'stdout', fake_stdout()):
             formatter = LsFormatter()


### PR DESCRIPTION
Please see the commit messages.

### Changes
- [x] This change is complete
