### PR TITLE
aggregate-metadata -r crashes with [ERROR] unhashable type: 'list' [metadata.py:_get_metadata:500] (TypeError)

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -491,16 +491,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
                     # aggregated list of a hopefully-kinda-ok structure
                     continue
                 vset = unique_cm.get(k, set())
-                try:
-                    vset.add(v)
-                except TypeError:
-                    if isinstance(v, dict):
-                        vset.add(ReadOnlyDict(v))
-                    elif isinstance(v, list):
-                        vset.add(tuple(v))
-                    else:
-                        # no idea
-                        raise
+                vset.add(_val2hashable(v))
                 unique_cm[k] = vset
 
         if unique_cm:
@@ -541,6 +532,21 @@ def _unique_value_key(x):
                 for k in sorted(x)]
     else:
         return x
+
+
+def _val2hashable(val):
+    """Small helper to convert incoming mutables to something hashable
+
+    The goal is to be able to put the return value into a set, while
+    avoiding conversions that would result in a change of representation
+    in a subsequent JSON string.
+    """
+    if isinstance(val, dict):
+        return ReadOnlyDict(val)
+    elif isinstance(val, list):
+        return tuple(map(_val2hashable, val))
+    else:
+        return val
 
 
 class ReadOnlyDict(Mapping):


### PR DESCRIPTION
#### What is the problem?
```shell
(git)smaug:/mnt/btrfs/datasets-meta6-1/datalad/crawl[master]git
$> time datalad aggregate-metadata -r 2>&1 | tee aggregate-run1.log
[INFO] Aggregate metadata for dataset /mnt/btrfs/datasets-meta6-1/datalad/crawl
[INFO] Aggregate metadata for dataset /mnt/btrfs/datasets-meta6-1/datalad/crawl/abide
...
[INFO] Aggregate metadata for dataset /mnt/btrfs/datasets-meta6-1/datalad/crawl/labs/haxby/attention
[INFO] Aggregate metadata for dataset /mnt/btrfs/datasets-meta6-1/datalad/crawl/labs/haxby/life
[WARNING] 18 files have no content present, skipped metadata extraction for them
[ERROR] unhashable type: 'list' [metadata.py:_get_metadata:500] (TypeError)
aggregate_metadata(impossible): /mnt/btrfs/datasets-meta6-1/datalad/crawl/dicoms [No matching aggregated metadata in Dataset at /mnt/btrfs/datasets-meta6-1/datalad/crawl]
datalad aggregate-metadata -r 2>&1  1476.50s user 289.51s system 103% cpu 28:33.03 total
tee aggregate-run1.log  0.01s user 0.02s system 0% cpu 28:33.03 total

$> cat datapackage.json
{ 
  "name": "datalad-datasets",
  "datapackage_version": "3",
  "title": "The Ultimate DataLad collection of datasets",
  "licenses": [{
    "name": "ODC-PDDL-1.0",
    "path": "http://opendatacommons.org/licenses/pddl/",
    "title": "Open Data Commons Public Domain Dedication and License v1.0"
   },
   {
    "title": "varying per each dataset"
   }
  ]
}


$> cat .datalad/config
[datalad "dataset"]
        id = 6d69ca68-7e85-11e6-904c-002590f97d84
[metadata]
        nativetype = frictionless_datapackage
```