### PR TITLE
[WIP] ENH: Add initial implementation of addurls plugin

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -528,16 +528,17 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
             "_repindex" can be added to the formatter.  Its value will
             start at 0 and increment every time a file name repeats.
 
-          - _url_hostname, _urlN, and _url_basename
+          - _url_hostname, _urlN, _url_basename
 
-            Various parts of the formatted URL are available.  If the
-            formatted URL is "http://datalad.org/for/git-users",
-            "datalad.org" is stored as "_url_hostname".
+            Various parts of the formatted URL are available.  Take
+            "http://datalad.org/asciicast/seamless_nested_repos.sh" as
+            an example.
 
-            Components of the URL's path can be referenced as "_urlN".
-            In the example URL above, "_url0" and "_url1" would map to
-            "for" and "git-users", respectively.  The final part of the
-            path is also available as "_url_basename".
+            "datalad.org" is stored as "_url_hostname".  Components of
+            the URL's path can be referenced as "_urlN".  "_url0" and
+            "_url1" would map to "asciicast" and "seamless_nested_repos.sh",
+            respectively.  The final part of the path is also available
+            as "_url_basename".
     exclude_autometa : str, optional
         By default, metadata field=value pairs are constructed with each
         column in `url_file`, excluding any single column that is

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -309,7 +309,8 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
 
     if not dataset.repo:
         # Populate a new dataset with the URLs.
-        dataset.create()
+        for r in dataset.create(result_xfm=None, return_type='generator'):
+            yield r
     elif not isinstance(dataset.repo, AnnexRepo):
         yield get_status_dict(action="addurls",
                               ds=dataset,
@@ -325,7 +326,9 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
                 "Not creating subdataset at existing path: %s",
                 spath)
         else:
-            dataset.create(spath)
+            for r in dataset.create(spath, result_xfm=None,
+                                    return_type='generator'):
+                yield r
 
     files_to_add = []
     meta_to_add = []

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -409,6 +409,13 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
                               message="Must specify url_file argument")
         return
 
+    if dataset.repo and not isinstance(dataset.repo, AnnexRepo):
+        yield get_status_dict(action="addurls",
+                              ds=dataset,
+                              status="error",
+                              message="not an annex repo")
+        return
+
     if input_type == "ext":
         extension = os.path.splitext(url_file)[1]
         input_type = "json" if extension == ".json" else "csv"
@@ -444,12 +451,6 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
         # Populate a new dataset with the URLs.
         for r in dataset.create(result_xfm=None, return_type='generator'):
             yield r
