### PR TITLE
Use lsfiles to obtain list of submodules (and maybe other info)

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -303,7 +303,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
         if start is not None and not subds.path.startswith(_with_sep(start)):
             # this one we can ignore, not underneath the start path
             continue
-        if sub['state'] != 'absent':
+        if sub.get('state', None) != 'absent':
             # dataset was already found to exist
             yield get_status_dict(
                 'install', ds=subds, status='notneeded', logger=lgr,

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -108,7 +108,10 @@ def _parse_git_submodules(dspath):
         sm = {}
         props = submodule_full_props.match(line)
         sm['revision'] = props.group(2)
-        sm['path'] = opj(dspath, props.group(4))
+        subpath = opj(dspath, props.group(4))
+        sm['path'] = subpath
+        if not exists(subpath) or not GitRepo.is_valid_repo(subpath):
+            sm['state'] = 'absent'
         yield sm
 
 

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -48,16 +48,8 @@ from .dataset import resolve_path
 lgr = logging.getLogger('datalad.distribution.subdatasets')
 
 
-submodule_full_props = re.compile(r'([0-9a-f]+) (.*) \((.*)\)$')
-submodule_nodescribe_props = re.compile(r'([0-9a-f]+) (.*)$')
+submodule_full_props = re.compile(r'([0-9]+) (.*) (.*)\t(.*)$')
 valid_key = re.compile(r'^[A-Za-z][-A-Za-z0-9]*$')
-
-status_map = {
-    ' ': 'clean',
-    '+': 'modified',
-    '-': 'absent',
-    'U': 'conflict',
-}
 
 
 def _parse_gitmodules(dspath):
@@ -84,7 +76,7 @@ def _parse_gitmodules(dspath):
     return mods
 
 
-def _parse_git_submodules(dspath, recursive):
+def _parse_git_submodules(dspath):
     """All known ones with some properties"""
     if not exists(opj(dspath, ".gitmodules")):
         # easy way out. if there is no .gitmodules file
@@ -92,9 +84,7 @@ def _parse_git_submodules(dspath, recursive):
         return
 
     # this will not work in direct mode, need better way #1422
-    cmd = ['git', '--work-tree=.', 'submodule', 'status']
-    if recursive:
-        cmd.append('--recursive')
+    cmd = ['git', 'ls-files', '--stage', '-z']
 
     # need to go rogue  and cannot use proper helper in GitRepo
     # as they also pull in all of GitPython's magic
@@ -112,20 +102,13 @@ def _parse_git_submodules(dspath, recursive):
     except CommandError as e:
         raise InvalidGitRepositoryError(exc_str(e))
 
-    for line in stdout.split('\n'):
-        if not line:
+    for line in stdout.split('\0'):
+        if not line or not line.startswith('160000'):
             continue
         sm = {}
-        sm['state'] = status_map[line[0]]
-        props = submodule_full_props.match(line[1:])
-        if props:
-            sm['revision'] = props.group(1)
-            sm['path'] = opj(dspath, props.group(2))
-            sm['revision_descr'] = props.group(3)
-        else:
-            props = submodule_nodescribe_props.match(line[1:])
-            sm['revision'] = props.group(1)
-            sm['path'] = opj(dspath, props.group(2))
+        props = submodule_full_props.match(line)
+        sm['revision'] = props.group(2)
+        sm['path'] = opj(dspath, props.group(4))
         yield sm
 
 
@@ -266,47 +249,6 @@ class Subdatasets(Interface):
                     raise ValueError(
                         "key '%s' is invalid (alphanumeric plus '-' only, must start with a letter)",
                         k)
-        try:
-            if not (bottomup or contains or set_property or delete_property or \
-                    (recursive and recursion_limit is not None)):
-                # FAST IMPLEMENTATION FOR THE STRAIGHTFORWARD CASE
-                # as fast as possible (just a single call to Git)
-                # need to track current parent
-                stack = [refds_path]
-                modinfo_cache = {}
-                for sm in _parse_git_submodules(refds_path, recursive=recursive):
-                    # unwind the parent stack until we find the right one
-                    # this assumes that submodules come sorted
-                    while not sm['path'].startswith(_with_sep(stack[-1])):
-                        stack.pop()
-                    parent = stack[-1]
-                    if parent not in modinfo_cache:
-                        # read the parent .gitmodules, if not done yet
-                        modinfo_cache[parent] = _parse_gitmodules(parent)
-                    # get URL info, etc.
-                    sm.update(modinfo_cache[parent].get(sm['path'], {}))
-                    subdsres = get_status_dict(
-                        'subdataset',
-                        status='ok',
-                        type='dataset',
-                        refds=refds_path,
-                        logger=lgr)
-                    subdsres.update(sm)
-                    subdsres['parentds'] = parent
-                    if (fulfilled is None or
-                            GitRepo.is_valid_repo(sm['path']) == fulfilled):
-                        yield subdsres
-                    # for the next "parent" commit this subdataset to the stack
-                    stack.append(sm['path'])
-                # MUST RETURN: the rest of the function is doing another implementation
-                return
-        except InvalidGitRepositoryError as e:
-            lgr.debug("fast subdataset query failed, trying slow robust one (%s)",
-                      exc_str(e))
-
-        # MORE ROBUST, FLEXIBLE, BUT SLOWER IMPLEMENTATION
-        # slow but flexible (one Git call per dataset), but deals with subdatasets in
-        # direct mode
         if contains:
             contains = resolve_path(contains, dataset)
         for r in _get_submodules(
@@ -337,7 +279,7 @@ def _get_submodules(dspath, fulfilled, recursive, recursion_limit,
     #        gitmodule_path, read_only=False, merge_includes=False)
     #    parser.read()
     # put in giant for-loop to be able to yield results before completion
-    for sm in _parse_git_submodules(dspath, recursive=False):
+    for sm in _parse_git_submodules(dspath):
         if contains and \
                 not (contains == sm['path'] or
                      contains.startswith(_with_sep(sm['path']))):

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -169,7 +169,6 @@ def test_get_subdatasets(path):
         [])
 
 
-@known_failure_direct_mode  #FIXME
 @with_tempfile
 def test_state(path):
     ds = Dataset.create(path)
@@ -194,6 +193,7 @@ def test_state(path):
         ds.subdatasets(), 1, path=sub.path, state='absent')
 
 
+@known_failure_direct_mode  #FIXME same issue as gh-2113
 @with_tempfile
 def test_get_subdatasets_types(path):
     from datalad.api import create

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -89,7 +89,8 @@ def test_get_subdatasets(path):
     res = ds.subdatasets(recursive=True)
     assert_status('ok', res)
     for r in res:
-        for prop in ('gitmodule_url', 'state', 'revision', 'gitmodule_name'):
+        #for prop in ('gitmodule_url', 'state', 'revision', 'gitmodule_name'):
+        for prop in ('gitmodule_url', 'revision', 'gitmodule_name'):
             assert_in(prop, r)
         # random property is unknown
         assert_not_in('mike', r)

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -125,7 +125,7 @@ def test_annotate_paths(dspath, nodspath):
     assert_result_count(base_res, 2)
     assert_result_count(base_res, 2, type='dataset')
     assert_result_count(
-        base_res, 1, type='dataset', state='clean', parentds=parentds.path,
+        base_res, 1, type='dataset', parentds=parentds.path,
         path=opj(parentds.path, 'aa'), status='')
     # same recursion but without a base dataset
     res = annotate_paths(path=opj(dspath, 'a'), recursive=True)


### PR DESCRIPTION
#### What is the problem?

we had discussion on possible other ways to get a list of submodules without invoking `git submodule status` which does additional stuff.

magit uses `git ls-files --stage` and then submodules have a leading magical tag `160000`.  There is also `--recurse-submodules` but that one is not compatible with `--stage` which directs to output those tags

# Timing

the fun part is that surprisingly `ls-files` although lists all the files in the repo, still comes out as a winner even with grep attached even when there is no submodules

```shell
falkor:/srv/datasets.datalad.org/www/openfmri/ds000115
$> time bash -c 'git ls-files --stage | grep ^160000'
bash -c 'git ls-files --stage | grep ^160000'  0.00s user 0.00s system 0% cpu 0.007 total

$> time git submodule status                         
git submodule status  0.00s user 0.00s system 12% cpu 0.033 total
```

more fun whenever we actually go to a repo with submodules:
```shell
(git)falkor:/srv/datasets.datalad.org/www/openfmri[master]
$> time git submodule status
 f47099a5124e8f619f763f44f70e1faf5154d41a ds000001 (2.0.4+3-2-gf47099a5)
 e1b7df06da8dd8f1d8802d699d9ad7781fad8bb6 ds000002 (2.0.5+3-1-ge1b7df06)
  ...
 git submodule status  0.02s user 0.08s system 7% cpu 1.324 total

$> time bash -c 'git ls-files --stage | grep ^160000'
160000 f47099a5124e8f619f763f44f70e1faf5154d41a 0	ds000001
160000 e1b7df06da8dd8f1d8802d699d9ad7781fad8bb6 0	ds000002
...
160000 58882ccf9e03f445beb39ae624934e49fba63bf6 0	ds000258
bash -c 'git ls-files --stage | grep ^160000'  0.00s user 0.00s system 0% cpu 0.008 total
```

so if we were after just a list of submodules -- this might be the way to get speeds up!

## Timing on our full hierarchy

```
   508   5ebf32dcf9068be18ee8403346957d3d6aee96c1 workshops/repronim-sfn-2017/challenge (0.0.20171111+1-1-g5ebf32d)
git submodule status --recursive  8.37s user 4.36s system 101% cpu 12.520 total
```

```
   508  ./workshops/repronim-sfn-2017/challenge
~/trash/subm.sh .  4.00s user 2.09s system 174% cpu 3.493 total
```
where the subm.sh is ls-files based script doing it recursively:
```bash
#!/bin/bash

git -C $1 ls-files --stage | grep '^160' | awk '{print $4;}' | while read d; do echo $1/$d; $0 $1/$d; done; 
```
