### PR TITLE
BF: interface: Don't be greedy when scanning for closing doc tags

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -99,7 +99,7 @@ def alter_interface_docs_for_api(docs):
     docs = dedent_docstring(docs)
     # clean cmdline sections
     docs = re.sub(
-        '\|\| CMDLINE \>\>.*\<\< CMDLINE \|\|',
+        '\|\| CMDLINE \>\>.*?\<\< CMDLINE \|\|',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -115,12 +115,12 @@ def alter_interface_docs_for_api(docs):
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| PYTHON \>\>(.*)\<\< PYTHON \|\|',
+        '\|\| PYTHON \>\>(.*?)\<\< PYTHON \|\|',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\|\| REFLOW \>\>\n(.*)\<\< REFLOW \|\|',
+        '\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -136,7 +136,7 @@ def alter_interface_docs_for_cmdline(docs):
     docs = dedent_docstring(docs)
     # clean cmdline sections
     docs = re.sub(
-        '\|\| PYTHON \>\>.*\<\< PYTHON \|\|',
+        '\|\| PYTHON \>\>.*?\<\< PYTHON \|\|',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -152,7 +152,7 @@ def alter_interface_docs_for_cmdline(docs):
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| CMDLINE \>\>(.*)\<\< CMDLINE \|\|',
+        '\|\| CMDLINE \>\>(.*?)\<\< CMDLINE \|\|',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -188,7 +188,7 @@ def alter_interface_docs_for_cmdline(docs):
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| REFLOW \>\>\n(.*)\<\< REFLOW \|\|',
+        '\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)

--- a/datalad/interface/tests/test_docs.py
+++ b/datalad/interface/tests/test_docs.py
@@ -34,6 +34,16 @@ demo_doc = """\
     << REFLOW ||
     << CMDLINE ||
 
+    || REFLOW >>
+    a
+    b
+    << REFLOW ||
+    not
+       reflowed
+    || REFLOW >>
+    c
+    << REFLOW ||
+
     || PYTHON >>
 
     || REFLOW >>
@@ -86,6 +96,8 @@ def test_alter_interface_docs_for_api():
     assert_not_in('CMD', alt)
     assert_not_in('PY', alt)
     assert_not_in('REFLOW', alt)
+    assert_in('a b', alt)
+    assert_in('not\n   reflowed', alt)
     assert_in("Some Python-only bits Multiline!", alt)
 
     altpd = alter_interface_docs_for_api(demo_paramdoc)
@@ -104,6 +116,8 @@ def test_alter_interface_docs_for_cmdline():
     assert_not_in('PY', alt)
     assert_not_in('CMD', alt)
     assert_not_in('REFLOW', alt)
+    assert_in('a b', alt)
+    assert_in('not\n   reflowed', alt)
     assert_in("Something for the cmdline only Multiline!", alt)
     # args
     altarg = alter_interface_docs_for_cmdline(demo_argdoc)


### PR DESCRIPTION
```
These should stop matching once the closing tag has been reached.
Otherwise it's not possible to write something like

    || REFLOW >>
    reflowed paragraph
    << REFLOW ||

      - a
      - b

    || REFLOW >>
    another reflowed paragraph
    << REFLOW ||
```


- [x] This change is complete

