### PR TITLE
DO NOT MERGE empty commit just to test effect on coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
     env:
     - _DATALAD_UPSTREAM_GITPYTHON=1
     - _DATALAD_UPSTREAM_GITANNEX=1
-    - _DATALAD_NONPR_ONLY=1
     # Just so we test if we did not screw up running under nose without -s as well
     - NOSE_OPTS=
   - python: 2.7
@@ -55,7 +54,6 @@ matrix:
     env:
     - DATALAD_LOG_LEVEL=INFO
     - DATALAD_LOG_TRACEBACK=1  # just a smoke test for now
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     # By default no logs will be output. This one is to test with low level but dumped to /dev/null
     env:
@@ -77,18 +75,15 @@ matrix:
     - NOSE_WRAPPER="sudo -E"
     # no key authentication for root:
     - DATALAD_TESTS_SSH=0
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     env:
     - DATALAD_TESTS_NONETWORK=1
     # must operate nicely with those env variables set
     - http_proxy=
     - https_proxy=
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     env:
     - PYTHONPATH=$PWD/tools/testing/bad_internals/_scrapy/
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     # To make sure that operates correctly whenever dataset directories have symlinks
     # in their path.
@@ -96,7 +91,6 @@ matrix:
     # Eventually we will get there, but atm causes a good number of failures
     # - TMPDIR="/tmp/sym ссылка"
     - TMPDIR="/tmp/sym link"
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     # apparently moving symlink outside has different effects on abspath
     # see  https://github.com/datalad/datalad/issues/878
@@ -108,7 +102,6 @@ matrix:
     env:
     # To make orthogonal test where it is not a symlink but a dir with spaces
     - TMPDIR="/tmp/d i r"
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     # Test under NFS mount  (only selected sub-set)
     env:
@@ -118,7 +111,6 @@ matrix:
     # Test under NFS mount  (full, only in master)
     env:
     - TMPDIR="/tmp/nfsmount"
-    - _DATALAD_NONPR_ONLY=1
   - python: 2.7
     # test whether known v6 failures still fail
     env:
@@ -143,7 +135,6 @@ matrix:
   - python: 2.7
     env:
     - TMPDIR="/tmp/nfsmount"
-    - _DATALAD_NONPR_ONLY=1
   # test whether known v6 failures still fail
   - env:
     - DATALAD_TESTS_SSH=1


### PR DESCRIPTION
Other PRs strangely show strange decreases in coverage -- this PR atm introduces no changes intentionally 
e.g. looking at https://codecov.io/gh/datalad/datalad/pull/2046/src/datalad/tests/utils.py#L427 -- codecov states that the line was covered before but not now.  But I do not see any test which (used to) use recently `ok_annex_get` with a list of files and not just one (previous condition, which is covered)

or https://codecov.io/gh/datalad/datalad/pull/2046/src/datalad/tests/utils.py#L500  -- how `__init__` declaration line could go from red to green while body from green to red.

I have also dropped a question to codecov support chat, was told that they will come back to it tomorrow