### PR TITLE
WIP: NF XNAT/NITRC-IR support

### DIFF
--- a/datalad/crawler/dbs/base.py
+++ b/datalad/crawler/dbs/base.py
@@ -198,6 +198,8 @@ class FileStatusesBaseDB(object):
         # TODO: make use of URL -- we should validate that url is among those associated
         #  with the file
         old_status = self.get(fpath)
+        if old_status is None:
+            return True
         if status.filename and not old_status.filename:
             old_status.filename = basename(fpath)
         return old_status != status

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -32,6 +32,7 @@ from ...utils import rmtree, updated
 from ...utils import lmtime
 from ...utils import find_files
 from ...utils import auto_repr
+from ...utils import check_free_space
 from ...utils import try_multiple
 from ...utils import assure_list
 
@@ -519,6 +520,10 @@ class Annexificator(object):
                 lgr.info("Need to download %s from %s. No progress indication will be reported"
                          % (naturalsize(url_status.size), url))
             try:
+                if url_status and url_status.size:
+                    # Get amount of freespace on the drive, and fail early if
+                    # we have no sufficient storage
+                    check_free_space(fpath, url_status.size)
                 out_json = try_multiple(
                     6, AnnexBatchCommandError, 3,  # up to 3**5=243 sec sleep
                     _call,

--- a/datalad/crawler/pipelines/fcptable.py
+++ b/datalad/crawler/pipelines/fcptable.py
@@ -182,4 +182,7 @@ def pipeline(dataset):
         ],
         annex.switch_branch('master'),
         annex.finalize(cleanup=True),
+        # TODO:  if we want to aggregate with info for data from NITRC XNAT, we should
+        # match 'label' for each subject which is "Site_subjid".  subjid you can
+        # get from this dataset by globing I guess
     ]

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -46,7 +46,7 @@ TOPURL = "https://openfmri.org/dataset/"
 # define a pipeline factory function accepting necessary keyword arguments
 # Should have no strictly positional arguments
 def superdataset_pipeline(url=TOPURL, **kwargs):
