### PR TITLE
Need some clever way of limiting the output of uniquification of metadata values

### DIFF
--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -15,6 +15,7 @@ __docformat__ = 'restructuredtext'
 import datalad
 from .base import Interface
 from datalad.interface.base import build_doc
+from datalad.utils import assure_list
 from ..support.param import Parameter
 
 
@@ -23,7 +24,7 @@ class Test(Interface):
     """Run internal DataLad (unit)tests.
 
     This can be used to verify correct operation on the system.
-    It is just a thin wrapper around a call to nose, so number of 
+    It is just a thin wrapper around a call to nose, so number of
     exposed options is minimal
     """
     # XXX prevent common args from being added to the docstring
@@ -48,10 +49,17 @@ class Test(Interface):
             doc="stop running tests after the first error or failure"),
         module=Parameter(
             args=("module",),
-            nargs="?",
-            doc="be verbose - list test names"),
+            nargs="*",
+            doc="""test name(s), by default all tests of DataLad core and any
+            installed extensions are executed"""),
     )
 
     @staticmethod
-    def __call__(module='datalad', verbose=False, nocapture=False, pdb=False, stop=False):
-        datalad.test(module=module, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)
+    def __call__(module=None, verbose=False, nocapture=False, pdb=False, stop=False):
+        if module is None:
+            from pkg_resources import iter_entry_points
+            module = ['datalad']
+            module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
+        module = assure_list(module)
+        for mod in module:
+            datalad.test(module=mod, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -320,7 +320,7 @@ def eval_results(func):
                 [i for i in mod.__dict__
                  if type(mod.__dict__[i]) == type and
                  issubclass(mod.__dict__[i], Interface) and
-                 i.lower().startswith(wrapped.__module__.split('.')[-1].replace('_', ''))]
+                 i.lower().startswith(wrapped.__module__.split('.')[-1].replace('datalad_', '').replace('_', ''))]
             assert len(command_class_names) == 1, (command_class_names, mod.__name__)
             command_class_name = command_class_names[0]
         else:

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -518,7 +518,7 @@ class AggregateMetaData(Interface):
     scientific metadata standards are supported, like DICOM, BIDS, or datacite.
     Some metadata extractors depend on particular 3rd-party software. The list of
     metadata extractors available to a particular DataLad installation is reported
-    by the 'wtf' plugin ('datalad wtf').
+    by the 'wtf' command ('datalad wtf').
 
     Enabling a metadata extractor for a dataset is done by adding its name to the
     'datalad.metadata.nativetype' configuration variable -- typically in the
@@ -530,8 +530,8 @@ class AggregateMetaData(Interface):
 
     Enabling multiple extractors is supported. In this case, metadata are
     extracted by each extractor individually, and stored alongside each other.
-    Metadata aggregation will also extract DataLad's own metadata (extractor
-    'datalad_core').
+    Metadata aggregation will also extract DataLad's own metadata (extractors
+    'datalad_core', and 'annex').
 
     Metadata aggregation can be performed recursively, in order to aggregate all
     metadata across all subdatasets, for example, to be able to search across
