### PR TITLE
BF: auto -- also proxy os.stat call which is now used by nibabel while opening files

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -99,6 +99,7 @@ class AutomagicIO(object):
         self._active = False
         self._builtin_open = __builtin__.open
         self._io_open = io.open
+        self._os_stat = os.stat
         self._builtin_exists = os.path.exists
         self._builtin_isfile = os.path.isfile
         if h5py:
@@ -200,6 +201,10 @@ class AutomagicIO(object):
 
     def _proxy_io_open(self, *args, **kwargs):
         return self._proxy_open_name_mode('io.open', self._io_open,
+                                          *args, **kwargs)
+
+    def _proxy_os_stat(self, *args, **kwargs):
+        return self._proxy_open_name_mode('os.stat', self._os_stat,
                                           *args, **kwargs)
 
     def _proxy_h5py_File(self, *args, **kwargs):
@@ -310,6 +315,7 @@ class AutomagicIO(object):
         # overloads
         __builtin__.open = self._proxy_open
         io.open = self._proxy_io_open
+        os.stat = self._proxy_os_stat
         os.path.exists = self._proxy_exists
         os.path.isfile = self._proxy_isfile
         if h5py:
@@ -326,6 +332,7 @@ class AutomagicIO(object):
             return
         __builtin__.open = self._builtin_open
         io.open = self._io_open
+        os.stat = self._os_stat
         if h5py:
             h5py.File = self._h5py_File
         if lzma:

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -119,13 +119,14 @@ def _test_proxying_open(generate_load, verify_load, repo):
     fpath1_2 = fpath1.replace(repo, repo2)
     fpath2_2 = fpath2.replace(repo, repo2)
 
-    assert_raises(IOError, verify_load, fpath1_2)
+    EXPECTED_EXCEPTIONS = (IOError, OSError)
+    assert_raises(EXPECTED_EXCEPTIONS, verify_load, fpath1_2)
 
     with AutomagicIO():
         # verify that it doesn't even try to get files which do not exist
         with patch('datalad.support.annexrepo.AnnexRepo.get') as gricm:
             # if we request absent file
-            assert_raises(IOError, open, fpath1_2+"_", 'r')
+            assert_raises(EXPECTED_EXCEPTIONS, open, fpath1_2+"_", 'r')
             # no get should be called
             assert_false(gricm.called)
         verify_load(fpath1_2)
@@ -244,3 +245,15 @@ def test_proxying_open_nibabel():
         assert_array_equal(ni.get_data(), d)
 
     yield _test_proxying_open, generate_nii, verify_nii
+
+
+def test_proxying_os_stat():
+    from os.path import exists
+    def generate_dat(f):
+        with io.open(f, "w", encoding='utf-8') as f:
+            f.write(u"123")
+
+    def verify_dat(f, mode="r"):
+        assert os.stat(f).st_size == 3
+
+    yield _test_proxying_open, generate_dat, verify_dat


### PR DESCRIPTION
So with upload of 2.3.0 nibabel all unpatched datalad builds will start to fail, so we might need a minor release sooner than later now