### PR TITLE
BFs (workarounds) for Windows: untaint DataLadRIs, use getcwd for PWD

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -16,29 +16,9 @@ if _seed:
     import random
     random.seed(_seed)
 
-# Other imports are interspersed with lgr.debug to ease troubleshooting startup
-# delays etc.
-
-# If there is a bundled git, make sure GitPython uses it too:
-from datalad.cmd import GitRunner
-GitRunner._check_git_path()
-if GitRunner._GIT_PATH:
-    import os
-    os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = \
-        os.path.join(GitRunner._GIT_PATH, 'git')
-
-from .config import ConfigManager
-cfg = ConfigManager()
-
-from .log import lgr
 import atexit
-from datalad.utils import on_windows, get_encoding_info, get_envvars_info
-
-lgr.log(5, "Instantiating ssh manager")
-from .support.sshconnector import SSHManager
-ssh_manager = SSHManager()
-atexit.register(ssh_manager.close, allow_fail=False)
-
+# Colorama (for Windows terminal colors) must be imported before we use/bind
+# any sys.stdout
 try:
     # this will fix the rendering of ANSI escape sequences
     # for colored terminal output on windows
@@ -54,6 +34,28 @@ except ImportError as e:
             "'colorama' Python module missing, terminal output may look garbled [%s]",
             exc_str(e))
     pass
+
+# Other imports are interspersed with lgr.debug to ease troubleshooting startup
+# delays etc.
+
+# If there is a bundled git, make sure GitPython uses it too:
+from datalad.cmd import GitRunner
+GitRunner._check_git_path()
+if GitRunner._GIT_PATH:
+    import os
+    os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = \
+        os.path.join(GitRunner._GIT_PATH, 'git')
+
+from .config import ConfigManager
+cfg = ConfigManager()
+
+from .log import lgr
+from datalad.utils import on_windows, get_encoding_info, get_envvars_info
+
+lgr.log(5, "Instantiating ssh manager")
+from .support.sshconnector import SSHManager
+ssh_manager = SSHManager()
+atexit.register(ssh_manager.close, allow_fail=False)
 
 atexit.register(lgr.log, 5, "Exiting")
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -28,12 +28,9 @@ try:
     colorama.init()
     atexit.register(colorama.deinit)
 except ImportError as e:
-    if on_windows:
-        from datalad.dochelpers import exc_str
-        lgr.warning(
-            "'colorama' Python module missing, terminal output may look garbled [%s]",
-            exc_str(e))
-    pass
+    # To not interfer with carefully crafted order of imports
+    # delay possibly issuing a warning until all needed imports are done
+    colorama = None
 
 # Other imports are interspersed with lgr.debug to ease troubleshooting startup
 # delays etc.
@@ -56,6 +53,14 @@ lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager
 ssh_manager = SSHManager()
 atexit.register(ssh_manager.close, allow_fail=False)
+
+if on_windows and colorama is None:
+    from datalad.dochelpers import exc_str
+
+    lgr.warning(
+        "'colorama' Python module missing, terminal output may look garbled ["
+        "%s]",
+        exc_str(e))
 
 atexit.register(lgr.log, 5, "Exiting")
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -168,8 +168,12 @@ def teardown_package():
     lgr.debug("Printing versioning information collected so far")
     from datalad.support.external_versions import external_versions as ev
     print(ev.dumps(query=True))
-    print("Obscure filename: str=%s repr=%r"
-            % (OBSCURE_FILENAME.encode('utf-8'), OBSCURE_FILENAME))
+    try:
+        print("Obscure filename: str=%s repr=%r"
+                % (OBSCURE_FILENAME.encode('utf-8'), OBSCURE_FILENAME))
+    except UnicodeEncodeError as exc:
+        from .dochelpers import exc_str
+        print("Obscure filename failed to print: %s" % exc_str(exc))
     def print_dict(d):
         return " ".join("%s=%r" % v for v in d.items())
     print("Encodings: %s" % print_dict(get_encoding_info()))

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -19,7 +19,11 @@ from six.moves import StringIO
 from mock import patch
 
 import datalad
-from ..main import main, fail_with_short_help
+from ..main import (
+    main,
+    fail_with_short_help,
+    _fix_datalad_ri,
+)
 from datalad import __version__
 from datalad.cmd import Runner
 from datalad.ui.utils import get_console_width
@@ -261,3 +265,13 @@ def test_fail_with_short_help():
                  "        mother\n"
                  "        father\n"
                  "Hint: You can become one\n")
+
+def test_fix_datalad_ri():
+    assert_equal(_fix_datalad_ri('/'), '/')
+    assert_equal(_fix_datalad_ri('/a/b'), '/a/b')
+    assert_equal(_fix_datalad_ri('//'), '///')
+    assert_equal(_fix_datalad_ri('///'), '///')
+    assert_equal(_fix_datalad_ri('//a'), '///a')
+    assert_equal(_fix_datalad_ri('///a'), '///a')
+    assert_equal(_fix_datalad_ri('//a/b'), '///a/b')
+    assert_equal(_fix_datalad_ri('///a/b'), '///a/b')

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1215,7 +1215,17 @@ def getpwd():
     If no PWD found in the env, output of getcwd() is returned
     """
     try:
-        return os.environ['PWD']
+        pwd = os.environ['PWD']
+        if on_windows and pwd and pwd.startswith('/'):
+            # It should be a path from MSYS.
+            # - it might start with a drive letter or not
+            # - it seems to be "illegal" to have a single letter directories
+            #   under / path, i.e. if created - they aren't found
+            # - 'ln -s' does not fail to create a "symlink" but it just copies!
+            #   so we are not likely to need original PWD purpose on those systems
+            # Verdict:
+            return os.getcwd()
+        return pwd
     except KeyError:
         return os.getcwd()
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -66,6 +66,9 @@ platform_system = platform.system().lower()
 on_windows = platform_system == 'windows'
 on_osx = platform_system == 'darwin'
 on_linux = platform_system == 'linux'
+on_msys_tainted_paths = on_windows \
+                        and 'MSYS_NO_PATHCONV' not in os.environ \
+                        and os.environ.get('MSYSTEM', '')[:4] in ('MSYS', 'MING')
 try:
     linux_distribution_name, linux_distribution_release \
         = platform.linux_distribution()[:2]


### PR DESCRIPTION
This pull request fixes #2643 , fixed #2700 

Ah, also while troubleshooting that git-annex compatibility issue, added to WTF output the maximal filename length in current path (yes - it just creates a bunch of files until it can't, might take awhile if on the floppy)