### PR TITLE
ENH: `search`

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -236,6 +236,13 @@ definitions = {
         'type': EnsureBool(),
         'default': True,
     },
+    'datalad.search.default-mode': {
+        'ui': ('question', {
+               'title': 'Default search mode',
+               'text': 'Label of the mode to be used by default'}),
+        'type': EnsureChoice('egrep', 'textblob', 'autofield'),  # graph,...
+        'default': 'egrep',
+    },
     'datalad.search.index-default-documenttype': {
         'ui': ('question', {
                'title': 'Type of search index documents',

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -665,6 +665,10 @@ class Search(Interface):
     command), in which case a search can discover any dataset or any file in
     of these datasets.
 
+    *Search modes*
+
+    WRITE ME
+
     A search index is automatically built from the available metadata of any
     dataset or file, and a schema for this index is generated dynamically, too.
     Consequently, the search index will be tailored to data provided in a
@@ -740,9 +744,9 @@ class Search(Interface):
             constraints=EnsureInt()),
         mode=Parameter(
             args=("--mode",),
-            choices=('default', 'autofield', 'egrep'),
-            doc="""Mode of search index structure and content. 'autofield': metadata
-            fields are discovered automatically, datasets and files can be discovered.
+            choices=('egrep', 'textblob', 'autofield'),
+            doc="""Mode of search index structure and content. See section
+            SEARCH MODES for details.
             """),
         show_keys=Parameter(
             args=('--show-keys',),
@@ -771,7 +775,7 @@ class Search(Interface):
                  dataset=None,
                  force_reindex=False,
                  max_nresults=20,
-                 mode='default',
+                 mode=None,
                  show_keys=False,
                  show_query=False):
         try:
@@ -786,12 +790,17 @@ class Search(Interface):
                 yield r
             return
 
-        if mode == 'default':
+        if mode is None:
+            # let's get inspired by what the dataset/user think is
+            # default
+            mode = ds.config.obtain('datalad.search.default-mode')
+
+        if mode == 'egrep':
+            searcher = _EGrepSearch
+        elif mode == 'textblob':
             searcher = _BlobSearch
         elif mode == 'autofield':
             searcher = _AutofieldSearch
-        elif mode == 'egrep':
-            searcher = _EGrepSearch
         else:
             raise ValueError(
                 'unknown search mode "{}"'.format(mode))

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 import logging
 lgr = logging.getLogger('datalad.metadata.search')
 
-import re
 import os
 from os.path import join as opj, exists
 from os.path import relpath
@@ -52,9 +51,6 @@ if PY3:
 else:
     unicode_srctypes = string_types
     str_contructor = unicode
-
-# regex for a cheap test if something looks like a URL
-r_url = re.compile(r"^https?://")
 
 
 def _any2unicode(val):
@@ -103,9 +99,6 @@ def _listdict2dictlist(lst):
         if len(v)}
 
 
-#
-# START: autofield mode functions
-#
 def _meta2autofield_dict(meta, val2str=True, schema=None):
     """Takes care of dtype conversion into unicode, potential key mappings
     and concatenation of sequence-type fields into CSV strings
@@ -166,258 +159,6 @@ def _meta2autofield_dict(meta, val2str=True, schema=None):
     }
 
 
-def _get_schema_autofield(ds):
-    from whoosh import fields as wf
-    from whoosh.analysis import StandardAnalyzer
-
-    # haven for terms that have been found to be undefined
-    # (for faster decision-making upon next encounter)
-    # this will harvest all discovered term definitions
-    definitions = {
-        '@id': 'unique identifier of an entity',
-        # TODO make proper JSON-LD definition
-        'path': 'path name of an entity relative to the searched base dataset',
-        # TODO make proper JSON-LD definition
-        'parentds': 'path of the datasets that contains an entity',
-        # 'type' will not come from a metadata field, hence will not be detected
-        'type': 'type of a record',
-    }
-
-    schema_fields = {
-        n.lstrip('@'): wf.ID(stored=True, unique=n == '@id')
-        for n in definitions}
-
-    lgr.info('Scanning for metadata keys')
-    # quick 1st pass over all dataset to gather the needed schema fields
-    for res in query_aggregated_metadata(
-            reporton='datasets',
-            ds=ds,
-            aps=[dict(path=ds.path, type='dataset')],
-            recursive=True):
-        meta = res.get('metadata', {})
-        # no stringification of values for speed, we do not need/use the
-        # actual values at this point, only the keys
-        idxd = _meta2autofield_dict(meta, val2str=False)
-
-        for k in idxd:
-            schema_fields[k] = wf.TEXT(stored=True,
-                                       analyzer=StandardAnalyzer(minsize=1))
-
-    schema = wf.Schema(**schema_fields)
-    return schema
-
-
-def _get_parser_autofield(idx_obj):
-    from whoosh import qparser as qparse
-
-    parser = qparse.MultifieldParser(
-        idx_obj.schema.names(),
-        idx_obj.schema)
-    # XXX: plugin is broken in Debian's whoosh 2.7.0-2, but already fixed
-    # upstream
-    parser.add_plugin(qparse.FuzzyTermPlugin())
-    parser.add_plugin(qparse.GtLtPlugin())
-    parser.add_plugin(qparse.SingleQuotePlugin())
-    # replace field defintion to allow for colons to be part of a field's name:
-    parser.replace_plugin(qparse.FieldsPlugin(expr=r"(?P<text>[()<>.\w]+|[*]):"))
-    return parser
-
-
-#
-# START: homoblob mode functions
-#
-def _meta2homoblob_dict(meta, val2str=True, schema=None):
-    # coerce the entire flattened metadata dict into a comma-separated string
-    # that also includes the keys
-    return dict(meta=u', '.join(
-        u'{}: {}'.format(k, v)
-        for k, v in _meta2autofield_dict(
-            meta,
-            val2str=True,
-            schema=None).items()))
-
-
-def _get_schema_homoblob(ds):
-    from whoosh import fields as wf
-    from whoosh.analysis import StandardAnalyzer
-
-    # TODO support some customizable mapping to homogenize some metadata fields
-    # onto a given set of index keys
-    schema = wf.Schema(
-        id=wf.ID,
-        path=wf.ID(stored=True),
-        type=wf.ID(stored=True),
-        parentds=wf.ID(stored=True),
-        meta=wf.TEXT(
-            stored=False,
-            analyzer=StandardAnalyzer(minsize=2))
-    )
-    return schema
-
-
-def _get_parser_homoblob(idx_obj):
-    from whoosh import qparser as qparse
-
-    # use whoosh default query parser for now
-    return qparse.QueryParser(
-        "meta",
-        schema=idx_obj.schema
-    )
-
-
-def _get_search_index(index_dir, label, ds, force_reindex, get_schema, meta2doc, documenttype):
-    """Generic entrypoint to index generation
-
-    The actual work that determines the structure and content of the index
-    is done by functions that are passed in as arguments
-
-    `get_schema` - must return whoosh schema
-    `meta2doc` - must return dict for index document from result input
-    `label` - string label to distinguish an index type from others (must be a valid
-              directory name
-    """
-    from whoosh import index as widx
-    from .metadata import agginfo_relpath
-    # what is the lastest state of aggregated metadata
-    metadata_state = ds.repo.get_last_commit_hash(agginfo_relpath)
-    # use location common to all index types, they would all invalidate
-    # simultaneously
-    stamp_fname = opj(index_dir, 'datalad_metadata_state')
-    index_dir = opj(index_dir, label)
-
-    if (not force_reindex) and \
-            exists(index_dir) and \
-            exists(stamp_fname) and \
-            open(stamp_fname).read() == metadata_state:
-        try:
-            # TODO check that the index schema is the same
-            # as the one we would have used for reindexing
-            # TODO support incremental re-indexing, whoosh can do it
-            idx = widx.open_dir(index_dir)
-            lgr.debug(
-                'Search index contains %i documents',
-                idx.doc_count())
-            return idx
-        except widx.LockError as e:
-            raise e
-        except widx.IndexError as e:
-            # Generic index error.
-            # we try to regenerate
-            # TODO log this
-            pass
-        except widx.IndexVersionError as e:  # (msg, version, release=None)
-            # Raised when you try to open an index using a format that the
-            # current version of Whoosh cannot read. That is, when the index
-            # you're trying to open is either not backward or forward
-            # compatible with this version of Whoosh.
-            # we try to regenerate
-            lgr.warning(exc_str(e))
-            pass
-        except widx.OutOfDateError as e:
-            # Raised when you try to commit changes to an index which is not
-            # the latest generation.
-            # this should not happen here, but if it does ... KABOOM
-            raise e
-        except widx.EmptyIndexError as e:
-            # Raised when you try to work with an index that has no indexed
-            # terms.
-            # we can just continue with generating an index
-            pass
-
-    lgr.info('{} search index'.format(
-        'Rebuilding' if exists(index_dir) else 'Building'))
-
-    if not exists(index_dir):
-        os.makedirs(index_dir)
-
-    # this is a pretty cheap call that just pull this info from a file
-    dsinfo = ds.metadata(
-        get_aggregates=True,
-        return_type='list',
-        result_renderer='disabled')
-
-    lgr.info('Processing metadata records for %i datasets', len(dsinfo))
-    schema = get_schema(ds)
-
-    idx_obj = widx.create_in(index_dir, schema)
-    idx = idx_obj.writer(
-        # cache size per process
-        limitmb=cfg.obtain('datalad.search.indexercachesize'),
-        # disable parallel indexing for now till #1927 is resolved
-        ## number of processes for indexing
-        #procs=multiprocessing.cpu_count(),
-        ## write separate index segments in each process for speed
-        ## asks for writer.commit(optimize=True)
-        #multisegment=True,
-    )
-
-    # load metadata of the base dataset and what it knows about all its subdatasets
-    # (recursively)
-    old_idx_size = 0
-    old_ds_rpath = ''
-    idx_size = 0
-    for res in query_aggregated_metadata(
-            reporton=documenttype,
-            ds=ds,
-            aps=[dict(path=ds.path, type='dataset')],
-            # MIH: I cannot see a case when we would not want recursion (within
-            # the metadata)
-            recursive=True):
-        # this assumes that files are reported after each dataset report,
-        # and after a subsequent dataset report no files for the previous
-        # dataset will be reported again
-        meta = res.get('metadata', {})
-        doc = meta2doc(
-            meta,
-            # this time stringification of values so whoosh can handle them
-            val2str=True,
-            schema=schema)
-        admin = {
-            'type': res['type'],
-            'path': relpath(res['path'], start=ds.path),
-        }
-        if 'parentds' in res:
-            admin['parentds'] = relpath(res['parentds'], start=ds.path)
-        if admin['type'] == 'dataset':
-            if old_ds_rpath:
-                lgr.info(
-                    'Added %s on dataset %s',
-                    single_or_plural(
-                        'document',
-                        'documents',
-                        idx_size - old_idx_size,
-                        include_count=True),
-                    old_ds_rpath)
-            old_idx_size = idx_size
-            old_ds_rpath = admin['path']
-
-        doc.update({k: assure_unicode(v) for k, v in admin.items()})
-        lgr.debug("Adding document to search index: {}".format(doc))
-        # inject into index
-        idx.add_document(**doc)
-        idx_size += 1
-
-    if old_ds_rpath:
-        lgr.info(
-            'Added %s on dataset %s',
-            single_or_plural(
-                'document',
-                'documents',
-                idx_size - old_idx_size,
-                include_count=True),
-            old_ds_rpath)
-
-    lgr.debug("Committing index")
-    idx.commit(optimize=True)
-
-    # "timestamp" the search index to allow for automatic invalidation
-    with open(stamp_fname, 'w') as f:
-        f.write(metadata_state)
-
-    lgr.info('Search index contains %i documents', idx_size)
-    return idx_obj
-
-
 def _search_from_virgin_install(dataset, query):
     #
     # this is to be nice to newbies
@@ -473,6 +214,359 @@ def _search_from_virgin_install(dataset, query):
         return
     else:
         raise
+
+
+class _Search(object):
+    def __init__(self, ds):
+        self.ds = ds
+
+    def __call__(self, query, max_nresults=None, force_reindex=False, show_keys=False, show_query=False):
+        raise NotImplementedError
+
+
+class _WhooshSearch(_Search):
+    def __init__(self, ds):
+        super(_WhooshSearch, self).__init__(ds)
+        self.documenttype = self.ds.config.obtain(
+            'datalad.search.index-{}-documenttype'.format(self._mode_label),
+            default=self._default_documenttype)
+
+        self.idx_obj = None
+        # where does the bunny have the eggs?
+        self.index_dir = opj(self.ds.path, get_git_dir(self.ds.path), SEARCH_INDEX_DOTGITDIR)
+
+    def _meta2doc(self, meta, val2str=True, schema=None):
+        raise NotImplementedError
+
+    def _mk_schema(self):
+        raise NotImplementedError
+
+    def _mk_parser(self):
+        raise NotImplementedError
+
+    def _mk_search_index(self, force_reindex):
+        """Generic entrypoint to index generation
+
+        The actual work that determines the structure and content of the index
+        is done by functions that are passed in as arguments
+
+        `meta2doc` - must return dict for index document from result input
+        """
+        from whoosh import index as widx
+        from .metadata import agginfo_relpath
+        # what is the lastest state of aggregated metadata
+        metadata_state = self.ds.repo.get_last_commit_hash(agginfo_relpath)
+        # use location common to all index types, they would all invalidate
+        # simultaneously
+        stamp_fname = opj(self.index_dir, 'datalad_metadata_state')
+        index_dir = opj(self.index_dir, self._mode_label)
+
+        if (not force_reindex) and \
+                exists(index_dir) and \
+                exists(stamp_fname) and \
+                open(stamp_fname).read() == metadata_state:
+            try:
+                # TODO check that the index schema is the same
+                # as the one we would have used for reindexing
+                # TODO support incremental re-indexing, whoosh can do it
+                idx = widx.open_dir(index_dir)
+                lgr.debug(
+                    'Search index contains %i documents',
+                    idx.doc_count())
+                self.idx_obj = idx
+                return
+            except widx.LockError as e:
+                raise e
+            except widx.IndexError as e:
+                # Generic index error.
+                # we try to regenerate
+                # TODO log this
+                pass
+            except widx.IndexVersionError as e:  # (msg, version, release=None)
+                # Raised when you try to open an index using a format that the
+                # current version of Whoosh cannot read. That is, when the index
+                # you're trying to open is either not backward or forward
+                # compatible with this version of Whoosh.
+                # we try to regenerate
+                lgr.warning(exc_str(e))
+                pass
+            except widx.OutOfDateError as e:
+                # Raised when you try to commit changes to an index which is not
+                # the latest generation.
+                # this should not happen here, but if it does ... KABOOM
+                raise e
+            except widx.EmptyIndexError as e:
+                # Raised when you try to work with an index that has no indexed
+                # terms.
+                # we can just continue with generating an index
+                pass
+
+        lgr.info('{} search index'.format(
+            'Rebuilding' if exists(index_dir) else 'Building'))
+
+        if not exists(index_dir):
+            os.makedirs(index_dir)
+
+        # this is a pretty cheap call that just pull this info from a file
+        dsinfo = self.ds.metadata(
+            get_aggregates=True,
+            return_type='list',
+            result_renderer='disabled')
+
+        lgr.info('Processing metadata records for %i datasets', len(dsinfo))
+        self._mk_schema()
+
+        idx_obj = widx.create_in(index_dir, self.schema)
+        idx = idx_obj.writer(
+            # cache size per process
+            limitmb=cfg.obtain('datalad.search.indexercachesize'),
+            # disable parallel indexing for now till #1927 is resolved
+            ## number of processes for indexing
+            #procs=multiprocessing.cpu_count(),
+            ## write separate index segments in each process for speed
+            ## asks for writer.commit(optimize=True)
+            #multisegment=True,
+        )
+
+        # load metadata of the base dataset and what it knows about all its subdatasets
+        # (recursively)
+        old_idx_size = 0
+        old_ds_rpath = ''
+        idx_size = 0
+        for res in query_aggregated_metadata(
+                reporton=self.documenttype,
+                ds=self.ds,
+                aps=[dict(path=self.ds.path, type='dataset')],
+                # MIH: I cannot see a case when we would not want recursion (within
+                # the metadata)
+                recursive=True):
+            # this assumes that files are reported after each dataset report,
+            # and after a subsequent dataset report no files for the previous
+            # dataset will be reported again
+            meta = res.get('metadata', {})
+            doc = self._meta2doc(meta)
+            admin = {
+                'type': res['type'],
+                'path': relpath(res['path'], start=self.ds.path),
+            }
+            if 'parentds' in res:
+                admin['parentds'] = relpath(res['parentds'], start=self.ds.path)
+            if admin['type'] == 'dataset':
+                if old_ds_rpath:
+                    lgr.info(
+                        'Added %s on dataset %s',
+                        single_or_plural(
+                            'document',
+                            'documents',
+                            idx_size - old_idx_size,
+                            include_count=True),
+                        old_ds_rpath)
+                old_idx_size = idx_size
+                old_ds_rpath = admin['path']
+
+            doc.update({k: assure_unicode(v) for k, v in admin.items()})
+            lgr.debug("Adding document to search index: {}".format(doc))
+            # inject into index
+            idx.add_document(**doc)
+            idx_size += 1
+
+        if old_ds_rpath:
+            lgr.info(
+                'Added %s on dataset %s',
+                single_or_plural(
+                    'document',
+                    'documents',
+                    idx_size - old_idx_size,
+                    include_count=True),
+                old_ds_rpath)
+
+        lgr.debug("Committing index")
+        idx.commit(optimize=True)
+
+        # "timestamp" the search index to allow for automatic invalidation
+        with open(stamp_fname, 'w') as f:
+            f.write(metadata_state)
+
+        lgr.info('Search index contains %i documents', idx_size)
+        self.idx_obj = idx_obj
+
+    def __call__(self, query, max_nresults=None, force_reindex=False, show_keys=False, show_query=False):
+
+        self._mk_search_index(force_reindex)
+
+        if show_keys:
+            for k in self.idx_obj.schema.names():
+                print(u'{}'.format(k))
+            return
+
+        if not query:
+            return
+
+        with self.idx_obj.searcher() as searcher:
+            # parse the query string
+            self._mk_parser()
+            # for convenience we accept any number of args-words from the
+            # shell and put them together to a single string here
+            querystr = ' '.join(assure_list(query))
+            # this gives a formal whoosh query
+            wquery = self.parser.parse(querystr)
+
+            if show_query:
+                print(wquery)
+                return
+            # perform the actual search
+            hits = searcher.search(
+                wquery,
+                terms=True,
+                limit=max_nresults if max_nresults > 0 else None)
+            # report query stats
+            topstr = '{} top {}'.format(
+                max_nresults,
+                single_or_plural('match', 'matches', max_nresults)
+            )
+            lgr.info('Query completed in {} sec.{}'.format(
+                hits.runtime,
+                ' Reporting {}.'.format(
+                    ('up to ' + topstr)
+                    if max_nresults > 0
+                    else 'all matches'
+                )
+                if not hits.is_empty()
+                else ' No matches.'
+            ))
+
+            if not hits:
+                return
+
+            nhits = 0
+            for hit in hits:
+                res = dict(
+                    action='search',
+                    status='ok',
+                    logger=lgr,
+                    refds=self.ds.path,
+                    # normpath to avoid trailing dot
+                    path=normpath(opj(self.ds.path, hit['path'])),
+                    query_matched={assure_unicode(k): assure_unicode(v)
+                                   if isinstance(v, unicode_srctypes) else v
+                                   for k, v in hit.matched_terms()},
+                    metadata={k: v for k, v in hit.fields().items()
+                              if k not in ('path', 'parentds')})
+                if 'parentds' in hit:
+                    res['parentds'] = normpath(opj(self.ds.path, hit['parentds']))
+                if res['metadata'].get('type', None) in ('file', 'dataset'):
+                    res['type'] = res['metadata']['type']
+                yield res
+                nhits += 1
+
+            if max_nresults and nhits == max_nresults:
+                lgr.info(
+                    "Reached the limit of {}, there could be more which "
+                    "were not reported.".format(topstr)
+                )
+
+
+class _BlobSearch(_WhooshSearch):
+    _mode_label = 'default'
+    _default_documenttype = 'datasets'
+
+    def _meta2doc(self, meta):
+        # coerce the entire flattened metadata dict into a comma-separated string
+        # that also includes the keys
+        return dict(meta=u', '.join(
+            u'{}: {}'.format(k, v)
+            for k, v in _meta2autofield_dict(
+                meta,
+                val2str=True,
+                schema=None).items()))
+
+    def _mk_schema(self):
+        from whoosh import fields as wf
+        from whoosh.analysis import StandardAnalyzer
+
+        # TODO support some customizable mapping to homogenize some metadata fields
+        # onto a given set of index keys
+        self.schema = wf.Schema(
+            id=wf.ID,
+            path=wf.ID(stored=True),
+            type=wf.ID(stored=True),
+            parentds=wf.ID(stored=True),
+            meta=wf.TEXT(
+                stored=False,
+                analyzer=StandardAnalyzer(minsize=2))
+        )
+
+    def _mk_parser(self):
+        from whoosh import qparser as qparse
+
+        # use whoosh default query parser for now
+        self.parser = qparse.QueryParser(
+            "meta",
+            schema=self.idx_obj.schema
+        )
+
+
+class _AutofieldSearch(_WhooshSearch):
+    _mode_label = 'autofield'
+    _default_documenttype = 'all'
+
+    def _meta2doc(self, meta):
+        return _meta2autofield_dict(meta, val2str=True, schema=self.schema)
+
+    def _mk_schema(self):
+        from whoosh import fields as wf
+        from whoosh.analysis import StandardAnalyzer
+        from whoosh.analysis import SimpleAnalyzer
+
+        # haven for terms that have been found to be undefined
+        # (for faster decision-making upon next encounter)
+        # this will harvest all discovered term definitions
+        definitions = {
+            '@id': 'unique identifier of an entity',
+            # TODO make proper JSON-LD definition
+            'path': 'path name of an entity relative to the searched base dataset',
+            # TODO make proper JSON-LD definition
+            'parentds': 'path of the datasets that contains an entity',
+            # 'type' will not come from a metadata field, hence will not be detected
+            'type': 'type of a record',
+        }
+
+        schema_fields = {
+            n.lstrip('@'): wf.ID(stored=True, unique=n == '@id')
+            for n in definitions}
+
+        lgr.info('Scanning for metadata keys')
+        # quick 1st pass over all dataset to gather the needed schema fields
+        for res in query_aggregated_metadata(
+                reporton='datasets',
+                ds=self.ds,
+                aps=[dict(path=self.ds.path, type='dataset')],
+                recursive=True):
+            meta = res.get('metadata', {})
+            # no stringification of values for speed, we do not need/use the
+            # actual values at this point, only the keys
+            idxd = _meta2autofield_dict(meta, val2str=False)
+
+            for k in idxd:
+                schema_fields[k] = wf.TEXT(stored=False,
+                                           analyzer=SimpleAnalyzer())
+
+        self.schema = wf.Schema(**schema_fields)
+
+    def _mk_parser(self):
+        from whoosh import qparser as qparse
+
+        parser = qparse.MultifieldParser(
+            self.idx_obj.schema.names(),
+            self.idx_obj.schema)
+        # XXX: plugin is broken in Debian's whoosh 2.7.0-2, but already fixed
+        # upstream
+        parser.add_plugin(qparse.FuzzyTermPlugin())
+        parser.add_plugin(qparse.GtLtPlugin())
+        parser.add_plugin(qparse.SingleQuotePlugin())
+        # replace field defintion to allow for colons to be part of a field's name:
+        parser.replace_plugin(qparse.FieldsPlugin(expr=r"(?P<text>[()<>.\w]+|[*]):"))
+        self.parser = parser
 
 
 @build_doc
@@ -607,103 +701,18 @@ class Search(Interface):
                 yield r
             return
 
-        # where does the bunny have the eggs?
-        index_dir = opj(ds.path, get_git_dir(ds.path), SEARCH_INDEX_DOTGITDIR)
-
         if mode == 'default':
-            get_schema_fx = _get_schema_homoblob
-            meta2doc_fx = _meta2homoblob_dict
-            get_parser = _get_parser_homoblob
-            documenttype = ds.config.obtain(
-                'datalad.search.index-default-documenttype',
-                default='datasets')
+            searcher = _BlobSearch(ds)
         elif mode == 'autofield':
-            get_schema_fx = _get_schema_autofield
-            meta2doc_fx = _meta2autofield_dict
-            get_parser = _get_parser_autofield
-            documenttype = ds.config.obtain(
-                'datalad.search.index-autofield-documenttype',
-                default='all')
+            searcher = _AutofieldSearch(ds)
         else:
             raise ValueError(
                 'unknown search mode "{}"'.format(mode))
 
-        idx_obj = _get_search_index(
-            index_dir,
-            mode,
-            ds,
-            force_reindex,
-            get_schema_fx,
-            meta2doc_fx,
-            documenttype)
-
-        if show_keys:
-            for k in idx_obj.schema.names():
-                print(u'{}'.format(k))
-            return
-
-        if not query:
-            return
-
-        with idx_obj.searcher() as searcher:
-            # parse the query string
-            parser = get_parser(idx_obj)
-            # for convenience we accept any number of args-words from the
-            # shell and put them together to a single string here
-            querystr = ' '.join(assure_list(query))
-            # this gives a formal whoosh query
-            wquery = parser.parse(querystr)
-
-            if show_query:
-                print(wquery)
-                return
-            # perform the actual search
-            hits = searcher.search(
-                wquery,
-                terms=True,
-                limit=max_nresults if max_nresults > 0 else None)
-            # report query stats
-            topstr = '{} top {}'.format(
-                max_nresults,
-                single_or_plural('match', 'matches', max_nresults)
-            )
-            lgr.info('Query completed in {} sec.{}'.format(
-                hits.runtime,
-                ' Reporting {}.'.format(
-                    ('up to ' + topstr)
-                    if max_nresults > 0
-                    else 'all matches'
-                )
-                if not hits.is_empty()
-                else ' No matches.'
-            ))
-
-            if not hits:
-                return
-
-            nhits = 0
-            for hit in hits:
-                res = dict(
-                    action='search',
-                    status='ok',
-                    logger=lgr,
-                    refds=ds.path,
-                    # normpath to avoid trailing dot
-                    path=normpath(opj(ds.path, hit['path'])),
-                    query_matched={assure_unicode(k): assure_unicode(v)
-                                   if isinstance(v, unicode_srctypes) else v
-                                   for k, v in hit.matched_terms()},
-                    metadata={k: v for k, v in hit.fields().items()
-                              if k not in ('path', 'parentds')})
-                if 'parentds' in hit:
-                    res['parentds'] = normpath(opj(ds.path, hit['parentds']))
-                if res['metadata'].get('type', None) in ('file', 'dataset'):
-                    res['type'] = res['metadata']['type']
-                yield res
-                nhits += 1
-
-            if max_nresults and nhits == max_nresults:
-                lgr.info(
-                    "Reached the limit of {}, there could be more which "
-                    "were not reported.".format(topstr)
-                )
+        for r in searcher(
+                query,
+                max_nresults=max_nresults,
+                force_reindex=force_reindex,
+                show_keys=show_keys,
+                show_query=show_query):
+            yield r

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -27,6 +27,7 @@ from datalad.tests.utils import slow
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_dict_equal
+from datalad.tests.utils import assert_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_direct_mode
@@ -163,14 +164,16 @@ def test_aggregation(path):
 
     # test search in search tests, not all over the place
     ## query smoke test
-    #assert_result_count(clone.search('mother*'), 1)
+    assert_result_count(clone.search('mother', mode='egrep'), 1)
     #assert_result_count(clone.search('MoTHER*'), 1)
 
-    #child_res = clone.search('*child*')
-    #assert_result_count(child_res, 2)
-    #for r in child_res:
-    #    if r['metadata']['type'] == 'dataset':
-    #        eq_(r['query_matched']['name'], r['metadata']['name'])
+    child_res = clone.search('child', mode='egrep')
+    assert_result_count(child_res, 2)
+    for r in child_res:
+        if r['type'] == 'dataset':
+            assert_in(
+                r['query_matched'],
+                r['metadata']['bids']['name'])
 
     ## Test 'and' for multiple search entries
     #assert_result_count(clone.search(['*child*', '*bids*']), 2)

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -219,7 +219,7 @@ def test_within_ds_file_search(path):
 
     # test default behavior
     with swallow_outputs() as cmo:
-        ds.search(show_keys=True)
+        ds.search(show_keys=True, mode='textblob')
 
         assert_equal(cmo.out, """\
 id
@@ -298,12 +298,12 @@ type
     # now check that we can discover things from the aggregated metadata
     for mode, query, hitpath, matched_key, matched_val in (
             # random keyword query
-            ('default',
+            ('textblob',
              'mp3',
              opj('stim', 'stim1.mp3'),
              'meta', 'mp3'),
             # multi word query implies AND
-            ('default',
+            ('textblob',
              ['bold', 'male'],
              opj('sub-01', 'func', 'sub-01_task-some_bold.nii.gz'),
              'meta', 'male'),
@@ -336,8 +336,8 @@ type
             # query language configuration
     ):
         res = ds.search(query, mode=mode)
-        if mode == 'default':
-            # 'default' does datasets by default only (be could be configured otherwise
+        if mode == 'textblob':
+            # 'textblob' does datasets by default only (be could be configured otherwise
             assert_result_count(res, 1)
         else:
             # the rest has always a file and the dataset, because they carry metadata in

--- a/datalad/plugin/bids2scidata.py
+++ b/datalad/plugin/bids2scidata.py
@@ -25,7 +25,6 @@ from os.path import split as psplit
 
 from datalad.utils import assure_list
 from datalad.metadata.metadata import query_aggregated_metadata
-from datalad.metadata.search import r_url
 from six.moves.urllib.parse import urlsplit
 from six.moves.urllib.parse import urlunsplit
 from posixpath import split as posixsplit
@@ -35,6 +34,8 @@ try:
 except ImportError:
     pd = None
 
+# regex for a cheap test if something looks like a URL
+r_url = re.compile(r"^https?://")
 
 # standardize columns from participants.tsv
 sample_property_name_map = {


### PR DESCRIPTION
- [x]  has modes encapsulated in different classes now. This gives a standard API for alternative searchers to implement.
- [x] "egrep" search mode with expression matching on a stringified metadata dump, slow but works without an intermediate metadata transformation into a search index
- [x] default search mode is configurable (by dataset if necessary) and defaults to 'egrep'
