### PR TITLE
ENH: inform user that no aggregated metadata was found for the dataset during query

### DIFF
--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -9,6 +9,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test metadata """
 
+import logging
 import os
 
 from os.path import join as opj
@@ -102,7 +103,7 @@ def test_aggregation(path):
     # a hierarchy of three (super/sub)datasets, each with some native metadata
     ds = Dataset(opj(path, 'origin')).create(force=True)
     # before anything aggregated we would get nothing and only a log warning
-    with swallow_logs() as cml:
+    with swallow_logs(new_level=logging.WARNING) as cml:
         assert_equal(list(query_aggregated_metadata('all', ds, [])), [])
     assert_re_in('.*Found no aggregated metadata.*update', cml.out)
     ds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -19,7 +19,7 @@ from datalad.api import aggregate_metadata
 from datalad.api import install
 from datalad.api import search
 from datalad.api import metadata
-from datalad.metadata.metadata import get_metadata_type
+from datalad.metadata.metadata import get_metadata_type, query_aggregated_metadata
 from datalad.utils import chpwd
 from datalad.utils import assure_unicode
 from datalad.tests.utils import with_tree, with_tempfile
@@ -34,6 +34,8 @@ from datalad.tests.utils import skip_direct_mode
 from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import assert_re_in
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetArgumentFound
 from datalad.support.gitrepo import GitRepo
@@ -99,6 +101,10 @@ def test_aggregation(path):
         assert_raises(InsufficientArgumentsError, aggregate_metadata, None)
     # a hierarchy of three (super/sub)datasets, each with some native metadata
     ds = Dataset(opj(path, 'origin')).create(force=True)
+    # before anything aggregated we would get nothing and only a log warning
+    with swallow_logs() as cml:
+        assert_equal(list(query_aggregated_metadata('all', ds, [])), [])
+    assert_re_in('.*Found no aggregated metadata.*update', cml.out)
     ds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                   where='dataset')
     subds = ds.create('sub', force=True)


### PR DESCRIPTION
I am not sure if that would be the best location but it is the location where info files are loaded (if present).

With message is for
- users who update to 0.10 while having only datasets with old aggregated metadata
- users who later fetch a dataset were metadata was agregated with newer version of datalad and no aggregated metadata present for their version of datalad
- users who do not exactly know yet the full workflow and that they need to aggregate it (I've heard already the question "but I've `git annex metadata` annotated it -- why search returns nothing?" a few times)
It could be more specific, but even without that it would be an improvement in comparison to just a silent exit.