### PR TITLE
RF: do not raise if git is not configured -- just issue a warning

### DIFF
--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -328,11 +328,6 @@ def test_uninstall_recursive(path):
     res = ds.drop(target_fname, recursive=True, on_failure='ignore')
     assert_status('error', res)
     assert_result_values_cond(
-            res, 'message',
-            lambda x: "(Use --force to override this check, "
-                      "or adjust numcopies.)" in x
-    )
-    assert_result_values_cond(
         res, 'message',
         lambda x: "configured minimum number of copies not found" in x or
         "Could only verify the existence of 0 out of 1 necessary copies" in x
@@ -417,11 +412,6 @@ def test_kill(path):
     # We have a second result with status 'impossible' for the ds, that we need
     # to filter out for those assertions:
     err_result = [r for r in res if r['status'] == 'error'][0]
-    assert_result_values_cond(
-            [err_result], 'message',
-            lambda x: "(Use --force to override this check, "
-                      "or adjust numcopies.)" in x
-    )
     assert_result_values_cond(
         [err_result], 'message',
         lambda x: "configured minimum number of copies not found" in x or

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -29,6 +29,7 @@ from ...tests.utils import assert_true
 from ...tests.utils import ok_archives_caches
 from ...tests.utils import SkipTest
 from ...tests.utils import assert_re_in
+from datalad.tests.utils import assert_result_values_cond
 
 from ...support.annexrepo import AnnexRepo
 from ...support.exceptions import FileNotInRepositoryError
@@ -294,7 +295,11 @@ def test_add_archive_content(path_orig, url, repo_path):
     unlink(opj(path_orig, '1.tar.gz'))
     res = repo.drop(key_1tar, key=True)
     assert_equal(res['success'], False)
-    assert_equal(res['note'], '(Use --force to override this check, or adjust numcopies.)')
+
+    assert_result_values_cond(
+        [res], 'note',
+        lambda x: '(Use --force to override this check, or adjust numcopies.)' in x
+    )
     assert exists(opj(repo.path, repo.get_contentlocation(key_1tar)))
 
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -54,6 +54,7 @@ from datalad.utils import assure_list
 from datalad.utils import _path_
 from datalad.utils import generate_chunks
 from datalad.utils import CMD_MAX_ARG
+from datalad.support.json_py import loads as json_loads
 from datalad.cmd import GitRunner
 
 # imports from same module:
@@ -2388,7 +2389,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             if progress_indicators:
                 progress_indicators.finish()
 
-        json_objects = (json.loads(line)
+        json_objects = (json_loads(line)
                         for line in out.splitlines() if line.startswith('{'))
         # protect against progress leakage
         json_objects = [j for j in json_objects if 'byte-progress' not in j]
@@ -3284,7 +3285,7 @@ def readlines_until_ok_or_failed(stdout, maxlines=100):
 
 
 def readline_json(stdout):
-    return json.loads(stdout.readline().strip())
+    return json_loads(stdout.readline().strip())
 
 
 @auto_repr
@@ -3493,7 +3494,7 @@ class ProcessAnnexProgressIndicators(object):
             # Just INFO was received without anything else -- we log it at INFO
             info = j['info']
             if info.startswith('PROGRESS-JSON: '):
-                j_ = json.loads(info[len('PROGRESS-JSON: '):])
+                j_ = json_loads(info[len('PROGRESS-JSON: '):])
                 if ('command' in j_ and 'key' in j_) or 'byte-progress' in j_:
                     j = j_
                 else:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -338,17 +338,20 @@ def check_git_configured():
 
     check_runner = GitRunner()
     vals = {}
+    exc_ = ""
     for c in 'user.name', 'user.email':
         try:
             v, err = check_runner.run(['git', 'config', c])
             vals[c] = v.rstrip('\n')
         except CommandError as exc:
-            lgr.debug("Failed to verify that git is configured: %s",
-                      exc_str(exc))
-            raise RuntimeError(
-                "You must configure git first (set both user.name and "
-                "user.email) before using DataLad."
-            )
+            exc_ += exc_str(exc)
+    if exc_:
+        lgr.warning(
+            "It is highly recommended to configure git first (set both "
+            "user.name and user.email) before using DataLad. Failed to "
+            "verify that git is configured: %s.  Some operations might fail or "
+            "not perform correctly." % exc_
+        )
     return vals
 
 

--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -17,7 +17,7 @@ import codecs
 from simplejson import load as jsonload
 from simplejson import dump as jsondump
 # simply mirrored for now
-from simplejson import loads
+from simplejson import loads as json_loads
 from simplejson import JSONDecodeError
 
 
@@ -35,6 +35,18 @@ def dump(obj, fname):
             obj,
             codecs.getwriter('utf-8')(f),
             **json_dump_kwargs)
+
+
+def loads(s, *args, **kwargs):
+    """Helper to log actual value which failed to be parsed"""
+    try:
+        return json_loads(s, *args, **kwargs)
+    except:
+        lgr.error(
+            "Failed to load content from %r with args=%r kwargs=%r"
+            % (s, args, kwargs)
+        )
+        raise
 
 
 def load(fname, fixup=True, **kw):

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1219,19 +1219,6 @@ def test_get_git_attributes(path):
 
 
 @with_tempfile(mkdir=True)
-def test_check_git_configured(newhome):
-    try:
-        old = GitRepo._config_checked
-        GitRepo._config_checked = False
-        with patch.dict('os.environ', {'HOME': newhome}):
-            # clear clear home
-            assert_raises(RuntimeError, GitRepo, newhome, create=True)
-        # But then if we
-    finally:
-        GitRepo._config_checked = old
-
-
-@with_tempfile(mkdir=True)
 def test_get_tags(path):
     gr = GitRepo(path, create=True)
     eq_(gr.get_tags(), [])

--- a/datalad/support/tests/test_json_py.py
+++ b/datalad/support/tests/test_json_py.py
@@ -10,6 +10,7 @@
 import logging
 
 from datalad.support.json_py import load
+from datalad.support.json_py import loads
 from datalad.support.json_py import JSONDecodeError
 
 from datalad.tests.utils import with_tempfile
@@ -27,3 +28,10 @@ def test_load_screwy_unicode(fname):
         eq_(load(fname), {'Authors': ['A1', 'A2']})
         assert_in('Failed to decode content', cml.out)
 
+
+def test_loads():
+    eq_(loads('{"a": 2}'), {'a': 2})
+    with assert_raises(JSONDecodeError),\
+            swallow_logs(new_level=logging.WARNING) as cml:
+        loads('{"a": 2}x')
+    assert_in('Failed to load content from', cml.out)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1221,7 +1221,8 @@ def assert_result_values_cond(results, prop, cond):
     cond: callable
     """
     for r in assure_list(results):
-        assert cond(r[prop])
+        ok_(cond(r[prop]),
+            msg="r[{prop}]: {value}".format(prop=prop, value=r[prop]))
 
 
 def ignore_nose_capturing_stdout(func):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1210,6 +1210,20 @@ def assert_result_values_equal(results, prop, values):
         values)
 
 
+def assert_result_values_cond(results, prop, cond):
+    """Verify that the values of all results for a given key in the status dicts
+    fullfill condition `cond`.
+
+    Parameters
+    ----------
+    results:
+    prop: str
+    cond: callable
+    """
+    for r in assure_list(results):
+        assert cond(r[prop])
+
+
 def ignore_nose_capturing_stdout(func):
     """Decorator workaround for nose's behaviour with redirecting sys.stdout
 


### PR DESCRIPTION
This pull request fixes #2272 

This pull request proposes to not fail if there is no git configuration -- just issue a warning.

The rationale is that git became even more "robust" in assigning some author name/email, and annex does some tricks too...  but if we always demand configuration -  that just complicates the simplest consumer usage.

### Changes
- [x] This change is complete

Please have a look @datalad/developers
