### PR TITLE
OPT: cmdline startup faster (more cruft removed)

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -1,0 +1,13 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Python DataLad API exposing user-oriented commands (also available via CLI)"""
+
+from datalad.coreapi import *
+
+# TODO load plugin commands

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -168,19 +168,6 @@ queue
         os.unlink(f.name)
 
 
-class RegexpType(object):
-    """Factory for creating regular expression types for argparse
-
-    DEPRECATED AFAIK -- now things are in the config file,
-    but we might provide a mode where we operate solely from cmdline
-    """
-    def __call__(self, string):
-        if string:
-            return re.compile(string)
-        else:
-            return None
-
-
 # TODO: useful also outside of cmdline, move to support/
 from os import curdir
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -286,16 +286,6 @@ def setup_parser(
         return parser
 
 
-# yoh: arn't used
-# def generate_api_call(cmdlineargs=None):
-#     parser = setup_parser()
-#     # parse cmd args
-#     cmdlineargs = parser.parse_args(cmdlineargs)
-#     # convert cmdline args into API call spec
-#     functor, args, kwargs = cmdlineargs.func(cmdlineargs)
-#     return cmdlineargs, functor, args, kwargs
-
-
 def main(args=None):
     lgr.log(5, "Starting main(%r)", args)
     # PYTHON_ARGCOMPLETE_OK

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -66,6 +66,7 @@ THE SOFTWARE.
 # I wondered if it could somehow decide on what commands to worry about etc
 # by going through sys.args first
 def setup_parser(
+        cmdlineargs,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         return_subparsers=False):
 
@@ -195,6 +196,7 @@ def setup_parser(
 
     # auto detect all available interfaces and generate a function-based
     # API from them
+    cmdlineargs = set(cmdlineargs) if cmdlineargs else set()
     grp_short_descriptions = []
     interface_groups = get_interface_groups()
     for grp_name, grp_descr, _interfaces \
@@ -203,6 +205,17 @@ def setup_parser(
         cmd_short_descriptions = []
 
         for _intfspec in _interfaces:
+            cmd_name = get_cmdline_command_name(_intfspec)
+            # for each interface to be imported decide if it is necessary
+            # test conditions from frequent to infrequent occasions
+            # we want to import everything for help requests of any kind
+            # including a cluecless `datalad` without args
+            if not (len(cmdlineargs) == 1 or
+                    cmd_name in cmdlineargs or
+                    '--help' in cmdlineargs or
+                    '-h' in cmdlineargs or
+                    '--help-np' in cmdlineargs):
+                continue
             # turn the interface spec into an instance
             lgr.log(5, "Importing module %s " % _intfspec[0])
             try:
@@ -212,7 +225,6 @@ def setup_parser(
                           _intfspec[0], exc_str(e))
                 continue
             _intf = getattr(_mod, _intfspec[1])
-            cmd_name = get_cmdline_command_name(_intfspec)
             # deal with optional parser args
             if hasattr(_intf, 'parser_args'):
                 parser_args = _intf.parser_args
@@ -289,7 +301,7 @@ def setup_parser(
 def main(args=None):
     lgr.log(5, "Starting main(%r)", args)
     # PYTHON_ARGCOMPLETE_OK
-    parser = setup_parser()
+    parser = setup_parser(args or sys.argv)
     try:
         import argcomplete
         argcomplete.autocomplete(parser)

--- a/datalad/cmdline/tests/test_formatters.py
+++ b/datalad/cmdline/tests/test_formatters.py
@@ -84,7 +84,7 @@ def test_cmdline_example_to_rst():
     assert_not_in('#', out_text)      # no comments
 
 def test_parser_access():
-    parsers = setup_parser(return_subparsers=True)
+    parsers = setup_parser(['datalad'], return_subparsers=True)
     # we have a bunch
     ok_(len(parsers) > 3)
     assert_in('install', parsers.keys())
@@ -93,7 +93,7 @@ def test_parser_access():
 def test_manpage_formatter():
     addonsections = {'mytest': "uniquedummystring"}
 
-    parsers = setup_parser(return_subparsers=True)
+    parsers = setup_parser(['datalad'], return_subparsers=True)
     for p in parsers:
         mp = fmt.ManPageFormatter(
             p, ext_sections=addonsections).format_man_page(parsers[p])
@@ -103,7 +103,7 @@ def test_manpage_formatter():
 
 
 def test_rstmanpage_formatter():
-    parsers = setup_parser(return_subparsers=True)
+    parsers = setup_parser(['datalad'], return_subparsers=True)
     for p in parsers:
         mp = fmt.RSTManPageFormatter(p).format_man_page(parsers[p])
         for section in ('Synopsis', 'Description', 'Options'):

--- a/datalad/coreapi.py
+++ b/datalad/coreapi.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Python DataLad API exposing user-oriented commands (also available via CLI)"""
+"""Python DataLad core API exposing essential command used by other DataLad commands"""
 
 # Should have no spurious imports/definitions at the module level
 from .distribution.dataset import Dataset

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -37,6 +37,8 @@ from datalad.dochelpers import exc_str
 from datalad.utils import rmtree
 from datalad.utils import assure_list
 
