### PR TITLE
Out of source tree tests fail, files missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,8 @@ setup(
     package_data={
         'datalad':
             findsome('resources', {'sh', 'html', 'js', 'css', 'png', 'svg'}) +
-            findsome('downloaders/configs', {'cfg'})
+            findsome(opj('downloaders', 'configs'), {'cfg'}) +
+            findsome(opj('metadata', 'tests', 'data'), {'mp3', 'dcm', 'jpg', 'gz', 'pdf'})
     },
     **setup_kwargs
 )


### PR DESCRIPTION
Running `datalad test` leads to this (I guess, because we do not install the test data files):

```
======================================================================
ERROR: datalad.metadata.extractors.tests.test_audio.test_audio
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 629, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/metadata/extractors/tests/test_audio.py", line 49, in test_audio
    path)
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/metadata/tests/data/audio.mp3'

======================================================================
ERROR: datalad.metadata.extractors.tests.test_dicom.test_dicom
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 629, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/metadata/extractors/tests/test_dicom.py", line 37, in test_dicom
    path)
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/metadata/tests/data/dicom.dcm'

======================================================================
ERROR: datalad.metadata.extractors.tests.test_exif.test_exif
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 629, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/metadata/extractors/tests/test_exif.py", line 83, in test_exif
    path)
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/metadata/tests/data/exif.jpg'

======================================================================
ERROR: datalad.metadata.extractors.tests.test_image.test_image
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 629, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/metadata/extractors/tests/test_image.py", line 44, in test_image
    path)
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/metadata/tests/data/exif.jpg'

======================================================================
ERROR: datalad.metadata.extractors.tests.test_nidm.test_nidm
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 629, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/metadata/extractors/tests/test_nidm.py", line 28, in test_nidm
    path)
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/metadata/tests/data/nifti1.nii.gz'

======================================================================
ERROR: datalad.metadata.extractors.tests.test_nifti1.test_nifti
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 629, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/metadata/extractors/tests/test_nifti1.py", line 63, in test_nifti
    path)
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/metadata/tests/data/nifti1.nii.gz'

```