### PR TITLE
BF: run: Fix handling of subdirectory inputs/outputs

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -15,6 +15,7 @@ import logging
 from itertools import dropwhile
 import json
 import os
+import os.path as op
 import re
 import sys
 
@@ -371,10 +372,13 @@ def _rerun(dset, results):
             # and enable re-modification ideally, we would bring back the
             # entire state of the tree with #1424, but we limit ourself to file
             # addition/not-in-place-modification for now
-            auto_outputs = (os.path.relpath(ap["path"], dset.path)
-                            for ap in new_or_modified(res["diff"]))
+            auto_outputs = (ap["path"] for ap in new_or_modified(res["diff"]))
+            # run records outputs relative to the "pwd" field.
+            auto_outputs = (op.relpath(p, op.join(dset.path, run_info["pwd"]))
+                            for p in auto_outputs)
             outputs = run_info.get("outputs", [])
             auto_outputs = [p for p in auto_outputs if p not in outputs]
+
             message = res["rerun_message"] or res["run_message"]
             for r in run_command(run_info['cmd'],
                                  dataset=dset,

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -153,17 +153,86 @@ class Run(Interface):
                 lgr.warning("No command given")
 
 
-def _expand_globs(patterns, pwd, warn=True):
-    patterns, dots = partition(patterns, lambda i: i.strip() == ".")
-    expanded = ["."] if list(dots) else []
-    with chpwd(pwd):
-        for pattern in patterns:
-            hits = glob(pattern)
-            if hits:
-                expanded.extend(hits)
-            elif warn:
-                lgr.warning("No matching files found for %s", pattern)
-    return expanded
+class GlobbedPaths(object):
+    """Helper for inputs and outputs.
+
+    Parameters
+    ----------
+    patterns : list of str
+        Call `glob.glob` with each of these patterns. "." is considered as
+        datalad's special "." path argument; it is not passed to glob and is
+        always left unexpanded.
+    pwd : str, optional
+        Glob in this directory.
+    expand : bool, optional
+       Whether the `paths` property returns unexpanded or expanded paths.
+    warn : bool, optional
+        Whether to warn when no glob hits are returned for `patterns`.
+    """
+
+    def __init__(self, patterns, pwd=None, expand=False, warn=True):
+        self.pwd = pwd or getpwd()
+        self._expand = expand
+        self._warn = warn
+
+        if patterns is None:
+            self._maybe_dot = []
+            self._paths = {"patterns": []}
+        else:
+            patterns, dots = partition(patterns, lambda i: i.strip() == ".")
+            self._maybe_dot = ["."] if list(dots) else []
+            self._paths = {
+                "patterns": [relpath(p, start=pwd) if isabs(p) else p
+                             for p in patterns]}
+
+    def __bool__(self):
+        return bool(self._maybe_dot or self.expand())
+
+    __nonzero__ = __bool__  # py2
+
+    def _expand_globs(self):
+        expanded = []
+        with chpwd(self.pwd):
+            for pattern in self._paths["patterns"]:
+                hits = glob(pattern)
+                if hits:
+                    expanded.extend([relpath(h) for h in hits])
+                elif self._warn:
+                    lgr.warning("No matching files found for '%s'", pattern)
+        return expanded
+
+    def expand(self, full=False):
+        """Return paths with the globs expanded.
+
+        Parameters
+        ----------
+        full : bool, optional
+            Return full paths rather than paths relative to `pwd`.
+        """
+        if not self._paths["patterns"]:
+            return self._maybe_dot + []
+
+        if "expanded" not in self._paths:
+            paths = self._expand_globs()
+            self._paths["expanded"] = paths
+        else:
+            paths = self._paths["expanded"]
+
+        if full and "expanded_full" not in self._paths:
+            paths = [opj(self.pwd, p) for p in paths]
+            self._paths["expanded_full"] = paths
+
+        return self._maybe_dot + paths
+
+    @property
+    def paths(self):
+        """Return paths relative to `pwd`.
+
+        Globs are expanded if `expand` was set to true during instantiation.
+        """
+        if self._expand:
+            return self.expand()
+        return self._maybe_dot + self._paths["patterns"]
 
 
 def get_command_pwds(dataset):
@@ -226,48 +295,26 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                      'cannot detect changes by command'))
         return
 
