### PR TITLE
Unicode issue in error reporting, crashes datalad

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -377,13 +377,9 @@ def main(args=None):
                 if exc.msg:
                     os.write(2, exc.msg.encode() if isinstance(exc.msg, text_type) else exc.msg)
                 if exc.stdout:
-                    os.write(1, exc.stdout.encode()) \
-                        if hasattr(exc.stdout, 'encode')  \
-                        else os.write(1, exc.stdout)
+                    os.write(1, exc.stdout.encode() if isinstance(exc.stdout, text_type) else exc.stdout)
                 if exc.stderr:
-                    os.write(2, exc.stderr.encode()) \
-                        if hasattr(exc.stderr, 'encode')  \
-                        else os.write(2, exc.stderr)
+                    os.write(2, exc.stderr.encode() if isinstance(exc.stderr, text_type) else exc.stderr)
                 # We must not exit with 0 code if any exception got here but
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)


### PR DESCRIPTION
#### What is the problem?

% datalad create-sibling -s mddatasrc XXX:/media/data/datasets/aggdemo --as-common-datasrc XXX --target-url http://XXX/aggdemo/.git     
[INFO   ] Connecting ... 
[INFO   ] Considering to create a target dataset XXX/scratch/aggdemo at /media/data/datasets/aggdemo of XXX 
Failed to run ['ssh', '-o', 'ControlPath="XXX/.cache/datalad/sockets/e43b2233"', 'XXX', 'export "PATH=/usr/bin:$PATH"; mkdir -p /media/data/datasets/aggdemo'] under None. Exit code=1. out= err=mkdir: cannot create directory ‘/media/data/datasets/aggdemo’: Permission denied
Traceback (most recent call last):
  File "/usr/bin/datalad", line 8, in <module>
    main()
  File "/usr/lib/python2.7/dist-packages/datalad/cmdline/main.py", line 381, in main
    if hasattr(exc.stderr, 'encode')  \
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 31: ordinal not in range(128)

#### What version of DataLad are you using (run `datalad --version`)? On what operating system (consider running `datalad plugin wtf`)?

% datalad --version
datalad 0.9.1