### PR TITLE
ENH: ad-hoc Bearer token authentication/session support for LORIS

### DIFF
--- a/datalad/downloaders/configs/loris.cfg
+++ b/datalad/downloaders/configs/loris.cfg
@@ -1,0 +1,11 @@
+[provider:loris-demo]
+url_re = https?://demo.loris.ca/api/v0.0.2/.*
+credential = loris-demo
+authentication_type = bearer_token
+bearer_token_failure_re = "User not authenticated"}$
+
+
+[credential:loris-demo]
+url = https://demo.loris.ca
+type = token
+

--- a/datalad/downloaders/configs/loris.cfg
+++ b/datalad/downloaders/configs/loris.cfg
@@ -1,11 +1,10 @@
 [provider:loris-demo]
 url_re = https?://demo.loris.ca/api/v0.0.2/.*
 credential = loris-demo
-authentication_type = bearer_token
-bearer_token_failure_re = "User not authenticated"}$
-
+authentication_type = loris-token
+loris-token_failure_re = "User not authenticated"}$
 
 [credential:loris-demo]
-url = https://demo.loris.ca
-type = token
+url = https://demo.loris.ca/api/v0.0.2/login
+type = loris-token
 

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -297,7 +297,7 @@ class HTTPDigestAuthAuthenticator(HTTPRequestsAuthenticator):
 
 @auto_repr
 class HTTPBearerTokenAuthenticator(HTTPRequestsAuthenticator):
-    """Authenticate via HTTP digest authentication
+    """Authenticate via HTTP Authorization header
     """
     def __init__(self, **kwargs):
         # so we have __init__ solely for a custom docstring

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -305,7 +305,7 @@ class HTTPBearerTokenAuthenticator(HTTPRequestsAuthenticator):
 
     def _post_credential(self, credentials, post_url, session):
         # we do not need to post anything, just inject token into the session
-        session.headers['Authorization'] = "Bearer: %s" % credentials['token']
+        session.headers['Authorization'] = "Bearer %s" % credentials['token']
         # TODO: actually access some location to verify that token is correct
         class DummyResponse(object):
             text = ''

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -251,6 +251,7 @@ class HTTPRequestsAuthenticator(HTTPBaseAuthenticator):
     """
 
     REQUESTS_AUTHENTICATOR = None
+    REQUESTS_FIELDS = ('user', 'password')
 
     def __init__(self, **kwargs):
         # so we have __init__ solely for a custom docstring
@@ -258,7 +259,8 @@ class HTTPRequestsAuthenticator(HTTPBaseAuthenticator):
 
     def _post_credential(self, credentials, post_url, session):
         response = session.post(post_url, data={},
-                                auth=self.REQUESTS_AUTHENTICATOR(credentials['user'], credentials['password']))
+                                auth=self.REQUESTS_AUTHENTICATOR(
+                                    *[credentials[f] for f in self.REQUESTS_FIELDS]))
         return response
 
 
@@ -291,6 +293,25 @@ class HTTPDigestAuthAuthenticator(HTTPRequestsAuthenticator):
 
     def _post_credential(self, *args, **kwargs):
         raise NotImplementedError("not yet functioning, see https://github.com/kennethreitz/requests/issues/2934")
+
+
+@auto_repr
+class HTTPBearerTokenAuthenticator(HTTPRequestsAuthenticator):
+    """Authenticate via HTTP digest authentication
+    """
+    def __init__(self, **kwargs):
+        # so we have __init__ solely for a custom docstring
+        super(HTTPBearerTokenAuthenticator, self).__init__(**kwargs)
+
+    def _post_credential(self, credentials, post_url, session):
+        # we do not need to post anything, just inject token into the session
+        session.headers['Authorization'] = "Bearer: %s" % credentials['token']
+        # TODO: actually access some location to verify that token is correct
+        class DummyResponse(object):
+            text = ''
+            cookies = None
+            status_code = 200
+        return DummyResponse()
 
 
 @auto_repr
