### PR TITLE
BF: Do not send files without content to metadata parsers

### DIFF
--- a/after1.txt
+++ b/after1.txt
@@ -1,0 +1,8 @@
+# About this dataset
+
+## General information
+
+This is a DataLad dataset.
+
+For more information on DataLad and on how to work with its datasets,
+see the DataLad documentation at: http://docs.datalad.org

--- a/after2.txt
+++ b/after2.txt
@@ -1,0 +1,8 @@
+# About this dataset
+
+## General information
+
+This is a DataLad dataset.
+
+For more information on DataLad and on how to work with its datasets,
+see the DataLad documentation at: http://docs.datalad.org

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -581,7 +581,7 @@ def _get_metadata(ds, types, merge_mode, global_meta=None, content_meta=None,
             vocabulary_version)}
 
     fullpathlist = paths
-    if isinstance(ds.repo, AnnexRepo):
+    if paths and isinstance(ds.repo, AnnexRepo):
         content_info = zip(paths, ds.repo.file_has_content(paths))
         paths = [p for p, c in content_info if c]
         nocontent = len(content_info) - len(paths)

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -582,8 +582,9 @@ def _get_metadata(ds, types, merge_mode, global_meta=None, content_meta=None,
 
     fullpathlist = paths
     if paths and isinstance(ds.repo, AnnexRepo):
-        content_info = zip(paths, ds.repo.file_has_content(paths))
-        paths = [p for p, c in content_info if c]
+        # Ugly? Jep: #2055
+        content_info = zip(paths, ds.repo.file_has_content(paths), ds.repo.is_under_annex(paths))
+        paths = [p for p, c, a in content_info if not a or c]
         nocontent = len(fullpathlist) - len(paths)
         if nocontent:
             lgr.warn(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -584,7 +584,7 @@ def _get_metadata(ds, types, merge_mode, global_meta=None, content_meta=None,
     if paths and isinstance(ds.repo, AnnexRepo):
         content_info = zip(paths, ds.repo.file_has_content(paths))
         paths = [p for p, c in content_info if c]
-        nocontent = len(content_info) - len(paths)
+        nocontent = len(fullpathlist) - len(paths)
         if nocontent:
             lgr.warn(
                 '{} files have no content present, skipped metadata extraction for {}'.format(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -590,7 +590,7 @@ def _get_metadata(ds, types, merge_mode, global_meta=None, content_meta=None,
             lgr.warn(
                 '{} files have no content present, skipped metadata extraction for {}'.format(
                     nocontent,
-                    'them' if nocontent > 10 else [p for p, c in content_info if not c]))
+                    'them' if nocontent > 10 else [p for p, c, a in content_info if not c and a]))
 
     # keep local, who knows what some parsers might pull in
     from . import parsers


### PR DESCRIPTION
Parsers may not be prepared to deal with this situtation and crash,
taking down the entire aggregation effort.

Some parsers may be able to infer some metadata from filenames, but in
general there is no point in feeding no-content files to parsers.

In general to-be-aggregated datasets should have content.