### PR TITLE
ENH: annotate a few tests for @slow and @integration

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import assert_equal, assert_raises, in_, ok_startswith
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_re_in
 from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import slow
 
 
 def run_main(args, exit_code=0, expect_stderr=False):
@@ -185,6 +186,7 @@ def test_script_shims():
                      get_numeric_portion(version))
 
 
+@slow  # 11.2591s
 @with_tempfile(mkdir=True)
 def test_cfg_override(path):
     with chpwd(path):

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -12,7 +12,9 @@
 
 from datalad.tests.utils import (
     known_failure_v6,
-    get_datasets_topdir
+    get_datasets_topdir,
+    integration,
+    slow
 )
 
 
@@ -80,6 +82,7 @@ def test_invalid_args(path, otherpath, alienpath):
     assert_status('error', ds_target.clone(ds.path, path=alienpath, on_failure='ignore'))
 
 
+@integration
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tempfile(mkdir=True)
@@ -97,6 +100,7 @@ def test_clone_crcns(tdir, ds_path):
     assert_in(crcns.path, ds.subdatasets(result_xfm='paths'))
 
 
+@integration
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tree(tree={'sub': {}})
@@ -215,6 +219,8 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
         {'subm 1', '2'})
 
 
+
+@slow  # 23.1478s
 @known_failure_v6   #FIXME
 @with_testrepos(flavors=['local'])
 # 'local-url', 'network'

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -33,8 +33,10 @@ from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in_results
+from datalad.tests.utils import slow
 
 
+@slow
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -126,6 +128,7 @@ def test_update_git_smoke(src_path, dst_path):
     ok_file_has_content(opj(target.path, 'file.dat'), '123')
 
 
+@slow  # 20.6910s
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -27,7 +27,7 @@ from ...tests.utils import assert_equal, assert_not_equal
 from ...tests.utils import assert_false
 from ...tests.utils import assert_true
 from ...tests.utils import ok_archives_caches
-from ...tests.utils import SkipTest
+from ...tests.utils import slow
 from ...tests.utils import assert_re_in
 from datalad.tests.utils import assert_result_values_cond
 
@@ -163,6 +163,7 @@ tree4uargs = dict(
 )
 
 
+@slow  # 29.4293s
 @known_failure_v6   # FIXME
 #  apparently fails only sometimes in PY3, but in a way that's common in V6
 @assert_cwd_unchanged(ok_to_chdir=True)

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -26,6 +26,8 @@ from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import create_tree
+from datalad.tests.utils import slow
+
 
 from datalad.distribution.dataset import Dataset
 from datalad.api import annotate_paths
@@ -75,6 +77,7 @@ def test_invalid_call(path):
         annotate_paths, dataset=path, modified="something")
 
 
+@slow  # 15.3509s
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
@@ -220,6 +223,7 @@ def test_annotate_paths(dspath, nodspath):
     eq_(orig_res, res_recursion_again)
 
 
+@slow  # 11.0891s
 @with_tree(demo_hierarchy['b'])
 @known_failure_direct_mode  #FIXME
 def test_get_modified_subpaths(path):
@@ -324,6 +328,7 @@ def test_get_modified_subpaths(path):
         type_src='dataset', path=suba.path)
 
 
+@slow  # 41.5367s
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -49,6 +49,7 @@ from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import skip_if_on_windows
 from datalad.tests.utils import ignore_nose_capturing_stdout
+from datalad.tests.utils import slow
 
 
 @with_tempfile(mkdir=True)
@@ -109,6 +110,7 @@ def test_basics(path, nodspath):
             assert_in("No command given", cml.out)
 
 
+@slow  # 17.1880s
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
This pull request fixes #2401  (although not fully but heaviest abusers)
(attaching to an issue failed for me... next time may be)

This pull request proposes to annotate a few more tests with `@slow` and `@integration`.  They will still be executed as a part of a single matrix run dedicated to run those heavy tests, but should make the "heavy debug" run shorter.

Altogether I think that many "slow" tests are simple a victim of `@with_testrepos` -- so we exercise them in "different" (but not much so) scenarios whenever they could actually be ran on a single test repo with nearly the same or the same "testing efficiency"

### Changes
- [x] This change is complete

Please have a look @datalad/developers