-    elif not isinstance(dataset.repo, AnnexRepo):
-        yield get_status_dict(action="addurls",
-                              ds=dataset,
-                              status="error",
-                              message="not an annex repo")
-        return
 
     annex_options = ["--fast"] if fast else []
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -172,8 +172,7 @@ def is_legal_metafield(name):
     The set of permitted characters is taken from git-annex's
     MetaData.hs:legalField.
     """
-    legal = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9_.-]*\Z")
-    return True if legal.match(name) else False
+    return bool(re.match(r"[a-zA-Z0-9][a-zA-Z0-9_.-]*\Z", name))
 
 
 def filter_legal_metafield(fields):

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -469,6 +469,8 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
     import logging
     import os
 
+    from datalad.distribution.add import Add
+    from datalad.distribution.create import Create
     from datalad.distribution.dataset import Dataset
     from datalad.interface.results import get_status_dict
     import datalad.plugin.addurls as me

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1,0 +1,282 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Create and update a dataset from a list of URLs.
+"""
+
+from collections import Mapping
+from functools import partial
+import logging
+import os
+import string
+
+lgr = logging.getLogger("datalad.plugin.addurls")
+
+__docformat__ = "restructuredtext"
+
+
+class Formatter(string.Formatter):
+    """Formatter that gives precedence to custom keys.
+
+    The first positional argument to the `format` call should be a
+    mapping whose keys are exposed as placeholders (e.g.,
+    "{key1}.py").
+
+    Parameters
+    ----------
+    idx_to_name : dict
+        A mapping from a positional index to a key.  If not provided,
+        "{N}" elements are not supported.
+    """
+
+    def __init__(self, idx_to_name, *args, **kwargs):
+        self.idx_to_name = idx_to_name or {}
+        super(Formatter, self).__init__(*args, **kwargs)
+
+    def get_value(self, key, args, kwargs):
+        """Look for key's value in `args[0]` mapping first.
+        """
+        # FIXME: This approach will fail for keys that contain "!" and
+        # ":" because they'll be interpreted as formatting flags.
+        data = args[0]
+        if not isinstance(data, Mapping):
+            raise ValueError("First positional argument should be mapping")
+
+        try:
+            key_int = int(key)
+        except ValueError:
+            pass
+        else:
+            return data[self.idx_to_name[key_int]]
+
+        try:
+            return data[key]
+        except KeyError:
+            return super(Formatter, self).get_value(
+                key, args, kwargs)
+
+
+def extract(stream, input_type, filename_format, url_format):
+    """Extract and format information from `url_file`.
+
+    Parameters
+    ----------
+    stream : file object
+        Items used to construct the file names and URLs.
+
+    All other parameters match those described in `dlplugin`.
+
+    Returns
+    -------
+    A generator that, for each item in `url_file`, yields a tuple that
+    contains the formatted filename (with any "//" collapsed to a
+    single separator), the formatted url, and a list of subdataset
+    paths.  The length of the subdataset paths list will be equal to
+    the number of "//" occurrences in the `filename_format`.
+    """
+    if input_type == "csv":
+        import csv
+        csvrows = csv.reader(stream)
+        headers = next(csvrows)
+        lgr.debug("Taking %s fields from first line as headers: %s",
+                  len(headers), headers)
+        colidx_to_name = dict(enumerate(headers))
+        rows = (dict(zip(headers, r)) for r in csvrows)
+    elif input_type == "json":
+        import json
+        rows = json.load(stream)
+        # For json input, we do not support indexing by position,
+        # only names.
+        colidx_to_name = {}
+    else:
+        raise ValueError("input_type must be 'csv', 'json', or 'ext'")
+
+    fmt = Formatter(colidx_to_name)
+    format_filename = partial(fmt.format, filename_format)
+    format_url = partial(fmt.format, url_format)
+
+    for row in rows:
+        url = format_url(row)
+        filename = format_filename(row)
+
+        subpaths = []
+        if "//" in filename:
+            for part in filename.split("//")[:-1]:
+                subpaths.append(os.path.join(*(subpaths + [part])))
+            filename = filename.replace("//", os.path.sep)
+        yield filename, url, subpaths
+
+
+def dlplugin(dataset=None, url_file=None, input_type="ext",
+             url_format="{0}", filename_format="{1}",
+             message=None, dry_run=False, fast=False):
+    """Create and update a dataset from a list of URLs.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        Add the URLs to this dataset (or possibly subdatasets of this
+        dataset).  An empty or non-existent directory is passed to
+        create a new dataset.  New subdatasets can be specified with
+        `filename_format`.
+    url_file : str
+        A file that contains URLs or information that can be used to
+        construct URLs.  Depending on the value of `input_type`, this
+        should be a CSV file (with a header as the first row) or a
+        JSON file (structured as a list of objects with string
+        values).
+    input_type : {"ext", "csv", "json"}, optional
+        Whether `url_file` should be considered a CSV file or a JSON
+        file.  The default value, "ext", means to consider `url_file`
+        as a JSON file if it ends with ".json".  Otherwise, treat it
+        as a CSV file.
+    url_format : str, optional
+        A format string that specifies the URL for each entry.  This
+        value is similar to a normal Python format string where the
+        names from `url_file` (column names for a CSV or properties
+        for JSON) are available as placeholders.  If `url_file` is a
+        CSV file, a positional index can also be used (i.e., "{0}" for
+        the first column).  Note that a placeholder cannot contain a
+        ':' or '!'.
+    filename_format : str, optional
+        Like `url_format`, but this format string specifies the file
+        to which the URL's content will be downloaded.  The file name
+        may contain directories.  The separator "//" can be used to
+        indicate that the left-side directory should be created as a
+        new subdataset.
+    message : str, optional
+        Use this message when committing the URL additions.
+    dry_run : bool, optional
+        Report which URLs would be downloaded to which files and then
+        exit.
+    fast : bool, optional
+        If True, add the URLs, but don't download their content.
+        Underneath, this passes the --fast flag to `git annex addurl`.
+
+    Examples
+    --------
+    Consider a file "avatars.csv" that contains
+
+        who,ext,link
+        neurodebian,png,https://avatars3.githubusercontent.com/u/260793
+        datalad,png,https://avatars1.githubusercontent.com/u/8927200
+
+    To download each link into a file name composed of the 'who' and
+    'ext' fields, we could run
+
+        $ datalad plugin -d avatar_ds addurls url_file=avatars.csv
+          url_format='{link}' filename_format='{who}.{ext}' fast=True
+
+    The '-d avatar_ds' is used to create a new dataset in
+    "$PWD/avatar_ds".
+
+    If we were already in a dataset and wanted to create a new
+    subdataset in an "avatars" subdirectory, we could use "//" in the
+    `filename_format` argument:
+
+        $ datalad plugin addurls url_file=avatars.csv
+          url_format='{link}' filename_format='avatars//{who}.{ext}'
+          fast=True
+
+    Note
+    ----
+    For users familiar with 'git annex addurl': A large part of this
+    plugin's functionality can be viewed as transforming data from
+    `url_file` into a "url filename" format that fed to 'git annex
+    addurl --batch --with-files'.
+    """
+    from itertools import dropwhile
+    import logging
+    import os
+
+    from datalad.distribution.dataset import Dataset
+    from datalad.interface.results import get_status_dict
+    import datalad.plugin.addurls as me
+    from datalad.support.annexrepo import AnnexRepo
+
+    lgr = logging.getLogger("datalad.plugin.addurls")
+
+    if url_file is None:
+        # `url_file` is not a required argument in `dlplugin` because
+        # the argument before it, `dataset`, needs to be optional to
+        # support the creation of new datasets.
+        yield get_status_dict(action="addurls",
+                              ds=dataset,
+                              status="error",
+                              message="Must specify url_file argument")
+        return
+
+    if input_type == "ext":
+        extension = os.path.splitext(url_file)[1]
+        input_type = "json" if extension == ".json" else "csv"
+
+    with open(url_file) as fd:
+        info = me.extract(fd, input_type, filename_format, url_format)
+
+        if dry_run:
+            for fname, url, _ in info:
+                lgr.info("Would download %s to %s",
+                         url, os.path.join(dataset.path, fname))
+            yield get_status_dict(action="addurls",
+                                  ds=dataset,
+                                  status="ok",
+                                  message="dry-run finished")
+            return
+
+        if not dataset.repo:
+            # Populate a new dataset with the URLs.
+            dataset.create()
+        elif not isinstance(dataset.repo, AnnexRepo):
+            yield get_status_dict(action="addurls",
+                                  ds=dataset,
+                                  status="error",
+                                  message="not an annex repo")
+            return
+
+        annex_options = ["--fast"] if fast else []
+
+        seen_subpaths = set()
+        to_add = []
+        for fname, url, subpaths in info:
+            for spath in subpaths:
+                if spath not in seen_subpaths:
+                    if os.path.exists(os.path.join(dataset.path, spath)):
+                        lgr.warning(
+                            "Not creating subdataset at existing path: %s",
+                            spath)
+                    else:
+                        dataset.create(spath)
+                seen_subpaths.add(spath)
+
+            if subpaths:
+                # Adjust the dataset and filename for an `addurl` call
+                # from within the subdataset that will actually contain
+                # the link.
+                datasets = [Dataset(os.path.join(dataset.path, sp))
+                            for sp in subpaths]
+                ds_current = next(dropwhile(lambda d: not d.repo,
+                                            reversed(datasets)))
+                ds_filename = os.path.relpath(
+                    os.path.join(dataset.path, fname),
+                    ds_current.path)
+            else:
+                ds_current = dataset
+                ds_filename = fname
+
+            ds_current.repo.add_url_to_file(ds_filename, url,
+                                            batch=True, options=annex_options)
+            to_add.append(fname)
+
+        msg = message or """\
+[DATALAD] add files from URLs
+
+url_file='{}'
+url_format='{}'
+filename_format='{}'""".format(url_file, url_format, filename_format)
+        for r in dataset.add(to_add, message=msg):
+            yield r

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -66,6 +66,11 @@ class Formatter(string.Formatter):
             return super(Formatter, self).get_value(
                 key, args, kwargs)
 
+    def convert_field(self, value, conversion):
+        if conversion == 'l':
+            return str(value).lower()
+        return super(Formatter, self).convert_field(value, conversion)
+
 
 class RepFormatter(Formatter):
     """Extend Formatter to support a {_repindex} placeholder.

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -41,10 +41,9 @@ class Formatter(string.Formatter):
         its place.
     """
 
-    def __init__(self, idx_to_name, missing_value=None, *args, **kwargs):
+    def __init__(self, idx_to_name, missing_value=None):
         self.idx_to_name = idx_to_name or {}
         self.missing = missing_value
-        super(Formatter, self).__init__(*args, **kwargs)
 
     def format(self, format_string, *args, **kwargs):
         if not isinstance(args[0], Mapping):

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -634,9 +634,14 @@ filename_format='{}'""".format(url_file, url_format, filename_format)
     for meta_idx, (ds, fname, meta) in enumerate(meta_to_add, 1):
         pbar_meta.update(meta_idx)
         lgr.debug("Adding metadata to %s in %s", fname, ds.path)
+
+        meta_args = []
         for arg in meta:
-            ds.repo._run_annex_command("metadata",
-                                       annex_options=["--set", arg, fname])
+            meta_args.extend(["--set", arg])
+        meta_args.append(fname)
+
+        ds.repo._run_annex_command("metadata", annex_options=meta_args)
+
         meta_results.append(
             get_status_dict(action="addurls-metadata",
                             ds=ds_current,

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -52,8 +52,6 @@ class Formatter(string.Formatter):
 
     def get_value(self, key, args, kwargs):
         """Look for key's value in `args[0]` mapping first.
