### PR TITLE
BF: import subdatasets, so Dataset could gets its .subdatasets

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -265,7 +265,7 @@ class Dataset(object):
         # with it. Internally we don't need or use it anymore.
         import inspect
         lgr.warning('%s still uses Dataset.get_subdatasets(). RF to use `subdatasets` command', inspect.stack()[1][3])
-        from datalad.api import subdatasets
+        from datalad.coreapi import subdatasets
         if edges:
             return [(r['parentpath'] if absolute else relpath(r['parentpath'], start=self.path),
                      r['path'] if absolute else relpath(r['path'], start=self.path))
@@ -343,6 +343,7 @@ class Dataset(object):
         -------
         Dataset or None
         """
+        from datalad.coreapi import subdatasets
         # TODO: return only if self is subdataset of the superdataset
         #       (meaning: registered as submodule)?
         path = self.path

--- a/datalad/metadata/extractors/tests/test_image.py
+++ b/datalad/metadata/extractors/tests/test_image.py
@@ -10,9 +10,11 @@
 
 from datalad.tests.utils import SkipTest
 try:
-    import PIL
-except ImportError:
-    raise SkipTest("No PIL module available")
+    from PIL import Image
+except ImportError as exc:
+    from datalad.dochelpers import exc_str
+    raise SkipTest(
+       "No PIL module available or it cannot be imported: %s" % exc_str(exc))
 
 from shutil import copy
 from os.path import dirname

--- a/datalad/metadata/extractors/tests/test_xmp.py
+++ b/datalad/metadata/extractors/tests/test_xmp.py
@@ -11,8 +11,9 @@
 from datalad.tests.utils import SkipTest
 try:
     import libxmp
-except ImportError:
-    raise SkipTest
+except Exception as exc:
+    from datalad.dochelpers import exc_str
+    raise SkipTest("libxmp cannot be imported: %s" % exc_str(exc))
 
 from shutil import copy
 from os.path import dirname


### PR DESCRIPTION
- This pull request fixes yet another absent binding issue: BF: import subdatasets, so Dataset could gets its .subdatasets
- Makes tests Skipped if PIL.Image fails to import and libxmp throws some other exception, not ImportError upon import (those recent OSX problems). Fixes #2374 
