### PR TITLE
Inappropriate message: [WARNING] Metadata query results might be incomplete

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -90,14 +90,14 @@ def test_help_np():
     # but order is still not guaranteed (dict somewhere)! TODO
     # see https://travis-ci.org/datalad/datalad/jobs/80519004
     # thus testing sets
-    assert_equal(set(sections),
-                 {'Commands for dataset operations',
-                  'Commands for metadata handling',
-                  'Miscellaneous commands',
-                  'General information',
-                  'Global options',
-                  'Plumbing commands',
-                  'Plugins'})
+    for s in {'Commands for dataset operations',
+              'Commands for metadata handling',
+              'Miscellaneous commands',
+              'General information',
+              'Global options',
+              'Plumbing commands',
+              'Plugins'}:
+        assert_in(s, sections)
 
     # none of the lines must be longer than 80 chars
     # TODO: decide on   create-sibling and possibly

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -19,10 +19,10 @@ from datalad.distribution.dataset import Dataset
 
 from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import with_tree
-from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_dict_equal
+from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_direct_mode
@@ -116,9 +116,9 @@ def test_aggregate_query(path):
     ds = Dataset(path).create(force=True)
     # no magic change to actual dataset metadata due to presence of
     # aggregated metadata
-    res = ds.metadata(reporton='datasets')
+    res = ds.metadata(reporton='datasets', on_failure='ignore')
     assert_result_count(res, 1)
-    _assert_metadata_empty(res[0]['metadata'])
+    assert_not_in('metadata', res[0])
     # but we can now ask for metadata of stuff that is unknown on disk
     res = ds.metadata(opj('sub', 'deep', 'some'), reporton='datasets')
     assert_result_count(res, 1)

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -198,7 +198,7 @@ def test_ignore_nondatasets(path):
         return meta
 
     ds = Dataset(path).create()
-    meta = _kill_time(ds.metadata(reporton='datasets'))
+    meta = _kill_time(ds.metadata(reporton='datasets', on_failure='ignore'))
     n_subm = 0
     # placing another repo in the dataset has no effect on metadata
     for cls, subpath in ((GitRepo, 'subm'), (AnnexRepo, 'annex_subm')):
@@ -209,11 +209,11 @@ def test_ignore_nondatasets(path):
         r.add('test')
         r.commit('some')
         assert_true(Dataset(subm_path).is_installed())
-        assert_equal(meta, _kill_time(ds.metadata(reporton='datasets')))
+        assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         # making it a submodule has no effect either
         ds.add(subpath)
         assert_equal(len(ds.subdatasets()), n_subm + 1)
-        assert_equal(meta, _kill_time(ds.metadata(reporton='datasets')))
+        assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         n_subm += 1
 
 
@@ -243,6 +243,6 @@ def test_bf2458(src, dst):
     # content is not here
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
     # check that plain metadata access does not `get` stuff
-    clone.metadata('.')
+    clone.metadata('.', on_failure='ignore')
     # XXX whereis says nothing in direct mode
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -81,6 +81,7 @@ class WTF(Interface):
         from datalad.api import metadata
         from datalad.support.external_versions import external_versions
         from datalad.dochelpers import exc_str
+        from datalad.interface.results import success_status_map
         import os
         import platform as pl
         import json
@@ -153,8 +154,8 @@ Metadata
         elif ds and ds.is_installed() and ds.id:
             ds_meta = metadata(
                 dataset=ds, reporton='datasets', return_type='list',
-                result_filter=lambda x: x['action'] == 'metadata',
-                result_renderer='disabled')
+                result_filter=lambda x: x['action'] == 'metadata' and success_status_map[x['status']] == 'success',
+                result_renderer='disabled', on_failure='ignore')
             if ds_meta:
                 ds_meta = [dm['metadata'] for dm in ds_meta]
                 if len(ds_meta) == 1:

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -13,7 +13,7 @@ import sys
 from os.path import lexists, dirname, join as opj, curdir
 
 # Hard coded version, to be done by release process
-__version__ = '0.10.0.rc2'
+__version__ = '0.10.0.rc3'
 __full_version__ = __version__
 
 # NOTE: might cause problems with "python setup.py develop" deployments


### PR DESCRIPTION
Warning is issued under wrong conditions. Even if the queried dataset has metadata to report, the message will be issued, if the source dataset (althoug not even queried) has none.