### PR TITLE
DOC: run: Rename cmd's metavar to COMMAND

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -61,7 +61,7 @@ def _format_cmd_shorty(cmd):
 
 @build_doc
 class Run(Interface):
-    """Run an arbitrary command and record its impact on a dataset.
+    """Run an arbitrary shell command and record its impact on a dataset.
 
     It is recommended to craft the command such that it can run in the root
     directory of the dataset that the command will be recorded in. However,
@@ -78,7 +78,7 @@ class Run(Interface):
         cmd=Parameter(
             args=("cmd",),
             nargs=REMAINDER,
-            metavar='SHELL COMMAND',
+            metavar='COMMAND',
             doc="command for execution"),
         dataset=Parameter(
             args=("-d", "--dataset"),


### PR DESCRIPTION
Mention that the command is a shell command in the top-level
description rather than using the metavar so that datalad
containers-run doesn't need to override this value.

Re: https://github.com/datalad/datalad-container/pull/11#discussion_r189292367

---

- [x] This change is complete
