### PR TITLE
Two litle fixes, commits are self explanatory

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -36,6 +36,9 @@ from datalad.support.sshconnector import sh_quote
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.network import URL, RI, SSHRI, is_ssh
 
+# haunted imports/bindings
+from datalad.interface.diff import Diff
+
 
 from datalad.utils import assure_list
 from datalad.dochelpers import exc_str

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1552,8 +1552,8 @@ class GitRepo(RepoInterface):
                 raise RemoteNotAvailableError(name,
                                               cmd="git remote remove",
                                               msg="No such remote",
-                                              stdout=out,
-                                              stderr=err)
+                                              stdout=e.stdout,
+                                              stderr=e.stderr)
             else:
                 raise e
 


### PR DESCRIPTION
commit 7a3c969ee4dc43d2517de9894e5b98490f03dbe7 (HEAD -> misc, gh-yarikoptic/misc)
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Sat Apr 14 21:01:56 2018 -0400

    BF: no out/err available in exc handling - get from exception

commit 3b67db7b7c93e1ea9b2db341819279ce132bf9b1
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Sat Apr 14 21:01:31 2018 -0400

    BF: yet another missing import for a binding of diff

