### PR TITLE
-c datalad.runtime.raiseonerror=yes  in command line is not passed into cfg

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -323,14 +323,14 @@ def main(args=None):
     # to possibly be passed into PBS scheduled call
     args_ = args or sys.argv
 
-    # enable overrides
-    datalad.cfg.reload()
-
     if cmdlineargs.cfg_overrides is not None:
         overrides = dict([
             (o.split('=')[0], '='.join(o.split('=')[1:]))
             for o in cmdlineargs.cfg_overrides])
         datalad.cfg.overrides.update(overrides)
+
+    # enable overrides
+    datalad.cfg.reload(force=True)
 
     if cmdlineargs.change_path is not None:
         from .common_args import change_path as change_path_opt

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -21,6 +21,9 @@ import datalad
 from ..main import main
 from datalad import __version__
 from datalad.cmd import Runner
+from datalad.api import create
+from datalad.utils import chpwd
+from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_equal, assert_raises, in_, ok_startswith
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_re_in
@@ -179,3 +182,34 @@ def test_script_shims():
         assert get_numeric_portion(version) # that my lambda is correctish
         assert_equal(get_numeric_portion(__version__),
                      get_numeric_portion(version))
+
+
+@with_tempfile(mkdir=True)
+def test_cfg_override(path):
+    with chpwd(path):
+        # control
+        out, err = Runner()('datalad plugin wtf', shell=True)
+        assert_not_in('datalad.dummy: this', out)
+        # ensure that this is not a dataset's cfg manager
+        assert_not_in('datalad.dataset.id', out)
+        # env var
+        out, err = Runner()('DATALAD_DUMMY=this datalad plugin wtf', shell=True)
+        assert_in('datalad.dummy: this', out)
+        # cmdline arg
+        out, err = Runner()('datalad -c datalad.dummy=this plugin wtf', shell=True)
+        assert_in('datalad.dummy: this', out)
+
+        # now create a dataset in the path. the wtf plugin will switch to
+        # using the dataset's config manager, which must inherit the overrides
+        create(dataset=path)
+        # control
+        out, err = Runner()('datalad plugin wtf', shell=True)
+        assert_not_in('datalad.dummy: this', out)
+        # ensure that this is a dataset's cfg manager
+        assert_in('datalad.dataset.id', out)
+        # env var
+        out, err = Runner()('DATALAD_DUMMY=this datalad plugin wtf', shell=True)
+        assert_in('datalad.dummy: this', out)
+        # cmdline arg
+        out, err = Runner()('datalad -c datalad.dummy=this plugin wtf', shell=True)
+        assert_in('datalad.dummy: this', out)

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -9,6 +9,7 @@
 """
 """
 
+import datalad
 from datalad.cmd import GitRunner
 from datalad.dochelpers import exc_str
 from distutils.version import LooseVersion
@@ -167,7 +168,12 @@ class ConfigManager(object):
         self._cfgmtimes = None
         # public dict to store variables that always override any setting
         # read from a file
-        self.overrides = {} if overrides is None else overrides
+        # `hasattr()` is needed because `datalad.cfg` is generated upon first module
+        # import, hence when this code runs first, there cannot be any config manager
+        # to inherit from
+        self.overrides = datalad.cfg.overrides.copy() if hasattr(datalad, 'cfg') else {}
+        if overrides is not None:
+            self.overrides.update(overrides)
         if dataset is None:
             self._dataset_path = None
             self._dataset_cfgfname = None


### PR DESCRIPTION
#### What is the problem?
I think I entered (copy/pasted actually from the message) it correctly, didn't I?
I expected to end up at ascii.py:decode:26 (ideally) ;)
```shell
$> datalad -c datalad.runtime.raiseonerror=yes aggregate-metadata
[INFO   ] Aggregate metadata for dataset /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 
[ERROR  ] Failed to get dataset metadata (bids): 'ascii' codec can't decode byte 0xc2 in position 1188: ordinal not in range(128) [ascii.py:decode:26] 
[ERROR  ] Metadata extraction failed (see previous error message, set datalad.runtime.raiseonerror=yes to fail immediately) [aggregate_metadata(/mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053)] 
aggregate_metadata(error): /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 [Metadata extraction failed (see previous error message, set datalad.runtime.raiseonerror=yes to fail immediately)]
[INFO   ] Update aggregate metadata in dataset at: /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 
aggregate_metadata(ok): /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 (dataset)                                                                                      
[INFO   ] Attempting to save 6 files/datasets 
save(notneeded): /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 (dataset)                                                                                             
action summary:
  aggregate_metadata (error: 1, ok: 1)
  save (notneeded: 1)
datalad -c datalad.runtime.raiseonerror=yes aggregate-metadata  7.57s user 2.24s system 105% cpu 9.312 total
(dev)3 10144 ->1.....................................:Mon 12 Feb 2018 10:46:40 AM EST:.
(git)smaug:\u2026nt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053[master]
$> datalad -c datalad.runtime.raiseonerror=yes --dbg aggregate-metadata
[INFO   ] Aggregate metadata for dataset /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 
[ERROR  ] Failed to get dataset metadata (bids): 'ascii' codec can't decode byte 0xc2 in position 1188: ordinal not in range(128) [ascii.py:decode:26] 
[ERROR  ] Metadata extraction failed (see previous error message, set datalad.runtime.raiseonerror=yes to fail immediately) [aggregate_metadata(/mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053)] 
aggregate_metadata(error): /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 [Metadata extraction failed (see previous error message, set datalad.runtime.raiseonerror=yes to fail immediately)]
[INFO   ] Update aggregate metadata in dataset at: /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 
aggregate_metadata(ok): /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 (dataset)                                                                                      
[INFO   ] Attempting to save 6 files/datasets 
save(notneeded): /mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053 (dataset)
action summary:
  aggregate_metadata (error: 1, ok: 1)
  save (notneeded: 1)
Traceback (most recent call last):
  File "/home/yoh/proj/datalad/datalad-master/venvs/dev/bin/datalad", line 8, in <module>
    main()
  File "/home/yoh/proj/datalad/datalad-master/datalad/cmdline/main.py", line 354, in main
    ret = cmdlineargs.func(cmdlineargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/base.py", line 432, in call_from_parser
    ret = list(ret)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 413, in generator_func
    msg="Command did not complete successfully")
IncompleteResultsError: Command did not complete successfully [{'action': 'aggregate_metadata', 'path': '/mnt/btrfs/datasets-meta6-1-redo1/datalad/crawl/openfmri/ds000053', 'status': 'error', 'message': 'Metadata extraction failed (see previous error message, set datalad.runtime.raiseonerror=yes to fail immediately)'}]
()
> /home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py(413)generator_func()
-> msg="Command did not complete successfully")
(Pdb) 

```

#### What steps will reproduce the problem?
just try within ds000053

#### What version of DataLad are you using (run `datalad --version`)? On what operating system (consider running `datalad plugin wtf`)?
0.9.1-740-g39bb73d9
