### PR TITLE
BF: Tolerate files starting with -

### DIFF
--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -133,9 +133,9 @@ def test_annex_get_from_subdir(topdir):
 
     with chpwd(opj(topdir, 'a', 'd')):
         runner = Runner()
-        runner(['git', 'annex', 'drop', fn_inarchive_obscure])  # run git annex drop
+        runner(['git', 'annex', 'drop', '--', fn_inarchive_obscure])  # run git annex drop
         assert_false(annex.file_has_content(fpath))             # and verify if file deleted from directory
-        runner(['git', 'annex', 'get', fn_inarchive_obscure])   # run git annex get
+        runner(['git', 'annex', 'get', '--', fn_inarchive_obscure])   # run git annex get
         assert_true(annex.file_has_content(fpath))              # and verify if file got into directory
 
 

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -272,7 +272,7 @@ def test_add_archive_content(path_orig, url, repo_path):
     ok_archives_caches(repo.path, 0, persistent=False)
 
     repo.drop(opj('1', '1 f.txt'))  # should be all kosher
-    repo.drop(key_1tar, options=['--key'])  # is available from the URL -- should be kosher
+    repo.drop(key_1tar, key=False)  # is available from the URL -- should be kosher
     repo.get(opj('1', '1 f.txt'))  # that what managed to not work
 
     # TODO: check if persistent archive is there for the 1.tar.gz
@@ -280,7 +280,7 @@ def test_add_archive_content(path_orig, url, repo_path):
     # We should be able to drop everything since available online
     with swallow_outputs():
         clean(dataset=repo.path)
-    repo.drop(key_1tar, options=['--key'])  # is available from the URL -- should be kosher
+    repo.drop(key_1tar, key=True)  # is available from the URL -- should be kosher
     chpwd(orig_pwd)  # just to avoid warnings ;)  move below whenever SkipTest removed
 
     repo.drop(opj('1', '1 f.txt'))  # should be all kosher
@@ -290,9 +290,9 @@ def test_add_archive_content(path_orig, url, repo_path):
     repo._annex_custom_command([], ["git", "annex", "drop", "--all"])
 
     # verify that we can't drop a file if archive key was dropped and online archive was removed or changed size! ;)
-    repo.get(key_1tar, options=['--key'])
+    repo.get(key_1tar, key=True)
     unlink(opj(path_orig, '1.tar.gz'))
-    res = repo.drop(key_1tar, options=['--key'])
+    res = repo.drop(key_1tar, key=True)
     assert_equal(res['success'], False)
     assert_equal(res['note'], '(Use --force to override this check, or adjust numcopies.)')
     assert exists(opj(repo.path, repo.get_contentlocation(key_1tar)))

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -272,7 +272,7 @@ def test_add_archive_content(path_orig, url, repo_path):
     ok_archives_caches(repo.path, 0, persistent=False)
 
     repo.drop(opj('1', '1 f.txt'))  # should be all kosher
-    repo.drop(key_1tar, key=False)  # is available from the URL -- should be kosher
+    repo.drop(key_1tar, key=True)  # is available from the URL -- should be kosher
     repo.get(opj('1', '1 f.txt'))  # that what managed to not work
 
     # TODO: check if persistent archive is there for the 1.tar.gz

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -618,7 +618,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 # Note, that _run_annex_command_json returns a generator
                 json_list = \
                     list(self._run_annex_command_json(
-                        'status', args=options_, expect_stderr=False))
+                        'status', opts=options_, expect_stderr=False))
             self.cmd_call_wrapper._log_opts['outputs'] = old_log_state
             if "fatal:" in cml.out:
                 raise CommandError(cmd="git annex status",
@@ -631,7 +631,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             else:
                 json_list = \
                     list(self._run_annex_command_json(
-                        'status', args=options, expect_stderr=False))
+                        'status', opts=options, expect_stderr=False))
         except CommandError as e:
             if submodules and \
                "fatal: " \
@@ -643,7 +643,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 options = [path] if path else []
                 options.extend(to_options(ignore_submodules='all'))
                 json_list = list(
-                    self._run_annex_command_json('status', args=options)
+                    self._run_annex_command_json('status', opts=options)
                 )
                 # separately get modified submodules:
                 m_subs = \
@@ -978,8 +978,11 @@ class AnnexRepo(GitRepo, RepoInterface):
     def __repr__(self):
         return "<AnnexRepo path=%s (%s)>" % (self.path, type(self))
 
