### PR TITLE
RF: do not issue warnings when progressbar regresses

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3503,11 +3503,9 @@ class ProcessAnnexProgressIndicators(object):
             # so above didn't help!
             # use warnings not lgr.warn since we apparently swallow stuff
             # upstairs!  Also it would take care about issuing it only once
-            import warnings
-            warnings.warn(
-                "Got negative diff for progressbar. old_value=%r, new_value=%r"
-                " no more warnings should come for this one and we will not update"
-                " until values start to make sense" % (old_value, new_value))
+            lgr.debug(
+                "Got negative diff for progressbar. old_value=%r, new_value=%r",
+                old_value, new_value)
             return
         if self.total_pbar:
             self.total_pbar.update(diff, increment=True)


### PR DESCRIPTION
The reason is still unknown but it is not worth bombarding users with those
developer-oriented warnings.  We will just log them at DEBUG level
for ourselves

I thought there was an issue mentioning it but can't find

Also emailed @joeyh asking if such cases (regress in reported progress) is legit and could happen for an ok reason somehow
