### PR TITLE
BF: cli: Don't ignore the default result_filter

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -413,7 +413,12 @@ class Interface(object):
             if args.common_on_failure:
                 kwargs['on_failure'] = args.common_on_failure
             # compose filter function from to be invented cmdline options
-            kwargs['result_filter'] = cls._get_result_filter(args)
+            res_filter = cls._get_result_filter(args)
+            if res_filter is not None:
+                # Don't add result_filter if it's None because then
+                # eval_results can't distinguish between --report-{status,type}
+                # not specified via the CLI and None passed via the Python API.
+                kwargs['result_filter'] = res_filter
         try:
             ret = cls.__call__(**kwargs)
             if inspect.isgenerator(ret):

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -90,6 +90,22 @@ def test_call_from_parser_default_args():
         eq_(val, ["nothing is", "magical"])
 
 
+def test_call_from_parser_result_filter():
+    class DummyOne(Interface):
+        @staticmethod
+        def __call__(**kwargs):
+            yield kwargs
+
+    with mock.patch.object(Interface, '_OLDSTYLE_COMMANDS', tuple()):
+        # call_from_parser doesn't add result_filter to the keyword arguments
+        # unless a CLI option sets it to a non-None value.
+        assert_not_in("result_filter",
+                      DummyOne.call_from_parser(_new_args())[0])
+        assert_in("result_filter",
+                  DummyOne.call_from_parser(
+                      _new_args(common_report_type="dataset"))[0])
+
+
 def test_get_result_filter_arg_vs_config():
     # just tests that we would be obtaining the same constraints via
     # cmdline argument or via config variable.  With cmdline overloading


### PR DESCRIPTION
eval_results only uses the result_filter value from the interface
class if its kwargs argument doesn't include "result_filter" as a key.
This does the right thing for the Python API because the key is only
present if result_filter=None is explicitly specified.  For the CLI,
however, result_filter is always present, so the class's result_filter
is ignored.

To fix this, adjust call_from_parser to only add the result_filter key
if a filter was explicitly specified on the command line (via
--report-status or --report-status).

Fixes #2482.

---

- [x] This change is complete
