### PR TITLE
Gets confused by symbolic links in the path

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -39,6 +39,7 @@ from datalad.support.network import RI
 from datalad.utils import getpwd
 from datalad.utils import optional_args, expandpath, is_explicit_path
 from datalad.utils import get_dataset_root
+from datalad.utils import dlabspath
 from datalad.distribution.utils import get_git_dir
 
 
@@ -65,7 +66,7 @@ def resolve_path(path, ds=None):
     path = expandpath(path, force_absolute=False)
     # TODO: normpath?!
     if is_explicit_path(path):
-        return abspath(path)
+        return dlabspath(path)
     # no dataset given, use CWD as reference
     # note: abspath would disregard symlink in CWD
     top_path = getpwd() \

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -64,9 +64,10 @@ def resolve_path(path, ds=None):
     Absolute path
     """
     path = expandpath(path, force_absolute=False)
-    # TODO: normpath?!
     if is_explicit_path(path):
-        return dlabspath(path)
+        # normalize path consistently between two (explicit and implicit) cases
+        return dlabspath(path, norm=True)
+
     # no dataset given, use CWD as reference
     # note: abspath would disregard symlink in CWD
     top_path = getpwd() \

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -34,6 +34,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_values_equal
+from datalad.tests.utils import known_failure_v6
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
@@ -362,4 +363,4 @@ def test_symlinked_relpath(path):
         ds.repo.add(later, git=True)
         ds.save("committing", path=later)
 
-    ok_clean_git(dspath)
+    known_failure_v6(ok_clean_git)(dspath)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -51,6 +51,7 @@ from ..utils import get_dataset_root
 from ..utils import better_wraps
 from ..utils import path_startswith
 from ..utils import path_is_subpath
+from ..utils import dlabspath
 from ..utils import safe_print
 from ..utils import generate_chunks
 from ..utils import disable_logger
@@ -961,4 +962,22 @@ def test_line_profile():
         assert_equal(f(3), 4)
         assert_equal(cmo.err, '')
         assert_in('i = j + 1  # xyz', cmo.out)
+
+
+@with_tempfile(mkdir=True)
+def test_dlabspath(path):
+    # initially ran into on OSX https://github.com/datalad/datalad/issues/2406
+    opath = opj(path, "origin")
+    os.makedirs(opath)
+    lpath = opj(path, "linked")
+    os.symlink('origin', lpath)
+    for d in opath, lpath:
+        # regardless under which directory, all results should not resolve
+        # anything
+        eq_(d, dlabspath(d))
+        # in the root of ds
+        with chpwd(d):
+            eq_(dlabspath("bu"), opj(d, "bu"))
+            eq_(dlabspath("./bu"), opj(d, "./bu"))  # we do not normpath by default
+            eq_(dlabspath("./bu", norm=True), opj(d, "bu"))
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1115,7 +1115,7 @@ def get_path_prefix(path, pwd=None):
     assumed
     """
     pwd = pwd or getpwd()
-    path = dlabspath()
+    path = dlabspath(path)
     path_ = with_pathsep(path)
     pwd_ = with_pathsep(pwd)
     common = commonprefix((path_, pwd_))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1088,6 +1088,20 @@ class chpwd(object):
             self.__class__(self._prev_pwd, logsuffix="(coming back)")
 
 
+def dlabspath(path, norm=False):
+    """Symlinks-in-the-cwd aware abspath
+
+    os.path.abspath relies on os.getcwd() with would not know about symlinks
+    in the path
+    TODO: we might want to norm=True by default to match behavior of os
+    .path.abspath?
+    """
+    if not isabs(path):
+        # if not absolute -- relative to pwd
+        path = opj(getpwd(), path)
+    return normpath(path) if norm else path
+
+
 def with_pathsep(path):
     """Little helper to guarantee that path ends with /"""
     return path + sep if not path.endswith(sep) else path
