### PR TITLE
ENH: run: Support runs with non-zero exit codes

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -178,15 +178,10 @@ def run_command(cmd, dataset=None, message=None, rerun_info=None):
         # went to stdout/err -- we just have to exitcode in the same way
         cmd_exitcode = e.code
 
-        if not rerun_info or rerun_info.get("exit", 0) != cmd_exitcode:
-            # we failed during a fresh run, or in a different way during a rerun
-            # the latter can easily happen if we try to alter a locked file
+        if rerun_info and rerun_info.get("exit", 0) != cmd_exitcode:
+            # we failed in a different way during a rerun.  This can easily
+            # happen if we try to alter a locked file
             #
-            # let's fail here, the command could have had a typo or some
-            # other undesirable condition. If we would `add` nevertheless,
-            # we would need to rerun and aggregate annex content that we
-            # likely don't want
-            # TODO add switch to ignore failure (some commands are stupid)
             # TODO add the ability to `git reset --hard` the dataset tree on failure
             # we know that we started clean, so we could easily go back, needs gh-1424
             # to be able to do it recursively
@@ -216,10 +211,15 @@ def run_command(cmd, dataset=None, message=None, rerun_info=None):
         message if message is not None else cmd_shorty,
         json.dumps(run_info, indent=1), sort_keys=True, ensure_ascii=False, encoding='utf-8')
 
-    for r in ds.add('.', recursive=True, message=msg):
-        yield r
-
-    # TODO bring back when we can ignore a command failure
-    #if cmd_exitcode:
-    #    # finally raise due to the original command error
-    #    raise CommandError(code=cmd_exitcode)
+    if not rerun_info and cmd_exitcode:
+        msg_path = opj(relpath(ds.repo.repo.git_dir), "COMMIT_EDITMSG")
+        with open(msg_path, "w") as ofh:
+            ofh.write(msg)
+        lgr.info("The command had a non-zero exit code. "
+                 "If this is expected, you can save the changes with "
+                 "'datalad save -r -F%s .'",
+                 msg_path)
+        raise CommandError(code=cmd_exitcode)
+    else:
+        for r in ds.add('.', recursive=True, message=msg):
+            yield r

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -194,7 +194,7 @@ def run_command(cmd, dataset=None, message=None, rerun_info=None):
 
     lgr.info("== Command exit (modification check follows) =====")
 
-    # ammend commit message with `run` info:
+    # amend commit message with `run` info:
     # - pwd if inside the dataset
     # - the command itself
     # - exit code of the command

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -202,9 +202,10 @@ class Save(Interface):
     @staticmethod
     @datasetmethod(name='save')
     @eval_results
-    def __call__(message=None, message_file=None, path=None, dataset=None,
+    def __call__(message=None, path=None, dataset=None,
                  all_updated=True, all_changes=None, version_tag=None,
-                 recursive=False, recursion_limit=None, super_datasets=False
+                 recursive=False, recursion_limit=None, super_datasets=False,
+                 message_file=None
                  ):
         if all_changes is not None:
             from datalad.support.exceptions import DeprecatedError

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -174,6 +174,11 @@ class Save(Interface):
             nargs='*',
             constraints=EnsureStr() | EnsureNone()),
         message=save_message_opt,
+        message_file=Parameter(
+            args=("-F", "--message-file"),
+            doc="""take the commit message from this file. This flag is
+            mutually exclusive with -m.""",
+            constraints=EnsureStr() | EnsureNone()),
         all_changes=Parameter(
             args=("-a", "--all-changes"),
             doc="""save all changes (even to not yet added files) of all components
@@ -197,7 +202,7 @@ class Save(Interface):
     @staticmethod
     @datasetmethod(name='save')
     @eval_results
-    def __call__(message=None, path=None, dataset=None,
+    def __call__(message=None, message_file=None, path=None, dataset=None,
                  all_updated=True, all_changes=None, version_tag=None,
                  recursive=False, recursion_limit=None, super_datasets=False
                  ):
@@ -208,11 +213,25 @@ class Save(Interface):
                 version="0.5.0",
                 msg="RF: all_changes option passed to the save"
             )
+
         if not dataset and not path:
             # we got nothing at all -> save what is staged in the repo in "this" directory?
             # we verify that there is an actual repo next
             dataset = abspath(curdir)
         refds_path = Interface.get_refds_path(dataset)
+
+        if message and message_file:
+            yield get_status_dict(
+                'save',
+                status='error',
+                path=refds_path,
+                message="Both a message and message file were specified",
+                logger=lgr)
+            return
+
+        if message_file:
+            with open(message_file) as mfh:
+                message = mfh.read()
 
         to_process = []
         got_nothing = True

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -36,6 +36,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import ok_exists
 from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import eq_
@@ -288,6 +289,45 @@ def test_rerun_just_one_commit(path):
     # run command.
     ds.repo.commit(msg="empty", options=["--allow-empty"])
     assert_raises(IncompleteResultsError, ds.rerun, since="", onto="")
+
+
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
+@known_failure_v6  #FIXME
+def test_run_failure(path):
+    ds = Dataset(path).create()
+
+    hexsha_initial = ds.repo.get_hexsha()
+
+    with assert_raises(CommandError):
+        ds.run("echo x$(cat grows) > grows && false")
+    eq_(hexsha_initial, ds.repo.get_hexsha())
+    ok_(ds.repo.dirty)
+
+    msgfile = opj(ds.repo.repo.git_dir, "COMMIT_EDITMSG")
+    ok_exists(msgfile)
+
+    ds.add(".", save=False)
+    ds.save(message_file=msgfile)
+    ok_clean_git(ds.path)
+    neq_(hexsha_initial, ds.repo.get_hexsha())
+
+    outfile = opj(ds.path, "grows")
+    eq_('x\n', open(outfile).read())
+
+    # There is no CommandError on rerun if the non-zero error matches the
+    # original code.
+    ds.rerun()
+    eq_('xx\n', open(outfile).read())
+
+    # On the other hand, we fail if we rerun a command and there is a non-zero
+    # error that doesn't match.
+    ds.run("[ ! -e bar ] && echo c >bar")
+    ok_clean_git(ds.path)
+    with assert_raises(CommandError):
+        ds.rerun()
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -47,7 +47,6 @@ from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import skip_if_on_windows
 from datalad.tests.utils import ignore_nose_capturing_stdout
-from datalad.tests.utils import swallow_logs
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -43,7 +43,7 @@ def _test_consistent_order_of_args(intf, spec_posargs):
 #    else:
 #        print intf, spec_posargs
     if intf.__name__ == 'Save':
-        # it makes sense there to have most command argument first
+        # it makes sense there to have most common argument first
         # -- the message. But we don't enforce it on cmdline so it is
         # optional
         spec_posargs.add('message')


### PR DESCRIPTION
This pull request

   * extends `save` to allow the message to be specified in a file (like `git commit`s `-F`)

   * makes `run` dump the log message to `.git/COMMIT_EDITMSG` when a command fails.  If the user expected the command to fail, they can then save the results using `save`s `-F` argument.  `datalad rerun` will happily re-execute commands unless they fail with a different code.

---

- [x] This change is complete
