### PR TITLE
ENH: Add --input flag

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -321,9 +321,9 @@ class Rerun(Interface):
                     yield r
 
                 for r in run_command(run_info['cmd'],
-                                     ds,
-                                     run_info.get("inputs", []),
-                                     message or rev["run_message"],
+                                     dataset=ds,
+                                     inputs=run_info.get("inputs", []),
+                                     message=message or rev["run_message"],
                                      rerun_info=run_info):
                     yield r
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -321,7 +321,9 @@ class Rerun(Interface):
                     yield r
 
                 for r in run_command(run_info['cmd'],
-                                     ds, message or rev["run_message"],
+                                     ds,
+                                     run_info.get("inputs", []),
+                                     message or rev["run_message"],
                                      rerun_info=run_info):
                     yield r
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -70,6 +70,11 @@ class Rerun(Interface):
         % # now on verify branch
         % datalad diff --revision=master..
         % git log --oneline --left-right --cherry-pick master...
+
+    .. note::
+      Currently the "onto" feature only sets the working tree of the current
+      dataset to a previous state. The working trees of any subdatasets remain
+      unchanged.
     """
     _params_ = dict(
         revision=Parameter(

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -323,6 +323,7 @@ class Rerun(Interface):
                 for r in run_command(run_info['cmd'],
                                      dataset=ds,
                                      inputs=run_info.get("inputs", []),
+                                     outputs=run_info.get("outputs", []),
                                      message=message or rev["run_message"],
                                      rerun_info=run_info):
                     yield r

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -94,14 +94,15 @@ class Run(Interface):
             metavar=("PATH"),
             action='append',
             doc="""A dependency for the run. Before running the command, the
-            content of this file will be retrieved. If the value doesn't match
-            any known annex file, it will be treated as a glob and passed to
-            :command:`git annex find --include=`. The value should be specified
-            relative to the top-level directory of the current dataset. Using
-            '*' for this value means "all current annex files". Note: Globbing
-            currently only considers the current dataset, not any subdatasets.
-            [CMD: This option can be given more than once.
-            CMD]"""),
+            content of this file will be retrieved. A value of "." means "run
+            :command:`datalad get .`", and any other values given are ignored.
+            If the value doesn't match any known annex file, it will be treated
+            as a glob and passed to :command:`git annex find --include=`. The
+            value should be specified relative to the top-level directory of
+            the current dataset. Using '*' for this value means "all current
+            annex files". Note: Globbing currently only considers the current
+            dataset, not any subdatasets. [CMD: This option can be given more
+            than once. CMD]"""),
         outputs=Parameter(
             args=("--output",),
             dest="outputs",
@@ -204,6 +205,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None,
 
     if inputs is None:
         inputs = []
+    elif any(i.strip() == "." for i in inputs):
+        inputs = ["."]
+        for res in ds.get(inputs):
+            yield res
     elif inputs:
         if not rerun_info:
             inputs = _resolve_files(ds, inputs)

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -148,6 +148,15 @@ class Run(Interface):
 
 def _resolve_files(dset, globs_or_files):
     """Expand --include globs in `globs_or_files` to file names.
+
+    Parameters
+    ----------
+    dset : GitRepo
+    globs_or_files : iterable
+
+    Returns
+    -------
+    List of paths, with globs expanded.
     """
     if not isinstance(dset.repo, AnnexRepo):
         return []

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -123,7 +123,8 @@ class Run(Interface):
                 yield r
         else:
             if cmd:
-                for r in run_command(cmd, dataset, inputs, message):
+                for r in run_command(cmd, dataset=dataset,
+                                     inputs=inputs, message=message):
                     yield r
             else:
                 lgr.warning("No command given")

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -175,15 +175,6 @@ def run_command(cmd, dataset=None, inputs=None, message=None, rerun_info=None):
     # not needed ATM
     #refds_path = ds.path
 
-    if inputs is None:
-        inputs = []
-    else:
-        inputs = _resolve_files(ds, inputs)
-        if not inputs:
-            lgr.warning("No matching files found for --input")
-        for res in ds.get(inputs):
-            yield res
-
     # delayed imports
     from datalad.cmd import Runner
 
@@ -196,6 +187,15 @@ def run_command(cmd, dataset=None, inputs=None, message=None, rerun_info=None):
             message=('unsaved modifications present, '
                      'cannot detect changes by command'))
         return
