### PR TITLE
ENH: create: Consider adding subdatasets when --nosave is given

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -383,12 +383,13 @@ class Create(Interface):
         # the next only makes sense if we saved the created dataset,
         # otherwise we have no committed state to be registered
         # in the parent
-        if save and isinstance(dataset, Dataset) and dataset.path != tbds.path:
+        if isinstance(dataset, Dataset) and dataset.path != tbds.path \
+           and tbds.repo.get_hexsha():
             # we created a dataset in another dataset
             # -> make submodule
             for r in dataset.add(
                     tbds.path,
-                    save=True,
+                    save=save,
                     return_type='generator',
                     result_filter=None,
                     result_xfm=None,


### PR DESCRIPTION
If we're creating a subdataset and --nosave is given, we don't
register the subdataset with the superdataset because 'git submodule
add' doesn't make much sense if the subdataset doesn't have a commit
yet.  (It modifies the .gitmodules file but no gitlink entry is
created.)  As a consequence, 'datalad save -d. -r .' cannot be used to
save changes after creating a subdataset with --nosave.

But in most cases, there is already a commit in a subdatasets (the one
that sets the annex backend), so add the subdataset as long as it has
at least one commit.  If the subdataset is a regular git repository,
there are no commits and the previous behavior is retained.

---

- [x] This change is complete

