### PR TITLE
BF: archives: Fix zip (PY2/PY3) and unzip (PY3)

### DIFF
--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -331,6 +331,20 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
 
 
 @assert_cwd_unchanged(ok_to_chdir=True)
+@with_tree(tree={"1.zip": {"dir": {"bar": "blah"}, "foo": "blahhhhh"}})
+def test_add_archive_content_zip(repo_path):
+    repo = AnnexRepo(repo_path, create=True)
+    with chpwd(repo_path):
+        with swallow_outputs():
+            repo.add(["1.zip"])
+        repo.commit("add 1.zip")
+        add_archive_content("1.zip")
+        ok_file_under_git(opj(repo.path, "1", "foo"), annexed=True)
+        ok_file_under_git(opj("1", "dir", "bar"), annexed=True)
+        ok_archives_caches(repo.path, 0)
+
+
+@assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 def test_add_archive_use_archive_dir(repo_path):
     direct = False  # TODO: test on undirect, but too long ATM

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -138,15 +138,12 @@ def decompress_file(archive, dir_, leading_directories='strip'):
         os.makedirs(dir_)
 
     with swallow_outputs() as cmo:
-        archive = assure_bytes(archive)
-        dir_ = assure_bytes(dir_)
+        archive = assure_unicode(archive)
+        dir_ = assure_unicode(dir_)
         patoolib.util.check_existing_filename(archive)
         patoolib.util.check_existing_filename(dir_, onlyfiles=False)
         # Call protected one to avoid the checks on existence on unixified path
         outdir = unixify_path(dir_)
-        if not PY2:
-            # should be supplied in PY3 to avoid b''
-            outdir = assure_unicode(outdir)
         patoolib._extract_archive(unixify_path(archive),
                                   outdir=outdir,
                                   verbosity=100)

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -138,12 +138,16 @@ def decompress_file(archive, dir_, leading_directories='strip'):
         os.makedirs(dir_)
 
     with swallow_outputs() as cmo:
-        archive = assure_unicode(archive)
-        dir_ = assure_unicode(dir_)
+        archive = assure_bytes(archive)
+        dir_ = assure_bytes(dir_)
         patoolib.util.check_existing_filename(archive)
         patoolib.util.check_existing_filename(dir_, onlyfiles=False)
         # Call protected one to avoid the checks on existence on unixified path
         outdir = unixify_path(dir_)
+        if not PY2:
+            # should be supplied in PY3 to avoid b''
+            outdir = assure_unicode(outdir)
+            archive = assure_unicode(archive)
         patoolib._extract_archive(unixify_path(archive),
                                   outdir=outdir,
                                   verbosity=100)

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -97,7 +97,8 @@ def check_compress_file(ext, path, name):
 def test_compress_file():
     yield check_compress_file, '.tar.gz'
     yield check_compress_file, '.tar'
-    # yield check_compress_file, '.zip'
+    yield check_compress_file, '.zip'
+
 
 @with_tree(**tree_simplearchive)
 def test_ExtractedArchive(path):


### PR DESCRIPTION
- Make `compress_files` work with zip files so that `with_tree` can create zip files and we can add a regression test for gh-2695.

- Fix a PY3-specific failure that occurs when `decompress_file` (and thus `add_archive_content`) is called on zip files.

Fixes #2695.