+
+    if inputs is None:
+        inputs = []
+    else:
+        inputs = _resolve_files(ds, inputs)
+        if not inputs:
+            lgr.warning("No matching files found for --input")
+        for res in ds.get(inputs):
+            yield res
 
     # anticipate quoted compound shell commands
     cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -195,8 +195,9 @@ def run_command(cmd, dataset=None, inputs=None, message=None, rerun_info=None):
             inputs = _resolve_files(ds, inputs)
         if not inputs:
             lgr.warning("No matching files found for --input")
-        for res in ds.get(inputs):
-            yield res
+        else:
+            for res in ds.get(inputs):
+                yield res
 
     # anticipate quoted compound shell commands
     cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -26,6 +26,7 @@ from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.interface.common_opts import save_message_opt
 
+from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureNone
 from datalad.support.exceptions import CommandError
 from datalad.support.param import Parameter
@@ -148,6 +149,9 @@ class Run(Interface):
 def _resolve_files(dset, globs_or_files):
     """Expand --include globs in `globs_or_files` to file names.
     """
+    if not isinstance(dset.repo, AnnexRepo):
+        return []
+
     globs, files = partition(
         globs_or_files,
         lambda f: dset.repo.is_under_annex([f], batch=True)[0])

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -201,19 +201,17 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None,
     if inputs is None:
         inputs = []
     elif inputs:
-        if not rerun_info:
-            inputs = _expand_globs(inputs, root_path=rel_pwd)
-        if inputs:
-            for res in ds.get(inputs):
+        inputs_expanded = _expand_globs(inputs, root_path=rel_pwd)
+        if inputs_expanded:
+            for res in ds.get(inputs_expanded):
                 yield res
 
     if outputs is None:
         outputs = []
     elif outputs:
