### PR TITLE
option (or make it also automagicly enabled) to disable loading full metadata record for search result 

### DIFF
--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -332,7 +332,7 @@ type
             # TODO extend with more complex queries to test whoosh
             # query language configuration
     ):
-        res = ds.search(query, mode=mode)
+        res = ds.search(query, mode=mode, full_record=True)
         if mode == 'textblob':
             # 'textblob' does datasets by default only (be could be configured otherwise
             assert_result_count(res, 1)


### PR DESCRIPTION
default rendering is just an "entry" (i.e. path for the file), but it still takes awhile to spit it out since according to @mih loads the full record