### PR TITLE
BF: run: Sort keys in the run record

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -40,6 +40,7 @@ from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.interface.unlock import Unlock
 
+from datalad.utils import assure_bytes
 from datalad.utils import chpwd
 from datalad.utils import get_dataset_root
 from datalad.utils import getpwd
@@ -324,7 +325,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     msg = msg.format(
         message if message is not None else _format_cmd_shorty(cmd),
         json.dumps(run_info, indent=1, sort_keys=True, ensure_ascii=False))
-    msg = msg.encode("utf-8")
+    msg = assure_bytes(msg)
 
     if not rerun_info and cmd_exitcode:
         msg_path = opj(relpath(ds.repo.repo.git_dir), "COMMIT_EDITMSG")

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -314,9 +314,17 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         run_info["dsid"] = ds.id
 
     # compose commit message
-    msg = u'[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
+    msg = u"""\
+[DATALAD RUNCMD] {}
+
+=== Do not change lines below ===
+{}
+^^^ Do not change lines above ^^^
+"""
+    msg = msg.format(
         message if message is not None else _format_cmd_shorty(cmd),
-        json.dumps(run_info, indent=1, sort_keys=True, ensure_ascii=False)).encode("utf-8")
+        json.dumps(run_info, indent=1, sort_keys=True, ensure_ascii=False))
+    msg = msg.encode("utf-8")
 
     if not rerun_info and cmd_exitcode:
         msg_path = opj(relpath(ds.repo.repo.git_dir), "COMMIT_EDITMSG")

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -314,13 +314,13 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         run_info["dsid"] = ds.id
 
     # compose commit message
-    msg = '[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
+    msg = u'[DATALAD RUNCMD] {}\n\n=== Do not change lines below ===\n{}\n^^^ Do not change lines above ^^^'.format(
         message if message is not None else _format_cmd_shorty(cmd),
-        json.dumps(run_info, indent=1), sort_keys=True, ensure_ascii=False, encoding='utf-8')
+        json.dumps(run_info, indent=1, sort_keys=True, ensure_ascii=False)).encode("utf-8")
 
     if not rerun_info and cmd_exitcode:
         msg_path = opj(relpath(ds.repo.repo.git_dir), "COMMIT_EDITMSG")
-        with open(msg_path, "w") as ofh:
+        with open(msg_path, "wb") as ofh:
             ofh.write(msg)
         lgr.info("The command had a non-zero exit code. "
                  "If this is expected, you can save the changes with "


### PR DESCRIPTION
Pass `sort_keys=True` to `json.dumps`, as intended.

Fixes #2581.

---

- [x] This change is complete
