### PR TITLE
`save` update, fix bug, test intended behavior, improve docs

### DIFF
--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -107,10 +107,12 @@ def save_dataset(
                    lexists(ap['path'])]
 
     if to_gitadd or save_entire_ds:
+        lgr.debug('Adding files straight to Git at %s: %s', ds, to_gitadd)
         ds.repo.add(to_gitadd, git=True, commit=False,
                     # this makes sure that pending submodule updates are added too
                     update=save_entire_ds)
     if to_annexadd:
+        lgr.debug('Adding files to annex at %s: %s', ds, to_annexadd)
         ds.repo.add(to_annexadd, commit=False)
 
     _datalad_msg = False
@@ -217,7 +219,9 @@ class Save(Interface):
 
         if not dataset and not path:
             # we got nothing at all -> save what is staged in the repo in "this" directory?
-            path = abspath(curdir)
+            # make sure we don't treat this as a user-provided '.' argument
+            path = [{'path': abspath(curdir), 'raw_input': False}]
+
         refds_path = Interface.get_refds_path(dataset)
 
         if message and message_file:

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -148,25 +148,33 @@ def save_dataset(
 class Save(Interface):
     """Save the current state of a dataset
 
-    Saving the state of a dataset records all changes that have been made
-    to it. This change record is annotated with a user-provided description.
+    Saving the state of a dataset records changes that have been made to it.
+    This change record is annotated with a user-provided description.
     Optionally, an additional tag, such as a version, can be assigned to the
-    saved state. Such tag enables straightforward retrieval of past versions
-    at a later point in time.
+    saved state. Such tag enables straightforward retrieval of past versions at
+    a later point in time.
 
-    || PYTHON >>
-    Returns
-    -------
-    commit or None
-      `None` if nothing was saved, the resulting commit otherwise.
-    << PYTHON ||
+    Examples:
+
+      Save any content underneath the current directory, without altering
+      any potential subdataset (use --recursive for that)::
+
+        % datalad save .
+
+      Save any modification of known dataset content, but leave untracked
+      files (e.g. temporary files) untouched::
+
+        % dataset save -d <path_to_dataset>
+
+      Tag the most recent saved state of a dataset::
+
+        % dataset save -d <path_to_dataset> --version-tag bestyet
     """
 
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc=""""specify the dataset to save. If a dataset is given, but
-            no `files`, the entire dataset will be saved.""",
+            doc=""""specify the dataset to save""",
             constraints=EnsureDataset() | EnsureNone()),
         path=Parameter(
             args=("path",),
@@ -181,6 +189,8 @@ class Save(Interface):
             doc="""take the commit message from this file. This flag is
             mutually exclusive with -m.""",
             constraints=EnsureStr() | EnsureNone()),
+        # switch not functional from cmdline: default True, action=store_true
+        # TODO remove from API? all_updated=False is not used anywhere in the codebase
         all_updated=Parameter(
             args=("-u", "--all-updated"),
             doc="""if no explicit paths are given, save changes of all known

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -181,11 +181,6 @@ class Save(Interface):
             doc="""take the commit message from this file. This flag is
             mutually exclusive with -m.""",
             constraints=EnsureStr() | EnsureNone()),
-        all_changes=Parameter(
-            args=("-a", "--all-changes"),
-            doc="""save all changes (even to not yet added files) of all components
-            in datasets that contain any of the given paths [DEPRECATED!].""",
-            action="store_true"),
         all_updated=Parameter(
             args=("-u", "--all-updated"),
             doc="""if no explicit paths are given, save changes of all known
@@ -205,18 +200,10 @@ class Save(Interface):
     @datasetmethod(name='save')
     @eval_results
     def __call__(message=None, path=None, dataset=None,
-                 all_updated=True, all_changes=None, version_tag=None,
+                 all_updated=True, version_tag=None,
                  recursive=False, recursion_limit=None, super_datasets=False,
                  message_file=None
                  ):
-        if all_changes is not None:
-            from datalad.support.exceptions import DeprecatedError
-            raise DeprecatedError(
-                new="all_updated option where fits and/or datalad add",
-                version="0.5.0",
-                msg="RF: all_changes option passed to the save"
-            )
-
         if not dataset and not path:
             # we got nothing at all -> save what is staged in the repo in "this" directory?
             # make sure we don't treat this as a user-provided '.' argument

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -422,6 +422,8 @@ def test_bf1886(path):
     '2': '',
     '3': ''})
 def test_gh2043p1(path):
+    # this tests documents the interim agreement on what should happen
+    # in the case documented in gh-2043
     ds = Dataset(path).create(force=True)
     ds.add('1')
     ok_clean_git(ds.path, untracked=['2', '3'])

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -38,7 +38,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_values_equal
-from datalad.tests.utils import known_failure_v6
+from datalad.tests.utils import skip_v6
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
@@ -363,7 +363,7 @@ def test_symlinked_relpath(path):
         ds.repo.add(later, git=True)
         ds.save("committing", path=later)
 
-    known_failure_v6(ok_clean_git)(dspath)
+    skip_v6(method='pass')(ok_clean_git)(dspath)
 
 
 # two subdatasets not possible in direct mode
