### PR TITLE
UI code bug somewhere

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -166,6 +166,12 @@ class BaseDownloader(object):
                         #  3. bug in out code which would render authentication/cookie handling
                         #     ineffective
                         #     - not sure what to do about it
+                        if not ui.is_interactive:
+                            # We cannot ask, so we just (re)blow
+                            lgr.error(
+                                "Interface is non interactive, so we are "
+                                "reraising: %s" % exc_str(e))
+                            raise
                         if ui.yesno(
                                 title="Authentication to access {url} has failed".format(url=url),
                                 text="Do you want to enter other credentials in case they were updated?"):

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -62,10 +62,10 @@ def _get_bucket_connection(credential):
 
 def _handle_exception(e, bucket_name):
     """Helper to handle S3 connection exception"""
-    if e.error_code == 'AccessDenied':
-        raise AccessDeniedError(exc_str(e))
-    else:
-        raise DownloadError(
+    raise (
+        AccessDeniedError
+        if e.error_code == 'AccessDenied'
+        else DownloadError)(
             "Cannot connect to %s S3 bucket. Exception: %s"
             % (bucket_name, exc_str(e))
         )
@@ -90,7 +90,7 @@ def get_bucket(conn, bucket_name):
             all_buckets = conn.get_all_buckets()
         except S3ResponseError as e2:
             lgr.debug("Cannot access all buckets: %s", exc_str(e2))
-            _handle_exception(e, 'any')
+            _handle_exception(e, 'any (originally requested %s)' % bucket_name)
         all_bucket_names = [b.name for b in all_buckets]
         lgr.debug("Found following buckets %s", ', '.join(all_bucket_names))
         if bucket_name in all_bucket_names:


### PR DESCRIPTION
#### What is the problem?

```
======================================================================
ERROR: datalad.interface.tests.test_ls.test_ls_s3
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/mih/hacking/datalad/git/datalad/tests/utils.py", line 841, in newfunc
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/wrapt/wrappers.py", line 518, in __call__
    args, kwargs)
  File "/usr/lib/python2.7/dist-packages/vcr/cassette.py", line 105, in __call__
    function, args, kwargs
  File "/usr/lib/python2.7/dist-packages/vcr/cassette.py", line 120, in _execute_function
    return self._handle_function(fn=handle_function)
  File "/usr/lib/python2.7/dist-packages/vcr/cassette.py", line 141, in _handle_function
    return fn(cassette)
  File "/usr/lib/python2.7/dist-packages/vcr/cassette.py", line 113, in handle_function
    return function(*args, **kwargs)
  File "/home/mih/hacking/datalad/git/datalad/interface/tests/test_ls.py", line 51, in test_ls_s3
    res = ls(url)
  File "/home/mih/hacking/datalad/git/datalad/interface/ls.py", line 147, in __call__
    **kw)
  File "/home/mih/hacking/datalad/git/datalad/interface/ls.py", line 911, in _ls_s3
    bucket = downloader.access(lambda url: downloader.bucket, loc)
  File "/home/mih/hacking/datalad/git/datalad/downloaders/base.py", line 169, in access
    if ui.yesno(
  File "/home/mih/hacking/datalad/git/datalad/ui/__init__.py", line 70, in __getattribute__
    return getattr(self._ui, key)
AttributeError: 'SilentConsoleLog' object has no attribute 'yesno'
```
The reason this happens at all is likely an absent S3 config, but the way it fails exactly seems to indicate a separate issue with the UI handling.

