### PR TITLE
Merge 0.9.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,6 +417,8 @@ Refer datalad/config.py for information on how to add these environment variable
   Any new DATALAD_CMD_PROTOCOL has to implement datalad.support.protocol.ProtocolInterface
 - *DATALAD_CMD_PROTOCOL_PREFIX*: 
   Sets a prefix to add before the command call times are noted by DATALAD_CMD_PROTOCOL.
+- *DATALAD_USE_DEFAULT_GIT*:
+  Instructs to use `git` as available in current environment, and not the one which possibly comes with git-annex (default behavior).
 
 
 # Changelog section

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -543,6 +543,17 @@ class GitRunner(Runner):
         """
         if GitRunner._GIT_PATH is None:
             from distutils.spawn import find_executable
+            # with all the nesting of config and this runner, cannot use our
+            # cfg here, so will resort to dark magic of environment options
+            if (os.environ.get('DATALAD_USE_DEFAULT_GIT', '0').lower()
+                    in ('1', 'on', 'true', 'yes')):
+                git_fpath = find_executable("git")
+                if git_fpath:
+                    GitRunner._GIT_PATH = ''
+                    lgr.log(9, "Will use default git %s", git_fpath)
+                    return  # we are done - there is a default git avail.
+                # if not -- we will look for a bundled one
+
             annex_fpath = find_executable("git-annex")
             if not annex_fpath:
                 # not sure how to live further anyways! ;)

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -349,6 +349,8 @@ def main(args=None):
         if cmdlineargs.common_debug or cmdlineargs.common_idebug:
             # so we could see/stop clearly at the point of failure
             setup_exceptionhook(ipython=cmdlineargs.common_idebug)
+            from datalad.interface.base import Interface
+            Interface._interrupted_exit_code = None
             ret = cmdlineargs.func(cmdlineargs)
         else:
             # otherwise - guard and only log the summary. Postmortem is not

--- a/datalad/crawler/nodes/matches.py
+++ b/datalad/crawler/nodes/matches.py
@@ -17,6 +17,7 @@ from six import PY3
 
 from ...utils import updated
 from ...support.network import dlurljoin
+from ...support.exceptions import MissingExternalDependency
 from ...utils import auto_repr
 
 from logging import getLogger
@@ -61,6 +62,12 @@ class ExtractorMatch(object):
     def __call__(self, data):
         input = data.pop(self._input) if self._pop_input else data[self._input]
 
+        if not Response:
+            # we have no scrapy
+            raise MissingExternalDependency(
+                "scrapy",
+                msg="It is needed for this type of crawling"
+            )
         if isinstance(input, Response):
             selector = Selector(response=input)
             if hasattr(input, 'url') and input.url and ('url' not in data):

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -266,7 +266,7 @@ def pipeline(dataset,
                                         # overlay layout to even bigger single one within a minor 2.0.1 "release"
                                         # 158 -- 1.0.1 changed layout completely so should not be overlayed ATM
                                         overlay=None
-                                            if dataset in ('ds000007', 'ds000114', 'ds000119', 'ds000158')
+                                            if dataset in ('ds000007', 'ds000114', 'ds000119', 'ds000158', 'ds000216')
                                             else versions_overlay_level,  # use major.minor to define overlays
                                         #overlay=None, # use major.minor to define overlays
                                         exclude='(README|changelog).*'),

--- a/datalad/crawler/pipelines/tests/test_crcns.py
+++ b/datalad/crawler/pipelines/tests/test_crcns.py
@@ -15,7 +15,7 @@ from ..crcns import get_metadata
 
 from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import ok_startswith
-from datalad.support.exceptions import AccessFailedError
+from datalad.support.exceptions import AccessFailedError, AccessDeniedError
 
 
 def test_smoke_pipelines():
@@ -42,3 +42,5 @@ def test_get_metadata():
         if str(e).startswith('Access to https://search.datacite.org') and \
                 str(e).endswith('has failed: status code 502'):
             raise SkipTest("Probably datacite.org blocked us once again")
+    except AccessDeniedError:
+        raise SkipTest("datacite denied us and we asked, but waiting for an answer")

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -67,6 +67,7 @@ _group_misc = (
          'add-archive-content'),
         ('datalad.interface.download_url', 'DownloadURL', 'download-url'),
         ('datalad.interface.run', 'Run', 'run'),
+        ('datalad.interface.rerun', 'Rerun', 'rerun'),
     ])
 
 _group_plumbing = (

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -312,6 +312,11 @@ def build_doc(cls, **kwargs):
 class Interface(object):
     """Base class for interface implementations"""
 
+    # exit code to return if user-interrupted
+    # if None, would just reraise the Exception, so if in --dbg
+    # mode would fall into the debugger
+    _interrupted_exit_code = 1
+
     @classmethod
     def setup_parser(cls, parser):
         # XXX needs safety check for name collisions
@@ -431,7 +436,10 @@ class Interface(object):
             return ret
         except KeyboardInterrupt as exc:
             ui.error("\nInterrupted by user while doing magic: %s" % exc_str(exc))
-            sys.exit(1)
+            if cls._interrupted_exit_code is not None:
+                sys.exit(cls._interrupted_exit_code)
+            else:
+                raise
 
     @classmethod
     def get_refds_path(cls, dataset):

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -1,0 +1,334 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Rerun commands recorded with `datalad run`"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+from collections import namedtuple
+from itertools import dropwhile
+import json
+import re
+
+from datalad.dochelpers import exc_str
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
+from datalad.interface.run import run_command
+
+from datalad.support.constraints import EnsureNone, EnsureStr
+from datalad.support.gitrepo import GitCommandError
+from datalad.support.param import Parameter
+
+from datalad.distribution.dataset import require_dataset
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import datasetmethod
+
+lgr = logging.getLogger('datalad.interface.rerun')
+
+
+@build_doc
+class Rerun(Interface):
+    """Re-execute previous `datalad run` commands.
+
+    This will unlock any dataset content that is on record to have
+    been modified by the command in the specified revision.  It will
+    then re-execute the command in the recorded path (if it was inside
+    the dataset). Afterwards, all modifications will be saved.
+
+    Examples:
+
+        Re-execute the command from the previous commit.
+
+        $ datalad rerun
+
+        Re-execute any commands in the last five commits.
+
+        $ datalad rerun --since=HEAD~5
+
+        Do the same as above, but re-execute the commands on top of
+        HEAD~5 in a detached state.
+
+        $ datalad rerun --onto= --since=HEAD~5
+
+        Re-execute all previous commands and compare the old and new
+        results.
+
+        $ # on master branch
+        $ datalad rerun --branch=verify --since=
+        $ # now on verify branch
+        $ datalad diff --revision=master..
+        $ git log --oneline --left-right --cherry-pick master...
+    """
+    _params_ = dict(
+        revision=Parameter(
+            args=("revision",),
+            metavar="REVISION",
+            nargs="?",
+            doc="""rerun command(s) in REVISION. By default, the
+            command from this commit will be executed, but the --since
+            option can be used to construct a revision range.""",
+            default="HEAD",
+            constraints=EnsureStr()),
+        since=Parameter(
+            args=("--since",),
+            doc="""If SINCE is a commit-ish, the commands from all
+            commits that are reachable from REVISION but not SINCE
+            will be re-executed (in other words, the commands in `git
+            log SINCE..REVISION`). If SINCE is an empty string, it is
+            set to the parent of the first commit that contains a
+            recorded command (i.e., all commands in `git log REVISION`
+            will be re-executed).""",
+            constraints=EnsureStr() | EnsureNone()),
+        branch=Parameter(
+            metavar="NAME",
+            args=("-b", "--branch",),
+            doc="create and checkout this branch before rerunning the commands.",
+            constraints=EnsureStr() | EnsureNone()),
+        onto=Parameter(
+            metavar="base",
+            args=("--onto",),
+            doc="""start point for rerunning the commands. If not
+            specified, commands are executed at HEAD. This option can
+            be used to specify an alternative start point, which will
+            be checked out with the branch name specified by --branch
+            or in a detached state otherwise. As a special case, an
+            empty value for this option means to use the commit
+            specified by --since.""",
+            constraints=EnsureStr() | EnsureNone()),
+        message=Parameter(
+            args=("-m", "--message",),
+            metavar="MESSAGE",
+            doc="""use MESSAGE for the reran commit rather than the
+            recorded commit message.  In the case of a multi-commit
+            rerun, all the reran commits will have this message.""",
+            constraints=EnsureStr() | EnsureNone()),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset from which to rerun a recorded
+            command. If no dataset is given, an attempt is made to
+            identify the dataset based on the current working
+            directory. If a dataset is given, the command will be
+            executed in the root directory of this dataset.""",
+            constraints=EnsureDataset() | EnsureNone()),
+        # TODO
+        # --list-commands
+        #   go through the history and report any recorded command. this info
+        #   could be used to unlock the associated output files for a rerun
+    )
+
+    @staticmethod
+    @datasetmethod(name='rerun')
+    @eval_results
+    def __call__(
+            revision="HEAD",
+            since=None,
+            dataset=None,
+            branch=None,
+            message=None,
+            onto=None):
+
+        ds = require_dataset(
+            dataset, check_installed=True,
+            purpose='rerunning a command')
+
+        lgr.debug('rerunning command output underneath %s', ds)
+
+        from datalad.tests.utils import ok_clean_git
+        try:
+            ok_clean_git(ds.path)
+        except AssertionError:
+            yield get_status_dict(
+                'run',
+                ds=ds,
+                status='impossible',
+                message=('unsaved modifications present, '
+                         'cannot detect changes by command'))
+            return
+
+        err_info = get_status_dict('run', ds=ds)
+        if not ds.repo.get_hexsha():
+            yield dict(
+                err_info, status='impossible',
+                message='cannot rerun command, nothing recorded')
+            return
+
+        if branch and branch in ds.repo.get_branches():
+            yield get_status_dict(
+                "run", ds=ds, status="error",
+                message="branch '{}' already exists".format(branch))
+            return
+
+        if not commit_exists(ds, revision + "^"):
+            # Only a single commit is reachable from `revision`.  In
+            # this case, --since has no effect on the range construction.
+            revrange = revision
+        elif since is None:
+            revrange = "{rev}^..{rev}".format(rev=revision)
+        elif since.strip() == "":
+            revrange = revision
+        else:
+            revrange = "{}..{}".format(since, revision)
+
+        if ds.repo.repo.git.rev_list("--merges", revrange, "--"):
+            yield get_status_dict(
+                "run", ds=ds, status="error",
+                message="cannot rerun history with merge commits")
+            return
+
+        Revision = namedtuple("Revision", ["id", "message", "info"])
+
+        def revision_with_info(rev):
+            msg, info = get_commit_runinfo(ds.repo, rev)
+            return Revision(rev, msg, info)
+
+        ids = ds.repo.repo.git.rev_list("--reverse", revrange, "--").split()
+
+        try:
+            revs = list(map(revision_with_info, ids))
+        except ValueError as exc:
+            yield dict(err_info, status='error', message=exc_str(exc))
+            return
+
+        if since is not None and since.strip() == "":
+            # For --since='', drop any leading commits that don't have
+            # a run command.
+            revs = list(dropwhile(lambda r: r.info is None, revs))
+
+        if onto is not None and onto.strip() == "":
+            # Special case: --onto='' is the value of --since.
+            # Because we're currently aborting if the revision list
+            # contains merges, we know that, regardless of if and how
+            # --since is specified, the effective value for --since is
+            # the parent of the first revision.
+            onto = revs[0].id + "^"
+            if not commit_exists(ds, onto):
+                # This is unlikely to happen in the wild because it
+                # means that the first commit is a datalad run commit.
+                # Just abort rather than trying to checkout on orphan
+                # branch or something like that.
+                yield get_status_dict(
+                    "run", ds=ds, status="error",
+                    message="Commit for --onto does not exist.")
+                return
+
+        if branch or onto:
+            start_point = onto or "HEAD"
+            if branch:
+                checkout_options = ["-b", branch]
+            else:
+                checkout_options = ["--detach"]
+            ds.repo.checkout(start_point, options=checkout_options)
+
+        for rev in revs:
+            if not rev.info:
+                pick = False
+                try:
+                    ds.repo.repo.git.merge_base("--is-ancestor", rev.id, "HEAD")
+                except GitCommandError:  # Revision is NOT an ancestor of HEAD.
+                    pick = True
+
+                shortrev = ds.repo.repo.git.rev_parse("--short", rev.id)
+                err_msg = "no command for {} found; {}".format(
+                    shortrev,
+                    "cherry picking" if pick else "skipping")
+                yield dict(err_info, status='ok', message=err_msg)
+
+                if pick:
+                    ds.repo.repo.git.cherry_pick(rev.id)
+                continue
+
+            # Keep a "rerun" trail.
+            if "chain" in rev.info:
+                rev.info["chain"].append(rev.id)
+            else:
+                rev.info["chain"] = [rev.id]
+
+            # now we have to find out what was modified during the
+            # last run, and enable re-modification ideally, we would
+            # bring back the entire state of the tree with #1424, but
+            # we limit ourself to file addition/not-in-place-modification
+            # for now
+            for r in ds.unlock(new_or_modified(ds, rev.id),
+                               return_type='generator', result_xfm=None):
+                yield r
+
+            for r in run_command(rev.info['cmd'], ds, message or rev.message,
+                                 rerun_info=rev.info):
+                yield r
+
+
+def get_commit_runinfo(repo, commit="HEAD"):
+    """Return message and run record from a commit message
+
+    If none found - returns None, None; if anything goes wrong - throws
+    ValueError with the message describing the issue
+    """
+    commit_msg = repo.repo.git.show(commit, "--format=%s%n%n%b", "--no-patch")
+    cmdrun_regex = r'\[DATALAD RUNCMD\] (.*)=== Do not change lines below ' \
+                   r'===\n(.*)\n\^\^\^ Do not change lines above \^\^\^'
+    runinfo = re.match(cmdrun_regex, commit_msg,
+                       re.MULTILINE | re.DOTALL)
+    if not runinfo:
+        return None, None
+
+    rec_msg, runinfo = runinfo.groups()
+
+    try:
+        runinfo = json.loads(runinfo)
+    except Exception as e:
+        raise ValueError(
+            'cannot rerun command, command specification is not valid JSON: '
+            '%s' % exc_str(e)
+        )
+    if 'cmd' not in runinfo:
+        raise ValueError(
+            "{} looks like a run commit but does not have a command".format(
+                repo.repo.git.rev_parse("--short", commit)))
+    return rec_msg, runinfo
+
+
+def new_or_modified(dataset, revision="HEAD"):
+    """Yield files that have been added or modified in `revision`.
+
+    Parameters
+    ----------
+    dataset : Dataset
+    revision : string, optional
+        Commit-ish of interest.
+
+    Returns
+    -------
+    Generator that yields AnnotatePaths instances
+    """
+    if commit_exists(dataset, revision + "^"):
+        revrange = "{rev}^..{rev}".format(rev=revision)
+    else:
+        # No other commits are reachable from this revision.  Diff
+        # with an empty tree instead.
+        #             git hash-object -t tree /dev/null
+        empty_tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        revrange = "{}..{}".format(empty_tree, revision)
+    diff = dataset.diff(recursive=True,
+                        revision=revrange,
+                        return_type='generator', result_renderer=None)
+    for r in diff:
+        if r.get('type') == 'file' and r.get('state') in ['added', 'modified']:
+            r.pop('status', None)
+            yield r
+
+
+def commit_exists(dataset, commit):
+    try:
+        dataset.repo.repo.git.rev_parse("--verify", commit + "^{commit}")
+    except:
+        return False
+    return True

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -13,7 +13,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import json
-import re
 
 from argparse import REMAINDER
 from os.path import join as opj
