### PR TITLE
BF: no duecredit should be needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,9 @@ requires = {
         'vcrpy',
     ],
     'metadata': [
-        'duecredit',
+        # was added in https://github.com/datalad/datalad/pull/1995 without
+        # due investigation, should not be needed until we add duecredit support
+        # 'duecredit',
         'simplejson',
         'whoosh',
     ] + req_lzma,


### PR DESCRIPTION
dependency was added in https://github.com/datalad/datalad/pull/1995 without us actually checking why it is needed... and AFAIK it shouldn't be (yet at least).  conda doesn't have it yet, so complicates packaging
