### PR TITLE
Improve CommandError rendering (particularly under 'datalad run')

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -524,8 +524,10 @@ class Runner(object):
                         self._log_err(out[1], expected=expect_stderr)
 
                 if status not in [0, None]:
-                    msg = "Failed to run %r%s. Exit code=%d. out=%s err=%s" \
-                        % (cmd, " under %r" % (cwd or self.cwd), status, out[0], out[1])
+                    msg = "Failed to run %r%s. Exit code=%d.%s%s" \
+                        % (cmd, " under %r" % (cwd or self.cwd), status,
+                           "" if log_online else " out=" + out[0],
+                           "" if log_online else " err=" + out[1])
                     lgr.log(9 if expect_fail else 11, msg)
                     raise CommandError(str(cmd), msg, status, out[0], out[1])
                 else:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -526,8 +526,8 @@ class Runner(object):
                 if status not in [0, None]:
                     msg = "Failed to run %r%s. Exit code=%d.%s%s" \
                         % (cmd, " under %r" % (cwd or self.cwd), status,
-                           "" if log_online else " out=" + out[0],
-                           "" if log_online else " err=" + out[1])
+                           "" if log_online else " out=%s" % out[0],
+                           "" if log_online else " err=%s" % out[1])
                     lgr.log(9 if expect_fail else 11, msg)
                     raise CommandError(str(cmd), msg, status, out[0], out[1])
                 else:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -534,7 +534,8 @@ def main(args=None):
                 # behave as if the command ran directly, importantly pass
                 # exit code as is
                 if exc.msg:
-                    os.write(2, exc.msg.encode() if isinstance(exc.msg, text_type) else exc.msg)
+                    msg = exc.msg.encode() if isinstance(exc.msg, text_type) else exc.msg
+                    os.write(2, msg + b"\n")
                 if exc.stdout:
                     os.write(1, exc.stdout.encode() if isinstance(exc.stdout, text_type) else exc.stdout)
                 if exc.stderr:


### PR DESCRIPTION
Under bash, this changes

```bash
%> datalad run ls doesntexist
[INFO   ] == Command start (output follows) =====
ls: cannot access 'doesntexist': No such file or directory
[INFO   ] == Command exit (modification check follows) =====
[INFO   ] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -r -F.git/COMMIT_EDITMSG .'
Failed to run 'ls doesntexist' under '/tmp/dl/err'. Exit code=2. out= err=%>
```

to

```bash
%> datalad run ls doesntexist
[INFO   ] == Command start (output follows) =====
ls: cannot access 'doesntexist': No such file or directory
[INFO   ] == Command exit (modification check follows) =====
[INFO   ] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -r -F.git/COMMIT_EDITMSG .'
Failed to run 'ls doesntexist' under '/tmp/dl/err'. Exit code=2.
%>
```

In particular, note the position of the final prompt.

#### Changes

- [x] add newline when rendering `CommandError`s message
- [x] don't show "out= err=" when `log_online=True`
