### PR TITLE
BF: Prevent argparse from showing an empty list of subparsers

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -194,7 +194,7 @@ def setup_parser(
     #                         only warnings and errors are printed.""")
 
     # subparsers
-    subparsers = parser.add_subparsers()
+    subparsers = None
 
     # auto detect all available interfaces and generate a function-based
     # API from them
@@ -248,6 +248,8 @@ def setup_parser(
                 parser_args['description'] = alter_interface_docs_for_cmdline(
                     intf_doc)
             # create subparser, use module suffix as cmd name
+            if subparsers is None:
+                subparsers = parser.add_subparsers()
             subparser = subparsers.add_parser(cmd_name, add_help=False, **parser_args)
             # our own custom help for all commands
             helpers.parser_add_common_opt(subparser, 'help')

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -150,7 +150,7 @@ def check_incorrect_option(opts, err_str):
 
 def test_incorrect_options():
     # apparently a bit different if following a good one so let's do both
-    err_invalid = "error: (invalid|too few arguments)"
+    err_invalid = "error: (invalid|too few arguments|unrecognized arguments)"
     yield check_incorrect_option, ('--buga',), err_invalid
     yield check_incorrect_option, ('--dbg', '--buga'), err_invalid
 


### PR DESCRIPTION
Fixes the inappropriate error message in gh-2295. Now:

```
% datalad wrongcommand
usage: datalad [-h] [-l LEVEL] [--pbs-runner {condor}] [-C PATH] [--version]
               [--dbg] [--idbg] [-c KEY=VALUE]
               [-f {default,json,json_pp,tailored,'<template>'}]
               [--report-status {success,failure,ok,notneeded,impossible,error}]
               [--report-type {dataset,file}]
               [--on-failure {ignore,continue,stop}] [--cmd]
datalad: error: unrecognized arguments: wrongcommand
```

Feel free to take this further if you feel like investing time.