-        if not rerun_info:
-            outputs = _expand_globs(outputs, root_path=rel_pwd)
-        if outputs:
-            for res in ds.unlock(outputs, on_failure="ignore"):
+        outputs_expanded = _expand_globs(outputs, root_path=rel_pwd)
+        if outputs_expanded:
+            for res in ds.unlock(outputs_expanded, on_failure="ignore"):
                 if res["status"] == "impossible":
                     if "no content" in res["message"]:
                         for rem_res in ds.remove(res["path"],

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -214,7 +214,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     elif inputs:
         inputs_expanded = _expand_globs(inputs, pwd)
         if inputs_expanded:
-            for res in ds.get(inputs_expanded):
+            for res in ds.get(inputs_expanded, on_failure="ignore"):
                 yield res
             if expand in ["inputs", "both"]:
                 inputs = inputs_expanded

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -152,14 +152,14 @@ class Run(Interface):
                 lgr.warning("No command given")
 
 
-def _expand_globs(patterns, root_path=""):
+def _expand_globs(patterns, root_path="", warn=True):
     patterns, dots = partition(patterns, lambda i: i.strip() == ".")
     expanded = ["."] if list(dots) else []
     for pattern in patterns:
         hits = glob(pattern)
         if hits:
             expanded.extend([opj(root_path, p) for p in hits])
-        else:
+        elif warn:
             lgr.warning("No matching files found for %s", pattern)
     return expanded
 
@@ -220,7 +220,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     if outputs is None:
         outputs = []
     elif outputs:
-        outputs_expanded = _expand_globs(outputs, root_path=rel_pwd)
+        outputs_expanded = _expand_globs(outputs, root_path=rel_pwd,
+                                         warn=not rerun_info)
         if outputs_expanded:
             for res in ds.unlock(outputs_expanded, on_failure="ignore"):
                 if res["status"] == "impossible":

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -90,9 +90,9 @@ class Run(Interface):
             any known annex file, it will be treated as a glob and passed to
             :command:`git annex find --include=`. The value should be specified
             relative to the top-level directory of the current dataset. Using
-            '*' for this value means "all current annex files". Note: This
-            operation currently only considers the current dataset, not any
-            subdatasets. [CMD: This option can be given more than once.
+            '*' for this value means "all current annex files". Note: Globbing
+            currently only considers the current dataset, not any subdatasets.
+            [CMD: This option can be given more than once.
             CMD]"""),
         message=save_message_opt,
         rerun=Parameter(

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -17,6 +17,7 @@ import json
 from argparse import REMAINDER
 from os.path import join as opj
 from os.path import curdir
+from os.path import isdir
 from os.path import normpath
 from os.path import relpath
 
@@ -158,12 +159,14 @@ def _resolve_files(dset, globs_or_files):
     -------
     List of paths, with globs expanded.
     """
+    maybe_globs, dirs = partition(globs_or_files,
+                                  lambda p: isdir(opj(dset.path, p)))
     globs, files = partition(
-        globs_or_files,
+        maybe_globs,
         lambda f: dset.repo.is_under_annex([f], batch=True)[0])
     globs, files = list(globs), list(files)
     globbed = dset.repo.get_annexed_files(patterns=globs) if globs else []
-    return files + globbed
+    return list(dirs) + files + globbed
 
 
 # This helper function is used to add the rerun_info argument.

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -54,13 +54,6 @@ def _format_cmd_shorty(cmd):
     return cmd_shorty
 
 
-def _partition(items, predicate=bool):
-    """Like utils.partition, but return a tuple of lists, not generators.
-    """
-    no, yes = partition(items, predicate)
-    return list(no), list(yes)
-
-
 @build_doc
 class Run(Interface):
     """Run an arbitrary command and record its impact on a dataset.
@@ -155,9 +148,10 @@ class Run(Interface):
 def _resolve_files(dset, globs_or_files):
     """Expand --include globs in `globs_or_files` to file names.
     """
-    globs, files = _partition(
+    globs, files = partition(
         globs_or_files,
         lambda f: dset.repo.is_under_annex([f], batch=True)[0])
+    globs, files = list(globs), list(files)
     globbed = dset.repo.get_annexed_files(patterns=globs) if globs else []
     return files + globbed
 

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -283,7 +283,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None,
         'exit': cmd_exitcode if cmd_exitcode is not None else 0,
         'chain': rerun_info["chain"] if rerun_info else [],
         'inputs': inputs,
-        'outputs': outputs
+        # Get outputs from the rerun_info because rerun adds new/modified files
+        # to the outputs argument.
+        'outputs': rerun_info["outputs"] if rerun_info else outputs
     }
     if rel_pwd is not None:
         # only when inside the dataset to not leak information

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -52,6 +52,13 @@ def _format_cmd_shorty(cmd):
     return cmd_shorty
 
 
+def _partition(items, predicate=bool):
+    """Like utils.partition, but return a tuple of lists, not generators.
+    """
+    no, yes = partition(items, predicate)
+    return list(no), list(yes)
+
+
 @build_doc
 class Run(Interface):
     """Run an arbitrary command and record its impact on a dataset.
@@ -133,10 +140,9 @@ class Run(Interface):
 def _resolve_files(dset, globs_or_files):
     """Expand --include globs in `globs_or_files` to file names.
     """
-    globs, files = partition(
+    globs, files = _partition(
         globs_or_files,
         lambda f: dset.repo.is_under_annex([f], batch=True)[0])
-    globs, files = list(globs), list(files)
     globbed = dset.repo.get_annexed_files(patterns=globs) if globs else []
     return files + globbed
 

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -190,7 +190,7 @@ def run_command(cmd, dataset=None, inputs=None, message=None, rerun_info=None):
 
     if inputs is None:
         inputs = []
-    else:
+    elif inputs:
         inputs = _resolve_files(ds, inputs)
         if not inputs:
             lgr.warning("No matching files found for --input")

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -151,16 +151,13 @@ def _resolve_files(dset, globs_or_files):
 
     Parameters
     ----------
-    dset : GitRepo
+    dset : AnnexRepo
     globs_or_files : iterable
 
     Returns
     -------
     List of paths, with globs expanded.
     """
-    if not isinstance(dset.repo, AnnexRepo):
-        return []
-
     globs, files = partition(
         globs_or_files,
         lambda f: dset.repo.is_under_annex([f], batch=True)[0])
@@ -195,6 +192,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None,
     ds = require_dataset(
         dataset, check_installed=True,
         purpose='tracking outcomes of a command')
+    is_annex = isinstance(ds.repo, AnnexRepo)
+
     # not needed ATM
     #refds_path = ds.path
 
@@ -211,7 +210,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None,
                      'cannot detect changes by command'))
         return
 
-    if inputs is None:
+    if inputs is None or not is_annex:
         inputs = []
     elif any(i.strip() == "." for i in inputs):
         inputs = ["."]
@@ -226,7 +225,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None,
             for res in ds.get(inputs):
                 yield res
 
-    if outputs is None:
+    if outputs is None or not is_annex:
         outputs = []
     elif outputs:
         if not rerun_info:

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -130,17 +130,15 @@ class Run(Interface):
                 lgr.warning("No command given")
 
 
-def _resolve_inputs(dset, inputs):
-    """Expand --include globs in `inputs` to file names.
+def _resolve_files(dset, globs_or_files):
+    """Expand --include globs in `globs_or_files` to file names.
     """
-    globs, file_inputs = partition(
-        inputs,
+    globs, files = partition(
+        globs_or_files,
         lambda f: dset.repo.is_under_annex([f], batch=True)[0])
-    globs, file_inputs = list(globs), list(file_inputs)
-
-    glob_inputs = dset.repo.get_annexed_files(patterns=globs) if globs else []
-
-    return file_inputs + glob_inputs
+    globs, files = list(globs), list(files)
+    globbed = dset.repo.get_annexed_files(patterns=globs) if globs else []
+    return files + globbed
 
 
 # This helper function is used to add the rerun_info argument.
@@ -174,7 +172,7 @@ def run_command(cmd, dataset=None, inputs=None, message=None, rerun_info=None):
     if inputs is None:
         inputs = []
     else:
-        inputs = _resolve_inputs(ds, inputs)
+        inputs = _resolve_files(ds, inputs)
         if not inputs:
             lgr.warning("No matching files found for --input")
         for res in ds.get(inputs):

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -191,7 +191,8 @@ def run_command(cmd, dataset=None, inputs=None, message=None, rerun_info=None):
     if inputs is None:
         inputs = []
     elif inputs:
-        inputs = _resolve_files(ds, inputs)
+        if not rerun_info:
+            inputs = _resolve_files(ds, inputs)
         if not inputs:
             lgr.warning("No matching files found for --input")
         for res in ds.get(inputs):

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -404,7 +404,11 @@ def test_rerun_cherry_pick(path):
     for onto, text in [("HEAD", "skipping"), ("prerun", "cherry picking")]:
         results = ds.rerun(since="prerun", onto=onto)
         assert_in_results(results, status='ok', path=ds.path)
-        assert any(r.get("message", "").endswith(text) for r in results)
+
+        messages = (r.get("message", "") for r in results)
+        # Message may be a tuple.
+        messages = (m for m in messages if hasattr(m, "endswith"))
+        assert any(m.endswith(text) for m in messages)
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -617,7 +617,8 @@ def test_run_inputs_outputs(path):
 
             ds.run("touch dummy{}".format(idx), inputs=inputs_arg)
             ok_(all(ds.repo.file_has_content(f) for f in expected_present))
-
+            # Globs are stored unexpanded by default.
+            assert_in(inputs_arg[0], ds.repo.repo.head.commit.message)
             ds.repo.drop(inputs, options=["--force"])
 
         # --input can be passed a subdirectory.
@@ -670,6 +671,11 @@ def test_run_inputs_outputs(path):
         ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
         ds.drop("sub/subfile", check=False)
         ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
+
+        # --input/--output globs can be stored in expanded form.
+        ds.run("touch expand-dummy", inputs=["a.*"], outputs=["b.*"], expand="both")
+        assert_in("a.dat", ds.repo.repo.head.commit.message)
+        assert_in("b.dat", ds.repo.repo.head.commit.message)
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -659,6 +659,16 @@ def test_run_inputs_outputs(path):
     ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
 
 
+@ignore_nose_capturing_stdout
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+def test_run_inputs_no_annex_repo(path):
+    ds = Dataset(path).create(no_annex=True)
+    # Running --input in a plain Git repo doesn't fail.
+    ds.run("touch dummy", inputs=["*"])
+    ok_exists(opj(ds.path, "dummy"))
+    ds.rerun()
+
 def test_rerun_commit_message_check():
     assert_raises(ValueError,
                   get_run_info,

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -578,94 +578,98 @@ def test_run_inputs_outputs(path):
 
     assert_false(ds.repo.file_has_content("test-annex.dat"))
 
-    # If we specify test-annex.dat as an input, it will be retrieved before the
-    # run.
-    ds.run("cat test-annex.dat test-annex.dat >doubled.dat",
-           inputs=["test-annex.dat"])
+    # We need to change directories for input/output globbing.
+    with chpwd(path):
+        # If we specify test-annex.dat as an input, it will be retrieved before
+        # the run.
+        ds.run("cat test-annex.dat test-annex.dat >doubled.dat",
+               inputs=["test-annex.dat"])
 
-    ok_clean_git(ds.path)
-    ok_(ds.repo.file_has_content("test-annex.dat"))
-    ok_(ds.repo.file_has_content("doubled.dat"))
+        ok_clean_git(ds.path)
+        ok_(ds.repo.file_has_content("test-annex.dat"))
+        ok_(ds.repo.file_has_content("doubled.dat"))
 
-    # Rerunning the commit will also get the input file.
-    ds.repo.drop("test-annex.dat", options=["--force"])
-    assert_false(ds.repo.file_has_content("test-annex.dat"))
-    ds.rerun()
-    ok_(ds.repo.file_has_content("test-annex.dat"))
+        # Rerunning the commit will also get the input file.
+        ds.repo.drop("test-annex.dat", options=["--force"])
+        assert_false(ds.repo.file_has_content("test-annex.dat"))
+        ds.rerun()
+        ok_(ds.repo.file_has_content("test-annex.dat"))
 
-    with swallow_logs(new_level=logging.WARN) as cml:
-        ds.run("touch dummy", inputs=["*.not-an-extension"])
-        assert_in("No matching files found for --input", cml.out)
+        with swallow_logs(new_level=logging.WARN) as cml:
+            ds.run("touch dummy", inputs=["*.not-an-extension"])
+            assert_in("No matching files found for *.not-an-extension",
+                      cml.out)
 
-    # Test different combinations of globs and explicit files.
-    inputs = ["a.dat", "b.dat", "c.txt", "d.txt"]
-    create_tree(ds.path, {i: i for i in inputs})
+        # Test different combinations of globs and explicit files.
+        inputs = ["a.dat", "b.dat", "c.txt", "d.txt"]
+        create_tree(ds.path, {i: i for i in inputs})
 
-    ds.add(".")
-    ds.repo.copy_to(inputs, remote="origin")
-    ds.repo.drop(inputs, options=["--force"])
-
-    test_cases = [(["*.dat"], ["a.dat", "b.dat"]),
-                  (["*.dat", "c.txt"], ["a.dat", "b.dat", "c.txt"]),
-                  (["*"], inputs)]
-
-    for idx, (inputs_arg, expected_present) in enumerate(test_cases):
-        assert_false(any(ds.repo.file_has_content(i) for i in inputs))
-
-        ds.run("touch dummy{}".format(idx), inputs=inputs_arg)
-        ok_(all(ds.repo.file_has_content(f) for f in expected_present))
-
+        ds.add(".")
+        ds.repo.copy_to(inputs, remote="origin")
         ds.repo.drop(inputs, options=["--force"])
 
-    # --input can be passed a subdirectory.
-    create_tree(ds.path, {"subdir": {"a": "subdir a",
-                                     "b": "subdir b"}})
-    ds.add("subdir")
-    ds.repo.copy_to(["subdir/a", "subdir/b"], remote="origin")
-    ds.repo.drop("subdir", options=["--force"])
-    ds.run("touch subdir-dummy", inputs=[opj(ds.path, "subdir")])
-    ok_(all(ds.repo.file_has_content(opj("subdir", f)) for f in ["a", "b"]))
+        test_cases = [(["*.dat"], ["a.dat", "b.dat"]),
+                      (["*.dat", "c.txt"], ["a.dat", "b.dat", "c.txt"]),
+                      (["*"], inputs)]
 
-    # --input=. runs "datalad get ."
-    ds.run("touch dot-dummy", inputs=["."])
-    eq_(ds.repo.get_annexed_files(),
-        ds.repo.get_annexed_files(with_content_only=True))
-    # On rerun, we get all files, even those that weren't in the tree at the
-    # time of the run.
-    create_tree(ds.path, {"after-dot-run": "after-dot-run content"})
-    ds.add(".")
-    ds.repo.copy_to(["after-dot-run"], remote="origin")
-    ds.repo.drop(["after-dot-run"], options=["--force"])
-    ds.rerun("HEAD^")
-    ds.repo.file_has_content("after-dot-run")
+        for idx, (inputs_arg, expected_present) in enumerate(test_cases):
+            assert_false(any(ds.repo.file_has_content(i) for i in inputs))
 
-    # --output will unlock files that are present.
-    ds.repo.get("a.dat")
-    ds.run("echo ' appended' >>a.dat", outputs=["a.dat"])
-    with open(opj(path, "a.dat")) as fh:
-        eq_(fh.read(), "a.dat appended\n")
+            ds.run("touch dummy{}".format(idx), inputs=inputs_arg)
+            ok_(all(ds.repo.file_has_content(f) for f in expected_present))
 
-    # --output will remove files that are not present.
-    ds.repo.drop("a.dat", options=["--force"])
-    ds.run("echo ' appended' >>a.dat", outputs=["a.dat"])
-    with open(opj(path, "a.dat")) as fh:
-        eq_(fh.read(), " appended\n")
+            ds.repo.drop(inputs, options=["--force"])
 
-    # --input can be combined with --output.
-    ds.repo.repo.git.reset("--hard", "HEAD~2")
-    ds.run("echo ' appended' >>a.dat", inputs=["a.dat"], outputs=["a.dat"])
-    with open(opj(path, "a.dat")) as fh:
-        eq_(fh.read(), "a.dat appended\n")
+        # --input can be passed a subdirectory.
+        create_tree(ds.path, {"subdir": {"a": "subdir a",
+                                         "b": "subdir b"}})
+        ds.add("subdir")
+        ds.repo.copy_to(["subdir/a", "subdir/b"], remote="origin")
+        ds.repo.drop("subdir", options=["--force"])
+        ds.run("touch subdir-dummy", inputs=[opj(ds.path, "subdir")])
+        ok_(all(ds.repo.file_has_content(opj("subdir", f)) for f in ["a", "b"]))
 
-    with swallow_logs(new_level=logging.WARN) as cml:
-        ds.run("echo blah", outputs=["*.not-an-extension"])
-        assert_in("No matching files found for --output", cml.out)
+        # --input=. runs "datalad get ."
+        ds.run("touch dot-dummy", inputs=["."])
+        eq_(ds.repo.get_annexed_files(),
+            ds.repo.get_annexed_files(with_content_only=True))
+        # On rerun, we get all files, even those that weren't in the tree at
+        # the time of the run.
+        create_tree(ds.path, {"after-dot-run": "after-dot-run content"})
+        ds.add(".")
+        ds.repo.copy_to(["after-dot-run"], remote="origin")
+        ds.repo.drop(["after-dot-run"], options=["--force"])
+        ds.rerun("HEAD^")
+        ds.repo.file_has_content("after-dot-run")
 
-    ds.create('sub')
-    ds.run("echo sub_orig >sub/subfile")
-    ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
-    ds.drop("sub/subfile", check=False)
-    ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
+        # --output will unlock files that are present.
+        ds.repo.get("a.dat")
+        ds.run("echo ' appended' >>a.dat", outputs=["a.dat"])
+        with open(opj(path, "a.dat")) as fh:
+            eq_(fh.read(), "a.dat appended\n")
+
+        # --output will remove files that are not present.
+        ds.repo.drop("a.dat", options=["--force"])
+        ds.run("echo ' appended' >>a.dat", outputs=["a.dat"])
+        with open(opj(path, "a.dat")) as fh:
+            eq_(fh.read(), " appended\n")
+
+        # --input can be combined with --output.
+        ds.repo.repo.git.reset("--hard", "HEAD~2")
+        ds.run("echo ' appended' >>a.dat", inputs=["a.dat"], outputs=["a.dat"])
+        with open(opj(path, "a.dat")) as fh:
+            eq_(fh.read(), "a.dat appended\n")
+
+        with swallow_logs(new_level=logging.WARN) as cml:
+            ds.run("echo blah", outputs=["*.not-an-extension"])
+            assert_in("No matching files found for *.not-an-extension",
+                      cml.out)
+
+        ds.create('sub')
+        ds.run("echo sub_orig >sub/subfile")
+        ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
+        ds.drop("sub/subfile", check=False)
+        ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
 
 
 @ignore_nose_capturing_stdout

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -157,6 +157,10 @@ def test_rerun(path, nodspath):
     # Or --since= to run all reachable commits.
     ds.rerun(since="")
     eq_('xxxxxxxxxx\n', open(probe_path).read())
+    # If a file is dropped, we remove it instead of unlocking it.
+    ds.drop(probe_path, check=False)
+    ds.rerun()
+    eq_('x\n', open(probe_path).read())
     # If the history to rerun has a merge commit, we abort.
     ds.repo.checkout("HEAD~3", options=["-b", "topic"])
     with open(opj(path, "topic-file"), "w") as f:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -617,6 +617,15 @@ def test_run_inputs_outputs(path):
 
         ds.repo.drop(inputs, options=["--force"])
 
+    # --input can be passed a subdirectory.
+    create_tree(ds.path, {"subdir": {"a": "subdir a",
+                                     "b": "subdir b"}})
+    ds.add("subdir")
+    ds.repo.copy_to(["subdir/a", "subdir/b"], remote="origin")
+    ds.repo.drop("subdir", options=["--force"])
+    ds.run("touch subdir-dummy", inputs=[opj(ds.path, "subdir")])
+    ok_(all(ds.repo.file_has_content(opj("subdir", f)) for f in ["a", "b"]))
+
     # --input=. runs "datalad get ."
     ds.run("touch dot-dummy", inputs=["."])
     eq_(ds.repo.get_annexed_files(),

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -648,6 +648,12 @@ def test_run_inputs_outputs(path):
         ds.run("echo blah", outputs=["*.not-an-extension"])
         assert_in("No matching files found for --output", cml.out)
 
+    ds.create('sub')
+    ds.run("echo sub_orig >sub/subfile")
+    ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
+    ds.drop("sub/subfile", check=False)
+    ds.run("echo sub_overwrite >sub/subfile", outputs=["sub/subfile"])
+
 
 def test_rerun_commit_message_check():
     assert_raises(ValueError,

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -613,6 +613,19 @@ def test_run_inputs_outputs(path):
 
         ds.repo.drop(inputs, options=["--force"])
 
+    # --input=. runs "datalad get ."
+    ds.run("touch dot-dummy", inputs=["."])
+    eq_(ds.repo.get_annexed_files(),
+        ds.repo.get_annexed_files(with_content_only=True))
+    # On rerun, we get all files, even those that weren't in the tree at the
+    # time of the run.
+    create_tree(ds.path, {"after-dot-run": "after-dot-run content"})
+    ds.add(".")
+    ds.repo.copy_to(["after-dot-run"], remote="origin")
+    ds.repo.drop(["after-dot-run"], options=["--force"])
+    ds.rerun("HEAD^")
+    ds.repo.file_has_content("after-dot-run")
+
     # --output will unlock files that are present.
     ds.repo.get("a.dat")
     ds.run("echo ' appended' >>a.dat", outputs=["a.dat"])

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2553,6 +2553,15 @@ class AnnexRepo(GitRepo, RepoInterface):
 
     def get_annexed_files(self, with_content_only=False):
         """Get a list of files in annex
+
+        Parameters
+        ----------
+        with_content_only : bool, optional
+            Only list files whose content is present.
+
+        Returns
+        -------
+        A list of file names
         """
         args = [] if with_content_only else ['--include', "*"]
         out, err = self._run_annex_command('find', annex_options=args)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2554,7 +2554,6 @@ class AnnexRepo(GitRepo, RepoInterface):
     def get_annexed_files(self, with_content_only=False):
         """Get a list of files in annex
         """
-        # TODO: Review!!
         args = [] if with_content_only else ['--include', "*"]
         out, err = self._run_annex_command('find', annex_options=args)
         # TODO: JSON

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2551,19 +2551,35 @@ class AnnexRepo(GitRepo, RepoInterface):
         assert(info.pop('command') == 'info')
         return info  # just as is for now
 
-    def get_annexed_files(self, with_content_only=False):
+    def get_annexed_files(self, with_content_only=False, patterns=None):
         """Get a list of files in annex
 
         Parameters
         ----------
         with_content_only : bool, optional
             Only list files whose content is present.
+        patterns : list, optional
+            Globs to pass to annex's `--include=`. Files that match any of
+            these will be returned (i.e., they'll be separated by `--or`).
 
         Returns
         -------
         A list of file names
         """
-        args = [] if with_content_only else ['--include', "*"]
+        if not patterns:
+            args = [] if with_content_only else ['--include', "*"]
+        else:
+            if len(patterns) == 1:
+                args = ['--include', patterns[0]]
+            else:
+                args = ['-(']
+                for pat in patterns[:-1]:
+                    args.extend(['--include', pat, "--or"])
+                args.extend(['--include', patterns[-1]])
+                args.append('-)')
+
+            if with_content_only:
+                args.extend(['--in', 'here'])
         out, err = self._run_annex_command('find', annex_options=args)
         # TODO: JSON
         return out.splitlines()

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1302,7 +1302,8 @@ def test_annex_drop(src, dst):
 @with_tree({"a.txt": "a", "b.txt": "b", "c.py": "c", "d": "d"})
 def test_annex_get_annexed_files(path):
     repo = AnnexRepo(path)
-    repo.add(".", commit=True)
+    repo.add(".")
+    repo.commit()
     eq_(set(repo.get_annexed_files()), {"a.txt", "b.txt", "c.py", "d"})
 
     repo.drop("a.txt", options=["--force"])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1310,6 +1310,21 @@ def test_annex_get_annexed_files(path):
     eq_(set(repo.get_annexed_files(with_content_only=True)),
         {"b.txt", "c.py", "d"})
 
+    eq_(set(repo.get_annexed_files(patterns=["*.txt"])),
+        {"a.txt", "b.txt"})
+    eq_(set(repo.get_annexed_files(with_content_only=True,
+                                   patterns=["*.txt"])),
+        {"b.txt"})
+
+    eq_(set(repo.get_annexed_files(patterns=["*.txt", "*.py"])),
+        {"a.txt", "b.txt", "c.py"})
+
+    eq_(set(repo.get_annexed_files()),
+        set(repo.get_annexed_files(patterns=["*"])))
+
+    eq_(set(repo.get_annexed_files(with_content_only=True)),
+        set(repo.get_annexed_files(with_content_only=True, patterns=["*"])))
+
 
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_annex_remove(path):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1299,6 +1299,18 @@ def test_annex_drop(src, dst):
     assert_raises(CommandError, ar.drop, ['.'], options=['--all'])
 
 
+@with_tree({"a.txt": "a", "b.txt": "b", "c.py": "c", "d": "d"})
+def test_annex_get_annexed_files(path):
+    repo = AnnexRepo(path)
+    repo.add(".", commit=True)
+    eq_(set(repo.get_annexed_files()), {"a.txt", "b.txt", "c.py", "d"})
+
+    repo.drop("a.txt", options=["--force"])
+    eq_(set(repo.get_annexed_files()), {"a.txt", "b.txt", "c.py", "d"})
+    eq_(set(repo.get_annexed_files(with_content_only=True)),
+        {"b.txt", "c.py", "d"})
+
+
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_annex_remove(path):
     repo = AnnexRepo(path, create=False)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -41,6 +41,7 @@ from ..utils import expandpath, is_explicit_path
 from ..utils import knows_annex
 from ..utils import any_re_search
 from ..utils import unique
+from ..utils import partition
 from ..utils import get_func_kwargs_doc
 from ..utils import make_tempfile
 from ..utils import on_windows
@@ -577,6 +578,21 @@ def test_unique():
                key=itemgetter(1)), [(1, 2), (1, 3)])
 
 
+def test_partition():
+    def fn(*args, **kwargs):
+        left, right = partition(*args, **kwargs)
+        return list(left), list(right)
+
+    eq_(fn([False, True, False]),
+        ([False, False], [True]))
+
+    eq_(fn([1, 5, 4, 10], lambda x: x > 4),
+        ([1, 4], [5, 10]))
+
+    eq_(fn([1, 5, 4, 10], lambda x: x < 0),
+        ([1, 5, 4, 10], []))
+
+
 def test_path_():
     eq_(_path_('a'), 'a')
     if on_windows:
@@ -775,7 +791,7 @@ def test_safe_print():
     """Just to test that we are getting two attempts to print"""
 
     called = [0]
-    
+
     def _print(s):
         assert_equal(s, "bua")
         called[0] += 1
@@ -1016,4 +1032,3 @@ def test_dlabspath(path):
             eq_(dlabspath("bu"), opj(d, "bu"))
             eq_(dlabspath("./bu"), opj(d, "./bu"))  # we do not normpath by default
             eq_(dlabspath("./bu", norm=True), opj(d, "bu"))
-

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -28,6 +28,7 @@ from contextlib import contextmanager
 from functools import wraps
 from time import sleep
 from inspect import getargspec
+from itertools import tee
 
 from os.path import sep as dirsep
 from os.path import commonprefix
@@ -641,6 +642,32 @@ def unique(seq, key=None):
         # OPT: could be optimized, since key is called twice, but for our cases
         # should be just as fine
         return [x for x in seq if not (key(x) in seen or seen_add(key(x)))]
+
+
+def partition(items, predicate=bool):
+    """Partition `items` by `predicate`.
+
+    Parameters
+    ----------
+    items : iterable
+    predicate : callable
+        A function that will be mapped over each element in `items`. The
+        elements will partitioned based on whether the return value is false or
+        true.
+
+    Returns
+    -------
+    A tuple with two generators, the first for 'false' items and the second for
+    'true' ones.
+
+    Notes
+    -----
+    Taken from Peter Otten's snippet posted at
+    https://nedbatchelder.com/blog/201306/filter_a_list_into_two_parts.html
+    """
+    a, b = tee((predicate(item), item) for item in items)
+    return ((item for pred, item in a if not pred),
+            (item for pred, item in b if pred))
 
 
 def generate_chunks(container, size):


### PR DESCRIPTION
This is a first pass at allowing inputs to be specified when calling `datalad run`.

WIP because

- [ ] I haven't tested it too thoroughly

- [x] I haven't yet tried to add `--output`, but we might want to do that here (as opposed to a separate PR)

- [x] I'm not sure how we should handle glob expansion.

  If a glob is given as the input value, it is expanded at the time of the run.  As an example, if '*' was used to indicate all annex files, a rerun would consider the inputs to be all of the annex files at the time of the initial run.


    Expansion during the initial run seems appropriate because most of the time re-executing a command should only require those inputs.  However, it's possible that the caller would want to rerun a command that uses globs itself to get its input files, in which case files that were added after the initial run wouldn't be retrieved.

    Perhaps we could also store the unexpanded inputs and add a rerun flag that says to use the unexpanded set.

    Update: I'm still not sure, but the current approach is to store unexpanded unless the `--expand` option is used.

Note: #2432 mentioned --input=. as meaning all annex files should be present, but I didn't end up adding that because it's possible with globbing (`--input='*'`).

re: #2158, #2432
