### PR TITLE
datalad_core _get_content_metadata - shouldn't it provide paths for all (annexed and not) files?

### DIFF
--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -53,13 +53,14 @@ class MetadataExtractor(BaseMetadataExtractor):
         if not isinstance(self.ds.repo, AnnexRepo):
             for p in self.paths:
                 # this extractor does give a response for ANY file as it serves
-                # an an indicator of file presence (i.e. a file list) in the
+                # as an indicator of file presence (i.e. a file list) in the
                 # content metadata, even if we know nothing but the filename
                 # about a file
                 yield (p, dict())
             return
 
         valid_paths = None
+        # this is done to avoid passing a too long cmdline arg to git annex
         if self.paths and sum(len(i) for i in self.paths) > 500000:
             valid_paths = set(self.paths)
         for file, meta in self.ds.repo.get_metadata(

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -56,6 +56,5 @@ def test_api_git():
     yield check_api, True
 
 
-@known_failure_direct_mode
 def test_api_annex():
     yield check_api, False


### PR DESCRIPTION
#### What is the problem?
initially ran into within https://github.com/datalad/datalad/pull/2190
https://travis-ci.org/datalad/datalad/jobs/342624112#L3010

apparently a basic test starts to fail in direct mode that for some reason in that repository `git annex metadata` does not return empty entries  for the annexed files queried.
But looking at the code I have also realized that because git annex metadata doesn't return any metadata for non-annexed files, no entries will be returned for them either.  But whenever repo is just a pure GitRepo we do return empty entries for each file.
So there is this discrepancy in behavior it seems

For now I will just mark it as failing in direct in #2190 and proceed