### PR TITLE
ENH: `run` can store records in sidecar files

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -136,12 +136,12 @@ class Run(Interface):
             args=('--sidecar',),
             metavar="yes|no",
             doc="""By default, the configuration variable
-            'datalad.run.record-sidecar' is used to determine whether a record
-            with information on a command execution is not placed into
-            the commit message, but into a separate record file instead
-            (default: off). This option can be used to override the configured
-            behavior on a case-by-case basis. Sidecar files are placed into
-            dataset's '.datalad/runinfo' directory (customizable via the
+            'datalad.run.record-sidecar' determines whether a record with
+            information on a command's execution is placed into a separate
+            record file instead of the commit message (default: off). This
+            option can be used to override the configured behavior on a
+            case-by-case basis. Sidecar files are placed into the dataset's
+            '.datalad/runinfo' directory (customizable via the
             'datalad.run.record-directory' configuration variable).""",
             constraints=EnsureNone() | EnsureBool()),
         rerun=Parameter(

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -135,9 +135,14 @@ class Run(Interface):
         sidecar=Parameter(
             args=('--sidecar',),
             metavar="yes|no",
-            doc="""If given, a record with information on the command execution
-            is not placed into the commit message, but into a separate record
-            file instead.""",
+            doc="""By default, the configuration variable
+            'datalad.run.record-sidecar' is used to determine whether a record
+            with information on a command execution is not placed into
+            the commit message, but into a separate record file instead
+            (default: off). This option can be used to override the configured
+            behavior on a case-by-case basis. Sidecar files are placed into
+            dataset's '.datalad/runinfo' directory (customizable via the
+            'datalad.run.record-directory' configuration variable).""",
             constraints=EnsureNone() | EnsureBool()),
         rerun=Parameter(
             args=('--rerun',),

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -455,8 +455,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         record_dir = ds.config.get('datalad.run.record-directory', default=op.join('.datalad', 'runinfo'))
         record_path = op.join(ds.path, record_dir, record_id)
         if not op.lexists(record_path):
-            # go for compression, even for minimal records still 2-3x smaller, despite offset cost
-            dump2stream(record, record_path, compressed=False)
+            # go for compression, even for minimal records not much difference, despite offset cost
+            # wrap in list -- there is just one record
+            dump2stream([run_info], record_path, compressed=True)
 
     # compose commit message
     msg = u"""\

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -468,7 +468,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 """
     msg = msg.format(
         message if message is not None else _format_cmd_shorty(cmd),
-        record_id if sidecar else record)
+        '"{}"'.format(record_id) if sidecar else record)
     msg = assure_bytes(msg)
 
     if not rerun_info and cmd_exitcode:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -584,6 +584,9 @@ def test_rerun_script(path):
     ds = Dataset(path).create()
     ds.run("echo a >foo")
     ds.run(["touch", "bar"], message='BAR', sidecar=True)
+    # a run record sidecar file was added with the last commit
+    assert(any(d['path'].startswith(opj(ds.path, '.datalad', 'runinfo'))
+               for d in ds.rerun(report=True, return_type='item-or-list')['diff']))
     bar_hexsha = ds.repo.get_hexsha()
 
     script_file = opj(path, "commands.sh")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -583,7 +583,7 @@ def test_new_or_modified(path):
 def test_rerun_script(path):
     ds = Dataset(path).create()
     ds.run("echo a >foo")
-    ds.run(["touch", "bar"], message='BAR')
+    ds.run(["touch", "bar"], message='BAR', sidecar=True)
     bar_hexsha = ds.repo.get_hexsha()
 
     script_file = opj(path, "commands.sh")


### PR DESCRIPTION
This is working towards #2576, but

- [x] `rerun` needs to learn how to work with this too
- [x] tests
- [x] documentation on added config switches