### PR TITLE
Ignore PSgxxxxx DICOM files during metadata extraction

### DIFF
--- a/datalad/metadata/extractors/dicom.py
+++ b/datalad/metadata/extractors/dicom.py
@@ -10,7 +10,7 @@
 from __future__ import absolute_import
 
 from six import string_types
-from os.path import join as opj
+from os.path import join as opj, basename
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.dicom')
 
@@ -60,6 +60,14 @@ class MetadataExtractor(BaseMetadataExtractor):
         imgs = {}
         lgr.info("Attempting to extract DICOM metadata from %i files", len(self.paths))
         for f in self.paths:
+            if basename(f).startswith('PSg'):
+                # ignore those dicom files, since they appear to not contain
+                # any relevant metadata for image series, but causing trouble
+                # (see gh-2210). We might want to change that whenever we get
+                # a better understanding of how to deal with those files.
+                lgr.debug("Ignoring DICOM file %s", f)
+                continue
+
             try:
                 d = dcm.read_file(opj(self.ds.path, f), stop_before_pixels=True)
             except InvalidDicomError:


### PR DESCRIPTION
This pull request addresses #2210 (partially)

This pull request proposes to ignore DICOM files with a name starting with `PSg`, since those files (apparently created by some QC routine on Philips scanners) seem to not carry any metadata relevant for describing the image series.

This PR was supported by funds from the 
German federal state of Saxony-Anhalt and the European Regional Development 
Fund (ERDF), Project: Center for Behavioral Brain Sciences, Imaging Platform
### Changes
- [X] This change is complete

Please have a look @datalad/developers
