### PR TITLE
datalad run causes 100% CPU utilization by datalad 

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -11,7 +11,7 @@ Wrapper for command and function calls, allowing for dry runs and output handlin
 
 """
 
-
+import time
 import subprocess
 import sys
 import logging
@@ -296,10 +296,17 @@ class Runner(object):
             # in another thread http://codereview.stackexchange.com/a/17959
             # current problem is that if there is no output on stderr
             # it stalls
+            # Monitor if anything was output and if nothing, sleep a bit
+            stdout_, stderr_ = None, None
             if log_stdout_:
-                stdout += self._process_one_line(*stdout_args)
+                stdout_ = self._process_one_line(*stdout_args)
+                stdout += stdout_
             if log_stderr_:
-                stderr += self._process_one_line(*stderr_args)
+                stderr_ = self._process_one_line(*stderr_args)
+                stderr += stderr_
+            if not (stdout_ or stderr_):
+                # no output was generated, so sleep a tiny bit
+                time.sleep(0.001)
 
         # Handle possible remaining output
         stdout_, stderr_ = proc.communicate()


### PR DESCRIPTION
#### What is the problem?
Just spotted that for me even running a dummy `datalad run sleep 100` causes datalad to become extremely busy with something... what is it doing? probably some side effect of how subprocess is used?

```
[DEBUG  ] tracking command output underneath <Dataset path=/tmp/QA> 
[Level 9] Running: ['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'annex', 'status', '--debug', '-c', 'remote.origin.annex-ssh-options=-o ControlMaster=auto -S /home/yoh/.cache/datalad/sockets/23d1f58a', '--json', '--ignore-submodules=all', '--'] 
[Level 8] Finished running ['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'annex', 'status', '--debug', '-c', 'remote.origin.annex-ssh-options=-o ControlMaster=auto -S /home/yoh/.cache/datalad/sockets/23d1f58a', '--json', '--ignore-submodules=all', '--'] with status 0 
[Level 8] Using existing Git repository at /tmp/QA 
[INFO   ] == Command start (output follows) ===== 
[Level 9] Running: ['sleep', '100']
```