### PR TITLE
BF(UTF8,PY3): pass utf-8 encoding to open while reading csv file

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1575,7 +1575,8 @@ def read_csv_lines(fname, dialect=None, readahead=16384, **kwargs):
                 )
                 dialect = 'excel-tab'
 
-    with open(fname, 'rb' if PY2 else 'r') as tsvfile:
+    kw = {} if PY2 else dict(encoding='utf-8')
+    with open(fname, 'rb' if PY2 else 'r', **kw) as tsvfile:
         # csv.py doesn't do Unicode; encode temporarily as UTF-8:
         csv_reader = csv.reader(
             tsvfile,


### PR DESCRIPTION
Discovered while building/testing for python3 on debian, with no locales installed and all LC_* pointing to C or POSIX.

For now many other problems will be concealed by not running tests with unicode strings for debian build.  Whenever automagics of python2 do some miracles, python3 logging etc just puke in various scenarios.  This one seemed to have a straight resolution