### PR TITLE
Propagate download progress all the way from datalad-archives into the main datalad 

### DIFF
--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -326,6 +326,10 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         # we should go through all and choose the one easiest to get or smth.
         from humanize import naturalsize
         for akey, afile in self._gen_akey_afiles(key, sorted=True, unique_akeys=True):
+            if not akey:
+                lgr.warning("Got an empty archive key %r for key %s. Skipping",
+                            akey, key)
+                continue
             akeys_tried.append(akey)
             try:
                 akey_fpath = self.get_contentlocation(akey)
@@ -338,7 +342,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                     self.info(
                         "To obtain some keys we need to fetch an archive "
                         "of size %s"
-                        % naturalsize(akey_size) if akey_size else "unknown"
+                        % (naturalsize(akey_size) if akey_size else "unknown")
                     )
 
                     def progress_indicators(l):

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -324,6 +324,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         # prune the list so we keep only the ones from unique akeys.
         # May be whenever we support extraction directly from the tarballs
         # we should go through all and choose the one easiest to get or smth.
+        from humanize import naturalsize
         for akey, afile in self._gen_akey_afiles(key, sorted=True, unique_akeys=True):
             akeys_tried.append(akey)
             try:
@@ -333,11 +334,11 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                     # Command could have fail to run if key was not present locally yet
                     # Thus retrieve the key using annex
                     # TODO: we need to report user somehow about this happening and progress on the download
-                    akey_size = self.repo.get_size_from_key(akey) or "unknown"
+                    akey_size = self.repo.get_size_from_key(akey)
                     self.info(
                         "To obtain some keys we need to fetch an archive "
-                        "of size %s bytes. Some sizes below might be reported incorrectly"
-                        % akey_size
+                        "of size %s"
+                        % naturalsize(akey_size) if akey_size else "unknown"
                     )
 
                     def progress_indicators(l):

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -333,6 +333,12 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                     # Command could have fail to run if key was not present locally yet
                     # Thus retrieve the key using annex
                     # TODO: we need to report user somehow about this happening and progress on the download
+                    akey_size = self.repo.get_size_from_key(akey) or "unknown"
+                    self.info(
+                        "To obtain some keys we need to fetch an archive "
+                        "of size %s. No progress indication will be provided"
+                        % akey_size
+                    )
                     self.runner(["git-annex", "get", "--key", akey],
                                 cwd=self.path, expect_stderr=True)
 

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -336,10 +336,21 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                     akey_size = self.repo.get_size_from_key(akey) or "unknown"
                     self.info(
                         "To obtain some keys we need to fetch an archive "
-                        "of size %s. No progress indication will be provided"
+                        "of size %s bytes. Some sizes below might be reported incorrectly"
                         % akey_size
                     )
-                    self.runner(["git-annex", "get", "--key", akey],
+
+                    def progress_indicators(l):
+                        self.info("PROGRESS-JSON: " + l.rstrip(os.linesep))
+
+                    self.runner(["git-annex", "get",
+                                 "--json", "--json-progress",
+                                 "--key", akey
+                                 ],
+                                log_stdout=progress_indicators,
+                                log_stderr='offline',
+                                # False, # to avoid lock down
+                                log_online=True,
                                 cwd=self.path, expect_stderr=True)
 
                     akey_fpath = self.get_contentlocation(akey)

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -28,6 +28,7 @@ lgr.log(5, "Importing datalad.customremotes.main")
 
 from ..ui import ui
 from ..support.protocol import ProtocolInterface
+from ..support.external_versions import external_versions
 from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 
@@ -249,6 +250,8 @@ class AnnexCustomRemote(object):
         # Delay introspection until the first instance gets born
         # could in principle be done once in the metaclass I guess
         self.__class__._introspect_req_signatures()
+        self._annex_supports_info = \
+            external_versions['cmd:annex'] >= '6.20180206'
 
     @classmethod
     def _introspect_req_signatures(cls):
@@ -372,6 +375,11 @@ class AnnexCustomRemote(object):
     def error(self, msg, annex_err="ERROR"):
         lgr.error(msg)
         self.send(annex_err, msg)
+
+    def info(self, msg):
+        lgr.info(msg)
+        if self._annex_supports_info:
+            self.send('INFO', msg)
 
     def progress(self, bytes):
         bytes = int(bytes)

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -207,7 +207,7 @@ def test_interactions(tdir):
             ('VALUE',
              re.compile(
                  'TRANSFER-FAILURE RETRIEVE somekey Failed to fetch any '
-                 'archive containing somekey. Tried: \[..\]')
+                 'archive containing somekey. Tried: \[\]')
              )
         ],
         # # incorrect response received from annex -- something isn't right but ... later

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -176,3 +176,41 @@ def test_no_rdflib_loaded():
         # print cmo.out
         assert_not_in("rdflib", cmo.out)
         assert_not_in("rdflib", cmo.err)