-
-
         """
         # FIXME: This approach will fail for keys that contain "!" and
         # ":" because they'll be interpreted as formatting flags.
@@ -388,16 +386,16 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
         subdataset.
 
         In addition to the placeholders described in `url_format`, there
-        are a few special placeholder.
+        are a few special placeholders.
 
-          - "_repindex"
+          - _repindex
 
             The constructed file names must be unique across all fields
             rows.  To avoid collisions, the special placeholder
-            "_repindex" can added to the formatter.  It value will start
-            at 0 and increment every time a file name repeats.
+            "_repindex" can be added to the formatter.  Its value will
+            start at 0 and increment every time a file name repeats.
 
-          - "_urlN"
+          - _urlN and _url_basename
 
             Each part of the formatted URL is available.  For example,
             in "http://datalad.org/for/git-users", "_url0" and "_url1"
@@ -430,7 +428,7 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
     ifexists : {None, 'overwrite', 'skip'}
         What to do if a constructed file name already exists.  The
         default (None) behavior to proceed with the `git annex addurl`,
-        which will failed if the file size has changed.  If set to
+        which will fail if the file size has changed.  If set to
         'overwrite', remove the old file before adding the new one.  If
         set to 'skip', do not add the new file.
     missing_value : str, optional

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -270,6 +270,13 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
 
             ds_current.repo.add_url_to_file(ds_filename, url,
                                             batch=True, options=annex_options)
+            yield get_status_dict(action="addurls",
+                                  ds=ds_current,
+                                  type="file",
+                                  path=os.path.join(ds_current.path,
+                                                    ds_filename),
+                                  status="ok")
+
             to_add.append(fname)
 
         msg = message or """\

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -41,14 +41,17 @@ class Formatter(string.Formatter):
         self.idx_to_name = idx_to_name or {}
         super(Formatter, self).__init__(*args, **kwargs)
 
+    def format(self, format_string, *args, **kwargs):
+        if not isinstance(args[0], Mapping):
+            raise ValueError("First positional argument should be mapping")
+        return super(Formatter, self).format(format_string, *args, **kwargs)
+
     def get_value(self, key, args, kwargs):
         """Look for key's value in `args[0]` mapping first.
         """
         # FIXME: This approach will fail for keys that contain "!" and
         # ":" because they'll be interpreted as formatting flags.
         data = args[0]
-        if not isinstance(data, Mapping):
-            raise ValueError("First positional argument should be mapping")
 
         try:
             key_int = int(key)

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -270,6 +270,30 @@ def _format_filenames(format_fn, rows, row_infos):
     return subpaths
 
 
+def get_file_parts(filename, prefix="name"):
+    """Assign a name to various parts of a file.
+
+    Parameters
+    ----------
+    filename : str
+        A file name (no leading path is permitted).
+    prefix : str
+        Prefix to prepend to the key names.
+
+    Returns
+    -------
+    A dict mapping each part to a value.
+    """
+    root, ext = os.path.splitext(filename)
+    root_lper, _, ext_lper = filename.partition(".")
+    if ext_lper:
+        ext_lper = "." + ext_lper
+    return {prefix: filename,
+            prefix + "_root": root,
+            prefix + "_ext": ext,
+            prefix + "_root_lper": root_lper,
+            prefix + "_ext_lper": ext_lper}
+
 def get_url_parts(url):
     """Assign a name to various parts of the URL.
 
@@ -296,7 +320,9 @@ def get_url_parts(url):
     url_parts = path.split("/")
     for pidx, part in enumerate(url_parts):
         names["_url{}".format(pidx)] = part
-    names["_url_basename"] = url_parts[-1]
+    basename = url_parts[-1]
+    names["_url_basename"] = basename
+    names.update(get_file_parts(basename, prefix="_url_basename"))
     return names
 
 
@@ -528,7 +554,7 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
             "_repindex" can be added to the formatter.  Its value will
             start at 0 and increment every time a file name repeats.
 
-          - _url_hostname, _urlN, _url_basename
+          - _url_hostname, _urlN, _url_basename*
 
             Various parts of the formatted URL are available.  Take
             "http://datalad.org/asciicast/seamless_nested_repos.sh" as
@@ -538,7 +564,14 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
             the URL's path can be referenced as "_urlN".  "_url0" and
             "_url1" would map to "asciicast" and "seamless_nested_repos.sh",
             respectively.  The final part of the path is also available
-            as "_url_basename".
+            as "_url_basename",
+
+           This name is broken down further.  "_url_basename_root" and
+           "_url_basename_ext" provide access to the result of
+           os.path.splitext ("seamless_nested_repos" and ".sh").  There
+           is also a "leftmost period" (lper) split.  Whereas the
+           regular split for "file.tar.gz" would label the extension as
+           ".gz", the lper split would label it as ".tar.gz".
     exclude_autometa : str, optional
         By default, metadata field=value pairs are constructed with each
         column in `url_file`, excluding any single column that is

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -494,6 +494,7 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
     from datalad.distribution.add import Add
     from datalad.distribution.create import Create
     from datalad.distribution.dataset import Dataset
+    from datalad.dochelpers import exc_str
     from datalad.interface.results import annexjson2result, get_status_dict
     import datalad.plugin.addurls as me
     from datalad.support.annexrepo import AnnexRepo
@@ -607,13 +608,13 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
         try:
             ds_current.repo.add_url_to_file(ds_filename, row["url"],
                                             batch=True, options=annex_options)
-        except AnnexBatchCommandError:
+        except AnnexBatchCommandError as exc:
             addurl_results.append(
                 get_status_dict(action="addurls",
                                 ds=ds_current,
                                 type="file",
                                 path=fname_abs,
-                                message="failed to add URL",
+                                message=exc_str(exc),
                                 status="error"))
 
             continue

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -612,8 +612,7 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
                 get_status_dict(action="addurls",
                                 ds=ds_current,
                                 type="file",
-                                path=os.path.join(ds_current.path,
-                                                  ds_filename),
+                                path=fname_abs,
                                 message="failed to add URL",
                                 status="error"))
 
@@ -624,8 +623,7 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
             get_status_dict(action="addurls",
                             ds=ds_current,
                             type="file",
-                            path=os.path.join(ds_current.path,
-                                              ds_filename),
+                            path=fname_abs,
                             status="ok"))
 
         files_to_add.append(row["filename"])

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -287,7 +287,7 @@ def get_url_names(url):
     return names
 
 
-def extract(stream, input_type, filename_format, url_format,
+def extract(stream, input_type, url_format, filename_format,
             exclude_autometa, meta, missing_value):
     """Extract and format information from `url_file`.
 
@@ -506,7 +506,7 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
 
     with open(url_file) as fd:
         rows, subpaths = me.extract(fd, input_type,
-                                    filename_format, url_format,
+                                    url_format, filename_format,
                                     exclude_autometa, meta,
                                     missing_value)
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -19,6 +19,8 @@ import string
 from six import string_types
 from six.moves.urllib.parse import urlparse
 
+from datalad.utils import assure_list
+
 lgr = logging.getLogger("datalad.plugin.addurls")
 
 __docformat__ = "restructuredtext"
@@ -287,8 +289,8 @@ def get_url_names(url):
     return names
 
 
-def extract(stream, input_type, url_format, filename_format,
-            exclude_autometa, meta, missing_value):
+def extract(stream, input_type, url_format="{0}", filename_format="{1}",
+            exclude_autometa=None, meta=None, missing_value=None):
     """Extract and format information from `url_file`.
 
     Parameters
@@ -304,6 +306,8 @@ def extract(stream, input_type, url_format, filename_format,
     for each row in `stream` and the second item is a set that contains all the
     subdataset paths.
     """
+    meta = assure_list(meta)
+
     rows, colidx_to_name = _read(stream, input_type)
 
     fmt = Formatter(colidx_to_name, missing_value)  # For URL and meta
@@ -476,12 +480,9 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
     import datalad.plugin.addurls as me
     from datalad.support.annexrepo import AnnexRepo
     from datalad.support.exceptions import AnnexBatchCommandError
-    from datalad.utils import assure_list
     from datalad.ui import ui
 
     lgr = logging.getLogger("datalad.plugin.addurls")
