### PR TITLE
Suboptimal error message

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -687,9 +687,10 @@ class RegexBasedURLMixin(object):
         if not re_match:
             # TODO: custom error?
             raise ValueError(
-                "Possibly incorrectly determined string %r correspond to %s address"
-                " -- it failed matching regex. Dunno how to handle. Contact developers"
-                % (cls, url_str,)
+                "Cannot handle URL '%s': categorized as %r, but does not match syntax.%s"
+                % (url_str,
+                   cls,
+                   " Did you intent to use '///'?" if url_str.startswith('//') else '')
             )
         fields = cls._get_blank_fields()
         fields.update({k: v for k, v in iteritems(re_match.groupdict()) if v})


### PR DESCRIPTION
#### What is the problem?

```
% datalad install //openfmri
[ERROR  ] Possibly incorrectly determined string <class 'datalad.support.network.DataLadRI'> correspond to //openfmri address -- it failed matching regex. Dunno how to handle. Contact developers [network.py:_str_to_fields:692] (ValueError) 
```

It should probably just say that it doesn't know how to treat this first. From this perspective an "incorrectly determined string" is an incomprehensible statement. And I also don't want to be contacted each time someone accidentally forgets the third slash ;-)

Changes:

Now looks like this:

```
% datalad install //openfmri
[ERROR  ] Cannot handle URL '//openfmri': categorized as <class 'datalad.support.network.DataLadRI'>, but does not match syntax. Did you intent to use '///'? [network.py:_str_to_fields:693] (ValueError) 
```