### PR TITLE
OPT: cmdline

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -92,7 +92,6 @@ def setup_parser(
         formatter_class=formatter_class,
         add_help=False)
     # common options
-    helpers.parser_add_common_opt(parser, 'help')
     helpers.parser_add_common_opt(parser, 'log_level')
     helpers.parser_add_common_opt(parser, 'pbs_runner')
     helpers.parser_add_common_opt(parser, 'change_path')
@@ -175,7 +174,7 @@ def setup_parser(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global
         command line options before the subcommand label. Options like
-        --run-before can take an arbitray number of arguments and may require
+        --run-before can take an arbitrary number of arguments and may require
         to be followed by a single --cmd in order to enable identification
         of the subcommand.""")
 
@@ -193,44 +192,92 @@ def setup_parser(
     #                    help="""level of verbosity of console output. By default
     #                         only warnings and errors are printed.""")
 
-    # subparsers
-    subparsers = None
-
     # auto detect all available interfaces and generate a function-based
     # API from them
-    cmdlineargs = set(cmdlineargs) if cmdlineargs else set()
-    grp_short_descriptions = []
+    # cmdlineargs = set(cmdlineargs) if cmdlineargs else set()
     interface_groups = get_interface_groups()
-    from pkg_resources import iter_entry_points  # delay expensive import
-    for ep in iter_entry_points('datalad.extensions'):
-        lgr.debug(
-            'Loading entrypoint %s from datalad.extensions for docs building',
-            ep.name)
-        try:
-            spec = ep.load()
-            interface_groups.append((ep.name, spec[0], spec[1]))
-            lgr.debug('Loaded entrypoint %s', ep.name)
-        except Exception as e:
-            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str(e))
-            continue
     interface_groups.append(('plugins', 'Plugins', _get_plugins()))
 
-    for grp_name, grp_descr, _interfaces \
-                in sorted(interface_groups, key=lambda x: x[1]):
+    def fail_with_short_help(msg=None, known=None, provided=None, what="command"):
+        if msg:
+            sys.stderr.write(msg + '\n')
+        if not known:
+            # just to appear in print_usage also consistent with --help output
+            parser.add_argument("command [command-opts]")
+            parser.print_usage(file=sys.stderr)
+        else:
+            sys.stderr.write("Unknown %s %s.\n" % (what, provided,))
+            import difflib
+            suggestions = difflib.get_close_matches(provided, known)
+            if suggestions:
+                sys.stderr.write(" Did you mean %s?\n" % " or ".join(suggestions))
+            sys.stderr.write(" All known %ss: %s\n" % (what, ", ".join(sorted(known))))
+        raise SystemExit(1)
+
+    def get_commands_from_groups(groups):
+        return {
+            get_cmdline_command_name(_intfspec): _intfspec
+            for _, _, _interfaces in groups
+            for _intfspec in _interfaces
+        }
+
+    # Before doing anything additional and possibly expensive see may be that
+    # we have got the command already
+    need_single_subparser = False if return_subparsers else None
+    try:
+        parsed_args, unparsed_args = parser._parse_known_args(
+            cmdlineargs[1:], argparse.Namespace())
+        if not unparsed_args:
+            raise InsufficientArgumentsError() # just to get our summary
+    except Exception as exc:
+        lgr.debug("Early parsing failed with %s", exc_str(exc))
+        fail_with_short_help()
+        need_single_subparser = False
+
+    # First unparsed could be either unknown option to top level "datalad"
+    # or a command. Among unknown could be --help/--help-np which would
+    # need to be dealt with
+    lgr.debug("Command line args 1st pass. Parsed: %s Unparsed: %s",
+              parsed_args, unparsed_args)
+    unparsed_arg = unparsed_args[0]
+    if unparsed_arg in ('--help', '--help-np', '-h'):
+        need_single_subparser = False
+        add_entrypoints_to_interface_groups(interface_groups)
+    elif unparsed_arg.startswith('-'):  # unknown option
+        fail_with_short_help(msg="Unknown option %s" % unparsed_arg)
+        # if we could get a list of options known to parser,
+        # we could suggest them
+        # known=get_all_options(parser), provided=unparsed_arg)
+    else:  # the command to handle
+        known_commands = get_commands_from_groups(interface_groups)
+        if unparsed_arg not in known_commands:
+            # need to load all the extensions and try again
+            add_entrypoints_to_interface_groups(interface_groups)
+            known_commands = get_commands_from_groups(interface_groups)
+
+        if unparsed_arg not in known_commands:
+            fail_with_short_help(
+                provided=unparsed_arg,
+                known=known_commands.keys()
+            )
+        if need_single_subparser is None:
+            need_single_subparser = unparsed_arg
+
+    # --help specification was delayed since it causes immediate printout of
+    # --help output before we setup --help for each command
+    helpers.parser_add_common_opt(parser, 'help')
+
+    grp_short_descriptions = []
+    # create subparser, use module suffix as cmd name
+    subparsers = parser.add_subparsers()
+    for _, _, _interfaces \
+            in sorted(interface_groups, key=lambda x: x[1]):
         # for all subcommand modules it can find
         cmd_short_descriptions = []
 
         for _intfspec in _interfaces:
             cmd_name = get_cmdline_command_name(_intfspec)
