### PR TITLE
ENH: addurls: Reduce the number of metadata commits

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -13,6 +13,7 @@ from collections import defaultdict, Mapping
 from functools import partial
 from itertools import dropwhile
 import logging
+from mock import patch
 import os
 import re
 import string
@@ -570,9 +571,7 @@ def add_meta(rows):
     for row in rows:
         ds, filename = row["ds"], row["ds_filename"]
 
-        old_always_commit = ds.repo.always_commit
-        ds.repo.always_commit = False
-        try:
+        with patch.object(ds.repo, "always_commit", False):
             lgr.debug("Adding metadata to %s in %s", filename, ds.path)
             for a in ds.repo.set_metadata(filename, add=row["meta_args"]):
                 res = annexjson2result(a, ds, type="file", logger=lgr)
@@ -580,8 +579,6 @@ def add_meta(rows):
                 # could quickly flood the output.
                 del res["message"]
                 yield res
-        finally:
-            ds.repo.always_commit = old_always_commit
 
 
 @build_doc

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -13,15 +13,18 @@ from collections import defaultdict, Mapping
 from functools import partial
 from itertools import dropwhile
 import logging
-from mock import patch
 import os
 import re
 import string
+
+from mock import patch
 
 from six import string_types
 from six.moves.urllib.parse import urlparse
 
 from datalad.dochelpers import exc_str
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
 from datalad.interface.results import annexjson2result, get_status_dict
 from datalad.interface.common_opts import nosave_opt
 from datalad.support import ansi_colors
@@ -33,9 +36,6 @@ from datalad.utils import assure_list, optional_args
 lgr = logging.getLogger("datalad.plugin.addurls")
 
 __docformat__ = "restructuredtext"
-
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
 
 
 class Formatter(string.Formatter):
@@ -760,15 +760,11 @@ class Addurls(Interface):
         # Temporarily work around gh-2269.
         url_file, url_format, filename_format = urlfile, urlformat, filenameformat
 
-        import logging
-        import os
-
         from requests.exceptions import RequestException
 
         from datalad.distribution.add import Add
         from datalad.distribution.create import Create
         from datalad.distribution.dataset import Dataset, require_dataset
-        from datalad.dochelpers import exc_str
         from datalad.interface.results import get_status_dict
         from datalad.support.annexrepo import AnnexRepo
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -310,7 +310,7 @@ def split_ext(filename):
 
     file_parts = parts[:1] + tail[::-1]
     ext_parts = parts[1+len(tail):]
-    return  ".".join(file_parts), "." + ".".join(ext_parts)
+    return ".".join(file_parts), "." + ".".join(ext_parts)
 
 
 def get_file_parts(filename, prefix="name"):
@@ -399,6 +399,7 @@ def add_extra_filename_values(filename_format, rows, urls, dry_run):
                         "{} does not contain a filename".format(url))
                 pbar.update(1, increment=True)
             pbar.finish()
