### PR TITLE
require GitPython >= 2.1.8 to assure compatibility with git 2.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
 requires = {
     'core': [
         'appdirs',
-        'GitPython>=2.1.7',
+        'GitPython>=2.1.8',
         'iso8601',
         'humanize',
         'mock>=1.0.1',  # mock is also used for auto.py, not only for testing


### PR DESCRIPTION
2.1.8 is compatible with fresh git 2.15.  I just uploaded 2.1.8 debian packages and it was released on pypi already.   For consistency we better just require this version


### Changes
- [x] This change is complete