-
-    meta = assure_list(meta)
 
     if url_file is None:
         # `url_file` is not a required argument in `dlplugin` because

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -270,7 +270,7 @@ def _format_filenames(format_fn, rows, row_infos):
     return subpaths
 
 
-def get_url_names(url):
+def get_url_parts(url):
     """Assign a name to various parts of the URL.
 
     Parameters
@@ -359,7 +359,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
     # information about the formatted URLs.
     if any(i.startswith("_url") for i in get_fmt_names(filename_format)):
         for row, info in zip(rows_with_url, infos):
-            row.update(get_url_names(info["url"]))
+            row.update(get_url_parts(info["url"]))
 
     # For the file name, we allow the _repindex special key.
     format_filename = partial(

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -41,7 +41,7 @@ class Formatter(string.Formatter):
         its place.
     """
 
-    def __init__(self, idx_to_name, missing_value=None):
+    def __init__(self, idx_to_name=None, missing_value=None):
         self.idx_to_name = idx_to_name or {}
         self.missing = missing_value
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -82,8 +82,7 @@ def clean_meta_args(args):
                 raise ValueError("Empty field name")
             field, value = parts
         else:
-            field = "tag"
-            value = parts[0]
+            raise ValueError("meta argument isn't in 'field=value' format")
 
         if not value:
             # The `url_file` may have an empty value.
@@ -218,9 +217,8 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
         A format string that specifies metadata.  It should be
         structured as "<field>=<value>".  The same placeholders from
         `url_format` can be used.  As an example, "location={3}" would
-        mean that the value for the "location" metadata field should
-        be set the value of the fourth column.  A plain value is
-        shorthand for "tag=<value>".  This option can be given
+        mean that the value for the "location" metadata field should be
+        set the value of the fourth column.  This option can be given
         multiple times.
     message : str, optional
         Use this message when committing the URL additions.

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -177,6 +177,9 @@ def is_legal_metafield(name):
 
 def filter_legal_metafield(fields):
     """Remove illegal names from `fields`.
+
+    Note: This is like `filter(is_legal_metafield, fields)` but the
+    dropped values are logged.
     """
     legal = []
     for field in fields:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -297,6 +297,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
     ----------
     stream : file object
         Items used to construct the file names and URLs.
+    input_type : {'csv', 'json'}
 
     All other parameters match those described in `dlplugin`.
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -265,7 +265,7 @@ def _format_filenames(format_fn, rows, row_infos):
 
 
 def get_url_names(url):
-    """Assign a name to each part of a URL's path.
+    """Assign a name to various parts of the URL.
 
     Parameters
     ----------
@@ -273,16 +273,21 @@ def get_url_names(url):
 
     Returns
     -------
