### PR TITLE
Some kind of progress bar for index construction?

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -43,7 +43,6 @@ import datalad.support.ansi_colors as ac
 from datalad.support.json_py import load as jsonload
 from datalad.support.json_py import load_xzstream
 from datalad.interface.common_opts import recursion_flag
-from datalad.interface.common_opts import recursion_limit
 from datalad.interface.common_opts import reporton_opt
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
@@ -57,9 +56,6 @@ from datalad.dochelpers import single_or_plural
 
 lgr = logging.getLogger('datalad.metadata.metadata')
 
-valid_key = re.compile(r'^[0-9a-z._-]+$')
-
-db_relpath = opj('.datalad', 'metadata', 'dataset.json')
 agginfo_relpath = opj('.datalad', 'metadata', 'aggregate_v1.json')
 
 # relative paths which to exclude from any metadata processing
@@ -189,10 +185,6 @@ def query_aggregated_metadata(reporton, ds, aps, recursive=False,
     generator
       Of result dictionaries.
     """
-    # TODO recursion_limit
-
-    # TODO rename function and query datalad/annex own metadata
-    # for all actually present dataset after looking at aggregated data
     # This import is relatively heavy, delayed until needed
     from datalad.auto import AutomagicIO
     with AutomagicIO(check_once=True):

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -653,17 +653,24 @@ class Metadata(Interface):
             if not exists(info_fpath):
                 return
             agginfos = _load_json_object(info_fpath)
-            for sd in agginfos:
+            parentds = []
+            for sd in sorted(agginfos):
                 info = agginfos[sd]
+                dspath = normpath(opj(refds_path, sd))
+                if parentds and not dspath.startswith(_with_sep(parentds[-1])):
+                    parentds.pop()
                 info.update(
-                    path=normpath(opj(refds_path, sd)),
+                    path=dspath,
                     type='dataset',
                     status='ok',
                 )
+                if parentds:
+                    info['parentds'] = parentds[-1]
                 yield dict(
                     info,
                     **res_kwargs
                 )
+                parentds.append(dspath)
             return
 
         if not dataset and not path:

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -327,6 +327,13 @@ def _get_search_index(index_dir, label, ds, force_reindex, get_schema, meta2doc,
     if not exists(index_dir):
         os.makedirs(index_dir)
 
+    # this is a pretty cheap call that just pull this info from a file
+    dsinfo = ds.metadata(
+        get_aggregates=True,
+        return_type='list',
+        result_renderer='disabled')
+
+    lgr.info('Processing metadata records for %i datasets', len(dsinfo))
     schema = get_schema(ds)
 
     idx_obj = widx.create_in(index_dir, schema)


### PR DESCRIPTION
#### What is the problem?
Search index construction might take a while... E.g. I have started one yesterday evening (5pm) and it is still going (after 18h, edit 1: I am pretty sure it is stuck -- it is 28th hour now) on a reasonably fast machine (smaug ;) ).  I have no clue either it is not just stuck, or when it should be complete, all I see is
```shell
(dev3) 2 11290.....................................:Fri 15 Dec 2017 05:01:52 PM EST:.
(git)smaug:/tmp/crawl[master]
$> datalad search Haxby type:dataset
[INFO   ] Building search index
[INFO   ] Scanning for metadata keys
```
I wondered, if it goes sequentially through datasets and datasets list is initially constructed (full or just top level) -- would be nice to have some kind of a progress bar with % or at least some indication of activity/progress.
