### PR TITLE
BF: assure that each line returned during processing of outputs ends with \n

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -326,8 +326,9 @@ class Runner(object):
                 # resolving a once in a while failing test #2185
                 if isinstance(out_, text_type):
                     out_ = out_.encode('utf-8')
-                for line in out_.split(linesep_bytes):
-                    out += self._process_one_line(*pargs, line=line)
+                out += linesep_bytes.join(
+                    self._process_one_line(*pargs, line=line)
+                    for line in out_.split(linesep_bytes))
         return out
 
     def _process_one_line(self, out_type, proc, log_, log_is_callable,

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -318,7 +318,7 @@ s
 п
 """
     out_bytes = out.encode('utf-8')
-    target = u"sп".encode('utf-8')
+    target = u"s\nп\n".encode('utf-8')
     args = ['stdout', None, False, False]
     #  probably #2185
     eq_(runner._process_remaining_output(None, out_bytes, *args), target)


### PR DESCRIPTION
Another blind attempt closer to the heart of things
This pull request fixes #2301 (if does not trigger failure after a few reruns)