@@ -50,12 +49,6 @@ class Run(Interface):
     as long as the command is executed somewhere underneath the dataset root,
     the exact location will be recorded relative to the dataset root.
 
-    Commands can be re-executed using the --rerun flag. This will unlock
-    any dataset content that is on record to have been modified by the
-    previous command run. It will then re-execute the command in the recorded
-    path (if it was inside the dataset). Afterwards, all modifications will be
-    saved.
-
     If the executed command did not alter the dataset in any way, no record of
     the command execution is made.
 
@@ -70,69 +63,59 @@ class Run(Interface):
             doc="command for execution"),
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc="""specify the dataset to record the command results in,
-            or to rerun a recorded command from (see --rerun).  If
-            no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory. If a dataset is given,
-            the command will be executed in the root directory of this
-            dataset.""",
+            doc="""specify the dataset to record the command results in.
+            An attempt is made to identify the dataset based on the current
+            working directory. If a dataset is given, the command will be
+            executed in the root directory of this dataset.""",
             constraints=EnsureDataset() | EnsureNone()),
         message=save_message_opt,
-        rerun=Parameter(
-            args=('--rerun',),
-            action='store_true',
-            doc="""re-run the command recorded in the last saved change (if any).
-            This will ignore any command given as an argument, and execute the
-            recorded command call in the recorded working directory. The recorded
-            changeset will be replaced by the outcome of the command re-run."""),
-        # TODO
-        # --list-commands
-        #   go through the history and report any recorded command. this info
-        #   could be used to unlock the associated output files for a rerun
-        # --rerun #
-        #   rerun command # from the list of recorded commands using the info/cmd
-        #   on record
     )
 
     @staticmethod
     @datasetmethod(name='run')
     @eval_results
     def __call__(
-            # it is optional, because `rerun` can get a recorded one
-            cmd=None,
+            cmd,
             dataset=None,
-            message=None,
-            rerun=False):
-        if rerun and cmd:
-            lgr.warning('Ignoring provided command in --rerun mode')
-            cmd = None
+            message=None):
+        for r in run_command(cmd, dataset, message):
+            yield r
 