-    def _run_annex_command(self, annex_cmd, git_options=None, annex_options=None,
-                           backend=None, jobs=None, **kwargs):
+    def _run_annex_command(self, annex_cmd,
+                           git_options=None, annex_options=None,
+                           backend=None, jobs=None,
+                           files=None,
+                           **kwargs):
         """Helper to run actual git-annex calls
 
         Unifies annex command calls.
@@ -997,6 +1000,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             achieved by having an item '--backend=XXX' in annex_options.
             This may change.
         jobs : int
+        files: list, optional
+            If command passes list of files
         **kwargs
             these are passed as additional kwargs to datalad.cmd.Runner.run()
 
@@ -1025,6 +1030,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         cmd_list += [annex_cmd] + backend + debug + annex_options
 
+        if files:
+            cmd_list += ['--'] + files
         try:
             return self.cmd_call_wrapper.run(cmd_list, **kwargs)
         except CommandError as e:
@@ -1302,7 +1309,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         #
         results = self._run_annex_command_json(
             'get',
-            args=options,
+            opts=options,
             # TODO: eventually make use of --batch mode
             files=files,  # fetch_files
             jobs=jobs,
@@ -1336,7 +1343,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         unknown_sizes = []  # unused atm
         # for now just record total size, and
         for j in self._run_annex_command_json(
-                'find', args=expr + files
+                'find', opts=expr, files=files
         ):
             # TODO: some files might not even be here.  So in current fancy
             # output reporting scheme we should then theoretically handle
@@ -1514,7 +1521,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return_list = list(self._run_annex_command_json(
                 'add',
-                args=options + files,
+                opts=options,
+                files=files,
                 backend=backend,
                 expect_fail=True,
                 jobs=jobs,
@@ -1596,9 +1604,11 @@ class AnnexRepo(GitRepo, RepoInterface):
             cmd_str = 'git annex lookupkey %s' % files  # have a string for messages
 
             try:
-                out, err = self._run_annex_command('lookupkey',
-                                                   annex_options=[files],
-                                                   expect_fail=True)
+                out, err = self._run_annex_command(
+                    'lookupkey',
+                    files=[files],
+                    expect_fail=True
+                )
             except CommandError as e:
                 if e.code == 1:
                     if not exists(opj(self.path, files)):
@@ -1644,7 +1654,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
 
         options = options[:] if options else []
-        self._run_annex_command('lock', annex_options=files + options)
+        self._run_annex_command('lock', annex_options=options, files=files)
         # note: there seems to be no output by annex if success.
 
     @normalize_paths
@@ -1688,7 +1698,9 @@ class AnnexRepo(GitRepo, RepoInterface):
 
             # TODO: catch and parse output if failed (missing content ...)
             std_out, std_err = \
-                self._run_annex_command('unlock', annex_options=files + options)
+                self._run_annex_command(
+                    'unlock', annex_options=options, files=files
+                )
 
             return [line.split()[1]
                     for line in std_out.splitlines()
@@ -1739,8 +1751,9 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         options = options[:] if options else []
 
-        std_out, std_err = self._run_annex_command('unannex',
-                                                   annex_options=files + options)
+        std_out, std_err = self._run_annex_command(
+            'unannex', annex_options=options, files=files
+        )
         return [line.split()[1] for line in std_out.splitlines()
                 if line.split()[0] == 'unannex' and line.split()[-1] == 'ok']
 
@@ -1767,7 +1780,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             for f in files:
                 try:
-                    obj, er = self._run_annex_command('find', annex_options=[f], expect_fail=True)
+                    obj, er = self._run_annex_command(
+                        'find', files=[f], expect_fail=True
+                    )
                     objects.append(obj)
                 except CommandError:
                     objects.append('')
@@ -2022,10 +2037,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             )
             os.unlink(opj(self.path, file_))
         if not batch:
-            self._run_annex_command('addurl',
-                                    annex_options=options + ['--file=%s' % file_] + [url],
-                                    log_online=True, log_stderr=False,
-                                    **kwargs)
+            self._run_annex_command(
+                'addurl',
+                annex_options=options + ['--file=%s' % file_] + [url],
+                log_online=True, log_stderr=False,
+                **kwargs
+            )
             # Don't capture stderr, since download progress provided by wget uses
             # stderr.
         else:
@@ -2104,7 +2121,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         url: str
         """
 
