### PR TITLE
Remove "This is in progress" and unmark "complete" - mutually exclusive

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@ This pull request fixes #
 This pull request proposes
 
 ### Changes
-- [x] This change is complete
-- [ ] This is in progress
+- [ ] This change is complete
 
 Please have a look @datalad/developers


### PR DESCRIPTION
This pull request fixes confusion I had for a while on the purpose of two edit boxes where both cannot be marked at the same time (it is either WiP or complete).  May be I have missed the point.

### Changes
- [x] This change is complete

Please have a look @datalad/developers
