### PR TITLE
unlock reported path is incorrect if operating on ds within subdir

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -25,8 +25,8 @@ def _load_plugins():
         globals()[camel.sub('\\1_\\2', pi.__name__).lower()] = pi.__call__
 
 
-def _generate_modules_api():
-    """Auto detect all available modules and generate an API from them
+def _generate_extension_api():
+    """Auto detect all available extensions and generate an API from them
     """
     from importlib import import_module
     from pkg_resources import iter_entry_points
@@ -36,9 +36,9 @@ def _generate_modules_api():
     import logging
     lgr = logging.getLogger('datalad.api')
 
-    for entry_point in iter_entry_points('datalad.modules'):
+    for entry_point in iter_entry_points('datalad.extensions'):
         try:
-            lgr.debug('Loading entrypoint %s from datalad.modules', entry_point.name)
+            lgr.debug('Loading entrypoint %s from datalad.extensions', entry_point.name)
             grp_descr, interfaces = entry_point.load()
         except Exception as e:
             lgr.warning('Failed to load entrypoint %s: %s', entry_point.name, exc_str(e))
@@ -51,15 +51,15 @@ def _generate_modules_api():
             api_name = get_api_name(intfspec)
             if api_name in globals():
                 lgr.debug(
-                    'Command %s from extension module %s is replacing a previously loaded implementation',
+                    'Command %s from extension %s is replacing a previously loaded implementation',
                     api_name,
                     entry_point.name)
             globals()[api_name] = intf.__call__
 
 
-_generate_modules_api()
+_generate_extension_api()
 _load_plugins()
 
 # Be nice and clean up the namespace properly
 del _load_plugins
-del _generate_modules_api
+del _generate_extension_api

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -203,8 +203,8 @@ def setup_parser(
     cmdlineargs = set(cmdlineargs) if cmdlineargs else set()
     grp_short_descriptions = []
     interface_groups = get_interface_groups()
-    for ep in iter_entry_points('datalad.modules'):
-        lgr.debug('Loading entrypoint %s from datalad.modules', ep.name)
+    for ep in iter_entry_points('datalad.extensions'):
+        lgr.debug('Loading entrypoint %s from datalad.extensions', ep.name)
         try:
             spec = ep.load()
             interface_groups.append((ep.name, spec[0], spec[1]))

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -106,7 +106,7 @@ def test_unlock(path):
     if ds.repo.is_direct_mode():
         assert_status('notneeded', result)
     else:
-        assert_in_results(result, path='test-annex.dat', status='ok')
+        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
 
     with open(opj(path, 'test-annex.dat'), "w") as f:
         f.write("change content")
@@ -131,15 +131,10 @@ def test_unlock(path):
     result = ds.unlock(path='test-annex.dat')
     assert_result_count(result, 1)
 
-    # TODO: Why in the following result there is the absolute path in direct mode
-    # while it's the relative one in indirect mode?
-    # Probably:
-    # => direct mode: no actual call to annex-unlock
-    # => indirect mode: it's what AnnexRepo.unlock returns
     if ds.repo.is_direct_mode():
         assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='notneeded')
     else:
-        assert_in_results(result, path='test-annex.dat', status='ok')
+        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
 
     with open(opj(path, 'test-annex.dat'), "w") as f:
         f.write("change content again")

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -14,6 +14,8 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
+from os.path import join as opj
+
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.exceptions import InsufficientArgumentsError
@@ -168,4 +170,7 @@ class Unlock(Interface):
 
             for r in ds.repo.unlock([ap['path'] for ap in to_unlock]):
                 yield get_status_dict(
-                    path=r, status='ok', type='file', **res_kwargs)
+                    path=opj(ds.path, r),
+                    status='ok',
+                    type='file',
+                    **res_kwargs)

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -202,7 +202,7 @@ Writing your own extensions
 ===========================
 
 A good starting point for implementing a new extension is the "helloworld" demo extension
-available at https://github.com/datalad/datalad-module-template. This repository can be cloned
+available at https://github.com/datalad/datalad-extension-template. This repository can be cloned
 and adjusted to suit one's needs. It includes:
 
 - a basic Python package setup


### PR DESCRIPTION
#### What is the problem?

was afraid that `add` etc have the same problem, but seems to be only unlock:
```shell
(git-annex)hopa:~/datalad/openfmri/ds000001[master]sub-01
$> datalad add -d .. sub-01/anat/sub-01_T1w.nii.gz           
add(ok): sub-01/anat/sub-01_T1w.nii.gz (file)                                                                         
save(notneeded): /home/yoh/datalad/openfmri/ds000001 (dataset)
action summary:
  add (ok: 1)
  save (notneeded: 1)

$> datalad unlock -d .. sub-01/anat/sub-01_T1w.nii.gz
unlock(ok): sub-01/sub-01/anat/sub-01_T1w.nii.gz (file)
```
as you can see  -- there is sub-01/sub-01

found while fixing for #1962 , and was confused by reported unlock -- so replicated independently