### PR TITLE
`aggregate_metadata` is not incremental

### DIFF
--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -314,6 +314,8 @@ def test_update_strategy(path):
     eq_(target_meta, base.metadata(return_type='list'))
 
 
+# needs two subdatasets, no possible in direct mode
+@skip_direct_mode  #FIXME
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},


### PR DESCRIPTION
#### What is the problem?

If I perform partial aggregation (not all subdatasets) the portion that wasn't aggregated is not only not aggregated, but wiped out.

```
(neuro-dev) mih@meiner /tmp/mytest (git)-[master] % datalad subdatasets
subdataset(ok): functional (dataset)
subdataset(ok): structural (dataset)
action summary:
  subdataset (ok: 2)
(neuro-dev) mih@meiner /tmp/mytest (git)-[master] % datalad metadata --get-aggregates
/tmp/mytest (dataset): aggregated
/tmp/mytest/functional (dataset): aggregated
(neuro-dev) mih@meiner /tmp/mytest (git)-[master] % datalad aggregate-metadata structural
[INFO   ] Aggregate metadata for dataset /tmp/mytest/structural 
[INFO   ] Engage metadata extractors: ['datalad_core', 'annex', 'dicom'] 
[INFO   ] Attempting to extract DICOM metadata from 386 files 
[INFO   ] Aggregate metadata for dataset /tmp/mytest 
[INFO   ] Update aggregate metadata in dataset at: /tmp/mytest/structural 
aggregate_metadata(ok): /tmp/mytest/structural (dataset)
[INFO   ] Update aggregate metadata in dataset at: /tmp/mytest 
aggregate_metadata(ok): /tmp/mytest (dataset)                                                
[INFO   ] Attempting to save 10 files/datasets 
save(notneeded): /tmp/mytest/structural (dataset)
save(ok): /tmp/mytest (dataset)
action summary:
  aggregate_metadata (ok: 2)
  save (notneeded: 1, ok: 1)
(neuro-dev) mih@meiner /tmp/mytest (git)-[master] % datalad metadata --get-aggregates
/tmp/mytest (dataset): aggregated
/tmp/mytest/structural (dataset): aggregated
```
A solution is actually not that simple. We need to distinguish, between not aggregated subdatasets, not installed datasets, no longer registered datasets, and maybe more.
