### PR TITLE
BF: blind attempt - assure there is a trailing new line while joining outputs from batches

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2301,8 +2301,10 @@ class AnnexRepo(GitRepo, RepoInterface):
                     command,
                     annex_options=annex_options + ['--'] + file_chunk,
                     **kwargs)
-                out += out_
-                err += err_
+                # Addition of \n is an attempt to address
+                # https://github.com/datalad/datalad/issues/2301
+                out += out_ + (os.linesep if not out_.endswith(os.linesep) else '')
+                err += err_ + (os.linesep if not err_.endswith(os.linesep) else '')
         except CommandError as e:
             # Note: A call might result in several 'failures', that can be or
             # cannot be handled here. Detection of something, we can deal with,


### PR DESCRIPTION
of git-annex runs.  It is unlikely the cause but the other possible causes lie even deeper.
Thought to check this one first

This pull request fixes #2301 (if passes upon a few trials). unlikely to be the one at fault

This pull request proposes

### Changes
- [ ] This change is complete

Please have a look @datalad/developers
