### PR TITLE
`add()` will put .gitignore, .gitattributes, etc in annex unless explicitly instructed not to

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -314,6 +314,9 @@ class Create(Interface):
             yield path
             return
 
+        # stuff that we create and want to have tracked with git (not annex)
+        add_to_git = []
+
         if no_annex:
             lgr.info("Creating a new git repo at %s", tbds.path)
             GitRepo(
@@ -342,6 +345,7 @@ class Create(Interface):
                 git_attributes_file = opj(tbds.path, '.gitattributes')
                 with open(git_attributes_file, 'a') as f:
                     f.write('* annex.largefiles=(not(mimetype=text/*))\n')
+                # TODO just use add_to_git and avoid separate commit
                 tbrepo.add([git_attributes_file], git=True)
                 tbrepo.commit(
                     "Instructed annex to add text files to git",
@@ -373,6 +377,8 @@ class Create(Interface):
             tbds.id if tbds.id is not None else uuid_id,
             where='dataset')
 
+        add_to_git.append('.datalad')
+
         # make sure that v6 annex repos never commit content under .datalad
         with open(opj(tbds.path, '.datalad', '.gitattributes'), 'a') as gitattr:
             # TODO this will need adjusting, when annex'ed aggregate metadata
@@ -383,10 +389,15 @@ class Create(Interface):
             gitattr.write('metadata/objects/** annex.largefiles=({})\n'.format(
                 cfg.obtain('datalad.metadata.create-aggregate-annex-limit')))
 
+        # prevent git annex from ever annexing .git* stuff (gh-1597)
+        with open(opj(tbds.path, '.gitattributes'), 'a') as gitattr:
+            gitattr.write('.git* annex.largefiles=nothing\n')
+        add_to_git.append('.gitattributes')
+
         # save everything, we need to do this now and cannot merge with the
         # call below, because we may need to add this subdataset to a parent
         # but cannot until we have a first commit
-        tbds.add('.datalad', to_git=True, save=save,
+        tbds.add(add_to_git, to_git=True, save=save,
                  message='[DATALAD] new dataset')
 
         # the next only makes sense if we saved the created dataset,

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -387,6 +387,17 @@ def test_add_mimetypes(path):
 
 
 @with_tempfile(mkdir=True)
+def test_gh1597_simpler(path):
+    ds = Dataset(path).create()
+    # same goes for .gitattributes
+    with open(opj(ds.path, '.gitignore'), 'a') as f:
+        f.write('*.swp\n')
+    ds.add('.gitignore')
+    ok_clean_git(ds.path)
+    ok_file_under_git(ds.path, '.gitignore', annexed=False)
+
+
+@with_tempfile(mkdir=True)
 def test_gh1597(path):
     ds = Dataset(path).create()
     sub = ds.create('sub', save=False)

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -397,6 +397,8 @@ def test_gh1597_simpler(path):
     ok_file_under_git(ds.path, '.gitignore', annexed=False)
 
 
+# Failed to run ['git', '--work-tree=.', 'diff', '--raw', '-z', '--ignore-submodules=none', '--abbrev=40', 'HEAD', '--'] This operation must be run in a work tree
+@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_gh1597(path):
     ds = Dataset(path).create()

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -13,7 +13,7 @@ import sys
 from os.path import lexists, dirname, join as opj, curdir
 
 # Hard coded version, to be done by release process
-__version__ = '0.10.0.rc2'
+__version__ = '0.10.0.rc3'
 __full_version__ = __version__
 
 # NOTE: might cause problems with "python setup.py develop" deployments


### PR DESCRIPTION
This is no case in which this would be useful. We must prevent it.