### PR TITLE
BF: run: Make dumped message honor datalad.run.record-sidecar

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -441,9 +441,12 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         run_info["dsid"] = ds.id
 
     record = json.dumps(run_info, indent=1, sort_keys=True, ensure_ascii=False)
-    if sidecar or (
-            sidecar is None and
-            ds.config.get('datalad.run.record-sidecar', default=False)):
+
+    use_sidecar = sidecar or (
+        sidecar is None and
+        ds.config.get('datalad.run.record-sidecar', default=False))
+
+    if use_sidecar:
         # record ID is hash of record itself
         from hashlib import md5
         record_id = md5(record.encode('utf-8')).hexdigest()
@@ -464,7 +467,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 """
     msg = msg.format(
         message if message is not None else _format_cmd_shorty(cmd),
-        '"{}"'.format(record_id) if sidecar else record)
+        '"{}"'.format(record_id) if use_sidecar else record)
     msg = assure_bytes(msg)
 
     if not rerun_info and cmd_exitcode:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -127,7 +127,7 @@ def test_basics(path, nodspath):
 
     real_get = ds.config.get
 
-    def mocked_get(key, default):
+    def mocked_get(key, default=None):
         if key == "datalad.run.record-sidecar":
             return True
         return real_get(key, default)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -121,6 +121,21 @@ def test_basics(path, nodspath):
             ds.run()
             assert_in("No command given", cml.out)
 
+    # Simple sidecar message checks.
+    ds.run(["touch", "dummy0"], message="sidecar arg", sidecar=True)
+    assert_not_in('"cmd":', ds.repo.repo.head.commit.message)
+
+    real_get = ds.config.get
+
+    def mocked_get(key, default):
+        if key == "datalad.run.record-sidecar":
+            return True
+        return real_get(key, default)
+
+    with patch.object(ds.config, "get", mocked_get):
+        ds.run(["touch", "dummy1"], message="sidecar config")
+    assert_not_in('"cmd":', ds.repo.repo.head.commit.message)
+
 
 @slow  # 17.1880s
 @ignore_nose_capturing_stdout


### PR DESCRIPTION
Don't show the full record when the sidecar argument is unspecified
and datalad.run.record-sidecar is true.

---
- [x] This change is complete
