### PR TITLE
TST: Verify how much path flexibility Python has across platforms

### DIFF
--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import os
+import os.path as op
 
 from .utils import (
     chpwd,
@@ -18,10 +19,29 @@ from .utils import (
     assert_raises,
     assert_equal,
     assert_in,
+    ok_file_has_content,
 )
 from datalad.support.gitrepo import check_git_configured
 
 from mock import patch
+
+
+# verify that any target platform can deal with forward slashes
+# as os.path.sep, regardless of its native preferences
+@with_tree(tree={'subdir': {'testfile': 'testcontent'}})
+def test_paths_with_forward_slashes(path):
+    # access file with native absolute path spec
+    print(path)
+    ok_file_has_content(op.join(path, 'subdir', 'testfile'), 'testcontent')
+    with chpwd(path):
+        # native relative path spec
+        ok_file_has_content(op.join('subdir', 'testfile'), 'testcontent')
+        # posix relative path spec
+        ok_file_has_content('subdir/testfile', 'testcontent')
+    # abspath with forward slash path sep char
+    ok_file_has_content(
+        op.join(path, 'subdir', 'testfile').replace(op.sep, '/'),
+        'testcontent')
 
 
 #@with_tempfile(mkdir=True)


### PR DESCRIPTION
Any target platform of ours (including Windows) can deal with paths that have forward-slashes as `os.path.sep`. That includes absolute paths with drive letters on Windows. They just have to use forward-slashes consistently and not mix and match back- and forward-slashes.

This  is just a test to verify that. But now we should move towards a consistent path handling. IMHO that requires two things:

1. stop using `os.path`, but use `posixpath` exclusively.
2. establish a layer (plus helper function) that converts any incoming path to a posix-like path, regardless of platform.

Here is a thing you are probably wondering about:

```python
>>> import posixpath
>>> p='C:/users/mike'
>>> posixpath.relpath(p, 'C:/users')
'mike'
>>> posixpath.relpath(p, 'C:/')
'users/mike'
```