### PR TITLE
RF/BF: get_commit_date to return authored date by default, handle detached head as well

### DIFF
--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -240,7 +240,7 @@ class GitModel(object):
     def date(self):
         """Date of the last commit
         """
-        return self.repo.get_committed_date()
+        return self.repo.get_commit_date()
 
     @property
     def count_objects(self):
@@ -310,7 +310,7 @@ class FsModel(AnnexModel):
         if self.type_ is not ['git', 'annex']:
             return lstat(self._path).st_mtime
         else:
-            super(self.__class__, self).date
+            return super(self.__class__, self).date
 
     @property
     def size(self):

--- a/datalad/plugin/export_tarball.py
+++ b/datalad/plugin/export_tarball.py
@@ -24,7 +24,7 @@ def dlplugin(dataset, output=None):
     lgr = logging.getLogger('datalad.plugin.tarball')
 
     repo = dataset.repo
-    committed_date = repo.get_committed_date()
+    committed_date = repo.get_commit_date()
 
     # could be used later on to filter files by some criterion
     def _filter_tarinfo(ti):

--- a/datalad/plugin/tests/test_tarball.py
+++ b/datalad/plugin/tests/test_tarball.py
@@ -49,7 +49,7 @@ def test_failure(path):
 def test_tarball(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
     ds.add('.')
-    committed_date = ds.repo.get_committed_date()
+    committed_date = ds.repo.get_commit_date()
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
     with chpwd(path):
         res = list(ds.plugin('export_tarball'))

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1253,3 +1253,25 @@ def test_get_tags(path):
     gr.tag("annotated", message="annotation")
     tags2 = tags1 + [{'name': 'annotated', 'hexsha': gr.get_hexsha()}]
     eq_(gr.get_tags(), tags2)
+
+
+@with_tree(tree={'1': ""})
+def test_get_committed_date(path):
+    gr = GitRepo(path, create=True)
+    assert_equal(gr.get_commit_date(), None)
+
+    # Let's make a commit with a custom date
+    DATE = "Wed Mar 14 03:47:30 2018 -0000"
+    DATE_EPOCH = 1520999250
+    gr.add('1')
+    gr.commit("committed", date=DATE)
+    gr = GitRepo(path, create=True)
+    date = gr.get_commit_date()
+    neq_(date, None)
+    eq_(date, DATE_EPOCH)
+
+    eq_(date, gr.get_commit_date('master'))
+    # and even if we get into a detached head
+    gr.checkout(gr.get_hexsha())
+    eq_(gr.get_active_branch(), None)
+    eq_(date, gr.get_commit_date('master'))


### PR DESCRIPTION
As pyout showed some times we were getting None for the date and it was
happening in detached head because we would just return None then since
there is no branch.

Later this function could be extended to print date of any commit, not just
the last one in the branch etc.

By default now returns "authored", not "committed" (thus rename) date since
it is the one of interest typically -- if date was altered, better be the
one specified

- [x] This change is complete

Please have a look @datalad/developers
