### PR TITLE
BF(TST): do not reuse the same providers in the vcr-taped test

### DIFF
--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -321,12 +321,12 @@ def get_versioned_url(url, guarantee_versioned=False, return_all=False, verify=F
     s3_bucket, fpath = None, url_rec.path.lstrip('/')
 
     if url_rec.netloc.endswith('.s3.amazonaws.com'):
-        if not url_rec.scheme in ('http', 'https'):
+        if url_rec.scheme not in ('http', 'https'):
             raise ValueError("Do not know how to handle %s scheme" % url_rec.scheme)
         # we know how to slice this cat
         s3_bucket = url_rec.netloc.split('.', 1)[0]
     elif url_rec.netloc == 's3.amazonaws.com':
-        if not url_rec.scheme in ('http', 'https'):
+        if url_rec.scheme not in ('http', 'https'):
             raise ValueError("Do not know how to handle %s scheme" % url_rec.scheme)
         # url is s3.amazonaws.com/bucket/PATH
         s3_bucket, fpath = fpath.split('/', 1)

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -19,9 +19,8 @@ from nose.tools import eq_, assert_raises
 from datalad.tests.utils import skip_if_no_network
 from ..downloaders.tests.utils import get_test_providers
 
-skip_if_no_network()  # ATM we don't ship fixtures, so if no network -- no network!
 
-
+@skip_if_no_network
 @use_cassette('s3_test_version_url')
 def test_version_url():
     get_test_providers('s3://openfmri/tarballs')  # to verify having credentials to access openfmri via S3
@@ -53,14 +52,16 @@ def test_version_url():
         ok_startswith(url, 'http://datalad-test0-versioned.s3.amazonaws.com/2versions-removed-recreated.txt?versionId=')
 
 
+@skip_if_no_network
 @use_cassette('s3_test_version_url_deleted')
 def test_version_url_deleted():
-    get_test_providers('s3://openneuro/')  # to verify having credentials to access
+    get_test_providers('s3://datalad-test0-versioned/', reload=True)  # to verify having credentials to access
     # openfmri via S3
     # it existed and then was removed
-    fpath = "ds000158/ds158_R1.0.1/compressed/ds000158_R1.0.1_sub001-055.zip"
-    url = "http://openneuro.s3.amazonaws.com/%s" % fpath
-    turl = "http://openneuro.s3.amazonaws.com/%s?versionId=null" % fpath
+    fpath = "1version-removed.txt"
+    url = "http://datalad-test0-versioned.s3.amazonaws.com/%s" % fpath
+    turl = "http://datalad-test0-versioned.s3.amazonaws.com/%s" \
+           "?versionId=eZ5Hgwo8azfBv3QT7aW9dmm2sbLUY.QP" % fpath
     eq_(get_versioned_url(url), turl)
     # too heavy for verification!
     #eq_(get_versioned_url(url, verify=True), turl)


### PR DESCRIPTION
The problem (will probably appear in other cases as well, that vcr
tapes gets "bound" in the previous test to the providers we get to reuse
in the next test, which then screws it up when both tests are ran.
I am afraid there are other places where this would reveal itself and more
systematic solution should come

This pull request fixes those reports where this test_s3.py was failing mumbling about not being able to override a cassette

### Changes
- [x] This change is complete

Please have a look @datalad/developers
