### PR TITLE
NF: run: Add a placeholder for the run's working directory

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -369,9 +369,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         for res in _unlock_or_remove(ds, rerun_outputs):
             yield res
 
-    if inputs_placeholder or outputs_placeholder:
+    if inputs_placeholder or outputs_placeholder or "{pwd" in cmd:
         sfmt = SequenceFormatter()
         cmd_expanded = sfmt.format(cmd,
+                                   pwd=pwd,
                                    inputs=inputs.expand(dot=False),
                                    outputs=outputs.expand(dot=False))
     else:

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -179,24 +179,20 @@ class GlobbedPaths(object):
     patterns : list of str
         Call `glob.glob` with each of these patterns. "." is considered as
         datalad's special "." path argument; it is not passed to glob and is
-        always left unexpanded.
+        always left unexpanded. Each set of glob results is sorted
+        alphabetically.
     pwd : str, optional
         Glob in this directory.
     expand : bool, optional
        Whether the `paths` property returns unexpanded or expanded paths.
     warn : bool, optional
         Whether to warn when no glob hits are returned for `patterns`.
-    sort : bool, optional
-        Whether to sort globs results alphabetically. This sorting applies
-        within the results for each item in `patterns`, not across the entire
-        collection of results.
     """
 
-    def __init__(self, patterns, pwd=None, expand=False, warn=True, sort=False):
+    def __init__(self, patterns, pwd=None, expand=False, warn=True):
         self.pwd = pwd or getpwd()
         self._expand = expand
         self._warn = warn
-        self._sort = sort
 
         if patterns is None:
             self._maybe_dot = []
@@ -219,9 +215,7 @@ class GlobbedPaths(object):
             for pattern in self._paths["patterns"]:
                 hits = glob(pattern)
                 if hits:
-                    if self._sort:
-                        hits = list(sorted(hits))
-                    expanded.extend([relpath(h) for h in hits])
+                    expanded.extend([relpath(h) for h in sorted(hits)])
                 elif self._warn:
                     lgr.warning("No matching files found for '%s'", pattern)
         return expanded
@@ -350,15 +344,13 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     outputs_placeholder = "{outputs" in cmd
 
     inputs = GlobbedPaths(inputs, pwd=pwd,
-                          expand=expand in ["inputs", "both"],
-                          sort=inputs_placeholder)
+                          expand=expand in ["inputs", "both"])
     if inputs:
         for res in ds.get(inputs.expand(full=True), on_failure="ignore"):
             yield res
 
     outputs = GlobbedPaths(outputs, pwd=pwd,
                            expand=expand in ["outputs", "both"],
-                           sort=outputs_placeholder,
                            warn=not rerun_info)
     if outputs:
         for res in _unlock_or_remove(ds, outputs.expand(full=True)):
@@ -372,14 +364,11 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         for res in _unlock_or_remove(ds, rerun_outputs):
             yield res
 
-    if inputs_placeholder or outputs_placeholder or "{pwd" in cmd:
-        sfmt = SequenceFormatter()
-        cmd_expanded = sfmt.format(cmd,
-                                   pwd=pwd,
-                                   inputs=inputs.expand(dot=False),
-                                   outputs=outputs.expand(dot=False))
-    else:
-        cmd_expanded = cmd
+    sfmt = SequenceFormatter()
+    cmd_expanded = sfmt.format(cmd,
+                               pwd=pwd,
+                               inputs=inputs.expand(dot=False),
+                               outputs=outputs.expand(dot=False))
 
     # TODO do our best to guess which files to unlock based on the command string
     #      in many cases this will be impossible (but see rerun). however,

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -88,6 +88,9 @@ class Run(Interface):
     line, with any globs expanded in alphabetical order (like bash). Individual
     values can be accessed with an integer index (e.g., "{inputs[0]}").
     << REFLOW ||
+
+    In addition, "{pwd}" will be replaced with the full path of the current
+    working directory.
     """
     _params_ = dict(
         cmd=Parameter(

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -79,18 +79,18 @@ class Run(Interface):
 
     *Command format*
 
-
     || REFLOW >>
-    The command supports using placeholders "{inputs}" and "{outputs}" for the
-    values specified by [CMD: --input and --output CMD][PY: `inputs` and
-    `outputs` PY]. If multiple values are specified, the values will be joined
-    by a space. The order of the values will match that order from the command
-    line, with any globs expanded in alphabetical order (like bash). Individual
+    A few placeholders are supported in the command via Python format
+    specification. "{pwd}" will be replaced with the full path of the current
+    working directory. "{inputs}" and "{outputs}" represent the values
+    specified by [CMD: --input and --output CMD][PY: `inputs` and `outputs`
+    PY]. If multiple values are specified, the values will be joined by a
+    space. The order of the values will match that order from the command line,
+    with any globs expanded in alphabetical order (like bash). Individual
     values can be accessed with an integer index (e.g., "{inputs[0]}").
     << REFLOW ||
 
-    In addition, "{pwd}" will be replaced with the full path of the current
-    working directory.
+    To escape a brace character, double it (i.e., "{{" or "}}").
     """
     _params_ = dict(
         cmd=Parameter(

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -801,13 +801,11 @@ def test_globbedpaths(path):
     eq_(gp.expand(), ["."])
     eq_(gp.paths, ["."])
 
-    # We can sort the glob output.
+    # We can the glob outputs.
     glob_results = {"z": "z",
                     "a": ["x", "d", "b"]}
     with patch('datalad.interface.run.glob', glob_results.get):
-        gp = GlobbedPaths(["z", "a"], sort=False)
-        eq_(gp.expand(), ["z", "x", "d", "b"])
-        gp = GlobbedPaths(["z", "a"], sort=True)
+        gp = GlobbedPaths(["z", "a"])
         eq_(gp.expand(), ["z", "b", "d", "x"])
 
     # glob expansion for paths property is determined by expand argument.

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -746,7 +746,8 @@ def test_run_inputs_no_annex_repo(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @known_failure_v6  #FIXME
-@with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c"})
+@with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c",
+                 "subdir": {}})
 def test_placeholders(path):
     ds = Dataset(path).create(force=True)
     ds.add(".")
@@ -759,6 +760,16 @@ def test_placeholders(path):
 
     ds.run("echo {inputs[0]} >getitem", inputs=["*.in"])
     ok_file_has_content(opj(path, "getitem"), "a.in\n")
+
+    ds.run("echo {pwd} >expanded-pwd")
+    ok_file_has_content(opj(path, "expanded-pwd"), path,
+                        strip=True)
+
+    subdir_path = opj(path, "subdir")
+    with chpwd(subdir_path):
+        run("echo {pwd} >expanded-pwd")
+    ok_file_has_content(opj(path, "subdir", "expanded-pwd"), subdir_path,
+                        strip=True)
 
     # Double brackets can be used to escape placeholders.
     ds.run("touch {{inputs}}", inputs=["*.in"])


### PR DESCRIPTION
This is useful when a command needs $PWD (e.g., mounting with
containers).  If it's hardcoded in the command, then that command
won't work reliably on different machines.  A more general approach is
to use a wrapper that resolves run-time values.  But many commands may
need $PWD, so let's add a placeholder to make a wrapper unnecessary in
this common, simple case.

Re: https://github.com/datalad/datalad-container/pull/35#issuecomment-393527318

---

- [x] mention in run's docstring