-        if not dataset:
-            # act on the whole dataset if nothing else was specified
-            dataset = get_dataset_root(curdir)
-            # Follow our generic semantic that if dataset is specified,
-            # paths are relative to it, if not -- relative to pwd
-            pwd = getpwd()
-            if dataset:
-                rel_pwd = relpath(pwd, dataset)
-            else:
-                rel_pwd = pwd  # and leave handling on deciding either we
-                               # deal with it or crash to checks below
+
+# This helper function is used to add the rerun_info argument.
+def run_command(cmd, dataset=None, message=None, rerun_info=None):
+    rel_pwd = rerun_info.get('pwd') if rerun_info else None
+    if rel_pwd and dataset:
+        # recording is relative to the dataset
+        pwd = normpath(opj(dataset.path, rel_pwd))
+        rel_pwd = relpath(pwd, dataset.path)
+    elif dataset:
+        pwd = dataset.path
+        rel_pwd = curdir
+    else:
+        # act on the whole dataset if nothing else was specified
+        dataset = get_dataset_root(curdir)
+        # Follow our generic semantic that if dataset is specified,
+        # paths are relative to it, if not -- relative to pwd
+        pwd = getpwd()
+        if dataset:
+            rel_pwd = relpath(pwd, dataset)
         else:
-            pwd = dataset.path
-            rel_pwd = curdir
+            rel_pwd = pwd  # and leave handling on deciding either we
+                           # deal with it or crash to checks below
 
