### PR TITLE
RF: do not write down index every time in __del__

### DIFF
--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -215,6 +215,7 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
         {'subm 1', '2'})
 
 
+@known_failure_v6   #FIXME
 @with_testrepos(flavors=['local'])
 # 'local-url', 'network'
 # TODO: Somehow annex gets confused while initializing installed ds, whose

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -733,10 +733,13 @@ class GitRepo(RepoInterface):
                     and self.repo is not None:
                 # gc might be late, so the (temporary)
                 # repo doesn't exist on FS anymore
-
                 self.repo.git.clear_cache()
-                if exists(opj(self.path, '.git')):  # don't try to write otherwise
-                    self.repo.index.write()
+                # We used to write out the index to flush GitPython's
+                # state... but such unconditional write is really a workaround
+                # and does not play nice with read-only operations - permission
+                # denied etc. So disabled 
+                #if exists(opj(self.path, '.git')):  # don't try to write otherwise
+                #    self.repo.index.write()
         except InvalidGitRepositoryError:
             # might have being removed and no longer valid
             pass


### PR DESCRIPTION
- causes all the ugly messages in read-only access
- not sure if needed any longer - hopefully all needed flushing was
  fixed in GitPython long ago

I want to see if any tests fail for us now after this change

### Changes
- [x] This change is complete

Please have a look @datalad/developers
