### PR TITLE
BF+ENH: delay import of lzma until used, informative mesage if undefined symbol: lzma_alone_encoder

### DIFF
--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -11,8 +11,8 @@
 
 
 import io
-import lzma
 import codecs
+from six import PY2
 from os.path import dirname
 from os.path import exists
 from os import makedirs
@@ -69,6 +69,19 @@ def LZMAFile(*args, **kwargs):
     calling dir() helps to avoid AttributeError __exit__
     see https://bugs.launchpad.net/pyliblzma/+bug/1219296
     """
+    try:
+        import lzma
+    except Exception as exc:
+        if PY2 and 'undefined symbol: lzma_alone_encoder' in str(exc):
+            lgr.error(
+                "lzma fails to import and a typical problem is installation "
+                "of pyliblzma via pip while pkg-config utility is missing. "
+                "If you did installed it using pip, please "
+                "1) pip uninstall pyliblzma; "
+                "2) install pkg-config (e.g. apt-get install pkg-config on "
+                "Debian-based systems); "
+                "3) pip install pyliblzma again.")
+        raise
     lzmafile = lzma.LZMAFile(*args, **kwargs)
     dir(lzmafile)
     return lzmafile


### PR DESCRIPTION
This pull request fixes #1934
