### PR TITLE
Change version number so that datalad-crawler can be installed

### DIFF
--- a/datalad/version.py
+++ b/datalad/version.py
@@ -13,7 +13,7 @@ import sys
 from os.path import lexists, dirname, join as opj, curdir
 
 # Hard coded version, to be done by release process
-__version__ = '0.10.0.dev1'
+__version__ = '0.10.1.dev1'
 __full_version__ = __version__
 
 # NOTE: might cause problems with "python setup.py develop" deployments


### PR DESCRIPTION
v0.10.0.dev1 < v0.10.0.rc3, which is the minimum required version for datalad-crawler.

I'm not entirely sure that this is the right way to fix it, but at least it lets me
install datalad-crawler against the master branch.

### Changes
- [x] This change is complete