### PR TITLE
coverage for (all) plugins code is reported at 0%

### DIFF
--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -16,17 +16,19 @@ import logging
 from glob import glob
 from os.path import join as opj, basename, dirname
 
+import datalad
 from datalad import cfg
 from datalad.dochelpers import exc_str
 
 lgr = logging.getLogger('datalad.plugin')
 
+BUILTIN_PLUGINS_PATH = dirname(__file__)
 magic_plugin_symbol = '__datalad_plugin__'
 
 
 def _get_plugins():
     locations = (
-        dirname(__file__),
+        BUILTIN_PLUGINS_PATH,
         cfg.obtain('datalad.locations.system-plugins'),
         cfg.obtain('datalad.locations.user-plugins'))
     for plugindir in locations:
@@ -37,7 +39,7 @@ def _get_plugins():
 def _load_plugin(filepath, fail=True):
     from datalad.utils import import_module_from_file
     try:
-        mod = import_module_from_file(filepath)
+        mod = import_module_from_file(filepath, pkg=datalad)
     except Exception as e:
         # any exception means full stop
         raise ValueError('plugin at {} is broken: {}'.format(


### PR DESCRIPTION
#### What is the problem?
Initially (or not for someone else) was spotted in #2382 that even though tests run/fail, coverage is reported at 0%:
```
datalad/plugin/__init__.py                                   27      7    74%
datalad/plugin/add_readme.py                                 61     61     0%
datalad/plugin/addurls.py                                   332    332     0%
datalad/plugin/check_dates.py                                72     72     0%
datalad/plugin/export_archive.py                             67     67     0%
datalad/plugin/export_to_figshare.py                        137    137     0%
datalad/plugin/extract_metadata.py                           38     38     0%
datalad/plugin/no_annex.py                                   49     49     0%
datalad/plugin/wtf.py                                        94     94     0%
```
Testing with coverage locally though reports correctly.  Wild guesses about possible causes:
- ~~Out of codebase testing somehow picks up plugin files within original (under git) sources? (should be easy to test locally)~~
- ~~some outdated coverage etc which doesn't work nicely with our way to import/load plugins~~
- Our (my) fault ;)