### PR TITLE
Locking at the repo level for datalad-archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ This is a high level and scarce summary of the changes between releases.
 We would recommend to consult log of the 
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
+
+## 0.9.3 (??? ??, 2018) -- if ever be released
+
+bet we will fix some bugs and we might need to kick it out before 0.10.
+
+### Major refactoring and deprecations
+
+- should be none
+
+### Fixes
+
+?
+
+### Enhancements and new features
+
+- very unlikely
+
+
 ## 0.9.2 (Mar 04, 2017) -- it is (again) better than ever
 
 Largely a bugfix release with a few enhancements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is a high level and scarce summary of the changes between releases.
 We would recommend to consult log of the 
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
-## 0.9.2 (Mar 03, 2017) -- it is (again) better than ever
+## 0.9.2 (Mar 04, 2017) -- it is (again) better than ever
 
 Largely a bugfix release with a few enhancements.
 
@@ -22,6 +22,8 @@ Largely a bugfix release with a few enhancements.
   handled correctly
 - Consider more remotes (not just tracking one, which might be none)
   while installing subdatasets
+- Compatibility with git 2.16 with some changed behaviors/annotations
+  for submodules
 - Fail `remove` if `annex drop` failed
 - Do not fail operating on files which start with dash (-)
 - URL unquote paths within S3, URLs and DataLad RIs (///)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,57 @@ This is a high level and scarce summary of the changes between releases.
 We would recommend to consult log of the 
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
-## 0.9.2 (??? ??, 2017) -- will be better than ever
+## 0.9.2 (Mar 03, 2017) -- it is (again) better than ever
 
-bet we will fix some bugs and make a world even a better place.
-
-### Major refactoring and deprecations
-
-- hopefully none
+Largely a bugfix release with a few enhancements.
 
 ### Fixes
 
-?
+- Execution of external commands (git) should not get stuck when
+  lots of both stdout and stderr output, and should not loose remaining
+  output in some cases
+- Config overrides provided in the command line (-c) should now be
+  handled correctly
+- Consider more remotes (not just tracking one, which might be none)
+  while installing subdatasets
+- Fail `remove` if `annex drop` failed
+- Do not fail operating on files which start with dash (-)
+- URL unquote paths within S3, URLs and DataLad RIs (///)
+- In non-interactive mode fail if authentication/access fails
+- Web UI:
+  - refactored a little to fix incorrect listing of submodules in
+    subdirectories
+  - now auto-focuses on search edit box upon entering the page
+- Assure that extracted from tarballs directories have executable bit set
 
 ### Enhancements and new features
 
-?
+- A log message and progress bar will now inform if a tarball to be
+  downloaded while getting specific files
+  (requires git-annex > 6.20180206)
+- A dedicated `datalad rerun` command capable of rerunning entire
+  sequences of previously `run` commands.
+  **Reproducibility through VCS. Use `run` even if not interested in `rerun`**
+- Alert the user if `git` is not yet configured but git operations
+  are requested
+- Delay collection of previous ssh connections until it is actually
+  needed.  Also do not require ':' while specifying ssh host
+- AutomagicIO: Added proxying of isfile, lzma.LZMAFile and io.open
+- Testing:
+  - added DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org to
+    run tests against another website to not obscure access stats
+  - tests run against temporary HOME to avoid side-effects
+  - better unit-testing of interactions with special remotes
+- CONTRIBUTING.md describes how to setup and use `git-hub` tool to
+  "attach" commits to an issue making it into a PR
+- DATALAD_USE_DEFAULT_GIT env variable could be used to cause DataLad
+  to use default (not the one possibly bundled with git-annex) git
+- Be more robust while handling not supported requests by annex in
+  special remotes
+- Use of `swallow_logs` in the code was refactored away -- less
+  mysteries now, just increase logging level
+- `wtf` plugin will report more information about environment, externals
+  and the system
 
 
 # 0.9.1 (Oct 01, 2017) -- "DATALAD!"(JBTM)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -461,7 +461,7 @@ Refer datalad/config.py for information on how to add these environment variable
 
 For the upcoming release use this template
 
-## 0.9.3 (??? ??, 2017) -- will be better than ever
+## 0.9.4 (??? ??, 2018) -- will be better than ever
 
 bet we will fix some bugs and make a world even a better place.
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -37,7 +37,7 @@ from ..dochelpers import exc_str
 
 def _license_info():
     return """\
-Copyright (c) 2013-2017 DataLad developers
+Copyright (c) 2013-2018 DataLad developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -315,6 +315,12 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         # except ValueError:
         #     self.send("WHEREIS-FAILURE")
 
+    def _prepare(self):
+        super(ArchiveAnnexCustomRemote, self)._prepare()
+        # TODO: wouldn't be sufficient in case of nested datalad-archives
+        # invocation when tarball within tarball
+        self.repo.acquire_lock(blocking=False)
+
     def _transfer(self, cmd, key, path):
 
         akeys_tried = []

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -54,6 +54,7 @@ from datalad.utils import get_dataset_root
 from datalad.utils import with_pathsep as _with_sep
 from datalad.utils import unique
 from datalad.utils import path_startswith
+from datalad.utils import path_is_subpath
 
 from .dataset import Dataset
 from .dataset import EnsureDataset
@@ -301,7 +302,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                 "subdataset %s is configured to be skipped on recursive installation",
                 sub['path'])
             continue
-        if start is not None and not path_startswith(subds.path, start):
+        if start is not None and not path_is_subpath(subds.path, start):
             # this one we can ignore, not underneath the start path
             continue
         if sub['state'] != 'absent':

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -117,7 +117,7 @@ def _parse_git_submodules(dspath, recursive):
         if not line:
             continue
         sm = {}
-        sm['state'] = status_map[line[0]]
+
         props = submodule_full_props.match(line[1:])
         if props:
             sm['revision'] = props.group(1)
@@ -127,6 +127,15 @@ def _parse_git_submodules(dspath, recursive):
             props = submodule_nodescribe_props.match(line[1:])
             sm['revision'] = props.group(1)
             sm['path'] = opj(dspath, props.group(2))
+
+        sm['state'] = status_map[line[0]]
+        if sm['state'] == 'clean':
+            # with git 2.16 we see " " for uninstalled dataset
+            # and ((null)) in the trailing of the line
+            # This code is RFed completely away in datalad 0.10
+            if '((null))' in line:
+                sm['state'] = 'absent'
+
         yield sm
 
 

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -43,6 +43,7 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.utils import get_dataset_root
 from datalad.utils import with_pathsep as _with_sep
 from datalad.utils import path_startswith
+from datalad.utils import path_is_subpath
 from datalad.utils import assure_list
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
@@ -154,7 +155,7 @@ def yield_recursive(ds, path, action, recursion_limit):
         # this check is not the same as subdatasets --contains=path
         # because we want all subdataset below a path, not just the
         # containing one
-        if path_startswith(subd_res['path'], path):
+        if path_is_subpath(subd_res['path'], path):
             # this subdatasets is underneath the search path
             # be careful to not overwrite anything, in case
             # this subdataset has been processed before
@@ -243,7 +244,7 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None,
                 ap.update(m)
                 yield ap
                 break
-            if path_startswith(m['path'], ap['path']):
+            if path_is_subpath(m['path'], ap['path']):
                 # a modified path is underneath this AP
                 # yield the modified one instead
                 yield m

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -22,7 +22,7 @@ from os.path import abspath
 from os.path import normpath
 from datalad.utils import assure_list
 from datalad.utils import with_pathsep as _with_sep
-from datalad.utils import path_startswith
+from datalad.utils import path_is_subpath
 
 from datalad.distribution.dataset import Dataset
 
@@ -330,7 +330,7 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
             # do we have any failures in a subdir of the requested dir?
             failure_results = [
                 fp for fp in respath_by_status.get('failure', [])
-                if path_startswith(fp, p)]
+                if path_is_subpath(fp, p)]
             if failure_results:
                 # we were not able to process all requested_paths, let's label
                 # this 'impossible' to get a warning-type report
@@ -344,7 +344,7 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
                 # otherwise cool, but how cool?
                 success_results = [
                     fp for fp in respath_by_status.get('success', [])
-                    if path_startswith(fp, p)]
+                    if path_is_subpath(fp, p)]
                 yield get_status_dict(
                     status='ok' if success_results else 'notneeded',
                     message=None if success_results else (noinfo_dir_msg, p),

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -34,6 +34,7 @@ import json
 # avoid import from API to not get into circular imports
 from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
 from datalad.utils import path_startswith
+from datalad.utils import path_is_subpath
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import IncompleteResultsError
 from datalad import cfg as dlcfg

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -155,6 +155,8 @@ class AnnexRepo(GitRepo, RepoInterface):
           Short description that humans can use to identify the
           repository/location, e.g. "Precious data on my laptop"
         """
+        self._lock = None  # just an early binding since super-constructor
+                           # is called later
         if self.git_annex_version is None:
             self._check_git_annex_version()
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -601,6 +601,7 @@ class GitRepo(RepoInterface):
         else:
             self.inode = None
 
+
     def acquire_lock(self, blocking=True):
         """Acquire lock on the repository
 
@@ -638,7 +639,12 @@ class GitRepo(RepoInterface):
         """Release lock if that one was acquired"""
         if self._lock:
             if self._lock.acquired:
-                self._lock.release()
+                try:
+                    os.unlink(self._lock.path)  # release does not remove it
+                except:
+                    pass
+                finally:
+                    self._lock.release()
             elif lgr:  # somehow in tests lgr was none -- probably __del__ effect
                 lgr.warning(
                     "Asked to release the lock for %s which we did not acquire",

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -589,31 +589,6 @@ class GitRepo(RepoInterface):
             if not _valid_repo:
                 raise InvalidGitRepositoryError(path)
 
-        # try to lock it down
-        # if not os.path.exists(opj(path, '.git')) or not os.path.isdir(opj(path, '.git')):
-        #     raise ValueError("blow %s" % path)
-        #     import pdb; pdb.set_trace()
-        #     # so it could happen we would have submodule links here
-        #     # so let's just do in the root directory of the dataset for now
-        #     # although should then read that .git file etc
-        #     # Hm - wouldn't work since would break many tests since
-        #     # it creates untracked file etc
-        lck_gitdir = opj(path, '.git')
-        if os.path.exists(lck_gitdir) and not os.path.isdir(lck_gitdir):
-            # a file with gitdir pointing to the original repo
-            with open(lck_gitdir) as f:
-                line = f.readline()
-            # do not want to rely on split
-            _pref = 'gitdir: '
-            assert line.startswith(_pref)
-            lck_gitdir = line[len(_pref):]
-
-        self._lock = InterProcessLock(
-            opj(lck_gitdir, 'datalad.lck')
-        )
-        if not self._lock.acquire(blocking=False):
-            raise RuntimeError("Cannot lock repo %s" % path)
-
         # inject git options into GitPython's git call wrapper:
         # Note: `None` currently can happen, when Runner's protocol prevents
         # calls above from being actually executed (DryRunProtocol)
@@ -625,6 +600,50 @@ class GitRepo(RepoInterface):
             self.inode = os.stat(self.realpath).st_ino
         else:
             self.inode = None
+
+    def acquire_lock(self, blocking=True):
+        """Acquire lock on the repository
+
+        If lock was already previously acquired - does not do anything.
+        If lock is not acquired, raises RuntimeError
+        """
+        if self._lock and self._lock.acquired:
+            return
+        # try to lock it down
+        # if not os.path.exists(opj(path, '.git')) or not os.path.isdir(opj(
+        # path, '.git')):
+        #     raise ValueError("blow %s" % path)
+        #     import pdb; pdb.set_trace()
+        #     # so it could happen we would have submodule links here
+        #     # so let's just do in the root directory of the dataset for now
+        #     # although should then read that .git file etc
+        #     # Hm - wouldn't work since would break many tests since
+        #     # it creates untracked file etc
+        lck_gitdir = opj(self.path, '.git')
+        if os.path.exists(lck_gitdir) and not os.path.isdir(lck_gitdir):
+            # a file with gitdir pointing to the original repo
+            with open(lck_gitdir) as f:
+                line = f.readline()
+            # do not want to rely on split
+            _pref = 'gitdir: '
+            assert line.startswith(_pref)
+            lck_gitdir = line[len(_pref):]
+        self._lock = InterProcessLock(
+            opj(lck_gitdir, 'datalad.lck')
+        )
+        if not self._lock.acquire(blocking=blocking):
+            raise RuntimeError("Cannot lock repo %s" % self.path)
+
+    def release_lock(self):
+        """Release lock if that one was acquired"""
+        if self._lock:
+            if self._lock.acquired:
+                self._lock.release()
+            elif lgr:  # somehow in tests lgr was none -- probably __del__ effect
+                lgr.warning(
+                    "Asked to release the lock for %s which we did not acquire",
+                    self)
+            self._lock = None
 
     @property
     def repo(self):
@@ -757,8 +776,7 @@ class GitRepo(RepoInterface):
         return gr
 
     def __del__(self):
-        if self._lock and self._lock.acquired:
-            self._lock.release()
+        self.release_lock()
 
         # unbind possibly bound ConfigManager, to prevent all kinds of weird
         # stalls etc

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -7,6 +7,8 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+import os
+
 from .utils import (
     chpwd,
     get_dataset_root,
@@ -38,10 +40,14 @@ def test_not_under_git(path):
 def test_git_config_fixture():
     # in the setup_package we setup a new HOME with custom config
     from datalad.support.gitrepo import check_git_configured
-    assert_equal(
-        check_git_configured(),
-        {
-            'user.name': 'DataLad Tester',
-            'user.email': 'test@example.com'
-         }
-    )
+    if 'GIT_HOME' not in os.environ:
+        assert_equal(
+            check_git_configured(),
+            {
+                'user.name': 'DataLad Tester',
+                'user.email': 'test@example.com'
+             }
+        )
+    else:
+        # we pick up the ones in the 'GIT_HOME' which might differ
+        assert_equal(sorted(check_git_configured()), ['user.email', 'user.name'])

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1060,10 +1060,39 @@ def get_path_prefix(path, pwd=None):
         return path
 
 
+def _get_normalized_paths(path, prefix):
+    if isabs(path) != isabs(prefix):
+        raise ValueError("Bot paths must either be absolute or relative. "
+                         "Got %r and %r" % (path, prefix))
+    path = with_pathsep(path)
+    prefix = with_pathsep(prefix)
+    return path, prefix
+
+
 def path_startswith(path, prefix):
-    """Return True if path starts with prefix path"""
-    return commonprefix((with_pathsep(path), with_pathsep(prefix))) \
-           == with_pathsep(prefix)
+    """Return True if path starts with prefix path
+
+    Parameters
+    ----------
+    path: str
+    prefix: str
+    """
+    path, prefix = _get_normalized_paths(path, prefix)
+    return path.startswith(prefix)
+
+
+def path_is_subpath(path, prefix):
+    """Return True if path is a subpath of prefix
+
+    It will return False if path == prefix.
+
+    Parameters
+    ----------
+    path: str
+    prefix: str
+    """
+    path, prefix = _get_normalized_paths(path, prefix)
+    return (len(prefix) < len(path)) and path.startswith(prefix)
 
 
 def knows_annex(path):

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -13,7 +13,7 @@ import sys
 from os.path import lexists, dirname, join as opj, curdir
 
 # Hard coded version, to be done by release process
-__version__ = '0.9.1.dev1'
+__version__ = '0.9.2'
 
 # NOTE: might cause problems with "python setup.py develop" deployments
 #  so I have even changed buildbot to use  pip install -e .

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -13,7 +13,7 @@ import sys
 from os.path import lexists, dirname, join as opj, curdir
 
 # Hard coded version, to be done by release process
-__version__ = '0.9.2'
+__version__ = '0.9.2.dev1'
 
 # NOTE: might cause problems with "python setup.py develop" deployments
 #  so I have even changed buildbot to use  pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ requires = {
         'GitPython>=2.1.8',
         'iso8601',
         'humanize',
+        'fasteners',
         'mock>=1.0.1',  # mock is also used for auto.py, not only for testing
         'patool>=1.7',
         'six>=1.8.0',

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ requires = {
     ] + pbar_requires,
     'downloaders': [
         'boto',
-        'msgpack-python',
+        'msgpack',
         'requests>=1.2',
     ] + keyring_requires,
     'downloaders-extra': [


### PR DESCRIPTION
This pull request fixes #???

I thought that if I make our datalad-archives refuse to prepare the 2nd instance, git-annex would just use the single instance of the custom special remote while downloading files, but it is not the case:
http://git-annex.branchable.com/bugs/howto_guarantee_a_single_instance_of_a_special_remote__63__/

so this one is just to see what else would break.

Ideally we should just lock "per file/operation", i.e. if I need to get a file - we lock for that operation and then other instances would just wait for that.  Similar for "extraction" and possibly "Cleanup". This way they could all co-exist in parallel while waiting for another instance to take care about getting the file, or may be meanwhile requesting another archive (if such rare case happens) and extracting it to serve individual files "in parallel" to git-annex

### Changes
- [ ] This change is complete

Please have a look @datalad/developers