@@ -1101,9 +1115,7 @@ def get_path_prefix(path, pwd=None):
     assumed
     """
     pwd = pwd or getpwd()
-    if not isabs(path):
-        # if not absolute -- relative to pwd
-        path = opj(getpwd(), path)
+    path = dlabspath()
     path_ = with_pathsep(path)
     pwd_ = with_pathsep(pwd)
     common = commonprefix((path_, pwd_))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1091,10 +1091,11 @@ class chpwd(object):
 def dlabspath(path, norm=False):
     """Symlinks-in-the-cwd aware abspath
 
-    os.path.abspath relies on os.getcwd() with would not know about symlinks
+    os.path.abspath relies on os.getcwd() which would not know about symlinks
     in the path
-    TODO: we might want to norm=True by default to match behavior of os
-    .path.abspath?
+
+    TODO: we might want to norm=True by default to match behavior of
+    os .path.abspath?
     """
     if not isabs(path):
         # if not absolute -- relative to pwd


### PR DESCRIPTION
#### What is the problem?
```shell
(datalad) Taylors-MacBook-Pro-4:tmp taylor$  datalad create --text-no-annex demo
[INFO   ] Creating a new annex repo at /tmp/demo 
create(ok): /tmp/demo (dataset)                                                                                      
(datalad) Taylors-MacBook-Pro-4:tmp taylor$ cd demo/
(datalad) Taylors-MacBook-Pro-4:demo taylor$ datalad -l debug crawl-init --save --template=simple_with_archives url=http://example.com
...
[DEBUG  ] Assigning credentials into 18 providers 
[INFO   ] Not adding annex.largefiles=exclude=README* and exclude=LICENSE* to git annex calls because already defined to be (not(mimetype=text/*)) 
[DEBUG  ] Creating crawler configuration for template simple_with_archives under . 
                                                                                                                     [DEBUG  ] Determined class of decorated function: <class 'datalad.interface.save.Save'> 
[DEBUG  ] Determined class of decorated function: <class 'datalad.interface.annotate_paths.AnnotatePaths'> 
[WARNING] path not part of the reference dataset at /tmp/demo [save(/private/tmp/demo/.datalad/crawl/crawl.cfg)] 
[DEBUG  ] could not perform all requested actions: Command did not complete successfully [{'status': 'impossible', 'orig_request': './.datalad/crawl/crawl.cfg', 'raw_input': True, 'message': ('path not part of the reference dataset at %s', '/tmp/demo'), 'parentds': '/private/tmp/demo', 'action': 'save', 'path': '/private/tmp/demo/.datalad/crawl/crawl.cfg', 'type': 'file', 'refds': '/tmp/demo'}] [utils.py:generator_func:446] 
(datalad) Taylors-MacBook-Pro-4:demo taylor$ echo $TMPDIR
/var/folders/_r/lnsx28mx03v58m6p1vfml2b00000gn/T/
(datalad) Taylors-MacBook-Pro-4:demo taylor$ ls -ld /tmp
lrwxr-xr-x@ 1 root  wheel  11 Mar 22 22:03 /tmp -> private/tmp
(datalad) Taylors-MacBook-Pro-4:demo taylor$ pwd
/tmp/demo
(datalad) Taylors-MacBook-Pro-4:demo taylor$ python -c 'import os.path; print(os.path.realpath("/var/folders/_r/lnsx28mx03v58m6p1vfml2b00000gn/T"))'
/private/var/folders/_r/lnsx28mx03v58m6p1vfml2b00000gn/T
(datalad) Taylors-MacBook-Pro-4:demo taylor$ ls -ld /var
lrwxr-xr-x@ 1 root  wheel  11 Mar 22 22:03 /var -> private/var
(datalad) Taylors-MacBook-Pro-4:demo taylor$ datalad --version
datalad 0.9.3.dev1004
```
#### What steps will reproduce the problem?

buy a Mac, do the above

#### What version of DataLad are you using (run `datalad --version`)? On what operating system (consider running `datalad wtf`)?
Master branch 0.9.3-1004-g7635f467 

it seems to be quite a regular setup on OSX 10.13.3 (Sierra)
