### PR TITLE
run-procedure without argument just ERRORs out

### DIFF
--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -23,7 +23,6 @@ from datalad import cfg
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
-from datalad.interface.results import get_status_dict
 
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import require_dataset
@@ -31,6 +30,7 @@ from datalad.distribution.dataset import EnsureDataset
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod
+from datalad.support.exceptions import InsufficientArgumentsError
 
 from datalad.utils import assure_list
 
@@ -193,6 +193,8 @@ class RunProcedure(Interface):
     def __call__(
             spec,
             dataset=None):
+        if not spec:
+            raise InsufficientArgumentsError('requires at least a procedure name')
         if not isinstance(spec, (tuple, list)):
             # maybe coming from config
             import shlex


### PR DESCRIPTION
#### What is the problem?
```
$> datalad run-procedure
[ERROR  ] list index out of range [run_procedure.py:__call__:200] (IndexError)
```
should instead spit out `--help` synopsis like any other misspecified command does