### PR TITLE
TST: Helper for testing singularity hub containers

### DIFF
--- a/tools/testing/test_singularity_container
+++ b/tools/testing/test_singularity_container
@@ -1,0 +1,37 @@
+#!/bin/bash
+#emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*-
+#ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+set -e
+set -u
+
+# test the lastest master image unless told otherwise
+flavor="${1:-fullmaster}"
+
+# where are we and where do we find the example runner script
+scriptdir=$(dirname `which $0 | xargs readlink -f `)
+
+# fresh workdir elsewhere
+wdir=$(mktemp --tmpdir -u -d datalad_singularity_test.XXXX)
+mkdir -p $wdir/bin
+cd $wdir/bin
+
+singularity pull --name datalad shub://datalad/datalad:${flavor}
+# some older singularity versions used different naming strategies
+[ ! -e datalad ] && mv datalad* datalad || true
+cd ..
+
+# put datalad front in the PATH
+PATH=$PWD/bin:$PATH
+export PATH
+
+# execute the cmdline examples as a crude test
+"$scriptdir"/run_doc_examples
+
+# TODO cleanup


### PR DESCRIPTION
- Optionally specify a container (defaults to 'fullmaster')
- pull the image
- rename to 'datalad', put in PATH to serve as a drop-in
  replacement for a full installation (like it would happen in an HPC
  environment)
- run the cmdline examples

This is all working splendidly, until it tries to invoke a special remote:

```
git-annex: Cannot run git-annex-remote-datalad-archives -- It is not installed in PATH (/usr/lib/git-annex.linux/bin:/usr/lib/git-core:/tmp/datalad_singularity_test.1yj8/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/home/mih/bin:/home/mih/bin/pycharm/bin:/usr/lib/git-annex.linux/extra)
I: done running docs/examples/nipype_workshop_dataset.sh: failed
```
However
```
% singularity exec bin/datalad ls -l /usr/local/bin |grep datalad
-rwxrwxr-x 1 root root   209 Mar  7 14:11 datalad
-rwxrwxr-x 1 root root   218 Mar  7 14:11 git-annex-remote-datalad
-rwxrwxr-x 1 root root   219 Mar  7 14:11 git-annex-remote-datalad-archives
% singularity exec bin/datalad git-annex-remote-datalad-archives
[ERROR  ] No annex repository found in /tmp/datalad_singularity_test.1yj8 (RuntimeError) 
```

So it is there and works. I suspect some hackery that we are doing for the test setup is getting in the way.

Outside the container I have no datalad installed, or importable:

```
% python -c 'import datalad'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named datalad
```

Any idea what is happening?