### PR TITLE
Remove redundant space in pip command

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -26,7 +26,7 @@ which is not set up automatically by using the pip method.
 Advanced users can chose from several installation schemes (e.g.
 ``publish``, ``metadata``, ``tests`` or ``crawl``)::
 
-  pip install datalad [SCHEME]
+  pip install datalad[SCHEME]
   
 where ``SCHEME`` could be
 


### PR DESCRIPTION
Otherwise an error would appear
```
pip._vendor.packaging.requirements.InvalidRequirement: Invalid requirement, parse error at "'[full]'"
```

This pull request fixes #

This pull request proposes

### Changes
- [x] This change is complete
- [ ] This is in progress

Please have a look @datalad/developers
