### PR TITLE
Naming question

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -164,7 +164,7 @@ def setup_parser(
         non-zero exit code; 'stop' halts on first failure and yields non-zero exit
         code. A failure is any result with status 'impossible' or 'error'.""")
     parser.add_argument(
-        '--run-before', dest='common_run_before',
+        '--proc-pre', dest='common_proc_pre',
         nargs='+',
         action='append',
         metavar=('<PROCEDURE NAME>', 'ARGS'),
@@ -174,17 +174,17 @@ def setup_parser(
         It is important to specify the target dataset via the --dataset argument
         of the main command."""),
     parser.add_argument(
-        '--run-after', dest='common_run_after',
+        '--proc-post', dest='common_proc_post',
         nargs='+',
         action='append',
         metavar=('<PROCEDURE NAME>', 'ARGS'),
-        help="""Like --run-before, but procedures are executed after the main command
+        help="""Like --proc-pre, but procedures are executed after the main command
         has finished."""),
     parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global
         command line options before the subcommand label. Options like
-        --run-before can take an arbitrary number of arguments and may require
+        --proc-pre can take an arbitrary number of arguments and may require
         to be followed by a single --cmd in order to enable identification
         of the subcommand.""")
 

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -317,7 +317,7 @@ def test_create_withprocedure(path):
         # needs to identify the dataset, otherwise post-proc
         # procedure doesn't know what to run on
         dataset=path,
-        run_after=[['cfg_metadatatypes', 'xmp', 'datacite']])
+        proc_post=[['cfg_metadatatypes', 'xmp', 'datacite']])
     ok_clean_git(path)
     ds.config.reload()
     eq_(ds.config['datalad.metadata.nativetype'], ('xmp', 'datacite'))

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -384,7 +384,7 @@ class Interface(object):
             # XXX define or better get from elsewhere
             common_opts = ('change_path', 'common_debug', 'common_idebug', 'func',
                            'help', 'log_level', 'logger', 'pbs_runner',
-                           'result_renderer', 'run_before', 'run_after', 'subparser')
+                           'result_renderer', 'proc_pre', 'proc_post', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]
         kwargs = {k: getattr(args, k) for k in argnames if is_api_arg(k)}
@@ -418,8 +418,8 @@ class Interface(object):
                 # eval_results can't distinguish between --report-{status,type}
                 # not specified via the CLI and None passed via the Python API.
                 kwargs['result_filter'] = res_filter
-            kwargs['run_before'] = args.common_run_before
-            kwargs['run_after'] = args.common_run_after
+            kwargs['proc_pre'] = args.common_proc_pre
+            kwargs['proc_post'] = args.common_proc_post
         try:
             ret = cls.__call__(**kwargs)
             if inspect.isgenerator(ret):

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -384,7 +384,7 @@ class Interface(object):
             # XXX define or better get from elsewhere
             common_opts = ('change_path', 'common_debug', 'common_idebug', 'func',
                            'help', 'log_level', 'logger', 'pbs_runner',
-                           'result_renderer', 'subparser')
+                           'result_renderer', 'run_before', 'run_after', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]
         kwargs = {k: getattr(args, k) for k in argnames if is_api_arg(k)}
@@ -418,6 +418,8 @@ class Interface(object):
                 # eval_results can't distinguish between --report-{status,type}
                 # not specified via the CLI and None passed via the Python API.
                 kwargs['result_filter'] = res_filter
