### PR TITLE
BF: move LOG_TRACEBACK=collide testing into leaner matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ matrix:
     - NOSE_SELECTION_OP=""
     # And the leading - in filenames for the most challenge
     - DATALAD_TESTS_OBSCURE_PREFIX=-
+    - DATALAD_LOG_TRACEBACK=collide  # just a smoke test for now
   - python: 3.5
     # A run loaded with various customizations to smoke test those functionalities
     # apparently moving symlink outside has different effects on abspath
@@ -75,7 +76,6 @@ matrix:
     env:
     - DATALAD_LOG_LEVEL=2
     - DATALAD_LOG_TARGET=/dev/null
-    - DATALAD_LOG_TRACEBACK=collide  # just a smoke test for now
     - DATALAD_TESTS_PROTOCOLREMOTE=1
     - DATALAD_TESTS_DATALADREMOTE=1
     - DATALAD_LOG_CMD_CWD=1

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -29,6 +29,7 @@ from datalad.config import ConfigManager
 from datalad.cmd import CommandError
 
 from datalad.tests.utils import with_testsui
+from datalad.support.external_versions import external_versions
 
 # XXX tabs are intentional (part of the format)!
 # XXX put back! confuses pep8
@@ -174,10 +175,11 @@ def test_something(path, new_home):
         # but after we unset the only value -- that section is no longer listed
         assert (not globalcfg.has_section('datalad.unittest'))
         assert_not_in('datalad.unittest.youcan', globalcfg)
-        # although it does leaves empty section behind in the file
-        ok_file_has_content(global_gitconfig, '[datalad "unittest"]', strip=True)
-        # remove_section to clean it up entirely
-        globalcfg.remove_section('datalad.unittest', where='global')
+        if external_versions['cmd:git'] < '2.18':
+            # older versions leave empty section behind in the file
+            ok_file_has_content(global_gitconfig, '[datalad "unittest"]', strip=True)
+            # remove_section to clean it up entirely
+            globalcfg.remove_section('datalad.unittest', where='global')
         ok_file_has_content(global_gitconfig, "")
 
     cfg = ConfigManager(


### PR DESCRIPTION
There is really no need to test it on the heavy debug output one,
and I think it is one of the reasons for that matrix run to be so slow,
now reaching critical 50min and failing testing as e.g. in #2663
So moved it into another and hope that testing would speed up for that run
enough to become usable again

note: it is probable that testing would fail on travis ATM due to https://github.com/datalad/datalad/pull/2670#issuecomment-400677339  but I will merge it as far as time reduces and no other immediate failures
