### PR TITLE
`Dataset.get_superdataset()` should be able to verify subdatasets

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -157,7 +157,9 @@ class initiate_dataset(object):
         )
         if self.add_to_super:
             # place hack from 'add-to-super' times here
-            sds = ds.get_superdataset()
+            # MIH: tests indicate that this wants to discover any dataset above
+            # not just true superdatasets
+            sds = ds.get_superdataset(registered_only=False)
             if sds is not None:
                 lgr.debug("Adding %s as a subdataset to %s", ds, sds)
                 sds.add(ds.path, save=False)

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -324,7 +324,7 @@ class Dataset(object):
             return was_once_installed
 
     def get_superdataset(self, datalad_only=False, topmost=False,
-                         registered_only=False):
+                         registered_only=True):
         """Get the dataset's superdataset
 
         Parameters

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -363,7 +363,9 @@ class Dataset(object):
                     break
             if registered_only:
                 if path not in sds.subdatasets(
-                        recursive=False, result_xfm='paths'):
+                        recursive=False,
+                        contains=path,
+                        result_xfm='paths'):
                     break
 
             # That was a good candidate

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -359,10 +359,7 @@ class Dataset(object):
             sds = Dataset(sds_path_)
             if datalad_only:
                 # test if current git is actually a dataset?
-                # can't use ATM since we just autogenerate and ID, see
-                # https://github.com/datalad/datalad/issues/986
-                # if not sds.id:
-                if not sds.config.get('datalad.dataset.id', None):
+                if not sds.id:
                     break
             if registered_only:
                 if path not in sds.subdatasets(

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -190,12 +190,16 @@ def test_subdatasets(path):
         result_xfm='datasets', return_type='item-or-list')
     assert_true(subsubds.is_installed())
     eq_(subsubds.get_superdataset(), subds)
-    eq_(subsubds.get_superdataset(topmost=True), ds)
+    # by default, it will only report a subperdataset that actually
+    # has the queries dataset as a registered true subdataset
+    eq_(subsubds.get_superdataset(topmost=True), subds)
+    # by we can also ask for a dataset that is merely above
+    eq_(subsubds.get_superdataset(topmost=True, registered_only=False), ds)
 
     # verify that '^' alias would work
     with chpwd(subsubds.path):
         dstop = Dataset('^')
-        eq_(dstop, ds)
+        eq_(dstop, subds)
         # and while in the dataset we still can resolve into central one
         dscentral = Dataset('///')
         eq_(dscentral.path, LOCAL_CENTRAL_PATH)


### PR DESCRIPTION
ATM this function return any dataset above a given dataset -- with `topmost=True` all the way up. However, despite the name, it does not actually check whether a "superdataset" actually knows about the original dataset as being a true subdataset (might be totally unrelated, or branch was switched, or previous version checked out, ...). As this function is a key player when saving dataset hierarchies, this behavior can lead to undesired outcomes, i.e. when a non-subdataset suddenly become one, just because somewhere upstairs another dataset is hanging around.

I think `get_superdataset()` should crosscheck by default, and get a switch to not do that when it is OK/desired.

In case you are wondering: yes, we do have a test that ensures that this "broken" behavior is maintained ;-)