### PR TITLE
TST+BF: run: Don't assume the environment has a "python" executable

### DIFF
--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -405,7 +405,7 @@ def test_rerun_subdir(path):
     subdir = opj(path, 'subdir')
     mkdir(subdir)
     with chpwd(subdir):
-        run("python -c 'open(\"test.dat\", \"wb\").close()'")
+        run("touch test.dat")
     ok_clean_git(ds.path)
     ok_file_under_git(opj(subdir, "test.dat"), annexed=True)
     rec_msg, runinfo = get_commit_runinfo(ds.repo)
@@ -420,7 +420,7 @@ def test_rerun_subdir(path):
 
     # but if we run ds.run -- runs within top of the dataset
     with chpwd(subdir):
-        ds.run("python -c 'open(\"test2.dat\", \"wb\").close()'")
+        ds.run("touch test2.dat")
     ok_clean_git(ds.path)
     ok_file_under_git(opj(ds.path, "test2.dat"), annexed=True)
     rec_msg, runinfo = get_commit_runinfo(ds.repo)


### PR DESCRIPTION
The Datalad Singularity image, for example, only has python3.

Re: #2287

This pull request should fix 2287, but I'm leaving out the "fixes" link in order to keep that issue open because there is a second set of unrelated errors being discussed.

### Changes
- [x] This change is complete
