### PR TITLE
RF: addurls: Use log_progress

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -21,6 +21,7 @@ from six import string_types
 from six.moves.urllib.parse import urlparse
 
 from datalad.dochelpers import exc_str
+from datalad.log import log_progress
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.interface.results import annexjson2result, get_status_dict
@@ -29,7 +30,6 @@ from datalad.support import ansi_colors
 from datalad.support.exceptions import AnnexBatchCommandError
 from datalad.support.network import get_url_filename
 from datalad.support.s3 import get_versioned_url
-from datalad.ui import ui
 from datalad.utils import assure_list, optional_args
 
 lgr = logging.getLogger("datalad.plugin.addurls")
@@ -383,8 +383,11 @@ def add_extra_filename_values(filename_format, rows, urls, dry_run):
                 row.update(
                     {k: v + str(idx) for k, v in dummy.items()})
         else:
-            pbar = ui.get_progressbar(total=len(urls),
-                                      label="Requesting names", unit=" Files")
+            num_urls = len(urls)
+            log_progress(lgr.info, "addurls_requestnames",
+                         "Requesting file names for %d URLs", num_urls,
+                         label="Requesting names", total=num_urls,
+                         unit=" Files")
             for row, url in zip(rows, urls):
                 # If we run into any issues here, we're just going to raise an
                 # exception and then abort inside dlplugin.  It'd be good to
@@ -396,8 +399,11 @@ def add_extra_filename_values(filename_format, rows, urls, dry_run):
                 else:
                     raise ValueError(
                         "{} does not contain a filename".format(url))
-                pbar.update(1, increment=True)
-            pbar.finish()
+                log_progress(lgr.info, "addurls_requestnames",
+                             "%s returned for %s", url, filename,
+                             update=1, increment=True)
+            log_progress(lgr.info, "addurls_requestnames",
+                         "Finished requesting file names")
 
 
 def extract(stream, input_type, url_format="{0}", filename_format="{1}",
@@ -482,7 +488,7 @@ def progress(fn, label="Total", unit="Files"):
         processing each item in the collection, it should yield a status
         dict.
     label, unit : str
-        Passed to ui.get_progressbar.
+        Passed to log.log_progress.
 
     Returns
     -------
@@ -500,24 +506,36 @@ def progress(fn, label="Total", unit="Files"):
                 msg = ansi_colors.color_word(msg, ansi_colors.RED)
             return msg
 
+    pid = str(fn)
+    base_label = label
+
     def wrapped(items, **kwargs):
         counts = defaultdict(int)
-        pbar = ui.get_progressbar(total=len(items),
-                                  label=label, unit=" " + unit)
+
+        label = base_label
+        log_progress(lgr.info, pid,
+                     "%s: starting", label,
+                     total=len(items), label=label, unit=" " + unit)
+
         results = []
         for res in fn(items, **kwargs):
             counts[res["status"]] += 1
             count_strs = (count_str(*args)
                           for args in [(counts["notneeded"], "skipped", False),
                                        (counts["error"], "failed", True)])
-            pbar.update(1, increment=True)
             if counts["notneeded"] or counts["error"]:
-                pbar.set_desc("{label} ({counts})".format(
-                    label=label,
-                    counts=", ".join(filter(None, count_strs))))
-            pbar.refresh()
+                label = "{} ({})".format(
+                    base_label,
+                    ", ".join(filter(None, count_strs)))
+
+            log_progress(
+                lgr.error if res["status"] == "error" else lgr.info,
+                pid,
+                "%s: processed result%s", base_label,
+                " for " + res["path"] if "path" in res else "",
+                label=label, update=1, increment=True)
             results.append(res)
-        pbar.finish()
+        log_progress(lgr.info, pid, "%s: done", base_label)
         return results
     return wrapped
 
@@ -863,12 +881,15 @@ class Addurls(Interface):
                         "ds_filename": ds_filename})
 
         if version_urls:
-            lgr.info("Versioning URLs")
-            pbar = ui.get_progressbar(total=len(rows),
-                                      label="Versioning URLs", unit=" URLs")
+            num_urls = len(rows)
+            log_progress(lgr.info, "addurls_versionurls",
+                         "Versioning %d URLs", num_urls,
+                         label="Versioning URLs",
+                         total=num_urls, unit=" URLs")
             for row in rows:
+                url = row["url"]
                 try:
-                    row["url"] = get_versioned_url(row["url"])
+                    row["url"] = get_versioned_url(url)
                 except (ValueError, NotImplementedError) as exc:
                     # We don't expect this to happen because get_versioned_url
                     # should return the original URL if it isn't an S3 bucket.
@@ -876,8 +897,10 @@ class Addurls(Interface):
                     # handle the scheme for what looks like an S3 bucket.
                     lgr.warning("error getting version of %s: %s",
                                 row["url"], exc_str(exc))
-                pbar.update(1, increment=True)
-            pbar.finish()
+                log_progress(lgr.info, "addurls_versionurls",
+                             "Versioned result for %s: %s", url, row["url"],
+                             update=1, increment=True)
+            log_progress(lgr.info, "addurls_versionurls", "Finished versioning URLs")
 
         files_to_add = set()
         for r in add_urls(rows, ifexists=ifexists, options=annex_options):

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -477,7 +477,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
 
 
 @optional_args
-def progress(fn, label="Total", unit="Files"):
+def progress(fn, label="Total", unit=" Files"):
     """Wrap a progress bar, with status counts, around a function.
 
     Parameters
@@ -515,7 +515,7 @@ def progress(fn, label="Total", unit="Files"):
         label = base_label
         log_progress(lgr.info, pid,
                      "%s: starting", label,
-                     total=len(items), label=label, unit=" " + unit)
+                     total=len(items), label=label, unit=unit)
 
         results = []
         for res in fn(items, **kwargs):

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -477,7 +477,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
 
 
 @optional_args
-def progress(fn, label="Total", unit=" Files"):
+def with_result_progress(fn, label="Total", unit=" Files"):
     """Wrap a progress bar, with status counts, around a function.
 
     Parameters
@@ -540,7 +540,7 @@ def progress(fn, label="Total", unit=" Files"):
     return wrapped
 
 
-@progress("Adding URLs")
+@with_result_progress("Adding URLs")
 def add_urls(rows, ifexists=None, options=None):
     """Call `git annex addurl` using information in `rows`.
     """
@@ -582,7 +582,7 @@ def add_urls(rows, ifexists=None, options=None):
                                   status="ok")
 
 
-@progress("Adding metadata")
+@with_result_progress("Adding metadata")
 def add_meta(rows):
     """Call `git annex metadata --set` using information in `rows`.
     """


### PR DESCRIPTION
This pull request

  * updates addurls to use the new `log_progress` helper added in #2351

  * moves addurl's progress decorator to log.py

    Its purpose is to wrap a function that yields result dicts with a progress bar in order to 1) delay the display of the results while the status bar is being updated and 2) check the dict for a status of "notneeded"/"error" and display these counts in the bar's description.

    It should be moved somewhere more general because it's not specific to addurls.  I chose log.py because it now uses `log_progress`.

---

- [x] This change is complete