+            kwargs['run_before'] = args.common_run_before
+            kwargs['run_after'] = args.common_run_after
         try:
             ret = cls.__call__(**kwargs)
             if inspect.isgenerator(ret):

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -302,18 +302,14 @@ eval_params = dict(
         that carries the result dictionaries of the failures in its `failed`
         attribute.""",
         constraints=EnsureChoice('ignore', 'continue', 'stop')),
-    run_before=Parameter(
-        doc="""DataLad plugin to run before the command. PLUGINSPEC is a list
-        comprised of a plugin name plus optional 2-tuples of key-value pairs
-        with arguments for the plugin call (see `plugin` command documentation
-        for details).
-        PLUGINSPECs must be wrapped in list where each item configures
-        one plugin call. Plugins are called in the order defined by this list.
-        For running plugins that require a `dataset` argument it is important
-        to provide the respective dataset as the `dataset` argument of the main
-        command, if it is not in the list of plugin arguments."""),
-    run_after=Parameter(
-        doc="""Like `run_before`, but plugins are executed after the main command
+    proc_pre=Parameter(
+        doc="""DataLad procedure to run prior to the main command. The argument
+        a list of lists with procedure names and optional arguments.
+        Procedures are called in the order their are given in this list.
+        It is important to provide the respective target dataset to run a procedure
+        on as the `dataset` argument of the main command."""),
+    proc_post=Parameter(
+        doc="""Like `proc_pre`, but procedures are executed after the main command
         has finished."""),
 )
 
@@ -323,6 +319,6 @@ eval_defaults = dict(
     result_renderer=None,
     result_xfm=None,
     on_failure='continue',
-    run_before=None,
-    run_after=None,
+    proc_pre=None,
+    proc_post=None,
 )

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -157,9 +157,9 @@ class RunProcedure(Interface):
     On execution of any commands, DataLad inspects two additional
     configuration settings:
 
-    - 'datalad.<name>.run-before'
+    - 'datalad.<name>.proc-pre'
 
-    - 'datalad.<name>.run-after'
+    - 'datalad.<name>.proc-post'
 
     where '<name>' is the name of a DataLad command. Using this mechanism
     DataLad can be instructed to run one or more procedures before or
@@ -167,7 +167,7 @@ class RunProcedure(Interface):
     a set of metadata types in any newly created dataset can be achieved
     via:
 
-      % datalad -c 'datalad.create.run-after=cfg_metadatatypes xmp image' create -d myds
+      % datalad -c 'datalad.create.proc-post=cfg_metadatatypes xmp image' create -d myds
 
     As procedures run on datasets, it is necessary to explicitly identify
     the target dataset via the -d (--dataset) option.

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -38,6 +38,8 @@ def _new_args(**kwargs):
                 common_on_failure=None,  # ['ignore', 'continue', 'stop']
                 common_report_status=None,  # ['all', 'success', 'failure', 'ok', 'notneeded', 'impossible', 'error']
                 common_report_type=None,  # ['dataset', 'file']
+                common_proc_pre=None,
+                common_proc_post=None,
             ),
             kwargs
         )

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -40,8 +40,12 @@ def test_basics(path):
     ds = Dataset(path).create(force=True)
     # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
     # input yet, so manual for now
+    # V6FACT: this leaves the file staged, but not committed
     ds.add('code', to_git=True)
+    # V6FACT: even this leaves it staged
     ds.add('.')
+    # V6FACT: but this finally commits it
+    ds.save()
     # TODO remove above two lines
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -56,7 +56,9 @@ def test_basics(path):
         'datalad_test_proc',
         where='dataset')
     # make clean (until run can handle it)
-    ds.save()
+    # XXX for some reason `save` doesn't do the job in direct mode
+    ds.add(op.join('.datalad', 'config'))
+    ok_clean_git(ds.path)
     # run command that should trigger the demo procedure
     ds.clean()
     # look for traces

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -1,0 +1,65 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""test command datalad run-procedure
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import os.path as op
+
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import with_tree
+
+from datalad.distribution.dataset import Dataset
+from datalad.api import run_procedure
+from datalad.api import clean
+
+
+@skip_if_on_windows
+#@ignore_nose_capturing_stdout
+@with_tree(tree={
+    'code': {'datalad_test_proc.py': """\
+import sys
+import os.path as op
+from datalad.api import add, Dataset
+
+with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
+    f.write('hello\\n')
+add(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
+"""}})
+def test_basics(path):
+    ds = Dataset(path).create(force=True)
+    # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
+    # input yet, so manual for now
+    ds.add('code', to_git=True)
+    ds.add('.')
+    # TODO remove above two lines
+    ds.run_procedure('setup_yoda_dataset')
+    ok_clean_git(ds.path)
+    # configure dataset to look for procedures in its code folder
+    ds.config.add(
+        'datalad.locations.dataset-procedures',
+        'code',
+        where='dataset')
+    # configure dataset to run the demo procedure prior to the clean command
+    ds.config.add(
+        'datalad.clean.proc-pre',
+        'datalad_test_proc',
+        where='dataset')
+    # make clean (until run can handle it)
+    ds.save()
+    # run command that should trigger the demo procedure
+    ds.clean()
+    # look for traces
+    ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'hello\n')
+    ok_clean_git(ds.path)
+

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -380,13 +380,13 @@ def eval_results(func):
         # query cfg for defaults
         cmdline_name = cls2cmdlinename(_func_class)
         dataset_arg = allkwargs.get('dataset', None)
