### PR TITLE
Add progress logging to any metadata extractor when #2351 is merged

### DIFF
--- a/datalad/metadata/extractors/annex.py
+++ b/datalad/metadata/extractors/annex.py
@@ -12,6 +12,7 @@ from datalad.metadata.extractors.base import BaseMetadataExtractor
 
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.annexmeta')
+from datalad.log import log_progress
 
 from datalad.support.annexrepo import AnnexRepo
 # use main version as core version
@@ -24,7 +25,20 @@ class MetadataExtractor(BaseMetadataExtractor):
         return {}
 
     def _get_content_metadata(self):
+        log_progress(
+            lgr.info,
+            'extractorannex',
+            'Start annex metadata extraction from %s', self.ds,
+            total=len(self.paths),
+            label='Annex metadata extraction',
+            unit=' Files',
+        )
         if not isinstance(self.ds.repo, AnnexRepo):
+            log_progress(
+                lgr.info,
+                'extractorannex',
+                'Done annex metadata extraction from %s', self.ds
+            )
             return
 
         valid_paths = None
@@ -35,6 +49,17 @@ class MetadataExtractor(BaseMetadataExtractor):
             if file.startswith('.datalad') or valid_paths and file not in valid_paths:
                 # do not report on our own internal annexed files (e.g. metadata blobs)
                 continue
+            log_progress(
+                lgr.info,
+                'extractorannex',
+                'Extracted annex metadata from %s', file,
+                update=1,
+                increment=True)
             meta = {k: v[0] if isinstance(v, list) and len(v) == 1 else v
                     for k, v in meta.items()}
             yield (file, meta)
+        log_progress(
+            lgr.info,
+            'extractorannex',
+            'Done annex metadata extraction from %s', self.ds
+        )

--- a/datalad/metadata/extractors/annex.py
+++ b/datalad/metadata/extractors/annex.py
@@ -37,7 +37,7 @@ class MetadataExtractor(BaseMetadataExtractor):
             log_progress(
                 lgr.info,
                 'extractorannex',
-                'Done annex metadata extraction from %s', self.ds
+                'Finished annex metadata extraction from %s', self.ds
             )
             return
 
@@ -61,5 +61,5 @@ class MetadataExtractor(BaseMetadataExtractor):
         log_progress(
             lgr.info,
             'extractorannex',
-            'Done annex metadata extraction from %s', self.ds
+            'Finished annex metadata extraction from %s', self.ds
         )

--- a/datalad/metadata/extractors/audio.py
+++ b/datalad/metadata/extractors/audio.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 from os.path import join as opj
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.audio')
+from datalad.log import log_progress
 
 from mutagen import File as audiofile
 from datalad.metadata.definitions import vocabulary_id
@@ -39,9 +40,24 @@ class MetadataExtractor(BaseMetadataExtractor):
     def get_metadata(self, dataset, content):
         if not content:
             return {}, []
+        log_progress(
+            lgr.info,
+            'extractoraudio',
+            'Start audio metadata extraction from %s', self.ds,
+            total=len(self.paths),
+            label='audio metadata extraction',
+            unit=' Files',
+        )
         contentmeta = []
         for f in self.paths:
