### PR TITLE
Bf urlencode webui

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -101,6 +101,9 @@ def test_installationpath_from_url():
         '///d1/+last bit',
     ):
         eq_(_get_installationpath_from_url(url), '+last bit')
+    # and the hostname alone
+    eq_(_get_installationpath_from_url("http://hostname"), 'hostname')
+    eq_(_get_installationpath_from_url("http://hostname/"), 'hostname')
 
 
 def test_get_git_url_from_source():

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -88,8 +88,19 @@ def test_installationpath_from_url():
               'lastbit.git/',
               'http://example.com/lastbit',
               'http://example.com/lastbit.git',
+              'http://lastbit:8000'
               ):
         eq_(_get_installationpath_from_url(p), 'lastbit')
+    # we need to deal with quoted urls
+    for url in (
+        # although some docs say that space could've been replaced with +
+        'http://localhost:8000/+last%20bit',
+        'http://localhost:8000/%2Blast%20bit',
+        '///%2Blast%20bit',
+        '///d1/%2Blast%20bit',
+        '///d1/+last bit',
+    ):
+        eq_(_get_installationpath_from_url(url), '+last bit')
 
 
 def test_get_git_url_from_source():

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -11,6 +11,8 @@
 """
 
 import logging
+import re
+
 from os.path import exists
 from os.path import isdir
 from os.path import join as opj
@@ -18,6 +20,8 @@ from os.path import islink
 from os.path import isabs
 from os.path import normpath
 import posixpath
+
+from six.moves.urllib.parse import unquote as urlunquote
 
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import DataLadRI
@@ -227,7 +231,12 @@ def _get_installationpath_from_url(url):
     This can be used to determine an installation path of a Dataset
     from a URL, analog to what `git clone` does.
     """
-    path = url.rstrip('/')
+    ri = RI(url)
+    if isinstance(ri, (URL, DataLadRI)):  # decode only if URL
+        path = urlunquote(ri.path) or ri.hostname
+    else:
+        path = url
+    path = path.rstrip('/')
     if '/' in path:
         path = path.split('/')
         if path[-1] == '.git':

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -233,7 +233,8 @@ def _get_installationpath_from_url(url):
     """
     ri = RI(url)
     if isinstance(ri, (URL, DataLadRI)):  # decode only if URL
-        path = urlunquote(ri.path) or ri.hostname
+        path = ri.path.rstrip('/')
+        path = urlunquote(path) if path else ri.hostname
     else:
         path = url
     path = path.rstrip('/')


### PR DESCRIPTION
This pull request proposes to urlunquote paths for installation deduced from URLs, and also quote within WebUI since otherwise navigation would break. This fixed up main.js is deployed ATM at datasets.datalad.org so you could browse into http://datasets.datalad.org/?dir=/dicoms/dartmouth-phantoms/bids_test6-PD+T2w/ 

### Changes
- [x] This change is complete (unless tests fail)

Please have a look @datalad/developers