-        run_before = _get_procedure_specs(
-            'run_before',
-            'datalad.{}.run-before'.format(cmdline_name),
+        proc_pre = _get_procedure_specs(
+            'proc_pre',
+            'datalad.{}.proc-pre'.format(cmdline_name),
             ds=dataset_arg)
-        run_after = _get_procedure_specs(
-            'run_after',
-            'datalad.{}.run-after'.format(cmdline_name),
+        proc_post = _get_procedure_specs(
+            'proc_post',
+            'datalad.{}.proc-post'.format(cmdline_name),
             ds=dataset_arg)
 
         # this internal helper function actually drives the command
@@ -398,9 +398,9 @@ def eval_results(func):
             # track what actions were performed how many times
             action_summary = {}
 
-            if run_before and cmdline_name != 'run-procedure':
+            if proc_pre and cmdline_name != 'run-procedure':
                 from datalad.interface.run_procedure import RunProcedure
-                for procspec in run_before:
+                for procspec in proc_pre:
                     lgr.debug('Running configured pre-procedure %s', procspec)
                     for r in _process_results(
                             RunProcedure.__call__(
@@ -421,9 +421,9 @@ def eval_results(func):
                     result_renderer, result_xfm, _result_filter, **_kwargs):
                 yield r
 
-            if run_after and cmdline_name != 'run-procedure':
+            if proc_post and cmdline_name != 'run-procedure':
                 from datalad.interface.run_procedure import RunProcedure
-                for procspec in run_after:
+                for procspec in proc_post:
                     lgr.debug('Running configured post-procedure %s', procspec)
                     for r in _process_results(
                             RunProcedure.__call__(

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -296,7 +296,7 @@ def eval_results(func):
 
     @wrapt.decorator
     def eval_func(wrapped, instance, args, kwargs):
-        # for result filters and pre/post plugins
+        # for result filters and pre/post procedures
         # we need to produce a dict with argname/argvalue pairs for all args
         # incl. defaults and args given as positionals
         allkwargs = get_allargs_as_kwargs(wrapped, args, kwargs)
@@ -361,7 +361,7 @@ def eval_results(func):
                 def _result_filter(res):
                     return result_filter(res, **allkwargs)
 
-        def _get_plugin_specs(param_key=None, cfg_key=None, ds=None):
+        def _get_procedure_specs(param_key=None, cfg_key=None, ds=None):
             spec = common_params.get(param_key, None)
             if spec is not None:
                 # this is already a list of lists
@@ -380,11 +380,11 @@ def eval_results(func):
         # query cfg for defaults
         cmdline_name = cls2cmdlinename(_func_class)
         dataset_arg = allkwargs.get('dataset', None)
-        run_before = _get_plugin_specs(
+        run_before = _get_procedure_specs(
             'run_before',
             'datalad.{}.run-before'.format(cmdline_name),
             ds=dataset_arg)
-        run_after = _get_plugin_specs(
+        run_after = _get_procedure_specs(
             'run_after',
             'datalad.{}.run-after'.format(cmdline_name),
             ds=dataset_arg)

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -72,15 +72,15 @@ def dlplugin(dataset, noval, withval='test'):
 #    ds = create(dataset=opj(path, 'ds1'))
 #    eq_(sorted(os.listdir(ds.path)), ['.datalad', '.git', '.gitattributes'])
 #    # now we configure a plugin to run twice after `create`
-#    cfg.add('datalad.create.run-after',
+#    cfg.add('datalad.create.proc-post',
 #            'add_readme filename=after1.txt',
 #            where='global')
-#    cfg.add('datalad.create.run-after',
+#    cfg.add('datalad.create.proc-post',
 #            'add_readme filename=after2.txt',
 #            where='global')
 #    # force reload to pick up newly populated .gitconfig
 #    cfg.reload(force=True)
-#    assert_in('datalad.create.run-after', cfg)
+#    assert_in('datalad.create.proc-post', cfg)
 #    # and now we create a dataset and expect the two readme files
 #    # to be part of it
 #    ds = create(dataset=opj(path, 'ds'))
@@ -89,9 +89,9 @@ def dlplugin(dataset, noval, withval='test'):
 #    assert(exists(opj(ds.path, 'after2.txt')))
 #    # cleanup
 #    cfg.unset(
-#        'datalad.create.run-after',
+#        'datalad.create.proc-post',
 #        where='global')
-#    assert_not_in('datalad.create.run-after', cfg)
+#    assert_not_in('datalad.create.proc-post', cfg)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -12,33 +12,26 @@
 
 from datalad.tests.utils import known_failure_direct_mode
 
-import os
-import logging
 from os.path import join as opj
-from os.path import exists
-from mock import patch
 
 from datalad.coreapi import create
 from datalad.coreapi import Dataset
 from datalad.dochelpers import exc_str
 from datalad.api import wtf
 from datalad.api import no_annex
-from datalad import cfg
 from datalad.plugin.wtf import _HIDDEN
 
-from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import chpwd
 from datalad.tests.utils import create_tree
-from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import skip_if, skip_if_no_module
+from datalad.tests.utils import skip_if_no_module
 from datalad.tests.utils import SkipTest
 
 
@@ -63,35 +56,6 @@ def dlplugin(dataset, noval, withval='test'):
             noval=noval,
             withval=withval))
 '''
-
-
-# TODO bring back when functionality is back
-#@with_tempfile(mkdir=True)
-#def test_plugin_config(path):
-#    # baseline behavior, empty datasets on create
-#    ds = create(dataset=opj(path, 'ds1'))
-#    eq_(sorted(os.listdir(ds.path)), ['.datalad', '.git', '.gitattributes'])
-#    # now we configure a plugin to run twice after `create`
-#    cfg.add('datalad.create.proc-post',
-#            'add_readme filename=after1.txt',
-#            where='global')
-#    cfg.add('datalad.create.proc-post',
-#            'add_readme filename=after2.txt',
-#            where='global')
-#    # force reload to pick up newly populated .gitconfig
-#    cfg.reload(force=True)
-#    assert_in('datalad.create.proc-post', cfg)
-#    # and now we create a dataset and expect the two readme files
-#    # to be part of it
-#    ds = create(dataset=opj(path, 'ds'))
-#    ok_clean_git(ds.path)
-#    assert(exists(opj(ds.path, 'after1.txt')))
-#    assert(exists(opj(ds.path, 'after2.txt')))
-#    # cleanup
-#    cfg.unset(
-#        'datalad.create.proc-post',
-#        where='global')
-#    assert_not_in('datalad.create.proc-post', cfg)
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
ATM:

```
usage: datalad
               [--run-before <PROCEDURE NAME> [ARGS ...]]
               [--run-after <PROCEDURE NAME> [ARGS ...]] [--cmd]
               command [command-opts]
```

However, those names confuse me. `--run-after` is supposed to mean "run this after the command you are mainly executing", and `--run-before` run this before that command. But given that the primary command is the main subject, one could easily get it the other way round. `--run-after` "run the command after you ran this.

I think we need to changes this NOW. Proposal:

- `--prepare <PROCEDURE NAME> [ARGS ...]]`
- `--fixup <PROCEDURE NAME> [ARGS ...]]`

What do you think? Better names, or even better ones on you mind?
