### PR TITLE
BF(workaround): Allow pandoc to be missing while pypandoc being available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,13 @@ README = opj(dirname(__file__), 'README.md')
 try:
     import pypandoc
     long_description = pypandoc.convert(README, 'rst')
-except ImportError:
+except (ImportError, OSError) as exc:
+    # attempting to install pandoc via brew on OSX currently hangs and
+    # pypandoc imports but throws OSError demanding pandoc
+    print(
+        "WARNING: pypandoc failed to import or thrown an error while converting"
+        " README.md to RST: %r   .md version will be used as is" % exc
+    )
     long_description = open(README).read()
 
 


### PR DESCRIPTION
also throw a WARNING message about that to alert the user.  That description
is used anyways only for upload to pypi

This pull request fixes failing OSX builds with requirements-devel 

- [x] This change is complete

Please do not look @datalad/developers
