### PR TITLE
OPT: delay import of mock, which is heavy (300ms)

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -17,8 +17,6 @@ import os
 import re
 import string
 
-from mock import patch
-
 from six import string_types
 from six.moves.urllib.parse import urlparse
 
@@ -570,6 +568,8 @@ def add_urls(rows, ifexists=None, options=None):
 def add_meta(rows):
     """Call `git annex metadata --set` using information in `rows`.
     """
+    from mock import patch
+
     for row in rows:
         ds, filename = row["ds"], row["ds_filename"]
 


### PR DESCRIPTION
Identified observing http://datalad.github.io/datalad/#core.startup.time_help_np

This pull request helps #2405

Actually on local runs of the `asv run -E existing -b core.startup.time_help_np` I didn't spot any improvement. So may be it is not there ;-)  But I know that we did move away import of mock into the code blocks everywhere but in tests, so should be the right thing to do

Ideally we should stop mocking within codebase anyways and find better ways ;-)

### Changes
- [x] This change is complete

Please have a look @datalad/developers
