### PR TITLE
minor OPT: metadata + logging during (commented out)

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -167,6 +167,11 @@ class ProgressHandler(logging.Handler):
         from datalad.ui import ui
         pid = getattr(record, 'dlm_progress')
         update = getattr(record, 'dlm_progress_update', None)
+        # would be an actual message, not used ATM here,
+        # and the record not passed to generic handler ATM
+        # (filtered away by NoProgressLog)
+        # so no final message is printed
+        # msg = record.getMessage()
         if pid not in self.pbars:
             # this is new
             pbar = ui.get_progressbar(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -566,29 +566,36 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
 
         unique_cm = {}
         extractor_unique_exclude = getattr(extractor_cls, "_unique_exclude", set())
-        log_progress(
-            lgr.debug,
-            'metadataextractors_loc',
-            'Metadata extraction per location for %s', mtype,
-            # contentmeta_t is a generator... so no cound is known
-            # total=len(contentmeta_t or []),
-            label='Metadata extraction per location',
-            unit=' locations',
-        )
+        # TODO: ATM neuroimaging extractors all provide their own internal
+        #  log_progress but if they are all generators, we could provide generic
+        #  handling of the progress here.  Note also that log message is actually
+        #  seems to be ignored and not used, only the label ;-)
+        # log_progress(
+        #     lgr.debug,
+        #     'metadataextractors_loc',
+        #     'Metadata extraction per location for %s', mtype,
+        #     # contentmeta_t is a generator... so no cound is known
+        #     # total=len(contentmeta_t or []),
+        #     label='Metadata extraction per location',
+        #     unit=' locations',
+        # )
         for loc, meta in contentmeta_t or {}:
-            log_progress(
-                lgr.debug,
-                'metadataextractors_loc',
-                'Consider %s', loc,
-                update=1,
-                increment=True)
+            lgr.log(5, "Analyzing metadata for %s", loc)
+            # log_progress(
+            #     lgr.debug,
+            #     'metadataextractors_loc',
+            #     'ignoredatm',
+            #     label=loc,
+            #     update=1,
+            #     increment=True)
             if not _ok_metadata(meta, mtype, ds, loc):
                 errored = True
-                log_progress(
-                    lgr.debug,
-                    'metadataextractors_loc',
-                    'Failed for %s', loc,
-                )
+                # log_progress(
+                #     lgr.debug,
+                #     'metadataextractors_loc',
+                #     'ignoredatm',
+                #     label='Failed for %s' % loc,
+                # )
                 continue
             # we also want to store info that there was no metadata(e.g. to get a list of
             # files that have no metadata)
@@ -642,10 +649,10 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
                     vset.add(_val2hashable(v))
                     unique_cm[k] = vset
 
-        log_progress(
-            lgr.debug,
-            'metadataextractors_loc',
-            'Finished metadata extraction across locations for %s', mtype)
+        # log_progress(
+        #     lgr.debug,
+        #     'metadataextractors_loc',
+        #     'Finished metadata extraction across locations for %s', mtype)
 
         if unique_cm:
             # per source storage here too

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -406,9 +406,9 @@ def _query_aggregated_metadata_singlepath(
 
 
 def _filter_metadata_fields(d, maxsize=None, blacklist=None):
-    lgr.debug("Analyzing metadata fields for maxsize=%s with blacklist=%s on "
-              "input with %d entries",
-              maxsize, blacklist, len(d))
+    lgr.log(5, "Analyzing metadata fields for maxsize=%s with blacklist=%s on "
+            "input with %d entries",
+            maxsize, blacklist, len(d))
     orig_keys = set(d.keys())
     if blacklist:
         d = {k: v for k, v in iteritems(d)


### PR DESCRIPTION
- use iteritems not .items so stays generator for both PY2 and PY3.  I do not think that it would result in the major memory relief, but still worth using it this way
- while going through the code came to realization that all extractors manually repeat the progress logging, although whenever they are generators we could handle it centrally, thus added commented out log_progress pieces.  log messages aren't actually logged at all, I've tried to resolve it with https://github.com/yarikoptic/datalad/compare/opt-metadata...yarikoptic:opt-metadata-log?expand=1  but then it doesn't look good anyways in case of nested progresses (embedded one would print final message thus ruining the progressbar for the above), so better to leave as is

This one should be safe, so next aggregation attempt will go with this one