### PR TITLE
BF: 'all' to allow to override having a report_status filter from cmdline

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -436,7 +436,9 @@ class Interface(object):
         if args.common_report_status or 'datalad.runtime.report-status' in cfg:
             report_status = args.common_report_status or \
                             cfg.obtain('datalad.runtime.report-status')
-            if report_status == 'success':
+            if report_status == "all":
+                pass  # no filter
+            elif report_status == 'success':
                 result_filter = EnsureKeyChoice('status', ('ok', 'notneeded'))
             elif report_status == 'failure':
                 result_filter = EnsureKeyChoice('status',

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -266,8 +266,8 @@ definitions = {
     'datalad.runtime.report-status': {
         'ui': ('question', {
                'title': 'Command line result reporting behavior',
-               'text': "If set, constrains command result report to records matching the given status. 'success' is a synonym for 'ok' OR 'notneeded', 'failure' stands for 'impossible' OR 'error'"}),
-        'type': EnsureChoice('success', 'failure', 'ok', 'notneeded', 'impossible', 'error'),
+               'text': "If set (to other than 'all'), constrains command result report to records matching the given status. 'success' is a synonym for 'ok' OR 'notneeded', 'failure' stands for 'impossible' OR 'error'"}),
+        'type': EnsureChoice('all', 'success', 'failure', 'ok', 'notneeded', 'impossible', 'error'),
         'default': None,
     },
     'datalad.search.indexercachesize': {

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -36,7 +36,7 @@ def _new_args(**kwargs):
         **updated(
             dict(
                 common_on_failure=None,  # ['ignore', 'continue', 'stop']
-                common_report_status=None,  # ['success', 'failure', 'ok', 'notneeded', 'impossible', 'error']
+                common_report_status=None,  # ['all', 'success', 'failure', 'ok', 'notneeded', 'impossible', 'error']
                 common_report_type=None,  # ['dataset', 'file']
             ),
             kwargs
@@ -102,9 +102,12 @@ def test_get_result_filter_arg_vs_config():
         assert cargs is not None
         with patch_config({"datalad.runtime.report-status": v}):
             ccfg = f(_new_args())
+            ccfg_none = f(_new_args(common_report_status="all"))
         # cannot compare directly but at least could verify based on repr
         print("%s -> %s" % (v, repr(cargs)))
         eq_(repr(cargs), repr(ccfg))
+        # and if 'all' - none filter
+        eq_(None, ccfg_none)
 
         # and we overload the "error" in config
         with patch_config({"datalad.runtime.report-status": "error"}):


### PR DESCRIPTION
There were no way to reset (override) config setting from command line using
report-status cmdline option.  Sure thing I could possible override config
setting itself (came to mind only while composing this message), but I thought
that it would make sense to have 'all' ;)

Feel free to close without merging if you see that cmdline options shouldn't be capable of overloading config settings ;)  (which is kinda a generic question, and they typically do, but may be we do not have a uniform way to say "disregard config setting, and keep default?")
