### PR TITLE
TST: Correct a silently failing assertion

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -223,7 +223,7 @@ def test_install_datasets_root(tdir):
 
         with assert_raises(IncompleteResultsError) as cme:
             install("sub", source='///')
-            assert_in("already exists and not empty", str(cme))
+        assert_in("already exists and not empty", str(cme.exception))
 
 
 @known_failure_v6  #FIXME


### PR DESCRIPTION
Move the assertion outside of the block so that it actually runs, and make it check the exception message rather than the string representation of unittest.case._AssertRaisesContext.


### Changes
- [X] This change is complete

