### PR TITLE
Symlink annotation issue; is a link to a dataset a type='dataset?

### DIFF
--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -20,6 +20,7 @@ from os import curdir
 from os.path import join as opj
 from os.path import lexists
 from os.path import isdir
+from os.path import islink
 from os.path import dirname
 from os.path import pardir
 from os.path import normpath
@@ -590,9 +591,9 @@ class AnnotatePaths(Interface):
                 path_props['type'] = \
                     path_props.get(
                         'type',
-                        'dataset' if GitRepo.is_valid_repo(path) else 'directory')
+                        'dataset' if not islink(path) and GitRepo.is_valid_repo(path) else 'directory')
                 # this could contain all types of additional content
-                containing_dir = path
+                containing_dir = path if not islink(path) else normpath(opj(path, pardir))
             else:
                 if lexists(path):
                     path_props['type'] = 'file'

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -369,6 +369,9 @@ def test_symlinked_relpath(path):
     known_failure_v6(ok_clean_git)(dspath)
 
 
+# two subdatasets not possible in direct mode
+@known_failure_direct_mode  #FIXME
+@with_tempfile(mkdir=True)
 def test_bf1886(path):
     parent = Dataset(path).create()
     sub = parent.create('sub')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -15,7 +15,8 @@ __docformat__ = 'restructuredtext'
 from datalad.tests.utils import known_failure_direct_mode
 
 import os
-from os.path import join as opj, pardir
+from os.path import pardir
+from os.path import join as opj
 from datalad.utils import chpwd
 
 from datalad.interface.results import is_ok_dataset
@@ -24,6 +25,8 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import DeprecatedError, IncompleteResultsError
 from datalad.tests.utils import ok_
 from datalad.api import save
+from datalad.api import create
+from datalad.api import add
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
@@ -364,3 +367,41 @@ def test_symlinked_relpath(path):
         ds.save("committing", path=later)
 
     known_failure_v6(ok_clean_git)(dspath)
+
+
+def test_bf1886(path):
+    parent = Dataset(path).create()
+    sub = parent.create('sub')
+    ok_clean_git(parent.path)
+    # create a symlink pointing down to the subdataset, and add it
+    os.symlink('sub', opj(parent.path, 'down'))
+    parent.add('down')
+    ok_clean_git(parent.path)
+    # now symlink pointing up
+    os.makedirs(opj(parent.path, 'subdir', 'subsubdir'))
+    os.symlink(opj(pardir, 'sub'), opj(parent.path, 'subdir', 'up'))
+    parent.add(opj('subdir', 'up'))
+    ok_clean_git(parent.path)
+    # now symlink pointing 2xup, as in #1886
+    os.symlink(opj(pardir, pardir, 'sub'), opj(parent.path, 'subdir', 'subsubdir', 'upup'))
+    parent.add(opj('subdir', 'subsubdir', 'upup'))
+    ok_clean_git(parent.path)
+    # simulatenously add a subds and a symlink pointing to it
+    # create subds, but don't register it
+    sub2 = create(opj(parent.path, 'sub2'))
+    os.symlink(
+        opj(pardir, pardir, 'sub2'),
+        opj(parent.path, 'subdir', 'subsubdir', 'upup2'))
+    parent.add(['sub2', opj('subdir', 'subsubdir', 'upup2')])
+    ok_clean_git(parent.path)
+    # full replication of #1886: the above but be in subdir of symlink
+    # with no reference dataset
+    sub3 = create(opj(parent.path, 'sub3'))
+    os.symlink(
+        opj(pardir, pardir, 'sub3'),
+        opj(parent.path, 'subdir', 'subsubdir', 'upup3'))
+    # need to use absolute paths
+    with chpwd(opj(parent.path, 'subdir', 'subsubdir')):
+        add([opj(parent.path, 'sub3'),
+             opj(parent.path, 'subdir', 'subsubdir', 'upup3')])
+    ok_clean_git(parent.path)

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -404,4 +404,10 @@ def test_bf1886(path):
     with chpwd(opj(parent.path, 'subdir', 'subsubdir')):
         add([opj(parent.path, 'sub3'),
              opj(parent.path, 'subdir', 'subsubdir', 'upup3')])
-    ok_clean_git(parent.path)
+    # here is where we need to disagree with the repo in #1886
+    # we would not expect that `add` registers sub3 as a subdataset
+    # of parent, because no reference dataset was given and the
+    # command cannot decide (with the current semantics) whether
+    # it should "add anything in sub3 to sub3" or "add sub3 to whatever
+    # sub3 is in"
+    ok_clean_git(parent.path, untracked=['sub3/'])


### PR DESCRIPTION
#### What is the problem?

I cannot add a symlink pointing to a subdataset of a dataset. But only when no reference dataset is given -- see test.

#### What steps will reproduce the problem?

```
mih@meiner ~/courses/stats/stats1/lecture (git)-[master] % datalad --dbg add 1_intro.html reveal.js --to-git
Traceback (most recent call last):
  File "/home/mih/hacking/datalad/git/bin/datalad", line 8, in <module>
    main()
  File "/home/mih/hacking/datalad/git/datalad/cmdline/main.py", line 354, in main
    ret = cmdlineargs.func(cmdlineargs)
  File "/home/mih/hacking/datalad/git/datalad/interface/base.py", line 427, in call_from_parser
    ret = list(ret)
  File "/home/mih/hacking/datalad/git/datalad/interface/utils.py", line 382, in generator_func
    result_renderer, result_xfm, _result_filter, **_kwargs):
  File "/home/mih/hacking/datalad/git/datalad/interface/utils.py", line 449, in _process_results
    for res in results:
  File "/home/mih/hacking/datalad/git/datalad/distribution/add.py", line 421, in __call__
    commit=False)
  File "/home/mih/hacking/datalad/git/datalad/support/gitrepo.py", line 270, in newfunc
    files_new = [normalize(self.path, path) for path in files]
  File "/home/mih/hacking/datalad/git/datalad/support/gitrepo.py", line 190, in _normalize_path
    % path, filename=path)
FileNotInRepositoryError: FileNotInRepositoryError: 
Path outside repository: /home/mih/courses/stats/stats1/lecture/reveal.js
[Errno None] : Path outside repository: /home/mih/courses/stats/stats1/lecture/reveal.js: '/home/mih/courses/stats/stats1/lecture/reveal.js'
()
> /home/mih/hacking/datalad/git/datalad/support/gitrepo.py(190)_normalize_path()
-> % path, filename=path)
```
```sh
% ls -l reveal.js
lrwxrwxrwx 1 mih mih 15 Okt  7 11:30 reveal.js -> ../../reveal.js/
```
```sh
mih@meiner ~/courses/stats/stats1/lecture (git)-[master] % datalad subdatasets -d ../..
subdataset(ok): plugins/collection (dataset)
subdataset(ok): plugins/reveal.js-menu (dataset)
subdataset(ok): reveal.js (dataset)
```

It seems DataLad tries to resolve too much and shoots itself in the foot. Here is what I wanted done with git, works just fine:

```sh
mih@meiner ~/courses/stats/stats1/lecture (git)-[master] % git add reveal.js
mih@meiner ~/courses/stats/stats1/lecture (git)-[master] % git commit -m "Add shortcut to reveal.js"
[master a793576] Add shortcut to reveal.js
 1 file changed, 1 insertion(+)
 create mode 120000 stats1/lecture/reveal.js
```

@bpoldrack this might be relevant in the context of #1883 and a more use of `normalize_paths()`