### PR TITLE
 DOC: Say that we s/__/-/ in the environment -> config mapping

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -18,8 +18,8 @@ All datalad-specific configuration variables are prefixed with ``datalad.``.
 It is possible to override or amend the configuration using environment
 variables. Any variable with a name that starts with ``DATALAD_`` will
 be available as the corresponding ``datalad.`` configuration variable,
-replacing any ``_`` in the name with a dot, and all letters converted
-to lower case. Values from environment variables take precedence over
+replacing any ``_`` in the name with a dot and converting all letters to
+lower case. Values from environment variables take precedence over
 configuration file settings.
 
 The following sections provide a (non-exhaustive) list of settings honored

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -18,7 +18,8 @@ All datalad-specific configuration variables are prefixed with ``datalad.``.
 It is possible to override or amend the configuration using environment
 variables. Any variable with a name that starts with ``DATALAD_`` will
 be available as the corresponding ``datalad.`` configuration variable,
-replacing any ``_`` in the name with a dot and converting all letters to
+replacing any ``__`` (two underscores) with a hyphen, then any ``__``
+(single underscore) with a dot, and finally converting all letters to
 lower case. Values from environment variables take precedence over
 configuration file settings.
 


### PR DESCRIPTION
`DATALAD_foo__bar` maps to `datalad.foo-bar`, but we don't mention the last bit in the docs.

---

- [x] This change is complete