-        self._run_annex_command('rmurl', annex_options=[file_] + [url])
+        self._run_annex_command('rmurl', files=[file_, url])
 
     @normalize_path
     def get_urls(self, file_, key=False, batch=False):
@@ -2153,17 +2170,19 @@ class AnnexRepo(GitRepo, RepoInterface):
                                              "specify 'files' or 'options'")
 
         options = assure_list(options)
-        files = assure_list(files)
 
         if key:
             # we can't drop multiple in 1 line, and there is no --batch yet, so
             # one at a time
+            files = assure_list(files)
             options = options + ['--key']
-            res = [self._run_annex_command_json(
-                'drop',
-                args=options + [k],
-                jobs=jobs)
-                for k in files]
+            res = [
+                self._run_annex_command_json(
+                    'drop',
+                    opts=options + [k],
+                    jobs=jobs)
+                for k in files
+            ]
             # `normalize_paths` ... magic, useful?
             if len(files) == 1:
                 return res[0]
@@ -2172,7 +2191,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return self._run_annex_command_json(
                 'drop',
-                args=options + files,
+                opts=options,
+                files=files,
                 jobs=jobs)
 
     def drop_key(self, keys, options=None, batch=False):
@@ -2194,9 +2214,15 @@ class AnnexRepo(GitRepo, RepoInterface):
         options = options[:] if options else []
         options += ['--force']
         if not batch:
-            json_objects = self._run_annex_command_json('dropkey', args=options + keys, expect_stderr=True)
+            json_objects = self._run_annex_command_json(
+                'dropkey', opts=options, files=keys, expect_stderr=True
+            )
         else:
-            json_objects = self._batched.get('dropkey', git_options=self._GIT_COMMON_OPTIONS, annex_options=options, json=True, path=self.path)(keys)
+            json_objects = self._batched.get(
+                'dropkey',
+                git_options=self._GIT_COMMON_OPTIONS,
+                annex_options=options, json=True, path=self.path
+            )(keys)
         for j in json_objects:
             assert j.get('success', True)
 
@@ -2206,16 +2232,20 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         assert (j.get('success', True) is True)
         # process 'whereis' containing list of remotes
