### PR TITLE
ENH: Rerun extensions

### DIFF
--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -15,7 +15,7 @@ from ..crcns import get_metadata
 
 from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import ok_startswith
-from datalad.support.exceptions import AccessFailedError
+from datalad.support.exceptions import AccessFailedError, AccessDeniedError
 
 
 def test_smoke_pipelines():
@@ -42,3 +42,5 @@ def test_get_metadata():
         if str(e).startswith('Access to https://search.datacite.org') and \
                 str(e).endswith('has failed: status code 502'):
             raise SkipTest("Probably datacite.org blocked us once again")
+    except AccessDeniedError:
+        raise SkipTest("datacite denied us and we asked, but waiting for an answer")

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -67,6 +67,7 @@ _group_misc = (
          'add-archive-content'),
         ('datalad.interface.download_url', 'DownloadURL', 'download-url'),
         ('datalad.interface.run', 'Run', 'run'),
+        ('datalad.interface.rerun', 'Rerun', 'rerun'),
     ])
 
 _group_plumbing = (

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -71,7 +71,7 @@ class Rerun(Interface):
             args=("revision",),
             metavar="REVISION",
             nargs="?",
-            doc="""re-run command(s) in REVISION.  By default, the
+            doc="""rerun command(s) in REVISION.  By default, the
             command from this commit will be executed, but the --since
             option can be used to construct a revision range.""",
             default="HEAD",
@@ -150,7 +150,7 @@ class Rerun(Interface):
         if not ds.repo.get_hexsha():
             yield dict(
                 err_info, status='impossible',
-                message='cannot re-run command, nothing recorded')
+                message='cannot rerun command, nothing recorded')
             return
 
         if branch and branch in ds.repo.get_branches():
@@ -260,12 +260,12 @@ def get_commit_runinfo(repo, commit="HEAD"):
         runinfo = json.loads(runinfo)
     except Exception as e:
         raise ValueError(
-            'cannot re-run command, command specification is not valid JSON: '
+            'cannot rerun command, command specification is not valid JSON: '
             '%s' % str(e)
         )
     if 'cmd' not in runinfo:
         raise ValueError(
-            'cannot re-run command, command specification missing in '
+            'cannot rerun command, command specification missing in '
             'recorded state'
         )
     return rec_msg, runinfo

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -303,3 +303,11 @@ def new_or_modified(dataset, revision="HEAD"):
         if r.get('type') == 'file' and r.get('state') in ['added', 'modified']:
             r.pop('status', None)
             yield r
+
+
+def commit_exists(dataset, commit):
+    try:
+        dataset.repo.repo.git.rev_parse("--verify", commit + "^{commit}")
+    except:
+        return False
+    return True

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -167,8 +167,12 @@ class Rerun(Interface):
                 message="branch '{}' already exists".format(branch))
             return
 
-        if since is None:
-            revrange = "{}^..{}".format(revision, revision)
+        if not commit_exists(ds, revision + "^"):
+            # Only a single commit is reachable from `revision`.  In
+            # this case, --since has no effect on the range construction.
+            revrange = revision
+        elif since is None:
+            revrange = "{rev}^..{rev}".format(rev=revision)
         elif since.strip() == "":
             revrange = revision
         else:

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -21,7 +21,6 @@ from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.interface.run import run_command
-from datalad.interface.common_opts import save_message_opt
 
 from datalad.support.constraints import EnsureNone, EnsureStr
 from datalad.support.gitrepo import GitCommandError
@@ -104,7 +103,13 @@ class Rerun(Interface):
             empty value for this option means to use the commit
             specified by --since.""",
             constraints=EnsureStr() | EnsureNone()),
-        message=save_message_opt,
+        message=Parameter(
+            args=("-m", "--message",),
+            metavar="MESSAGE",
+            doc="""use MESSAGE for the reran commit rather than the
+            recorded commit message.  In the case of a multi-commit
+            rerun, all the reran commits will have this message.""",
+            constraints=EnsureStr() | EnsureNone()),
         dataset=Parameter(
             args=("-d", "--dataset"),
             doc="""specify the dataset from which to rerun a recorded

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -1,0 +1,159 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Rerun commands recorded with `datalad run`"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import json
+import re
+
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
+from datalad.interface.run import run_command
+from datalad.interface.common_opts import save_message_opt
+
+from datalad.support.constraints import EnsureNone
+from datalad.support.param import Parameter
+
+from datalad.distribution.dataset import require_dataset
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import datasetmethod
+
+lgr = logging.getLogger('datalad.interface.run')
+
+
+@build_doc
+class Rerun(Interface):
+    """Re-execute the previous `datalad run` command.
+
+    This will unlock any dataset content that is on record to have
+    been modified by the previous command run. It will then re-execute
+    the command in the recorded path (if it was inside the
+    dataset). Afterwards, all modifications will be saved.
+    """
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset from which to rerun a recorded command.
+            If no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory. If a dataset is given,
+            the command will be executed in the root directory of this
+            dataset.""",
+            constraints=EnsureDataset() | EnsureNone()),
+        message=save_message_opt,
+        # TODO
+        # --list-commands
+        #   go through the history and report any recorded command. this info
+        #   could be used to unlock the associated output files for a rerun
+    )
+
+    @staticmethod
+    @datasetmethod(name='rerun')
+    @eval_results
+    def __call__(
+            dataset=None,
+            message=None):
+
+        ds = require_dataset(
+            dataset, check_installed=True,
+            purpose='rerunning a command')
+
+        lgr.debug('rerunning command output underneath %s', ds)
+
+        from datalad.tests.utils import ok_clean_git
+        try:
+            ok_clean_git(ds.path)
+        except AssertionError:
+            yield get_status_dict(
+                'run',
+                ds=ds,
+                status='impossible',
+                message=('unsaved modifications present, '
+                         'cannot detect changes by command'))
+            return
+
+        err_info = get_status_dict('run', ds=ds)
+        if not ds.repo.get_hexsha():
+            yield dict(
+                err_info, status='impossible',
+                message='cannot re-run command, nothing recorded')
+            return
+
+        # pull run info out of the last commit message
+        try:
+            rec_msg, runinfo = get_commit_runinfo(ds.repo)
+        except ValueError as exc:
+            yield dict(
+                err_info, status='error',
+                message=str(exc)
+            )
+            return
+        if not runinfo:
+            yield dict(
+                err_info, status='impossible',
+                message=('cannot re-run command, last saved state does not '
+                         'look like a recorded command run'))
+            return
+
+        # now we have to find out what was modified during the last run, and enable re-modification
+        # ideally, we would bring back the entire state of the tree with #1424, but we limit ourself
+        # to file addition/not-in-place-modification for now
+        to_unlock = []
+        for r in ds.diff(
+                recursive=True,
+                revision='HEAD~1...HEAD',
+                return_type='generator',
+                result_renderer=None):
+            if r.get('type') == 'file' and \
+                    r.get('state') in ('added', 'modified'):
+                r.pop('status')
+                to_unlock.append(r)
+        if to_unlock:
+            for r in ds.unlock(to_unlock, return_type='generator', result_xfm=None):
+                yield r
+
+            for r in run_command(runinfo['cmd'], ds, rec_msg or message,
+                                 rerun_info=runinfo):
+                yield r
+
+
+def get_commit_runinfo(repo, commit=None):
+    """Return message and run record from a commit message
+
+    If none found - returns None, None; if anything goes wrong - throws
+    ValueError with the message describing the issue
+    """
+    assert commit is None, "TODO: implement for anything but the last commit"
+    last_commit_msg = repo.repo.head.commit.message
+    cmdrun_regex = r'\[DATALAD RUNCMD\] (.*)=== Do not change lines below ' \
+                   r'===\n(.*)\n\^\^\^ Do not change lines above \^\^\^'
+    runinfo = re.match(cmdrun_regex, last_commit_msg,
+                       re.MULTILINE | re.DOTALL)
+    if not runinfo:
+        return None, None
+
+    rec_msg, runinfo = runinfo.groups()
+
+    try:
+        runinfo = json.loads(runinfo)
+    except Exception as e:
+        raise ValueError(
+            'cannot re-run command, command specification is not valid JSON: '
+            '%s' % str(e)
+        )
+    if 'cmd' not in runinfo:
+        raise ValueError(
+            'cannot re-run command, command specification missing in '
+            'recorded state'
+        )
+    return rec_msg, runinfo

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -272,9 +272,8 @@ def get_commit_runinfo(repo, commit="HEAD"):
         )
     if 'cmd' not in runinfo:
         raise ValueError(
-            'cannot rerun command, command specification missing in '
-            'recorded state'
-        )
+            "{} looks like a run commit but does not have a command".format(
+                repo.repo.git.rev_parse("--short", commit)))
     return rec_msg, runinfo
 
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -149,7 +149,7 @@ class Rerun(Interface):
                     message="--root is incompatible with revision range")
                 return
 
