### PR TITLE
ENH(webui): autofocus on searchbox when entering a page

### DIFF
--- a/datalad/resources/website/assets/js/jquery.dataTables-1.10.12.js
+++ b/datalad/resources/website/assets/js/jquery.dataTables-1.10.12.js
@@ -4160,7 +4160,7 @@
 		var language = settings.oLanguage;
 		var previousSearch = settings.oPreviousSearch;
 		var features = settings.aanFeatures;
-		var input = '<input type="search" class="'+classes.sFilterInput+'"/>';
+		var input = '<input type="search" class="'+classes.sFilterInput+'" autofocus="autofocus"/>';
 	
 		var str = language.sSearch;
 		str = str.match(/_INPUT_/) ?


### PR DESCRIPTION
Allows for quick(er) navigation of the site

For now I just quickly manually patched website's .js to achieve that so you could try

the only cons I am aware of would be for vimperator and alike users -- you would need to press Esc first to make shortcuts of those extensions work instead of just being in edit mode. But imho it is a small price to pay ;)

### Changes
- [x] This change is complete

Please have a look @datalad/developers