-        ds = require_dataset(
-            dataset, check_installed=True,
-            purpose='tracking outcomes of a command')
-        # not needed ATM
-        #refds_path = ds.path
+    ds = require_dataset(
+        dataset, check_installed=True,
+        purpose='tracking outcomes of a command')
+    # not needed ATM
+    #refds_path = ds.path
 
-        # delayed imports
-        from datalad.cmd import Runner
-        from datalad.tests.utils import ok_clean_git
+    # delayed imports
+    from datalad.cmd import Runner
+    from datalad.tests.utils import ok_clean_git
 
-        lgr.debug('tracking command output underneath %s', ds)
+    lgr.debug('tracking command output underneath %s', ds)
+    if not rerun_info:  # Rerun already takes care of this.
         try:
             # base assumption is that the animal smells superb
             ok_clean_git(ds.path)
@@ -141,169 +124,81 @@ class Run(Interface):
                 'run',
                 ds=ds,
                 status='impossible',
-                message='unsaved modifications present, cannot detect changes by command')
+                message=('unsaved modifications present, '
+                         'cannot detect changes by command'))
             return
 
-        if not cmd and not rerun:
-            # TODO here we would need to recover a cmd when a rerun is attempted
-            return
+    # anticipate quoted compound shell commands
+    cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd
 
-        if rerun:
-            # pull run info out of the last commit message
-            err_info = get_status_dict('run', ds=ds)
-            if not ds.repo.get_hexsha():
-                yield dict(
-                    err_info, status='impossible',
-                    message='cannot re-run command, nothing recorded')
-                return
-            try:
-                rec_msg, runinfo = get_commit_runinfo(ds.repo)
-            except ValueError as exc:
-                yield dict(
-                    err_info, status='error',
-                    message=str(exc)
-                )
-                return
-            if not runinfo:
-                yield dict(
-                    err_info, status='impossible',
-                    message='cannot re-run command, last saved state does not look like a recorded command run')
-                return
-            if message is None:
-                # re-use commit message, if nothing new was given
-                message = rec_msg
-            cmd = runinfo['cmd']
-            rec_exitcode = runinfo.get('exit', 0)
-            rel_pwd = runinfo.get('pwd', None)
-            if rel_pwd:
-                # recording is relative to the dataset
-                pwd = normpath(opj(ds.path, rel_pwd))
-            else:
-                rel_pwd = None  # normalize, just in case
-                pwd = None
+    # TODO do our best to guess which files to unlock based on the command string
+    #      in many cases this will be impossible (but see rerun). however,
+    #      generating new data (common case) will be just fine already
 
-            # now we have to find out what was modified during the last run, and enable re-modification
-            # ideally, we would bring back the entire state of the tree with #1424, but we limit ourself
-            # to file addition/not-in-place-modification for now
-            to_unlock = []
-            for r in ds.diff(
-                    recursive=True,
-                    revision='HEAD~1...HEAD',
-                    return_type='generator',
-                    result_renderer=None):
-                if r.get('type', None) == 'file' and \
-                        r.get('state', None) in ('added', 'modified'):
-                    r.pop('status', None)
-                    to_unlock.append(r)
-            if to_unlock:
-                for r in ds.unlock(to_unlock, return_type='generator', result_xfm=None):
-                    yield r
-        else:
-            # not a rerun, use previously assigned pwd, rel_pwd depending
-            # on either dataset was specified
-            pass
-
-        # anticipate quoted compound shell commands
-        cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd
-
-        # TODO do our best to guess which files to unlock based on the command string
-        #      in many cases this will be impossible (but see --rerun). however,
-        #      generating new data (common case) will be just fine already
-
-        # we have a clean dataset, let's run things
-        cmd_exitcode = None
-        runner = Runner(cwd=pwd)
-        try:
-            lgr.info("== Command start (output follows) =====")
-            runner.run(
-                cmd,
-                # immediate output
-                log_online=True,
-                # not yet sure what we should do with the command output
-                # IMHO `run` itself should be very silent and let the command talk
-                log_stdout=False,
-                log_stderr=False,
-                expect_stderr=True,
-                expect_fail=True,
-                # TODO stdin
-            )
-        except CommandError as e:
-            # strip our own info from the exception. The original command output
-            # went to stdout/err -- we just have to exitcode in the same way
-            cmd_exitcode = e.code
-            if not rerun or rec_exitcode != cmd_exitcode:
-                # we failed during a fresh run, or in a different way during a rerun
-                # the latter can easily happen if we try to alter a locked file
-                #
-                # let's fail here, the command could have had a typo or some
-                # other undesirable condition. If we would `add` nevertheless,
-                # we would need to rerun and aggregate annex content that we
-                # likely don't want
-                # TODO add switch to ignore failure (some commands are stupid)
-                # TODO add the ability to `git reset --hard` the dataset tree on failure
-                # we know that we started clean, so we could easily go back, needs gh-1424
-                # to be able to do it recursively
-                raise CommandError(code=cmd_exitcode)
-
-        lgr.info("== Command exit (modification check follows) =====")
-
-        # ammend commit message with `run` info:
-        # - pwd if inside the dataset
-        # - the command itself
-        # - exit code of the command
-        run_info = {
-            'cmd': cmd,
-            'exit': cmd_exitcode if cmd_exitcode is not None else 0,
-        }
-        if rel_pwd is not None:
-            # only when inside the dataset to not leak information
-            run_info['pwd'] = rel_pwd
-
-        # compose commit message
-        cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
-        cmd_shorty = '{}{}'.format(
-            cmd_shorty[:40],
-            '...' if len(cmd_shorty) > 40 else '')
-        msg = '[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
-            message if message is not None else cmd_shorty,
-            json.dumps(run_info, indent=1), sort_keys=True, ensure_ascii=False, encoding='utf-8')
-
-        for r in ds.add('.', recursive=True, message=msg):
-            yield r
-
-        # TODO bring back when we can ignore a command failure
-        #if cmd_exitcode:
-        #    # finally raise due to the original command error
-        #    raise CommandError(code=cmd_exitcode)
-
-
-def get_commit_runinfo(repo, commit=None):
-    """Return message and run record from a commit message
-
-    If none found - returns None, None; if anything goes wrong - throws
-    ValueError with the message describing the issue
-    """
-    assert commit is None, "TODO: implement for anything but the last commit"
-    last_commit_msg = repo.repo.head.commit.message
-    cmdrun_regex = r'\[DATALAD RUNCMD\] (.*)=== Do not change lines below ' \
-                   r'===\n(.*)\n\^\^\^ Do not change lines above \^\^\^'
-    runinfo = re.match(cmdrun_regex, last_commit_msg,
-                       re.MULTILINE | re.DOTALL)
-    if not runinfo:
-        return None, None
-
-    rec_msg, runinfo = runinfo.groups()
-
+    # we have a clean dataset, let's run things
+    cmd_exitcode = None
+    runner = Runner(cwd=pwd)
     try:
