### PR TITLE
Kill *Repo.add(commit=True)

### DIFF
--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -52,8 +52,10 @@ def test_basic_scenario(direct, d, d2):
     assert annex.is_special_annex_remote(ARCHIVES_SPECIAL_REMOTE)
     # We want two maximally obscure names, which are also different
     assert(fn_extracted != fn_inarchive_obscure)
-    annex.add(fn_archive, commit=True, msg="Added tarball")
-    annex.add(fn_extracted, commit=True, msg="Added the load file")
+    annex.add(fn_archive)
+    annex.commit(msg="Added tarball")
+    annex.add(fn_extracted)
+    annex.commit(msg="Added the load file")
 
     # Operations with archive remote URL
     annexcr = ArchiveAnnexCustomRemote(path=d)
@@ -129,7 +131,8 @@ def test_basic_scenario(direct, d, d2):
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)
-    annex.add('a.tar.gz', commit=True)
+    annex.add('a.tar.gz')
+    annex.commit()
     add_archive_content('a.tar.gz', annex=annex, delete=True)
     fpath = opj(topdir, 'a', 'd', fn_inarchive_obscure)
 

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -419,7 +419,6 @@ class Add(Interface):
             added = ds.repo.add(
                 list(torepoadd.keys()),
                 git=to_git if is_annex else True,
-                commit=False,
                 **add_kw
             )
             for a in added:

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -96,7 +96,8 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
     fn = opj(path, "file%d.dat" % random.randint(1, 1000))
     with open(fn, 'w') as f:
         f.write(fn)
-    repo.add(fn, git=True, commit=True, msg="Added %s" % fn, _datalad_msg=True)
+    repo.add(fn, git=True)
+    repo.commit(msg="Added %s" % fn)
 
     yield path
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -133,7 +133,8 @@ def test_get_git_url_from_source():
 @with_tempfile
 def _test_guess_dot_git(annex, path, url, tdir):
     repo = (AnnexRepo if annex else GitRepo)(path, create=True)
