### PR TITLE
BF: Escape dots in URL regular expressions

### DIFF
--- a/datalad/downloaders/configs/crawdad.cfg
+++ b/datalad/downloaders/configs/crawdad.cfg
@@ -1,5 +1,5 @@
 [provider:crawdad]
-url_re = http://(?P<mirror>\s\.)?crawdad.org/.*
+url_re = http://(?P<mirror>\s\.)?crawdad\.org/.*
 credential = crawdad
 authentication_type = http_auth
 

--- a/datalad/downloaders/configs/crcns.cfg
+++ b/datalad/downloaders/configs/crcns.cfg
@@ -1,6 +1,6 @@
 [provider:crcns]
-url_re = https?://crcns.org/.*
-         ftp://crcns.org/.*
+url_re = https?://crcns\.org/.*
+         ftp://crcns\.org/.*
 # certificates = ??? ; (uses https)
 credential = crcns
 # for HTTP: could be html_form (see below), user_password,
@@ -24,7 +24,7 @@ html_form_success_re = You are now logged in
 #         With separateing authenticator out we could easier reuse pairs
 #         of credential_authenticator pairs!
 [provider:crcns-nersc]
-url_re = https://portal.nersc.gov/project/crcns/download/.*
+url_re = https://portal\.nersc\.gov/project/crcns/download/.*
 credential = crcns
 authentication_type = html_form
 html_form_url = https://portal.nersc.gov/project/crcns/download/index.php

--- a/datalad/downloaders/configs/hcp.cfg
+++ b/datalad/downloaders/configs/hcp.cfg
@@ -1,7 +1,7 @@
 # lots of js and some redirects, not yet clear what's needed to work properly
 # the hcp-http below works!
 [provider:hcp-web]
-url_re = __https://db.humanconnectome.org/.*__
+url_re = __https://db\.humanconnectome\.org/.*__
 credential = hcp-db
 authentication_type = html_form
 html_form_url = https://db.humanconnectome.org/app/template/Login.vm
@@ -14,7 +14,7 @@ html_form_failure_re = HTTP Status 404
 html_form_success_re = Public Connectome Data
 
 [provider:hcp-http]
-url_re = https://db.humanconnectome.org/data/.*
+url_re = https://db\.humanconnectome\.org/data/.*
 credential = hcp-db
 authentication_type = http_auth
 http_auth_url = https://db.humanconnectome.org/data/JSESSION
@@ -30,7 +30,7 @@ credential = hcp-s3
 authentication_type = aws-s3
 
 [provider:balsa]
-url_re = https?://balsa.wustl.edu/.*
+url_re = https?://balsa\.wustl\.edu/.*
 # or could be a different custom one!  so we might allow for a choice
 # https://balsa.wustl.edu/register/register
 credential = hcp-db

--- a/datalad/downloaders/configs/kaggle.cfg
+++ b/datalad/downloaders/configs/kaggle.cfg
@@ -1,5 +1,5 @@
 [provider:kaggle]
-url_re = https?://(.*\.|)kaggle.com/.*
+url_re = https?://(.*\.|)kaggle\.com/.*
 credential = kaggle
 authentication_type = html_form
 html_form_url = https://www.kaggle.com/account/login

--- a/datalad/downloaders/configs/nitrc.cfg
+++ b/datalad/downloaders/configs/nitrc.cfg
@@ -8,7 +8,7 @@
 # they aren't usable yet since folks need to agree over and over again
 # (upon each login) to download files -- so we need to figure out how
 # to accomplish the mission here
-url_re = https?://fcon_1000\.projects\.nitrc\.org/indi/adhd200/index.html
+url_re = https?://fcon_1000\.projects\.nitrc\.org/indi/adhd200/index\.html
          https?://www\.nitrc\.org/frs/downloadlink\.php/(7058|3075|3479|9108)
 credential = nitrc
 authentication_type = html_form
@@ -24,7 +24,7 @@ html_form_failure_re = Invalid Password Or User Name
 
 # requires JSESSIONID= cookie for the session... ???
 [provider:nitrc-ir]
-url_re = https?://www.nitrc.org/ir/.*
+url_re = https?://www\.nitrc\.org/ir/.*
 credential = nitrc
 authentication_type = http_auth
 http_auth_url = https://www.nitrc.org/ir/

--- a/datalad/downloaders/configs/openfmri.cfg
+++ b/datalad/downloaders/configs/openfmri.cfg
@@ -1,5 +1,5 @@
 [provider:openfmri]
-url_re = https?://openfmri.org/.*
+url_re = https?://openfmri\.org/.*
 # does not require any, good folks
 authentication_type = none
 


### PR DESCRIPTION
This pull request fixes unescaped dots in some regular expressions for URLs.