-    A dict with keys '_url0' through '_urlN' for a path with N+1
-    components.  There is also a `_url_basename` for the rightmost
-    entry.
+    A dict with keys `_url_hostname` and, for a path with N+1 parts,
+    '_url0' through '_urlN' .  There is also a `_url_basename` key for
+    the rightmost part of the path.
     """
-    path = urlparse(url).path.strip("/")
-    if not path:
+    parsed = urlparse(url)
+    if not parsed.netloc:
         return {}
 
+    names = {"_url_hostname": parsed.netloc}
+
+    path = parsed.path.strip("/")
+    if not path:
+        return names
+
     url_parts = path.split("/")
-    names = {}
     for pidx, part in enumerate(url_parts):
         names["_url{}".format(pidx)] = part
     names["_url_basename"] = url_parts[-1]
@@ -400,13 +405,16 @@ def dlplugin(dataset=None, url_file=None, input_type="ext",
             "_repindex" can be added to the formatter.  Its value will
             start at 0 and increment every time a file name repeats.
 
-          - _urlN and _url_basename
+          - _url_hostname, _urlN, and _url_basename
 
-            Each part of the formatted URL is available.  For example,
-            in "http://datalad.org/for/git-users", "_url0" and "_url1"
-            would map to "for" and "git-users", respectively.
+            Various parts of the formatted URL are available.  If the
+            formatted URL is "http://datalad.org/for/git-users",
+            "datalad.org" is stored as "_url_hostname".
 
-            The final part is also available as "_url_basename".
+            Components of the URL's path can be referenced as "_urlN".
+            In the example URL above, "_url0" and "_url1" would map to
+            "for" and "git-users", respectively.  The final part of the
+            path is also available as "_url_basename".
     exclude_autometa : str, optional
         By default, metadata field=value pairs are constructed with each
         column in `url_file`, excluding any single column that is

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -62,6 +62,19 @@ def test_formatter_placeholder_nonpermitted_chars():
                   fmt.format, "{key:<5}", {"key:<5": "value0"})
 
 
+def test_repformatter():
+    fmt = addurls.RepFormatter({})
+
+    for i in range(3):
+        assert fmt.format("{c}{_repindex}", {"c": "x"}) == "x{}".format(i)
+    # A new result gets a fresh index.
+    for i in range(2):
+        assert fmt.format("{c}{_repindex}", {"c": "y"}) == "y{}".format(i)
+    # We count even if _repindex isn't there.
+    assert fmt.format("{c}", {"c": "z0"}) == "z0"
+    assert fmt.format("{c}{_repindex}", {"c": "z"}) == "z1"
+
+
 def test_clean_meta_args():
     for args, expect in [(["field="], []),
                          ([" field=yes "], ["field=yes"]),

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -151,17 +151,20 @@ def test_fmt_to_name():
 
 def test_get_url_names():
     eq_(addurls.get_url_names(""), {})
-    eq_(addurls.get_url_names("http://datalad.org"), {})
+    assert_dict_equal(addurls.get_url_names("http://datalad.org"),
+                      {"_url_hostname": "datalad.org"})
 
     assert_dict_equal(addurls.get_url_names("http://datalad.org/about.html"),
-                      {"_url0": "about.html",
+                      {"_url_hostname": "datalad.org",
+                       "_url0": "about.html",
                        "_url_basename": "about.html"})
     assert_dict_equal(addurls.get_url_names("http://datalad.org/about.html"),
                       addurls.get_url_names("http://datalad.org//about.html"))
 
     assert_dict_equal(
         addurls.get_url_names("http://datalad.org/for/git-users"),
-        {"_url0": "for",
+        {"_url_hostname": "datalad.org",
+         "_url0": "for",
          "_url1": "git-users",
          "_url_basename": "git-users"})
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -74,6 +74,16 @@ def test_clean_meta_args():
                   addurls.clean_meta_args(["=value"]))
 
 
+def test_get_subpaths():
+    for fname, expect in [("no/dbl/slash", ("no/dbl/slash", [])),
+                          ("p1//n", ("p1/n", ["p1"])),
+                          ("p1//p2/p3//n", ("p1/p2/p3/n",
+                                            ["p1", "p1/p2/p3"])),
+                          ("//n", ("/n", [""])),
+                          ("n//", ("n/", ["n"]))]:
+        assert addurls.get_subpaths(fname) == expect
+
+
 ST_DATA = {"header": ["name", "debut_season", "age_group", "now_dead"],
            "rows": [{"name": "will", "debut_season": 1,
                      "age_group": "kid", "now_dead": "no"},

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -151,6 +151,15 @@ def test_fmt_to_name():
     assert_false(addurls.fmt_to_name("{}", {}))
 
 
+def test_get_file_parts():
+    assert_dict_equal(addurls.get_file_parts("file.tar.gz", "prefix"),
+                      {"prefix": "file.tar.gz",
+                       "prefix_root": "file.tar",
+                       "prefix_ext": ".gz",
+                       "prefix_root_lper": "file",
+                       "prefix_ext_lper": ".tar.gz"})
+
+
 def test_get_url_parts():
     eq_(addurls.get_url_parts(""), {})
     assert_dict_equal(addurls.get_url_parts("http://datalad.org"),
@@ -159,7 +168,11 @@ def test_get_url_parts():
     assert_dict_equal(addurls.get_url_parts("http://datalad.org/about.html"),
                       {"_url_hostname": "datalad.org",
                        "_url0": "about.html",
-                       "_url_basename": "about.html"})
+                       "_url_basename": "about.html",
+                       "_url_basename_root": "about",
+                       "_url_basename_ext": ".html",
+                       "_url_basename_root_lper": "about",
+                       "_url_basename_ext_lper": ".html"})
     assert_dict_equal(addurls.get_url_parts("http://datalad.org/about.html"),
                       addurls.get_url_parts("http://datalad.org//about.html"))
 
@@ -168,7 +181,11 @@ def test_get_url_parts():
         {"_url_hostname": "datalad.org",
          "_url0": "for",
          "_url1": "git-users",
-         "_url_basename": "git-users"})
+         "_url_basename": "git-users",
+         "_url_basename_root": "git-users",
+         "_url_basename_ext": "",
+         "_url_basename_root_lper": "git-users",
+         "_url_basename_ext_lper": ""})
 
 
 ST_DATA = {"header": ["name", "debut_season", "age_group", "now_dead"],

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -151,20 +151,20 @@ def test_fmt_to_name():
     assert_false(addurls.fmt_to_name("{}", {}))
 
 
-def test_get_url_names():
-    eq_(addurls.get_url_names(""), {})
-    assert_dict_equal(addurls.get_url_names("http://datalad.org"),
+def test_get_url_parts():
+    eq_(addurls.get_url_parts(""), {})
+    assert_dict_equal(addurls.get_url_parts("http://datalad.org"),
                       {"_url_hostname": "datalad.org"})
 
-    assert_dict_equal(addurls.get_url_names("http://datalad.org/about.html"),
+    assert_dict_equal(addurls.get_url_parts("http://datalad.org/about.html"),
                       {"_url_hostname": "datalad.org",
                        "_url0": "about.html",
                        "_url_basename": "about.html"})
-    assert_dict_equal(addurls.get_url_names("http://datalad.org/about.html"),
-                      addurls.get_url_names("http://datalad.org//about.html"))
+    assert_dict_equal(addurls.get_url_parts("http://datalad.org/about.html"),
+                      addurls.get_url_parts("http://datalad.org//about.html"))
 
     assert_dict_equal(
-        addurls.get_url_names("http://datalad.org/for/git-users"),
+        addurls.get_url_parts("http://datalad.org/for/git-users"),
         {"_url_hostname": "datalad.org",
          "_url0": "for",
          "_url1": "git-users",

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -187,9 +187,8 @@ def json_stream(data):
 def test_extract():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
-        "{name}_{debut_season}.com",
-        "{age_group}//{now_dead}//{name}.csv",
-        None, [], None)
+        url_format="{name}_{debut_season}.com",
+        filename_format="{age_group}//{now_dead}//{name}.csv")
 
     eq_(subpaths,
         {"kid", "kid/no", "adult", "adult/yes", "adult/no"})
@@ -214,11 +213,11 @@ def test_extract():
 def test_extract_disable_autometa():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
-        "{name}_{debut_season}.com",
-        "{age_group}//{now_dead}//{name}.csv",
-        "*",
-        ["group={age_group}"],
-        None)
+        url_format="{name}_{debut_season}.com",
+        filename_format="{age_group}//{now_dead}//{name}.csv",
+        exclude_autometa="*",
+        meta=["group={age_group}"])
+
 
     eq_([d["meta_args"] for d in info],
         [["group=kid"], ["group=adult"], ["group=adult"], ["group=kid"]])
@@ -227,11 +226,9 @@ def test_extract_disable_autometa():
 def test_extract_exclude_autometa_regexp():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
-        "{name}_{debut_season}.com",
-        "{age_group}//{now_dead}//{name}.csv",
-        "ea",
-        [],
-        None)
+        url_format="{name}_{debut_season}.com",
+        filename_format="{age_group}//{now_dead}//{name}.csv",
+        exclude_autometa="ea")
 
     eq_([set(d["meta_args"]) for d in info],
         [{"name=will", "age_group=kid"},
@@ -245,22 +242,20 @@ def test_extract_csv_json_equal():
     csv_rows.extend(",".join(str(row[k]) for k in keys)
                     for row in ST_DATA["rows"])
 
-    args = ["{name}_{debut_season}.com",
-            "{age_group}//{now_dead}//{name}.csv",
-            None,
-            ["group={age_group}"],
-            None]
+    kwds = dict(filename_format="{age_group}//{now_dead}//{name}.csv",
+                url_format="{name}_{debut_season}.com",
+                meta=["group={age_group}"])
 
-    json_output = addurls.extract(json_stream(ST_DATA["rows"]), "json", *args)
-    csv_output = addurls.extract(csv_rows, "csv", *args)
+
+    json_output = addurls.extract(json_stream(ST_DATA["rows"]), "json", **kwds)
+    csv_output = addurls.extract(csv_rows, "csv", **kwds)
 
     eq_(json_output, csv_output)
 
 
 def test_extract_wrong_input_type():
     assert_raises(ValueError,
-                  addurls.extract,
-                  None, "not_csv_or_json", None, None, None, None, None)
+                  addurls.extract, None, "not_csv_or_json")
 
 
 def test_addurls_no_urlfile():

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -101,17 +101,17 @@ def test_repformatter():
 
 
 def test_clean_meta_args():
-    for args, expect in [(["field="], []),
-                         ([" field=yes "], ["field=yes"]),
-                         (["field= value="], ["field=value="])]:
-        eq_(list(addurls.clean_meta_args(args)), expect)
+    for args, expect in [(["field="], {}),
+                         ([" field=yes "], {"field": "yes"}),
+                         (["field= value="], {"field": "value="})]:
+        eq_(addurls.clean_meta_args(args), expect)
 
     assert_raises(ValueError,
-                  list,
-                  addurls.clean_meta_args(["noequal"]))
+                  addurls.clean_meta_args,
+                  ["noequal"])
     assert_raises(ValueError,
-                  list,
-                  addurls.clean_meta_args(["=value"]))
+                  addurls.clean_meta_args,
+                  ["=value"])
 
 
 def test_get_subpaths():
@@ -203,11 +203,16 @@ def test_extract():
         ["kid/no/will.csv", "adult/yes/bob.csv",
          "adult/no/scott.csv", "kid/no/max.csv"])
 
-    eq_([set(d["meta_args"]) for d in info],
-        [{"name=will", "age_group=kid", "debut_season=1", "now_dead=no"},
-         {"name=bob", "age_group=adult", "debut_season=2", "now_dead=yes"},
-         {"name=scott", "age_group=adult", "debut_season=1", "now_dead=no"},
-         {"name=max", "age_group=kid", "debut_season=2", "now_dead=no"}])
+    expects = [{"name": "will", "age_group": "kid", "debut_season": "1",
+                "now_dead": "no"},
+               {"name": "bob", "age_group": "adult", "debut_season": "2",
+                "now_dead": "yes"},
+               {"name": "scott", "age_group": "adult", "debut_season": "1",
+                "now_dead": "no"},
+               {"name": "max", "age_group": "kid", "debut_season": "2",
+                "now_dead": "no"}]
+    for d, expect in zip(info, expects):
+        assert_dict_equal(d["meta_args"], expect)
 
     eq_([d["subpath"] for d in info],
         ["kid/no", "adult/yes", "adult/no", "kid/no"])
@@ -223,7 +228,8 @@ def test_extract_disable_autometa():
 
 
     eq_([d["meta_args"] for d in info],
-        [["group=kid"], ["group=adult"], ["group=adult"], ["group=kid"]])
+        [{"group": "kid"}, {"group": "adult"}, {"group": "adult"},
+         {"group": "kid"}])
 
 
 def test_extract_exclude_autometa_regexp():
@@ -233,11 +239,13 @@ def test_extract_exclude_autometa_regexp():
         filename_format="{age_group}//{now_dead}//{name}.csv",
         exclude_autometa="ea")
 
-    eq_([set(d["meta_args"]) for d in info],
-        [{"name=will", "age_group=kid"},
-         {"name=bob", "age_group=adult"},
-         {"name=scott", "age_group=adult"},
-         {"name=max", "age_group=kid"}])
+    expects = [{"name": "will", "age_group": "kid"},
+               {"name": "bob", "age_group": "adult"},
+               {"name": "scott", "age_group": "adult"},
+               {"name": "max", "age_group": "kid"}]
+    for d, expect in zip(info, expects):
+        assert_dict_equal(d["meta_args"], expect)
+
 
 def test_extract_csv_json_equal():
     keys = ST_DATA["header"]

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -63,12 +63,14 @@ def test_formatter_placeholder_nonpermitted_chars():
 
 
 def test_clean_meta_args():
-    for args, expect in [(["", "field="], []),
+    for args, expect in [(["field="], []),
                          ([" field=yes "], ["field=yes"]),
-                         ([" atag "], ["tag=atag"]),
                          (["field= value="], ["field=value="])]:
         assert list(addurls.clean_meta_args(args)) == expect
 
+    assert_raises(ValueError,
+                  list,
+                  addurls.clean_meta_args(["noequal"]))
     assert_raises(ValueError,
                   list,
                   addurls.clean_meta_args(["=value"]))

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -93,11 +93,15 @@ def json_stream(data):
 
 
 def test_extract():
-    fnames, urls, meta, subpaths = zip(*addurls.extract(
+    info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
         "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
-        ["group={age_group}"]))
+        ["group={age_group}"])
+
+    assert subpaths == {"kid", "kid/no", "adult", "adult/yes", "adult/no"}
+
+    fnames, urls, meta, subdss = zip(*info)
 
     assert urls == ("will_1.com", "bob_2.com", "scott_1.com", "max_2.com")
 
@@ -107,8 +111,7 @@ def test_extract():
     assert meta == (["group=kid"], ["group=adult"],
                     ["group=adult"], ["group=kid"])
 
-    assert subpaths == (["kid", "kid/no"], ["adult", "adult/yes"],
-                        ["adult", "adult/no"], ["kid", "kid/no"])
+    assert subdss == ("kid/no", "adult/yes", "adult/no", "kid/no")
 
 
 def test_extract_csv_json_equal():
@@ -124,10 +127,10 @@ def test_extract_csv_json_equal():
     json_output = addurls.extract(json_stream(ST_DATA["rows"]), "json", *args)
     csv_output = addurls.extract(csv_rows, "csv", *args)
 
-    assert list(json_output) == list(csv_output)
+    assert json_output == csv_output
 
 
 def test_extract_wrong_input_type():
     assert_raises(ValueError,
-                  list,
-                  addurls.extract(None, "not_csv_or_json", None, None, None))
+                  addurls.extract,
+                  None, "not_csv_or_json", None, None, None)

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -1,0 +1,116 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test addurls plugin"""
+
+import json
+from six.moves import StringIO
+
+from datalad.tests.utils import assert_raises
+from datalad.plugin import addurls
+
+
+def test_formatter():
+    idx_to_name = {i: "col{}".format(i) for i in range(4)}
+    values = {"col{}".format(i): "value{}".format(i) for i in range(4)}
+
+    fmt = addurls.Formatter(idx_to_name)
+
+    fmt.format("{0}", values) == "value0"
+    fmt.format("{0}", values) == fmt.format("{col0}", values)
+
+    # Integer placeholders outside of `idx_to_name` don't work.
+    assert_raises(KeyError, fmt.format, "{4}", values, 1, 2, 3, 4)
+
+    # If the named placeholder is not in `values`, falls back to normal
+    # formatting.
+    fmt.format("{notinvals}", values, notinvals="ok") == "ok"
+
+
+def test_formatter_no_idx_map():
+    fmt = addurls.Formatter({})
+    assert_raises(KeyError, fmt.format, "{0}", {"col0": "value0"})
+
+
+def test_formatter_no_mapping_arg():
+    fmt = addurls.Formatter({})
+    assert_raises(ValueError, fmt.format, "{0}", "not a mapping")
+
+
+def test_formatter_placeholder_with_spaces():
+    fmt = addurls.Formatter({})
+    fmt.format("{with spaces}", {"with spaces": "value0"}) == "value0"
+
+
+def test_formatter_placeholder_nonpermitted_chars():
+    fmt = addurls.Formatter({})
+
+    # Can't assess keys with !, which will be interpreted as a conversion flag.
+    fmt.format("{key!r}", {"key!r": "value0"}, key="x") == "x"
+    assert_raises(KeyError,
+                  fmt.format, "{key!r}", {"key!r": "value0"})
+
+    # Same for ":".
+    fmt.format("{key:<5}", {"key:<5": "value0"}, key="x") == "x    "
+    assert_raises(KeyError,
+                  fmt.format, "{key:<5}", {"key:<5": "value0"})
+
+
+ST_DATA = {"header": ["name", "debut_season", "age_group", "now_dead"],
+           "rows": [{"name": "will", "debut_season": 1,
+                     "age_group": "kid", "now_dead": "no"},
+                    {"name": "bob", "debut_season": 2,
+                     "age_group": "adult", "now_dead": "yes"},
+                    {"name": "scott", "debut_season": 1,
+                     "age_group": "adult", "now_dead": "no"},
+                    {"name": "max", "debut_season": 2,
+                     "age_group": "kid", "now_dead": "no"}]}
+
+
+def json_stream(data):
+    stream = StringIO()
+    json.dump(data, stream)
+    stream.seek(0)
+    return stream
+
+
+def test_extract():
+    fnames, urls, subpaths = zip(*addurls.extract(
+        json_stream(ST_DATA["rows"]), "json",
+        "{age_group}//{now_dead}//{name}.csv",
+        "{name}_{debut_season}.com"))
+
+    assert urls == ("will_1.com", "bob_2.com", "scott_1.com", "max_2.com")
+
+    assert fnames == ("kid/no/will.csv", "adult/yes/bob.csv",
+                      "adult/no/scott.csv", "kid/no/max.csv")
+
+    assert subpaths == (["kid", "kid/no"], ["adult", "adult/yes"],
+                        ["adult", "adult/no"], ["kid", "kid/no"])
+
+
+def test_extract_csv_json_equal():
+    keys = ST_DATA["header"]
+    csv_rows = [",".join(keys)]
+    csv_rows.extend(",".join(str(row[k]) for k in keys)
+                    for row in ST_DATA["rows"])
+
+    args = ["{age_group}//{now_dead}//{name}.csv",
+            "{name}_{debut_season}.com"]
+
+    json_output = addurls.extract(json_stream(ST_DATA["rows"]), "json", *args)
+    csv_output = addurls.extract(csv_rows, "csv", *args)
+
+    assert list(json_output) == list(csv_output)
+
+
+def test_extract_wrong_input_type():
+    assert_raises(ValueError,
+                  list,
+                  addurls.extract(None, "not_csv_or_json", None, None))

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -81,6 +81,12 @@ def test_formatter_placeholder_nonpermitted_chars():
                   fmt.format, "{key:<5}", {"key:<5": "value0"})
 
 
