### PR TITLE
BF: Direct mode git-add

### DIFF
--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -422,7 +422,6 @@ def test_autoresolve_multiple_datasets(src, path):
 @slow  # 20 sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_get_autoresolve_recurse_subdatasets(src, path):
 
     origin = Dataset(src).create()
@@ -450,7 +449,6 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
 @slow  # 92sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_recurse_existing(src, path):
     origin_ds = _make_dataset_hierarchy(src)
 
@@ -493,7 +491,6 @@ def test_recurse_existing(src, path):
 @slow  # 33sec
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_get_in_unavailable_subdataset(src, path):
     _make_dataset_hierarchy(src)
     root = install(

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -80,7 +80,6 @@ def test_invalid_call(path):
 @slow  # 15.3509s
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -231,7 +231,6 @@ def test_rerun_onto(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_rerun_chain(path):
     ds = Dataset(path).create()
@@ -301,7 +300,6 @@ def test_rerun_just_one_commit(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_run_failure(path):
     ds = Dataset(path).create()
@@ -393,7 +391,6 @@ def test_rerun_branch(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()
@@ -413,7 +410,6 @@ def test_rerun_cherry_pick(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_rerun_outofdate_tree(path):
     ds = Dataset(path).create()
@@ -434,7 +430,6 @@ def test_rerun_outofdate_tree(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_rerun_ambiguous_revision_file(path):
     ds = Dataset(path).create()
@@ -532,7 +527,6 @@ def test_new_or_modified(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_script(path):
     ds = Dataset(path).create()
     ds.run("echo a >foo", message='FOO')

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -309,7 +309,6 @@ def test_result_filter():
 
 @with_tree({k: v for k, v in demo_hierarchy.items() if k in ['a', 'd']})
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_discover_ds_trace(path, otherdir):
     ds = make_demo_hierarchy_datasets(
         path,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1510,7 +1510,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             # explicitly use git-add with --update instead of git-annex-add
             # TODO: This might still need some work, when --update AND files
             # are specified!
-            if self.is_direct_mode():
+            if self.is_direct_mode() and not files:
                 self.GIT_DIRECT_MODE_PROXY = True
             try:
                 return_list = super(AnnexRepo, self).add(
@@ -1524,7 +1524,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                                            _datalad_msg=_datalad_msg,
                                            update=update)
             finally:
-                if self.is_direct_mode():
+                if self.is_direct_mode() and not files:
                     # don't accidentally cause other git calls to be done
                     # via annex-proxy
                     self.GIT_DIRECT_MODE_PROXY = False


### PR DESCRIPTION
This pull request fixes certain cases of adding things (particularly submodules) to git in direct mode.
Note that it removes 12 `known_failure_direct_mode` markers.

### Changes
- [x] This change is complete

Please have a look @datalad/developers
