### PR TITLE
NF: DATALAD_LOG_VMEM  borrowed from pymvpa logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
     # By default no logs will be output. This one is to test with log output at INFO level
     - DATALAD_LOG_LEVEL=INFO
     - DATALAD_LOG_TRACEBACK=1  # just a smoke test for now
+    - DATALAD_LOG_VMEM=1
   - python: 3.5
     # By default no logs will be output. This one is to test with low level but dumped to /dev/null
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -476,6 +476,8 @@ Refer datalad/config.py for information on how to add these environment variable
 - *DATALAD_LOG_TRACEBACK*:
   Runs TraceBack function with collide set to True, if this flag is set to 'collide'.
   This replaces any common prefix between current traceback log and previous invocation with "..."
+- *DATALAD_LOG_VMEM*:
+  Reports memory utilization (resident/virtual) at every log line, needs `psutil` module
 - *DATALAD_EXC_STR_TBLIMIT*: 
   This flag is used by the datalad extract_tb function which extracts and formats stack-traces.
   It caps the number of lines to DATALAD_EXC_STR_TBLIMIT of pre-processed entries from traceback.

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -31,6 +31,7 @@ from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import ok_endswith
+from datalad.tests.utils import assert_re_in
 
 # pretend we are in interactive mode so we could check if coloring is
 # disabled
@@ -49,18 +50,19 @@ def test_logging_to_a_file(dst):
     assert_equal(len(lines), 1, "Read more than a single log line: %s" %  lines)
     line = lines[0]
     ok_(msg in line)
-    ok_(not '\033[' in line,
+    ok_('\033[' not in line,
         msg="There should be no color formatting in log files. Got: %s" % line)
     # verify that time stamp and level are present in the log line
     # do not want to rely on not having race conditions around date/time changes
     # so matching just with regexp
-    # .* is added to swallow possible traceback logs
+    # (...)? is added to swallow possible traceback logs
+    regex = "\[ERROR\](\s+\S+\s*)? "
     if EnsureBool()(cfg.get('datalad.log.timestamp', False)):
-        ok_(re.match("\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \[ERROR\](\s+\S+\s*)? %s" % msg,
-                    line))
-    else:
-        ok_(re.match("\[ERROR\](\s+\S+\s*)? %s" % msg,
-                    line))
+        regex = "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} " + regex
+    if EnsureBool()(cfg.get('datalad.log.vmem', False)):
+        regex += 'RSS/VMS: \S+/\S+ \S+\s*'
+    regex += msg
+    assert_re_in(regex, line, match=True)
 
 
 @with_tempfile

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -56,12 +56,12 @@ def test_logging_to_a_file(dst):
     # do not want to rely on not having race conditions around date/time changes
     # so matching just with regexp
     # (...)? is added to swallow possible traceback logs
-    regex = "\[ERROR\](\s+\S+\s*)? "
+    regex = "\[ERROR\]"
     if EnsureBool()(cfg.get('datalad.log.timestamp', False)):
         regex = "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} " + regex
     if EnsureBool()(cfg.get('datalad.log.vmem', False)):
-        regex += 'RSS/VMS: \S+/\S+ \S+\s*'
-    regex += msg
+        regex += ' RSS/VMS: \S+/\S+( \S+)?\s*'
+    regex += "(\s+\S+\s*)? " + msg
     assert_re_in(regex, line, match=True)
 
 


### PR DESCRIPTION
To chase which steps take lots of RAM... for that to work there should be log messages interspersed around the functions in question