### PR TITLE
Fails to datalad install subdataset when dataset path has ~

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -862,6 +862,21 @@ def test_install_subds_with_space(opath, tpath):
     assert Dataset(opj(tpath, 'sub ds')).is_installed()
 
 
+# https://github.com/datalad/datalad/issues/2232
+@with_tempfile
+@with_tempfile
+def test_install_from_tilda(opath, tpath):
+    ds = create(opath)
+    ds.create('sub ds')
+    orelpath = os.path.join(
+        '~',
+        os.path.relpath(opath, os.path.expanduser('~'))
+    )
+    assert orelpath.startswith('~')  # just to make sure no normalization
+    install(tpath, source=orelpath, recursive=True)
+    assert Dataset(opj(tpath, 'sub ds')).is_installed()
+
+
 @skip_ssh
 @usecase
 @with_tempfile(mkdir=True)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -61,7 +61,7 @@ from .exceptions import CommandError
 from .exceptions import DeprecatedError
 from .exceptions import FileNotInRepositoryError
 from .exceptions import MissingBranchError
-from .network import RI
+from .network import RI, PathRI
 from .network import is_ssh
 from .repo import Flyweight
 from .repo import RepoInterface
@@ -667,22 +667,30 @@ class GitRepo(RepoInterface):
                 # didn't exist - all fine
                 pass
 
+        # Massage URL
+        url_ri = RI(url) if not isinstance(url, RI) else url
         # try to get a local path from `url`:
         try:
-            if not isinstance(url, RI):
-                url = RI(url).localpath
-            else:
-                url = url.localpath
+            url = url_ri.localpath
+            url_ri = RI(url)
         except ValueError:
             pass
 
-        if is_ssh(url):
+        if is_ssh(url_ri):
             ssh_manager.get_connection(url).open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
             env = GitRepo.GIT_SSH_ENV
         else:
+            if isinstance(url_ri, PathRI):
+                new_url = os.path.expanduser(url)
+                if url != new_url:
+                    # TODO: remove whenever GitPython is fixed:
+                    # https://github.com/gitpython-developers/GitPython/issues/731
+                    lgr.info("Expanded source path to %s from %s", new_url, url)
+                    url = new_url
             env = None
+
         ntries = 5  # 3 is not enough for robust workaround
         for trial in range(ntries):
             try:


### PR DESCRIPTION
```shell
snastase$ datalad -l debug install -r -g .
...
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.install.Install'> 
[DEBUG  ] Building doc for <class 'datalad.plugin.Plugin'> 
[DEBUG  ] Install passes into get 1 items 
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.get.Get'> 
[DEBUG  ] Determined class of decorated function: <class 'datalad.interface.annotate_paths.AnnotatePaths'> 
[DEBUG  ] already installed [get(/Users/snastase/Work/storyteller/data)] 
get(notneeded): /Users/snastase/Work/storyteller/data (dataset) [already installed]
[DEBUG  ] Building doc for <class 'datalad.distribution.subdatasets.Subdatasets'> 
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.subdatasets.Subdatasets'> 
[DEBUG  ] Resolved dataset for subdataset reporting/modification: <Dataset path=/Users/snastase/Work/storyteller/data> 
[INFO   ] Installing <Dataset path=/Users/snastase/Work/storyteller/data> recursively 
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.subdatasets.Subdatasets'> 
[DEBUG  ] Resolved dataset for subdataset reporting/modification: <Dataset path=/Users/snastase/Work/storyteller/data> 
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.subdatasets.Subdatasets'> 
[DEBUG  ] Resolved dataset for subdataset reporting/modification: <Dataset path=/Users/snastase/Work/storyteller/data> 
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.clone.Clone'> 
[DEBUG  ] Resolved clone source from '~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc' to '~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc' 
[DEBUG  ] Resolved clone target path to: '/Users/snastase/Work/storyteller/data/derivatives/mriqc' 
[INFO   ] Cloning ~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc to '/Users/snastase/Work/storyteller/data/derivatives/mriqc' 
[DEBUG  ] Attempting to clone ~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc (1 out of 1 candidates) to '/Users/snastase/Work/storyteller/data/derivatives/mriqc' 
[DEBUG  ] Git clone from ~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc to /Users/snastase/Work/storyteller/data/derivatives/mriqc 
[DEBUG  ] Failed to clone from URL: ~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc (Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v ~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc /Users/snastase/Work/storyteller/data/derivatives/mriqc
  stderr: 'fatal: repository '~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc' does not exist
' [cmd.py:wait:418]) 
[ERROR  ] Failed to clone data from any candidate source URL: ['~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc'] [install(/Users/snastase/Work/storyteller/data/derivatives/mriqc)] 
[ERROR  ] Installation of subdatasets <Dataset path=/Users/snastase/Work/storyteller/data/derivatives/mriqc> failed with exception: InstallFailedError: 
Failed to install dataset from: ['~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc'] [get.py:_install_subds_from_flexible_source:183] [install(/Users/snastase/Work/storyteller/data/derivatives/mriqc)] 
install(error): /Users/snastase/Work/storyteller/data/derivatives/mriqc (dataset) [Installation of subdatasets <Dataset path=/Users/snastase/Work/storyteller/data/derivatives/mriqc> failed with exception: InstallFailedError: 
Failed to install dataset from: ['~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc'] [get.py:_install_subds_from_flexible_source:183]]
[DEBUG  ] Determine what files match the query to work with 
[DEBUG  ] No files found needing fetching. 
[DEBUG  ] nothing to get from /Users/snastase/Work/storyteller/data [get(/Users/snastase/Work/storyteller/data)] 
get(notneeded): /Users/snastase/Work/storyteller/data (directory) [nothing to get from /Users/snastase/Work/storyteller/data]
[DEBUG  ] no dataset annex, content already present [get(/Users/snastase/Work/storyteller/data/derivatives/mriqc)] 
get(notneeded): /Users/snastase/Work/storyteller/data/derivatives/mriqc [no dataset annex, content already present]
action summary:
  get (notneeded: 3)
  install (error: 1)
[DEBUG  ] could not perform all requested actions: Command did not complete successfully [{'status': 'error', 'action': 'install', 'path': '/Users/snastase/Work/storyteller/data/derivatives/mriqc', 'type': 'dataset', 'message': ('Installation of subdatasets %s failed with exception: %s', <Dataset path=/Users/snastase/Work/storyteller/data/derivatives/mriqc>, "InstallFailedError: \nFailed to install dataset from: ['~/Work/vagrant/ubuntu-xenial-16.04.3/storyteller/data/derivatives/mriqc'] [get.py:_install_subds_from_flexible_source:183]")}] [utils.py:generator_func:442] 
```
This was fixed by changing to full path in .git/config