### PR TITLE
BF: do not log traceback for log msgs deep within auto

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -180,8 +180,8 @@ class AutomagicIO(object):
                 else:
                     raise _EarlyExit("mode=%r", mode)
         except _EarlyExit as e:
-            lgr.log(2, " skipping since " + (e.msg % e.args))
-            pass
+            lgr.log(2, " skipping since " + e.msg, *e.args,
+                    extra={'notraceback': True})
         except Exception as e:
             # If anything goes wrong -- we should complain and proceed
             with self._patch(origname, origfunc):

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -65,7 +65,7 @@ class TraceBack(object):
         self._extract_stack = traceback.extract_stack
 
     def __call__(self):
-        ftb = self._extract_stack(limit=200)[:-2]
+        ftb = self._extract_stack(limit=self.limit+10)[:-2]
         entries = [[mbasename(x[0]), str(x[1])]
                    for x in ftb if mbasename(x[0]) != 'logging.__init__']
         entries = [e for e in entries if e[0] != 'unittest']
@@ -148,7 +148,8 @@ class ColorFormatter(logging.Formatter):
             record.levelname = levelname_color
         record.msg = record.msg.replace("\n", "\n| ")
         if self._tb:
-            record.msg = self._tb() + "  " + record.msg
+            if not getattr(record, 'notraceback', False):
+                record.msg = self._tb() + "  " + record.msg
 
         return logging.Formatter.format(self, record)
 


### PR DESCRIPTION
traceback might try to open some files, which causes infinite recursion
within auto -- so we just do not log msgs there and be done

might lead to a bit of overhead while logging with a traceback, but otherwise shouldn't impair
 
This pull request fixes #2107

### Changes
- [x] This change is complete

Please have a look @datalad/developers
