### PR TITLE
Even more Windows tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ test_script:
   - python -m nose -s -v datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_datacite_xml datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822
   # nothing runs here
   #- python -m nose -s -v datalad.plugin
-  - python -m nose -s -v datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network
+  - python -m nose -s -v datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector
   - python -m nose -s -v datalad.tests.test_api datalad.tests.test_base
   - python -m nose -s -v datalad.ui
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda35
-      DATALAD_TESTS_SSH: 0
+      DATALAD_TESTS_SSH: 1
 
 cache:
   # cache the pip cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
   - python -m nose -s -v datalad.cmdline
   # nothing runs here
   #- python -m nose -s -v datalad.customremotes
-  - python -m nose -s -v datalad.distribution.tests.test_create datalad.distribution.tests.test_create_github datalad.distribution.tests.test_dataset_binding datalad.distribution.tests.test_dataset_config datalad.distribution.tests.test_siblings datalad.distribution.tests.test_update datalad.distribution.tests.test_dataset datalad.distribution.tests.test_install datalad.distribution.tests.test_publish datalad.distribution.tests.test_subdataset
+  - python -m nose -s -v datalad.distribution.tests.test_create datalad.distribution.tests.test_create_github datalad.distribution.tests.test_dataset_binding datalad.distribution.tests.test_dataset_config datalad.distribution.tests.test_siblings datalad.distribution.tests.test_update datalad.distribution.tests.test_dataset datalad.distribution.tests.test_install datalad.distribution.tests.test_publish datalad.distribution.tests.test_subdataset datalad.distribution.tests.test_clone
   - python -m nose -s -v datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3
   - python -m nose -s -v datalad.interface.tests.test_base datalad.interface.tests.test_clean datalad.interface.tests.test_docs datalad.interface.tests.test_ls
   - python -m nose -s -v datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_datacite_xml datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,8 @@ install:
   # ATM datalad does not pull in colorama, which is needed for color output
   # on windows
   - pip install colorama
+  - git config --global user.email "test@appveyor.land"
+  - git config --global user.name "Appveyor Almighty"
 
 test_script:
   # establish baseline, if annex doesn't work, we are not even trying

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -34,13 +34,10 @@ from .log import lgr
 import atexit
 from datalad.utils import on_windows, get_encoding_info, get_envvars_info
 
-if not on_windows:
-    lgr.log(5, "Instantiating ssh manager")
-    from .support.sshconnector import SSHManager
-    ssh_manager = SSHManager()
-    atexit.register(ssh_manager.close, allow_fail=False)
-else:
-    ssh_manager = None
+lgr.log(5, "Instantiating ssh manager")
+from .support.sshconnector import SSHManager
+ssh_manager = SSHManager()
+atexit.register(ssh_manager.close, allow_fail=False)
 
 try:
     # this will fix the rendering of ANSI escape sequences

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -50,7 +50,6 @@ from datalad.support.network import is_ssh
 from datalad.support.sshconnector import sh_quote
 from datalad.support.param import Parameter
 from datalad.utils import make_tempfile
-from datalad.utils import not_supported_on_windows
 from datalad.utils import _path_
 from datalad.utils import slash_join
 from datalad.utils import assure_list
@@ -416,11 +415,6 @@ class CreateSibling(Interface):
                  annex_wanted=None, annex_group=None, annex_groupwanted=None,
                  inherit=False,
                  since=None):