-    def get_abspaths(pwd_paths):
-        """Get absolute paths of inputs and outputs.
+    inputs = GlobbedPaths(inputs, pwd=pwd,
+                          expand=expand in ["inputs", "both"])
+    if inputs:
+        for res in ds.get(inputs.expand(full=True), on_failure="ignore"):
+            yield res
 
-        These are relative the commands working directory. Make them absolute
-        so that get/unlock can those that are relative to a dataset
-        subdirectory.
-        """
-        if pwd_paths[0] == ["."]:
-            maybe_dot = ["."]
-            pwd_paths = pwd_paths[1:]
-        else:
-            maybe_dot = []
-        return maybe_dot + [opj(ds.path, rel_pwd, p) for p in pwd_paths]
-
-    if inputs is None:
-        inputs = []
-    elif inputs:
-        inputs_expanded = _expand_globs(inputs, pwd)
-        if inputs_expanded:
-            for res in ds.get(get_abspaths(inputs_expanded), on_failure="ignore"):
-                yield res
-            if expand in ["inputs", "both"]:
-                inputs = inputs_expanded
-
-    if outputs is None:
-        outputs = []
-    elif outputs:
-        outputs_expanded = _expand_globs(outputs, pwd, warn=not rerun_info)
-        if outputs_expanded:
-            for res in ds.unlock(get_abspaths(outputs_expanded),
-                                 on_failure="ignore"):
-                if res["status"] == "impossible":
-                    if "no content" in res["message"]:
-                        for rem_res in ds.remove(res["path"],
-                                                 check=False, save=False):
-                            yield rem_res
-                        continue
-                    elif "path does not exist" in res["message"]:
-                        continue
-                yield res
-            if expand in ["outputs", "both"]:
-                outputs = outputs_expanded
+    outputs = GlobbedPaths(outputs, pwd=pwd,
+                           expand=expand in ["outputs", "both"],
+                           warn=not rerun_info)
+    if outputs:
+        for res in ds.unlock(outputs.expand(full=True), on_failure="ignore"):
+            if res["status"] == "impossible":
+                if "no content" in res["message"]:
+                    for rem_res in ds.remove(res["path"],
+                                             check=False, save=False):
+                        yield rem_res
+                    continue
+                elif "path does not exist" in res["message"]:
+                    continue
+            yield res
 
     # anticipate quoted compound shell commands
     cmd = cmd[0] if isinstance(cmd, list) and len(cmd) == 1 else cmd
@@ -319,11 +366,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         'cmd': cmd,
         'exit': cmd_exitcode if cmd_exitcode is not None else 0,
         'chain': rerun_info["chain"] if rerun_info else [],
-        'inputs': [relpath(p, start=pwd) if isabs(p) else p for p in inputs],
+        'inputs': inputs.paths,
         # Get outputs from the rerun_info because rerun adds new/modified files
         # to the outputs argument.
-        'outputs': rerun_info["outputs"]
-        if rerun_info else [relpath(p, start=pwd) if isabs(p) else p for p in outputs]
+        'outputs': rerun_info["outputs"] if rerun_info else outputs.paths,
     }
     if rel_pwd is not None:
         # only when inside the dataset to not leak information

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -668,6 +668,12 @@ def test_run_inputs_outputs(path):
     ds.run("touch subdir-dummy", inputs=[opj(ds.path, "subdir")])
     ok_(all(ds.repo.file_has_content(opj("subdir", f)) for f in ["a", "b"]))
 
