### PR TITLE
provide basic appveyor setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ environment:
       MINICONDA: C:\Miniconda35
       DATALAD_TESTS_SSH: 0
 
+cache:
+  # cache the pip cache
+  - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor.yml
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
   # this will display login RDP info for the build VM, but if the build VM should block
@@ -30,7 +34,7 @@ install:
   - python -c "import sys; print(sys.path)"
   # when something works we can go full
   #- pip install -e ".[full]"
-  - pip install "."
+  - pip install ".[tests]"
   # fixup
   # ATM datalad does not pull in colorama, which is needed for color output
   # on windows
@@ -47,8 +51,10 @@ test_script:
   - git annex version
   # first sign of life
   - datalad wtf
-  # and now this...
-  #- python -m nose -s -v datalad.distribution.tests.test_create
+  # and now this... [keep appending tests that should work!!]
+  # this is not good!
+  # - python -m nose -s -v datalad.plugin
+  - python -m nose -s -v datalad.cmdline datalad.tests.test_api datalad.tests.test_base datalad.ui
 
 #after_test:
 #  - bash <(curl -s https://codecov.io/bash)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,57 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.1"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda35
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+  # this will display login RDP info for the build VM, but if the build VM should block
+  # see on_finish below instead
+  #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  #- "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib pytest pandas"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION%"
+  - activate test-environment
+  - mkdir resources
+  - appveyor DownloadFile https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -FileName resources\git-annex-installer.exe
+  # extract git annex into the system Git installation path
+  - 7z x -o"C:\\Program Files\Git" resources\git-annex-installer.exe
+  # info on how python is ticking
+  - python -c "import sys; print(sys.path)"
+  # when something works we can go full
+  #- pip install -e ".[full]"
+  - pip install "."
+  # fixup
+  # ATM datalad does not pull in colorama, which is needed for color output
+  # on windows
+  - pip install colorama
+
+test_script:
+  # establish baseline, if annex doesn't work, we are not even trying
+  #- git annex test
+  # run tests on installed module, not source tree files
+  - mkdir -p __testhome__
+  - cd __testhome__
+  # report basic info
+  - git version
+  - git annex version
+  # first sign of life
+  - datalad wtf
+  # and now this...
+  #- python -m nose -s -v datalad.distribution.tests.test_create
+
+#after_test:
+#  - bash <(curl -s https://codecov.io/bash)
+
+on_finish:
+  # enable the next to let the build VM block for up to 60min to log in via RDP and debug
+  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda35
+      DATALAD_TESTS_SSH: 0
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -10,6 +10,7 @@
 
 from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
+from datalad.tests.utils import skip_if_on_windows
 
 
 import re
@@ -160,6 +161,7 @@ def test_incorrect_options():
     yield check_incorrect_option, tuple(), err_insufficient
 
 
+@skip_if_on_windows
 def test_script_shims():
     runner = Runner()
     for script in [

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -196,7 +196,12 @@ def test_cfg_override(path):
         # ensure that this is not a dataset's cfg manager
         assert_not_in('datalad.dataset.id', out)
         # env var
-        out, err = Runner()('DATALAD_DUMMY=this datalad wtf -s some', shell=True)
+        from datalad.utils import on_windows
+        if on_windows:
+            cmd_str = 'set DATALAD_DUMMY=this&& datalad wtf -s some'
+        else:
+            cmd_str = 'DATALAD_DUMMY=this datalad wtf -s some'
+        out, err = Runner()(cmd_str, shell=True)
         assert_in('datalad.dummy: this', out)
         # cmdline arg
         out, err = Runner()('datalad -c datalad.dummy=this wtf -s some', shell=True)
@@ -211,7 +216,11 @@ def test_cfg_override(path):
         # ensure that this is a dataset's cfg manager
         assert_in('datalad.dataset.id', out)
         # env var
-        out, err = Runner()('DATALAD_DUMMY=this datalad wtf -s some', shell=True)
+        if on_windows:
+            cmd_str = 'set DATALAD_DUMMY=this&& datalad wtf -s some'
+        else:
+            cmd_str = 'DATALAD_DUMMY=this datalad wtf -s some'
+        out, err = Runner()(cmd_str, shell=True)
         assert_in('datalad.dummy: this', out)
         # cmdline arg
         out, err = Runner()('datalad -c datalad.dummy=this wtf -s some', shell=True)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -178,12 +178,14 @@ def create_tree(path, tree, archives_leading_dir=True):
             else:
                 create_tree(full_name, load, archives_leading_dir=archives_leading_dir)
         else:
-            #encoding = sys.getfilesystemencoding()
-            #if isinstance(full_name, text_type):
-            #    import pydb; pydb.debugger()
-            with open(full_name, 'w') as f:
-                if PY2 and isinstance(load, text_type):
+            if PY2:
+                open_kwargs = {'mode': "w"}
+                if isinstance(load, text_type):
                     load = load.encode('utf-8')
+            else:
+                open_kwargs = {'mode': "w", 'encoding': "utf-8"}
+
+            with open(full_name, **open_kwargs) as f:
                 f.write(load)
         if executable:
             os.chmod(full_name, os.stat(full_name).st_mode | stat.S_IEXEC)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -267,8 +267,12 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
             lgr.warning("head_modified and index_modified are not supported "
                         "for direct mode repositories!")
         else:
-            ok_(not r.is_dirty(untracked_files=not untracked,
-                               submodules=not ignore_submodules))
+            test_untracked = not untracked
+            test_submodules = not ignore_submodules
+            ok_(not r.is_dirty(untracked_files=test_untracked,
+                               submodules=test_submodules),
+                msg="Repo unexpectly dirty (tested for: untracked({}), submodules({})".format(
+                    test_untracked, test_submodules))
     else:
         repo = r.repo
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1610,7 +1610,7 @@ def import_module_from_file(modpath, pkg=None, log=lgr.debug):
         for pkgpath in pkg.__path__:
             if path_is_subpath(modpath, pkgpath):
                 # for now relying on having .py extension -- assertion above
-                relmodpath = '.' + relpath(modpath[:-3], pkgpath).replace('/', '.')
+                relmodpath = '.' + relpath(modpath[:-3], pkgpath).replace(sep, '.')
                 break
 
     try:


### PR DESCRIPTION
Summary after a long time:

This should be merged ASAP, because we are going backwards on windows and we are not aware of it.

All this does (besides few fixes) is do a basic installation on windows and run `wtf` to see if anything works.

Future changes should slowly introduce stuff that out to work to the
    tests


----

and now the stuff from January....


#### What is the problem?
With all the annotations of tests which fail in direct and v6 modes, may be it is feasible now to approach having testing done on windows as well, and I think appveyor would be a good free service for that purpose ;)  It could help to catch issues "spawning" from windows origins, such as the one reported in https://github.com/datalad/datalad/pull/2066 