### PR TITLE
BF: annexjson2result: Adjust for multi-line note values

### DIFF
--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -224,10 +224,12 @@ def annexjson2result(d, ds, **kwargs):
                            for k, v in d['fields'].items()
                            if not k.endswith('lastchanged')}
     # avoid meaningless standard messages
-    if 'note' in d and (
-            d['note'] != 'checksum...' and
-            not d['note'].startswith('checking file')):
-        res['message'] = translate_annex_notes.get(d['note'], d['note'])
+    if 'note' in d:
+        note = "; ".join(ln for ln in d['note'].splitlines()
+                         if ln != 'checksum...'
+                         and not ln.startswith('checking file'))
+        if note:
+            res['message'] = translate_annex_notes.get(note, note)
     return res
 
 


### PR DESCRIPTION
As of git-annex's 7e454ee34 (--json: multi-line notes, 2018-02-16),
the json "note" values can contain multiple lines.  (Before, only the
last line was included.)

We want to restrict a message to one line, so replace the newlines
with " ;" when translating these a note to a result message.

Fixes #2465.

---

- [x] This change is complete