@@ -375,9 +396,10 @@ class HTTPDownloader(BaseDownloader):
     """
 
     @borrowkwargs(BaseDownloader)
-    def __init__(self, **kwargs):
+    def __init__(self, headers={}, **kwargs):
         super(HTTPDownloader, self).__init__(**kwargs)
         self._session = None
+        self._headers = headers
 
     def _establish_session(self, url, allow_old=True):
         """
@@ -433,7 +455,9 @@ class HTTPDownloader(BaseDownloader):
         nretries = 1
         for retry in range(1, nretries+1):
             try:
-                response = self._session.get(url, stream=True, allow_redirects=allow_redirects, headers=headers)
+                response = self._session.get(
+                    url, stream=True, allow_redirects=allow_redirects,
+                    headers=headers)
             #except (MaxRetryError, NewConnectionError) as exc:
             except Exception as exc:
                 # happen to run into those with urls pointing to Amazon, so let's rest and try again

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -47,6 +47,7 @@ AUTHENTICATION_TYPES = {
     'bearer_token': HTTPBearerTokenAuthenticator,
     'aws-s3': S3Authenticator,  # TODO: check if having '-' is kosher
     'nda-s3': S3Authenticator,
+    'loris-token': HTTPBearerTokenAuthenticator,
     'xnat': NotImplementedAuthenticator,
     'none': NoneAuthenticator,
 }

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -20,8 +20,12 @@ from collections import OrderedDict
 
 from .base import NoneAuthenticator, NotImplementedAuthenticator
 
-from .http import HTMLFormAuthenticator, HTTPBasicAuthAuthenticator, HTTPDigestAuthAuthenticator
-from .http import HTTPDownloader
+from .http import (
+    HTMLFormAuthenticator, HTTPBasicAuthAuthenticator,
+    HTTPDigestAuthAuthenticator,
+    HTTPBearerTokenAuthenticator,
+    HTTPDownloader,
+)
 from .s3 import S3Authenticator, S3Downloader
 from ..support.configparserinc import SafeConfigParserWithIncludes
 from ..support.external_versions import external_versions
@@ -40,6 +44,7 @@ AUTHENTICATION_TYPES = {
     'http_auth': HTTPBasicAuthAuthenticator,
     'http_basic_auth': HTTPBasicAuthAuthenticator,
     'http_digest_auth': HTTPDigestAuthAuthenticator,
+    'bearer_token': HTTPBearerTokenAuthenticator,
     'aws-s3': S3Authenticator,  # TODO: check if having '-' is kosher
     'nda-s3': S3Authenticator,
     'xnat': NotImplementedAuthenticator,

--- a/datalad/downloaders/tests/test_credentials.py
+++ b/datalad/downloaders/tests/test_credentials.py
@@ -55,7 +55,7 @@ def test_keyring():
     raise SkipTest("provide tests for Keyring which interfaces keyring module")
 
 
-def _cred1_adapter(user=None, password=None):
+def _cred1_adapter(composite, user=None, password=None):
     """Just a sample adapter from one user/pw type to another"""
     return dict(user=user + "_1", password=password + "_2")
 

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -1,0 +1,31 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+import sys
+import json
+
+if sys.version_info[0] == 2:
+    import urllib2 as urllib_request
+else:
+    from urllib import request as urllib_request
+
+class LORISTokenGenerator(object):
+    def __init__(self, url=None):
+        assert(url is not None)
+        self.url = url
+
+    def generate_token(self, user=None, password=None):
+        data = {'username': user, 'password' : password}
+        encoded_data = json.dumps(data).encode('utf-8')
+
+        request = urllib_request.Request(self.url, encoded_data)
+
+        response = urllib_request.urlopen(request)
+        data = json.load(response)
+        return data["token"]
+

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -15,6 +15,14 @@ else:
     from urllib import request as urllib_request
 
 class LORISTokenGenerator(object):
+    """
+    Generate a LORIS API token by making a request to the
+    LORIS login API endpoint with the given username
+    and password.
+
+    url is the complete URL of the $LORIS/api/$VERSION/login
+    endpoint.
+    """
     def __init__(self, url=None):
         assert(url is not None)
         self.url = url


### PR DESCRIPTION
TODOs
- [x] either just to switch to use proper oauth support library or implement chaining manually similarly to how was done for NDA
- [x] tests