+from datalad.distribution.add import Add
+
 from .dataset import Dataset
 from .dataset import datasetmethod
 from .dataset import resolve_path

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -38,6 +38,9 @@ from datalad.support.gitrepo import GitRepo
 from datalad.utils import getpwd
 from datalad.utils import get_dataset_root
 
+# required to get the binding of `add` as a dataset method
+from datalad.distribution.add import Add
+
 from .dataset import Dataset
 from .dataset import datasetmethod
 from .dataset import EnsureDataset

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -149,6 +149,7 @@ def yield_recursive(ds, path, action, recursion_limit):
     # make sure we get everything relevant in all _checked out_
     # subdatasets, obtaining of previously unavailable subdataset
     # is elsewhere
+    from datalad.distribution.subdatasets import Subdatasets
     for subd_res in ds.subdatasets(
             recursive=True,
             recursion_limit=recursion_limit,
@@ -180,6 +181,8 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None,
     revision : str
       Commit-ish
     """
+    from datalad.interface.diff import Diff
+
     # TODO needs recursion limit
     # NOTE this is implemented as a generator despite that fact that we need
     # to sort through _all_ the inputs initially, diff'ing each involved
@@ -681,6 +684,7 @@ class AnnotatePaths(Interface):
                     (path_type == 'dataset' and 'registered_subds' not in path_props) or
                     path_type == 'directory' or
                     not lexists(path)):
+                from datalad.distribution.subdatasets import Subdatasets
                 # if the path doesn't exist, or is labeled a directory, or a dataset even
                 # a dataset (without this info) -> record whether this is a known subdataset
                 # to its parent

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -37,6 +37,8 @@ from ..support import ansi_colors
 from ..support.constraints import EnsureStr, EnsureNone
 from ..distribution.dataset import Dataset
 
+from datalad.distribution.subdatasets import Subdatasets
+
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.annexrepo import GitRepo
 

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -38,6 +38,8 @@ from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import nosave_opt
 from datalad.interface.results import get_status_dict
 from datalad.distribution.dataset import Dataset
+from datalad.distribution.get import Get
+from datalad.distribution.subdatasets import Subdatasets
 from datalad.metadata.metadata import agginfo_relpath
 from datalad.metadata.metadata import exclude_from_metadata
 from datalad.metadata.metadata import get_metadata_type

--- a/setup_support.py
+++ b/setup_support.py
@@ -68,6 +68,7 @@ class BuildManPage(Command):
         try:
             mod = __import__(mod_name, fromlist=fromlist)
             self._parser = getattr(mod, func_name)(
+                ['datalad'],
                 formatter_class=fmt.ManPageFormatter,
                 return_subparsers=True)
 


### PR DESCRIPTION
This should have no visible differences for actual cmdline use, but
the startup time for individual commands should be noticeably reduced
Here is an example:

Pre:
```
In [2]: %timeit !datalad subdatasets
subdataset(ok): .asv (dataset)
subdataset(ok): .asv (dataset)
subdataset(ok): .asv (dataset)
subdataset(ok): .asv (dataset)
1 loop, best of 3: 317 ms per loop
```
Post:
```
In [3]: %timeit !datalad subdatasets
subdataset(ok): .asv (dataset)
subdataset(ok): .asv (dataset)
subdataset(ok): .asv (dataset)
subdataset(ok): .asv (dataset)
1 loop, best of 3: 223 ms per loop
```
Please have a look @datalad/developers
