### PR TITLE
TST/BF: Adapt assertions on error message to new annex version

### DIFF
--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -328,11 +328,6 @@ def test_uninstall_recursive(path):
     res = ds.drop(target_fname, recursive=True, on_failure='ignore')
     assert_status('error', res)
     assert_result_values_cond(
-            res, 'message',
-            lambda x: "(Use --force to override this check, "
-                      "or adjust numcopies.)" in x
-    )
-    assert_result_values_cond(
         res, 'message',
         lambda x: "configured minimum number of copies not found" in x or
         "Could only verify the existence of 0 out of 1 necessary copies" in x
@@ -417,11 +412,6 @@ def test_kill(path):
     # We have a second result with status 'impossible' for the ds, that we need
     # to filter out for those assertions:
     err_result = [r for r in res if r['status'] == 'error'][0]
-    assert_result_values_cond(
-            [err_result], 'message',
-            lambda x: "(Use --force to override this check, "
-                      "or adjust numcopies.)" in x
-    )
     assert_result_values_cond(
         [err_result], 'message',
         lambda x: "configured minimum number of copies not found" in x or

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -29,6 +29,7 @@ from ...tests.utils import assert_true
 from ...tests.utils import ok_archives_caches
 from ...tests.utils import SkipTest
 from ...tests.utils import assert_re_in
+from datalad.tests.utils import assert_result_values_cond
 
 from ...support.annexrepo import AnnexRepo
 from ...support.exceptions import FileNotInRepositoryError
@@ -294,7 +295,11 @@ def test_add_archive_content(path_orig, url, repo_path):
     unlink(opj(path_orig, '1.tar.gz'))
     res = repo.drop(key_1tar, key=True)
     assert_equal(res['success'], False)
-    assert_equal(res['note'], '(Use --force to override this check, or adjust numcopies.)')
+
+    assert_result_values_cond(
+        [res], 'note',
+        lambda x: '(Use --force to override this check, or adjust numcopies.)' in x
+    )
     assert exists(opj(repo.path, repo.get_contentlocation(key_1tar)))
 
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1225,6 +1225,20 @@ def assert_result_values_equal(results, prop, values):
         values)
 
 
+def assert_result_values_cond(results, prop, cond):
+    """Verify that the values of all results for a given key in the status dicts
+    fullfill condition `cond`.
+
+    Parameters
+    ----------
+    results:
+    prop: str
+    cond: callable
+    """
+    for r in assure_list(results):
+        assert cond(r[prop])
+
+
 def ignore_nose_capturing_stdout(func):
     """Decorator workaround for nose's behaviour with redirecting sys.stdout
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1236,7 +1236,8 @@ def assert_result_values_cond(results, prop, cond):
     cond: callable
     """
     for r in assure_list(results):
-        assert cond(r[prop])
+        ok_(cond(r[prop]),
+            msg="r[{prop}]: {value}".format(prop=prop, value=r[prop]))
 
 
 def ignore_nose_capturing_stdout(func):


### PR DESCRIPTION
This pull request fixes test assertions, that check the error message of `git-annex-drop`, which changed recently.


Please note, that #2277 for example already suffers from that in a not-allowed-to-fail-build.

### Changes
- [ ] This change is complete

Please have a look @datalad/developers
