### PR TITLE
ENH: do not update progressbar upon each entry - every 100ms

### DIFF
--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -85,9 +85,9 @@ try:
         # Newer versions seems to behave more consistently so do not require
         # those settings
         _default_pbar_params = \
-            dict(smoothing=0, miniters=1, mininterval=0) \
+            dict(smoothing=0, miniters=1, mininterval=0.1) \
             if external_versions['tqdm'] < '4.10.0' \
-            else dict(mininterval=0)
+            else dict(mininterval=0.1)
 
         def __init__(self, label='', fill_text=None,
                      total=None, unit='B', out=sys.stdout, leave=False):

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -81,7 +81,12 @@ def _test_progress_bar(backend, len, increment):
         if not (increment and x == 0):
             # do not increment on 0
             pb.update(x if not increment else 1, increment=increment)
-        out.flush()  # needed atm
+        #out.flush()  # needed atm... no longer?
+        # Progress bar is having 0.1 sec between updates by default, so
+        # we could either sleep:
+        #import time; time.sleep(0.1)
+        # or just force the refresh
+        pb.refresh()
         pstr = out.getvalue()
         if backend not in ('annex-remote', 'silent'):  # no str repr
             ok_startswith(pstr.lstrip('\r'), 'label:')


### PR DESCRIPTION
I am not clear now why I wanted to set it to 0sec, I guess something
did not update nicely.  I think it should be safe to set it to 100ms.

This should make progressbars smoother whenever each iteration is too
fast (e.g. during checking dates within git objects)


### Changes
- [x] This change is complete

Please have a look @datalad/developers