-
-        # there is no point in doing anything further
-        not_supported_on_windows(
-            "Support for SSH connections is not yet implemented in Windows")
-
         #
         # nothing without a base dataset
         #

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -63,6 +63,11 @@ def resolve_path(path, ds=None):
     -------
     Absolute path
     """
+    # first make sure it's actually a valid path:
+    from datalad.support.network import PathRI
+    if not isinstance(RI(path), PathRI):
+        raise ValueError("%s is not a valid path" % path)
+
     path = expandpath(path, force_absolute=False)
     if is_explicit_path(path):
         # normalize path consistently between two (explicit and implicit) cases

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -50,6 +50,7 @@ from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import slow
+from datalad.tests.utils import skip_if_on_windows
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import InsufficientArgumentsError
 
@@ -135,6 +136,7 @@ def test_invalid_call(path):
                 'bogus'))
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_testrepos('.*basic.*', flavors=['local'])
 @with_tempfile(mkdir=True)
@@ -301,6 +303,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         assert_set_equal(modified_files, ok_modified_files)
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @slow  # 53.8496s
 @skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])
@@ -373,6 +376,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
         publish(dataset=source, to=remote_name, recursive=True, since='') # just a smoke test
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
@@ -418,6 +422,7 @@ def test_target_ssh_since(origin, src_path, target_path):
     ok_(Dataset(_path_(target_path, 'brandnew2/sub/sub')).is_installed())
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -438,6 +443,7 @@ def test_failon_no_permissions(src_path, target_path):
         sshurl="ssh://localhost" + opj(target_path, 'ds'))
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile
@@ -494,6 +500,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     eq_(len(logs_post), len(logs_prior) + 1)
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile(suffix="target")
@@ -548,6 +555,7 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
         assert_false(target_sub.repo.file_has_content('sub.dat'))
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 def test_target_ssh_inherit():
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -63,6 +63,7 @@ from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import use_cassette
 from datalad.tests.utils import skip_if_no_network
+from datalad.tests.utils import skip_if_on_windows
 from datalad.tests.utils import put_file_under_git
 from datalad.tests.utils import integration
 from datalad.tests.utils import slow
@@ -879,6 +880,7 @@ def test_install_from_tilda(opath, tpath):
     assert Dataset(opj(tpath, 'sub ds')).is_installed()
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @usecase
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -884,6 +884,7 @@ def test_install_from_tilda(opath, tpath):
 @with_tempfile(mkdir=True)
 def test_install_subds_from_another_remote(topdir):
     # https://github.com/datalad/datalad/issues/1905
+    from datalad.support.network import PathRI
     with chpwd(topdir):
         origin_ = 'origin'
         clone1_ = 'clone1'
@@ -892,7 +893,7 @@ def test_install_subds_from_another_remote(topdir):
         origin = create(origin_, no_annex=True)
         clone1 = install(source=origin, path=clone1_)
         # print("Initial clone")
-        clone1.create_sibling('ssh://localhost%s/%s' % (getpwd(), clone2_), name=clone2_)
+        clone1.create_sibling('ssh://localhost%s/%s' % (PathRI(getpwd()).posixpath, clone2_), name=clone2_)
 
         # print("Creating clone2")
         clone1.publish(to=clone2_)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -32,6 +32,7 @@ from datalad.api import install
 from datalad.api import get
 from datalad import consts
 from datalad.utils import chpwd
+from datalad.utils import on_windows
 from datalad.interface.results import YieldDatasets
 from datalad.interface.results import YieldRelativePaths
 from datalad.support.exceptions import InsufficientArgumentsError
@@ -860,8 +861,13 @@ def test_install_subds_with_space(opath, tpath):
     ds.create('sub ds')
     # works even now, boring
     # install(tpath, source=opath, recursive=True)
-    # do via ssh!
-    install(tpath, source="localhost:" + opath, recursive=True)
+    if on_windows:
+        # on windows we cannot simply prepend localhost: to a path
+        # and get a working sshurl...
+        install(tpath, source=opath, recursive=True)
+    else:
+        # do via ssh!
+        install(tpath, source="localhost:" + opath, recursive=True)
     assert Dataset(opj(tpath, 'sub ds')).is_installed()
 
 

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -47,6 +47,7 @@ from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import serve_path_via_http
+from datalad.tests.utils import skip_if_on_windows
 
 
 @with_testrepos('submodule_annex', flavors=['local'])
@@ -78,6 +79,7 @@ def test_invalid_call(origin, tdir):
         type='dataset')
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile
 @with_tempfile
@@ -486,6 +488,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
     assert_result_count(res, 1, status='notneeded', path=source.path)
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
@@ -598,6 +601,7 @@ def test_gh1426(origin_path, target_path):
     eq_(origin.repo.get_hexsha(), target.get_hexsha())
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
@@ -630,6 +634,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
     assert_result_count(results, 1, status='impossible', type='dataset', action='publish')
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree={'1': '123'})
 @with_tempfile(mkdir=True)
@@ -647,6 +652,7 @@ def test_publish_target_url(src, desttop, desturl):
     ok_file_has_content(_path_(desttop, 'subdir/1'), '123')
 
 
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile()

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -83,8 +83,9 @@ def test_invalid_call(origin, tdir):
 @with_tempfile
 def test_smth_about_not_supported(p1, p2):
     source = Dataset(p1).create()
+    from datalad.support.network import PathRI
     source.create_sibling(
-        'ssh://localhost' + p2,
+        'ssh://localhost' + PathRI(p2).posixpath,
         name='target1')
     # source.publish(to='target1')
     with chpwd(p1):

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -22,7 +22,7 @@ from datalad.utils import chpwd
 from datalad.interface.results import is_ok_dataset
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
-from datalad.support.exceptions import DeprecatedError, IncompleteResultsError
+from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import ok_
 from datalad.api import save
 from datalad.api import create
@@ -39,6 +39,7 @@ from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_values_equal
 from datalad.tests.utils import skip_v6
+from datalad.tests.utils import skip_if_on_windows
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
@@ -334,6 +335,7 @@ def test_subdataset_save(path):
     ok_clean_git(parent.path, untracked=['untracked'])
 
 
+@skip_if_on_windows  # gh-2536
 @with_tempfile(mkdir=True)
 def test_symlinked_relpath(path):
     # initially ran into on OSX https://github.com/datalad/datalad/issues/2406

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import skip_if_on_windows
 
 
 def _assert_metadata_empty(meta):
@@ -179,6 +180,7 @@ def test_reaggregate_with_unavailable_objects(path):
 
 
 # this is for gh-1987
+@skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree=_dataset_hierarchy_template)
 @skip_direct_mode  #FIXME

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -48,6 +48,17 @@ from datalad.support.cache import lru_cache
 # import requests
 
 
+def is_windows_path(path):
+    win_split = win_splitdrive(path)
+    # Note, that ntpath.splitdrive also deals with UNC paths. In that case
+    # the "drive" wouldn't be a windows drive letter followed by a colon
+    if win_split[0] and win_split[1] and \
+            win_split[0].endswith(":") and len(win_split[0]) == 2:
+        # seems to be a windows path
+        return True
+    return False
+
+
 def get_response_disposition_filename(s):
     """Given a string s as from HTTP Content-Disposition field in the response
     return possibly present filename if any
