### PR TITLE
save does not work within subdirectory of a subdataset: given reference dataset is not a dataset 

### DIFF
--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -217,8 +217,7 @@ class Save(Interface):
 
         if not dataset and not path:
             # we got nothing at all -> save what is staged in the repo in "this" directory?
-            # we verify that there is an actual repo next
-            dataset = abspath(curdir)
+            path = abspath(curdir)
         refds_path = Interface.get_refds_path(dataset)
 
         if message and message_file:


### PR DESCRIPTION
#### What is the problem?
```shell
(git-annex)hopa:~/datalad____/openfmri/ds000001[master]sub-01/func
$> git add 1
(dev) 2 9981.....................................:Thu 30 Nov 2017 09:25:58 AM EST:.
(git-annex)hopa:~/datalad____/openfmri/ds000001[master]sub-01/func
$> datalad save -m "try to save within subdir" -S
[WARNING] given reference dataset is not a dataset [save(/home/yoh/datalad____/openfmri/ds000001/sub-01/func)] 
> /home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py(496)_process_results()
-> if result_renderer == 'default':
(Pdb) c
> /home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py(496)_process_results()
-> if result_renderer == 'default':
(Pdb) c
save(impossible): . [given reference dataset is not a dataset]
(dev) 2 9982 ->1.....................................:Thu 30 Nov 2017 09:26:12 AM EST:.
(git-annex)hopa:~/datalad____/openfmri/ds000001[master]sub-01/func
$> datalad save -m "try to save within subdir"   
[WARNING] given reference dataset is not a dataset [save(/home/yoh/datalad____/openfmri/ds000001/sub-01/func)] 
> /home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py(496)_process_results()
-> if result_renderer == 'default':
(Pdb) c
> /home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py(496)_process_results()
-> if result_renderer == 'default':
(Pdb) c
save(impossible): . [given reference dataset is not a dataset]

```

fix must come with a test and must come against 0.9.x branch!

#### What version of DataLad are you using (run `datalad --version`)? On what operating system (consider running `datalad plugin wtf`)?
current master  0.9.1-434-gf1bcabb9  although originally detected on 0.9.1