@@ -432,12 +432,14 @@ def test_gh2043p1(path):
         save('.')  #  because the first arg is the dataset
     # state of the file (unlocked/locked) is committed as well, and the
     # test doesn't lock the file again
-    known_failure_v6(ok_clean_git)(ds.path, untracked=['2', '3'])
+    skip_v6(method='pass')(ok_clean_git)(ds.path, untracked=['2', '3'])
     with chpwd(path):
         # but when a path is given, anything that matches this path
         # untracked or not is added/saved
         save(path='.')
-    ok_clean_git(ds.path)
+    # state of the file (unlocked/locked) is committed as well, and the
+    # test doesn't lock the file again
+    skip_v6(method='pass')(ok_clean_git)(ds.path)
 
 
 @with_tree({

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -418,9 +418,28 @@ def test_bf1886(path):
 
 
 @with_tree({
+    '1': '',
+    '2': '',
+    '3': ''})
+def test_bf2043p1(path):
+    ds = Dataset(path).create(force=True)
+    ds.add('1')
+    ok_clean_git(ds.path, untracked=['2', '3'])
+    ds.unlock('1')
+    ok_clean_git(ds.path, index_modified=['1'], untracked=['2', '3'])
+    # save(.) should recommit unlocked file, and not touch anything else
+    # this tests the second issue in #2043
+    with chpwd(path):
+        # this would work: save('.'), because the first arg is the dataset
+        # but this doesn't
+        save(path='.')
+    ok_clean_git(ds.path, untracked=['2', '3'])
+
+
+@with_tree({
     'staged': 'staged',
     'untracked': 'untracked'})
-def test_bf2043(path):
+def test_bf2043p2(path):
     ds = Dataset(path).create(force=True)
     ds.add('staged', save=False)
     ok_clean_git(ds.path, head_modified=['staged'], untracked=['untracked'])

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -430,7 +430,9 @@ def test_gh2043p1(path):
     with chpwd(path):
         # only save modified bits by default
         save('.')  #  because the first arg is the dataset
-    ok_clean_git(ds.path, untracked=['2', '3'])
+    # state of the file (unlocked/locked) is committed as well, and the
+    # test doesn't lock the file again
+    known_failure_v6(ok_clean_git)(ds.path, untracked=['2', '3'])
     with chpwd(path):
         # but when a path is given, anything that matches this path
         # untracked or not is added/saved

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -421,7 +421,7 @@ def test_bf1886(path):
     '1': '',
     '2': '',
     '3': ''})
-def test_bf2043p1(path):
+def test_gh2043p1(path):
     ds = Dataset(path).create(force=True)
     ds.add('1')
     ok_clean_git(ds.path, untracked=['2', '3'])
@@ -430,10 +430,14 @@ def test_bf2043p1(path):
     # save(.) should recommit unlocked file, and not touch anything else
     # this tests the second issue in #2043
     with chpwd(path):
-        # this would work: save('.'), because the first arg is the dataset
-        # but this doesn't
-        save(path='.')
+        # only save modified bits by default
+        save('.')  #  because the first arg is the dataset
     ok_clean_git(ds.path, untracked=['2', '3'])