-            info = audiofile(opj(self.ds.path, f), easy=True)
+            absfp = opj(self.ds.path, f)
+            log_progress(
+                lgr.info,
+                'extractoraudio',
+                'Extract audio metadata from %s', absfp,
+                update=1,
+                increment=True)
+            info = audiofile(absfp, easy=True)
             if info is None:
                 continue
             meta = {vocab_map.get(k, k): info[k][0]
@@ -58,6 +74,11 @@ class MetadataExtractor(BaseMetadataExtractor):
                     meta[vocab_map.get(k, k)] = val
             contentmeta.append((f, meta))
 
+        log_progress(
+            lgr.info,
+            'extractoraudio',
+            'Finished audio metadata extraction from %s', self.ds
+        )
         return {
             '@context': {
                 'music': {

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -108,7 +108,7 @@ class MetadataExtractor(BaseMetadataExtractor):
             log_progress(
                 lgr.info,
                 'extractordataladcore',
-                'Extract core metadata from %s', file,
+                'Extracted core metadata from %s', file,
                 update=1,
                 increment=True)
             # pull out proper (public) URLs

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -92,7 +92,7 @@ class MetadataExtractor(BaseMetadataExtractor):
             log_progress(
                 lgr.info,
                 'extractordataladcore',
-                'Done core metadata extraction from %s', self.ds
+                'Finished core metadata extraction from %s', self.ds
             )
             return
         valid_paths = None
@@ -122,5 +122,5 @@ class MetadataExtractor(BaseMetadataExtractor):
         log_progress(
             lgr.info,
             'extractordataladcore',
-            'Done core metadata extraction from %s', self.ds
+            'Finished core metadata extraction from %s', self.ds
         )

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -12,6 +12,7 @@ from datalad.metadata.extractors.base import BaseMetadataExtractor
 
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.datalad_core')
+from datalad.log import log_progress
 
 from os.path import join as opj
 from os.path import exists
@@ -73,6 +74,14 @@ class MetadataExtractor(BaseMetadataExtractor):
         -------
         generator((location, metadata_dict))
         """
+        log_progress(
+            lgr.info,
+            'extractordataladcore',
+            'Start core metadata extraction from %s', self.ds,
+            total=len(self.paths),
+            label='Core metadata extraction',
+            unit=' Files',
+        )
         if not isinstance(self.ds.repo, AnnexRepo):
             for p in self.paths:
                 # this extractor does give a response for ANY file as it serves
@@ -80,6 +89,11 @@ class MetadataExtractor(BaseMetadataExtractor):
                 # content metadata, even if we know nothing but the filename
                 # about a file
                 yield (p, dict())
+            log_progress(
+                lgr.info,
+                'extractordataladcore',
+                'Done core metadata extraction from %s', self.ds
+            )
             return
         valid_paths = None
         if self.paths and sum(len(i) for i in self.paths) > 500000:
@@ -91,6 +105,12 @@ class MetadataExtractor(BaseMetadataExtractor):
             if file.startswith('.datalad') or valid_paths and file not in valid_paths:
                 # do not report on our own internal annexed files (e.g. metadata blobs)
                 continue
+            log_progress(
+                lgr.info,
+                'extractordataladcore',
+                'Extract core metadata from %s', file,
+                update=1,
+                increment=True)
             # pull out proper (public) URLs
             # TODO possibly extend with special remote info later on
             meta = {'url': whereis[remote].get('urls', [])
@@ -99,3 +119,8 @@ class MetadataExtractor(BaseMetadataExtractor):
                     if remote == "00000000-0000-0000-0000-000000000001" and
                     whereis[remote].get('urls', None)}
             yield (file, meta)
+        log_progress(
+            lgr.info,
+            'extractordataladcore',
+            'Done core metadata extraction from %s', self.ds
+        )

--- a/datalad/metadata/extractors/exif.py
+++ b/datalad/metadata/extractors/exif.py
@@ -11,6 +11,7 @@
 from os.path import join as opj
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.exif')
+from datalad.log import log_progress
 
 from exifread import process_file
 from datalad.metadata.definitions import vocabulary_id
@@ -34,8 +35,23 @@ class MetadataExtractor(BaseMetadataExtractor):
     def get_metadata(self, dataset, content):
         if not content:
             return {}, []
+        log_progress(
+            lgr.info,
+            'extractorexif',
+            'Start EXIF metadata extraction from %s', self.ds,
+            total=len(self.paths),
+            label='EXIF metadata extraction',
+            unit=' Files',
+        )
         contentmeta = []
         for f in self.paths:
+            absfp = opj(self.ds.path, f)
+            log_progress(
+                lgr.info,
+                'extractorexif',
+                'Extract EXIF metadata from %s', absfp,
+                update=1,
+                increment=True)
             # TODO we might want to do some more elaborate extraction in the future
             # but for now plain EXIF, no maker extensions, no thumbnails
             info = process_file(open(opj(self.ds.path, f), 'rb'), details=False)
@@ -46,6 +62,11 @@ class MetadataExtractor(BaseMetadataExtractor):
                     for k in info}
             contentmeta.append((f, meta))
 
+        log_progress(
+            lgr.info,
+            'extractorexif',
+            'Finished EXIF metadata extraction from %s', self.ds
+        )
         return {
             '@context': {
                 'exif': {

--- a/datalad/metadata/extractors/image.py
+++ b/datalad/metadata/extractors/image.py
@@ -11,6 +11,7 @@
 from os.path import join as opj
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.image')
+from datalad.log import log_progress
 
 from PIL import Image
 from datalad.metadata.extractors.base import BaseMetadataExtractor
@@ -57,13 +58,27 @@ class MetadataExtractor(BaseMetadataExtractor):
         if not content:
             return {}, []
         contentmeta = []
+        log_progress(
+            lgr.info,
+            'extractorimage',
+            'Start image metadata extraction from %s', self.ds,
+            total=len(self.paths),
+            label='image metadata extraction',
+            unit=' Files',
+        )
         for f in self.paths:
-            fpath = opj(self.ds.path, f)
+            absfp = opj(self.ds.path, f)
+            log_progress(
+                lgr.info,
+                'extractorimage',
+                'Extract image metadata from %s', absfp,
+                update=1,
+                increment=True)
             try:
-                img = Image.open(fpath)
+                img = Image.open(absfp)
             except Exception as e:
                 lgr.debug("Image metadata extractor failed to load %s: %s",
-                          fpath, exc_str(e))
+                          absfp, exc_str(e))
                 continue
             meta = {
                 'type': 'dctype:Image',
@@ -76,6 +91,11 @@ class MetadataExtractor(BaseMetadataExtractor):
                     if not (hasattr(v, '__len__') and not len(v))}
             contentmeta.append((f, meta))
 
+        log_progress(
+            lgr.info,
+            'extractorimage',
+            'Finished image metadata extraction from %s', self.ds
+        )
         return {
             '@context': vocabulary,
         }, \

--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -15,6 +15,7 @@ import re
 from os.path import join as opj
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.xmp')
+from datalad.log import log_progress
 
 from libxmp.utils import file_to_dict
 from datalad.metadata.definitions import vocabulary_id
@@ -31,8 +32,23 @@ class MetadataExtractor(BaseMetadataExtractor):
             return {}, []
         context = {}
         contentmeta = []
+        log_progress(
+            lgr.info,
+            'extractorxmp',
+            'Start XMP metadata extraction from %s', self.ds,
+            total=len(self.paths),
+            label='XMP metadata extraction',
+            unit=' Files',
+        )
         for f in self.paths:
-            info = file_to_dict(opj(self.ds.path, f))
+            absfp = opj(self.ds.path, f)
+            log_progress(
+                lgr.info,
+                'extractorxmp',
+                'Extract XMP metadata from %s', absfp,
+                update=1,
+                increment=True)
+            info = file_to_dict(absfp)
             if not info:
                 # got nothing, likely nothing there
                 # TODO check if this is an XMP sidecar file, parse that, and assign metadata
@@ -80,6 +96,11 @@ class MetadataExtractor(BaseMetadataExtractor):
 
             contentmeta.append((f, meta))
 
+        log_progress(
+            lgr.info,
+            'extractorxmp',
+            'Done XMP metadata extraction from %s', self.ds
+        )
         return {
             '@context': context,
         }, \

--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -99,7 +99,7 @@ class MetadataExtractor(BaseMetadataExtractor):
         log_progress(
             lgr.info,
             'extractorxmp',
-            'Done XMP metadata extraction from %s', self.ds
+            'Finished XMP metadata extraction from %s', self.ds
         )
         return {
             '@context': context,


### PR DESCRIPTION
All file metadata extractor loop over a given list of files -- ideal for progress logging.
Actually, there could be an output progress bar that tracks the extractors that already ran -- if more than one is scheduled.