-    annex = Annexificator(no_annex=True, allow_dirty=True)
+    annex = Annexificator(no_annex=True, allow_dirty=False)
     lgr.info("Creating a pipeline with kwargs %s" % str(kwargs))
     return [
         crawl_url(url),

--- a/datalad/crawler/pipelines/tests/test_xnat.py
+++ b/datalad/crawler/pipelines/tests/test_xnat.py
@@ -63,12 +63,16 @@ NITRC_IR = 'https://www.nitrc.org/ir'
 CENTRAL_XNAT = 'https://central.xnat.org'
 
 
-def check_basic_xnat_interface(url, project, subjects):
+def check_basic_xnat_interface(url, project, empty_project, subjects):
     nitrc = XNATServer(url)
     projects = nitrc.get_projects()
     # verify that we still have projects we want!
-
     assert_in(project, projects)
+    if empty_project:
+        all_projects = nitrc.get_projects(drop_empty=False)
+        assert len(all_projects) > len(projects)
+        assert empty_project in all_projects
+        assert empty_project not in projects
     projects_public = nitrc.get_projects(limit='public')
     import json
     print json.dumps(projects_public, indent=2)
@@ -105,15 +109,15 @@ def check_basic_xnat_interface(url, project, subjects):
 #@skip_if_no_network
 @use_cassette('test_basic_xnat_interface')
 def test_basic_xnat_interface():
-    for url, project, subjects in [
-        (NITRC_IR, 'fcon_1000', ['xnat_S00401', 'xnat_S00447']),
-        (CENTRAL_XNAT, 'CENTRAL_OASIS_LONG', ['OAS2_0001', 'OAS2_0176']),
+    for url, project, empty_project, subjects in [
+        (NITRC_IR, 'fcon_1000', None, ['xnat_S00401', 'xnat_S00447']),
+        (CENTRAL_XNAT, 'CENTRAL_OASIS_LONG', 'ADHD200', ['OAS2_0001', 'OAS2_0176']),
     # Should have worked, since we do have authentication setup for hcp, but
     # failed to authenticate.  need to recall what is differently done for the test
     # since it downloads just fine using download-url
     #   ('https://db.humanconnectome.org', 'HCP_Retest', ['103818', '149741']),
     ]:
-        yield check_basic_xnat_interface, url, project, subjects
+        yield check_basic_xnat_interface, url, project, empty_project, subjects
 
 
 @skip_if_no_network

--- a/datalad/crawler/pipelines/tests/test_xnat.py
+++ b/datalad/crawler/pipelines/tests/test_xnat.py
@@ -72,7 +72,7 @@ def check_basic_xnat_interface(url, project, subjects):
     projects_public = nitrc.get_projects(limit='public')
     import json
     print json.dumps(projects_public, indent=2)
-    assert len(projects_public) < len(projects)
+    assert len(projects_public) <= len(projects)
     assert not set(projects_public).difference(projects)
     eq_(set(projects),
         set(nitrc.get_projects(limit=PROJECT_ACCESS_TYPES)))

--- a/datalad/crawler/pipelines/tests/test_xnat.py
+++ b/datalad/crawler/pipelines/tests/test_xnat.py
@@ -1,0 +1,121 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import os
+from glob import glob
+from os.path import join as opj
+from os.path import exists
+from mock import patch
+
+from ...nodes.crawl_url import crawl_url
+from ...nodes.matches import *
+from ...pipeline import run_pipeline, FinishPipeline
+
+from ...nodes.misc import Sink, assign, range_node, interrupt_if
+from ...nodes.annex import Annexificator, initiate_dataset
+from ...pipeline import load_pipeline_from_module
+
+from ....support.stats import ActivityStats
+from ....support.gitrepo import GitRepo
+from ....support.annexrepo import AnnexRepo
+
+from ....api import clean
+from ....utils import chpwd
+from ....utils import find_files
+from ....utils import swallow_logs
+from ....tests.utils import with_tree
+from ....tests.utils import SkipTest
+from ....tests.utils import eq_, assert_not_equal, ok_, ok_startswith
+from ....tests.utils import assert_in, assert_is_generator
+from ....tests.utils import skip_if_no_module
+from ....tests.utils import with_tempfile
+from ....tests.utils import serve_path_via_http
+from ....tests.utils import skip_if_no_network
+from ....tests.utils import use_cassette
+from ....tests.utils import ok_file_has_content
+from ....tests.utils import ok_file_under_git
+
+from .. import openfmri
+from ..openfmri import pipeline as ofpipeline
+
+import logging
+from logging import getLogger
+lgr = getLogger('datalad.crawl.tests')
+
+
+#
+# Some helpers
+#
+
+from ..xnat import XNATServer
+from ..xnat import PROJECT_ACCESS_TYPES
+
+
+def check_basic_xnat_interface(url, project, subjects):
+    nitrc = XNATServer(url)
+    projects = nitrc.get_projects()
+    # verify that we still have projects we want!
+
+    assert_in(project, projects)
+    projects_public = nitrc.get_projects(limit='public')
+    import json
+    print json.dumps(projects_public, indent=2)
+    assert len(projects_public) < len(projects)
+    assert not set(projects_public).difference(projects)
+    eq_(set(projects),
+        set(nitrc.get_projects(limit=PROJECT_ACCESS_TYPES)))
+
+    subjects_ = nitrc.get_subjects(project)
+    assert len(subjects_)
+    experiments = nitrc.get_experiments(project, subjects[0])
+    # NOTE: assumption that there is only one experiment
+    files1 = nitrc.get_files(project, subjects[0], experiments.keys()[0])
+    assert files1
+
+    experiments = nitrc.get_experiments(project, subjects[1])
+    files2 = nitrc.get_files(project, subjects[1], experiments.keys()[0])
+    assert files2
+
+    ok_startswith(files1[0]['uri'], '/data')
+    gen = nitrc.get_all_files_for_project(project,
+                                          subjects=subjects,
+                                          experiments=[experiments.keys()[0]])
+    assert_is_generator(gen)
+    all_files = list(gen)
+    if len(experiments) == 1:
+        eq_(len(all_files), len(files1) + len(files2))
+    else:
+        # there should be more files due to multiple experiments which we didn't actually check
+        assert len(all_files) > len(files1) + len(files2)
+
+
+# THIS SOMEHOW CAUSES the test to not run!!! wtf? TODO
+#@skip_if_no_network
+@use_cassette('test_basic_xnat_interface')
+def test_basic_xnat_interface():
+    for url, project, subjects in [
+        ('https://www.nitrc.org/ir', 'fcon_1000', ['xnat_S00401', 'xnat_S00447']),
+        ('https://central.xnat.org', 'CENTRAL_OASIS_LONG', ['OAS2_0001', 'OAS2_0176']),
+    # Should have worked, since we do have authentication setup for hcp, but
+    # failed to authenticate.  need to recall what is differently done for the test
+    # since it downloads just fine using download-url
+    #   ('https://db.humanconnectome.org', 'HCP_Retest', ['103818', '149741']),
+    ]:
+        yield check_basic_xnat_interface, url, project, subjects
+
+
+# TODO: RF to provide a generic/reusable test for this
+@with_tempfile(mkdir=True)
+def _test_smoke_pipelines(d):
+    # Just to verify that we can correctly establish the pipelines
+    AnnexRepo(d, create=True)
+    with chpwd(d):
+        with swallow_logs():
+            for p in [pipeline('bogus'), collection_pipeline()]:
+                ok_(len(p) > 1)

--- a/datalad/crawler/pipelines/xnat.py
+++ b/datalad/crawler/pipelines/xnat.py
@@ -1,0 +1,172 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A pipeline for crawling XNAT servers/datasets (e.g. NITRC/ir)"""
+
+"""
+Notes:
+
+- xml entries for subject contain meta-data
+- in longitudinal studies there could be multiple ages for a subject... find where
+  it is
+"""
+
+import os
+import re
+import json
+from os.path import lexists
+
+# Import necessary nodes
+from ..nodes.crawl_url import crawl_url
+from ..nodes.matches import css_match, a_href_match
+from ..nodes.misc import assign
+from ..nodes.misc import sub
+from ..nodes.misc import switch
+from ..nodes.misc import func_to_node
+from ..nodes.misc import find_files
+from ..nodes.misc import skip_if
+from ..nodes.misc import debug
+from ..nodes.misc import fix_permissions
+from ..nodes.annex import Annexificator
+from ...support.s3 import get_versioned_url
+from ...utils import updated
+from ...consts import ARCHIVES_SPECIAL_REMOTE, DATALAD_SPECIAL_REMOTE
+from datalad.downloaders.providers import Providers
+
+# For S3 crawling
+from ..nodes.s3 import crawl_s3
+from .openfmri_s3 import pipeline as s3_pipeline
+from datalad.api import ls
+from datalad.dochelpers import exc_str
+
+# Possibly instantiate a logger if you would like to log
+# during pipeline creation
+from logging import getLogger
+lgr = getLogger("datalad.crawler.pipelines.openfmri")
+
+from datalad.tests.utils import eq_
+from datalad.utils import assure_list
+
+
+def list_to_dict(l, field):
+    return {r.pop(field): r for r in l}
+
+DEFAULT_RESULT_FIELDS = {'totalrecords', 'result'}
+PROJECT_ACCESS_TYPES = {'public', 'protected', 'private'}
+
+
+def lower_case_the_keys(d):
+    """Create a dict with keys being lower cased but with a check against collisions
+    
+    If d is a list of tuple, would recurse into its elements
+    """
+    if not isinstance(d, dict):
+        assert isinstance(d, (list, tuple))
+        return d.__class__(
+            lower_case_the_keys(x) for x in d
+        )
+    out = {}
+    for k, v in d.items():
+        kl = k.lower()
+        if kl in out:
+            raise ValueError(
+                "We already got key %s=%r, but trying to add =%r"
+                % (kl, out[kl], v)
+            )
+        out[kl] = v
+    return out
+
+
+class XNATServer(object):
+    def __init__(self, topurl):
+        self.topurl = topurl
+        from datalad.downloaders.providers import Providers
+        providers = Providers.from_config_files()
+        self.downloader = providers.get_provider(topurl).get_downloader(topurl)
+
+    def __call__(self, query,
+                 format='json',
+                 options=None,
+                 fields_to_check=DEFAULT_RESULT_FIELDS):
+        query_url = "%s/%s" % (self.topurl, query)
+        options = options or {}
+        if format:
+            options['format'] = format
+        if options:
+            # TODO: use the helper we have
+            query_url += "?" + '&'.join(("%s=%s" % (o, v) for o, v in options.items()))
+        out = self.downloader.fetch(query_url)
+        if format == 'json':
+            j = json.loads(out)
+            j = lower_case_the_keys(j)
+            assert j.keys() == ['resultset']
+            j = lower_case_the_keys(j['resultset'])
+            if fields_to_check:
+                eq_(set(j.keys()), fields_to_check)
+            return lower_case_the_keys(j['result'])
+        return out
+
+    def get_projects(self, limit=None):
+        """Get list of projects 
+        
+        Parameters
+        ----------
+        limit: {'public', 'protected', 'private', None} or list of thereoff
+           'private' -- projects you have no any access to. 'protected' -- you could
+           fetch description but not the data. None - would list all the projects
+        """
+        # accessible  option could limit to the projects I have access to
+        kw = {}
+        if limit:
+            kw['options'] = {"accessible": "true"} if limit else None
+            kw['fields_to_check'] = DEFAULT_RESULT_FIELDS | {'title', 'xdat_user_id'}
+        out = list_to_dict(self('data/projects', **kw), 'id')
+        if limit:
+            limit = assure_list(limit)
+            # double check that all the project_access thingies in the set which
+            # we know
+            assert all(p['project_access'] in PROJECT_ACCESS_TYPES
+                       for p in out.values())
+            out = {
+                pid: p for pid, p in out.items()
+                if p['project_access'] in limit
+            }
+        return out
+
+    def get_subjects(self, project):
+        return list_to_dict(
+            self('data/projects/%(project)s/subjects' % locals()),
+            'id'
+        )
+
+    def get_experiments(self, project, subject):
+        return list_to_dict(
+            # http://www.nitrc.org/ir/data/projects/fcon_1000/subjects/SaintLouis_sub82830/experiments?
+            self('data/projects/%(project)s/subjects/%(subject)s/experiments' % locals()),
+            'id'
+        )
+
+    def get_files(self, project, subject, experiment):
+        files = []
+        for rec_type in ('scans', 'assessors'):
+            url = 'data/projects/%(project)s/subjects/%(subject)s/experiments/%(experiment)s/%(rec_type)s' % \
+                      locals()
+            recs = self(url)
+            files_ = []
+            for rec in recs:
+                files_.extend(self(url + '/%(id)s/files' % rec, fields_to_check={'title', 'result', 'columns'}))
+            for f in files_:
+                f['rec_type'] = rec_type
+            files.extend(files_)
+        return files
+
+    def get_all_files_for_project(self, project, subjects=None, experiments=None):
+        for subject in (subjects or self.get_subjects(project)):
+            for experiment in (experiments or self.get_experiments(project, subject)):
+                for file_ in self.get_files(project, subject, experiment):
+                    yield file_

--- a/datalad/crawler/pipelines/xnat.py
+++ b/datalad/crawler/pipelines/xnat.py
@@ -230,6 +230,8 @@ def pipeline(url, dataset, project_access='public', subjects=None):
         out = xnat('data/projects/%s' % dataset,
                    return_plain=True
                    )
+        # for NITRC I need to get more!
+        # "http://nitrc_es.projects.nitrc.org/datalad/%s" % dataset
         items = out['items']
         assert len(items) == 1
         dataset_meta = items[0]['data_fields']

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -55,6 +55,7 @@ from ..utils import safe_print
 from ..utils import generate_chunks
 from ..utils import disable_logger
 from ..utils import import_modules
+from ..utils import check_free_space
 
 from ..support.annexrepo import AnnexRepo
 
@@ -952,3 +953,18 @@ def test_line_profile():
         assert_equal(cmo.err, '')
         assert_in('i = j + 1  # xyz', cmo.out)
 
+
+@with_tempfile(mkdir=True)
+def test_check_free_space(topdir):
+    from datalad.support.exceptions import OutOfSpaceError
+    # We would be golden whenever we would this much of free space
+    abit = 1
+    lots = 1024**10  # 1000000.0 YB
+
+    targetpath = _path_(topdir, "some/subdir/file")
+    check_free_space(targetpath, 0)     # we have that much
+    check_free_space(targetpath, abit)  # we have that much
+
+    with assert_raises(OutOfSpaceError) as exc:
+        check_free_space(targetpath, lots)
+        ok_startswith(str(exc), "For %s of size " % targetpath)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -7,6 +7,8 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+from humanize.filesize import naturalsize
+
 import collections
 import hashlib
 import re
@@ -1134,6 +1136,36 @@ def path_is_subpath(path, prefix):
     """
     path, prefix = _get_normalized_paths(path, prefix)
     return (len(prefix) < len(path)) and path.startswith(prefix)
+
+
+def get_deepest_existing_dir(path):
+    """Return the deepest existing directory containing path"""
+    while path and not (os.path.exists(path) and os.path.isdir(path)):
+        path = os.path.dirname(path)
+    return path or "."
+
+
+def check_free_space(target_path, size):
+    """Check for free space to be available
+
+    Raises
+    ------
+    OutOfSpaceError
+    """
+    if not size:
+        return
+    fpath_dir = get_deepest_existing_dir(target_path)
+    statvfs = os.statvfs(fpath_dir)
+    # statvfs.f_frsize * statvfs.f_bfree  # Actual number of free bytes
+    free_bytes = statvfs.f_frsize * statvfs.f_bavail  # Number of free
+    # bytes that ordinary users
+    if free_bytes < size:
+        from datalad.support.exceptions import OutOfSpaceError
+        raise OutOfSpaceError(
+            msg="For %s of size %s: %s"
+                % (target_path, naturalsize(size), fpath_dir),
+            sizemore_msg="%s" % naturalsize(size - free_bytes)
+        )
 
 
 def knows_annex(path):


### PR DESCRIPTION
For #1552.

datalad/crawler/pipelines/xnat.py XNATServer.get_projects() contains drop_empty to address the empty XNAT projects (#1552 Point 1).  Defaults to False to preserve old behavior -- do you want it always True?

NITRC pipeline returns more descriptive filenames, but they're long.  Let me know if you'd like to simplify those further.

I've just noticed I'm ignoring subject and experiment metadata in the file information -- to follow.