### PR TITLE
BF(TST): Catch also io.UnsupportedOperation looking for fileno if nose catches output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
     - _DL_UPSTREAM_GITANNEX=1
     # Just so we test if we did not screw up running under nose without -s as well
     - NOSE_OPTS=
-    - _DL_CRON=1
+    # TEMP - _DL_CRON=1
   # run if git-annex version in neurodebian -devel differs
   - python: 3.5
     env:

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1290,12 +1290,13 @@ def ignore_nose_capturing_stdout(func):
 
     @make_decorator(func)
     def newfunc(*args, **kwargs):
+        import io
         try:
             func(*args, **kwargs)
-        except AttributeError as e:
+        except (AttributeError, io.UnsupportedOperation) as e:
             # Use args instead of .message which is PY2 specific
             message = e.args[0] if e.args else ""
-            if message.find('StringIO') > -1 and message.find('fileno') > -1:
+            if re.search('^(.*StringIO.*)?fileno', message):
                 raise SkipTest("Triggered nose defect in masking out real stdout")
             else:
                 raise


### PR DESCRIPTION
This pull request fixes #2359

This pull request proposes

### Changes
- [ ] This change is complete -- need to strip away TEMP commit if tests pass


