### PR TITLE
DOC: Revise remove's top-level description

### DIFF
--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -71,7 +71,7 @@ def _drop_files(ds, paths, check, noannex_iserror=False, **kwargs):
       whether to instruct annex to perform minimum copy availability
       checks
     noannex_iserror : bool
-      whether calling this function on a pur Git repo results in an
+      whether calling this function on a pure Git repo results in an
       'impossible' or 'notneeded' result.
     **kwargs
       additional payload for the result dicts

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -122,12 +122,12 @@ class Drop(Interface):
     interpreted relative to this dataset.
 
     Recursion into subdatasets needs to be explicitly enabled, while recursion
-    in subdirectories within a dataset is always done automatically. An
-    optional recursion limit is applied relative to each given input path.
+    into subdirectories within a dataset is done automatically. An optional
+    recursion limit is applied relative to each given input path.
 
-    By default, the availability of at least one remote copy is verified,
-    before file content is dropped. As these checks could lead to slow
-    operation (network latencies, etc), they can be disabled.
+    By default, the availability of at least one remote copy is verified before
+    file content is dropped. As these checks could lead to slow operation
+    (network latencies, etc), they can be disabled.
 
     Examples:
 

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -52,20 +52,15 @@ lgr = logging.getLogger('datalad.distribution.remove')
 class Remove(Interface):
     """Remove components from datasets
 
-    This command can remove any components (subdatasets, and (directories with)
-    files) from datasets. Removing a component implies any present content to
-    be dropped, and any associated subdatasets to be uninstalled. Subsequently,
-    the component is "unregistered" from the respective dataset. This means
-    that the respective component is no longer present on the file system.
+    This command can remove subdatasets and paths, including non-empty
+    directories, from datasets. Removing a component implies dropping present
+    content and uninstalling associated subdatasets. Subsequently, the
+    component is "unregistered" from the respective dataset. This means that
+    the component is no longer present on the file system.
 
-    By default, the availability of at least one remote copy is verified, by
-    default, before file content is dropped. As these checks could lead to slow
-    operation (network latencies, etc), they can be disabled.
-
-    Any number of paths to process can be given as input. Recursion into
-    subdatasets needs to be explicitly enabled, while recursion in
-    subdirectories within a dataset as always done automatically. An optional
-    recursion limit is applied relative to each given input path.
+    By default, the availability of at least one remote copy is verified before
+    file content is dropped. As these checks could lead to slow operation
+    (network latencies, etc), they can be disabled.
 
     Examples:
 

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -89,22 +89,19 @@ def _uninstall_dataset(ds, check, has_super, **kwargs):
 class Uninstall(Interface):
     """Uninstall subdatasets
 
-    This command can be used to uninstall any number of installed subdataset.
-    If a to-be-uninstalled subdataset contains presently installed subdatasets
-    itself, their recursive removal has to be enabled explicitly to avoid the
-    command to exit with an error. This command will error if individual files
-    or non-dataset directories are given as input (use the drop or remove
-    command depending in the desired goal), nor will it uninstall top-level
-    datasets (i.e. datasets that or not a subdataset in another dataset; use
-    the remove command for this purpose).
+    This command can be used to uninstall any number of installed subdatasets.
+    This command will error if individual files or non-dataset directories are
+    given as input (use the drop or remove command depending on the desired
+    goal), nor will it uninstall top-level datasets (i.e. datasets that are not
+    a subdataset in another dataset; use the remove command for this purpose).
 
     By default, the availability of at least one remote copy for each currently
     available file in any dataset is verified. As these checks could lead to
     slow operation (network latencies, etc), they can be disabled.
 
     Any number of paths to process can be given as input. Recursion into
-    subdatasets needs to be explicitly enabled, while recursion in
-    subdirectories within a dataset as always done automatically. An optional
+    subdatasets needs to be explicitly enabled, while recursion into
+    subdirectories within a dataset is done automatically. An optional
     recursion limit is applied relative to each given input path.
 
     Examples:
@@ -112,7 +109,6 @@ class Uninstall(Interface):
       Uninstall a subdataset (undo installation)::
 
         ~/some/dataset$ datalad uninstall somesubdataset1
-
     """
     _action = 'uninstall'
 


### PR DESCRIPTION
Fix typos, reword, and cut arguably redundant information.  Also, drop
the mention of recursion limits because, unlike 'datalad drop',
'datalad remove' doesn't have a --recursion-limit flag.