-    repo.add('file.txt', commit=True, git=not annex)
+    repo.add('file.txt', git=not annex)
+    repo.commit()
 
     # we need to prepare to be served via http, otherwise it must fail
     with swallow_logs() as cml:

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -145,8 +145,8 @@ def test_publish_simple(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.repo.add(opj(src_path, 'test_mod_file'), git=True,
-                    commit=True, msg="Modified.")
+    source.add(opj(src_path, 'test_mod_file'), to_git=True,
+               message="Modified.")
     ok_clean_git(source.repo, annex=None)
 
     res = publish(dataset=source, to='target', result_xfm='datasets')
@@ -202,8 +202,8 @@ def test_publish_plain_git(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.repo.add(opj(src_path, 'test_mod_file'), git=True,
-                    commit=True, msg="Modified.")
+    source.add(opj(src_path, 'test_mod_file'), to_git=True,
+               message="Modified.")
     ok_clean_git(source.repo, annex=None)
 
     res = publish(dataset=source, to='target', result_xfm='datasets')

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -144,12 +144,14 @@ def test_update_fetch_all(src, remote_1, remote_2):
     # modify the remotes:
     with open(opj(remote_1, "first.txt"), "w") as f:
         f.write("some file load")
-    rmt1.add("first.txt", commit=True)
+    rmt1.add("first.txt")
+    rmt1.commit()
     # TODO: Modify an already present file!
 
     with open(opj(remote_2, "second.txt"), "w") as f:
         f.write("different file load")
-    rmt2.add("second.txt", git=True, commit=True, msg="Add file to git.")
+    rmt2.add("second.txt", git=True)
+    rmt2.commit(msg="Add file to git.")
 
     # Let's init some special remote which we couldn't really update/fetch
     if not os.environ.get('DATALAD_TESTS_DATALADREMOTE'):

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -108,12 +108,12 @@ def save_dataset(
 
     if to_gitadd or save_entire_ds:
         lgr.debug('Adding files straight to Git at %s: %s', ds, to_gitadd)
-        ds.repo.add(to_gitadd, git=True, commit=False,
+        ds.repo.add(to_gitadd, git=True,
                     # this makes sure that pending submodule updates are added too
                     update=save_entire_ds)
     if to_annexadd:
         lgr.debug('Adding files to annex at %s: %s', ds, to_annexadd)
-        ds.repo.add(to_annexadd, commit=False)
+        ds.repo.add(to_annexadd)
 
     _datalad_msg = False
     if not message:

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -22,6 +22,8 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import with_tree
 from datalad.utils import swallow_logs, swallow_outputs, _path_
+# needed below as bound dataset method
+from datalad.api import add
 
 
 def test_machinesize():
@@ -60,7 +62,8 @@ def test_fs_traverse(topdir):
     AnnexRepo(opj(topdir, 'annexdir'), create=True)
     GitRepo(opj(topdir, 'gitdir'), create=True)
     GitRepo(opj(topdir, 'dir', 'subgit'), create=True)
-    annex.add(opj(topdir, 'dir'), commit=True)
+    annex.add(opj(topdir, 'dir'))
+    annex.commit()
     annex.drop(opj(topdir, 'dir', 'subdir', 'file2.txt'), options=['--force'])
 
     # traverse file system in recursive and non-recursive modes
@@ -145,9 +148,11 @@ def test_ls_json(topdir):
     subdirds.add('file')
 
     git = GitRepo(opj(topdir, 'dir', 'subgit'), create=True)                    # create git repo
-    git.add(opj(topdir, 'dir', 'subgit', 'fgit.txt'), commit=True)              # commit to git to init git repo
-    annex.add(opj(topdir, 'dir', 'subgit'), commit=True)                        # add the non-dataset git repo to annex
-    annex.add(opj(topdir, 'dir'), commit=True)                                  # add to annex (links)
+    git.add(opj(topdir, 'dir', 'subgit', 'fgit.txt'))              # commit to git to init git repo
+    git.commit()
+    annex.add(opj(topdir, 'dir', 'subgit'))                        # add the non-dataset git repo to annex
+    annex.add(opj(topdir, 'dir'))                                  # add to annex (links)
+    annex.commit()
     annex.drop(opj(topdir, 'dir', 'subdir', 'file2.txt'), options=['--force'])  # broken-link
 
     meta_dir = opj('.git', 'datalad', 'metadata')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -489,7 +489,7 @@ def test_new_or_modified(path):
     # Check out an orphan branch so that we can test the "one commit
     # in a repo" case.
     ds.repo.checkout("orph", options=["--orphan"])
-    ds.repo.add(".", commit=True)
+    ds.add(".")
     assert_false(ds.repo.dirty)
     assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
     # Diffing doesn't fail when the branch contains a single commit.
@@ -501,7 +501,7 @@ def test_new_or_modified(path):
 
     with open(opj(path, "to_add"), "w") as f:
         f.write("content5")
-    ds.repo.add(["to_add"], commit=True)
+    ds.repo.add(["to_add"])
     ds.repo.commit("add one, remove another")
 
     eq_(list(apfiles(new_or_modified(ds, "HEAD"))),
@@ -512,7 +512,7 @@ def test_new_or_modified(path):
         f.write("updated 1")
     with open(opj(path, "d/to_modify"), "w") as f:
         f.write("updated 2")
-    ds.repo.add(["to_modify", "d/to_modify"], commit=True)
+    ds.add(["to_modify", "d/to_modify"])
 
     eq_(set(apfiles(new_or_modified(ds, "HEAD"))),
         {"to_modify", "d/to_modify"})

--- a/datalad/plugin/tests/test_check_dates.py
+++ b/datalad/plugin/tests/test_check_dates.py
@@ -53,7 +53,8 @@ def test_check_dates(path):
     repo = os.path.join(path, "repo")
     with set_date(ref_ts + 5000):
         ar = AnnexRepo(repo)
-        ar.add(".", commit=True)
+        ar.add(".")
+        ar.commit()
 
     # The standard renderer outputs json.
     with swallow_outputs() as cmo:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1385,8 +1385,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         return expected_files, fetch_files
 
     @normalize_paths
-    def add(self, files, git=None, backend=None, options=None, commit=False,
-            msg=None,
+    def add(self, files, git=None, backend=None, options=None,
             jobs=None,
             git_options=None, annex_options=None, _datalad_msg=False,
             update=False):
@@ -1398,11 +1397,6 @@ class AnnexRepo(GitRepo, RepoInterface):
           list of paths to add to the annex
         git: bool
           if True, add to git instead of annex.
-        commit: bool
-          whether or not to directly commit
-        msg: str
-          commit message in case `commit=True`. A default message, containing
-          the list of files that were added, is created by default.
         backend:
         options:
         update: bool
@@ -1520,10 +1514,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             try:
                 return_list = super(AnnexRepo, self).add(
                                            files,
-                                           # Note: committing is dealed with
-                                           # later on
-                                           commit=False,
-                                           msg=msg,
                                            git=True,
                                            git_options=git_options,
                                            _datalad_msg=_datalad_msg,
@@ -1546,19 +1536,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 expect_stderr=True
             ))
 
-        if commit:
-            if msg is None:
-                # TODO: centralize JSON handling
-                if isinstance(return_list, list):
-                    file_list = [d['file'] for d in return_list if d['success']]
-                elif isinstance(return_list, dict):
-                    file_list = [return_list['file']] \
-                        if return_list['success'] else []
-                else:
-                    raise ValueError("Unexpected return type: %s" %
-                                     type(return_list))
-                msg = self._get_added_files_commit_msg(file_list)
-            self.commit(msg, _datalad_msg=_datalad_msg)  # TODO: For consisteny: Also json return value (success)?
         return return_list
 
     def proxy(self, git_cmd, **kwargs):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -863,7 +863,7 @@ class GitRepo(RepoInterface):
         return msg + '\n\nFiles:\n' + '\n'.join(files)
 
     @normalize_paths
-    def add(self, files, commit=False, msg=None, git=True, git_options=None,
+    def add(self, files, git=True, git_options=None,
             _datalad_msg=False, update=False):
         """Adds file(s) to the repository.
 
@@ -871,11 +871,6 @@ class GitRepo(RepoInterface):
         ----------
         files: list
           list of paths to add
-        commit: bool
-          whether or not to directly commit
-        msg: str
-          commit message in case `commit=True`. A default message, containing
-          the list of files that were added, is created by default.
         git: bool
           somewhat ugly construction to be compatible with AnnexRepo.add();
           has to be always true.
@@ -934,11 +929,6 @@ class GitRepo(RepoInterface):
 
         else:
             lgr.warning("add was called with empty file list and no options.")
-
-        if commit:
-            if msg is None:
-                msg = self._get_added_files_commit_msg(files)
-            self.commit(msg=msg, _datalad_msg=_datalad_msg)
 
         # Make sure return value from GitRepo is consistent with AnnexRepo
         # currently simulating similar return value, assuming success

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -890,45 +890,47 @@ class GitRepo(RepoInterface):
         # instead of options to the git executable => rename for consistency
 
         # needs to be True - see docstring:
+        # XXX why is this done? this is add() of GitRepo, there is not even a
+        # question
         assert(git)
 
         files = _remove_empty_items(files)
         out = []
 
-        if files or git_options or update:
-            try:
-                # without --verbose git 2.9.3  add does not return anything
-                add_out = self._git_custom_command(
-                    files,
-                    ['git', 'add'] + assure_list(git_options) +
-                    to_options(update=update) + ['--verbose']
-                )
-                # get all the entries
-                out = self._process_git_get_output(*add_out)
-                # Note: as opposed to git cmdline, force is True by default in
-                #       gitpython, which would lead to add things, that are
-                #       ignored or excluded otherwise
-                # 2. Note: There is an issue with globbing (like adding '.'),
-                #       which apparently doesn't care for 'force' and therefore
-                #       adds '.git/...'. May be it's expanded at the wrong
-                #       point in time or sth. like that.
-                # For now, use direct call to git add.
-                #self.cmd_call_wrapper(self.repo.index.add, files, write=True,
-                #                      force=False)
-                # TODO: May be make use of 'fprogress'-option to indicate
-                # progress
-                # But then, we don't have it for git-annex add, anyway.
-                #
-                # TODO: Is write=True a reasonable way to do it?
-                # May be should not write until success of operation is
-                # confirmed?
-                # What's best in case of a list of files?
-            except OSError as e:
-                lgr.error("add: %s" % e)
-                raise
-
-        else:
+        if not (files or git_options or update):
             lgr.warning("add was called with empty file list and no options.")
+            return out
+
+        try:
+            # without --verbose git 2.9.3  add does not return anything
+            add_out = self._git_custom_command(
+                files,
+                ['git', 'add'] + assure_list(git_options) +
+                to_options(update=update) + ['--verbose']
+            )
+            # get all the entries
+            out = self._process_git_get_output(*add_out)
+            # Note: as opposed to git cmdline, force is True by default in
+            #       gitpython, which would lead to add things, that are
+            #       ignored or excluded otherwise
+            # 2. Note: There is an issue with globbing (like adding '.'),
+            #       which apparently doesn't care for 'force' and therefore
+            #       adds '.git/...'. May be it's expanded at the wrong
+            #       point in time or sth. like that.
+            # For now, use direct call to git add.
+            #self.cmd_call_wrapper(self.repo.index.add, files, write=True,
+            #                      force=False)
+            # TODO: May be make use of 'fprogress'-option to indicate
+            # progress
+            # But then, we don't have it for git-annex add, anyway.
+            #
+            # TODO: Is write=True a reasonable way to do it?
+            # May be should not write until success of operation is
+            # confirmed?
+            # What's best in case of a list of files?
+        except OSError as e:
+            lgr.error("add: %s" % e)
+            raise
 
         # Make sure return value from GitRepo is consistent with AnnexRepo
         # currently simulating similar return value, assuming success

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -546,7 +546,8 @@ def __test_get_md5s(path):
     # was used just to generate above dict
     annex = AnnexRepo(path, init=True, backend='MD5E')
     files = [basename(f) for f in find_files('.*', path)]
-    annex.add(files, commit=True)
+    annex.add(files)
+    annex.commit()
     print({f: annex.get_file_key(f) for f in files})
 
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -556,7 +556,8 @@ def test_dropkey(batch, direct, path):
     kw = {'batch': batch}
     annex = AnnexRepo(path, init=True, backend='MD5E', direct=direct)
     files = list(tree1_md5e_keys)
-    annex.add(files, commit=True)
+    annex.add(files)
+    annex.commit()
     # drop one key
     annex.drop_key(tree1_md5e_keys[files[0]], **kw)
     # drop multiple
@@ -768,7 +769,8 @@ def test_AnnexRepo_add_to_annex(path):
     with open(opj(repo.path, filename), "w") as f:
         f.write("something else")
 
-    repo.add(filename, commit=True, msg="Added another file to annex.")
+    repo.add(filename)
+    repo.commit(msg="Added another file to annex.")
     # known to annex:
     ok_(repo.get_file_key(filename))
     ok_(repo.file_has_content(filename))
@@ -806,8 +808,8 @@ def test_AnnexRepo_add_to_git(path):
     with open(opj(repo.path, filename), "w") as f:
         f.write("something else")
 
-    repo.add(filename, git=True, commit=True,
-             msg="Added another file to annex.")
+    repo.add(filename, git=True)
+    repo.commit(msg="Added another file to annex.")
     # not in annex, but in git:
     assert_raises(FileInGitError, repo.get_file_key, filename)
 
@@ -1870,7 +1872,8 @@ def _test_status(ar):
     eq_(stat, ar.get_status())
 
     # add to subrepo
-    sub.add('fourth', commit=True, msg="birther mod init'ed")
+    sub.add('fourth')
+    sub.commit(msg="birther mod init'ed")
     stat['untracked'].remove(opj('submod', 'fourth'))
 
     if ar.get_active_branch().endswith('(unlocked)') and \

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -139,7 +139,8 @@ def test_GitRepo_add(src, path):
     assert_raises(AssertionError, gr.add, filename, git=None)
 
     # include committing:
-    added2 = gr.add(filename, commit=True, msg="Add two files.")
+    added2 = gr.add(filename)
+    gr.commit(msg="Add two files.")
     assert_equal(added2, {'success': True, 'file': filename})
 
     assert_in(filename, gr.get_indexed_files(),
@@ -1046,7 +1047,8 @@ def test_get_missing(path):
         f.write('some')
     with open(opj(path, 'deep', 'test2'), 'w') as f:
         f.write('some more')
-    repo.add('.', commit=True)
+    repo.add('.')
+    repo.commit()
     ok_clean_git(path, annex=False)
     os.unlink(opj(path, 'test1'))
     eq_(repo.get_missing_files(), ['test1'])

--- a/datalad/support/tests/utils.py
+++ b/datalad/support/tests/utils.py
@@ -17,7 +17,8 @@ def check_repo_deals_with_inode_change(class_, path, temp_store):
     repo = class_(path, create=True)
     with open(opj(path, "testfile.txt"), "w") as f:
         f.write("whatever")
-    repo.add("testfile.txt", commit=True, msg="some load")
+    repo.add("testfile.txt")
+    repo.commit(msg="some load")
 
     # requesting HEAD info from
     hexsha = repo.repo.head.object.hexsha

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -325,9 +325,10 @@ def put_file_under_git(path, filename=None, content=None, annexed=False):
     if annexed:
         if not isinstance(repo, AnnexRepo):
             repo = AnnexRepo(repo.path)
-        repo.add(file_repo_path, commit=True, _datalad_msg=True)
+        repo.add(file_repo_path)
     else:
-        repo.add(file_repo_path, git=True, _datalad_msg=True)
+        repo.add(file_repo_path, git=True)
+    repo.commit(_datalad_msg=True)
     ok_file_under_git(repo.path, file_repo_path, annexed)
     return repo
 


### PR DESCRIPTION
I am debugging in the context of #1921 and get to see the code layer again after months/years. I really think these functions should do much less than they do now. In particular, I would like to RF away the ability to `commit=True`. It makes the structure of those functions needlessly complicated, it prevents them from being usable as a generator, and (I hope) we don't need this functionality anywhere.

To be precise: we need it in oldish test code, but no real functionality uses it:
```
datalad/customremotes/tests/test_archives.py:    annex.add(fn_archive, commit=True, msg="Added tarball")
datalad/customremotes/tests/test_archives.py:    annex.add(fn_extracted, commit=True, msg="Added the load file")
datalad/customremotes/tests/test_archives.py:    annex.add('a.tar.gz', commit=True)
datalad/distribution/create_test_dataset.py:    repo.add(fn, git=True, commit=True, msg="Added %s" % fn, _datalad_msg=True)
datalad/distribution/tests/test_install.py:    repo.add('file.txt', commit=True, git=not annex)
datalad/distribution/tests/test_publish.py:                    commit=True, msg="Modified.")
datalad/distribution/tests/test_publish.py:                    commit=True, msg="Modified.")
datalad/distribution/tests/test_update.py:    rmt1.add("first.txt", commit=True)
datalad/distribution/tests/test_update.py:    rmt2.add("second.txt", git=True, commit=True, msg="Add file to git.")
datalad/interface/tests/test_ls_webui.py:    annex.add(opj(topdir, 'dir'), commit=True)
datalad/interface/tests/test_ls_webui.py:    git.add(opj(topdir, 'dir', 'subgit', 'fgit.txt'), commit=True)              # commit to git to init git repo
datalad/interface/tests/test_ls_webui.py:    annex.add(opj(topdir, 'dir', 'subgit'), commit=True)                        # add the non-dataset git repo to annex
datalad/interface/tests/test_ls_webui.py:    annex.add(opj(topdir, 'dir'), commit=True)                                  # add to annex (links)
datalad/interface/tests/test_run.py:    ds.repo.add(".", commit=True)
datalad/interface/tests/test_run.py:    ds.repo.add(["to_add"], commit=True)
datalad/interface/tests/test_run.py:    ds.repo.add(["to_modify", "d/to_modify"], commit=True)
datalad/support/tests/test_annexrepo.py:    annex.add(files, commit=True)
datalad/support/tests/test_annexrepo.py:    annex.add(files, commit=True)
datalad/support/tests/test_annexrepo.py:    repo.add(filename, commit=True, msg="Added another file to annex.")
datalad/support/tests/test_annexrepo.py:    repo.add(filename, git=True, commit=True,
datalad/support/tests/test_annexrepo.py:    sync_wrapper(pull=False, push=False, commit=True)
datalad/support/tests/test_annexrepo.py:    sub.add('fourth', commit=True, msg="birther mod init'ed")
datalad/support/tests/test_gitrepo.py:    added2 = gr.add(filename, commit=True, msg="Add two files.")
datalad/support/tests/test_gitrepo.py:    repo.add('.', commit=True)
datalad/support/tests/utils.py:    repo.add("testfile.txt", commit=True, msg="some load")
datalad/tests/utils.py:        repo.add(file_repo_path, commit=True, _datalad_msg=True)
```