-        revs = ds.repo.repo.git.rev_list("--reverse", revision).split()
+        revs = ds.repo.repo.git.rev_list("--reverse", revision, "--").split()
 
         if onto:
             ds.repo.checkout(onto, options=["--detach"])

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -47,10 +47,14 @@ class Rerun(Interface):
             args=("revision",),
             metavar="<revision or range>",
             nargs="?",
-            doc="""re-run command(s) in this revision or range.  This can be a
-            commit-ish that resolves to a single commit whose command
-            should be re-run. Otherwise, it is taken as a revision
-            range, and all the commands that would be shown by `git
+            doc="""re-run command(s) in this revision or range.
+            This argument can take one of two forms. The first is a
+            commit-ish that resolves to a single commit.  By default,
+            the command from this commit will be executed, but, if
+            --root is given, the commands from all commits that are
+            reachable from that commit (including itself) will be
+            executed. The second acceptable form is a revision range,
+            in which case all the commands that would be shown by `git
             log <range>` are re-executed.""",
             default="HEAD",
             constraints=EnsureStr()),

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -180,9 +180,9 @@ class Rerun(Interface):
         do_checkout = branch
         if onto is not None:
             if onto.strip() == "":
-                ## An empty argument means go to the parent of the
-                ## first revision, but that doesn't exist for
-                ## --since=.  Instead check out an orphan branch.
+                # An empty argument means go to the parent of the
+                # first revision, but that doesn't exist for --since=.
+                # Instead check out an orphan branch.
                 if root and branch:
                     ds.repo.checkout(branch, options=["--orphan"])
                     # Make sure we are actually on an orphan branch

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -78,7 +78,6 @@ class Rerun(Interface):
             constraints=EnsureStr()),
         since=Parameter(
             args=("--since",),
-            nargs="?",
             doc="""If SINCE is a commit-ish, the commands from all
             commits that are reachable from REVISION but not SINCE
             will be re-executed (in other words, the commands in `git

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -127,6 +127,12 @@ class Rerun(Interface):
                 message='cannot re-run command, nothing recorded')
             return
 
+        if branch and branch in ds.repo.get_branches():
+            yield get_status_dict(
+                "run", ds=ds, status="error",
+                message="branch '{}' already exists".format(branch))
+            return
+
         try:
             # Transform a single-commit revision into a range.  Don't
             # rely on `".." in` for the range check because it's
@@ -148,12 +154,6 @@ class Rerun(Interface):
         if onto:
             ds.repo.checkout(onto, options=["--detach"])
         if branch:
-            if branch in ds.repo.get_branches():
-                yield get_status_dict("run",
-                    ds=ds,
-                    status="error",
-                    message="branch '{}' already exists".format(branch))
-                return
             ds.repo.checkout("HEAD", ["-b", branch])
 
         for rev in revs:

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -30,7 +30,7 @@ from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
-lgr = logging.getLogger('datalad.interface.run')
+lgr = logging.getLogger('datalad.interface.rerun')
 
 
 @build_doc

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -87,15 +87,6 @@ class Rerun(Interface):
             REVISION`). Currently, the range cannot include merge
             commits.""",
             constraints=EnsureStr() | EnsureNone()),
-        dataset=Parameter(
-            args=("-d", "--dataset"),
-            doc="""specify the dataset from which to rerun a recorded
-            command. If no dataset is given, an attempt is made to
-            identify the dataset based on the current working
-            directory. If a dataset is given, the command will be
-            executed in the root directory of this dataset.""",
-            constraints=EnsureDataset() | EnsureNone()),
-        message=save_message_opt,
         branch=Parameter(
             metavar="NAME",
             args=("-b", "--branch",),
@@ -112,6 +103,15 @@ class Rerun(Interface):
             empty value for this option means to use the commit
             specified by --since.""",
             constraints=EnsureStr() | EnsureNone()),
