### PR TITLE
ENH: download_url: Support adding downloaded file to dataset

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -317,8 +317,7 @@ class Interface(object):
 
     _OLDSTYLE_COMMANDS = (
         'AddArchiveContent', 'CrawlInit', 'Crawl', 'CreateSiblingGithub',
-        'CreateTestDataset', 'DownloadURL', 'Export', 'Ls', 'Move', 'SSHRun',
-        'Test')
+        'CreateTestDataset', 'Export', 'Ls', 'Move', 'SSHRun', 'Test')
 
     @classmethod
     def setup_parser(cls, parser):

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -35,7 +35,7 @@ class DownloadURL(Interface):
     """Download content
 
     It allows for a uniform download interface to various supported URL
-    schemes, re-using or asking for authentication detail maintained by
+    schemes, re-using or asking for authentication details maintained by
     datalad.
 
     Examples:

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -80,12 +80,10 @@ class DownloadURL(Interface):
 
         urls = assure_list_from_str(urls)
 
-        if len(urls) > 1:
-            if path:
-                if not(isdir(path)):
-                    raise ValueError(
-                        "When specifying multiple urls, --path should point to "
-                        "an existing directory. Got %r" % path)
+        if len(urls) > 1 and path and not isdir(path):
+            raise ValueError(
+                "When specifying multiple urls, --path should point to "
+                "an existing directory. Got %r" % path)
         if not path:
             path = curdir
 

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -19,7 +19,7 @@ __docformat__ = 'restructuredtext'
 from os.path import isdir, curdir
 
 from .base import Interface
-from datalad.interface.base import build_doc
+from ..interface.base import build_doc
 from ..ui import ui
 from ..utils import assure_list_from_str
 from ..dochelpers import exc_str

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -145,7 +145,7 @@ class DownloadURL(Interface):
 [DATALAD] Download URLs
 
 path: {}
-url:
+URLs:
   {}""".format(path, "\n  ".join(urls))
 
             for r in ds.add(downloaded_paths, message=msg):

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -9,23 +9,26 @@
 """Interface to DataLad downloaders
 """
 
-# TODO:  or may be it should be converted to 'addurl' thus with option for
-# adding into annex or git, depending on the largefiles option, and
-# --download-only  to only download... I see myself using it in other projects
-# as well I think.
-
 __docformat__ = 'restructuredtext'
 
 from os.path import isdir, curdir
 
 from .base import Interface
 from ..interface.base import build_doc
+from ..interface.common_opts import nosave_opt
+from ..interface.common_opts import save_message_opt
 from ..interface.results import get_status_dict
 from ..interface.utils import eval_results
 from ..utils import assure_list_from_str
+from ..distribution.add import Add
+from ..distribution.dataset import datasetmethod
+from ..distribution.dataset import EnsureDataset
+from ..distribution.dataset import require_dataset
 from ..dochelpers import exc_str
+from ..support.annexrepo import AnnexRepo
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr, EnsureNone
+from ..support.exceptions import NoDatasetArgumentFound
 
 from logging import getLogger
 lgr = getLogger('datalad.api.download-url')
@@ -50,6 +53,14 @@ class DownloadURL(Interface):
             constraints=EnsureStr(),  # TODO: EnsureURL
             metavar='url',
             nargs='+'),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            metavar='PATH',
+            doc="""specify the dataset to add files to. If no dataset is given,
+            an attempt is made to identify the dataset based on the current
+            working directory and/or the `path` given. Use [CMD: --nosave
+            CMD][PY: save=False PY] to prevent adding files to the dataset.""",
+            constraints=EnsureDataset() | EnsureNone()),
         overwrite=Parameter(
             args=("-o", "--overwrite"),
             action="store_true",
@@ -59,15 +70,27 @@ class DownloadURL(Interface):
             doc="path (filename or directory path) where to store downloaded file(s).  "
                 "In case of multiple URLs provided, must point to a directory.  Otherwise current "
                 "directory is used",
-            constraints=EnsureStr() | EnsureNone())
+            constraints=EnsureStr() | EnsureNone()),
+        save=nosave_opt,
+        message=save_message_opt
     )
 
-    @eval_results
     @staticmethod
-    def __call__(urls, path=None, overwrite=False):
+    @datasetmethod(name="download_url")
+    @eval_results
+    def __call__(urls, dataset=None, path=None, overwrite=False,
+                 save=True, message=None):
         from ..downloaders.providers import Providers
 
-        common_report = {"action": "download_url"}
+        try:
+            ds = require_dataset(
+                dataset, check_installed=True,
+                purpose='downloading urls')
+        except NoDatasetArgumentFound:
+            ds = None
+
+        common_report = {"action": "download_url",
+                         "ds": ds}
 
         urls = assure_list_from_str(urls)
 
@@ -82,12 +105,13 @@ class DownloadURL(Interface):
                 **common_report)
             return
         if not path:
-            path = curdir
+            path = ds.path if ds else curdir
 
         # TODO setup fancy ui.progressbars doing this in parallel and reporting overall progress
         # in % of urls which were already downloaded
         providers = Providers.from_config_files()
         downloaded_paths = []
+        path_urls = {}
         for url in urls:
             # somewhat "ugly"
             # providers.get_provider(url).get_downloader(url).download(url, path=path)
