### PR TITLE
BF: Handle 401 errors from LORIS tokens

### DIFF
--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -9,13 +9,8 @@
 import sys
 import json
 
-
-if sys.version_info[0] == 2:
-    import urllib2 as urllib_request
-    from urllib2 import HTTPError
-else:
-    from urllib import request as urllib_request
-    from urllib import HTTPError
+from six.moves.urllib.request import Request, urlopen
+from six.moves.urllib.error import HTTPError
 
 from datalad.downloaders.base import AccessDeniedError, AccessFailedError
 
@@ -37,10 +32,10 @@ class LORISTokenGenerator(object):
         data = {'username': user, 'password' : password}
         encoded_data = json.dumps(data).encode('utf-8')
 
-        request = urllib_request.Request(self.url, encoded_data)
+        request = Request(self.url, encoded_data)
 
         try:
-            response = urllib_request.urlopen(request)
+            response = urlopen(request)
         except HTTPError:
             raise AccessDeniedError("Could not authenticate into LORIS")
 

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -9,10 +9,16 @@
 import sys
 import json
 
+
 if sys.version_info[0] == 2:
     import urllib2 as urllib_request
+    from urllib2 import HTTPError
 else:
     from urllib import request as urllib_request
+    from urllib import HTTPError
+
+from datalad.downloaders.base import AccessDeniedError, AccessFailedError
+
 
 class LORISTokenGenerator(object):
     """
@@ -33,7 +39,11 @@ class LORISTokenGenerator(object):
 
         request = urllib_request.Request(self.url, encoded_data)
 
-        response = urllib_request.urlopen(request)
+        try:
+            response = urllib_request.urlopen(request)
+        except HTTPError:
+            raise AccessDeniedError("Could not authenticate into LORIS")
+
         data = json.load(response)
         return data["token"]
 


### PR DESCRIPTION
When a request is made with an incorrect username/password,
urllib.urlopen raises an HTTPError exception. Since datalad
is looking for AccessDeniedError exceptions in order to decide
whether to re-prompt for new credentials, it doesn't get caught
and there's no easy way to enter the correct credentials if
you don't get it right the first time.

This converts the implicit exception in LORIS token generator
to an AccessDeniedError.