-        runinfo = json.loads(runinfo)
-    except Exception as e:
-        raise ValueError(
-            'cannot re-run command, command specification is not valid JSON: '
-            '%s' % str(e)
+        lgr.info("== Command start (output follows) =====")
+        runner.run(
+            cmd,
+            # immediate output
+            log_online=True,
+            # not yet sure what we should do with the command output
+            # IMHO `run` itself should be very silent and let the command talk
+            log_stdout=False,
+            log_stderr=False,
+            expect_stderr=True,
+            expect_fail=True,
+            # TODO stdin
         )
-    if 'cmd' not in runinfo:
-        raise ValueError(
-            'cannot re-run command, command specification missing in '
-            'recorded state'
-        )
-    return rec_msg, runinfo
+    except CommandError as e:
+        # strip our own info from the exception. The original command output
+        # went to stdout/err -- we just have to exitcode in the same way
+        cmd_exitcode = e.code
+
+        if not rerun_info or rerun_info.get("exit", 0) != cmd_exitcode:
+            # we failed during a fresh run, or in a different way during a rerun
+            # the latter can easily happen if we try to alter a locked file
+            #
+            # let's fail here, the command could have had a typo or some
+            # other undesirable condition. If we would `add` nevertheless,
+            # we would need to rerun and aggregate annex content that we
+            # likely don't want
+            # TODO add switch to ignore failure (some commands are stupid)
+            # TODO add the ability to `git reset --hard` the dataset tree on failure
+            # we know that we started clean, so we could easily go back, needs gh-1424
+            # to be able to do it recursively
+            raise CommandError(code=cmd_exitcode)
+
+    lgr.info("== Command exit (modification check follows) =====")
+
+    # ammend commit message with `run` info:
+    # - pwd if inside the dataset
+    # - the command itself
+    # - exit code of the command
+    run_info = {
+        'cmd': cmd,
+        'exit': cmd_exitcode if cmd_exitcode is not None else 0,
+        'chain': rerun_info["chain"] if rerun_info else [],
+    }
+    if rel_pwd is not None:
+        # only when inside the dataset to not leak information
+        run_info['pwd'] = rel_pwd
+
+    # compose commit message
+    cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
+    cmd_shorty = '{}{}'.format(
+        cmd_shorty[:40],
+        '...' if len(cmd_shorty) > 40 else '')
+    msg = '[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
+        message if message is not None else cmd_shorty,
+        json.dumps(run_info, indent=1), sort_keys=True, ensure_ascii=False, encoding='utf-8')
+
+    for r in ds.add('.', recursive=True, message=msg):
+        yield r
+
+    # TODO bring back when we can ignore a command failure
+    #if cmd_exitcode:
+    #    # finally raise due to the original command error
+    #    raise CommandError(code=cmd_exitcode)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""test command datalad run
+"""test command datalad {re,}run
 
 """
 
@@ -17,19 +17,22 @@ from datalad.tests.utils import (
     known_failure_v6,
 )
 
-import logging
 from os.path import join as opj
+from os.path import relpath
 from os import mkdir
 from datalad.utils import chpwd
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import NoDatasetArgumentFound
 from datalad.support.exceptions import CommandError
-from datalad.tests.utils import ok_
+from datalad.support.exceptions import IncompleteResultsError
+from datalad.support.gitrepo import GitCommandError
+from datalad.tests.utils import ok_, assert_false, neq_
 from datalad.api import run
-from datalad.interface.run import get_commit_runinfo
+from datalad.interface.rerun import get_commit_runinfo, new_or_modified
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import create_tree
@@ -39,6 +42,7 @@ from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import swallow_outputs
+from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import skip_if_on_windows
 from datalad.tests.utils import ignore_nose_capturing_stdout
 
@@ -64,9 +68,6 @@ def test_basics(path, nodspath):
     # run inside the dataset
     with chpwd(path), \
             swallow_outputs():
-        # runs nothing, does nothing
-        assert_result_count(ds.run(), 0)
-        eq_(last_state, ds.repo.get_hexsha())
         # provoke command failure
         with assert_raises(CommandError) as cme:
             ds.run('7i3amhmuch9invalid')
@@ -119,18 +120,254 @@ def test_rerun(path, nodspath):
     # subdatasets
     with chpwd(nodspath), \
             swallow_outputs():
