### PR TITLE
 NF: Switch to select type of metadata aggregation update (fixes gh-2378)

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -1316,7 +1316,7 @@ class Annexificator(object):
 
             if aggregate:
                 from datalad.api import aggregate_metadata
-                aggregate_metadata(dataset='^', path=self.repo.path)
+                aggregate_metadata(dataset='^', path=self.repo.path, update_mode='all')
 
             if tag and stats:
                 # versions survive only in total_stats

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -215,7 +215,7 @@ def _extract_metadata(agginto_ds, aggfrom_ds, db, to_save):
     # shorten to MD5sum
     objid = md5(objid.encode()).hexdigest()
 
-    metasources = [('ds', 'dataset', dsmeta, aggfrom_ds, json_py.dump)]
+    metasources = [('ds', 'dataset', dsmeta, agginto_ds, json_py.dump)]
 
     # do not store content metadata if either the source or the target dataset
     # do not want it
@@ -232,7 +232,7 @@ def _extract_metadata(agginto_ds, aggfrom_ds, db, to_save):
             'content',
             # sort by path key to get deterministic dump content
             (dict(contentmeta[k], path=k) for k in sorted(contentmeta)),
-            aggfrom_ds,
+            agginto_ds,
             json_py.dump2xzstream))
 
     # for both types of metadata
@@ -458,7 +458,9 @@ def _update_ds_agginfo(refds_path, ds_path, subds_paths, agginfo_db, to_save):
 
     # must copy object files to local target destination
     # make sure those objects are present
-    ds.get([f for f, t in objs2copy], result_renderer='disabled')
+    # use the reference dataset to resolve paths, as they might point to
+    # any location in the dataset tree
+    Dataset(refds_path).get([f for f, t in objs2copy], result_renderer='disabled')
     for copy_from, copy_to in objs2copy:
         if copy_to == copy_from:
             continue

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -111,7 +111,7 @@ def test_aggregation(path):
     ok_clean_git(ds.path)
     # aggregate metadata from all subdatasets into any superdataset, including
     # intermediate ones
-    res = ds.aggregate_metadata(recursive=True)
+    res = ds.aggregate_metadata(recursive=True, update_mode='all')
     # we get success report for both subdatasets and the superdataset,
     # and they get saved
     assert_result_count(res, 6)


### PR DESCRIPTION
Mode `all` what we used to do: extract from all datasets and update in all datasets throughout the entire tree.

Now there is a mode `target` that still extracts from all datasets, but only updates the aggregated metadata in the top-level target/base/ref dataset.

The `target` mode is a more suitable default IMHO, as otherwise any user gets subdatasets modified whenever they had no metadata pre-aggregated. However, in general one likely does not want to create a diff to upstream just because we want to get metadata aggregated in a local superdataset.

Due to the change in default, all previous usage of `aggregate_metadata()` has the mode spelled out now.