### PR TITLE
RF: Leaner .gitattribute settings forcing content into Git

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -385,7 +385,8 @@ class Create(Interface):
             # comes around
             gitattr.write('# Text files (according to file --mime-type) are added directly to git.\n')
             gitattr.write('# See http://git-annex.branchable.com/tips/largefiles/ for more info.\n')
-            gitattr.write('** annex.largefiles=nothing\n')
+            gitattr.write('config annex.largefiles=nothing\n')
+            gitattr.write('metadata/aggregate* annex.largefiles=nothing\n')
             gitattr.write('metadata/objects/** annex.largefiles=({})\n'.format(
                 cfg.obtain('datalad.metadata.create-aggregate-annex-limit')))
 


### PR DESCRIPTION
Inspired by https://github.com/datalad/datalad-container/issues/15

@kyleam 