### PR TITLE
BF: cast2script: Don't interpret argument as printf's format

### DIFF
--- a/tools/cast2script
+++ b/tools/cast2script
@@ -21,17 +21,17 @@ function execute () {
 function say()
 {
 	printf "\n"
-	printf "# $1\n" | fmt -w 72 --prefix '# '
+	printf "# %s\n" "$1" | fmt -w 72 --prefix '# '
 }
 function show () {
 	# same as say
-	printf "# $1\n" | fmt -w 72 --prefix '# '
+	printf "# %s\n" "$1" | fmt -w 72 --prefix '# '
 }
 function run () {
-	printf "$1\n"
+        printf "%s\n" "$1"
 }
 function run_expfail () {
-	printf "$1 || true\n"
+	printf "%s || true\n" "$1"
 }
 
 


### PR DESCRIPTION
```
Otherwise, if $1 has a sequence like reproducible_analysis.sh's
"printf %03d", it will be formatted, leading to the script having
"printf 000" rather than the intended "printf %03d".
```

Fixes #2074.

I'll follow up with a diff of the converted `docs/casts/*.sh`.

### Changes
- [x] This change is complete
- [ ] This is in progress

Please have a look @datalad/developers
