### PR TITLE
BF: Don't fail too early when parsing cmdline arguments

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -205,9 +205,8 @@ def setup_parser(
                   parsed_args, unparsed_args)
     except Exception as exc:
         lgr.debug("Early parsing failed with %s", exc_str(exc))
-        fail_handler(parser)
         need_single_subparser = False
-
+        unparsed_args = cmdlineargs[1:]  # referenced before assignment otherwise
 
     interface_groups = get_interface_groups()
     # TODO: see if we could retain "generator" for plugins


### PR DESCRIPTION
This pull request fixes #2524

This pull request proposes to throw away (too) early failing when parsing cmdline arguments.

### Changes
- [ ] This change is complete

Please have a look @datalad/developers
