### PR TITLE
one more missing import for the api?

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -507,6 +507,8 @@ def _get_remote_info(ds_path, ds_remote_info, to, missing):
             if not superds:
                 return ('error',
                         ("No super-dataset to inherit settings for remote %s", to))
+            # avoid global import, only needed for this corner case
+            from datalad.distribution.create_sibling import CreateSibling
             # XXX due to difference between create-sibling and create-sibling-github
             # would not be as transparent to inherit for -github
             lgr.info("Will try to create a sibling inheriting settings from %s", superds)


### PR DESCRIPTION
#### What is the problem?
tried to publish
```shell
$> datalad --dbg publish -r --since= --to=datalad-public --missing=inherit        
[INFO   ] Will try to create a sibling inheriting settings from <Dataset path=/mnt/btrfs/datasets/datalad/crawl/dicoms/dartmouth-phantoms> 
Traceback (most recent call last):
  File "/home/yoh/proj/datalad/datalad-master/venvs/dev/bin/datalad", line 8, in <module>
    main()
  File "/home/yoh/proj/datalad/datalad-master/datalad/cmdline/main.py", line 356, in main
    ret = cmdlineargs.func(cmdlineargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/base.py", line 422, in call_from_parser
    ret = list(ret)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 411, in generator_func
    result_renderer, result_xfm, _result_filter, **_kwargs):
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 478, in _process_results
    for res in results:
  File "/home/yoh/proj/datalad/datalad-master/datalad/distribution/publish.py", line 751, in __call__
    ap['path'], ds_remote_info, to, missing)
  File "/home/yoh/proj/datalad/datalad-master/datalad/distribution/publish.py", line 515, in _get_remote_info
    ds.create_sibling(None, name=to, inherit=True)
AttributeError: 'Dataset' object has no attribute 'create_sibling'
()
> /home/yoh/proj/datalad/datalad-master/datalad/distribution/publish.py(515)_get_remote_info()
-> ds.create_sibling(None, name=to, inherit=True)

```
