### PR TITLE
Metadata unique value sort broken for PY3

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -562,12 +562,13 @@ def _unique_value_key(x):
     if isinstance(x, ReadOnlyDict):
         # turn into an item tuple with keys sorted and values plain
         # or as a hash if *dicts
-        return [(k,
-                 hash(x[k])
-                 if isinstance(x[k], ReadOnlyDict) else x[k])
-                for k in sorted(x)]
-    else:
-        return x
+        x = [(k,
+              hash(x[k])
+              if isinstance(x[k], ReadOnlyDict) else x[k])
+             for k in sorted(x)]
+    # we need to force str, because sorted in PY3 refuses to compare
+    # any heterogeneous type combinations, such as str/int, tuple(int)/tuple(str)
+    return str(x)
 
 
 def _val2hashable(val):


### PR DESCRIPTION
The reason is an unexpected behavior change of the built-in `sorted()` for built-in types. Demo:

```
% python -c "sorted({('5.1.1', '5.1.1.0'), '0.4.11'})" && echo "happy"
happy
% python3 -c "sorted({('5.1.1', '5.1.1.0'), '0.4.11'})" && echo "happy"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: '<' not supported between instances of 'tuple' and 'str'
```

I do not have an idea how to fix that.