+        message=save_message_opt,
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset from which to rerun a recorded
+            command. If no dataset is given, an attempt is made to
+            identify the dataset based on the current working
+            directory. If a dataset is given, the command will be
+            executed in the root directory of this dataset.""",
+            constraints=EnsureDataset() | EnsureNone()),
         # TODO
         # --list-commands
         #   go through the history and report any recorded command. this info

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -233,6 +233,12 @@ class Rerun(Interface):
                     ds.repo.repo.git.cherry_pick(rev)
                 continue
 
+            # Keep a "rerun" trail.
+            if "chain" in runinfo:
+                runinfo["chain"].append(rev)
+            else:
+                runinfo["chain"] = [rev]
+
             # now we have to find out what was modified during the
             # last run, and enable re-modification ideally, we would
             # bring back the entire state of the tree with #1424, but

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -210,6 +210,15 @@ class Rerun(Interface):
             # --since is specified, the effective value for --since is
             # the parent of the first revision.
             onto = revs[0].id + "^"
+            if not commit_exists(ds, onto):
+                # This is unlikely to happen in the wild because it
+                # means that the first commit is a datalad run commit.
+                # Just abort rather than trying to checkout on orphan
+                # branch or something like that.
+                yield get_status_dict(
+                    "run", ds=ds, status="error",
+                    message="Commit for --onto does not exist.")
+                return
 
         if branch or onto:
             start_point = onto or "HEAD"

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -15,6 +15,7 @@ import logging
 import json
 import re
 
+from datalad.dochelpers import exc_str
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
@@ -267,7 +268,7 @@ def get_commit_runinfo(repo, commit="HEAD"):
     except Exception as e:
         raise ValueError(
             'cannot rerun command, command specification is not valid JSON: '
-            '%s' % str(e)
+            '%s' % exc_str(e)
         )
     if 'cmd' not in runinfo:
         raise ValueError(

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -63,6 +63,14 @@ class Rerun(Interface):
             dataset.""",
             constraints=EnsureDataset() | EnsureNone()),
         message=save_message_opt,
+        onto=Parameter(
+            metavar="base",
+            args=("--onto",),
+            doc="""start point for rerunning the commands.  If not specified, commands
+            are executed at HEAD.  This option can be used to specify
+            an alternative start point, which will be checked out in a
+            detached state.""",
+            constraints=EnsureStr() | EnsureNone()),
         # TODO
         # --list-commands
         #   go through the history and report any recorded command. this info
@@ -75,7 +83,8 @@ class Rerun(Interface):
     def __call__(
             revision="HEAD",
             dataset=None,
-            message=None):
+            message=None,
+            onto=None):
 
         ds = require_dataset(
             dataset, check_installed=True,
@@ -114,6 +123,10 @@ class Rerun(Interface):
             pass
 
         revs = ds.repo.repo.git.rev_list("--reverse", revision).split()
+
+        if onto:
+            ds.repo.checkout(onto, options=["--detach"])
+
         for rev in revs:
             # pull run info out of the revision's commit message
             try:

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -248,7 +248,7 @@ class Rerun(Interface):
                                return_type='generator', result_xfm=None):
                 yield r
 
