### PR TITLE
Add support for loading provider configs from other locations

### DIFF
--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -211,6 +211,7 @@ class Providers(object):
             # System config
             if dirs.site_config_dir is not None:
                 files.extend(glob(pathjoin(dirs.site_config_dir, "providers", "*.cfg")))
+
             # User config
             if dirs.user_config_dir is not None:
                 files.extend(glob(pathjoin(dirs.user_config_dir, 'providers', '*.cfg')))

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -9,8 +9,6 @@
 """Data providers - bind downloaders and credentials together
 """
 
-import os
-
 from glob import glob
 from logging import getLogger
 from six import iteritems

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -155,6 +155,7 @@ class Providers(object):
     """
 
     _DEFAULT_PROVIDERS = None
+    _DS_ROOT = None
 
     def __init__(self, providers=None):
         """
@@ -192,7 +193,8 @@ class Providers(object):
         can also be called to reset the cached providers.
         """
         # lazy part
-        if files is None and cls._DEFAULT_PROVIDERS and not reload:
+        dsroot = get_dataset_root("")
+        if files is None and cls._DEFAULT_PROVIDERS and not reload and dsroot==cls._DS_ROOT:
             return cls._DEFAULT_PROVIDERS
 
         config = SafeConfigParserWithIncludes()
@@ -202,9 +204,9 @@ class Providers(object):
             files = glob(pathjoin(dirname(abspath(__file__)), 'configs', '*.cfg'))
 
             # Dataset config
-            dsroot = get_dataset_root("")
             if dsroot is not None:
                 files.extend(glob(pathjoin(dsroot, '.datalad', 'providers', '*.cfg')))
+            cls._DS_ROOT = dsroot
 
             # System config
             if dirs.site_config_dir is not None:
@@ -308,7 +310,7 @@ class Providers(object):
 
         # Range backwards to ensure that more locally defined
         # configuration wins in conflicts between url_re
-        for provider in self._providers[::-1]
+        for provider in self._providers[::-1]:
             if not provider.url_res:
                 continue
             for url_re in provider.url_res:

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -305,22 +305,14 @@ class Providers(object):
     def get_provider(self, url, only_nondefault=False):
         """Given a URL returns matching provider
         """
-        nproviders = len(self._providers)
 
         # Range backwards to ensure that more locally defined
         # configuration wins in conflicts between url_re
-        for i in range(nproviders-1, -1, -1):
-            provider = self._providers[i]
+        for provider in self._providers[::-1]
             if not provider.url_res:
                 continue
             for url_re in provider.url_res:
                 if re.match(url_re, url):
-                    #if i != 0:
-                        # place it first
-                        # TODO: optimize with smarter datastructures if this becomes a burden
-                        #del self._providers[i]
-                        #self._providers = [provider] + self._providers
-                        #assert(len(self._providers) == nproviders)
                     lgr.debug("Returning provider %s for url %s", provider, url)
                     return provider
 

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -140,6 +140,7 @@ authentication_type = none
 
     # Test that the dataset provider overrides the datalad
     # default
+    owd = os.getcwd()
     os.chdir(dsdir)
     providers = Providers.from_config_files(reload=True)
     provider = providers.get_provider('https://crcns.org/data....')
@@ -160,6 +161,7 @@ authentication_type = none
         assert_equal(provider.name, 'usercrcns')
 
     # Cleanup
+    os.chdir(owd)
     shutil.rmtree(sysdir)
     shutil.rmtree(userdir)
     shutil.rmtree(dsdir)

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -8,8 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for data providers"""
 
-import os
-
 from mock import patch
 from tempfile import mkdtemp
 


### PR DESCRIPTION
This adds support for loading config for providers from places
other than those configs that are distributed with the datalad
distribution. In particular, it adds support for:

 - dataset/.datalad/providers/
 - $HOME/.config/datalad/providers/
 - $HOME/.datalad/providers/
 - /etc/datalad/providers/

I'm not sure if this is the most idiomatic way to do this in the datalad codebase or if there's a more centralized location, but it seems to work.

(I also cleaned up the English in the function comment and clarified it slightly.)