+    # Inputs are specified relative the a dataset's subdirectory.
+    ds.repo.drop(opj("subdir", "a"), options=["--force"])
+    with chpwd(opj(path, "subdir")):
+        run("touch subdir-dummy1", inputs=["a"])
+    ok_(ds.repo.file_has_content(opj("subdir", "a")))
+
     # --input=. runs "datalad get ."
     ds.run("touch dot-dummy", inputs=["."])
     eq_(ds.repo.get_annexed_files(),

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -34,6 +34,7 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.gitrepo import GitCommandError, GitRepo
 from datalad.tests.utils import ok_, assert_false, neq_
 from datalad.api import run
+from datalad.interface.run import GlobbedPaths
 from datalad.interface.rerun import get_run_info
 from datalad.interface.rerun import diff_revision, new_or_modified
 from datalad.tests.utils import assert_raises
@@ -635,7 +636,7 @@ def test_run_inputs_outputs(path):
 
     with swallow_logs(new_level=logging.WARN) as cml:
         ds.run("touch dummy", inputs=["*.not-an-extension"])
-        assert_in("No matching files found for *.not-an-extension",
+        assert_in("No matching files found for '*.not-an-extension'",
                   cml.out)
 
     # Test different combinations of globs and explicit files.
@@ -707,7 +708,7 @@ def test_run_inputs_outputs(path):
 
     with swallow_logs(new_level=logging.WARN) as cml:
         ds.run("echo blah", outputs=["*.not-an-extension"])
-        assert_in("No matching files found for *.not-an-extension",
+        assert_in("No matching files found for '*.not-an-extension'",
                   cml.out)
 
     ds.create('sub')
@@ -735,6 +736,42 @@ def test_run_inputs_no_annex_repo(path):
     ds.run("touch dummy", inputs=["*"])
     ok_exists(opj(ds.path, "dummy"))
     ds.rerun()
+
+
+@with_tree(tree={"1.txt": "",
+                 "2.dat": "",
+                 "3.txt": ""})
+def test_globbedpaths(path):
+    for patterns, expected in [
+            (["1.txt", "2.dat"], {"1.txt", "2.dat"}),
+            (["*.txt", "*.dat"], {"1.txt", "2.dat", "3.txt"}),
+            (["*.txt"], {"1.txt", "3.txt"})]:
+        gp = GlobbedPaths(patterns, pwd=path)
+        eq_(set(gp.expand()), expected)
+        eq_(set(gp.expand(full=True)),
+            {opj(path, p) for p in expected})
+
+    # Full patterns still get returned as relative to pwd.
+    gp = GlobbedPaths([opj(path, "*.dat")], pwd=path)
+    eq_(gp.expand(), ["2.dat"])
+
+    # "." gets special treatment.
+    gp = GlobbedPaths([".", "*.dat"], pwd=path)
+    eq_(set(gp.expand()), {"2.dat", "."})
+    gp = GlobbedPaths(["."], pwd=path, expand=False)
+    eq_(gp.expand(), ["."])
+    eq_(gp.paths, ["."])
+
+    # glob expansion for paths property is determined by expand argument.
+    for expand, expected in [(True, ["2.dat"]), (False, ["*.dat"])]:
+        gp = GlobbedPaths(["*.dat"], pwd=path, expand=expand)
+        eq_(gp.paths, expected)
+
+    with swallow_logs(new_level=logging.WARN) as cml:
+        GlobbedPaths(["not here"], pwd=path).expand()
+        assert_in("No matching files found for 'not here'", cml.out)
+        GlobbedPaths(["also not"], pwd=path, warn=False).expand()
+        assert_not_in("No matching files found for 'also not'", cml.out)
 
 
 def test_rerun_commit_message_check():


### PR DESCRIPTION
Fixes bug mentioned in  https://github.com/datalad/datalad/pull/2587#discussion_r191758806.

 * Ensure that inputs and outputs are resolved correctly by `get` and `unlock`.  The issue arises when run is called from subdirectories because globbing for inputs and outputs is done relative to the pwd.

  * Add helper class to deal with handling of inputs and outputs.

---

- [x] This change is complete
