### PR TITLE
`datalad add -d. . --recursive` doesn't not produce a clean repo

### DIFF
--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -118,6 +118,26 @@ def test_add_files(path):
 
 
 @with_tempfile(mkdir=True)
+def test_update_known_submodule(path):
+    def get_baseline(p):
+        ds = Dataset(p).create()
+        sub = ds.create('sub', save=False)
+        # subdataset saw another commit after becoming a submodule
+        ok_clean_git(ds.path, index_modified=['sub'])
+        return ds
+    # attempt one
+    ds = get_baseline(opj(path, 'wo_ref'))
+    with chpwd(ds.path):
+        add('.', recursive=True)
+    ok_clean_git(ds.path)
+
+    # attempt two, same as above but call add via reference dataset
+    ds = get_baseline(opj(path, 'w_ref'))
+    ds.add('.', recursive=True)
+    ok_clean_git(ds.path)
+
+
+@with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 def test_add_recursive(path):
     # make simple hierarchy


### PR DESCRIPTION
While `datalad add . --recursive` does. Test is coming.