### PR TITLE
ENH: adds python cast example

### DIFF
--- a/docs/casts/nipype_tutorial_intro.sh
+++ b/docs/casts/nipype_tutorial_intro.sh
@@ -1,0 +1,83 @@
+say "Import nipype building blocks"
+show "Import nipype building blocks"
+run "from nipype import Node, Workflow"
+
+say "Import relevant interfaces"
+show "Import relevant interfaces"
+run "from nipype.interfaces.fsl import SliceTimer, MCFLIRT, Smooth"
+
+say "Create SliceTime correction node"
+show "Create SliceTime correction node"
+run "slicetimer = Node(SliceTimer(index_dir=False,
+                             interleaved=True,
+                             time_repetition=2.5),
+                  name='slicetimer')
+"
+
+say "Create Motion correction node"
+show "Create Motion correction node"
+run "mcflirt = Node(MCFLIRT(mean_vol=True,
+                       save_plots=True),
+               name='mcflirt')
+"
+
+show "Create Smoothing node"
+run "smooth = Node(Smooth(fwhm=4), name='smooth')"
+
+show "Create Workflow"
+run "preproc01 = Workflow(name='preproc01', base_dir='.')"
+
+show "Connect nodes within the workflow"
+run "preproc01.connect([(slicetimer, mcflirt, [('slice_time_corrected_file', 'in_file')]),
+                   (mcflirt, smooth, [('out_file', 'in_file')])])
+"
+
+show "Create a visualization of the workflow"
+run "preproc01.write_graph(graph2use='orig')"
+
+show "Visualize the figure"
+run "!eog preproc01/graph_detailed.png
+"
+
+show "Feed some input to the workflow"
+run "slicetimer.inputs.in_file = 'path/to/your/func.nii.gz'"
+
+show "Run the Workflow and stop the time"
+run "%time preproc01.run('MultiProc', plugin_args={'n_procs': 5})"
+
+show "Investigate the output"
+run "!tree preproc01 -I '*js|*json|*pklz|_report|*.dot|*html'"
+
+show "Change the size of the smoothing kernel"
+run "smooth.inputs.fwhm = 2"
+
+show "Rerun the workflow"
+run "%time preproc01.run('MultiProc', plugin_args={'n_procs': 5})"
+
+show "Create 4 additional copies of the workflow"
+run "preproc02 = preproc01.clone('preproc02')
+preproc03 = preproc01.clone('preproc03')
+preproc04 = preproc01.clone('preproc04')
+preproc05 = preproc01.clone('preproc05')
+"
+
+show "Create a new workflow - metaflow"
+run "metaflow = Workflow(name='metaflow', base_dir='.')"
+
+show "Add the 5 workflows to this metaflow"
+run "metaflow.add_nodes([preproc01, preproc02, preproc03,
+                    preproc04, preproc05])
+"
+
+show "Visualize the workflow"
+run "metaflow.write_graph(graph2use='flat')
+!eog metaflow/graph_detailed.png
+"
+
+show "Run this metaflow in parallel"
+run "%time metaflow.run('MultiProc', plugin_args={'n_procs': 5})"
+
+show "Investigate the output"
+run "!tree metaflow -I '*js|*json|*pklz|_report|*.dot|*html'"
+
+show "The End."

--- a/tools/cast_ipython.rc
+++ b/tools/cast_ipython.rc
@@ -1,0 +1,16 @@
+# This file contains ipython configuration variables to be used for generating
+# asciinema demos to guarantee consistent appearance.
+
+# make a fake temporary home dir and go into it
+SCREENCAST_HOME=~/demo
+if [ ! -e "$SCREENCAST_HOME" ]; then
+    mkdir -p ${SCREENCAST_HOME} || {
+        echo "FAILED to create $SCREENCAST_HOME" >&2
+        exit 1;  # we need demo directory!
+    }
+fi
+cd $SCREENCAST_HOME
+ipython
+
+# cleanup at the end
+trap "cd ; rm -rf ~/demo > /dev/null 2>&1" EXIT

