### PR TITLE
ENH: run: Record dataset ID and check on rerun

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -310,6 +310,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     if rel_pwd is not None:
         # only when inside the dataset to not leak information
         run_info['pwd'] = rel_pwd
+    if ds.id:
+        run_info["dsid"] = ds.id
 
     # compose commit message
     msg = '[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -18,7 +18,6 @@ from argparse import REMAINDER
 from glob import glob
 from os.path import join as opj
 from os.path import curdir
-from os.path import isdir
 from os.path import normpath
 from os.path import relpath
 
@@ -28,7 +27,6 @@ from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.interface.common_opts import save_message_opt
 
-from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureNone
 from datalad.support.exceptions import CommandError
@@ -193,6 +191,7 @@ def get_command_pwds(dataset):
             rel_pwd = pwd  # and leave handling on deciding either we
                            # deal with it or crash to checks below
     return pwd, rel_pwd
+
 
 # This helper function is used to add the rerun_info argument.
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -143,6 +143,12 @@ def test_rerun(path, nodspath):
     # ran twice now
     eq_('xx\n', open(probe_path).read())
 
+    # Rerunning from a subdataset skips the command.
+    assert_result_count(
+        sub.rerun(return_type="list", on_failure="ignore"),
+        1, status="impossible", action="run", rerun_action="skip")
+    eq_('xx\n', open(probe_path).read())
+
     # Rerun fails with a dirty repo.
     dirt = opj(path, "dirt")
     with open(dirt, "w") as fh:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -144,6 +144,8 @@ def test_rerun(path, nodspath):
     eq_('xx\n', open(probe_path).read())
 
     # Rerunning from a subdataset skips the command.
+    _, sub_info = get_run_info(sub.repo.repo.head.commit.message)
+    eq_(ds.id, sub_info["dsid"])
     assert_result_count(
         sub.rerun(return_type="list", on_failure="ignore"),
         1, status="impossible", action="run", rerun_action="skip")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -718,6 +718,7 @@ def test_run_inputs_no_annex_repo(path):
     ok_exists(opj(ds.path, "dummy"))
     ds.rerun()
 
+
 def test_rerun_commit_message_check():
     assert_raises(ValueError,
                   get_run_info,


### PR DESCRIPTION
When a command is run in a dataset, the same run information is recorded in all subdatasets that have added/modified files.  Rerunning the command from a subdataset isn't supported, so check the dataset ID on rerun and, if it is different, skip or cherry pick the commit using the same logic that's used for non-run commits.

Closes #1799.

---
- [x] This change is complete