@@ -103,8 +127,38 @@ class DownloadURL(Interface):
                     **common_report)
             else:
                 downloaded_paths.append(downloaded_path)
+                path_urls[downloaded_path] = url
                 yield get_status_dict(
                     status="ok",
                     type="file",
                     path=downloaded_path,
                     **common_report)
+
+        if downloaded_paths and save and ds is not None:
+            msg = message or """\
+[DATALAD] Download URLs
+
+path: {}
+url:
+  {}""".format(path, "\n  ".join(urls))
+
+            for r in ds.add(downloaded_paths, message=msg):
+                yield r
+
+            if isinstance(ds.repo, AnnexRepo):
+                annex_paths = [p for p, annexed in
+                               zip(downloaded_paths,
+                                   ds.repo.is_under_annex(downloaded_paths))
+                               if annexed]
+                if annex_paths:
+                    keys = assure_list_from_str(
+                        ds.repo.get_file_key(annex_paths))
+                    for key, path in zip(keys, annex_paths):
+                        if key:
+                            # TODO: Add a registerurl method to annexrepo?
+                            # export_to_figshare also uses it.
+                            ds.repo._annex_custom_command(
+                                [], ["git", "annex", "registerurl",
+                                     key, path_urls[path]])
+                        else:
+                            lgr.warning("Key not found for %s", path)

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -144,9 +144,8 @@ class DownloadURL(Interface):
             msg = message or """\
 [DATALAD] Download URLs
 
-path: {}
 URLs:
-  {}""".format(path, "\n  ".join(urls))
+  {}""".format("\n  ".join(urls))
 
             for r in ds.add(downloaded_paths, message=msg):
                 yield r

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -40,7 +40,7 @@ class DownloadURL(Interface):
 
     Examples:
 
-      $ datalad download http://example.com/file.dat s3://bucket/file2.dat
+      $ datalad download-url http://example.com/file.dat s3://bucket/file2.dat
     """
     # XXX prevent common args from being added to the docstring
     _no_eval_results = True

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -71,6 +71,12 @@ class DownloadURL(Interface):
                 "In case of multiple URLs provided, must point to a directory.  Otherwise current "
                 "directory is used",
             constraints=EnsureStr() | EnsureNone()),
+        archive=Parameter(
+            args=("--archive",),
+            action="store_true",
+            doc="""pass the downloaded files to [CMD: :command:`datalad
+            add-archive-content --delete` CMD][PY: add_archive_content(...,
+            delete=True) PY]"""),
         save=nosave_opt,
         message=save_message_opt
     )
@@ -79,7 +85,7 @@ class DownloadURL(Interface):
     @datasetmethod(name="download_url")
     @eval_results
     def __call__(urls, dataset=None, path=None, overwrite=False,
-                 save=True, message=None):
+                 archive=False, save=True, message=None):
         from ..downloaders.providers import Providers
 
         try:
@@ -162,3 +168,8 @@ url:
                                      key, path_urls[path]])
                         else:
                             lgr.warning("Key not found for %s", path)
+
+                    if archive:
+                        from datalad.api import add_archive_content
+                        for path in annex_paths:
+                            add_archive_content(path, annex=ds.repo, delete=True)

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -97,3 +97,12 @@ def test_download_url_dataset(toppath, topurl, path):
 
     ds.download_url([opj(topurl, "file3.txt")], save=False)
     assert_false(ds.repo.file_has_content("file3.txt"))
+
+
+@with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})
+@serve_path_via_http
+@with_tempfile(mkdir=True)
+def test_download_url_archive(toppath, topurl, path):
+    ds = Dataset(path).create()
+    ds.download_url([opj(topurl, "archive.tar.gz")], archive=True)
+    ok_(ds.repo.file_has_content(opj("archive", "file1.txt")))

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -22,6 +22,7 @@ from ...tests.utils import ok_, ok_exists, eq_, assert_cwd_unchanged, \
     with_tempfile
 from ...tests.utils import with_tree
 from ...tests.utils import serve_path_via_http
+from ...tests.utils import known_failure_direct_mode
 
 
 def test_download_url_exceptions():
@@ -72,6 +73,7 @@ def test_download_url_return(toppath, topurl, outdir):
 ])
 @serve_path_via_http
 @with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
 def test_download_url_dataset(toppath, topurl, path):
     # Non-dataset directory.
     file1_fullpath = opj(path, "file1.txt")
@@ -102,6 +104,7 @@ def test_download_url_dataset(toppath, topurl, path):
 @with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})
 @serve_path_via_http
 @with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
 def test_download_url_archive(toppath, topurl, path):
     ds = Dataset(path).create()
     ds.download_url([opj(topurl, "archive.tar.gz")], archive=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1987,6 +1987,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         If annex knows `file` already,
         records that it can be downloaded from `url`.
 
+        Note: Consider using the higher-level `download_url` instead.
+
         Parameters
         ----------
         file_: str


### PR DESCRIPTION

   * Convert `download_url` to use `eval_results`.

   * Add the downloaded files to the dataset if invoked from a dataset or with `-d`.

     For annex repos, this includes registering the URL.  Adding to the dataset can be disabled with `--nosave`.

   * Add `--archive` flag indicates that to run `add_archive_content` on the downloaded files.


Closes #2123.

---

- [x] This change is complete