@@ -586,6 +586,8 @@ class AggregateMetaData(Interface):
     _params_ = dict(
         # TODO add option to not update aggregated data/info in intermediate
         # datasets
+        # TODO add option to not store aggregated metadata in the leaf-dataset
+        # it was extracted from
         # TODO add option for full aggregation (not incremental), so when something
         # is not present nothing about it is preserved in the aggregated metadata
         dataset=Parameter(

--- a/datalad/metadata/extractors/__init__.py
+++ b/datalad/metadata/extractors/__init__.py
@@ -7,28 +7,3 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Metadata extractors"""
-
-import logging as __logging
-from datalad.utils import import_modules as __import_modules
-
-__all__ = [
-    'annex',
-    'audio',
-    'bids',
-    'datacite',
-    'datalad_core',
-    'datalad_rfc822',
-    'dicom',
-    'exif',
-    'frictionless_datapackage',
-    'image',
-    'nidm',
-    'nifti1',
-    'xmp',
-]
-
-__import_modules(
-    __all__,
-    pkg=__name__,
-    msg='Metadata extractor {module} is unusable',
-    log=__logging.getLogger(__name__).debug)

--- a/datalad/metadata/extractors/audio.py
+++ b/datalad/metadata/extractors/audio.py
@@ -33,6 +33,9 @@ vocab_map = {
 
 
 class MetadataExtractor(BaseMetadataExtractor):
+
+    _unique_exclude = {'bitrate'}
+
     def get_metadata(self, dataset, content):
         if not content:
             return {}, []

--- a/datalad/metadata/extractors/tests/test_audio.py
+++ b/datalad/metadata/extractors/tests/test_audio.py
@@ -22,9 +22,9 @@ from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import eq_
-from datalad.tests.utils import assert_in
 
 
 target = {
@@ -68,3 +68,8 @@ def test_audio(path):
     # for discovering whole datasets
     assert_in('bitrate', meta)
     eq_(uniques['audio']['bitrate'], None)
+
+    # 'date' field carries not value, hence gets exclude from the unique report
+    assert_in('date', meta)
+    assert(not meta['date'])
+    assert_not_in('date', uniques['audio'])

--- a/datalad/metadata/extractors/tests/test_audio.py
+++ b/datalad/metadata/extractors/tests/test_audio.py
@@ -21,6 +21,7 @@ from datalad.api import Dataset
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import eq_
 from datalad.tests.utils import assert_in
@@ -60,3 +61,10 @@ def test_audio(path):
         eq_(meta[k], v)
 
     assert_in('@context', meta)
+
+    uniques = ds.metadata(
+        reporton='datasets', return_type='item-or-list')['metadata']['datalad_unique_content_properties']
+    # test file has it, but uniques have it blanked out, because the extractor considers it worthless
+    # for discovering whole datasets
+    assert_in('bitrate', meta)
+    eq_(uniques['audio']['bitrate'], None)

--- a/datalad/metadata/extractors/tests/test_dicom.py
+++ b/datalad/metadata/extractors/tests/test_dicom.py
@@ -27,7 +27,6 @@ from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 
-
 @with_tempfile(mkdir=True)
 def test_dicom(path):
     ds = Dataset(path).create()
@@ -61,10 +60,12 @@ def test_dicom(path):
 
     # for this artificial case pretty much the same info also comes out as
     # unique props, but wrapped in lists
+    udp = res[0]['metadata']["datalad_unique_content_properties"]['dicom']
     assert_dict_equal(
         {k: [v]
-         for k, v in dsmeta['Series'][0].items()},
-        res[0]['metadata']["datalad_unique_content_properties"]['dicom'])
+         for k, v in dsmeta['Series'][0].items()
+         if k in udp},
+        udp)
 
     # buuuut, if we switch of file-based metadata storage
     ds.config.add('datalad.metadata.aggregate-content-dicom', 'false', where='dataset')

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -556,7 +556,13 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
                     for i in sorted(
                         v,
                         key=_unique_value_key)] if v is not None else None
-                for k, v in unique_cm.items()}
+                for k, v in unique_cm.items()
+                # v == None (disable unique, but there was a value at some point)
+                # otherwise we only want actual values, and also no single-item-lists
+                # of a non-value
+                # those contribute no information, but bloat the operation
+                # (inflated number of keys, inflated storage, inflated search index, ...)
+                if v is None or (v and not v == {''})}
             dsmeta['datalad_unique_content_properties'] = ucp
 
     # always identify the effective vocabulary - JSON-LD style

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -118,7 +118,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
                     # ignore any generated unique value list in favor of the
                     # tailored data
                     continue
-                srcmeta[uk] = _listdict2dictlist(umeta[uk])
+                srcmeta[uk] = _listdict2dictlist(umeta[uk]) if umeta[uk] is not None else None
 
     def _deep_kv(basekey, dct):
         """Return key/value pairs of any depth following a rule for key

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -227,7 +227,6 @@ type
 
     target_out = """\
 audio.bitrate
-audio.date
 audio.duration(s)
 audio.format
 audio.music-Genre

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -215,7 +215,7 @@ def test_within_ds_file_search(path):
 
     # test default behavior
     with swallow_outputs() as cmo:
-        ds.search(show_keys=True, mode='textblob')
+        ds.search(show_keys='name', mode='textblob')
 
         assert_in("""\
 id
@@ -289,7 +289,7 @@ type
 
     # check generated autofield index keys
     with swallow_outputs() as cmo:
-        ds.search(mode='autofield', show_keys=True)
+        ds.search(mode='autofield', show_keys='name')
         # it is impossible to assess what is different from that dump
         assert_in(target_out, cmo.out)
 

--- a/datalad/plugin/extract_metadata.py
+++ b/datalad/plugin/extract_metadata.py
@@ -14,23 +14,23 @@ from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 
 
+@build_doc
 class ExtractMetadata(Interface):
     """Run one or more of DataLad's metadata extractors on a dataset or file.
 
     The result(s) are structured like the metadata DataLad would extract
     during metadata aggregation. There is one result per dataset/file.
 
-    Examples
-    --------
+    Examples:
 
-    Extract metadata with two extractors from a dataset in the current directory
-    and also from all its files::
+      Extract metadata with two extractors from a dataset in the current directory
+      and also from all its files::
 
-      $ datalad extract-metadata -d . --type frictionless_datapackage datalad_core
+        $ datalad extract-metadata -d . --type frictionless_datapackage --type datalad_core
 
-    Extract XMP metadata from a single PDF that is not part of any dataset::
+      Extract XMP metadata from a single PDF that is not part of any dataset::
 
-      $ datalad extract-metadata --type xmp --file Downloads/freshfromtheweb.pdf
+        $ datalad extract-metadata --type xmp Downloads/freshfromtheweb.pdf
     """
 
     from datalad.support.param import Parameter
@@ -45,12 +45,12 @@ class ExtractMetadata(Interface):
             args=("--type",),
             dest="types",
             metavar=("NAME"),
-            nargs="+",
+            action='append',
             required=True,
-            doc="""Name of the metadata extractor to be executed."""),
+            doc="""Name of a metadata extractor to be executed.
+            [CMD: This option can be given more than once CMD]"""),
         files=Parameter(
-            args=("--file",),
-            dest="files",
+            args=("files",),
             metavar="FILE",
             nargs="*",
             doc="Path of a file to extract metadata from.",
@@ -72,7 +72,6 @@ class ExtractMetadata(Interface):
         from datalad.distribution.dataset import require_dataset
         from datalad.metadata.metadata import _get_metadata
         from datalad.metadata.metadata import _get_metadatarelevant_paths
-
 
         dataset = require_dataset(dataset or curdir,
                                   purpose="extract metadata",

--- a/datalad/plugin/tests/test_metadata.py
+++ b/datalad/plugin/tests/test_metadata.py
@@ -20,7 +20,7 @@ from datalad.utils import chpwd
 
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in
 
@@ -34,10 +34,7 @@ testpath = opj(dirname(dirname(dirname(__file__))), 'metadata', 'tests', 'data',
 def test_error(path):
     # go into virgin dir to avoid detection of any dataset
     with chpwd(path):
-        res = extract_metadata(
-            types=['bogus__'],
-            files=[testpath])
-        assert_status('error', res)
+        assert_raises(ValueError, extract_metadata, types=['bogus__'], files=[testpath])
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2847,9 +2847,13 @@ class AnnexRepo(GitRepo, RepoInterface):
                 path=self.path)(key_)
             try:
                 return {
-                    # None: False,  # happens on travis in direct/heavy-debug mode
-                    #               # reason is unknown, but causes pain and suffering
-                    #               # and so far was consistent with "False" result
+                    # happens on travis in direct/heavy-debug mode, that process
+                    # exits and closes stdout (upon unknown key) before we could
+                    # read it, so we get None as the stdout.
+                    # see https://github.com/datalad/datalad/issues/2330
+                    # but it is associated with an unknown key, and for consistency
+                    # we report False there too, as to ''
+                    None: False,
                     '': False,  # when remote is misspecified ... stderr carries the msg
                     '0': False,
                     '1': True,

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -67,6 +67,7 @@ from .utils import assert_cwd_unchanged, skip_if_on_windows
 from .utils import assure_dict_from_str, assure_list_from_str
 from .utils import assure_unicode
 from .utils import assure_bool
+from .utils import assure_iter
 from .utils import assure_list
 from .utils import ok_generator
 from .utils import assert_not_in
@@ -384,6 +385,15 @@ def test_auto_repr():
         "buga(a=1, b=<<[0, 1, 2, 3, 4, 5, 6, ...>>, c=<WithoutReprClass>)"
     )
     assert_equal(buga().some(), "some")
+
+
+def test_assure_iter():
+    s = {1}
+    assert assure_iter(None, set) == set()
+    assert assure_iter(1, set) == s
+    assert assure_iter(1, list) == [1]
+    assert assure_iter(s, set) is s
+    assert assure_iter(s, set, copy=True) is not s
 
 
 def test_assure_list_copy():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -23,6 +23,7 @@ import gc
 import glob
 import wrapt
 
+from copy import copy as shallow_copy
 from contextlib import contextmanager
 from functools import wraps
 from time import sleep
@@ -432,6 +433,33 @@ def assure_tuple_or_list(obj):
     return (obj,)
 
 
+def assure_iter(s, cls, copy=False, iterate=True):
+    """Given not a list, would place it into a list. If None - empty list is returned
+
+    Parameters
+    ----------
+    s: list or anything
+    cls: class
+      Which iterable class to assure
+    copy: bool, optional
+      If correct iterable is passed, it would generate its shallow copy
+    iterate: bool, optional
+      If it is not a list, but something iterable (but not a text_type)
+      iterate over it.
+    """
+
+    if isinstance(s, cls):
+        return s if not copy else shallow_copy(s)
+    elif isinstance(s, text_type):
+        return cls((s,))
+    elif iterate and hasattr(s, '__iter__'):
+        return cls(s)
+    elif s is None:
+        return cls()
+    else:
+        return cls((s,))
+
+
 def assure_list(s, copy=False, iterate=True):
     """Given not a list, would place it into a list. If None - empty list is returned
 
@@ -444,17 +472,7 @@ def assure_list(s, copy=False, iterate=True):
       If it is not a list, but something iterable (but not a text_type)
       iterate over it.
     """
-
-    if isinstance(s, list):
-        return s if not copy else s[:]
-    elif isinstance(s, text_type):
-        return [s]
-    elif iterate and hasattr(s, '__iter__'):
-        return list(s)
-    elif s is None:
-        return []
-    else:
-        return [s]
+    return assure_iter(s, list, copy=copy, iterate=iterate)
 
 
 def assure_list_from_str(s, sep='\n'):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'datalad'
+project = u'DataLad'
 copyright = u'2016-2018, DataLad team'
 author = u'DataLad team'
 

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -10,10 +10,20 @@ Customization and extension of functionality
 DataLad provides numerous commands that cover many use cases. However, there
 will always be a demand for further customization or extensions of built-in
 functionality at a particular site, or for an individual user. DataLad
-addresses this need by providing a generic plugin interface.
+addresses this need with two mechanisms:
 
-Using plugins
-=============
+- Plugins_
+- `Extension packages`_
+
+Plugins are a quick'n'dirty way to implement a single additional command with very
+little overhead. They are, however, not the method of choice for extending particular
+Datalad functionality, such as metadata extractor, or providing entire command suites
+for a specialized purpose. For all these scenarios extension packages are the
+recommended method.
+
+
+Plugins
+^^^^^^^
 
 A number of plugins are shipped with DataLad. This includes plugins which
 operate on a particular dataset, but also general functionality that can be
@@ -162,3 +172,47 @@ The following keys should exists if possible:
     string message annotating the result, particularly important for
     non-ok results. This can be a tuple with 'logging'-style string
     expansion.
+
+
+Extension packages
+^^^^^^^^^^^^^^^^^^
+
+As the name suggests, an extension package is a proper Python package.
+Consequently, there is a significant amount of boilerplate code involved in the
+creation of a new Datalad extension. However, this overhead enables a number of
+useful features for extension developers:
+
+- extensions can provide any number of additional commands that can be grouped into
+  labeled command suites, and are automatically exposed via the standard DataLad commandline
+  and Python API
+- extensions can define `entry_points` for any number of additional metadata extractors
+  that become automatically available to DataLad
+- extensions can define `entry_points` for their test suites, such that the standard `datalad test`
+  command will automatically run these tests in addition to the tests shipped with Datalad core
+
+
+Using an extension
+==================
+
+A DataLad extension is a standard Python package. Beyond installation of the package there is
+no additional setup required.
+
+
+Writing your own extensions
+===========================
+
+A good starting point for implementing a new extension is the "helloworld" demo extension
+available at https://github.com/datalad/datalad-module-template. This repository can be cloned
+and adjusted to suit one's needs. It includes:
+
+- a basic Python package setup
+- simple demo command implementation
+- Travis test setup
+
+A more complex extension setup can be seen in the DataLad Neuroimaging
+extension: https://github.com/datalad/datalad-neuroimaging, including additional metadata extractors,
+test suite registration, and a sphinx-based documentation setup for a DataLad extension.
+
+As a DataLad extension is a standard Python package, an extension should declare
+dependencies on an appropriate DataLad version, and possibly other extensions
+via the standard mechanisms.

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,22 @@ setup(
         'datalad':
             findsome('resources', {'sh', 'html', 'js', 'css', 'png', 'svg', 'txt'}) +
             findsome(opj('downloaders', 'configs'), {'cfg'}) +
-            findsome(opj('metadata', 'tests', 'data'), {'mp3', 'dcm', 'jpg', 'gz', 'pdf'})
-    },
+            findsome(opj('metadata', 'tests', 'data'), {'mp3', 'dcm', 'jpg', 'gz', 'pdf'})},
+    entry_points={
+        'datalad.metadata.extractors': [
+            'annex=datalad.metadata.extractors.annex:MetadataExtractor',
+            'audio=datalad.metadata.extractors.audio:MetadataExtractor',
+            'bids=datalad.metadata.extractors.bids:MetadataExtractor',
+            'datacite=datalad.metadata.extractors.datacite:MetadataExtractor',
+            'datalad_core=datalad.metadata.extractors.datalad_core:MetadataExtractor',
+            'datalad_rfc822=datalad.metadata.extractors.datalad_rfc822:MetadataExtractor',
+            'dicom=datalad.metadata.extractors.dicom:MetadataExtractor',
+            'exif=datalad.metadata.extractors.exif:MetadataExtractor',
+            'frictionless_datapackage=datalad.metadata.extractors.frictionless_datapackage:MetadataExtractor',
+            'image=datalad.metadata.extractors.image:MetadataExtractor',
+            'nidm=datalad.metadata.extractors.nidm:MetadataExtractor',
+            'nifti1=datalad.metadata.extractors.nifti1:MetadataExtractor',
+            'xmp=datalad.metadata.extractors.xmp:MetadataExtractor',
+        ]},
     **setup_kwargs
 )


### PR DESCRIPTION
The can grow really large. Example: DICOM slice timestamps aggregated over a 2h session (24 per seconds...).

For the `dicom` extractor is makes sense to disable uniquification completely, because it produces nice `Series` metadata, but we need something for the general case.

Also, unique value keys is what `search --mode autofield` bases the index build on during the first pass, hence we have to keep those for such use cases (what keys do you know).

Apparently already a concern in #2342