+
+
+from datalad.tests.utils import serve_path_via_http
+@with_tree(tree=
+    {'1.tar.gz':
+         {
+             'bu.dat': '52055957098986598349795121365535'*10000,
+             'bu3.dat': '8236397048205454767887168342849275422'*10000
+          },
+    '2.tar.gz':
+         {
+             'bu2.dat': '17470674346319559612580175475351973007892815102'*10000
+          },
+    }
+)
+@serve_path_via_http()
+@with_tempfile
+def check_observe_tqdm(topdir, topurl, outdir):
+    # just a helper to enable/use when want quickly to get some
+    # repository with archives and observe tqdm
+    from datalad.api import create, download_url, add_archive_content
+    ds = create(outdir)
+    for f in '1.tar.gz', '2.tar.gz':
+        with chpwd(outdir):
+            ds.repo.add_url_to_file(f, topurl + f)
+            ds.add(f)
+            add_archive_content(f, delete=True, drop_after=True)
+    files = glob.glob(opj(outdir, '*'))
+    ds.drop(files) # will not drop tarballs
+    ds.repo.drop([], options=['--all', '--fast'])
+    ds.get(files)
+    ds.repo.drop([], options=['--all', '--fast'])
+    # now loop so we could play with it outside
+    print(outdir)
+    # import pdb; pdb.set_trace()
+    while True:
+       sleep(0.1)
+

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -622,8 +622,14 @@ class Get(Interface):
                 res = annexjson2result(res, ds, type='file', logger=lgr,
                                        refds=refds_path)
                 success = success_status_map[res['status']]
-                respath_by_status[success] = \
-                    respath_by_status.get(success, []) + [res['path']]
+                # TODO: in case of some failed commands (e.g. get) there might
+                # be no path in the record.  yoh has only vague idea of logic
+                # here so just checks for having 'path', but according to
+                # results_from_annex_noinfo, then it would be assumed that
+                # `content` was acquired successfully, which is not the case
+                if 'path' in res:
+                    respath_by_status[success] = \
+                        respath_by_status.get(success, []) + [res['path']]
                 yield res
 
             for r in results_from_annex_noinfo(

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -447,6 +447,10 @@ def _process_results(
     # loop over results generated from some source and handle each
     # of them according to the requested behavior (logging, rendering, ...)
     for res in results:
+        if 'action' not in res:
+            # XXX Yarik has to no clue on how to track the origin of the
+            # record to figure out WTF, so he just skips it
+            continue
         actsum = action_summary.get(res['action'], {})
         if res['status']:
             actsum[res['status']] = actsum.get(res['status'], 0) + 1

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3423,6 +3423,14 @@ class ProcessAnnexProgressIndicators(object):
             self.total_pbar.update(diff, increment=True)
         pbar.update(new_value)
 
+    def _log_info(self, msg):
+        """Helper to log a message, so we need to clear up the pbars first"""
+        if self.total_pbar:
+            self.total_pbar.clear()
+        for pbar in self.pbars.values():
+            pbar.clear()
+        lgr.info(msg)
+
     def __call__(self, line):
         try:
             j = json.loads(line)
@@ -3440,10 +3448,9 @@ class ProcessAnnexProgressIndicators(object):
                 if ('command' in j_ and 'key' in j_) or 'byte-progress' in j_:
                     j = j_
                 else:
-                    # XXX
-                    lgr.info(info)
+                    self._log_info(info)
             else:
-                lgr.info(info)
+                self._log_info(info)
                 return
 
         target_size = None

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3430,6 +3430,13 @@ class ProcessAnnexProgressIndicators(object):
             # if we fail to parse, just return this precious thing for
             # possibly further processing
             return line
+
+        # Process some messages which remotes etc might push to us
+        if list(j) == ['info']:
+            # Just INFO was received without anything else -- we log it at INFO
+            lgr.info(j['info'])
+            return
+
         target_size = None
         if 'command' in j and 'key' in j:
             # might be the finish line message

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -52,6 +52,9 @@ class ProgressBarBase(object):
     def finish(self):
         pass
 
+    def clear(self):
+        pass
+
     def set_desc(self, value):
         pass  # to override in subclass on how to handle description
 


### PR DESCRIPTION
This pull request fixes #??? (I thought we had an issue, yet to find it)

This pull request proposes to take advantage of the new feature in git-annex since today to be able to pass INFO level message to the git-annex, which then gets provided to us as well in --json output.  This way we could channel not only a dummy message that we need to download a tarball of size X, but also entire progress report for more progress bars appearing on the screen (for each tarball being downloaded).  ~~~It is a bit mouthfull on the screen, and not playing nicely with tqdm and probably expected sizes,  but it is better than silence of current implementation ;)~~~  Now it looks actually quite pretty, with progressbars being cleared if a log message is displayed, so the whole output is quite sensible!

### Changes
- [x] This change is complete
- [x] Force rerunning tests whenever new git-annex-standlone gets uploadedd -- now goes through local testing

Please have a look @datalad/developers