+
 
 def extract(stream, input_type, url_format="{0}", filename_format="{1}",
             exclude_autometa=None, meta=None,
@@ -652,9 +653,10 @@ class Addurls(Interface):
 
     .. note::
 
-       For users familiar with 'git annex addurl': A large part of this plugin's
-       functionality can be viewed as transforming data from `URL-FILE` into a
-       "url filename" format that fed to 'git annex addurl --batch --with-files'.
+       For users familiar with 'git annex addurl': A large part of this
+       plugin's functionality can be viewed as transforming data from
+       `URL-FILE` into a "url filename" format that fed to 'git annex addurl
+       --batch --with-files'.
     """
 
     from datalad.distribution.dataset import datasetmethod
@@ -758,7 +760,8 @@ class Addurls(Interface):
                  message=None, dry_run=False, fast=False, ifexists=None,
                  missing_value=None, save=True):
         # Temporarily work around gh-2269.
-        url_file, url_format, filename_format = urlfile, urlformat, filenameformat
+        url_file = urlfile
+        url_format, filename_format = urlformat, filenameformat
 
         from requests.exceptions import RequestException
 
@@ -769,7 +772,6 @@ class Addurls(Interface):
         from datalad.support.annexrepo import AnnexRepo
 
         lgr = logging.getLogger("datalad.plugin.addurls")
-
 
         dataset = require_dataset(dataset, check_installed=False)
         if dataset.repo and not isinstance(dataset.repo, AnnexRepo):
@@ -810,7 +812,8 @@ class Addurls(Interface):
                 lgr.info("Would create a subdataset at %s", subpath)
             for row in rows:
                 lgr.info("Would download %s to %s",
-                         row["url"], os.path.join(dataset.path, row["filename"]))
+                         row["url"],
+                         os.path.join(dataset.path, row["filename"]))
                 lgr.info("Metadata: %s",
                          sorted(u"{}={}".format(k, v)
                                 for k, v in row["meta_args"].items()))
@@ -822,7 +825,8 @@ class Addurls(Interface):
 
         if not dataset.repo:
             # Populate a new dataset with the URLs.
-            for r in dataset.create(result_xfm=None, return_type='generator', save=save):
+            for r in dataset.create(result_xfm=None, return_type='generator',
+                                    save=save):
                 yield r
 
         annex_options = ["--fast"] if fast else []
@@ -842,7 +846,8 @@ class Addurls(Interface):
             # operations.
             filename_abs = os.path.join(dataset.path, row["filename"])
             if row["subpath"]:
-                ds_current = Dataset(os.path.join(dataset.path, row["subpath"]))
+                ds_current = Dataset(os.path.join(dataset.path,
+                                                  row["subpath"]))
                 ds_filename = os.path.relpath(filename_abs, ds_current.path)
             else:
                 ds_current = dataset
@@ -877,5 +882,6 @@ filename_format='{}'""".format(url_file, url_format, filename_format)
             if save:
                 for r in dataset.save(message=msg, recursive=True):
                     yield r
+
 
 __datalad_plugin__ = Addurls

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -259,7 +259,6 @@ def test_extract_disable_autometa():
         exclude_autometa="*",
         meta=["group={age_group}"])
 
-
     eq_([d["meta_args"] for d in info],
         [{"group": "kid"}, {"group": "adult"}, {"group": "adult"},
          {"group": "kid"}])
@@ -289,7 +288,6 @@ def test_extract_csv_json_equal():
     kwds = dict(filename_format="{age_group}//{now_dead}//{name}.csv",
                 url_format="{name}_{debut_season}.com",
                 meta=["group={age_group}"])
-
 
     json_output = au.extract(json_stream(ST_DATA["rows"]), "json", **kwds)
     csv_output = au.extract(csv_rows, "csv", **kwds)
