### PR TITLE
NF: Add generic support for independent extension modules

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -25,7 +25,26 @@ def _load_plugins():
         globals()[camel.sub('\\1_\\2', pi.__name__).lower()] = pi.__call__
 
 
+def _generate_modules_api():
+    """Auto detect all available modules and generate an API from them
+    """
+    from importlib import import_module
+    from pkg_resources import iter_entry_points
+    from .interface.base import get_api_name
+
+    for entry_point in iter_entry_points('datalad.modules'):
+        grp_descr, interfaces = entry_point.load()
+        for intfspec in interfaces:
+            # turn the interface spec into an instance
+            mod = import_module(intfspec[0])
+            intf = getattr(mod, intfspec[1])
+            api_name = get_api_name(intfspec)
+            globals()[api_name] = intf.__call__
+
+
+_generate_modules_api()
 _load_plugins()
 
 # Be nice and clean up the namespace properly
 del _load_plugins
+del _generate_modules_api

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -24,6 +24,8 @@ import os
 
 from six import text_type
 
+from pkg_resources import iter_entry_points
+
 import datalad
 
 from datalad.cmdline import helpers
@@ -201,6 +203,9 @@ def setup_parser(
     cmdlineargs = set(cmdlineargs) if cmdlineargs else set()
     grp_short_descriptions = []
     interface_groups = get_interface_groups()
+    for ep in iter_entry_points('datalad.modules'):
+        spec = ep.load()
+        interface_groups.append((ep.name, spec[0], spec[1]))
     interface_groups.append(('plugins', 'Plugins', _get_plugins()))
 
     for grp_name, grp_descr, _interfaces \


### PR DESCRIPTION
In the spirit of #2326 this enables independent packages to provide
DataLad command (suites), simply by defining the required info in a
structure reachable via a setuptools entrypoint.

This following repo implements a rather minimal extension module that
demonstrates this. The idea is that people could fork this, if they
want to implement an extension.

https://github.com/datalad/datalad-module-template

If this gets installed, DataLad will offer an additional "hello..."
command in a dedicated (and labeled) suite.

Not sure how we want to test this, but we could start installing this
extension in the standard travis builds and see that it does what it
should.