### PR TITLE
RF: @with_direct to run in one mode on travis/windows, but in both locally/buildbots

### DIFF
--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -34,13 +34,15 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 
 # TODO: with_tree ATM for archives creates this nested top directory
 # matching archive name, so it will be a/d/test.dat ... we don't want that probably
+@with_direct
 @with_tree(
     tree=(('a.tar.gz', {'d': {fn_inarchive_obscure: '123'}}),
           ('simple.txt', '123'),
           (fn_archive_obscure, (('d', ((fn_inarchive_obscure, '123'),)),)),
           (fn_extracted_obscure, '123')))
 @with_tempfile()
-def check_basic_scenario(fn_archive, fn_extracted, direct, d, d2):
+def test_basic_scenario(direct, d, d2):
+    fn_archive, fn_extracted = fn_archive_obscure, fn_extracted_obscure
     annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
     annex.init_remote(
         ARCHIVES_SPECIAL_REMOTE,
@@ -154,15 +156,6 @@ def test_get_git_environ_adjusted():
     # test import of sys_env if no environment passed to function
     sys_env = gitrunner.get_git_environ_adjusted()
     assert_equal(sys_env["PWD"], os.environ.get("PWD"))
-
-
-def test_basic_scenario():
-    yield check_basic_scenario, 'a.tar.gz', 'simple.txt', False
-    if not on_windows:
-        yield check_basic_scenario, 'a.tar.gz', 'simple.txt', True
-    #yield check_basic_scenario, 'a.tar.gz', fn_extracted_obscure, False
-    #yield check_basic_scenario, fn_archive_obscure, 'simple.txt', False
-    yield check_basic_scenario, fn_archive_obscure, fn_extracted_obscure, False
 
 
 def test_no_rdflib_loaded():

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -17,6 +17,7 @@ from ...support.exceptions import CommandError
 from ...downloaders.tests.utils import get_test_providers
 from ..datalad import DataladAnnexCustomRemote
 
+
 @with_tempfile()
 @skip_if_no_network
 def check_basic_scenario(direct, url, d):
@@ -57,21 +58,17 @@ def check_basic_scenario(direct, url, d):
 
 # unfortunately with_tree etc decorators aren't generators friendly thus
 # this little adapters to test both on local and s3 urls
+@with_direct
 @with_tree(tree={'3versions-allversioned.txt': "somefile"})
 @serve_path_via_http
-def check_basic_scenario_local_url(direct, p, local_url):
+def test_basic_scenario_local_url(direct, p, local_url):
     check_basic_scenario(direct, "%s3versions-allversioned.txt" % local_url)
 
 
-def check_basic_scenario_s3(direct):
+@with_direct
+def test_basic_scenario_s3(direct):
     check_basic_scenario(direct, 's3://datalad-test0-versioned/3versions-allversioned.txt')
 
-
-def test_basic_scenario():
-    for test in check_basic_scenario_local_url, :#check_basic_scenario_s3:
-        yield test, False
-        if not on_windows:
-            yield test, True
 
 
 from .test_base import BASE_INTERACTION_SCENARIOS, check_interaction_scenario

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -64,6 +64,10 @@ from . import _TEMP_PATHS_GENERATED
 _TEMP_PATHS_CLONES = set()
 
 
+# Additional indicators
+on_travis = bool(os.environ.get('TRAVIS', False))
+
+
 # additional shortcuts
 neq_ = assert_not_equal
 nok_ = assert_false
@@ -1405,6 +1409,28 @@ def with_testsui(t, responses=None, interactive=True):
     return newfunc
 
 with_testsui.__test__ = False
+
+
+@optional_args
+def with_direct(func):
+    """To test functions under both direct and indirect mode
+
+    Unlike fancy generators would just fail on the first failure
+    """
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        if on_windows or on_travis:
+            # since on windows would become indirect anyways
+            # on travis -- we have a dedicated matrix run
+            # which would select one or another based on config
+            # if we specify None
+            directs = [None]
+        else:
+            # otherwise we assume that we have to test both modes
+            directs = [True, False]
+        for direct in directs:
+            func(*(args + (direct,)), **kwargs)
+    return newfunc
 
 
 def assert_no_errors_logged(func, skip_re=None):


### PR DESCRIPTION
As a minimal refactoring of how those tests ran before testing both modes.
On Travis we have now dedicated matrix run to check direct, but not on
buildbots.  So I have decided to retain that sweeping.

On travis it might shave off 20-30 sec of time with this change since
would run only in "as config says" mode

- [x] This change is complete