+def test_formatter_missing_arg():
+    fmt = addurls.Formatter({}, "NA")
+    eq_(fmt.format("{here},{nothere}", {"here": "ok", "nothere": ""}),
+        "ok,NA")
+
+
 def test_repformatter():
     fmt = addurls.RepFormatter({})
 
@@ -183,7 +189,7 @@ def test_extract():
         json_stream(ST_DATA["rows"]), "json",
         "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
-        False, [])
+        False, [], None)
 
     eq_(subpaths,
         {"kid", "kid/no", "adult", "adult/yes", "adult/no"})
@@ -211,7 +217,8 @@ def test_extract_no_autometa():
         "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
         True,
-        ["group={age_group}"])
+        ["group={age_group}"],
+        None)
 
     eq_([d["meta_args"] for d in info],
         [["group=kid"], ["group=adult"], ["group=adult"], ["group=kid"]])
@@ -226,7 +233,8 @@ def test_extract_csv_json_equal():
     args = ["{age_group}//{now_dead}//{name}.csv",
             "{name}_{debut_season}.com",
             False,
-            ["group={age_group}"]]
+            ["group={age_group}"],
+            None]
 
     json_output = addurls.extract(json_stream(ST_DATA["rows"]), "json", *args)
     csv_output = addurls.extract(csv_rows, "csv", *args)