-        ds.run(rerun=True)
+        ds.rerun()
     ok_clean_git(ds.path)
     # ran twice now
     eq_('xx\n', open(probe_path).read())
-    # if I give another command, it will be ignored
-    with chpwd(nodspath), \
-            swallow_logs(new_level=logging.WARNING) as cml, \
-            swallow_outputs():
-        ds.run('30BANG3934', rerun=True)
-        cml.assert_logged("Ignoring provided command in --rerun mode", level="WARNING")
-    ok_clean_git(ds.path)
+    # Make a non-run commit.
+    with open(opj(path, "nonrun-file"), "w") as f:
+        f.write("foo")
+    ds.add("nonrun-file")
+    # Now rerun the buried command.
+    ds.rerun(revision="HEAD~", message="rerun buried")
     eq_('xxx\n', open(probe_path).read())
+    # Also check that the messasge override worked.
+    eq_(ds.repo.repo.head.commit.message.splitlines()[0],
+        "[DATALAD RUNCMD] rerun buried")
+    # Or a range of commits, skipping non-run commits.
+    ds.rerun(since="HEAD~3")
+    eq_('xxxxx\n', open(probe_path).read())
+    # Or --since= to run all reachable commits.
+    ds.rerun(since="")
+    eq_('xxxxxxxxxx\n', open(probe_path).read())
+    # If the history to rerun has a merge commit, we abort.
+    ds.repo.checkout("HEAD~3", options=["-b", "topic"])
+    with open(opj(path, "topic-file"), "w") as f:
+        f.write("topic")
+    ds.add("topic-file")
+    ds.repo.checkout("master")
+    ds.repo.merge("topic")
+    ok_clean_git(ds.path)
+    assert_raises(IncompleteResultsError, ds.rerun)
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_onto(path):
+    ds = Dataset(path).create()
+
+    grow_file = opj(path, "grows")
+
+    ds.run('echo static-content > static')
+    ds.repo.repo.git.tag("static")
+    ds.run('echo x$(cat grows) > grows')
+    ds.rerun()
+    eq_('xx\n', open(grow_file).read())
+
+    # If we run the "static" change on top of itself, we end up in the
+    # same (but detached) place.
+    ds.rerun(revision="static", onto="static")
+    ok_(ds.repo.get_active_branch() is None)
+    eq_(ds.repo.repo.git.rev_parse("HEAD"),
+        ds.repo.repo.git.rev_parse("static"))
+
+    # If we run the "static" change from the same "base", we end up
+    # with a new commit.
+    ds.repo.checkout("master")
+    ds.rerun(revision="static", onto="static^")
+    ok_(ds.repo.get_active_branch() is None)
+    neq_(ds.repo.repo.git.rev_parse("HEAD"),
+         ds.repo.repo.git.rev_parse("static"))
+    assert_result_count(ds.diff(revision="HEAD..static"), 0)
+    for revrange in ["..static", "static.."]:
+        assert_result_count(
+            ds.repo.repo.git.rev_list(revrange).split(), 1)
+
+    # Unlike the static change, if we run the ever-growing change on
+    # top of itself, we end up with a new commit.
+    ds.repo.checkout("master")
+    ds.rerun(onto="HEAD")
+    ok_(ds.repo.get_active_branch() is None)
+    neq_(ds.repo.repo.git.rev_parse("HEAD"),
+         ds.repo.repo.git.rev_parse("master"))
+
+    # An empty `onto` means use the parent of the first revision.
+    ds.repo.checkout("master")
+    ds.rerun(since="static^", onto="")
+    ok_(ds.repo.get_active_branch() is None)
+    for revrange in ["..master", "master.."]:
+        assert_result_count(
+            ds.repo.repo.git.rev_list(revrange).split(), 3)
+
+    # An empty `onto` means use the parent of the first revision that
+    # has a run command.
+    ds.repo.checkout("master")
+    ds.rerun(since="", onto="", branch="from-base")
+    eq_(ds.repo.get_active_branch(), "from-base")
+    assert_result_count(ds.diff(revision="master..from-base"), 0)
+    eq_(ds.repo.get_merge_base(["static", "from-base"]),
+        ds.repo.repo.git.rev_parse("static^"))
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_chain(path):
+    ds = Dataset(path).create()
+    commits = []
+
+    grow_file = opj(path, "grows")
+    ds.run('echo x$(cat grows) > grows')
+    ds.repo.repo.git.tag("first-run")
+
+    for _ in range(3):
+        commits.append(ds.repo.get_hexsha())
+        ds.rerun()
+        _, info = get_commit_runinfo(ds.repo, "HEAD")
+        assert info["chain"] == commits
+
+    ds.rerun(revision="first-run")
+    _, info = get_commit_runinfo(ds.repo, "HEAD")
+    assert info["chain"] == commits[:1]
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_just_one_commit(path):
+    ds = Dataset(path).create()
+
+    # Check out an orphan branch so that we can test the "one commit
+    # in a repo" case.
+    ds.repo.checkout("orph", options=["--orphan"])
+    ds.repo.repo.git.reset("--hard")
+
+    ds.run('echo static-content > static')
+    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+
+    # Rerunning with just one commit doesn't raise an error ...
+    ds.rerun()
+    # ... but we're still at one commit because the content didn't
+    # change.
+    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+
+    # We abort rather than trying to do anything when --onto='' and
+    # --since='' are given together and the first commit contains a
+    # run command.
+    ds.repo.commit(msg="empty", options=["--allow-empty"])
+    assert_raises(IncompleteResultsError, ds.rerun, since="", onto="")
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+def test_rerun_branch(path):
+    ds = Dataset(path).create()
+
+    ds.repo.repo.git.tag("prerun")
+
+    outfile = opj(path, "run-file")
+
+    with open(opj(path, "nonrun-file"), "w") as f:
+        f.write("foo")
+    ds.add("nonrun-file")
+
+    ds.run('echo x$(cat run-file) > run-file')
+    ds.rerun()
+    eq_('xx\n', open(outfile).read())
+
+    # Rerun the commands on a new branch that starts at the parent
+    # commit of the first run.
+    ds.rerun(since="prerun", onto="prerun", branch="rerun")
+
+    eq_(ds.repo.get_active_branch(), "rerun")
+    eq_('xx\n', open(outfile).read())
+
+    for revrange in ["rerun..master", "master..rerun"]:
+        assert_result_count(
+            ds.repo.repo.git.rev_list(revrange).split(), 3)
+    eq_(ds.repo.get_merge_base(["master", "rerun"]),
+        ds.repo.repo.git.rev_parse("prerun"))
+
+    # Start rerun branch at tip of current branch.
+    ds.repo.checkout("master")
+    ds.rerun(since="prerun", branch="rerun2")
+    eq_(ds.repo.get_active_branch(), "rerun2")
+    eq_('xxxx\n', open(outfile).read())
+
+    assert_result_count(
+        ds.repo.repo.git.rev_list("master..rerun2").split(), 2)
+    assert_result_count(
+        ds.repo.repo.git.rev_list("rerun2..master").split(), 0)
+
+    # Using an existing branch name fails.
+    ds.repo.checkout("master")
+    assert_raises(IncompleteResultsError,
+                  ds.rerun, since="prerun", branch="rerun2")
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_cherry_pick(path):
+    ds = Dataset(path).create()
+
+    ds.repo.repo.git.tag("prerun")
+    ds.run('echo abc > runfile')
+    with open(opj(path, "nonrun-file"), "w") as f:
+        f.write("foo")
+    ds.add("nonrun-file")
+
+    for onto, text in [("HEAD", "skipping"), ("prerun", "cherry picking")]:
+        results = ds.rerun(since="prerun", onto=onto)
+        assert_in_results(results, status='ok', path=ds.path)
+        assert any(r.get("message", "").endswith(text) for r in results)
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_outofdate_tree(path):
+    ds = Dataset(path).create()
+    input_file = opj(path, "foo")
+    output_file = opj(path, "out")
+    with open(input_file, "w") as f:
+        f.write("abc\ndef")
+    ds.add("foo", to_git=True)
+    # Create inital run.
+    ds.run('grep def foo > out')
+    eq_('def\n', open(output_file).read())
+    # Change tree so that it is no longer compatible.
+    ds.remove("foo")
+    # Now rerunning should fail because foo no longer exists.
+    assert_raises(CommandError, ds.rerun, revision="HEAD~")
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_rerun_ambiguous_revision_file(path):
+    ds = Dataset(path).create()
+    ds.run('echo ambig > ambig')
+    ds.repo.repo.git.tag("ambig")
+    # Don't fail when "ambig" refers to both a file and revision.
+    ds.rerun(since="", revision="ambig", branch="rerun")
+    eq_(len(ds.repo.repo.git.rev_list("rerun").split()),
+        len(ds.repo.repo.git.rev_list("ambig", "--").split()))
 
 
 @ignore_nose_capturing_stdout
