### PR TITLE
"Old" and new search in one command

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -617,7 +617,10 @@ class Metadata(Interface):
             action='store_true',
             doc="""if set, yields all (sub)datasets for which aggregate
             metadata are available in the dataset. No other action is
-            performed, even if other arguments are given."""),
+            performed, even if other arguments are given. The reported
+            results contain a datasets's ID, the commit hash at which
+            metadata aggregation was performed, and the location of the
+            object file(s) containing the aggregated metadata."""),
         reporton=reporton_opt,
         recursive=recursion_flag)
         # MIH: not sure of a recursion limit makes sense here
@@ -650,11 +653,16 @@ class Metadata(Interface):
                 return
             agginfos = _load_json_object(info_fpath)
             for sd in agginfos:
-                yield get_status_dict(
+                info = agginfos[sd]
+                info.update(
                     path=normpath(opj(refds_path, sd)),
                     type='dataset',
                     status='ok',
-                    **res_kwargs)
+                )
+                yield dict(
+                    info,
+                    **res_kwargs
+                )
             return
 
         if not dataset and not path and not show_keys:

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -382,6 +382,7 @@ def _get_search_index(index_dir, label, ds, force_reindex, get_schema, meta2doc,
             old_ds_rpath = admin['path']
 
         doc.update({k: assure_unicode(v) for k, v in admin.items()})
+        lgr.debug("Adding document to search index: {}".format(doc))
         # inject into index
         idx.add_document(**doc)
         idx_size += 1

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -552,7 +552,6 @@ class Search(Interface):
         mode=Parameter(
             args=("--mode",),
             choices=('default', 'autofield',),
-            nargs=1,
             doc="""Mode of search index structure and content. 'autofield': metadata
             fields are discovered automatically, datasets and files can be discovered.
             """),
@@ -615,6 +614,9 @@ class Search(Interface):
             documenttype = ds.config.obtain(
                 'datalad.metadata.searchindex-autofield-documenttype',
                 default='all')
+        else:
+            raise ValueError(
+                'unknown search mode "{}"'.format(mode))
 
         idx_obj = _get_search_index(
             index_dir,

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -103,7 +103,7 @@ def _listdict2dictlist(lst):
         if len(v)}
 
 
-def _meta2autofield_dict(meta, val2str=True):
+def _meta2autofield_dict(meta, val2str=True, schema=None):
     """Takes care of dtype conversion into unicode, potential key mappings
     and concatenation of sequence-type fields into CSV strings
     """
@@ -154,6 +154,9 @@ def _meta2autofield_dict(meta, val2str=True):
          # and the rest into unicode
          _any2unicode(v)) if val2str else v
         for k, v in _deep_kv('', meta or {})
+        # auto-exclude any key that is not a defined field in the schema (if there is
+        # a schema
+        if schema is None or k in schema
     }
 
 
@@ -207,11 +210,11 @@ def _doc_gen_autofield(ds, schema):
             # the metadata)
             recursive=True):
         meta = res.get('metadata', {})
-        # TODO have it validate field based on the actual schema -> pass that in
         doc = _meta2autofield_dict(
             meta,
             # this time stringification of values so whoosh can handle them
-            val2str=True)
+            val2str=True,
+            schema=schema)
         admin = {
             'type': res['type'],
             'path': relpath(res['path'], start=ds.path),
@@ -235,7 +238,7 @@ def _get_parser_autofield(idx_obj):
     # replace field defintion to allow for colons to be part of a field's name:
     parser.replace_plugin(qparse.FieldsPlugin(expr=r"(?P<text>[()<>.\w]+|[*]):"))
     return parser
- 
+
 
 def _get_search_index(index_dir, label, ds, force_reindex, get_schema, doc_gen):
     """Generic entrypoint to index generation

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -292,6 +292,8 @@ path
 type
 """)
 
+    # stupid yields nothing
+    assert_result_count(ds.search('blablob#'), 0)
     # now check that we can discover things from the aggregated metadata
     for mode, query, hitpath, matched_key, matched_val in (
             # random keyword query

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -333,13 +333,17 @@ type
             # query language configuration
     ):
         res = ds.search(query, mode=mode)
-        # always a file and the dataset, because they carry metadata in
-        # the same structure
-        assert_result_count(res, 2)
+        if mode == 'default':
+            # 'default' does datasets by default only (be could be configured otherwise
+            assert_result_count(res, 1)
+        else:
+            # the rest has always a file and the dataset, because they carry metadata in
+            # the same structure
+            assert_result_count(res, 2)
+            assert_result_count(
+                res, 1, type='file', path=opj(ds.path, hitpath))
         assert_result_count(
             res, 1, type='dataset', path=ds.path)
-        assert_result_count(
-            res, 1, type='file', path=opj(ds.path, hitpath))
         # test the key and specific value of the match
         assert_in(matched_key, res[-1]['query_matched'])
         assert_equal(res[-1]['query_matched'][matched_key], matched_val)


### PR DESCRIPTION
This PR RFs the `search` command to be able to handle multiple search modes. Currently supported are:

- `autofield`: this is what used to be the new search (two-pass, autodiscover schema, files and datasets)
- `default`: this is some some ways the old search, in some ways not

The new default behavior is to works on datasets only (but it has the ability to do files as well, unlike the old command). All metadata is currently coerced into a single string using a default whoosh text analyzer. Unit tests document what kind of searches work.

Additional metadata homogenization could be supported by introducing custom mappings (e.g. for neuro* datasets, etc.). This would be necessary to support the previously available 'search by field' in the old command. The current aggregated metadata has no homogenized fields, hence such thing is impossible without a known mapping.

Performance: I can generate a search index for a datasets that contains aggregated metadata from two subdatasets with 36k files each in under a second.

Multiple concurrent search indices for the respective search modes are supported too.

This is the end of the road folks... @datalad/developers 

As before, the buildbots cannot succeed, because the lack a suitable pybids version for the tests.