+    with chpwd(path):
+        # but when a path is given, anything that matches this path
+        # untracked or not is added/saved
+        save(path='.')
+    ok_clean_git(ds.path)
 
 
 @with_tree({

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -30,6 +30,7 @@ from datalad.api import add
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import assert_equal
@@ -414,3 +415,17 @@ def test_bf1886(path):
     # it should "add anything in sub3 to sub3" or "add sub3 to whatever
     # sub3 is in"
     ok_clean_git(parent.path, untracked=['sub3/'])
+
+
+@with_tree({
+    'staged': 'staged',
+    'untracked': 'untracked'})
+def test_bf2043(path):
+    ds = Dataset(path).create(force=True)
+    ds.add('staged', save=False)
+    ok_clean_git(ds.path, head_modified=['staged'], untracked=['untracked'])
+    # plain save does not commit untracked content
+    # this tests the second issue in #2043
+    with chpwd(path):
+        save()
+    ok_clean_git(ds.path, untracked=['untracked'])

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -53,10 +53,6 @@ def test_save(path):
     ds.repo.add("new_file.tst", git=True)
     ok_(ds.repo.dirty)
 
-    # no all_changes any longer
-    with assert_raises(DeprecatedError):
-        ds.save("add a new file", all_changes=True)
-
     ds.save("add a new file")
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -77,7 +77,7 @@ from .utils import ok_startswith
 from .utils import skip_if_no_module
 from .utils import (
     probe_known_failure, skip_known_failure, known_failure, known_failure_v6,
-    known_failure_direct_mode
+    known_failure_direct_mode, skip_if
 )
 
 
@@ -796,6 +796,23 @@ def test_probe_known_failure():
         # if probing is disabled it should just fail/pass as is:
         assert_raises(AssertionError, failing)
         not_failing()
+
+
+def test_skip_if():
+
+    def dummy():
+        raise AssertionError
+
+    assert_raises(AssertionError, dummy)
+    # if cond is False, call the decorated function:
+    assert_raises(AssertionError, skip_if(cond=False, method='raise')(dummy))
+    # raises SkipTest if cond is True
+    assert_raises(SkipTest, skip_if(cond=True, method='raise')(dummy))
+    # but with method 'pass', there is neither SkipTest nor AssertionError.
+    # Instead the function call is just skipped:
+    skip_if(cond=True, method='pass')(dummy)
+    # But if condition is False, the original function is still called:
+    assert_raises(AssertionError, skip_if(cond=False, method='pass')(dummy))
 
 
 def test_skip_known_failure():

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -208,8 +208,8 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
     Note
     ----
     Parameters head_modified and index_modified currently work
-    in pure git or indirect mode annex only and are ignored otherwise!
-    Implementation is yet to do!
+    in pure git or indirect mode annex only. If they are given, no
+    test of modification of known repo content is performed.
 
     Parameters
     ----------
@@ -263,15 +263,8 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
 
     if annex and r.is_direct_mode():
         if head_modified or index_modified:
-            lgr.warning("head_modified and index_modified are not quite valid "
-                        "concepts in direct mode! Looking for any change "
-                        "(staged or not) instead.")
-            status = r.get_status(untracked=False, submodules=not ignore_submodules)
-            modified = []
-            for s in status:
-                modified.extend(status[s])
-            eq_(sorted(head_modified + index_modified),
-                sorted(f for f in modified))
+            lgr.warning("head_modified and index_modified are not supported "
+                        "for direct mode repositories!")
         else:
             ok_(not r.is_dirty(untracked_files=not untracked,
                                submodules=not ignore_submodules))


### PR DESCRIPTION
#### What is the problem?
well -- we have `add` to add stuff, which also `saves`.  git allows for a convenient "commit ." which saves all changes in the current sub directory, so I thought that it would only make sense to call "datalad save -m msg ."... to my surprise it added all kinds of stuff which it should have not!

#### What steps will reproduce the problem?

```shell
hopa:~
$> datalad create /tmp/repro
[INFO   ] Creating a new annex repo at /tmp/repro 
create(ok): /tmp/repro (dataset)                                                 
(dev3) 2 13324.....................................:Mon 18 Dec 2017 09:47:55 PM EST:.
hopa:~
$> cd /tmp/repro
(dev3) 2 13325.....................................:Mon 18 Dec 2017 09:47:56 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> touch 1 2 3
(dev3) 2 13326.....................................:Mon 18 Dec 2017 09:48:03 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> datalad add -m added\ 1 1
add(ok): /tmp/repro/1 (file)00:00, ?B/s]                                         
save(ok): /tmp/repro (dataset)
action summary:
  add (ok: 1)
  save (ok: 1)
(dev3) 2 13327.....................................:Mon 18 Dec 2017 09:48:16 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> rm 1; echo 2>1

(dev3) 2 13328.....................................:Mon 18 Dec 2017 09:48:28 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> ls -l
total 0
-rw------- 1 yoh yoh 0 Dec 18 21:48 1
-rw------- 1 yoh yoh 0 Dec 18 21:48 2
-rw------- 1 yoh yoh 0 Dec 18 21:48 3
(dev3) 2 13329.....................................:Mon 18 Dec 2017 09:48:31 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> datalad save -m "123" .
save(ok): /tmp/repro (dataset)                                                   
(dev3) 2 13330.....................................:Mon 18 Dec 2017 09:48:40 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> git show --stat
commit 58562e29e3f3469f5e8b7b3f176dafe8044d6ad0 (HEAD -> master)
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Mon Dec 18 21:48:40 2017 -0500

    123

 2 | 1 +
 3 | 1 +
 2 files changed, 2 insertions(+)
(dev3) 2 13331.....................................:Mon 18 Dec 2017 09:48:43 PM EST:.
(git-annex)hopa:/tmp/repro[master]
$> ls -l 
total 12
lrwxrwxrwx 1 yoh yoh 108 Dec 18 21:48 1 -> .git/annex/objects/2W/kW/MD5E-s0--d41d8cd98f00b204e9800998ecf8427e/MD5E-s0--d41d8cd98f00b204e9800998ecf8427e
lrwxrwxrwx 1 yoh yoh 108 Dec 18 21:48 2 -> .git/annex/objects/2W/kW/MD5E-s0--d41d8cd98f00b204e9800998ecf8427e/MD5E-s0--d41d8cd98f00b204e9800998ecf8427e
lrwxrwxrwx 1 yoh yoh 108 Dec 18 21:48 3 -> .git/annex/objects/2W/kW/MD5E-s0--d41d8cd98f00b204e9800998ecf8427e/MD5E-s0--d41d8cd98f00b204e9800998ecf8427e
```
#### What version of DataLad are you using (run `datalad --version`)? On what operating system (consider running `datalad plugin wtf`)?
current master: 0.9.1-521-gf16f652d

#### Is there anything else that would be useful to know in this context?
#### Have you had any success using DataLad before? (Sometimes we get tired of reading bug reports all day and a lil' positive end note does wonders)
