### PR TITLE
RF: use existing path_startswith instead of repeating pattern of .startswith(_with_sep

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -53,6 +53,7 @@ from datalad.dochelpers import single_or_plural
 from datalad.utils import get_dataset_root
 from datalad.utils import with_pathsep as _with_sep
 from datalad.utils import unique
+from datalad.utils import path_startswith
 
 from .dataset import Dataset
 from .dataset import EnsureDataset
@@ -300,7 +301,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                 "subdataset %s is configured to be skipped on recursive installation",
                 sub['path'])
             continue
-        if start is not None and not subds.path.startswith(_with_sep(start)):
+        if start is not None and not path_startswith(subds.path, start):
             # this one we can ignore, not underneath the start path
             continue
         if sub['state'] != 'absent':

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -38,6 +38,7 @@ from datalad.distribution.dataset import require_dataset
 from datalad.cmd import GitRunner
 from datalad.support.gitrepo import GitRepo
 from datalad.utils import with_pathsep as _with_sep
+from datalad.utils import path_startswith
 from datalad.utils import assure_list
 from datalad.dochelpers import exc_str
 
@@ -277,7 +278,7 @@ class Subdatasets(Interface):
                 for sm in _parse_git_submodules(refds_path, recursive=recursive):
                     # unwind the parent stack until we find the right one
                     # this assumes that submodules come sorted
-                    while not sm['path'].startswith(_with_sep(stack[-1])):
+                    while not path_startswith(sm['path'], stack[-1]):
                         stack.pop()
                     parent = stack[-1]
                     if parent not in modinfo_cache:
@@ -340,7 +341,7 @@ def _get_submodules(dspath, fulfilled, recursive, recursion_limit,
     for sm in _parse_git_submodules(dspath, recursive=False):
         if contains and \
                 not (contains == sm['path'] or
-                     contains.startswith(_with_sep(sm['path']))):
+                     path_startswith(contains, sm['path'])):
             # we are not looking for this subds, because it doesn't
             # match the target path
             continue

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -42,6 +42,7 @@ from datalad.distribution.dataset import datasetmethod
 
 from datalad.utils import get_dataset_root
 from datalad.utils import with_pathsep as _with_sep
+from datalad.utils import path_startswith
 from datalad.utils import assure_list
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
@@ -126,7 +127,7 @@ def annotated2content_by_ds(annotated, refds_path, path_only=False):
                 toappendto.append(r['path'] if path_only else r)
                 content_by_ds[r['path']] = toappendto
             if parentds and refds_path and \
-                    _with_sep(parentds).startswith(_with_sep(refds_path)):
+                    path_startswith(parentds, refds_path):
                 # put also in parentds record if there is any, and the parent
                 # is underneath or identical to the reference dataset
                 toappendto = content_by_ds.get(parentds, [])
@@ -153,7 +154,7 @@ def yield_recursive(ds, path, action, recursion_limit):
         # this check is not the same as subdatasets --contains=path
         # because we want all subdataset below a path, not just the
         # containing one
-        if subd_res['path'].startswith(_with_sep(path)):
+        if path_startswith(subd_res['path'], path):
             # this subdatasets is underneath the search path
             # be careful to not overwrite anything, in case
             # this subdataset has been processed before
@@ -242,7 +243,7 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None,
                 ap.update(m)
                 yield ap
                 break
-            if m['path'].startswith(_with_sep(ap['path'])):
+            if path_startswith(m['path'], ap['path']):
                 # a modified path is underneath this AP
                 # yield the modified one instead
                 yield m
@@ -537,7 +538,7 @@ class AnnotatePaths(Interface):
                 for r in requested_paths:
                     p = r['path'] if isinstance(r, dict) else r
                     p = resolve_path(p, ds=refds_path)
-                    if _with_sep(p).startswith(_with_sep(refds_path)):
+                    if path_startswith(p, refds_path):
                         # all good
                         continue
                     # not the refds
