### PR TITLE
bids2scidata is missing installed resource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ setup(
     cmdclass=cmdclass,
     package_data={
         'datalad':
-            findsome('resources', {'sh', 'html', 'js', 'css', 'png', 'svg'}) +
+            findsome('resources', {'sh', 'html', 'js', 'css', 'png', 'svg', 'txt'}) +
             findsome(opj('downloaders', 'configs'), {'cfg'}) +
             findsome(opj('metadata', 'tests', 'data'), {'mp3', 'dcm', 'jpg', 'gz', 'pdf'})
     },


### PR DESCRIPTION
Running tests in our singularity image (an installed datalad, out of tree tests) reveals that we are not installing a resource file:

```
======================================================================
ERROR: datalad.plugin.tests.test_bids2scidata.test_minimal
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.5/dist-packages/datalad/tests/utils.py", line 494, in newfunc
    return t(*(arg + (d,)), **kw)
  File "/usr/local/lib/python3.5/dist-packages/datalad/plugin/tests/test_bids2scidata.py", line 114, in test_minimal
    repo_url='http://example.com',
  File "/usr/local/lib/python3.5/dist-packages/wrapt/wrappers.py", line 562, in __call__
    args, kwargs)
  File "/usr/local/lib/python3.5/dist-packages/datalad/distribution/dataset.py", line 436, in apply_func
    return f(**kwargs)
  File "/usr/local/lib/python3.5/dist-packages/wrapt/wrappers.py", line 523, in __call__
    args, kwargs)
  File "/usr/local/lib/python3.5/dist-packages/datalad/interface/utils.py", line 466, in eval_func
    return return_func(generator_func)(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/wrapt/wrappers.py", line 523, in __call__
    args, kwargs)
  File "/usr/local/lib/python3.5/dist-packages/datalad/interface/utils.py", line 454, in return_func
    results = list(results)
  File "/usr/local/lib/python3.5/dist-packages/datalad/interface/utils.py", line 411, in generator_func
    result_renderer, result_xfm, _result_filter, **_kwargs):
  File "/usr/local/lib/python3.5/dist-packages/datalad/interface/utils.py", line 478, in _process_results
    for res in results:
  File "/usr/local/lib/python3.5/dist-packages/datalad/plugin/__init__.py", line 264, in __call__
    for res in plugin_call(**supported_args):
  File "/usr/local/lib/python3.5/dist-packages/datalad/plugin/bids2scidata.py", line 611, in dlplugin
    itmpl = open(itmpl_path, encoding='utf-8').read()
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/datalad/resources/isatab/scidata_bids_investigator.txt'
```