-            for r in run_command(runinfo['cmd'], ds, rec_msg or message,
+            for r in run_command(runinfo['cmd'], ds, message or rec_msg,
                                  rerun_info=runinfo):
                 yield r
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -41,6 +41,30 @@ class Rerun(Interface):
     been modified by the command in the specified revision.  It will
     then re-execute the command in the recorded path (if it was inside
     the dataset). Afterwards, all modifications will be saved.
+
+    Examples:
+
+        Re-execute the command from the previous commit.
+
+        $ datalad rerun
+
+        Re-execute any commands in the last five commits.
+
+        $ datalad rerun HEAD~5..
+
+        Do the same as above, but re-execute the commands on top of
+        HEAD~5 in a detached state.
+
+        $ datalad rerun --onto= HEAD~5..
+
+        Re-execute all previous commands and compare the old and new
+        results.
+
+        $ # on master branch
+        $ datalad rerun --root --branch=verify
+        $ # now on verify branch
+        $ datalad diff --revision=master..
+        $ git log --oneline --left-right --cherry-pick master...
     """
     _params_ = dict(
         revision=Parameter(

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -71,7 +71,7 @@ class Rerun(Interface):
             args=("revision",),
             metavar="REVISION",
             nargs="?",
-            doc="""rerun command(s) in REVISION.  By default, the
+            doc="""rerun command(s) in REVISION. By default, the
             command from this commit will be executed, but the --since
             option can be used to construct a revision range.""",
             default="HEAD",
@@ -79,21 +79,21 @@ class Rerun(Interface):
         since=Parameter(
             args=("--since",),
             nargs="?",
-            doc="""If SINCE is commit-ish, the commands from all
+            doc="""If SINCE is a commit-ish, the commands from all
             commits that are reachable from REVISION but not SINCE
-            will be re-executed.  In other words, the commands shown
-            in `git log SINCE..REVISION` are re-executed.  If SINCE is
-            an empty string, commands from all commits that are
-            reachable from REVISION are re-executed (i.e., the
-            commands in `git log REVISION`).""",
+            will be re-executed (in other words, the commands in `git
+            log SINCE..REVISION`). If SINCE is an empty string,
+            commands from all commits that are reachable from REVISION
+            are re-executed (i.e., the commands in `git log
+            REVISION`).""",
             constraints=EnsureStr() | EnsureNone()),
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc="""specify the dataset from which to rerun a recorded command.
-            If no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory. If a dataset is given,
-            the command will be executed in the root directory of this
-            dataset.""",
+            doc="""specify the dataset from which to rerun a recorded
+            command. If no dataset is given, an attempt is made to
+            identify the dataset based on the current working
+            directory. If a dataset is given, the command will be
+            executed in the root directory of this dataset.""",
             constraints=EnsureDataset() | EnsureNone()),
         message=save_message_opt,
         branch=Parameter(
@@ -104,12 +104,13 @@ class Rerun(Interface):
         onto=Parameter(
             metavar="base",
             args=("--onto",),
-            doc="""start point for rerunning the commands.  If not specified, commands
-            are executed at HEAD.  This option can be used to specify
-            an alternative start point, which will be checked out with
-            the branch name specified with --branch or in a detached
-            state otherwise.  As a special case, an empty value for
-            this option means to use the commit specified by --since.""",
+            doc="""start point for rerunning the commands. If not
+            specified, commands are executed at HEAD. This option can
+            be used to specify an alternative start point, which will
+            be checked out with the branch name specified by --branch
+            or in a detached state otherwise. As a special case, an
+            empty value for this option means to use the commit
+            specified by --since.""",
             constraints=EnsureStr() | EnsureNone()),
         # TODO
         # --list-commands

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -296,8 +296,16 @@ def new_or_modified(dataset, revision="HEAD"):
     -------
     Generator that yields AnnotatePaths instances
     """
+    if commit_exists(dataset, revision + "^"):
+        revrange = "{rev}^..{rev}".format(rev=revision)
+    else:
+        # No other commits are reachable from this revision.  Diff
+        # with an empty tree instead.
+        #             git hash-object -t tree /dev/null
+        empty_tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        revrange = "{}..{}".format(empty_tree, revision)
     diff = dataset.diff(recursive=True,
-                        revision="{rev}^..{rev}".format(rev=revision),
+                        revision=revrange,
                         return_type='generator', result_renderer=None)
     for r in diff:
         if r.get('type') == 'file' and r.get('state') in ['added', 'modified']:

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -174,7 +174,7 @@ class Run(Interface):
                 message = rec_msg
             cmd = runinfo['cmd']
             rec_exitcode = runinfo.get('exit', 0)
-            rel_pwd = runinfo.get('pwd', None)
+            rel_pwd = runinfo.get('pwd')
             if rel_pwd:
                 # recording is relative to the dataset
                 pwd = normpath(opj(ds.path, rel_pwd))
@@ -191,9 +191,9 @@ class Run(Interface):
                     revision='HEAD~1...HEAD',
                     return_type='generator',
                     result_renderer=None):
-                if r.get('type', None) == 'file' and \
-                        r.get('state', None) in ('added', 'modified'):
-                    r.pop('status', None)
+                if r.get('type') == 'file' and \
+                        r.get('state') in ('added', 'modified'):
+                    r.pop('status')
                     to_unlock.append(r)
             if to_unlock:
                 for r in ds.unlock(to_unlock, return_type='generator', result_xfm=None):

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -13,7 +13,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import json
-import re
 
 from argparse import REMAINDER
 from os.path import join as opj
@@ -50,12 +49,6 @@ class Run(Interface):
     as long as the command is executed somewhere underneath the dataset root,
     the exact location will be recorded relative to the dataset root.
 
-    Commands can be re-executed using the --rerun flag. This will unlock
-    any dataset content that is on record to have been modified by the
-    previous command run. It will then re-execute the command in the recorded
-    path (if it was inside the dataset). Afterwards, all modifications will be
-    saved.
-
     If the executed command did not alter the dataset in any way, no record of
     the command execution is made.
 
@@ -70,69 +63,59 @@ class Run(Interface):
             doc="command for execution"),
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc="""specify the dataset to record the command results in,
-            or to rerun a recorded command from (see --rerun).  If
-            no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory. If a dataset is given,
-            the command will be executed in the root directory of this
-            dataset.""",
+            doc="""specify the dataset to record the command results in.
+            An attempt is made to identify the dataset based on the current
+            working directory. If a dataset is given, the command will be
+            executed in the root directory of this dataset.""",
             constraints=EnsureDataset() | EnsureNone()),
         message=save_message_opt,
-        rerun=Parameter(
-            args=('--rerun',),
-            action='store_true',
-            doc="""re-run the command recorded in the last saved change (if any).
-            This will ignore any command given as an argument, and execute the
-            recorded command call in the recorded working directory. The recorded
-            changeset will be replaced by the outcome of the command re-run."""),
-        # TODO
-        # --list-commands
-        #   go through the history and report any recorded command. this info
-        #   could be used to unlock the associated output files for a rerun
-        # --rerun #
-        #   rerun command # from the list of recorded commands using the info/cmd
-        #   on record
     )
 
     @staticmethod
     @datasetmethod(name='run')
     @eval_results
     def __call__(
-            # it is optional, because `rerun` can get a recorded one
-            cmd=None,
+            cmd,
             dataset=None,
-            message=None,
-            rerun=False):
-        if rerun and cmd:
-            lgr.warning('Ignoring provided command in --rerun mode')
-            cmd = None
+            message=None):
+        for r in run_command(cmd, dataset, message):
+            yield r
 
-        if not dataset:
-            # act on the whole dataset if nothing else was specified
-            dataset = get_dataset_root(curdir)
-            # Follow our generic semantic that if dataset is specified,
-            # paths are relative to it, if not -- relative to pwd
-            pwd = getpwd()
-            if dataset:
-                rel_pwd = relpath(pwd, dataset)
-            else:
-                rel_pwd = pwd  # and leave handling on deciding either we
-                               # deal with it or crash to checks below
+
+# This helper function is used to add the rerun_info argument.
+def run_command(cmd, dataset=None, message=None, rerun_info=None):
+    rel_pwd = rerun_info.get('pwd') if rerun_info else None
+    if rel_pwd and dataset:
+        # recording is relative to the dataset
+        pwd = normpath(opj(dataset.path, rel_pwd))
+        rel_pwd = relpath(pwd, dataset.path)
+    elif dataset:
+        pwd = dataset.path
+        rel_pwd = curdir
+    else:
+        # act on the whole dataset if nothing else was specified
+        dataset = get_dataset_root(curdir)
+        # Follow our generic semantic that if dataset is specified,
+        # paths are relative to it, if not -- relative to pwd
+        pwd = getpwd()
+        if dataset:
+            rel_pwd = relpath(pwd, dataset)
         else:
-            pwd = dataset.path
-            rel_pwd = curdir
+            rel_pwd = pwd  # and leave handling on deciding either we
+                           # deal with it or crash to checks below
 
-        ds = require_dataset(
-            dataset, check_installed=True,
-            purpose='tracking outcomes of a command')
-        # not needed ATM
-        #refds_path = ds.path
+    ds = require_dataset(
+        dataset, check_installed=True,
+        purpose='tracking outcomes of a command')
+    # not needed ATM
+    #refds_path = ds.path
 
-        # delayed imports
-        from datalad.cmd import Runner
-        from datalad.tests.utils import ok_clean_git
+    # delayed imports
+    from datalad.cmd import Runner
+    from datalad.tests.utils import ok_clean_git
 
-        lgr.debug('tracking command output underneath %s', ds)
+    lgr.debug('tracking command output underneath %s', ds)
+    if not rerun_info:  # Rerun already takes care of this.
         try:
             # base assumption is that the animal smells superb
             ok_clean_git(ds.path)
@@ -141,169 +124,80 @@ class Run(Interface):
                 'run',
                 ds=ds,
                 status='impossible',
-                message='unsaved modifications present, cannot detect changes by command')
+                message=('unsaved modifications present, '
+                         'cannot detect changes by command'))
             return
 
-        if not cmd and not rerun:
-            # TODO here we would need to recover a cmd when a rerun is attempted
-            return
+    # anticipate quoted compound shell commands
+    cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd
 
-        if rerun:
-            # pull run info out of the last commit message
-            err_info = get_status_dict('run', ds=ds)
-            if not ds.repo.get_hexsha():
-                yield dict(
-                    err_info, status='impossible',
-                    message='cannot re-run command, nothing recorded')
-                return
-            try:
-                rec_msg, runinfo = get_commit_runinfo(ds.repo)
-            except ValueError as exc:
-                yield dict(
-                    err_info, status='error',
-                    message=str(exc)
-                )
-                return
-            if not runinfo:
-                yield dict(
-                    err_info, status='impossible',
-                    message='cannot re-run command, last saved state does not look like a recorded command run')
-                return
-            if message is None:
-                # re-use commit message, if nothing new was given
-                message = rec_msg
-            cmd = runinfo['cmd']
-            rec_exitcode = runinfo.get('exit', 0)
-            rel_pwd = runinfo.get('pwd')
-            if rel_pwd:
-                # recording is relative to the dataset
-                pwd = normpath(opj(ds.path, rel_pwd))
-            else:
-                rel_pwd = None  # normalize, just in case
-                pwd = None
+    # TODO do our best to guess which files to unlock based on the command string
+    #      in many cases this will be impossible (but see rerun). however,
+    #      generating new data (common case) will be just fine already
 
-            # now we have to find out what was modified during the last run, and enable re-modification
-            # ideally, we would bring back the entire state of the tree with #1424, but we limit ourself
-            # to file addition/not-in-place-modification for now
-            to_unlock = []
-            for r in ds.diff(
-                    recursive=True,
-                    revision='HEAD~1...HEAD',
-                    return_type='generator',
-                    result_renderer=None):
-                if r.get('type') == 'file' and \
-                        r.get('state') in ('added', 'modified'):
-                    r.pop('status')
-                    to_unlock.append(r)
-            if to_unlock:
-                for r in ds.unlock(to_unlock, return_type='generator', result_xfm=None):
-                    yield r
-        else:
-            # not a rerun, use previously assigned pwd, rel_pwd depending
-            # on either dataset was specified
-            pass
-
-        # anticipate quoted compound shell commands
-        cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd
-
-        # TODO do our best to guess which files to unlock based on the command string
-        #      in many cases this will be impossible (but see --rerun). however,
-        #      generating new data (common case) will be just fine already
-
-        # we have a clean dataset, let's run things
-        cmd_exitcode = None
-        runner = Runner(cwd=pwd)
-        try:
-            lgr.info("== Command start (output follows) =====")
-            runner.run(
-                cmd,
-                # immediate output
-                log_online=True,
-                # not yet sure what we should do with the command output
-                # IMHO `run` itself should be very silent and let the command talk
-                log_stdout=False,
-                log_stderr=False,
-                expect_stderr=True,
-                expect_fail=True,
-                # TODO stdin
-            )
-        except CommandError as e:
-            # strip our own info from the exception. The original command output
-            # went to stdout/err -- we just have to exitcode in the same way
-            cmd_exitcode = e.code
-            if not rerun or rec_exitcode != cmd_exitcode:
-                # we failed during a fresh run, or in a different way during a rerun
-                # the latter can easily happen if we try to alter a locked file
-                #
-                # let's fail here, the command could have had a typo or some
-                # other undesirable condition. If we would `add` nevertheless,
-                # we would need to rerun and aggregate annex content that we
-                # likely don't want
-                # TODO add switch to ignore failure (some commands are stupid)
-                # TODO add the ability to `git reset --hard` the dataset tree on failure
-                # we know that we started clean, so we could easily go back, needs gh-1424
-                # to be able to do it recursively
-                raise CommandError(code=cmd_exitcode)
-
-        lgr.info("== Command exit (modification check follows) =====")
-
-        # ammend commit message with `run` info:
-        # - pwd if inside the dataset
-        # - the command itself
-        # - exit code of the command
-        run_info = {
-            'cmd': cmd,
-            'exit': cmd_exitcode if cmd_exitcode is not None else 0,
-        }
-        if rel_pwd is not None:
-            # only when inside the dataset to not leak information
-            run_info['pwd'] = rel_pwd
-
-        # compose commit message
-        cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
-        cmd_shorty = '{}{}'.format(
-            cmd_shorty[:40],
-            '...' if len(cmd_shorty) > 40 else '')
-        msg = '[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
-            message if message is not None else cmd_shorty,
-            json.dumps(run_info, indent=1), sort_keys=True, ensure_ascii=False, encoding='utf-8')
-
-        for r in ds.add('.', recursive=True, message=msg):
-            yield r
-
-        # TODO bring back when we can ignore a command failure
-        #if cmd_exitcode:
-        #    # finally raise due to the original command error
-        #    raise CommandError(code=cmd_exitcode)
-
-
-def get_commit_runinfo(repo, commit=None):
-    """Return message and run record from a commit message
-
-    If none found - returns None, None; if anything goes wrong - throws
-    ValueError with the message describing the issue
-    """
-    assert commit is None, "TODO: implement for anything but the last commit"
-    last_commit_msg = repo.repo.head.commit.message
-    cmdrun_regex = r'\[DATALAD RUNCMD\] (.*)=== Do not change lines below ' \
-                   r'===\n(.*)\n\^\^\^ Do not change lines above \^\^\^'
-    runinfo = re.match(cmdrun_regex, last_commit_msg,
-                       re.MULTILINE | re.DOTALL)
-    if not runinfo:
-        return None, None
-
-    rec_msg, runinfo = runinfo.groups()
-
+    # we have a clean dataset, let's run things
+    cmd_exitcode = None
+    runner = Runner(cwd=pwd)
     try:
-        runinfo = json.loads(runinfo)
-    except Exception as e:
-        raise ValueError(
-            'cannot re-run command, command specification is not valid JSON: '
-            '%s' % str(e)
+        lgr.info("== Command start (output follows) =====")
+        runner.run(
+            cmd,
+            # immediate output
+            log_online=True,
+            # not yet sure what we should do with the command output
+            # IMHO `run` itself should be very silent and let the command talk
+            log_stdout=False,
+            log_stderr=False,
+            expect_stderr=True,
+            expect_fail=True,
+            # TODO stdin
         )
-    if 'cmd' not in runinfo:
-        raise ValueError(
-            'cannot re-run command, command specification missing in '
-            'recorded state'
-        )
-    return rec_msg, runinfo
+    except CommandError as e:
+        # strip our own info from the exception. The original command output
+        # went to stdout/err -- we just have to exitcode in the same way
+        cmd_exitcode = e.code
+
+        if not rerun_info or rerun_info.get("exit", 0) != cmd_exitcode:
+            # we failed during a fresh run, or in a different way during a rerun
+            # the latter can easily happen if we try to alter a locked file
+            #
+            # let's fail here, the command could have had a typo or some
+            # other undesirable condition. If we would `add` nevertheless,
+            # we would need to rerun and aggregate annex content that we
+            # likely don't want
+            # TODO add switch to ignore failure (some commands are stupid)
+            # TODO add the ability to `git reset --hard` the dataset tree on failure
+            # we know that we started clean, so we could easily go back, needs gh-1424
+            # to be able to do it recursively
+            raise CommandError(code=cmd_exitcode)
+
+    lgr.info("== Command exit (modification check follows) =====")
+
+    # ammend commit message with `run` info:
+    # - pwd if inside the dataset
+    # - the command itself
+    # - exit code of the command
+    run_info = {
+        'cmd': cmd,
+        'exit': cmd_exitcode if cmd_exitcode is not None else 0,
+    }
+    if rel_pwd is not None:
+        # only when inside the dataset to not leak information
+        run_info['pwd'] = rel_pwd
+
+    # compose commit message
+    cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
+    cmd_shorty = '{}{}'.format(
+        cmd_shorty[:40],
+        '...' if len(cmd_shorty) > 40 else '')
+    msg = '[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
+        message if message is not None else cmd_shorty,
+        json.dumps(run_info, indent=1), sort_keys=True, ensure_ascii=False, encoding='utf-8')
+
+    for r in ds.add('.', recursive=True, message=msg):
+        yield r
+
+    # TODO bring back when we can ignore a command failure
+    #if cmd_exitcode:
+    #    # finally raise due to the original command error
+    #    raise CommandError(code=cmd_exitcode)

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -180,6 +180,7 @@ def run_command(cmd, dataset=None, message=None, rerun_info=None):
     run_info = {
         'cmd': cmd,
         'exit': cmd_exitcode if cmd_exitcode is not None else 0,
+        'chain': rerun_info["chain"] if rerun_info else [],
     }
     if rel_pwd is not None:
         # only when inside the dataset to not leak information

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -129,7 +129,6 @@ def test_rerun(path, nodspath):
     ds.rerun(revision="HEAD~3..")
     eq_('xxxxx\n', open(probe_path).read())
     # Or --root and a revision to run all reachable commits.
-    # Or a range of commits, skipping non-run commits.
     ds.rerun(revision="HEAD", root=True)
     eq_('xxxxxxxxxx\n', open(probe_path).read())
     # But a revision range with --root will fail.

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -122,6 +122,9 @@ def test_rerun(path, nodspath):
     # Now rerun the buried command.
     ds.rerun(revision="HEAD~")
     eq_('xxx\n', open(probe_path).read())
+    # Or a range of commits, skipping non-run commits.
+    ds.rerun(revision="HEAD~3..")
+    eq_('xxxxx\n', open(probe_path).read())
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -127,6 +127,13 @@ def test_rerun(path, nodspath):
     # Or a range of commits, skipping non-run commits.
     ds.rerun(revision="HEAD~3..")
     eq_('xxxxx\n', open(probe_path).read())
+    # Or --root and a revision to run all reachable commits.
+    # Or a range of commits, skipping non-run commits.
+    ds.rerun(revision="HEAD", root=True)
+    eq_('xxxxxxxxxx\n', open(probe_path).read())
+    # But a revision range with --root will fail.
+    assert_raises(IncompleteResultsError,
+                  ds.rerun, revision="HEAD~3..", root=True)
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -252,6 +252,12 @@ def test_rerun_just_one_commit(path):
     # change.
     assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
 
+    # We abort rather than trying to do anything when --onto='' and
+    # --since='' are given together and the first commit contains a
+    # run command.
+    ds.repo.commit(msg="empty", options=["--allow-empty"])
+    assert_raises(IncompleteResultsError, ds.rerun, since="", onto="")
+
 
 @ignore_nose_capturing_stdout
 @skip_if_on_windows

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -209,6 +209,30 @@ def test_rerun_onto(path):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_chain(path):
+    ds = Dataset(path).create()
+    commits = []
+
+    grow_file = opj(path, "grows")
+    ds.run('echo x$(cat grows) > grows')
+    ds.repo.repo.git.tag("first-run")
+
+    for _ in range(3):
+        commits.append(ds.repo.get_hexsha())
+        ds.rerun()
+        _, info = get_commit_runinfo(ds.repo, "HEAD")
+        assert info["chain"] == commits
+
+    ds.rerun(revision="first-run")
+    _, info = get_commit_runinfo(ds.repo, "HEAD")
+    assert info["chain"] == commits[:1]
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
 def test_rerun_branch(path):
     ds = Dataset(path).create()
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -185,7 +185,7 @@ def test_rerun_onto(path):
     neq_(ds.repo.repo.git.rev_parse("HEAD"),
          ds.repo.repo.git.rev_parse("master"))
 
-    ## An empty `onto` means use the parent of the first revision.
+    # An empty `onto` means use the parent of the first revision.
     ds.repo.checkout("master")
     ds.rerun(since="static^", onto="")
     ok_(ds.repo.get_active_branch() is None)
@@ -193,13 +193,13 @@ def test_rerun_onto(path):
         assert_result_count(
             ds.repo.repo.git.rev_list(revrange).split(), 3)
 
-    ## An empty `onto` means use the parent of the first revision.
+    # An empty `onto` means use the parent of the first revision.
     ds.repo.checkout("master")
     ds.rerun(since="", revision="static", onto="", branch="orph")
     eq_(ds.repo.get_active_branch(), "orph")
     assert_result_count(ds.diff(revision="static..orph"), 0)
     assert_false(ds.repo.get_merge_base(["static", "orph"]))
-    ## But it fails when no branch is given.
+    # But it fails when no branch is given.
     ds.repo.checkout("master")
     assert_raises(IncompleteResultsError,
                   ds.rerun, revision="static", since="", onto="")
@@ -304,7 +304,7 @@ def test_rerun_ambiguous_revision_file(path):
     ds = Dataset(path).create()
     ds.run('echo ambig > ambig')
     ds.repo.repo.git.tag("ambig")
-    ## Don't fail when "ambig" refers to both a file and revision.
+    # Don't fail when "ambig" refers to both a file and revision.
     ds.rerun(since="", revision="ambig", branch="orph")
     eq_(len(ds.repo.repo.git.rev_list("orph").split()),
         len(ds.repo.repo.git.rev_list("ambig", "--").split()))

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -123,7 +123,7 @@ def test_rerun(path, nodspath):
         f.write("foo")
     ds.add("nonrun-file")
     # Now rerun the buried command.
-    ds.rerun(until="HEAD~")
+    ds.rerun(revision="HEAD~")
     eq_('xxx\n', open(probe_path).read())
     # Or a range of commits, skipping non-run commits.
     ds.rerun(since="HEAD~3")
@@ -151,7 +151,7 @@ def test_rerun_onto(path):
 
     # If we run the "static" change on top of itself, we end up in the
     # same (but detached) place.
-    ds.rerun(until="static", onto="static")
+    ds.rerun(revision="static", onto="static")
     ok_(ds.repo.get_active_branch() is None)
     eq_(ds.repo.repo.git.rev_parse("HEAD"),
         ds.repo.repo.git.rev_parse("static"))
@@ -159,7 +159,7 @@ def test_rerun_onto(path):
     # If we run the "static" change from the same "base", we end up
     # with a new commit.
     ds.repo.checkout("master")
-    ds.rerun(until="static", onto="static^")
+    ds.rerun(revision="static", onto="static^")
     ok_(ds.repo.get_active_branch() is None)
     neq_(ds.repo.repo.git.rev_parse("HEAD"),
          ds.repo.repo.git.rev_parse("static"))
@@ -186,14 +186,14 @@ def test_rerun_onto(path):
 
     ## An empty `onto` means use the parent of the first revision.
     ds.repo.checkout("master")
-    ds.rerun(since="", until="static", onto="", branch="orph")
+    ds.rerun(since="", revision="static", onto="", branch="orph")
     eq_(ds.repo.get_active_branch(), "orph")
     assert_result_count(ds.diff(revision="static..orph"), 0)
     assert_false(ds.repo.get_merge_base(["static", "orph"]))
     ## But it fails when no branch is given.
     ds.repo.checkout("master")
     assert_raises(IncompleteResultsError,
-                  ds.rerun, until="static", since="", onto="")
+                  ds.rerun, revision="static", since="", onto="")
 
 
 @ignore_nose_capturing_stdout
@@ -283,7 +283,7 @@ def test_rerun_outofdate_tree(path):
     # Change tree so that it is no longer compatible.
     ds.remove("foo")
     # Now rerunning should fail because foo no longer exists.
-    assert_raises(CommandError, ds.rerun, until="HEAD~")
+    assert_raises(CommandError, ds.rerun, revision="HEAD~")
 
 
 @ignore_nose_capturing_stdout
@@ -296,7 +296,7 @@ def test_rerun_ambiguous_revision_file(path):
     ds.run('echo ambig > ambig')
     ds.repo.repo.git.tag("ambig")
     ## Don't fail when "ambig" refers to both a file and revision.
-    ds.rerun(since="", until="ambig", branch="orph")
+    ds.rerun(since="", revision="ambig", branch="orph")
     eq_(len(ds.repo.repo.git.rev_list("orph").split()),
         len(ds.repo.repo.git.rev_list("ambig", "--").split()))
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -379,8 +379,15 @@ def test_new_or_modified(path):
             yield relpath(ap["path"], path)
 
     ds = Dataset(path).create(force=True, no_annex=True)
+
+    # Check out an orphan branch so that we can test the "one commit
+    # in a repo" case.
+    ds.repo.checkout("orph", options=["--orphan"])
     ds.repo.add(".", commit=True)
     assert_false(ds.repo.dirty)
+    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+    # Diffing doesn't fail when the branch contains a single commit.
+    assert_in("to_modify", apfiles(new_or_modified(ds, "HEAD")))
 
     # New files are detected, deletions are not.
     ds.repo.remove(["to_remove"])

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -141,6 +141,7 @@ def test_rerun(path, nodspath):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_rerun_onto(path):
     ds = Dataset(path).create()
 
@@ -252,6 +253,7 @@ def test_rerun_branch(path):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()
 
@@ -271,6 +273,7 @@ def test_rerun_cherry_pick(path):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_rerun_outofdate_tree(path):
     ds = Dataset(path).create()
     input_file = opj(path, "foo")
@@ -291,6 +294,7 @@ def test_rerun_outofdate_tree(path):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
 def test_rerun_ambiguous_revision_file(path):
     ds = Dataset(path).create()
     ds.run('echo ambig > ambig')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -268,6 +268,20 @@ def test_rerun_outofdate_tree(path):
 
 
 @ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+def test_rerun_ambiguous_revision_file(path):
+    ds = Dataset(path).create()
+    ds.run('echo ambig > ambig')
+    ds.repo.repo.git.tag("ambig")
+    ## Don't fail when "ambig" refers to both a file and revision.
+    ds.rerun(revision="ambig", root=True, branch="orph")
+    eq_(len(ds.repo.repo.git.rev_list("orph").split()),
+        len(ds.repo.repo.git.rev_list("ambig", "--").split()))
+
+
+@ignore_nose_capturing_stdout
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -167,8 +167,8 @@ def test_rerun_onto(path):
          ds.repo.repo.git.rev_parse("static"))
     assert_result_count(ds.diff(revision="HEAD..static"), 0)
     for revrange in ["..static", "static.."]:
-        assert_result_count(ds.repo.repo.git.rev_list(revrange).splitlines(),
-                            1)
+        assert_result_count(
+            ds.repo.repo.git.rev_list(revrange).split(), 1)
 
     # Unlike the static change, if we run the ever-growing change on
     # top of itself, we end up with a new commit.
@@ -207,7 +207,7 @@ def test_rerun_branch(path):
 
     for revrange in ["rerun..master", "master..rerun"]:
         assert_result_count(
-            ds.repo.repo.git.rev_list(revrange).splitlines(), 3)
+            ds.repo.repo.git.rev_list(revrange).split(), 3)
     eq_(ds.repo.get_merge_base(["master", "rerun"]),
         ds.repo.repo.git.rev_parse("prerun"))
 
@@ -218,9 +218,9 @@ def test_rerun_branch(path):
     eq_('xxxx\n', open(outfile).read())
 
     assert_result_count(
-        ds.repo.repo.git.rev_list("master..rerun2").splitlines(), 2)
+        ds.repo.repo.git.rev_list("master..rerun2").split(), 2)
     assert_result_count(
-        ds.repo.repo.git.rev_list("rerun2..master").splitlines(), 0)
+        ds.repo.repo.git.rev_list("rerun2..master").split(), 0)
 
     # Using an existing branch name fails.
     ds.repo.checkout("master")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -131,6 +131,15 @@ def test_rerun(path, nodspath):
     # Or --since= to run all reachable commits.
     ds.rerun(since="")
     eq_('xxxxxxxxxx\n', open(probe_path).read())
+    # If the history to rerun has a merge commit, we abort.
+    ds.repo.checkout("HEAD~3", options=["-b", "topic"])
+    with open(opj(path, "topic-file"), "w") as f:
+        f.write("topic")
+    ds.add("topic-file")
+    ds.repo.checkout("master")
+    ds.repo.merge("topic")
+    ok_clean_git(ds.path)
+    assert_raises(IncompleteResultsError, ds.rerun)
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -123,8 +123,11 @@ def test_rerun(path, nodspath):
         f.write("foo")
     ds.add("nonrun-file")
     # Now rerun the buried command.
-    ds.rerun(revision="HEAD~")
+    ds.rerun(revision="HEAD~", message="rerun buried")
     eq_('xxx\n', open(probe_path).read())
+    # Also check that the messasge override worked.
+    eq_(ds.repo.repo.head.commit.message.splitlines()[0],
+        "[DATALAD RUNCMD] rerun buried")
     # Or a range of commits, skipping non-run commits.
     ds.rerun(since="HEAD~3")
     eq_('xxxxx\n', open(probe_path).read())

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -196,16 +196,14 @@ def test_rerun_onto(path):
         assert_result_count(
             ds.repo.repo.git.rev_list(revrange).split(), 3)
 
-    # An empty `onto` means use the parent of the first revision.
+    # An empty `onto` means use the parent of the first revision that
+    # has a run command.
     ds.repo.checkout("master")
-    ds.rerun(since="", revision="static", onto="", branch="orph")
-    eq_(ds.repo.get_active_branch(), "orph")
-    assert_result_count(ds.diff(revision="static..orph"), 0)
-    assert_false(ds.repo.get_merge_base(["static", "orph"]))
-    # But it fails when no branch is given.
-    ds.repo.checkout("master")
-    assert_raises(IncompleteResultsError,
-                  ds.rerun, revision="static", since="", onto="")
+    ds.rerun(since="", onto="", branch="from-base")
+    eq_(ds.repo.get_active_branch(), "from-base")
+    assert_result_count(ds.diff(revision="master..from-base"), 0)
+    eq_(ds.repo.get_merge_base(["static", "from-base"]),
+        ds.repo.repo.git.rev_parse("static^"))
 
 
 @ignore_nose_capturing_stdout
@@ -332,8 +330,8 @@ def test_rerun_ambiguous_revision_file(path):
     ds.run('echo ambig > ambig')
     ds.repo.repo.git.tag("ambig")
     # Don't fail when "ambig" refers to both a file and revision.
-    ds.rerun(since="", revision="ambig", branch="orph")
-    eq_(len(ds.repo.repo.git.rev_list("orph").split()),
+    ds.rerun(since="", revision="ambig", branch="rerun")
+    eq_(len(ds.repo.repo.git.rev_list("rerun").split()),
         len(ds.repo.repo.git.rev_list("ambig", "--").split()))
 
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -234,6 +234,29 @@ def test_rerun_chain(path):
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_just_one_commit(path):
+    ds = Dataset(path).create()
+
+    # Check out an orphan branch so that we can test the "one commit
+    # in a repo" case.
+    ds.repo.checkout("orph", options=["--orphan"])
+    ds.repo.repo.git.reset("--hard")
+
+    ds.run('echo static-content > static')
+    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+
+    # Rerunning with just one commit doesn't raise an error ...
+    ds.rerun()
+    # ... but we're still at one commit because the content didn't
+    # change.
+    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
 def test_rerun_branch(path):
     ds = Dataset(path).create()
 

--- a/docs/casts/reproducible_analysis.sh
+++ b/docs/casts/reproducible_analysis.sh
@@ -59,7 +59,7 @@ run "git show --stat"
 say "DataLad has enough information stored to be able to re-run a command."
 say "On command exit, it will inspect the results and save them again, but only if they are different."
 say "In our case, the re-run yields bit-identical results, hence nothing new is saved."
-run "datalad run --rerun"
+run "datalad rerun"
 
 say "Now that we are done, and have checked that we can reproduce the results ourselves, we can clean up"
 say "DataLad can easily verify if any part of our input dataset was modified since we configured our analysis"
@@ -78,7 +78,7 @@ run "ls inputs/*"
 say "Only the remaining data (our code and the results) need to be kept and require a backup for long term archival. Everything else can be re-obtained as needed, when needed."
 
 say "As DataLad knows everything needed about the inputs, including where to get the right version, we can re-run the analysis with a single command. Watch how DataLad re-obtains all required data, re-runs the code, and checks that none of the results changed and need saving"
-run "datalad run --rerun"
+run "datalad rerun"
 
 say "Reproduced!"
 

--- a/docs/casts/reproducible_analysis.sh
+++ b/docs/casts/reproducible_analysis.sh
@@ -57,7 +57,7 @@ say "The analysis step is done, all generated results were saved in the dataset.
 run "git show --stat"
 
 say "DataLad has enough information stored to be able to re-run a command."
-say "On command exit, it will inspect the results and save them gain, but only if they are different."
+say "On command exit, it will inspect the results and save them again, but only if they are different."
 say "In our case, the re-run yields bit-identical results, hence nothing new is saved."
 run "datalad run --rerun"
 

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -46,6 +46,15 @@ Meta data handling
    generated/man/datalad-metadata
    generated/man/datalad-aggregate-metadata
 
+Reproducible execution
+======================
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-run
+   generated/man/datalad-rerun
+
 Miscellaneous commands
 ======================
 
@@ -58,7 +67,6 @@ Miscellaneous commands
    generated/man/datalad-crawl-init
    generated/man/datalad-download-url
    generated/man/datalad-ls
-   generated/man/datalad-run
    generated/man/datalad-test
 
 Plumbing commands


### PR DESCRIPTION
This pull request supersedes #2070.  The old branch name was too
narrow in scope, so that seemed to be a good indicator that it was
worth opening a new PR for.

Some of the main differences:

  * The rerun functionality is now under its own command, `datalad
    rerun` (Closes #2072).

  * You can now specify the base for re-execution explicitly using
    `--onto`.

    Specifying a branch name for the re-execution and the base is no
    longer coupled.  Now you can re-execute on top of HEAD with a new
    branch name, or re-execute at another point but in a detached
    state.

  * The `--root` flag can be used to say "execute all commands in
    commits reachable from REVISION" rather than "execute *the*
    command in REVISION".  This has a similar behavior to
    `git rebase --root`.

  * The branch is rebased on top of `0.9.x` (at the request of
    @yarikoptic).

Here are how the examples given in #2070 would now look:

  * `datalad run --rerun --revision=COMMIT`

    re-run command from COMMIT with state still at HEAD.

    **Now**: `datalad rerun COMMIT`

  * `datalad run --rerun --revision=HEAD~10..`

    re-run commands from commits that a reachable from `HEAD` but not
    from `HEAD~10`, keeping HEAD's state.

    **Now**: `datalad rerun HEAD~10..`

  * `datalad run --rerun --branch=rerun --revision=HEAD~10..`

    Create a new branch rerun that starts at `HEAD~10` and then
    replay the commands from commits in `HEAD` but not `HEAD~10`.

    **Now**: `datalad rerun --branch=rerun --onto=HEAD~10 HEAD~10..`

    This one has become more unwieldy because you have to specify
    `HEAD~10` twice.  That's a tradeoff for the added flexibility of
    being able to specify other revisions with `--onto` rather than
    implicitly setting the base to the equivalent of
    `--onto=<start of range>`.

    Perhaps we could add a convenience option that wraps this behavior
    since it would probably be a common case.


### Changes
- [x] This change is complete
- [ ] This is in progress

Please have a look @datalad/developers

Re: https://github.com/datalad/datalad/issues/2068#issuecomment-356978452
