### PR TITLE
RF: report relative paths by default (configurable, 'datalad.runtime.report-pathstyle')

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -272,6 +272,15 @@ definitions = {
         'type': EnsureBool(),
         'default': False,
     },
+    'datalad.runtime.report-pathstyle': {
+        'ui': ('question', {
+            'title': 'Path',
+            'text': 'How to report paths in UI (default renderer, progressbars,'
+                    ' etc) '}),
+        # ATM progressbars report relative from the top of dataset even within subdir
+        'type': EnsureChoice('relative', 'full'),  # 'mixed' for reporting full when upstairs??? 'reldataset' for from the top of dataset
+        'default': 'relative',
+    },
     'datalad.runtime.report-status': {
         'ui': ('question', {
                'title': 'Command line result reporting behavior',

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -331,6 +331,7 @@ def results_from_annex_noinfo(ds, requested_paths, respath_by_status, dir_fail_m
         if any(p in ps for ps in respath_by_status.values()):
             # we have a report for this path already
             continue
+        # TODO: handle full vs relative here as well
         common_report = dict(path=p, **kwargs)
         if isdir(p):
             # `annex` itself will not report on directories, but if a

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -292,7 +292,8 @@ def test_result_filter():
             TestUtils().__call__(
                 4,
                 result_filter=filt)[-1],
-            {'action': 'off', 'path': 'some', 'status': 'ok', 'somekey': 2})
+            {'action': 'off', 'path': 'some', 'relpath': 'some',
+             'status': 'ok', 'somekey': 2})
 
     # test more sophisticated filters that actually get to see the
     # API call's kwargs


### PR DESCRIPTION
I do appreciate the fact that we can have wide terminals now, but working with datalad deep within some hierarchy floods the screen with full paths, causing unpleasant wraps etc.  So I took a first attempt at trying to report relpaths by default to seek your feedback.  E.g. now it would report
```shell
(git-annex)hopa:~/datalad/openfmri/ds000001[master]sub-01
$> datalad get anat/
get(ok): anat/sub-01_inplaneT2.nii.gz (file) [from web...]
get(ok): anat/sub-01_T1w.nii.gz (file) [from web...]
get(ok): anat (directory)
```
instead of 
```shell
$> datalad get anat/                                                                                         
get(ok): /home/yoh/datalad/openfmri/ds000001/sub-01/anat/sub-01_inplaneT2.nii.gz (file) [from web...]
get(ok): /home/yoh/datalad/openfmri/ds000001/sub-01/anat/sub-01_T1w.nii.gz (file) [from web...]
get(ok): /home/yoh/datalad/openfmri/ds000001/sub-01/anat (directory)
```
but I've not yet taken any precautions against cases where I run datalad commands outside providing full paths and thus leading to horrendous
```shell
hopa:/tmp
$> datalad get /home/yoh/datalad/openfmri/ds000001/sub-01/anat
get(ok): ../home/yoh/datalad/openfmri/ds000001/sub-01/anat/sub-01_inplaneT2.nii.gz (file) [from web...]
get(ok): ../home/yoh/datalad/openfmri/ds000001/sub-01/anat/sub-01_T1w.nii.gz (file) [from web...]
get(ok): ../home/yoh/datalad/openfmri/ds000001/sub-01/anat (directory)
```
This is just a first trial to bring discussion back

IMHO ultimately/ideally it should report path inline with the specification in the original request, but for many commands it seems that `orig_request` path is not provided for "subpaths" -- could we retain the last one seen and act from it? I don't think so since those seems to come out of order (here is with the printout of `res` structures):
```shell
$> datalad get /home/yoh/datalad/openfmri/ds000001/sub-0{1,2}/anat
{'status': '', 'orig_request': '/home/yoh/datalad/openfmri/ds000001/sub-01/anat', 'parentds': '/home/yoh/datalad/openfmri/ds000001', 'action': 'get', 'path': '/home/yoh/datalad/openfmri/ds000001/sub-01/anat', 'logger': <logging.Logger object at 0x7f7c42750f50>, 'type': 'directory', 'raw_input': True}
{'status': '', 'orig_request': '/home/yoh/datalad/openfmri/ds000001/sub-02/anat', 'parentds': '/home/yoh/datalad/openfmri/ds000001', 'action': 'get', 'path': '/home/yoh/datalad/openfmri/ds000001/sub-02/anat', 'logger': <logging.Logger object at 0x7f7c42750f50>, 'type': 'directory', 'raw_input': True}
{'status': 'notneeded', 'action': 'get', 'path': u'/home/yoh/datalad/openfmri/ds000001/sub-01/anat', 'logger': <logging.Logger object at 0x7f7c427502d0>, 'type': 'directory', 'message': ('nothing to get from %s', u'/home/yoh/datalad/openfmri/ds000001/sub-01/anat')}
get(notneeded): ../home/yoh/datalad/openfmri/ds000001/sub-01/anat (directory) [nothing to get from /home/yoh/datalad/openfmri/ds000001/sub-01/anat]
{'status': 'notneeded', 'action': 'get', 'path': u'/home/yoh/datalad/openfmri/ds000001/sub-02/anat', 'logger': <logging.Logger object at 0x7f7c427502d0>, 'type': 'directory', 'message': ('nothing to get from %s', u'/home/yoh/datalad/openfmri/ds000001/sub-02/anat')}
get(notneeded): ../home/yoh/datalad/openfmri/ds000001/sub-02/anat (directory) [nothing to get from /home/yoh/datalad/openfmri/ds000001/sub-02/anat]
```
but may be we could retain full list of orig_request and deduce the common base? e.g. if any is full path -- go with full paths; otherwise relative, unless the path is not under any of the ones within `orig_request`ed?

just food for thought (like we do not have enough ;-) )
