### PR TITLE
ENH: downloaders: Abort earlier when there is no file name

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -288,6 +288,9 @@ class BaseDownloader(object):
             if isdir(path):
                 # provided path is a directory under which to save
                 filename = downloader_session.filename
+                if not filename:
+                    raise DownloadError(
+                        "File name could not be determined from {}".format(url))
                 filepath = opj(path, filename)
             else:
                 filepath = path

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -107,6 +107,12 @@ def test_HTTPDownloader_basic(toppath, topurl):
     assert_equal(downloaded_path, tfpath)
     ok_file_has_content(tfpath, 'abc')
 
+    # Fail with an informative message if we're downloading into a directory
+    # and the file name can't be determined from the URL.
+    with assert_raises(DownloadError) as cm:
+        download(topurl, toppath)
+    assert_in("File name could not be determined", str(cm.exception))
+
     # Some errors handling
     # XXX obscure mocking since impossible to mock write alone
     # and it still results in some warning being spit out


### PR DESCRIPTION
Otherwise, the download fails with an uninformative error message,
either

    File <path> already exists

if overwrite is false or

    Not a directory: '<path>/.datalad-download-temp' -> '<path>'

if overwrite is true.

Fixes #2652.

---
- [x] This change is complete
