### PR TITLE
BF: instruct .gitattributes to add itself to git not annex

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -384,6 +384,7 @@ class Create(Interface):
             # TODO this will need adjusting, when annex'ed aggregate metadata
             # comes around
             gitattr.write('config annex.largefiles=nothing\n')
+            gitattr.write('.gitattributes annex.largefiles=nothing\n')
             gitattr.write('metadata/aggregate* annex.largefiles=nothing\n')
             gitattr.write('metadata/objects/** annex.largefiles=({})\n'.format(
                 cfg.obtain('datalad.metadata.create-aggregate-annex-limit')))


### PR DESCRIPTION
otherwise if I just copy, and datalad add it - it would go into annex
