### PR TITLE
BF 2276: pass path_src into commit as well (so we commit renamed files removal as well)

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -323,8 +323,7 @@ class Add(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 annotated_paths,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         if not content_by_ds:

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -205,8 +205,7 @@ class Drop(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_drop,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         # iterate over all datasets, order doesn't matter

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -593,8 +593,7 @@ class Get(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_get,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         # hand over to git-annex, get files content,

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -760,8 +760,7 @@ class Publish(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_process,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         lgr.debug(

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -160,8 +160,7 @@ class Remove(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_process,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         # iterate over all datasets, starting at the bottom

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -336,8 +336,7 @@ class Diff(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_process,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         for ds_path in sorted(content_by_ds.keys()):

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -121,9 +121,19 @@ def save_dataset(
     # we will blindly call commit not knowing if there is anything to
     # commit -- this is cheaper than to anticipate all possible ways
     # a repo in whatever mode is dirty
+    paths_to_commit = None
+    if not save_entire_ds:
+        paths_to_commit = []
+        for ap in paths:
+            paths_to_commit.append(ap['path'])
+            # was file renamed?
+            path_src = ap.get('path_src')
+            if path_src and path_src != ap['path']:
+                paths_to_commit.append(path_src)
+
     ds.repo.commit(
         message,
-        files=[ap['path'] for ap in paths] if not save_entire_ds else None,
+        files=paths_to_commit,
         _datalad_msg=_datalad_msg,
         careless=True)
 
@@ -248,7 +258,7 @@ class Save(Interface):
                 ap['process_content'] = True
                 ap['process_updated_only'] = all_updated
             to_process.append(ap)
-
+        lgr.log(2, "save, to_process=%r", to_process)
         if got_nothing and recursive and refds_path:
             # path annotation yielded nothing, most likely cause is that nothing
             # was found modified, we need to say something about the reference

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -357,8 +357,7 @@ class Save(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 annotated_paths,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         # iterate over all datasets, starting at the bottom

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -261,6 +261,21 @@ def test_recursive_save(path):
                  'saving sub')
 
 
+def test_renamed_file():
+    @with_tempfile()
+    def check_renamed_file(recursive, no_annex, path):
+        ds = Dataset(path).create(no_annex=no_annex)
+        create_tree(path, {'old': ''})
+        ds.add('old')
+        ds.repo._git_custom_command(['old', 'new'], ['git', 'mv'])
+        ds.save(recursive=recursive)
+        ok_clean_git(path)
+
+    for recursive in True, False:
+        for no_annex in True, False:
+            yield check_renamed_file, recursive, no_annex
+
+
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 def test_subdataset_save(path):

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -101,8 +101,7 @@ class Unlock(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_process,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         for ds_path in sorted(content_by_ds.keys()):

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -320,8 +320,7 @@ class Metadata(Interface):
         content_by_ds, ds_props, completed, nondataset_paths = \
             annotated2content_by_ds(
                 to_process,
-                refds_path=refds_path,
-                path_only=False)
+                refds_path=refds_path)
         assert(not completed)
 
         # iterate over all datasets, order doesn't matter


### PR DESCRIPTION
This pull request fixes #2276

This pull request proposes to provide `path_src` portions of the annotated paths while doing the commit in `save`.  Also while at it in aa0143b14982438392e98eb24880fc312d13f113  I did something along the same lines -- return path_src as well in annotated2content_by_ds  if only paths are requested.  I am not sure even if that line of logic gets triggered by any test/use-case.  Running all the tests will show. Otherwise it should be ready for review etc

### Changes
- [x] This change is complete

Please have a look @datalad/developers
