### PR TITLE
remaining two tests to fail while using bleeding edge git-annex 6.20180519+gitgf6f199be3-1~ndall+1

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1459,7 +1459,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     if re.match(
                             r'.*This operation must be run in a work tree.*git status.*failed in submodule',
                             e.stderr,
-                            re.MULTILINE | re.DOTALL):
+                            re.MULTILINE | re.DOTALL | re.IGNORECASE):
 
                         lgr.warning(
                             "Known bug in direct mode."

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -898,7 +898,8 @@ def test_git_custom_calls(path, path2):
     with assert_raises(GitCommandError) as cm:
         repo._gitpy_custom_call('status', git_options={'C': path2})
     assert_in("-C %s status" % path2, str(cm.exception))
-    assert_in("fatal: Not a git repository", str(cm.exception))
+    assert_re_in("fatal: [Nn]ot a git repository",
+                 str(cm.exception), match=False)
 
     # TODO: How to test 'env'?
 


### PR DESCRIPTION
#### What is the problem?
I've not uploaded most recent git-annex since it caused few other tests to fail in comparison to previous one ()
```shell
$> DATALAD_TESTS_SSH=1 python -m nose -s -v datalad.support.tests.test_gitrepo:test_git_custom_calls datalad.support.tests.test_annexrepo:test_AnnexRepo_add_unexpected_direct_mode       
datalad.support.tests.test_gitrepo.test_git_custom_calls ... FAIL
datalad.support.tests.test_annexrepo.test_AnnexRepo_add_unexpected_direct_mode ... ERROR
Versions: appdirs=1.4.3 boto=2.44.0 cmd:annex=6.20180519+gitgf6f199be3-1~ndall+1 cmd:git=2.17.0 cmd:system-git=2.17.0 cmd:system-ssh=7.6p1 exifread=2.1.2 git=2.1.8 gitdb=2.0.3 humanize=0.5.1 iso8601=0.1.11 msgpack=0.5.1 mutagen=1.40.0 requests=2.18.4 scrapy=1.5.0 six=1.11.0 tqdm=4.19.5 wrapt=1.9.0

======================================================================
ERROR: datalad.support.tests.test_annexrepo.test_AnnexRepo_add_unexpected_direct_mode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 836, in newfunc
    t(*(arg + (uri,)), **kw)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/tests/test_annexrepo.py", line 838, in test_AnnexRepo_add_unexpected_direct_mode
    top.add('.')
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py", line 301, in newfunc
    result = func(self, files_new, *args, **kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/annexrepo.py", line 1482, in add
    to_be_added_recs = _get_to_be_added_recs(files)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/annexrepo.py", line 1475, in _get_to_be_added_recs
    raise e
CommandError: CommandError: command '['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'add', '--dry-run', '-N', '--ignore-missing', '--verbose', '--', '.']' failed with exitcode 128
Failed to run ['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'add', '--dry-run', '-N', '--ignore-missing', '--verbose', '--', '.'] under '/home/yoh/.tmp/datalad_temp_clone_url_vhdYI1'. Exit code=128. out= err=fatal: this operation must be run in a work tree
fatal: 'git status --porcelain=2' failed in submodule subm 1


======================================================================
FAIL: datalad.support.tests.test_gitrepo.test_git_custom_calls
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 663, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 663, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/tests/test_gitrepo.py", line 901, in test_git_custom_calls
    assert_in("fatal: Not a git repository", str(cm.exception))
AssertionError: 'fatal: Not a git repository' not found in "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git -c receive.autogc=0 -c gc.auto=0 -C /home/yoh/.tmp/datalad_temp_test_git_custom_callsQbgSw9 status\n  stderr: 'fatal: not a git repository (or any parent up to mount point /)\nStopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).'"
-------------------- >> begin captured logging << --------------------
datalad.utils: Level 5: Importing datalad.utils
datalad.utils: Level 5: Done importing datalad.utils
datalad.cmd: Level 9: Will use git under '/usr/lib/git-annex.linux' (no adjustments to PATH if empty string)
datalad.cmd: Level 9: Running: ['git', 'version']
datalad.cmd: Level 8: Finished running ['git', 'version'] with status 0
datalad.cmd: Level 9: Running: ['git', 'config', '-z', '-l', '--show-origin']
datalad.cmd: Level 8: Finished running ['git', 'config', '-z', '-l', '--show-origin'] with status 0
datalad.ui: Level 5: Starting importing ui
datalad.ui.dialog: Level 5: Starting importing ui.dialog
datalad.ui.dialog: Level 5: Done importing ui.dialog
datalad.ui: Level 5: Initiating UI switcher
datalad.ui: DEBUG: UI set to DialogUI(out=<file>)
datalad.ui: Level 5: Done importing ui
datalad.gitrepo: DEBUG: stdout| On branch master
datalad.gitrepo: DEBUG: stdout| nothing to commit, working tree clean
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 2 tests in 17.074s

FAILED (errors=1, failures=1)
DATALAD_TESTS_SSH=1 python -m nose -s -v    12.89s user 5.46s system 99% cpu 18.414 total

```
and they pass fine with 6.20180416+gitg86b18966f-1~ndall+1 ... 2nd one seems to be just casing (heh heh)... will fix up for those now