@@ -328,7 +326,7 @@ def test_addurls_dry_run(path):
             ds.addurls(json_file,
                        "{url}",
                        "{subdir}//{_url_filename_root}",
-                      dry_run=True)
+                       dry_run=True)
 
             for dir_ in ["foo", "bar"]:
                 assert_in("Would create a subdataset at {}".format(dir_),
@@ -397,7 +395,7 @@ class TestAddurls(object):
 
             # Add to already existing links, overwriting.
             with swallow_logs(new_level=logging.DEBUG) as cml:
-                ds.addurls(self.json_file,"{url}", "{name}",
+                ds.addurls(self.json_file, "{url}", "{name}",
                            ifexists="overwrite")
                 for fname in filenames:
                     assert_in("Removing {}".format(os.path.join(path, fname)),
@@ -491,7 +489,6 @@ class TestAddurls(object):
             for fname in ["udir/a.dat", "udir/b.dat", "udir/c.dat"]:
                 ok_exists(fname)
 
-
     @with_tempfile(mkdir=True)
     def test_addurls_url_filename_fail(self, path):
         ds = Dataset(path).create(force=True)
@@ -508,6 +505,7 @@ class TestAddurls(object):
 
         # Force failure by passing a non-existent file name to annex.
         fn = ds.repo.set_metadata
+
         def set_meta(files, **kwargs):
             for i in fn("wreaking-havoc-and-such", **kwargs):
                 yield i

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -252,7 +252,7 @@ def test_extract():
 
 
 def test_extract_disable_autometa():
-    info, subpaths = au.extract(
+    info, _ = au.extract(
         json_stream(ST_DATA["rows"]), "json",
         url_format="{name}_{debut_season}.com",
         filename_format="{age_group}//{now_dead}//{name}.csv",
@@ -265,7 +265,7 @@ def test_extract_disable_autometa():
 
 
 def test_extract_exclude_autometa_regexp():
-    info, subpaths = au.extract(
+    info, _ = au.extract(
         json_stream(ST_DATA["rows"]), "json",
         url_format="{name}_{debut_season}.com",
         filename_format="{age_group}//{now_dead}//{name}.csv",
@@ -506,12 +506,12 @@ class TestAddurls(object):
         # Force failure by passing a non-existent file name to annex.
         fn = ds.repo.set_metadata
 
-        def set_meta(files, **kwargs):
+        def set_meta(_, **kwargs):
             for i in fn("wreaking-havoc-and-such", **kwargs):
                 yield i
 
         with chpwd(path), patch.object(ds.repo, 'set_metadata', set_meta):
-            with assert_raises(IncompleteResultsError) as raised:
+            with assert_raises(IncompleteResultsError):
                 ds.addurls(self.json_file, "{url}", "{name}")
 
     @with_tempfile(mkdir=True)

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -66,19 +66,19 @@ def test_formatter_no_mapping_arg():
 
 def test_formatter_placeholder_with_spaces():
     fmt = au.Formatter({})
-    fmt.format("{with spaces}", {"with spaces": "value0"}) == "value0"
+    eq_(fmt.format("{with spaces}", {"with spaces": "value0"}), "value0")
 
 
 def test_formatter_placeholder_nonpermitted_chars():
     fmt = au.Formatter({})
 
     # Can't assess keys with !, which will be interpreted as a conversion flag.
-    fmt.format("{key!r}", {"key!r": "value0"}, key="x") == "x"
+    eq_(fmt.format("{key!r}", {"key!r": "value0"}, key="x"), "'x'")
     assert_raises(KeyError,
                   fmt.format, "{key!r}", {"key!r": "value0"})
 
     # Same for ":".
-    fmt.format("{key:<5}", {"key:<5": "value0"}, key="x") == "x    "
+    eq_(fmt.format("{key:<5}", {"key:<5": "value0"}, key="x"), "x    ")
     assert_raises(KeyError,
                   fmt.format, "{key:<5}", {"key:<5": "value0"})
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -372,6 +372,12 @@ class TestAddurls(object):
     def test_addurls(self, path):
         ds = Dataset(path).create(force=True)
 
+        def get_annex_commit_counts():
+            return int(
+                ds.repo.repo.git.rev_list("--count", "git-annex").strip())
+
+        n_annex_commits = get_annex_commit_counts()
+
         with chpwd(path):
             ds.addurls(self.json_file, "{url}", "{name}")
 
@@ -383,6 +389,10 @@ class TestAddurls(object):
                                              ["foo", "bar", "foo"]):
                 assert_dict_equal(meta,
                                   {"subdir": [subdir], "name": [fname]})
+
+            # We should have two new commits on the git-annex: one for the
+            # added urls and one for the added metadata.
+            eq_(n_annex_commits + 2, get_annex_commit_counts())
 
             # Add to already existing links, overwriting.
             with swallow_logs(new_level=logging.DEBUG) as cml:

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -11,9 +11,10 @@
 
 import json
 import logging
-from mock import patch
 import os
 import tempfile
+
+from mock import patch
 
 from six.moves import StringIO
 
@@ -25,7 +26,7 @@ from datalad.tests.utils import assert_false, assert_true, assert_raises
 from datalad.tests.utils import assert_in, assert_re_in, assert_in_results
 from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import eq_, ok_exists
-from datalad.tests.utils import create_tree, with_tree, with_tempfile, HTTPPath
+from datalad.tests.utils import create_tree, with_tempfile, HTTPPath
 from datalad.utils import get_tempfile_kwargs, rmtemp
 
 


### PR DESCRIPTION
Disable annex.alwayscommit during the set_metadata calls so that, for
each dataset, there is only one metadata commit on the git-annex
branch rather than a commit per file.

By default, the metadata changes will be committed when addurls calls
save (the following block of code).  If --nosave is given, the
metadata changes will remain in .git/annex/journal until an action
outside of addurls triggers the commit.

---

- [x] This change is complete
