### PR TITLE
RF: Define and use entrypoints for metadata extractors (fixes gh-2356)

### DIFF
--- a/datalad/metadata/extractors/__init__.py
+++ b/datalad/metadata/extractors/__init__.py
@@ -7,28 +7,3 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Metadata extractors"""
-
-import logging as __logging
-from datalad.utils import import_modules as __import_modules
-
-__all__ = [
-    'annex',
-    'audio',
-    'bids',
-    'datacite',
-    'datalad_core',
-    'datalad_rfc822',
-    'dicom',
-    'exif',
-    'frictionless_datapackage',
-    'image',
-    'nidm',
-    'nifti1',
-    'xmp',
-]
-
-__import_modules(
-    __all__,
-    pkg=__name__,
-    msg='Metadata extractor {module} is unusable',
-    log=__logging.getLogger(__name__).debug)

--- a/datalad/plugin/tests/test_metadata.py
+++ b/datalad/plugin/tests/test_metadata.py
@@ -20,7 +20,7 @@ from datalad.utils import chpwd
 
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in
 
@@ -34,10 +34,7 @@ testpath = opj(dirname(dirname(dirname(__file__))), 'metadata', 'tests', 'data',
 def test_error(path):
     # go into virgin dir to avoid detection of any dataset
     with chpwd(path):
-        res = extract_metadata(
-            types=['bogus__'],
-            files=[testpath])
-        assert_status('error', res)
+        assert_raises(ValueError, extract_metadata, types=['bogus__'], files=[testpath])
 
 
 @with_tempfile(mkdir=True)

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,22 @@ setup(
         'datalad':
             findsome('resources', {'sh', 'html', 'js', 'css', 'png', 'svg', 'txt'}) +
             findsome(opj('downloaders', 'configs'), {'cfg'}) +
-            findsome(opj('metadata', 'tests', 'data'), {'mp3', 'dcm', 'jpg', 'gz', 'pdf'})
-    },
+            findsome(opj('metadata', 'tests', 'data'), {'mp3', 'dcm', 'jpg', 'gz', 'pdf'})},
+    entry_points={
+        'datalad.metadata.extractors': [
+            'annex=datalad.metadata.extractors.annex:MetadataExtractor',
+            'audio=datalad.metadata.extractors.audio:MetadataExtractor',
+            'bids=datalad.metadata.extractors.bids:MetadataExtractor',
+            'datacite=datalad.metadata.extractors.datacite:MetadataExtractor',
+            'datalad_core=datalad.metadata.extractors.datalad_core:MetadataExtractor',
+            'datalad_rfc822=datalad.metadata.extractors.datalad_rfc822:MetadataExtractor',
+            'dicom=datalad.metadata.extractors.dicom:MetadataExtractor',
+            'exif=datalad.metadata.extractors.exif:MetadataExtractor',
+            'frictionless_datapackage=datalad.metadata.extractors.frictionless_datapackage:MetadataExtractor',
+            'image=datalad.metadata.extractors.image:MetadataExtractor',
+            'nidm=datalad.metadata.extractors.nidm:MetadataExtractor',
+            'nifti1=datalad.metadata.extractors.nifti1:MetadataExtractor',
+            'xmp=datalad.metadata.extractors.xmp:MetadataExtractor',
+        ]},
     **setup_kwargs
 )


### PR DESCRIPTION
This makes it possible for 3rd-party packages to provide additional extractors.