-        remotes = {remote['uuid']: {x: remote.get(x, None) for x in ('description', 'here', 'urls')}
+        remotes = {remote['uuid']: {x: remote.get(x, None)
+                                    for x in ('description', 'here', 'urls')
+                                    }
                    for remote in j.get('whereis')}
         if self.WEB_UUID in remotes:
             assert(remotes[self.WEB_UUID]['description'] == 'web')
         return remotes
 
-    def _run_annex_command_json(self, command, args=None,
+    def _run_annex_command_json(self, command,
+                                opts=None,
                                 jobs=None,
-                                files=[],
-                                expected_entries=None, **kwargs):
+                                files=None,
+                                expected_entries=None,
+                                **kwargs):
         """Run an annex command with --json and load output results into a tuple of dicts
 
         Parameters
@@ -2240,14 +2270,15 @@ class AnnexRepo(GitRepo, RepoInterface):
             annex_options = ['--json']
             if jobs:
                 annex_options += ['-J%d' % jobs]
-            if args:
-                annex_options += args
+            if opts:
+                annex_options += opts
 
             # TODO: RF to use --batch where possible instead of splitting
             # into multiple invocations
             if not files:
                 file_chunks = [[]]
             else:
+                files = assure_list(files)
                 maxl = max(map(len, files))
                 chunk_size = CMD_MAX_ARG // maxl
                 file_chunks = generate_chunks(files, chunk_size)
@@ -2255,7 +2286,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             for file_chunk in file_chunks:
                 out_, err_ = self._run_annex_command(
                     command,
-                    annex_options=annex_options + file_chunk,
+                    annex_options=annex_options + ['--'] + file_chunk,
                     **kwargs)
                 out += out_
                 err += err_
@@ -2410,19 +2441,24 @@ class AnnexRepo(GitRepo, RepoInterface):
         options = assure_list(options, copy=True)
         options += ["--key"] if key else []
 
-        json_objects = self._run_annex_command_json('whereis', args=options + files)
+        json_objects = self._run_annex_command_json(
+            'whereis', opts=options, files=files
+        )
         if output in {'descriptions', 'uuids'}:
             return [
                 [remote.get(output[:-1]) for remote in j.get('whereis')]
                 if j.get('success') else []
-                for j in json_objects]
+                for j in json_objects
+            ]
         elif output == 'full':
             # TODO: we might want to optimize storage since many remotes entries will be the
             # same so we could just reuse them instead of brewing copies
-            return {j['key' if (key or '--all' in options) else 'file']:
-                        self._whereis_json_to_dict(j)
-                    for j in json_objects
-                    if not j.get('key').endswith('.this-is-a-test-key')}
+            return {
+                j['key' if (key or '--all' in options) else 'file']
+                : self._whereis_json_to_dict(j)
+                for j in json_objects
+                if not j.get('key').endswith('.this-is-a-test-key')
+            }
 
     # TODO:
     # I think we should make interface cleaner and less ambigious for those annex
@@ -2450,7 +2486,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         options = ['--bytes', '--fast'] if fast else ['--bytes']
 
         if not batch:
-            json_objects = self._run_annex_command_json('info', args=options + files)
+            json_objects = self._run_annex_command_json(
+                'info', opts=options, files=files)
         else:
             json_objects = self._batched.get(
                 'info',
@@ -2487,7 +2524,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         options = ['--bytes', '--fast'] if fast else ['--bytes']
 
-        json_records = list(self._run_annex_command_json('info', args=options))
+        json_records = list(self._run_annex_command_json('info', opts=options))
         assert(len(json_records) == 1)
 
         # TODO: we need to abstract/centralize conversion from annex fields
@@ -2953,7 +2990,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         #  from annex failed ones
         results = self._run_annex_command_json(
             'copy',
-            args=annex_options,
+            opts=annex_options,
             files=files,  # copy_files,
             jobs=jobs,
             expected_entries=expected_copys
@@ -3083,9 +3120,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         if not files:
             return
         files = assure_list(files)
-        args = ['--json']
-        args.extend(files)
-        for res in self._run_annex_command_json('metadata', args):
+        opts = ['--json']
+        for res in self._run_annex_command_json(
+                'metadata', opts=opts, files=files):
             yield (
                 res['file'],
                 res['fields'] if timestamps else \
@@ -3154,12 +3191,11 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         if recursive:
             args.append('--force')
-        # append actual file path arguments
-        args.extend(assure_list(files))
 
         for jsn in self._run_annex_command_json(
                 'metadata',
-                args):
+                args,
+                files=files):
             yield jsn
 
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1277,17 +1277,18 @@ def dump_graph(graph, flatten=False):
 # List of most obscure filenames which might or not be supported by different
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_FILENAMES = (
-    " \"';a&b/&cd `| ",  # shouldn't be supported anywhere I guess due to /
-    " \"';a&b&cd `| ",
-    " \"';abcd `| ",
-    " \"';abcd | ",
-    " \"';abcd ",
-    " ;abcd ",
-    " ;abcd",
-    " ab cd ",
-    " ab cd",
-    "a",
-    " abc d.dat ",  # they all should at least support spaces and dots
+    "- \"';a&b/&cd `| ",  # shouldn't be supported anywhere I guess due to /
+    "- \"';a&b&cd `| ",
+    "- \"';abcd `| ",
+    "- \"';abcd | ",
+    "- \"';abcd ",
+    "- ;abcd ",
+    "- ;abcd",
+    "- ab cd ",
+    "- ab cd",
+    "-a",
+    "- abc d.dat ",
+    "abc d.dat ",  # they all should at least support spaces and dots
 )
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
This pull request reveals the spread of #2131 and may be then will attempt at a few fixes.  "Sing along" - contributions will be open

This pull request proposes someone to
- [x] RF to provide `files` after `--` in a call to `git annex` commands
- (unlikely here) make `get_most_obscure_filename` into a generator to produce few of those lovely ones.  We cannot have just one pointing to all the issues, although I think spaces in the middle are nearly always as bad as in the beginning (trailing ones are trickier)
- [  x?  ] as a quicker resolution to above - make prefix to obscure filename controllable from env, so we could have a matrix run with `-` as a prefix. **I already have it but do not want to push until I make sure that all of the issues are caught first -- tests are still running although buildbots are already happy**

### Changes
- [x] This change is complete for whatever it wanted to show

Please have a look @datalad/developers
