### PR TITLE
BF: Resolve interaction between batch commands and set_metadata

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3206,6 +3206,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         if recursive:
             args.append('--force')
 
+        # Make sure that batch add/addurl operations are closed so that we can
+        # operate on files that were just added.
+        self.precommit()
+
         for jsn in self._run_annex_command_json(
                 'metadata',
                 args,

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2118,6 +2118,17 @@ def test_AnnexRepo_metadata(path):
     eq_(['best'], dict(ar.get_metadata(playfile))[playfile]['novel'])
 
 
+@with_tree(tree={'file.txt': 'content'})
+@serve_path_via_http()
+@with_tempfile
+def test_AnnexRepo_addurl_batched_and_set_metadata(path, url, dest):
+    ar = AnnexRepo(dest, create=True)
+    fname = "file.txt"
+    ar.add_url_to_file(fname, urljoin(url, fname), batch=True)
+    list(ar.set_metadata(fname, init={"number": "one"}))
+    eq_(["one"], dict(ar.get_metadata(fname))[fname]["number"])
+
+
 @with_tempfile(mkdir=True)
 def test_change_description(path):
     # prelude


### PR DESCRIPTION
If files are being added in an active batch process, set_metadata will
silently fail (return a generator that yields no values).  This is
because the underlying git annex command has a zero-exit status but no
output.  As an example, this can be triggered by running

    $ echo content >foo
    $ ( echo "foo" && sleep 30 ) | git annex add --batch

in one shell and then running 'git annex metadata --json --set f=v -- foo'
in another before the first completes.

This issue was noticed when running the addurls plugin with the
--nosave option, in which case no metadata gets registered for
subdatasets.

Work around it by running precommit before setting metadata.  It's not
clear whether there are similar issues elsewhere, and in general it
might be better make the cleanup of batch processes more local (e.g.,
a context manager), but this at least fixes the immediate issue.

Re: http://git-annex.branchable.com/bugs/annex_metadata___40__not_--batch__39__ed__41___is_not_aware_of_files_added_via_addurls_--batch/

---

- [x] This change is complete

