### PR TITLE
BF(TST): do not require url in the error message if proxy is the reason

### DIFF
--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -34,7 +34,11 @@ def test_download_url_exceptions():
 
     res1 = download_url('http://example.com/bogus', on_failure='ignore')
     assert_result_count(res1, 1, status='error')
-    assert_in('http://example.com/bogus', res1[0]['message'])
+    msg = res1[0]['message']
+    # when running under bogus proxy, on older systems we could get
+    # no URL reported in the message
+    if 'Cannot connect to proxy.' not in msg:
+        assert_in('http://example.com/bogus', msg)
 
 
 @assert_cwd_unchanged


### PR DESCRIPTION
This pull request should fix FTBFS on 14.04
