### PR TITLE
BF: check if directory does not exist while creating a temp HOME

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -108,7 +108,8 @@ def setup_package():
         # TODO: split into a function + context manager
         with make_tempfile(mkdir=True) as new_home:
             os.environ['HOME'] = new_home
-        os.makedirs(new_home)
+        if not os.path.exists(new_home):
+            os.makedirs(new_home)
         with open(os.path.join(new_home, '.gitconfig'), 'w') as f:
             f.write("""\
 [user]


### PR DESCRIPTION
Whenever we use our make_tempfile and also set DATALAD_TESTS_TEMP_KEEP=1
it would be kept and not removed -- so we just need to check if it still exists

I thought that os.makedirs also does not fail if leaf dir exists, but
apparently I was wrong

### Changes
- [x] This change is complete

Please have a look @datalad/developers