@@ -149,7 +386,7 @@ def test_rerun_subdir(path):
     eq_(runinfo['pwd'], 'subdir')
     # now, rerun within root of the dataset
     with chpwd(ds.path):
-        ds.run(rerun=True)
+        ds.rerun()
     ok_clean_git(ds.path)
     ok_file_under_git(opj(subdir, "test.dat"), annexed=True)
     # and not on top
@@ -164,4 +401,96 @@ def test_rerun_subdir(path):
     eq_(runinfo['pwd'], '.')
     # now, rerun within subdir -- smoke for now
     with chpwd(subdir):
-        ds.run(rerun=True)
+        ds.rerun()
+
+
+@with_tree(tree={"d": {"to_modify": "content1"},
+                 "to_remove": "content2",
+                 "to_modify": "content3",
+                 "unchanged": "content4"})
+def test_new_or_modified(path):
+    def apfiles(aps):
+        for ap in aps:
+            yield relpath(ap["path"], path)
+
+    ds = Dataset(path).create(force=True, no_annex=True)
+
+    # Check out an orphan branch so that we can test the "one commit
+    # in a repo" case.
+    ds.repo.checkout("orph", options=["--orphan"])
+    ds.repo.add(".", commit=True)
+    assert_false(ds.repo.dirty)
+    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+    # Diffing doesn't fail when the branch contains a single commit.
+    assert_in("to_modify", apfiles(new_or_modified(ds, "HEAD")))
+
+    # New files are detected, deletions are not.
+    ds.repo.remove(["to_remove"])
+    ok_(ds.repo.dirty)
+
+    with open(opj(path, "to_add"), "w") as f:
+        f.write("content5")
+    ds.repo.add(["to_add"], commit=True)
+    ds.repo.commit("add one, remove another")
+
+    eq_(list(apfiles(new_or_modified(ds, "HEAD"))),
+        ["to_add"])
+
+    # Modifications are detected.
+    with open(opj(path, "to_modify"), "w") as f:
+        f.write("updated 1")
+    with open(opj(path, "d/to_modify"), "w") as f:
+        f.write("updated 2")
+    ds.repo.add(["to_modify", "d/to_modify"], commit=True)
+
+    eq_(set(apfiles(new_or_modified(ds, "HEAD"))),
+        {"to_modify", "d/to_modify"})
+
+    # Non-HEAD revisions work.
+    ds.repo.commit("empty", options=["--allow-empty"])
+    assert_false(list(apfiles(new_or_modified(ds, "HEAD"))))
+    eq_(set(apfiles(new_or_modified(ds, "HEAD~"))),
+        {"to_modify", "d/to_modify"})
+
+
+@with_tempfile(mkdir=True)
+def test_rerun_commit_message_check(path):
+    ds = Dataset(path).create()
+    ds.repo.commit(options=["--allow-empty"], msg="""\
+[DATALAD RUNCMD] no command
+
+=== Do not change lines below ===
+{
+ "pwd": ".",
+ "exit": 0
+}
+^^^ Do not change lines above ^^^""")
+
+    ds.repo.commit(options=["--allow-empty"], msg="""\
+[DATALAD RUNCMD] junk json
+
+=== Do not change lines below ===
+{
+ "pwd": ".,
+ "cmd": "echo ok >okfile",
+ "exit": 0
+}
+^^^ Do not change lines above ^^^""")
+
+    ds.repo.commit(options=["--allow-empty"], msg="""\
+[DATALAD RUNCMD] fine
+
+=== Do not change lines below ===
+{
+ "pwd": ".",
+ "cmd": "echo ok >okfile",
+ "exit": 0
+}
+^^^ Do not change lines above ^^^""")
+
+    assert_raises(ValueError,
+                  get_commit_runinfo, ds.repo, "HEAD~2")
+    assert_raises(ValueError,
+                  get_commit_runinfo, ds.repo, "HEAD~")
+
+    get_commit_runinfo(ds.repo, "HEAD")

