### PR TITLE
Make --show-keys more useful - report stats

### DIFF
--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -215,7 +215,7 @@ def test_within_ds_file_search(path):
 
     # test default behavior
     with swallow_outputs() as cmo:
-        ds.search(show_keys=True, mode='textblob')
+        ds.search(show_keys='name', mode='textblob')
 
         assert_in("""\
 id
@@ -289,7 +289,7 @@ type
 
     # check generated autofield index keys
     with swallow_outputs() as cmo:
-        ds.search(mode='autofield', show_keys=True)
+        ds.search(mode='autofield', show_keys='name')
         # it is impossible to assess what is different from that dump
         assert_in(target_out, cmo.out)
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -67,6 +67,7 @@ from .utils import assert_cwd_unchanged, skip_if_on_windows
 from .utils import assure_dict_from_str, assure_list_from_str
 from .utils import assure_unicode
 from .utils import assure_bool
+from .utils import assure_iter
 from .utils import assure_list
 from .utils import ok_generator
 from .utils import assert_not_in
@@ -384,6 +385,15 @@ def test_auto_repr():
         "buga(a=1, b=<<[0, 1, 2, 3, 4, 5, 6, ...>>, c=<WithoutReprClass>)"
     )
     assert_equal(buga().some(), "some")
+
+
+def test_assure_iter():
+    s = {1}
+    assert assure_iter(None, set) == set()
+    assert assure_iter(1, set) == s
+    assert assure_iter(1, list) == [1]
+    assert assure_iter(s, set) is s
+    assert assure_iter(s, set, copy=True) is not s
 
 
 def test_assure_list_copy():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -23,6 +23,7 @@ import gc
 import glob
 import wrapt
 
+from copy import copy as shallow_copy
 from contextlib import contextmanager
 from functools import wraps
 from time import sleep
@@ -432,6 +433,33 @@ def assure_tuple_or_list(obj):
     return (obj,)
 
 
+def assure_iter(s, cls, copy=False, iterate=True):
+    """Given not a list, would place it into a list. If None - empty list is returned
+
+    Parameters
+    ----------
+    s: list or anything
+    cls: class
+      Which iterable class to assure
+    copy: bool, optional
+      If correct iterable is passed, it would generate its shallow copy
+    iterate: bool, optional
+      If it is not a list, but something iterable (but not a text_type)
+      iterate over it.
+    """
+
+    if isinstance(s, cls):
+        return s if not copy else shallow_copy(s)
+    elif isinstance(s, text_type):
+        return cls((s,))
+    elif iterate and hasattr(s, '__iter__'):
+        return cls(s)
+    elif s is None:
+        return cls()
+    else:
+        return cls((s,))
+
+
 def assure_list(s, copy=False, iterate=True):
     """Given not a list, would place it into a list. If None - empty list is returned
 
@@ -444,17 +472,7 @@ def assure_list(s, copy=False, iterate=True):
       If it is not a list, but something iterable (but not a text_type)
       iterate over it.
     """
-
-    if isinstance(s, list):
-        return s if not copy else s[:]
-    elif isinstance(s, text_type):
-        return [s]
-    elif iterate and hasattr(s, '__iter__'):
-        return list(s)
-    elif s is None:
-        return []
-    else:
-        return [s]
+    return assure_iter(s, list, copy=copy, iterate=iterate)
 
 
 def assure_list_from_str(s, sep='\n'):


### PR DESCRIPTION
I bet there is a better/proper way but I could not think about one... I thought that may be `metadata` call on the superdataset could just report those aggregated unique values but I was not smart enough to figure out if that was possible.

This pull request proposes to make --show-keys more versatile and report statistics on the key values since they are known at no additional cost while listing them.  My original goal was to check what unique values for dicom fields we collected and in how many datasets.  While still waiting (for an hour now) for output of (a more informative, since provides pairs)
```shell

$> datalad -f '{metadata[dicom][Manufacturer]}: {metadata[dicom][ManufacturerModelName]}  Version(s):{metadata[dicom][SoftwareVersions]}' --report-type file search --max-nresult=0 --mode=autofield 'dicom.Manufacturer:*' -f > /tmp/allhits
```
I achieved following with the suggested here changes:
```shell
$> datalad --dbg search --show-keys=full | grep -A2 dicom.Manufa
dicom.Manufacturer
 in  16 datasets
 has 3 unique values: u'SIEMENS', u'GE MEDICAL SYSTEMS', u'Philips Medical Systems'
dicom.ManufacturerModelName
 in  16 datasets
 has 7 unique values: u'Prisma', u'SIGNA HDx', u'DISCOVERY MR750', u'Achieva', u'TrioTim', u'Prisma_fit', u'Intera'

$> datalad --dbg search --show-keys=short | grep -A2 dicom.Manufa    
dicom.Manufacturer
 in  16 datasets
 has 3 unique values: u'SIEMENS', u'GE MEDICAL SYSTEMS', u'Philips Medical Systems'
dicom.ManufacturerModelName
 in  16 datasets
 has 7 unique values: u'Prisma', u'SIGNA HDx', u'DISCOVERY MR750', u'Achieva', u'TrioTim', u'Prisma_f ....

$> datalad --dbg search --show-keys=name | grep -A2 dicom.Manufa     
dicom.Manufacturer
dicom.ManufacturerModelName
dicom.MedicalAlerts
dicom.Modality
```

Feel free to scrape it especially if above results could be obtained in some different, smoother way

### Changes
- [x] This change is complete

Please have a look @datalad/developers
