### PR TITLE
BF: Fix missing .gitattributes newlines with no_annex plugin

### DIFF
--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -134,7 +134,7 @@ class NoAnnex(Interface):
         gitattr_file = opj(gitattr_dir, '.gitattributes')
         with open(gitattr_file, 'a') as fp:
             for p in pattern:
-                fp.write('{} annex.largefiles=nothing'.format(p))
+                fp.write('{} annex.largefiles=nothing\n'.format(p))
             yield dict(res_kwargs, status='ok')
 
         for r in dataset.add(

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -125,11 +125,13 @@ def test_no_annex(path):
         ds.path,
         {'code': {
             'inannex': 'content',
-            'notinannex': 'othercontent'}})
-    # add two files, pre and post configuration
+            'notinannex': 'othercontent'},
+         'README': 'please'})
+    # add inannex pre configuration
     ds.add(opj('code', 'inannex'))
-    no_annex(pattern='code/**', dataset=ds)
-    ds.add(opj('code', 'notinannex'))
+    no_annex(pattern=['code/**', 'README'], dataset=ds)
+    # add inannex and README post configuration
+    ds.add([opj('code', 'notinannex'), 'README'])
     ok_clean_git(ds.path)
     # one is annex'ed, the other is not, despite no change in add call
     # importantly, also .gitattribute is not annexed


### PR DESCRIPTION
I ran into this .gitattributes formatting bug using the no_annex plugin with a list of patterns.

```
* annex.backend=MD5E
**/.git* annex.largefiles=nothing
*.tsv annex.largefiles=nothing*.json annex.largefiles=nothing*.bvec annex.largefiles=nothing*.bval annex.largefiles=nothingREADME annex.largefiles=nothingCHANGES annex.largefiles=nothing.bidsignore annex.largefiles=nothing
```

It should be:
```
* annex.backend=MD5E
**/.git* annex.largefiles=nothing
*.tsv annex.largefiles=nothing
*.json annex.largefiles=nothing
*.bvec annex.largefiles=nothing
*.bval annex.largefiles=nothing
README annex.largefiles=nothing
CHANGES annex.largefiles=nothing
.bidsignore annex.largefiles=nothing
```

### Changes
- [x] Adds a newline for each no_annex pattern appended to .gitattributes

Please have a look @datalad/developers