### PR TITLE
DOC: param: Strip doc before extending with a default

### DIFF
--- a/datalad/support/param.py
+++ b/datalad/support/param.py
@@ -115,7 +115,7 @@ class Parameter(object):
         doc = self._doc
         if doc is None:
             doc = ''
-        doc.strip()
+        doc = doc.strip()
         if len(doc) and not doc.endswith('.'):
             doc += '.'
         if has_default:


### PR DESCRIPTION
This seems to be the intention of the original code.

A benefit of stripping whitespace here is that it avoids adding an
unnecessary period when there are trailing spaces, which can easily
happen if the string ends with "[CMD: ... CMD]".

---

- [x] This change is complete
