### PR TITLE
RF: Delete 'Move' from list of old-style commands

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -317,7 +317,7 @@ class Interface(object):
 
     _OLDSTYLE_COMMANDS = (
         'AddArchiveContent', 'CrawlInit', 'Crawl', 'CreateSiblingGithub',
-        'CreateTestDataset', 'Export', 'Ls', 'Move', 'SSHRun', 'Test')
+        'CreateTestDataset', 'Export', 'Ls', 'SSHRun', 'Test')
 
     @classmethod
     def setup_parser(cls, parser):


### PR DESCRIPTION
The module datalad/distribution/move.py was deleted in aaefa25d5 (RF:
Remove carcass, 2017-06-10).

---

- [x] This change is complete