--- a/datalad/resources/website/assets/js/jquery.dataTables-1.10.12.js
+++ b/datalad/resources/website/assets/js/jquery.dataTables-1.10.12.js
@@ -4160,7 +4160,7 @@
 		var language = settings.oLanguage;
 		var previousSearch = settings.oPreviousSearch;
 		var features = settings.aanFeatures;
-		var input = '<input type="search" class="'+classes.sFilterInput+'"/>';
+		var input = '<input type="search" class="'+classes.sFilterInput+'" autofocus="autofocus"/>';
 	
 		var str = language.sSearch;
 		str = str.match(/_INPUT_/) ?

--- a/docs/casts/reproducible_analysis.sh
+++ b/docs/casts/reproducible_analysis.sh
@@ -57,9 +57,9 @@ say "The analysis step is done, all generated results were saved in the dataset.
 run "git show --stat"
 
 say "DataLad has enough information stored to be able to re-run a command."
-say "On command exit, it will inspect the results and save them gain, but only if they are different."
+say "On command exit, it will inspect the results and save them again, but only if they are different."
 say "In our case, the re-run yields bit-identical results, hence nothing new is saved."
-run "datalad run --rerun"
+run "datalad rerun"
 
 say "Now that we are done, and have checked that we can reproduce the results ourselves, we can clean up"
 say "DataLad can easily verify if any part of our input dataset was modified since we configured our analysis"
@@ -78,7 +78,7 @@ run "ls inputs/*"
 say "Only the remaining data (our code and the results) need to be kept and require a backup for long term archival. Everything else can be re-obtained as needed, when needed."
 
 say "As DataLad knows everything needed about the inputs, including where to get the right version, we can re-run the analysis with a single command. Watch how DataLad re-obtains all required data, re-runs the code, and checks that none of the results changed and need saving"
-run "datalad run --rerun"
+run "datalad rerun"
 
 say "Reproduced!"
 

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -46,6 +46,15 @@ Metadata handling
    generated/man/datalad-metadata
    generated/man/datalad-aggregate-metadata
 
+Reproducible execution
+======================
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-run
+   generated/man/datalad-rerun
+
 Miscellaneous commands
 ======================
 
@@ -58,7 +67,6 @@ Miscellaneous commands
    generated/man/datalad-crawl-init
    generated/man/datalad-download-url
    generated/man/datalad-ls
-   generated/man/datalad-run
    generated/man/datalad-test
 
 Plumbing commands

--- a/tools/cast2script
+++ b/tools/cast2script
@@ -21,17 +21,17 @@ function execute () {
 function say()
 {
 	printf "\n"
-	printf "# $1\n" | fmt -w 72 --prefix '# '
+	printf "# %s\n" "$1" | fmt -w 72 --prefix '# '
 }
 function show () {
 	# same as say
-	printf "# $1\n" | fmt -w 72 --prefix '# '
+	printf "# %s\n" "$1" | fmt -w 72 --prefix '# '
 }
 function run () {
-	printf "$1\n"
+        printf "%s\n" "$1"
 }
 function run_expfail () {
-	printf "$1 || true\n"
+	printf "%s || true\n" "$1"
 }
 
 


### PR DESCRIPTION
This pull request merges 0.9.x into master.  There were conflicts in
test_run.py and auto.py.  I was less sure of the auto.py resolutions
(since none of the changes were mine), so I've included the conflicts
below.  In both cases, I took HEAD's variant.

```diff
diff --cc datalad/auto.py
index f6548052,e04af467..00000000
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@@ -154,21 -132,13 +154,30 @@@ class AutomagicIO(object)
                      filearg = "name" if PY2 else "file"
                      if filearg not in kwargs:
                          # so the name was missing etc, just proxy into original open call and let it puke
 -                        lgr.debug("No name/file was given, avoiding proxying")
 -                        raise _EarlyExit
 +                        raise _EarlyExit("no name/file was given")
                      file = kwargs.get(filearg)
++<<<<<<< HEAD
 +
 +                if isinstance(file, int):
 +                    raise _EarlyExit("already a file descriptor")
 +
 +                if self._paths_cache is not None:
 +                    filefull = file if isabs(file) else os.path.abspath(file)
 +                    if filefull in self._paths_cache:
 +                        raise _EarlyExit("considered before")
 +                    else:
 +                        self._paths_cache.add(filefull)
 +
 +                if _DOT_GIT_DIR in file:
 +                    raise _EarlyExit("we ignore paths under .git/")
++||||||| merged common ancestors
++
++=======
+                 if isinstance(file, int):
+                     lgr.debug(
+                         "Skipping operation on %i, already a file descriptor", file)
+                     raise _EarlyExit
++>>>>>>> 0.9.x
                  mode = 'r'
                  if len(args) > 1:
                      mode = args[1]
@@@ -276,12 -224,8 +285,20 @@@
              under_annex = None
          # either it has content
          if (under_annex or under_annex is None) and not annex.file_has_content(filepath):
++<<<<<<< HEAD
 +            lgr.info("AutomagicIO: retrieving file content of %s", filepath)
 +            out = annex.get(filepath)
 +            if not out.get('success', False):
 +                # to assure that it is present and without trailing/leading new lines
 +                out['note'] = out.get('note', '').strip()
 +                lgr.error("Failed to retrieve %(file)s: %(note)s", out)
++||||||| merged common ancestors
++            lgr.info("File %s has no content -- retrieving", filepath)
++            annex.get(filepath)
++=======
+             lgr.info("AutomagicIO: retrieving file content of %s", filepath)
+             annex.get(filepath)
++>>>>>>> 0.9.x

      def activate(self):
          # we should stay below info for this message. With PR #1630 we

```


Please have a look @datalad/developers
