### PR TITLE
ENH: More stringent and improved error handling on metadata extraction

### DIFF
--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -667,7 +667,7 @@ class AggregateMetaData(Interface):
                 if errored:
                     yield get_status_dict(
                         status='error',
-                        message='Metadata extraction failed (see previous error message)',
+                        message='Metadata extraction failed (see previous error message, set datalad.runtime.raiseonerror=yes to fail immediately)',
                         action='aggregate_metadata',
                         path=aggsrc,
                         logger=lgr)


### PR DESCRIPTION
Should address complaint in gh-2142

@yarikoptic Should help with debugging metadata extraction crashes. Also catches a condition in which non-compliant metadata would have been processed even though it was detected and reported as broken.