### PR TITLE
A variety of tuneups to AutomagicIO to avoid redoing the same queries in 'search'

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -32,6 +32,9 @@ from .support.annexrepo import AnnexRepo
 from .cmdline.helpers import get_repo_instance
 from .consts import HANDLE_META_DIR
 
+# To be used for a quick detection of path being under .git/
+_DOT_GIT_DIR = pathsep + '.git' + pathsep
+
 lgr = logging.getLogger("datalad.auto")
 
 h5py = None
@@ -164,8 +167,7 @@ class AutomagicIO(object):
                     else:
                         self._paths_cache.add(filefull)
 
-                # TODO: Windows-proof?
-                if '/.git/' in file:
+                if _DOT_GIT_DIR in file:
                     raise _EarlyExit("we ignore paths under .git/")
                 mode = 'r'
                 if len(args) > 1:

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -277,7 +277,11 @@ class AutomagicIO(object):
         # either it has content
         if (under_annex or under_annex is None) and not annex.file_has_content(filepath):
             lgr.info("AutomagicIO: retrieving file content of %s", filepath)
-            annex.get(filepath)
+            out = annex.get(filepath)
+            if not out.get('success', False):
+                # to assure that it is present and without trailing/leading new lines
+                out['note'] = out.get('note', '').strip()
+                lgr.error("Failed to retrieve %(file)s: %(note)s", out)
 
     def activate(self):
         # we should stay below info for this message. With PR #1630 we

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -324,7 +324,7 @@ def query_aggregated_metadata(reporton, ds, aps, merge_mode, recursive=False,
     # TODO rename function and query datalad/annex own metadata
     # for all actually present dataset after looking at aggregated data
 
-    with AutomagicIO():
+    with AutomagicIO(check_once=True):
         # look for and load the aggregation info for the base dataset
         info_fpath = opj(ds.path, agginfo_relpath)
         agg_base_path = dirname(info_fpath)

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -295,7 +295,7 @@ def _get_search_index(index_dir, ds, force_reindex):
             # you're trying to open is either not backward or forward
             # compatible with this version of Whoosh.
             # we try to regenerate
-            # TODO log this
+            lgr.warning(exc_str(e))
             pass
         except widx.OutOfDateError as e:
             # Raised when you try to commit changes to an index which is not
@@ -391,6 +391,7 @@ def _get_search_index(index_dir, ds, force_reindex):
                 include_count=True),
             old_ds_rpath)
 
+    lgr.debug("Committing index")
     idx.commit(optimize=True)
 
     # "timestamp" the search index to allow for automatic invalidation
@@ -400,6 +401,7 @@ def _get_search_index(index_dir, ds, force_reindex):
     # dump the term/field definitions records for later introspection
     # use compressed storage, the is not point in inflating the
     # diskspace requirements
+    lgr.debug("Storing definitions to %s", definitions_fname)
     with gzopen(definitions_fname, 'wb') as f:
         # TODO actually go through all, incl. compound, defintions ('@id' plus 'unit'
         # or similar) and resolve terms to URLs, if anyhow possible

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -139,6 +139,17 @@ def _test_proxying_open(generate_load, verify_load, repo):
         assert_false(annex2.file_has_content(fpath2_2))
         assert_true(os.path.isfile(fpath2_2))
 
+    # In check_once mode, if we drop it, it wouldn't be considered again
+    annex2.drop(fpath2_2)
+    assert_false(annex2.file_has_content(fpath2_2))
+    with AutomagicIO(check_once=True):
+        verify_load(fpath2_2)
+        assert_true(annex2.file_has_content(fpath2_2))
+        annex2.drop(fpath2_2)
+        assert_false(annex2.file_has_content(fpath2_2))
+        assert_false(os.path.isfile(fpath2_2))
+
+
     # if we override stdout with something not supporting fileno, like tornado
     # does which ruins using get under IPython
     # TODO: we might need to refuse any online logging in other places like that


### PR DESCRIPTION
It might fix the "stalling" I have reported somewhere (probably was closed since "happened on smaug")
It should make AutomagicIO of lesser burden on 'search' since before now it would query for the same files over and over again , and look for git repo for every directory etc. So now

- gets a mode to consider each path only once
- caches repos for each directory considered
- skips paths containing `/.git/` since also not expecting anything to be under annex control there
- assumes that there could be no subdataset under .datalad (for now) which helps to avoid
  looking up for .git for every bloody objects/XX directory (funny part is that then it was all in vein in my case since repo is anyways is git, not annex)
- a bit improved and harmonized logging there
- potentially, at least partially addresses #2041 (thanks @mih for digging the # out)

Disclaimer: some of the fixes will make also into 0.9.x branch later on