### PR TITLE
DATALAD_USE_DEFAULT_GIT to override detection and use default git in the PATH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,6 +417,8 @@ Refer datalad/config.py for information on how to add these environment variable
   Any new DATALAD_CMD_PROTOCOL has to implement datalad.support.protocol.ProtocolInterface
 - *DATALAD_CMD_PROTOCOL_PREFIX*: 
   Sets a prefix to add before the command call times are noted by DATALAD_CMD_PROTOCOL.
+- *DATALAD_USE_DEFAULT_GIT*:
+  Instructs to use `git` as available in current environment, and not the one which possibly comes with git-annex (default behavior).
 
 
 # Changelog section

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -543,6 +543,17 @@ class GitRunner(Runner):
         """
         if GitRunner._GIT_PATH is None:
             from distutils.spawn import find_executable
+            # with all the nesting of config and this runner, cannot use our
+            # cfg here, so will resort to dark magic of environment options
+            if (os.environ.get('DATALAD_USE_DEFAULT_GIT', '0').lower()
+                    in ('1', 'on', 'true', 'yes')):
+                git_fpath = find_executable("git")
+                if git_fpath:
+                    GitRunner._GIT_PATH = ''
+                    lgr.log(9, "Will use default git %s", git_fpath)
+                    return  # we are done - there is a default git avail.
+                # if not -- we will look for a bundled one
+
             annex_fpath = find_executable("git-annex")
             if not annex_fpath:
                 # not sure how to live further anyways! ;)


### PR DESCRIPTION
Introduced to answer the question in #2089 

### Changes
- [x] This change is complete