@@ -237,7 +245,7 @@ def test_extract_csv_json_equal():
 def test_extract_wrong_input_type():
     assert_raises(ValueError,
                   addurls.extract,
-                  None, "not_csv_or_json", None, None, None, None)
+                  None, "not_csv_or_json", None, None, None, None, None)
 
 
 def test_addurls_no_urlfile():

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -171,22 +171,21 @@ def test_extract():
     eq_(subpaths,
         {"kid", "kid/no", "adult", "adult/yes", "adult/no"})
 
-    fnames, urls, meta, subdss = zip(*info)
+    eq_([d["url"] for d in info],
+        ["will_1.com", "bob_2.com", "scott_1.com", "max_2.com"])
 
-    eq_(urls,
-        ("will_1.com", "bob_2.com", "scott_1.com", "max_2.com"))
+    eq_([d["filename"] for d in info],
+        ["kid/no/will.csv", "adult/yes/bob.csv",
+         "adult/no/scott.csv", "kid/no/max.csv"])
 
-    eq_(fnames,
-        ("kid/no/will.csv", "adult/yes/bob.csv",
-         "adult/no/scott.csv", "kid/no/max.csv"))
-
-    eq_(list(map(set, meta)),
+    eq_([set(d["meta_args"]) for d in info],
         [{"name=will", "age_group=kid", "debut_season=1", "now_dead=no"},
          {"name=bob", "age_group=adult", "debut_season=2", "now_dead=yes"},
          {"name=scott", "age_group=adult", "debut_season=1", "now_dead=no"},
          {"name=max", "age_group=kid", "debut_season=2", "now_dead=no"}])
 
-    eq_(subdss, ("kid/no", "adult/yes", "adult/no", "kid/no"))
+    eq_([d["subpath"] for d in info],
+        ["kid/no", "adult/yes", "adult/no", "kid/no"])
 
 
 def test_extract_no_autometa():
@@ -197,10 +196,8 @@ def test_extract_no_autometa():
         True,
         ["group={age_group}"])
 
-    meta = list(zip(*info))[2]
-
-    eq_(meta,
-        (["group=kid"], ["group=adult"], ["group=adult"], ["group=kid"]))
+    eq_([d["meta_args"] for d in info],
+        [["group=kid"], ["group=adult"], ["group=adult"], ["group=kid"]])
 
 
 def test_extract_csv_json_equal():

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -187,8 +187,8 @@ def json_stream(data):
 def test_extract():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
-        "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
+        "{age_group}//{now_dead}//{name}.csv",
         None, [], None)
 
     eq_(subpaths,
@@ -214,8 +214,8 @@ def test_extract():
 def test_extract_disable_autometa():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
-        "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
+        "{age_group}//{now_dead}//{name}.csv",
         "*",
         ["group={age_group}"],
         None)
@@ -227,8 +227,8 @@ def test_extract_disable_autometa():
 def test_extract_exclude_autometa_regexp():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
-        "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
+        "{age_group}//{now_dead}//{name}.csv",
         "ea",
         [],
         None)
@@ -245,8 +245,8 @@ def test_extract_csv_json_equal():
     csv_rows.extend(",".join(str(row[k]) for k in keys)
                     for row in ST_DATA["rows"])
 
-    args = ["{age_group}//{now_dead}//{name}.csv",
-            "{name}_{debut_season}.com",
+    args = ["{name}_{debut_season}.com",
+            "{age_group}//{now_dead}//{name}.csv",
             None,
             ["group={age_group}"],
             None]

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -189,7 +189,7 @@ def test_extract():
         json_stream(ST_DATA["rows"]), "json",
         "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
-        False, [], None)
+        None, [], None)
 
     eq_(subpaths,
         {"kid", "kid/no", "adult", "adult/yes", "adult/no"})
@@ -211,18 +211,33 @@ def test_extract():
         ["kid/no", "adult/yes", "adult/no", "kid/no"])
 
 
-def test_extract_no_autometa():
+def test_extract_disable_autometa():
     info, subpaths = addurls.extract(
         json_stream(ST_DATA["rows"]), "json",
         "{age_group}//{now_dead}//{name}.csv",
         "{name}_{debut_season}.com",
-        True,
+        "*",
         ["group={age_group}"],
         None)
 
     eq_([d["meta_args"] for d in info],
         [["group=kid"], ["group=adult"], ["group=adult"], ["group=kid"]])
 
+
+def test_extract_exclude_autometa_regexp():
+    info, subpaths = addurls.extract(
+        json_stream(ST_DATA["rows"]), "json",
+        "{age_group}//{now_dead}//{name}.csv",
+        "{name}_{debut_season}.com",
+        "ea",
+        [],
+        None)
+
+    eq_([set(d["meta_args"]) for d in info],
+        [{"name=will", "age_group=kid"},
+         {"name=bob", "age_group=adult"},
+         {"name=scott", "age_group=adult"},
+         {"name=max", "age_group=kid"}])
 
 def test_extract_csv_json_equal():
     keys = ST_DATA["header"]
@@ -232,7 +247,7 @@ def test_extract_csv_json_equal():
 
     args = ["{age_group}//{now_dead}//{name}.csv",
             "{name}_{debut_season}.com",
-            False,
+            None,
             ["group={age_group}"],
             None]
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -33,6 +33,13 @@ def test_formatter():
     fmt.format("{notinvals}", values, notinvals="ok") == "ok"
 
 
+def test_formatter_lower_case():
+    fmt = addurls.Formatter({0: "key"})
+    assert fmt.format("{key!l}", {"key": "UP"}) == "up"
+    assert fmt.format("{0!l}", {"key": "UP"}) == "up"
+    assert fmt.format("{other!s}", {}, other=[1, 2]) == "[1, 2]"
+
+
 def test_formatter_no_idx_map():
     fmt = addurls.Formatter({})
     assert_raises(KeyError, fmt.format, "{0}", {"col0": "value0"})

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -344,16 +344,10 @@ class TestAddurls(object):
             for fname in filenames:
                 ok_exists(fname)
 