@@ -291,10 +302,7 @@ def _guess_ri_cls(ri):
         'file': PathRI,
         'datalad': DataLadRI
     }
-    # go in exotic mode if this is an absolute windows path
-    win_split = win_splitdrive(ri)
-    # we need a drive and a path, otherwise this could be a false positive
-    if win_split[0] and win_split[1]:
+    if is_windows_path(ri):
         # OMG we got something from windows
         lgr.log(5, "Detected file ri")
         return TYPES['file']
@@ -671,6 +679,14 @@ class PathRI(RI):
     @property
     def localpath(self):
         return self.path
+
+    @property
+    def posixpath(self):
+        if is_windows_path(self.path):
+            win_split = win_splitdrive(self.path)
+            return "/" + win_split[0][0] + win_split[1].replace('\\', '/')
+        else:
+            return self.path
 
 
 class RegexBasedURLMixin(object):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -35,7 +35,6 @@ except ImportError:
 
 from datalad.support.exceptions import CommandError
 from datalad.dochelpers import exc_str
-from datalad.utils import not_supported_on_windows
 from datalad.utils import assure_dir
 from datalad.utils import auto_repr
 from datalad.cmd import Runner
@@ -347,9 +346,6 @@ class SSHManager(object):
     """
 
     def __init__(self):
-        not_supported_on_windows("TODO: Make this an abstraction to "
-                                 "interface platform dependent SSH")
-
         self._socket_dir = None
         self._connections = dict()
         # Initialization of prev_connections is happening during initial

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -24,6 +24,7 @@ from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import ok_
 from datalad.tests.utils import assert_is_instance
+from datalad.tests.utils import skip_if_on_windows
 
 from ..sshconnector import SSHConnection, SSHManager, sh_quote
 from ..sshconnector import get_connection_hash
@@ -63,6 +64,7 @@ def test_ssh_get_connection():
     manager.close()
 
 
+@skip_if_on_windows  # our test setup has no SSH server running
 @skip_ssh
 @with_tempfile(suffix=' "`suffix:;& ',  # get_most_obscure_supported_name(),
                content="1")
@@ -99,6 +101,7 @@ def test_ssh_open_close(tfile1):
     ok_(exists(path) == existed_before)
 
 
+@skip_if_on_windows  # our test setup has no SSH server running
 @skip_ssh
 def test_ssh_manager_close():
 
@@ -155,6 +158,7 @@ def test_ssh_manager_close_no_throw(bogus_socket):
         assert_in('Failed to close a connection: oh I am so bad', cml.out)
 
 
+@skip_if_on_windows  # our test setup has no `scp` command
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile(content="one")
@@ -197,6 +201,7 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
     ssh.close()
 
 
+@skip_if_on_windows  # our test setup has no SSH server running
 @skip_ssh
 def test_ssh_compound_cmds():
     ssh = SSHManager().get_connection('ssh://localhost')
@@ -205,6 +210,7 @@ def test_ssh_compound_cmds():
     ssh.close()  # so we get rid of the possibly lingering connections
 
 
+@skip_if_on_windows  # our test setup has no SSH server running
 @skip_ssh
 def test_ssh_git_props():
     remote_url = 'ssh://localhost'

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -612,11 +612,6 @@ def test_setup():
 
 
 def test_skip_ssh():
-    # no ssh testing on Windows ATM
-    with patch.object(utils, 'on_windows', return_value=True):
-        with assert_raises(SkipTest):
-            skip_ssh(lambda: False)()
-
     with patch_config({'datalad.tests.ssh': False}):
         with assert_raises(SkipTest):
             skip_ssh(lambda: False)()

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -943,8 +943,6 @@ def skip_ssh(func):
     """
     @wraps(func)
     def newfunc(*args, **kwargs):
-        if on_windows:
-            raise SkipTest("SSH currently not available on windows.")
         from datalad import cfg
         test_ssh = cfg.get("datalad.tests.ssh", '')
         if not test_ssh or test_ssh in ('0', 'false', 'no'):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -337,7 +337,8 @@ def rmtemp(f, *args, **kwargs):
             # WindowsError is not known on Linux, and if IOError
             # or any other exception is thrown then if except
             # statement has WindowsError in it -- NameError
-            exceptions = (OSError, WindowsError) if on_windows else OSError
+            # also see gh-2533
+            exceptions = (OSError, WindowsError, PermissionError) if on_windows else OSError
             for i in range(50):
                 try:
                     os.unlink(f)


### PR DESCRIPTION
Biggest bits:

- Discontinue categorical refusal to do anything SSH-related on Windows
- Bunch of fixes that remove assumtions on POSIX-style path in various parts of the code/tests
- Disable a bunch of SSH-related tests on Windows that require a working SSH server on localhost, see #2559 for the path ahead