-            # for each interface to be imported decide if it is necessary
-            # test conditions from frequent to infrequent occasions
-            # we want to import everything for help requests of any kind
-            # including a cluecless `datalad` without args
-            if not (len(cmdlineargs) == 1 or
-                    cmd_name in cmdlineargs or
-                    '--help' in cmdlineargs or
-                    '-h' in cmdlineargs or
-                    '--help-np' in cmdlineargs):
+            if need_single_subparser and cmd_name != need_single_subparser:
                 continue
             if isinstance(_intfspec[1], dict):
                 # plugin
@@ -252,16 +299,13 @@ def setup_parser(
                 parser_args = _intf.parser_args
             else:
                 parser_args = dict(formatter_class=formatter_class)
-            # use class description, if no explicit description is available
+                # use class description, if no explicit description is available
                 intf_doc = '' if _intf.__doc__ is None else _intf.__doc__.strip()
                 if hasattr(_intf, '_docs_'):
                     # expand docs
                     intf_doc = intf_doc.format(**_intf._docs_)
                 parser_args['description'] = alter_interface_docs_for_cmdline(
                     intf_doc)
-            # create subparser, use module suffix as cmd name
-            if subparsers is None:
-                subparsers = parser.add_subparsers()
             subparser = subparsers.add_parser(cmd_name, add_help=False, **parser_args)
             # our own custom help for all commands
             helpers.parser_add_common_opt(subparser, 'help')
@@ -277,18 +321,35 @@ def setup_parser(
             if hasattr(_intf, 'result_renderer_cmdline'):
                 plumbing_args['result_renderer'] = _intf.result_renderer_cmdline
             subparser.set_defaults(**plumbing_args)
+            parts[cmd_name] = subparser
             # store short description for later
             sdescr = getattr(_intf, 'short_description',
                              parser_args['description'].split('\n')[0])
             cmd_short_descriptions.append((cmd_name, sdescr))
-            parts[cmd_name] = subparser
         grp_short_descriptions.append(cmd_short_descriptions)
 
     # create command summary
+    if '--help' in cmdlineargs or '--help-np' in cmdlineargs:
+        parser.description = get_description_with_cmd_summary(
+            grp_short_descriptions,
+            interface_groups,
+            parser.description)
+
+    parts['datalad'] = parser
+    lgr.log(5, "Finished setup_parser")
+    if return_subparsers:
+        return parts
+    else:
+        return parser
+
+
+def get_description_with_cmd_summary(grp_short_descriptions, interface_groups,
+                                     parser_description):
+    from ..interface.base import dedent_docstring
+    lgr.debug("Generating detailed description for the parser")
     cmd_summary = []
     console_width = shutil.get_terminal_size()[0] \
         if hasattr(shutil, 'get_terminal_size') else 80
-
     for i, grp in enumerate(
             sorted(interface_groups, key=lambda x: x[1])):
         grp_descr = grp[1]
@@ -298,28 +359,41 @@ def setup_parser(
         for cd in grp_cmds:
             cmd_summary.append('  %s\n%s'
                                % ((cd[0],
-                                  textwrap.fill(
-                                      cd[1].rstrip(' .'),
-                                      console_width - 5,
-                                      initial_indent=' ' * 6,
-                                      subsequent_indent=' ' * 6))))
+                                   textwrap.fill(
+                                       cd[1].rstrip(' .'),
+                                       console_width - 5,
+                                       initial_indent=' ' * 6,
+                                       subsequent_indent=' ' * 6))))
     # we need one last formal section to not have the trailed be
     # confused with the last command group
     cmd_summary.append('\n*General information*\n')