-            meta_results = dict(
-                zip(filenames,
-                    ds.repo._run_annex_command_json("metadata",
-                                                    files=filenames)))
-
-            for fname, subdir in zip(filenames, ["foo", "bar", "foo"]):
-                assert_dict_equal(
-                    {k: v for k, v in meta_results[fname]["fields"].items()
-                     if not k.endswith("lastchanged")},
-                    {"subdir": [subdir], "name": [fname]})
+            for (fname, meta), subdir in zip(ds.repo.get_metadata(filenames),
+                                             ["foo", "bar", "foo"]):
+                assert_dict_equal(meta,
+                                  {"subdir": [subdir], "name": [fname]})
 
             # Add to already existing links, overwriting.
             with swallow_logs(new_level=logging.DEBUG) as cml:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2076,8 +2076,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             if not out_json.get('success', False):
                 raise AnnexBatchCommandError(
                     cmd="addurl",
-                    msg="Error, annex reported failure for addurl: %s"
-                    % str(out_json))
+                    msg="Error, annex reported failure for addurl (url='%s'): %s"
+                    % (url, str(out_json)))
             return out_json
 
     def add_urls(self, urls, options=None, backend=None, cwd=None,

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -178,7 +178,7 @@ def __urlopen_requests(url):
     if isinstance(url, Request):
         url = url.get_full_url()
     from requests import Session
-    return Session().get(url)
+    return Session().get(url, stream=True)
 
 
 def retry_urlopen(url, retries=3):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -521,6 +521,68 @@ def _multiproc_serve_path_via_http(hostname, path_to_serve_from, queue): # pragm
     httpd.serve_forever()
 
 
+class HTTPPath(object):
+    """Serve the content of a path via an HTTP URL.
+
+    This class can be used as a context manager, in which case it returns the
+    URL.
+
+    Alternatively, the `start` and `stop` methods can be called directly.
+
+    Parameters
+    ----------
+    path : str
+        Directory with content to serve.
+    """
+    def __init__(self, path):
+        self.path = path
+        self.url = None
+        self._env_patch = None
+        self._mproc = None
+
+    def __enter__(self):
+        self.start()
+        return self.url
+
+    def __exit__(self, *args):
+        self.stop()
+
+    def start(self):
+        """Start serving `path` via HTTP.
+        """
+        # There is a problem with Haskell on wheezy trying to
+        # fetch via IPv6 whenever there is a ::1 localhost entry in
+        # /etc/hosts.  Apparently fixing that docker image reliably
+        # is not that straightforward, although see
+        # http://jasonincode.com/customizing-hosts-file-in-docker/
+        # so we just force to use 127.0.0.1 while on wheezy
+        #hostname = '127.0.0.1' if on_debian_wheezy else 'localhost'
+        hostname = '127.0.0.1'
+
+        queue = multiprocessing.Queue()
+        self._mproc = multiprocessing.Process(
+            target=_multiproc_serve_path_via_http,
+            args=(hostname, self.path, queue))
+        self._mproc.start()
+        port = queue.get(timeout=300)
+        self.url = 'http://{}:{}/'.format(hostname, port)
+        lgr.debug("HTTP: serving %s under %s", self.path, self.url)
+
+        # Such tests don't require real network so if http_proxy settings were
+        # provided, we remove them from the env for the duration of this run
+        env = os.environ.copy()
+        env.pop('http_proxy', None)
+        self._env_patch = patch.dict('os.environ', env, clear=True)
+        self._env_patch.start()
+
+    def stop(self):
+        """Stop serving `path`.
+        """
+        lgr.debug("HTTP: stopping server under %s", self.path)
+        self._env_patch.stop()
+        self._mproc.terminate()
+
+
 @optional_args
 def serve_path_via_http(tfunc, *targs):
     """Decorator which serves content of a directory via http url
@@ -539,35 +601,8 @@ def serve_path_via_http(tfunc, *targs):
         else:
             args, path = (), args[0]
 
-        # There is a problem with Haskell on wheezy trying to
-        # fetch via IPv6 whenever there is a ::1 localhost entry in
-        # /etc/hosts.  Apparently fixing that docker image reliably
-        # is not that straightforward, although see
-        # http://jasonincode.com/customizing-hosts-file-in-docker/
-        # so we just force to use 127.0.0.1 while on wheezy
-        #hostname = '127.0.0.1' if on_debian_wheezy else 'localhost'
-        hostname = '127.0.0.1'
-
-        queue = multiprocessing.Queue()
-        multi_proc = multiprocessing.Process(
-            target=_multiproc_serve_path_via_http,
-            args=(hostname, path, queue))
-        multi_proc.start()
-        port = queue.get(timeout=300)
-        url = 'http://{}:{}/'.format(hostname, port)
-        lgr.debug("HTTP: serving {} under {}".format(path, url))
-
-        try:
-            # Such tests don't require real network so if http_proxy settings were
-            # provided, we remove them from the env for the duration of this run
-            env = os.environ.copy()
-            env.pop('http_proxy', None)
-            with patch.dict('os.environ', env, clear=True):
-                return tfunc(*(args + (path, url)), **kwargs)
-        finally:
-            lgr.debug("HTTP: stopping server under %s" % path)
-            multi_proc.terminate()
-
+        with HTTPPath(path) as url:
+            return tfunc(*(args + (path, url)), **kwargs)
     return newfunc
 
 


### PR DESCRIPTION
This covers some basic features mentioned at gh-1665.

The few things it can do:

  * Data from a CSV or JSON file can be used to construct URLs and file names to be passed to 'git annex addurl'.

    The field names from the data file (header names for CSV or properties for JSON) can be used as placeholders like "{participant_id}.mgz".  However, names with "!" or ":" aren't currently supported because these are interpreted as formatting flags.

  * Subdatasets can be created by using "//" in the filename format string.

  * fast=True will pass --fast to 'git annex addurl'.

Some of what it can't do:

  * ~It doesn't yet have an option for specifying which columns should be used as metadata.~

  * ~There's no support for the Content-Disposition filename.~

  * There isn't a jobs flag that's passed --jobs=N to 'git annex addurl'.

  * There aren't any reserved formatting keys like "url_filename" or "disposition_filename".

    Update: Parts of the URL path are now exposed.

  * There isn't a non-'git annex addurl' download option (e.g., providers.download).

    And if we want to provide a non-addurl option, perhaps my choice to call this plugin `addurls` wasn't a good one.


And it of course needs tests.

### To add

Here's my current plan for what to add to this PR.

- [x] tests

- [x] support for setting metadata based on information in the file

- [x] add support for metadata

- [x] ability to provide replace empty strings with another missing value

- [x] parts of the URL path are now accessible in `filename_format` as `_url_0`, ..., `_url_N`.  There's also `_url_basename` for the rightmost url part.

- [x] progress bars for `addurl` and metadata actions

- [ ] batch `git annex metadata --set` calls?

  ~At the least, I should group the calls so that it calls once per file rather than once per file per metadata field.  (I hadn't realized you could use `--set` multiple times.)~

  Update: The call is now made once per file.

- [x] add support for the Content-Disposition filename.

### Maybe later

Things that I don't plan to add to this PR

- [ ] better way to handle the placeholder formatting?

  Nothing better has occurred to me yet.

- [ ] jobs flag

  I'm not sure if this is possible with batch commands.


### Changes

- [X] This is in progress

Please have a look @datalad/developers
