### PR TITLE
Store 'offline' output (typically stderr) into a file to avoid lockdowns

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -347,7 +347,7 @@ class Runner(object):
                 raise RuntimeError("must not get here")
             return line
         # it was output already directly but for code to work, return ""
-        return ""
+        return binary_type()
 
     def run(self, cmd, log_stdout=True, log_stderr=True, log_online=False,
             expect_stderr=False, expect_fail=False,

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -298,12 +298,11 @@ class Runner(object):
             if log_stderr_:
                 stderr += self._process_one_line(*stderr_args)
 
-        if log_stdout in {'offline'} or log_stderr in {'offline'}:
-            lgr.log(4, "Issuing proc.communicate() since one of the targets "
-                       "is 'offline'")
-            stdout_, stderr_ = proc.communicate()
-            stdout += self._process_remaining_output(outputstream, stdout_, *stdout_args)
-            stderr += self._process_remaining_output(errstream, stderr_, *stderr_args)
+        # Handle possible remaining output
+        stdout_, stderr_ = proc.communicate()
+        # ??? should we condition it on log_stdout in {'offline'} ???
+        stdout += self._process_remaining_output(outputstream, stdout_, *stdout_args)
+        stderr += self._process_remaining_output(errstream, stderr_, *stderr_args)
 
         return stdout, stderr
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -92,7 +92,7 @@ def _get_output(stream, out_):
         if not stream.closed:
             stream.close()
         with open(stream.name, 'rb') as f:
-            return f.read().decode()
+            return f.read()
     else:
         return out_
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2341,6 +2341,13 @@ class AnnexRepo(GitRepo, RepoInterface):
             # Or if we had empty stdout but there was stderr
             if out is None or (not out and e.stderr):
                 raise e
+            if e.stderr:
+                # else just warn about present errors
+                shorten = lambda x: x[:1000] + '...' if len(x) > 1000 else x
+                lgr.warning(
+                    "Running %s resulted in stderr output: %s",
+                    command, shorten(e.stderr)
+                )
         finally:
             if progress_indicators:
                 progress_indicators.finish()

--- a/datalad/tests/heavyoutput.py
+++ b/datalad/tests/heavyoutput.py
@@ -5,4 +5,7 @@ import sys
 
 if __name__ == "__main__":
     x = str(list(range(1000))) + '\n'
-    [(sys.stdout.writelines(x), sys.stderr.writelines(x)) for i in range(100)]
+    for i in range(100):
+        s = "%d " % i + x
+        sys.stdout.writelines(s)
+        sys.stderr.writelines(s)

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -215,9 +215,14 @@ def check_runner_heavy_output(log_online):
                 log_stderr='offline',
                 expect_stderr=True
             )
-        assert not ret[0], "all messages went into `logged`"
         assert_equal(len(logged), 100)
         assert len(ret[1]) > 1000  # stderr all here
+
+        from datalad.utils import on_osx
+        if on_osx:
+            raise SkipTest("For some reason we also get ret[0] here on OSX. TODO")
+        else:
+            assert not ret[0], "all messages went into `logged`"
 
     return
     # and now original problematic command with a massive single line

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -217,12 +217,7 @@ def check_runner_heavy_output(log_online):
             )
         assert_equal(len(logged), 100)
         assert_greater(len(ret[1]), 1000)  # stderr all here
-
-        from datalad.utils import on_osx
-        if on_osx:
-            raise SkipTest("For some reason we also get ret[0] here on OSX. TODO")
-        else:
-            assert not ret[0], "all messages went into `logged`"
+        assert not ret[0], "all messages went into `logged`"
 
 
 def test_runner_heavy_output():

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -187,7 +187,7 @@ def check_runner_heavy_output(log_online):
                          log_stderr=False, log_stdout=False,
                          expect_stderr=True)
         eq_(cm.err, cm.out)  # they are identical in that script
-        eq_(cm.out[:10], "[0, 1, 2, ")
+        eq_(cm.out[:10], "0 [0, 1, 2")
         eq_(cm.out[-15:], "997, 998, 999]\n")
 
     # for some reason swallow_logs is not effective, so we just skip altogether
@@ -216,24 +216,13 @@ def check_runner_heavy_output(log_online):
                 expect_stderr=True
             )
         assert_equal(len(logged), 100)
-        assert len(ret[1]) > 1000  # stderr all here
+        assert_greater(len(ret[1]), 1000)  # stderr all here
 
         from datalad.utils import on_osx
         if on_osx:
             raise SkipTest("For some reason we also get ret[0] here on OSX. TODO")
         else:
             assert not ret[0], "all messages went into `logged`"
-
-    return
-    # and now original problematic command with a massive single line
-    if not log_online:
-        # We know it would get stuck in online mode
-        cmd = '%s -c "import sys; x=str(list(range(1000))); ' \
-              '[(sys.stdout.write(x), sys.stderr.write(x)) ' \
-              'for i in range(100)];"' % sys.executable
-        with swallow_logs():
-            ret = runner.run(cmd, log_stderr=True, log_stdout=True,
-                             expect_stderr=True)
 
 
 def test_runner_heavy_output():

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -215,8 +215,9 @@ def check_runner_heavy_output(log_online):
                 log_stderr='offline',
                 expect_stderr=True
             )
-        assert_equal(len(l), 100)
-        import pdb; pdb.set_trace()
+        assert not ret[0], "all messages went into `logged`"
+        assert_equal(len(logged), 100)
+        assert len(ret[1]) > 1000  # stderr all here
 
     return
     # and now original problematic command with a massive single line

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -712,12 +712,14 @@ def swallow_outputs():
 
         @property
         def out(self):
-            self._out.flush()
+            if not self._out.closed:
+                self._out.flush()
             return self._read(self._out)
 
         @property
         def err(self):
-            self._err.flush()
+            if not self._err.closed:
+                self._err.flush()
             return self._read(self._err)
 
         @property


### PR DESCRIPTION
This pull request fixes #2116 

This pull request proposes
- [x] store output marked as 'offline' into a file and then load from file whenever "done"
- [x] report at least a portion of stderr if git annex --json exited abnormally (e.g. as if permissions didn't allow `add`).  Ideally I guess all that code should become a generator, but not sure how feasible it is anyways since stderr isn't necessarily "coupled" with stdin so we wouldn't be able to generally assign specifically stderr to particular files.  Hence: http://git-annex.branchable.com/todo/include_msg_with_possible_reason_why_command___40__e.g._add__41___failed_into_--json_output/
- [x] more tests revealed an issue on OSX on not having processed lines which are still available upon process completes (.poll returns None).  So it demanded heavy code refactoring.  I am not sure if it became anyhow easier to follow but at least it became a bit more modular.  Also removed some conditions checking since seems to work without ;-)  

overall -- it came out much larger than what I hoped/expected/initially did.  But hopefully would be resilient enough to not introduce regressions

This might result in negative impact on performance while calling those batch commands (since would require creation of a file) but imho better slower but more reliable ;)

Unless immediate objections, I would like to merge it asap.  We could fix up/refactor later if needed, but "stuck" operation of datalad without any error msg isn't fun

### Changes
- [x] This change is complete

Please have a look @datalad/developers