-    parser.description = '%s\n%s\n\n%s' \
-        % (parser.description,
-           '\n'.join(cmd_summary),
-           textwrap.fill(dedent_docstring("""\
+    detailed_description = '%s\n%s\n\n%s' \
+                           % (parser_description,
+                              '\n'.join(cmd_summary),
+                              textwrap.fill(dedent_docstring("""\
     Detailed usage information for individual commands is
     available via command-specific --help, i.e.:
     datalad <command> --help"""),
-                         console_width - 5, initial_indent='', subsequent_indent=''))
-    parts['datalad'] = parser
-    lgr.log(5, "Finished setup_parser")
-    if return_subparsers:
-        return parts
-    else:
-        return parser
+                                            console_width - 5,
+                                            initial_indent='',
+                                            subsequent_indent=''))
+    return detailed_description
+
+
+def add_entrypoints_to_interface_groups(interface_groups):
+    lgr.debug("Loading entrypoints")
+    from pkg_resources import iter_entry_points  # delay expensive import
+    for ep in iter_entry_points('datalad.extensions'):
+        lgr.debug(
+            'Loading entrypoint %s from datalad.extensions for docs building',
+            ep.name)
+        try:
+            spec = ep.load()
+            interface_groups.append((ep.name, spec[0], spec[1]))
+            lgr.debug('Loaded entrypoint %s', ep.name)
+        except Exception as e:
+            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str(e))
+            continue
 
 
 def main(args=None):

--- a/datalad/cmdline/tests/test_formatters.py
+++ b/datalad/cmdline/tests/test_formatters.py
@@ -83,6 +83,7 @@ def test_cmdline_example_to_rst():
     assert_not_in('shame', out_text)  # no SKIP'ed
     assert_not_in('#', out_text)      # no comments
 
+
 def test_parser_access():
     parsers = setup_parser(['datalad'], return_subparsers=True)
     # we have a bunch

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -51,8 +51,8 @@ def run_main(args, exit_code=0, expect_stderr=False):
     with patch('sys.stderr', new_callable=StringIO) as cmerr:
         with patch('sys.stdout', new_callable=StringIO) as cmout:
             with assert_raises(SystemExit) as cm:
-                main(args)
-            assert_equal(cm.exception.code, exit_code)  # exit code must be 0
+                main(["datalad"] + list(args))
+            assert_equal(cm.exception.code, exit_code)
             stdout = cmout.getvalue()
             stderr = cmerr.getvalue()
             if expect_stderr is False:
@@ -123,7 +123,7 @@ def test_usage_on_insufficient_args():
 
 
 def test_subcmd_usage_on_unknown_args():
-    stdout, stderr = run_main(['get', '--murks'], exit_code=1)
+    stdout, stderr = run_main(['get', '--murks'], exit_code=1, expect_stderr=True)
     in_('get', stdout)
 
 
@@ -143,7 +143,7 @@ def check_incorrect_option(opts, err_str):
     # checked to meet its constraints.
     # But sys.argv[0] actually isn't used by main at all. It simply doesn't
     # matter what's in there. The only thing important to pass here is `opts`.
-    stdout, stderr = run_main(('datalad',) + opts, expect_stderr=True, exit_code=2)
+    stdout, stderr = run_main(opts, expect_stderr=True, exit_code=2)
     out = stdout + stderr
     assert_in("usage: ", out)
     assert_re_in(err_str, out, match=False)
@@ -151,11 +151,11 @@ def check_incorrect_option(opts, err_str):
 
 def test_incorrect_options():
     # apparently a bit different if following a good one so let's do both
-    err_invalid = "error: (invalid|too few arguments|unrecognized arguments)"
+    err_invalid = "error: (invalid|too few arguments|unrecognized argument)"
     yield check_incorrect_option, ('--buga',), err_invalid
     yield check_incorrect_option, ('--dbg', '--buga'), err_invalid
 
-    err_insufficient = err_invalid # "specify"
+    err_insufficient = err_invalid  # "specify"
     yield check_incorrect_option, ('--dbg',), err_insufficient
     yield check_incorrect_option, tuple(), err_insufficient
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -505,3 +505,6 @@ def require_dataset(dataset, check_installed=True, purpose=None):
                          "{0}.".format(dataset.path))
 
     return dataset
+
+
+lgr.log(5, "Done importing dataset")

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -81,3 +81,9 @@ _group_plumbing = (
         ('datalad.support.sshrun', 'SSHRun', 'sshrun'),
         ('datalad.distribution.subdatasets', 'Subdatasets', 'subdatasets'),
     ])
+
+# Some known extensions and their commands to suggest whenever lookup fails
+_known_extension_commands = {
+    'datalad-crawler': ('crawl', 'crawl-init'),
+    'datalad-neuroimaging': ('bids2scidata',)
+}

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -28,7 +28,7 @@ from datalad.distribution.dataset import Dataset
 
 
 lgr = logging.getLogger('datalad.interface.results')
-
+lgr.log(5, "Importing datalad.interface.results")
 
 # which status is a success , which is failure
 success_status_map = {
@@ -369,3 +369,6 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
                 status=noinfo_status, type='file',
                 message=noinfo_file_msg,
                 **common_report)
+
+
+lgr.log(5, "Done importing datalad.interface.results")

--- a/datalad/plugin/__init__.py
+++ b/datalad/plugin/__init__.py
@@ -27,6 +27,7 @@ magic_plugin_symbol = '__datalad_plugin__'
 
 
 def _get_plugins():
+    lgr.debug("Discovering plugins")
     locations = (
         BUILTIN_PLUGINS_PATH,
         cfg.obtain('datalad.locations.system-plugins'),

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -22,7 +22,7 @@ from datalad.tests.utils import with_tempfile
 @skip_ssh
 def test_exit_code():
     # will relay actual exit code on CommandError
-    cmd = ['sshrun', 'localhost', 'exit 42']
+    cmd = ['datalad', 'sshrun', 'localhost', 'exit 42']
     with assert_raises(SystemExit) as cme:
         # running nosetests without -s
         if isinstance(sys.stdout, StringIO):  # pragma: no cover


### PR DESCRIPTION
This pull request addresses some items in #2494 and adds sugaring like

```shell
$> time datalad instal -s /// /tmp/ds2                    
Unknown command instal.
 Did you mean install or uninstall?
 All known commands: add, add-archive-content, add-readme, addurls, aggregate-metadata, annotate-paths, check-dates, clean, clone, create, create-sibling, create-sibling-github, create-test-dataset, diff, download-url, drop, export-archive, export-to-figshare, extract-metadata, get, install, ls, metadata, no-annex, publish, remove, rerun, run, save, search, siblings, sshrun, subdatasets, test, uninstall, unlock, update, wtf
datalad instal -s /// /tmp/ds2  0.59s user 0.07s system 99% cpu 0.661 total
```
(in such cases I do not see a point of spiting out regular summary on options).  We could have done similar thing for options themselves but I did not see any way to extract options from the parser

Core commands now should "fire up" and provide help in up to ~300ms (so there is room for improvement) on my laptop (instead of a second or so)

I do feel that it is "piling up"... partial parsing is also done later in `main()` itself but I didn't want to dig up there for this one.

### Changes
- [x] This change is complete

Please have a look @datalad/developers
