### PR TITLE
BF: download_url: Download to current directory within dataset

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -11,7 +11,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from os.path import isdir, curdir
+import os.path as op
 
 from .base import Interface
 from ..interface.base import build_doc
@@ -100,7 +100,7 @@ class DownloadURL(Interface):
 
         urls = assure_list_from_str(urls)
 
-        if len(urls) > 1 and path and not isdir(path):
+        if len(urls) > 1 and path and not op.isdir(path):
             yield get_status_dict(
                 status="error",
                 message=(
@@ -111,7 +111,7 @@ class DownloadURL(Interface):
                 **common_report)
             return
         if not path:
-            path = ds.path if ds else curdir
+            path = ds.path if ds else op.curdir
 
         # TODO setup fancy ui.progressbars doing this in parallel and reporting overall progress
         # in % of urls which were already downloaded

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -20,6 +20,7 @@ from ..interface.common_opts import save_message_opt
 from ..interface.results import get_status_dict
 from ..interface.utils import eval_results
 from ..utils import assure_list_from_str
+from ..utils import get_dataset_pwds
 from ..distribution.add import Add
 from ..distribution.dataset import datasetmethod
 from ..distribution.dataset import EnsureDataset
@@ -88,6 +89,8 @@ class DownloadURL(Interface):
                  archive=False, save=True, message=None):
         from ..downloaders.providers import Providers
 
+        pwd, rel_pwd = get_dataset_pwds(dataset)
+
         try:
             ds = require_dataset(
                 dataset, check_installed=True,
@@ -110,8 +113,13 @@ class DownloadURL(Interface):
                 path=path,
                 **common_report)
             return
-        if not path:
-            path = ds.path if ds else op.curdir
+
+        if dataset:  # A dataset was explicitly given.
+            path = op.join(ds.path, path or op.curdir)
+        elif ds:
+            path = op.join(ds.path, rel_pwd, path or op.curdir)
+        elif not path:
+            path = op.curdir
 
         # TODO setup fancy ui.progressbars doing this in parallel and reporting overall progress
         # in % of urls which were already downloaded

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -48,7 +48,8 @@ from datalad.interface.unlock import Unlock
 
 from datalad.utils import assure_bytes
 from datalad.utils import chpwd
-from datalad.utils import get_dataset_root
+# Rename get_dataset_pwds for the benefit of containers_run.
+from datalad.utils import get_dataset_pwds as get_command_pwds
 from datalad.utils import getpwd
 from datalad.utils import partition
 from datalad.utils import SequenceFormatter
@@ -312,40 +313,6 @@ def _unlock_or_remove(dset, paths):
                         yield rem_res
                     continue
             yield res
-
-
-def get_command_pwds(dataset):
-    """Return the directory for the command.
-
-    Parameters
-    ----------
-    dataset : Dataset
-
-    Returns
-    -------
-    A tuple, where the first item is the absolute path of the pwd and the
-    second is the pwd relative to the dataset's path.
-    """
-    if dataset:
-        pwd = dataset.path
-        rel_pwd = curdir
-    else:
-        # act on the whole dataset if nothing else was specified
-
-        # Follow our generic semantic that if dataset is specified,
-        # paths are relative to it, if not -- relative to pwd
-        pwd = getpwd()
-        # Pass pwd to get_dataset_root instead of os.path.curdir to handle
-        # repos whose leading paths have a symlinked directory (see the
-        # TMPDIR="/var/tmp/sym link" test case).
-        dataset = get_dataset_root(pwd)
-
-        if dataset:
-            rel_pwd = relpath(pwd, dataset)
-        else:
-            rel_pwd = pwd  # and leave handling on deciding either we
-                           # deal with it or crash to checks below
-    return pwd, rel_pwd
 
 
 def normalize_command(command):

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -74,6 +74,9 @@ def test_download_url_return(toppath, topurl, outdir):
     ('file1.txt', 'abc'),
     ('file2.txt', 'def'),
     ('file3.txt', 'ghi'),
+    ('file4.txt', 'jkl'),
+    ('file5.txt', 'mno'),
+    ('file6.txt', 'pqr'),
 ])
 @serve_path_via_http
 @with_tempfile(mkdir=True)
@@ -103,6 +106,18 @@ def test_download_url_dataset(toppath, topurl, path):
 
     ds.download_url([opj(topurl, "file3.txt")], save=False)
     assert_false(ds.repo.file_has_content("file3.txt"))
+
+    subdir_path = opj(path, "subdir")
+    os.mkdir(subdir_path)
+    with chpwd(subdir_path):
+        download_url(opj(topurl, "file4.txt"))
+        download_url(opj(topurl, "file5.txt"), path="five.txt")
+        ds.download_url(opj(topurl, "file6.txt"))
+    # download_url calls within a subdirectory save the file there
+    ok_(ds.repo.file_has_content(opj("subdir", "file4.txt")))
+    ok_(ds.repo.file_has_content(opj("subdir", "five.txt")))
+    # ... unless the dataset is provided.
+    ok_(ds.repo.file_has_content("file6.txt"))
 
 
 @with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1545,6 +1545,39 @@ def get_dataset_root(path):
     return None
 
 
+def get_dataset_pwds(dataset):
+    """Return the current directory for the dataset.
+
+    Parameters
+    ----------
+    dataset : Dataset
+
+    Returns
+    -------
+    A tuple, where the first item is the absolute path of the pwd and the
+    second is the pwd relative to the dataset's path.
+    """
+    if dataset:
+        pwd = dataset.path
+        rel_pwd = curdir
+    else:
+        # act on the whole dataset if nothing else was specified
+
+        # Follow our generic semantic that if dataset is specified,
+        # paths are relative to it, if not -- relative to pwd
+        pwd = getpwd()
+        # Pass pwd to get_dataset_root instead of os.path.curdir to handle
+        # repos whose leading paths have a symlinked directory (see the
+        # TMPDIR="/var/tmp/sym link" test case).
+        dataset = get_dataset_root(pwd)
+
+        if dataset:
+            rel_pwd = relpath(pwd, dataset)
+        else:
+            rel_pwd = pwd  # and leave handling to caller
+    return pwd, rel_pwd
+
+
 def try_multiple(ntrials, exception, base, f, *args, **kwargs):
     """Call f multiple times making exponentially growing delay between the calls"""
     from .dochelpers import exc_str


### PR DESCRIPTION
If 'datalad download-url' is called (without -d) from a dataset's
subdirectory, the downloaded file should be stored within that
directory.  Similarly, a path specified with --path should be relative
to that directory.

Fixes #2676.

---
- [x] This change is complete
