### PR TITLE
DOC: Delete an incorrect comment from .datalad/.gitattributes

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -383,8 +383,6 @@ class Create(Interface):
         with open(opj(tbds.path, '.datalad', '.gitattributes'), 'a') as gitattr:
             # TODO this will need adjusting, when annex'ed aggregate metadata
             # comes around
-            gitattr.write('# Text files (according to file --mime-type) are added directly to git.\n')
-            gitattr.write('# See http://git-annex.branchable.com/tips/largefiles/ for more info.\n')
             gitattr.write('config annex.largefiles=nothing\n')
             gitattr.write('metadata/aggregate* annex.largefiles=nothing\n')
             gitattr.write('metadata/objects/** annex.largefiles=({})\n'.format(


### PR DESCRIPTION
The rules below it do not say "add text files directly to git".

Closes #2466.
