### PR TITLE
Change test setup to run *installed* datalad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
-    - TESTS_TO_PERFORM=
+    - TESTS_TO_PERFORM=datalad
     - NOSE_OPTS=-s
     - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
     # Special settings/helper for combined coverage from special remotes execution
@@ -126,7 +126,7 @@ matrix:
     # Test under NFS mount  (only selected sub-set)
     env:
     - TMPDIR="/tmp/nfsmount"
-    - TESTS_TO_PERFORM="datalad/tests datalad/support"
+    - TESTS_TO_PERFORM="datalad.tests datalad.support"
   - python: 3.5
     # Test under NFS mount  (full, only in master)
     env:
@@ -224,8 +224,8 @@ install:
   - npm install grunt-contrib-qunit
 
 script:
-  # Verify that setup.py build doesn't puke
-  - python setup.py build
+  # Test installation system-wide
+  - sudo pip install .
   # Run tests
   - WRAPT_DISABLE_EXTENSIONS=1 http_proxy=
     PATH=$PWD/tools/coverage-bin:$PATH
@@ -248,8 +248,6 @@ script:
     else
       $NOSE_WRAPPER tools/testing/run_doc_examples;
     fi
-  # Test installation system-wide
-  - sudo pip install .
   # Report WTF information using system wide installed version
   - datalad wtf
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -226,6 +226,8 @@ install:
 script:
   # Test installation system-wide
   - sudo pip install .
+  - mkdir -p __testhome__
+  - cd __testhome__
   # Run tests
   - WRAPT_DISABLE_EXTENSIONS=1 http_proxy=
     PATH=$PWD/tools/coverage-bin:$PATH
@@ -235,6 +237,13 @@ script:
       --with-cov --cover-package datalad
       --logging-level=INFO
       $TESTS_TO_PERFORM
+  # Run doc examples if no spaces in the TMPDIR and SSH is allowed
+  - if [ $DATALAD_TESTS_SSH != 1 ] || echo "${TMPDIR:-}" | grep -q ' '; then
+      echo "skipping due spaces in $TMPDIR";
+    else
+      $NOSE_WRAPPER ../tools/testing/run_doc_examples;
+    fi
+  - cd ..
   # Generate documentation and run doctests
   # but do only when we do not have obnoxious logging turned on -- something screws up sphinx on travis
   - if [ ! "${DATALAD_LOG_LEVEL:-}" = 2 ]; then
@@ -242,12 +251,6 @@ script:
     fi
   # Run javascript tests
   - grunt test --verbose
-  # Run doc examples if no spaces in the TMPDIR and SSH is allowed
-  - if [ $DATALAD_TESTS_SSH != 1 ] || echo "${TMPDIR:-}" | grep -q ' '; then
-      echo "skipping due spaces in $TMPDIR";
-    else
-      $NOSE_WRAPPER tools/testing/run_doc_examples;
-    fi
   # Report WTF information using system wide installed version
   - datalad wtf
 


### PR DESCRIPTION
It hit me in the past, and I still find it suboptimal, hence this proposal:

Let's change the travis setup to run tests on the installed datalad. ATM we run the tests on the result of `setup.py build` and only after the tests ran, we try to install.

At the same time, we offer a `test` command that is designed to pick up the installed tests.

With the new extension setup things become even weirder, as they need to be installed in order for the entrypoints to have any effect.

If there is any benefit to testing the non-installed datalad over the installed one, please let me know. Otherwise, I will push this change.