@@ -654,7 +655,7 @@ class AnnotatePaths(Interface):
                 continue
 
             # check that we only got SUBdatasets
-            if refds_path and not _with_sep(dspath).startswith(_with_sep(refds_path)):
+            if refds_path and not path_startswith(dspath, refds_path):
                 res = get_status_dict(**dict(res_kwargs, **path_props))
                 res['status'] = nondataset_path_status
                 res['message'] = \

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -38,6 +38,7 @@ from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
 from datalad.utils import with_pathsep as _with_sep
+from datalad.utils import path_startswith
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
 
@@ -115,7 +116,7 @@ def _get_untracked_content(dspath, report_untracked, paths=None):
             # strip state marker
             line[3:])
         norm_apath = normpath(apath)
-        if paths and not any([norm_apath == p or apath.startswith(_with_sep(p)) for p in paths]):
+        if paths and not any([norm_apath == p or path_startswith(apath, p) for p in paths]):
             # we got a whitelist for paths, don't report any other
             continue
         ap = dict(

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -22,6 +22,8 @@ from os.path import abspath
 from os.path import normpath
 from datalad.utils import assure_list
 from datalad.utils import with_pathsep as _with_sep
+from datalad.utils import path_startswith
+
 from datalad.distribution.dataset import Dataset
 
 
@@ -328,7 +330,7 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
             # do we have any failures in a subdir of the requested dir?
             failure_results = [
                 fp for fp in respath_by_status.get('failure', [])
-                if fp.startswith(_with_sep(p))]
+                if path_startswith(fp, p)]
             if failure_results:
                 # we were not able to process all requested_paths, let's label
                 # this 'impossible' to get a warning-type report
@@ -342,7 +344,7 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
                 # otherwise cool, but how cool?
                 success_results = [
                     fp for fp in respath_by_status.get('success', [])
-                    if fp.startswith(_with_sep(p))]
+                    if path_startswith(fp, p)]
                 yield get_status_dict(
                     status='ok' if success_results else 'notneeded',
                     message=None if success_results else (noinfo_dir_msg, p),

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -33,6 +33,7 @@ import json
 
 # avoid import from API to not get into circular imports
 from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
+from datalad.utils import path_startswith
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import IncompleteResultsError
 from datalad import cfg as dlcfg
@@ -210,7 +211,7 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace, spec
             # ignore gitdir to speed things up
             continue
         p = opj(basepath, p)
-        if all(t != p and not t.startswith(_with_sep(p)) for t in targetpaths):
+        if all(t != p and not path_startswith(t, p) for t in targetpaths):
             # OPT listdir might be large and we could have only few items
             # in `targetpaths` -- so traverse only those in spec which have
             # leading dir basepath

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -20,6 +20,8 @@ from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import if_dirty_opt
 from datalad.interface.common_opts import nosave_opt
 from datalad.utils import with_pathsep as _with_sep
+from datalad.utils import path_startswith
+
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     Dataset, require_dataset
 from ..support.param import Parameter
@@ -192,7 +194,7 @@ def _dump_submeta(ds, submetas, matchpath, save, modified_ds):
     known_subds = list(submetas.keys())
     for p in known_subds:
         smeta = submetas[p]
-        if matchpath and not p.startswith(_with_sep(matchpath)):
+        if matchpath and not path_startswith(p, matchpath):
             continue
         subds_relpath = relpath(p, matchpath)
         # inject proper inter-dataset relationships


### PR DESCRIPTION
Following commands used
```shell
 git grep -l '\.startswith(_with_sep(' | xargs sed -i -e 's|\(\<[^ ]*\)\.startswith(_with_sep(\([^)]*\)))|path_startswith(\1, \2)|g'
git-sedi -e 's|\(\<[^ ]*\)\.startswith(_with_sep(\([^)]*\)))|path_startswith(\1, \2)|g' 
```
should be done on master as well after this merged -- there is more uses
### Changes
- [x] This change is complete

Please have a look @datalad/developers
