### PR TITLE
BF: use GitPython for getting information about tags, get hexsha for nonannotated tags as well

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2071,20 +2071,25 @@ class GitRepo(RepoInterface):
             ['git', 'symbolic-ref' if symbolic else 'update-ref', ref, value]
         )
 
-    def tag(self, tag):
+    def tag(self, tag, message=None):
         """Assign a tag to current commit
 
         Parameters
         ----------
         tag : str
           Custom tag label.
+        message : str, optional
+          If provided, would create an annotated tag with that message
         """
         # TODO later to be extended with tagging particular commits and signing
         # TODO: call in save.py complains about extensive logging. When does it
         # happen in what way? Figure out, whether to just silence it or raise or
         # whatever else.
+        options = []
+        if message:
+            options += ['-m', message]
         self._git_custom_command(
-            '', ['git', 'tag', str(tag)]
+            '', ['git', 'tag'] + options + [str(tag)]
         )
 
     def get_tags(self, output=None):
@@ -2102,17 +2107,20 @@ class GitRepo(RepoInterface):
           Each item is a dictionary with information on a tag. At present
           this includes 'hexsha', and 'name', where the latter is the string
           label of the tag, and the format the hexsha of the object the tag
-          is attched to. The list is sorted by commit date, with the most
+          is attached to. The list is sorted by commit date, with the most
           recent commit being the last element.
         """
-        # TODO it would be straightforward to add more info and tweak the
-        # sorting
-        stdout, stderr = self._git_custom_command(
-            '',
-            ['git', 'tag', '--format=%(refname:strip=2)%00%(object)',
-             '--sort=*committerdate'])
-        fields = ('name', 'hexsha')
-        tags = [dict(zip(fields, line.split('\0'))) for line in stdout.splitlines()]
+        tag_objs = sorted(
+            self.repo.tags,
+            key=lambda t: t.commit.committed_date
+        )
+        tags = [
+            {
+                'name': t.name,
+                'hexsha': t.commit.hexsha
+             }
+            for t in tag_objs
+        ]
         if output:
             return [t[output] for t in tags]
         else:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1229,3 +1229,27 @@ def test_check_git_configured(newhome):
         # But then if we
     finally:
         GitRepo._config_checked = old
+
+
+@with_tempfile(mkdir=True)
+def test_get_tags(path):
+    gr = GitRepo(path, create=True)
+    eq_(gr.get_tags(), [])
+
+    create_tree(gr.path, {'file': ""})
+    gr.add('file')
+    gr.commit(msg="msg")
+    eq_(gr.get_tags(), [])
+
+    gr.tag("nonannotated")
+    tags1 = [{'name': 'nonannotated', 'hexsha': gr.get_hexsha()}]
+    eq_(gr.get_tags(), tags1)
+
+    sleep(1)  # so timestamp changes -- we sort in incremental order
+    create_tree(gr.path, {'file': "123"})
+    gr.add('file')
+    gr.commit(msg="changed")
+
+    gr.tag("annotated", message="annotation")
+    tags2 = tags1 + [{'name': 'annotated', 'hexsha': gr.get_hexsha()}]
+    eq_(gr.get_tags(), tags2)


### PR DESCRIPTION
Fixes #2153

cons:  GitPython does not support workdir's yet, but as such we do not support them as well anyways

### Changes
- [x] This change is complete

Please have a look @datalad/developers