--- a/tools/cast_live_python
+++ b/tools/cast_live_python
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+set -u -e
+
+# reduce confusion with xdotool
+setxkbmap us
+
+test ! -e $1 && echo "input file does not exist" && exit 1
+title="$(echo $(basename $1) | sed -e 's/.sh$//')"
+bashrc_file="$(dirname $0)/cast_ipython.rc"
+
+# shortcut for making xdotool use the right window
+function xdt() {
+    winid=$1
+    shift
+    xdotool windowactivate --sync $winid
+    if [ "$#" -gt 0 ]; then
+        xdotool "$@"
+    fi
+}
+
+# make sure the target xterm is up and running
+width=106
+height=29
+fs=15
+text_width=$(($width - 8))
+
+geometry=${width}x${height}
+this_window=$(xdotool getwindowfocus)
+
+# For consistent appearance
+xterm +sb -fa Hermit -fs $fs -bg black -fg white -geometry $geometry -title Screencast-xterm -e "bash  --rcfile cast_ipython.rc" &
+xterm_pid=$!
+sleep 2
+
+xterm_window=$(xdotool search --pid $xterm_pid)
+
+# By default should stay in the xterm window, so when we need to deal with
+# current one (waiting etc), then switch
+function wait () {
+    xdt $this_window
+    read -p "$@" in
+    echo "$in"
+    xdt $xterm_window
+}
+function instruct () {
+    xdt $this_window
+    wait "$@"
+}
+function type () {
+	xdt $xterm_window type --clearmodifiers --delay 40  "$1"
+}
+function key () {
+	xdt $xterm_window key --clearmodifiers  $*
+}
+function sleep () {
+	xdotool sleep $1
+}
+function execute () {
+	xdt $xterm_window sleep 0.5 key Return
+    sleep 0.2
+}
+function say()
+{
+	ac=$(instruct "SAY: $1")
+	if [ "$ac" != "s" ] ; then
+	    echo "skipping"
+	    return
+	fi
+	type "$(printf "#\n# $1" | fmt -w ${text_width} --prefix '# ')"
+	key Return
+}
+function show () {
+    xdt $xterm_window type --clearmodifiers --delay 0 "$(printf "$1" | sed -e 's/^/# /g')"
+    sleep 0.1
+    key Return
+}
+function run () {
+    help="Press Enter to type, s to skip this action"
+    ac=$(instruct "EXEC: $1.  $help")
+    if [ "$ac" = "s" ]; then
+        echo "skipping"
+        return
+    fi
+    type "$1"
+    ac=$(instruct "EXEC: $1.  $help")
+    if [ "$ac" = "s" ]; then
+        echo "skipping"
+        return
+    fi
+    execute
+}
+function run_expfail () {
+	# TODO we could announce or visualize the expected failure
+	run "$1"
+}
+
+xdt $xterm_window sleep 0.1
+
+echo "xterm PID $xterm_pid (window $xterm_window)  this window $this_window"
+
+# now get the process tree attached to the terminal so we can
+# figure out when it is idle, and when it is not
+# XXX must happen after asciinema is running
+xterm_pstree="$(pstree -p -A $xterm_pid)"
+
+. $1
+
+sleep 1
+
+show "$(cowsay "Demo was using $(datalad --version 2>&1 | head -n1). Discover more at http://datalad.org")"
+
+# key Control_L+d
+
+echo "INSTRUCTION: Press Ctrl-D or run exit to close the terminal"


### PR DESCRIPTION
I've created a python `cast` example, based on the [`nipype_tutorial` showcase](https://miykael.github.io/nipype_tutorial/notebooks/introduction_showcase.html). Perhaps this is useful for some?

I'm not sure if the `rm -rf ~/demo` command in [cast_ipython.rc](https://github.com/miykael/datalad/blob/1d14d4b2057c7bdf76eaecf6f7412f0458cab029/tools/cast_ipython.rc#L16) is a horrible abomination and perhaps should be changed.