### PR TITLE
OPT: delay import of pkg_resources until use, adjust log messages to differ

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -38,8 +38,13 @@ def _generate_extension_api():
 
     for entry_point in iter_entry_points('datalad.extensions'):
         try:
-            lgr.debug('Loading entrypoint %s from datalad.extensions', entry_point.name)
+            lgr.debug(
+                'Loading entrypoint %s from datalad.extensions for API building',
+                entry_point.name)
             grp_descr, interfaces = entry_point.load()
+            lgr.debug(
+                'Loaded entrypoint %s from datalad.extensions',
+                entry_point.name)
         except Exception as e:
             lgr.warning('Failed to load entrypoint %s: %s', entry_point.name, exc_str(e))
             continue

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -24,8 +24,6 @@ import os
 
 from six import text_type
 
-from pkg_resources import iter_entry_points
-
 import datalad
 
 from datalad.cmdline import helpers
@@ -203,11 +201,15 @@ def setup_parser(
     cmdlineargs = set(cmdlineargs) if cmdlineargs else set()
     grp_short_descriptions = []
     interface_groups = get_interface_groups()
+    from pkg_resources import iter_entry_points  # delay expensive import
     for ep in iter_entry_points('datalad.extensions'):
-        lgr.debug('Loading entrypoint %s from datalad.extensions', ep.name)
+        lgr.debug(
+            'Loading entrypoint %s from datalad.extensions for docs building',
+            ep.name)
         try:
             spec = ep.load()
             interface_groups.append((ep.name, spec[0], spec[1]))
+            lgr.debug('Loaded entrypoint %s', ep.name)
         except Exception as e:
             lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str(e))
             continue

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -25,8 +25,6 @@ from collections import OrderedDict
 from collections import Mapping
 from six import binary_type, string_types
 
-from pkg_resources import iter_entry_points
-
 from datalad import cfg
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.base import Interface
@@ -459,6 +457,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
     # enforce size limits
     max_fieldsize = ds.config.obtain('datalad.metadata.maxfieldsize')
     # keep local, who knows what some extractors might pull in
+    from pkg_resources import iter_entry_points  # delayed heavy import
     extractors = {ep.name: ep for ep in iter_entry_points('datalad.metadata.extractors')}
 
     log_progress(


### PR DESCRIPTION
loading extensions is duplicating in two places with identical log messages making it difficult to localize that code while tracing the log msgs

delaying import of `pkg_resources` is heavy and should get closer to when actually needed. Eventually we might manage to avoid loading extensions if not needed (command is decided)
