### PR TITLE
intermittent test failure: 'str' does not support the buffer interface

### DIFF
--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -1,4 +1,4 @@
-# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -27,6 +27,7 @@ from .utils import with_tempfile, assert_cwd_unchanged, \
     ignore_nose_capturing_stdout, swallow_outputs, swallow_logs, \
     on_linux, on_osx, on_windows, with_testrepos
 from .utils import lgr
+from ..utils import assure_unicode
 
 from .utils import local_testrepo_flavors
 
@@ -308,3 +309,17 @@ def test_runner_stdin(path):
     with swallow_outputs() as cmo, open(opj(path, "test_input.txt"), "r") as fake_input:
         runner.run(['cat'], log_stdout=False, stdin=fake_input)
         assert_in("whatever", cmo.out)
+
+
+def test_process_remaining_output():
+    runner = Runner()
+    out = u"""\
+s
+п
+"""
+    out_bytes = out.encode('utf-8')
+    target = u"sп".encode('utf-8')
+    args = ['stdout', None, False, False]
+    #  probably #2185
+    eq_(runner._process_remaining_output(None, out_bytes, *args), target)
+    eq_(runner._process_remaining_output(None, out, *args), target)


### PR DESCRIPTION
#### What is the problem?
happened on travis:
https://travis-ci.org/datalad/datalad/jobs/342143094
in python 3.4 DATALAD_REPO_VERSION=5 on 0.9.x branch
but not sure if anything but it being python3 is related:
```
======================================================================
ERROR: datalad.tests.test_cmd.test_runner_heavy_output(False,)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/travis/build/datalad/datalad/datalad/tests/utils.py", line 1225, in newfunc
    func(*args, **kwargs)
  File "/home/travis/build/datalad/datalad/datalad/tests/test_cmd.py", line 202, in check_runner_heavy_output
    expect_stderr=True)
  File "/home/travis/build/datalad/datalad/datalad/cmd.py", line 488, in run
    expect_fail=expect_fail)
  File "/home/travis/build/datalad/datalad/datalad/cmd.py", line 304, in _get_output_online
    stdout += self._process_remaining_output(outputstream, stdout_, *stdout_args)
  File "/home/travis/build/datalad/datalad/datalad/cmd.py", line 323, in _process_remaining_output
    for line in out_.split(os.linesep):
TypeError: 'str' does not support the buffer interface
```
