### PR TITLE
run: Add --explicit flag

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -202,14 +202,11 @@ class GlobbedPaths(object):
         Glob in this directory.
     expand : bool, optional
        Whether the `paths` property returns unexpanded or expanded paths.
-    warn : bool, optional
-        Whether to warn when no glob hits are returned for `patterns`.
     """
 
-    def __init__(self, patterns, pwd=None, expand=False, warn=True):
+    def __init__(self, patterns, pwd=None, expand=False):
         self.pwd = pwd or getpwd()
         self._expand = expand
-        self._warn = warn
 
         if patterns is None:
             self._maybe_dot = []
@@ -234,8 +231,7 @@ class GlobbedPaths(object):
                 if hits:
                     expanded.extend([relpath(h) for h in sorted(hits)])
                 else:
-                    if self._warn:
-                        lgr.warning("No matching files found for '%s'", pattern)
+                    lgr.debug("No matching files found for '%s'", pattern)
                     expanded.extend([pattern])
         return expanded
 
@@ -394,8 +390,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 yield res
 
     outputs = GlobbedPaths(outputs, pwd=pwd,
-                           expand=expand in ["outputs", "both"],
-                           warn=not rerun_info)
+                           expand=expand in ["outputs", "both"])
     if outputs:
         for res in _unlock_or_remove(ds, outputs.expand(full=True)):
             yield res

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -331,7 +331,8 @@ def normalize_command(command):
 
 # This helper function is used to add the rerun_info argument.
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
-                message=None, rerun_info=None, rerun_outputs=None, sidecar=None):
+                message=None, sidecar=None,
+                rerun_info=None, rerun_outputs=None):
     rel_pwd = rerun_info.get('pwd') if rerun_info else None
     if rel_pwd and dataset:
         # recording is relative to the dataset

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -643,9 +643,8 @@ def test_run_inputs_outputs(path):
     ok_(ds.repo.file_has_content("test-annex.dat"))
 
     with swallow_logs(new_level=logging.WARN) as cml:
-        ds.run("touch dummy", inputs=["*.not-an-extension"])
-        assert_in("No matching files found for '*.not-an-extension'",
-                  cml.out)
+        ds.run("touch dummy", inputs=["not-there"])
+        assert_in("Input does not exist: ", cml.out)
 
     # Test different combinations of globs and explicit files.
     inputs = ["a.dat", "b.dat", "c.txt", "d.txt"]
@@ -714,10 +713,9 @@ def test_run_inputs_outputs(path):
     with open(opj(path, "a.dat")) as fh:
         eq_(fh.read(), "a.dat appended\n")
 
-    with swallow_logs(new_level=logging.WARN) as cml:
-        ds.run("echo blah", outputs=["*.not-an-extension"])
-        assert_in("No matching files found for '*.not-an-extension'",
-                  cml.out)
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        ds.run("echo blah", outputs=["not-there"])
+        assert_in("Filtered out non-existing path: ", cml.out)
 
     ds.create('sub')
     ds.run("echo sub_orig >sub/subfile")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -814,11 +814,9 @@ def test_globbedpaths(path):
         gp = GlobbedPaths(["*.dat"], pwd=path, expand=expand)
         eq_(gp.paths, expected)
 
-    with swallow_logs(new_level=logging.WARN) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         GlobbedPaths(["not here"], pwd=path).expand()
         assert_in("No matching files found for 'not here'", cml.out)
-        GlobbedPaths(["also not"], pwd=path, warn=False).expand()
-        assert_not_in("No matching files found for 'also not'", cml.out)
 
 
 def test_rerun_commit_message_check():


### PR DESCRIPTION
This PR add the `--explicit` flag discussed in #2593.

---
- [ ] make `inputs` with `explicit=True` check the specified inputs for modifications.  I'm not sure what the best way to do that check is or how to handle untracked files here

  https://github.com/datalad/datalad/blob/e1a58b001c5378eea3f32d3abd8fea8d32c9b241/datalad/interface/run.py#L382-L384

- [ ] add support for running with no dataset (though there's no reason that has to be here)
