### PR TITLE
BF: s3: Don't duplicate ID when getting versioned URL

### DIFF
--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -28,8 +28,8 @@ def test_version_url():
         eq_(get_versioned_url(url_pref + "/tarballs/ds001_raw.tgz"),
             url_pref + "/tarballs/ds001_raw.tgz?versionId=null")
 
-        eq_(get_versioned_url("http://openfmri.s3.amazonaws.com/tarballs/ds001_raw.tgz?param=1"),
-            "http://openfmri.s3.amazonaws.com/tarballs/ds001_raw.tgz?param=1&versionId=null")
+        eq_(get_versioned_url(url_pref + "tarballs/ds001_raw.tgz?param=1"),
+            url_pref + "/tarballs/ds001_raw.tgz?param=1&versionId=null")
 
     # something is wrong there
     #print(get_versioned_url("http://openfmri.s3.amazonaws.com/ds001/demographics.txt"))

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -51,7 +51,7 @@ def test_get_versioned_url():
         eq_(get_versioned_url(url_pref + "/tarballs/ds001_raw.tgz"),
             url_pref + "/tarballs/ds001_raw.tgz?versionId=null")
 
-        eq_(get_versioned_url(url_pref + "tarballs/ds001_raw.tgz?param=1"),
+        eq_(get_versioned_url(url_pref + "/tarballs/ds001_raw.tgz?param=1"),
             url_pref + "/tarballs/ds001_raw.tgz?param=1&versionId=null")
 
         # We don't duplicate the version if it already exists.

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -47,7 +47,7 @@ def test_unparse_versioned_url():
 
 @skip_if_no_network
 @use_cassette('s3_test_version_url')
-def test_version_url():
+def test_get_versioned_url():
     get_test_providers('s3://openfmri/tarballs')  # to verify having credentials to access openfmri via S3
     for url_pref in ('http://openfmri.s3.amazonaws.com', 'https://s3.amazonaws.com/openfmri'):
         eq_(get_versioned_url(url_pref + "/tarballs/ds001_raw.tgz"),

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -81,8 +81,8 @@ def test_get_versioned_url():
     # Update a versioned URL with a newer version tag.
     url_3ver = "http://datalad-test0-versioned.s3.amazonaws.com/3versions-allversioned.txt"
     url_3ver_input = url_3ver + "?versionId=b.qCuh7Sg58VIYj8TVHzbRS97EvejzEl"
-    eq_(get_versioned_url(url_3ver_input), url_3ver)
-    eq_(get_versioned_url(url_3ver, update=True),
+    eq_(get_versioned_url(url_3ver_input), url_3ver_input)
+    eq_(get_versioned_url(url_3ver_input, update=True),
         url_3ver + "?versionId=Kvuind11HZh._dCPaDAb0OY9dRrQoTMn")
 
 

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -10,9 +10,8 @@
 
 """
 
-from six.moves.urllib.parse import urlparse
-
-from ..support.s3 import get_versioned_url, unparse_versioned_url
+from ..support.network import URL
+from ..support.s3 import add_version_to_url, get_versioned_url
 from .utils import use_cassette
 from .utils import ok_startswith
 
@@ -21,27 +20,26 @@ from datalad.tests.utils import skip_if_no_network
 from ..downloaders.tests.utils import get_test_providers
 
 
-def test_unparse_versioned_url():
+def test_add_version_to_url():
     base_url = "http://ex.com/f.txt"
     base_url_query = "http://ex.com/f.txt?k=v"
     for replace in True, False:
-        eq_(unparse_versioned_url(urlparse(base_url),
-                                  "new.id", replace=replace),
+        eq_(add_version_to_url(URL(base_url), "new.id", replace=replace),
             base_url + "?versionId=new.id")
 
-        eq_(unparse_versioned_url(urlparse(base_url_query),
-                                  "new.id", replace=replace),
+        eq_(add_version_to_url(URL(base_url_query),
+                               "new.id", replace=replace),
             base_url_query + "&versionId=new.id")
 
         expected = "new.id" if replace else "orig.id"
-        eq_(unparse_versioned_url(urlparse(base_url + "?versionId=orig.id"),
-                                  "new.id",
-                                  replace=replace),
+        eq_(add_version_to_url(URL(base_url + "?versionId=orig.id"),
+                               "new.id",
+                               replace=replace),
             base_url + "?versionId=" + expected)
 
-        eq_(unparse_versioned_url(urlparse(base_url_query + "&versionId=orig.id"),
-                                  "new.id",
-                                  replace=replace),
+        eq_(add_version_to_url(URL(base_url_query + "&versionId=orig.id"),
+                               "new.id",
+                               replace=replace),
             base_url_query + "&versionId=" + expected)
 
 


### PR DESCRIPTION
Check whether the query already has a versionId component so that we don't construct URLs that contain multiple versionIDs.  Depending on the situation, the caller may want to update an existing versionId to the latest version, so add a flag that enables this behavior.

---

This pull request fixes #2379.

- [x] This change is complete

Marked WIP because I haven't  run the test_version_url tests and they're based on a [guess][0] about the latest file version.  Let's see.

[0]:  https://github.com/datalad/datalad/issues/2379#issuecomment-379085453
