### PR TITLE
BF: pass newline straight into _process_one_line to avoid joining empty new lines

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -326,13 +326,13 @@ class Runner(object):
                 # resolving a once in a while failing test #2185
                 if isinstance(out_, text_type):
                     out_ = out_.encode('utf-8')
-                out += linesep_bytes.join(
-                    self._process_one_line(*pargs, line=line)
-                    for line in out_.split(linesep_bytes))
+                for line in out_.split(linesep_bytes):
+                    out += self._process_one_line(
+                        *pargs, line=line, suf=linesep_bytes)
         return out
 
     def _process_one_line(self, out_type, proc, log_, log_is_callable,
-                          expected=False, line=None):
+                          expected=False, line=None, suf=None):
         if line is None:
             lgr.log(3, "Reading line from %s", out_type)
             line = {'stdout': proc.stdout, 'stderr': proc.stderr}[out_type].readline()
@@ -352,7 +352,7 @@ class Runner(object):
                               expected)
             else:  # pragma: no cover
                 raise RuntimeError("must not get here")
-            return line
+            return (line + suf) if suf else line
         # it was output already directly but for code to work, return ""
         return binary_type()
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -134,15 +134,23 @@ def test_wtf(path):
         assert_in('user.name: ', cmo.out)
 
     skip_if_no_module('pyperclip')
+
+    # verify that it works correctly in the env/platform
+    import pyperclip
     with swallow_outputs() as cmo:
-        import pyperclip
         try:
+            pyperclip.copy("xxx")
+            pyperclip_works = pyperclip.paste().strip() == "xxx"
             wtf(dataset=ds.path, clipboard=True)
         except (AttributeError, pyperclip.PyperclipException) as exc:
             # AttributeError could come from pyperclip if no DISPLAY
             raise SkipTest(exc_str(exc))
         assert_in("WTF information of length", cmo.out)
         assert_not_in('user.name', cmo.out)
+        if not pyperclip_works:
+            # Some times does not throw but just fails to work
+            raise SkipTest(
+                "Pyperclip seems to be not functioning here correctly")
         assert_not_in('user.name', pyperclip.paste())
         assert_in(_HIDDEN, pyperclip.paste())  # by default no sensitive info
         assert_in("cmd:annex=", pyperclip.paste())  # but the content is there


### PR DESCRIPTION
for handled entries

Revealed by good old OSX that a recent fix in fe62e46955f5a428bcf72b28a0861194a59183b0
introduced breeding trailing \n in the output which should have already been handled
by the output processor. See e.g. http://smaug.datalad.org:8020/builders/datalad-pr-dl-osx-64/builds/3979/steps/nosetests/logs/stdio

The problem was that even if processor returns None, i.e. the line was already handled
we would have returned a newline to outside where we would have joined them with \n.
Fix, is to pass the suffix (used only in the case of handling those manually split lines)
to add to the end of the line if there was one remaining.

It should fix OSX buildbot issue 
