### PR TITLE
ENH+BF: S3 and downloaders: support anonymous access + interface to add new providers

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -199,7 +199,7 @@ class BaseDownloader(object):
                             url,
                             denied_msg=access_denied,
                             auth_types=supported_auth_types,
-                            new_provider=not self.credential)
+                            new_provider=False)
                         allow_old_session = False
                         continue
                 else:  # None or False
@@ -266,24 +266,10 @@ class BaseDownloader(object):
                          " to access url?",
                     default=True
             ):
-                if not self.authenticator:
-                    raise DownloadError(
-                        title +
-                        " No authenticator is known, cannot set any credential")
-                # we could try to just
-                credential_type = self.authenticator.DEFAULT_CREDENTIAL_TYPE
-                if not credential_type:
-                    raise DownloadError(
-                        title +
-                        " %s does not have a default credential type,"
-                        " cannot authenticate" % self.authenticator)
-
-                name = 'one-time-record'
-                if not credential_type:
-                    raise ValueError(
-                        "Do not know what type of credential record is needed")
-                self.credential = CREDENTIAL_TYPES[credential_type](name=name)
-                self.credential.enter_new()
+                assert not self.authenticator, "bug: incorrect assumption"
+                raise DownloadError(
+                    title +
+                    " No authenticator is known, cannot set any credential")
             else:
                 provider = self._setup_new_provider(
                     title, url, auth_types=auth_types)

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -194,14 +194,7 @@ class BaseDownloader(object):
                             lgr.error(
                                 "Interface is non interactive, so we are "
                                 "reraising: %s" % exc_str(e))
-                            if exc_info:
-                                reraise(*exc_info)
-                            else:
-                                # must not happen but who knows
-                                raise AccessDeniedError(
-                                    "Interface is not interactive and we were denied access."
-                                    " Run in interactive mode to get provider "
-                                    " setup, or configure it manually.")
+                            reraise(*exc_info)
                         self._enter_credentials(
                             url,
                             denied_msg=access_denied,

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -77,7 +77,6 @@ class BaseDownloader(object):
         authenticator: Authenticator, optional
           Authenticator to use for authentication.
         """
-        # Allow for anonymous connection if no credential is provided
         if not authenticator and self._DEFAULT_AUTHENTICATOR:
             authenticator = self._DEFAULT_AUTHENTICATOR()
 
@@ -194,7 +193,7 @@ class BaseDownloader(object):
                         if not ui.is_interactive:
                             lgr.error(
                                 "Interface is non interactive, so we are "
-                                "re-raising: %s" % exc_str(e))
+                                "reraising: %s" % exc_str(e))
                             if exc_info:
                                 reraise(*exc_info)
                             else:
@@ -270,25 +269,21 @@ class BaseDownloader(object):
             # appropriate one
             if not ui.yesno(
                     title=title,
-                    text="Would you like to setup a new provider "
-                         "configuration to "
-                         "access url?",
+                    text="Would you like to setup a new provider configuration"
+                         " to access url?",
                     default=True
             ):
                 if not self.authenticator:
-                    raise DownloadError(title +
-                                        " No authenticator is known, cannot "
-                                        "set "
-                                        "any credential")
+                    raise DownloadError(
+                        title +
+                        " No authenticator is known, cannot set any credential")
                 # we could try to just
                 credential_type = self.authenticator.DEFAULT_CREDENTIAL_TYPE
                 if not credential_type:
                     raise DownloadError(
                         title +
-                        " %s does not have a default credential type, "
-                        "cannot authenticate"
-                        % self.authenticator
-                    )
+                        " %s does not have a default credential type,"
+                        " cannot authenticate" % self.authenticator)
 
                 name = 'one-time-record'
                 if not credential_type:
@@ -313,7 +308,8 @@ class BaseDownloader(object):
                 self.credential.enter_new()
             else:
                 raise DownloadError(
-                    "Failed to download from %s given available credentials" % url)
+                    "Failed to download from %s given available credentials"
+                    % url)
 
     @staticmethod
     def _get_temp_download_filename(filepath):

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -118,11 +118,11 @@ class BaseDownloader(object):
         """
         # TODO: possibly wrap this logic outside within a decorator, which
         # would just call the corresponding method
-
         authenticator = self.authenticator
-        needs_authentication = (
-            authenticator and authenticator.requires_authentication
-        ) or self.credential
+        if authenticator:
+            needs_authentication = authenticator.requires_authentication
+        else:
+            needs_authentication = self.credential
 
         attempt, incomplete_attempt = 0, 0
         while True:

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -80,7 +80,7 @@ class BaseDownloader(object):
         if not authenticator and self._DEFAULT_AUTHENTICATOR:
             authenticator = self._DEFAULT_AUTHENTICATOR()
 
-        if authenticator:
+        if authenticator and authenticator.requires_authentication:
             if not credential and not authenticator.allows_anonymous:
                 msg = "Both authenticator and credentials must be provided." \
                       " Got only authenticator %s" % repr(authenticator)

--- a/datalad/downloaders/configs/crawdad.cfg
+++ b/datalad/downloaders/configs/crawdad.cfg
@@ -1,7 +1,7 @@
 [provider:crawdad]
-url_re = http://(?P<mirror>\s\.)?crawdad\.org/.*
+url_re = https?://(?P<mirror>\S+\.)?crawdad\.org/.*
 credential = crawdad
-authentication_type = http_auth
+authentication_type = http_basic_auth
 
 [credential:crawdad]
 url = http://crawdad.org/joinup.html

--- a/datalad/downloaders/configs/providers.cfg
+++ b/datalad/downloaders/configs/providers.cfg
@@ -3,7 +3,7 @@
 #
 
 [provider:datalad-test-s3]
-url_re = s3://datalad-test.*
+url_re = s3://datalad.test.*
 credential = datalad-test-s3
 authentication_type = aws-s3
 

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -318,6 +318,7 @@ class LORIS_Token(CompositeCredential):
     def __init__(self, name, url=None, keyring=None):
         super(CompositeCredential, self).__init__(name, url, keyring)
 
+
 CREDENTIAL_TYPES = {
     'user_password': UserPassword,
     'aws-s3': AWS_S3,

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -307,7 +307,7 @@ class Providers(object):
             authenticator = None
 
         # bringing url_re to "standard" format of a list and populating _providers_ordered
-        url_res = assure_list_from_str(items.pop('url_re'))
+        url_res = assure_list_from_str(items.pop('url_re', []))
         assert url_res, "current implementation relies on having url_re defined"
 
         credential = items.pop('credential', None)

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -380,19 +380,19 @@ class Providers(object):
                 except AttributeError:
                     pass
         known_providers_by_name = {p.name: p for p in self._providers}
-        PROVIDERS_USER_DIR = self._get_providers_dirs()['user']
+        providers_user_dir = self._get_providers_dirs()['user']
         while True:
             name = ui.question(
                 title="New provider name",
                 text="Unique name to identify 'provider' for %s" % url,
                 default=name
             )
-            filename = pathjoin(PROVIDERS_USER_DIR, '%s.cfg' % name)
+            filename = pathjoin(providers_user_dir, '%s.cfg' % name)
             if name in known_providers_by_name:
                 if ui.yesno(
                     title="Known provider %s" % name,
                     text="Provider with name %s already known. Do you want to "
-                         "use it for this session? If 'No' - enter another name"
+                         "use it for this session?"
                          % name,
                     default=True
                 ):
@@ -406,7 +406,7 @@ class Providers(object):
         url_re = re.escape(url)
         while True:
             url_re = ui.question(
-                title="New provider regular_expression",
+                title="New provider regular expression",
                 text="A (Python) regular expression to specify for which URLs "
                      "this provider should be used",
                 default=url_re

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -13,6 +13,7 @@ from glob import glob
 from logging import getLogger
 from six import iteritems
 
+import os
 import re
 from os.path import dirname, abspath, join as pathjoin
 from six.moves.urllib.parse import urlparse
@@ -447,8 +448,8 @@ class Providers(object):
         )
 
         # Just create a configuration file and reload the thing
-        if not path.lexists(PROVIDERS_USER_DIR):
-            path.makedirs(PROVIDERS_USER_DIR)
+        if not path.lexists(providers_user_dir):
+            os.makedirs(providers_user_dir)
         cfg = """\
 # Provider configuration file created to initially access
 # {url}

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -403,7 +403,7 @@ class Providers(object):
             else:
                 break
 
-        url_re = re.escape(url)
+        url_re = re.escape(url) if url else None
         while True:
             url_re = ui.question(
                 title="New provider regular expression",

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -338,8 +338,6 @@ class Providers(object):
         # configuration wins in conflicts between url_re
         matching_providers = []
         for provider in self._providers[::-1]:
-            if not provider.url_res:
-                continue
             for url_re in provider.url_res:
                 if re.match(url_re, url):
                     lgr.debug("Returning provider %s for url %s", provider, url)

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -21,7 +21,9 @@ from collections import OrderedDict
 from .base import NoneAuthenticator, NotImplementedAuthenticator
 
 from .http import (
-    HTMLFormAuthenticator, HTTPBasicAuthAuthenticator,
+    HTMLFormAuthenticator,
+    HTTPAuthAuthenticator,
+    HTTPBasicAuthAuthenticator,
     HTTPDigestAuthAuthenticator,
     HTTPBearerTokenAuthenticator,
     HTTPDownloader,
@@ -29,6 +31,8 @@ from .http import (
 from .s3 import S3Authenticator, S3Downloader
 from ..support.configparserinc import SafeConfigParserWithIncludes
 from ..support.external_versions import external_versions
+from ..support.network import RI
+from ..support import path
 from ..utils import assure_list_from_str
 from ..utils import auto_repr
 from ..utils import get_dataset_root
@@ -41,7 +45,7 @@ lgr = getLogger('datalad.downloaders.providers')
 # parameters will be fetched from config file itself
 AUTHENTICATION_TYPES = {
     'html_form': HTMLFormAuthenticator,
-    'http_auth': HTTPBasicAuthAuthenticator,
+    'http_auth': HTTPAuthAuthenticator,
     'http_basic_auth': HTTPBasicAuthAuthenticator,
     'http_digest_auth': HTTPDigestAuthAuthenticator,
     'bearer_token': HTTPBearerTokenAuthenticator,
@@ -170,7 +174,10 @@ class Providers(object):
         self._default_providers = {}
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, "" if not self._providers else repr(self._providers))
+        return "%s(%s)" % (
+            self.__class__.__name__,
+            "" if not self._providers else repr(self._providers)
+        )
 
     def __len__(self):
         return len(self._providers)
@@ -180,6 +187,27 @@ class Providers(object):
 
     def __iter__(self):
         return self._providers.__iter__()
+
+    @classmethod
+    def _get_providers_dirs(cls, dsroot=None):
+        """Return an ordered dict with directories to look for provider config files
+
+        Is implemented as a function to ease mock testing depending on dirs.
+        values
+        """
+        paths = OrderedDict()
+        paths['dist'] = pathjoin(dirname(abspath(__file__)), 'configs')
+        if dsroot is not None:
+            paths['ds'] = pathjoin(dsroot, '.datalad', 'providers')
+        paths['site'] = pathjoin(dirs.site_config_dir, "providers") \
+            if dirs.site_config_dir else None
+        paths['user'] = pathjoin(dirs.user_config_dir, "providers") \
+            if dirs.user_config_dir else None
+        return paths
+
+    @classmethod
+    def _get_configs(cls, dir, files='*.cfg'):
+        return glob(pathjoin(dir, files)) if dir is not None else []
 
     @classmethod
     def from_config_files(cls, files=None, reload=False):
@@ -204,23 +232,10 @@ class Providers(object):
         config = SafeConfigParserWithIncludes()
         files_orig = files
         if files is None:
-            # Config files from the datalad dist
-            files = glob(pathjoin(dirname(abspath(__file__)), 'configs', '*.cfg'))
-
-            # Dataset config
-            if dsroot is not None:
-                files.extend(glob(pathjoin(dsroot, '.datalad', 'providers', '*.cfg')))
             cls._DS_ROOT = dsroot
-
-            # System config
-            if dirs.site_config_dir is not None:
-                files.extend(glob(pathjoin(dirs.site_config_dir, "providers", "*.cfg")))
-
-            # User config
-            if dirs.user_config_dir is not None:
-                files.extend(glob(pathjoin(dirs.user_config_dir, 'providers', '*.cfg')))
-
-
+            files = []
+            for p in cls._get_providers_dirs(dsroot).values():
+                files.extend(cls._get_configs(p))
         config.read(files)
 
         # We need first to load Providers and credentials
@@ -304,24 +319,39 @@ class Providers(object):
     def _process_credential(cls, name, items):
         assert 'type' in items, "Credential must specify type.  Missing in %s" % name
         cred_type = items.pop('type')
-        if not cred_type in CREDENTIAL_TYPES:
+        if cred_type not in CREDENTIAL_TYPES:
             raise ValueError("I do not know type %s credential. Known: %s"
                              % (cred_type, CREDENTIAL_TYPES.keys()))
         return CREDENTIAL_TYPES[cred_type](name=name, url=items.pop('url', None))
 
-    def get_provider(self, url, only_nondefault=False):
+    def reload(self):
+        new_providers = self.from_config_files(reload=True)
+        self._providers = new_providers._providers
+        self._default_providers = new_providers._default_providers
+
+    def get_provider(self, url, only_nondefault=False, return_all=False):
         """Given a URL returns matching provider
         """
 
         # Range backwards to ensure that more locally defined
         # configuration wins in conflicts between url_re
+        matching_providers = []
         for provider in self._providers[::-1]:
             if not provider.url_res:
                 continue
             for url_re in provider.url_res:
                 if re.match(url_re, url):
                     lgr.debug("Returning provider %s for url %s", provider, url)
-                    return provider
+                    matching_providers.append(provider)
+
+        if matching_providers:
+            if return_all:
+                return matching_providers
+            if len(matching_providers) > 1:
+                lgr.warning(
+                    "Multiple providers matched for %s, using the first one"
+                    % url)
+            return matching_providers[0]
 
         if only_nondefault:
             return None
@@ -336,6 +366,119 @@ class Providers(object):
         lgr.debug("No dedicated provider, returning default one for %s: %s",
                   scheme, provider)
         return provider
+
+    def enter_new(self, url=None, auth_types=[]):
+        from datalad.ui import ui
+        name = None
+        if url:
+            ri = RI(url)
+            for f in ('hostname', 'name'):
+                try:
+                    # might need sanitarization
+                    name = str(getattr(ri, f))
+                except AttributeError:
+                    pass
+        known_providers_by_name = {p.name: p for p in self._providers}
+        PROVIDERS_USER_DIR = self._get_providers_dirs()['user']
+        while True:
+            name = ui.question(
+                title="New provider name",
+                text="Unique name to identify 'provider' for %s" % url,
+                default=name
+            )
+            filename = pathjoin(PROVIDERS_USER_DIR, '%s.cfg' % name)
+            if name in known_providers_by_name:
+                if ui.yesno(
+                    title="Known provider %s" % name,
+                    text="Provider with name %s already known. Do you want to "
+                         "use it for this session? If 'No' - enter another name"
+                         % name,
+                    default=True
+                ):
+                    return known_providers_by_name[name]
+            elif path.lexists(filename):
+                ui.error(
+                    "File %s already exists, choose another name" % filename)
+            else:
+                break
+
+        url_re = re.escape(url)
+        while True:
+            url_re = ui.question(
+                title="New provider regular_expression",
+                text="A (Python) regular expression to specify for which URLs "
+                     "this provider should be used",
+                default=url_re
+            )
+            if not re.match(url_re, url):
+                ui.error("Provided regular expression doesn't match original "
+                         "url.  Please re-enter")
+            # TODO: url_re of another provider might match it as well
+            #  I am not sure if we have any kind of "priority" setting ATM
+            #  to differentiate or to to try multiple types :-/
+            else:
+                break
+
+        authentication_type = None
+        if auth_types:
+            auth_types = [
+                t for t in auth_types if t in AUTHENTICATION_TYPES
+            ]
+            if auth_types:
+                authentication_type = auth_types[0]
+
+        # Setup credential
+        authentication_type = ui.question(
+            title="Authentication type",
+            text="What authentication type to use",
+            default=authentication_type,
+            choices=sorted(AUTHENTICATION_TYPES)
+        )
+        authenticator_class = AUTHENTICATION_TYPES[authentication_type]
+
+        # TODO: need to figure out what fields that authenticator might
+        #       need to have setup and ask for them here!
+
+        credential_type = ui.question(
+            title="Credential",
+            text="What type of credential should be used?",
+            choices=sorted(CREDENTIAL_TYPES),
+            default=getattr(authenticator_class, 'DEFAULT_CREDENTIAL_TYPE')
+        )
+
+        # Just create a configuration file and reload the thing
+        if not path.lexists(PROVIDERS_USER_DIR):
+            path.makedirs(PROVIDERS_USER_DIR)
+        cfg = """\
+# Provider configuration file created to initially access
+# {url}
+
+[provider:{name}]
+url_re = {url_re}
+authentication_type = {authentication_type}
+# Note that you might need to specify additional fields specific to the
+# authenticator.  Fow now "look into the docs/source" of {authenticator_class}
+# {authentication_type}_
+credential = {name}
+
+[credential:{name}]
+# If known, specify URL or email to how/where to request credentials
+# url = ???
+type = {credential_type}
+""".format(**locals())
+        if ui.yesno(
+            title="Save provider configuration file",
+            text="Following configuration will be written to %s:\n%s"
+                % (filename, cfg),
+            default='yes'
+        ):
+            with open(filename, 'wb') as f:
+                f.write(cfg.encode('utf-8'))
+        else:
+            return None
+        self.reload()
+        # XXX see above note about possibly multiple matches etc
+        return self.get_provider(url)
 
     # TODO: avoid duplication somehow ;)
     # Sugarings to get easier access to downloaders

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -84,6 +84,8 @@ class S3Authenticator(Authenticator):
             conn_kind = "anonymously"
             conn_args = []
             conn_kwargs['anon'] = True
+        if '.' in bucket_name:
+            conn_kwargs['calling_format']=OrdinaryCallingFormat()
 
         lgr.info(
             "S3 session: Connecting to the bucket %s %s", bucket_name, conn_kind

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -26,6 +26,7 @@ from ..credentials import LORIS_Token
 from ..http import HTMLFormAuthenticator
 from ..http import HTTPDownloader
 from ..http import HTTPBearerTokenAuthenticator
+from ..http import process_www_authenticate
 from ...support.network import get_url_straight_filename
 from ...tests.utils import with_fake_cookies_db
 from ...tests.utils import skip_if_no_network
@@ -88,6 +89,17 @@ def fake_open(write_=None):
 
 def _raise_IOError(*args, **kwargs):
     raise IOError("Testing here")
+
+
+def test_process_www_authenticate():
+    assert_equal(process_www_authenticate("Basic"),
+                 ["http_basic_auth"])
+    assert_equal(process_www_authenticate("Digest"),
+                 ["http_digest_auth"])
+    assert_equal(process_www_authenticate("Digest more"),
+                 ["http_digest_auth"])
+    assert_equal(process_www_authenticate("Unknown"),
+                 [])
 
 
 @with_tree(tree=[('file.dat', 'abc')])

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -169,7 +169,8 @@ def test_HTTPDownloader_basic(toppath, topurl):
 
 @with_tree(tree=[('file.dat', 'abc')])
 @serve_path_via_http
-def test_access_denied(toppath, topurl):
+@with_memory_keyring
+def test_access_denied(toppath, topurl, keyring):
     furl = topurl + "file.dat"
 
     def deny_access(*args, **kwargs):

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -11,15 +11,18 @@
 import time
 from calendar import timegm
 from six import PY3
+import re
 
 import os
 import six.moves.builtins as __builtin__
 from os.path import join as opj
 
 from datalad.downloaders.tests.utils import get_test_providers
+from ..base import AccessFailedError
 from ..base import DownloadError
 from ..base import IncompleteDownloadError
 from ..base import BaseDownloader
+from ..base import NoneAuthenticator
 from ..credentials import UserPassword
 from ..credentials import Token
 from ..credentials import LORIS_Token
@@ -62,6 +65,8 @@ from ...tests.utils import with_tempfile
 from ...tests.utils import use_cassette
 from ...tests.utils import skip_if
 from ...tests.utils import without_http_proxy
+from ...support.exceptions import AccessDeniedError
+from ...support.exceptions import AnonymousAccessDeniedError
 from ...support.status import FileStatus
 from ...support.network import get_url_disposition_filename
 
@@ -160,6 +165,65 @@ def test_HTTPDownloader_basic(toppath, topurl):
 
     # TODO: access denied scenario
     # TODO: access denied detection
+
+
+@with_tree(tree=[('file.dat', 'abc')])
+@serve_path_via_http
+def test_access_denied(toppath, topurl):
+    furl = topurl + "file.dat"
+
+    def deny_access(*args, **kwargs):
+        raise AccessDeniedError(supported_types=["http_basic_auth"])
+
+    def deny_anon_access(*args, **kwargs):
+        raise AnonymousAccessDeniedError(supported_types=["http_basic_auth"])
+
+    downloader = HTTPDownloader()
+
+    # Test different paths that should lead to a DownloadError.
+
+    for denier in deny_access, deny_anon_access:
+        @with_testsui(responses=["no"])
+        def run_refuse_provider_setup():
+            with patch.object(downloader, '_download', denier):
+                downloader.download(furl)
+        assert_raises(DownloadError, run_refuse_provider_setup)
+
+    downloader_creds = HTTPDownloader(credential="irrelevant")
+
+    @with_testsui(responses=["no"])
+    def run_refuse_creds_update():
+        with patch.object(downloader_creds, '_download', deny_access):
+            downloader_creds.download(furl)
+    assert_raises(DownloadError, run_refuse_creds_update)
+
+    downloader_noauth = HTTPDownloader(authenticator=NoneAuthenticator())
+
+    def run_noauth():
+        with patch.object(downloader_noauth, '_download', deny_access):
+            downloader_noauth.download(furl)
+    assert_raises(DownloadError, run_noauth)
+
+    # Complete setup for a new provider.
+
+    @with_testsui(responses=[
+        "yes",  # Set up provider?
+        # Enter provider details, but then don't save ...
+        "newprovider", re.escape(furl), "http_auth", "user_password", "no",
+        # No provider, try again?
+        "yes",
+        # Enter same provider detains but save this time.
+        "newprovider", re.escape(furl), "http_auth", "user_password", "yes",
+        # Enter credentials.
+        "me", "mypass"
+    ])
+    def run_set_up_provider():
+        with patch.object(downloader, '_download', deny_access):
+            downloader.download(furl)
+
+    # We've forced an AccessDenied error and then set up bogus credentials,
+    # leading to a 501 (not implemented) error.
+    assert_raises(AccessFailedError, run_set_up_provider)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -9,13 +9,11 @@
 """Tests for data providers"""
 
 from mock import patch
-from tempfile import mkdtemp
 
 from ..providers import Provider
 from ..providers import Providers
 from ..providers import HTTPDownloader
 from ...utils import chpwd
-from ...tests.utils import eq_
 from ...tests.utils import assert_in
 from ...tests.utils import assert_greater
 from ...tests.utils import assert_equal
@@ -23,7 +21,6 @@ from ...tests.utils import assert_raises
 from ...tests.utils import with_tree
 
 from ...support.external_versions import external_versions
-from ...interface.common_cfg import dirs
 
 
 def test_Providers_OnStockConfiguration():

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -8,17 +8,24 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for data providers"""
 
+import os.path as op
+
 from mock import patch
 
 from ..providers import Provider
 from ..providers import Providers
 from ..providers import HTTPDownloader
 from ...utils import chpwd
+from ...utils import create_tree
 from ...tests.utils import assert_in
+from ...tests.utils import assert_false
 from ...tests.utils import assert_greater
 from ...tests.utils import assert_equal
 from ...tests.utils import assert_raises
+from ...tests.utils import ok_exists
+from ...tests.utils import with_tempfile
 from ...tests.utils import with_tree
+from ...tests.utils import with_testsui
 
 from ...support.external_versions import external_versions
 
@@ -144,3 +151,57 @@ def test_Providers_from_config__files(sysdir, userdir, dsdir):
             providers = Providers.from_config_files(reload=True)
             provider = providers.get_provider('https://crcns.org/data....')
             assert_equal(provider.name, 'usercrcns')
+
+
+@with_tempfile(mkdir=True)
+def test_providers_enter_new(path):
+    with patch.multiple("appdirs.AppDirs", site_config_dir=None,
+                        user_config_dir=path):
+        providers_dir = op.join(path, "providers")
+        providers = Providers.from_config_files(reload=True)
+
+        url = "blah://thing"
+        url_re = "blah:\/\/.*"
+        auth_type = "http_auth"
+        creds = "user_password"
+
+        @with_testsui(responses=["foo", url_re, auth_type,
+                                 creds, "no"])
+        def no_save():
+            providers.enter_new(url)
+        no_save()
+        assert_false(op.exists(op.join(providers_dir, "foo.cfg")))
+
+        @with_testsui(responses=["foo", url_re, auth_type,
+                                 creds, "yes"])
+        def save():
+            providers.enter_new(url)
+        save()
+        ok_exists(op.join(providers_dir, "foo.cfg"))
+
+        create_tree(path=providers_dir, tree={"exists.cfg": ""})
+        @with_testsui(responses=["exists", "foobert", url_re,
+                                 auth_type, creds, "yes"])
+        def already_exists():
+            providers.enter_new(url)
+        already_exists()
+        ok_exists(op.join(providers_dir, "foobert.cfg"))
+
+        @with_testsui(responses=["crawdad", "yes"])
+        def known_provider():
+            providers.enter_new(url)
+        known_provider()
+
+        @with_testsui(responses=["foo2", url_re, auth_type,
+                                 creds, "yes"])
+        def auth_types():
+            providers.enter_new(url, auth_types=["http_basic_auth"])
+        auth_types()
+        ok_exists(op.join(providers_dir, "foo2.cfg"))
+
+        @with_testsui(responses=["foo3", "doesn't match", url_re, auth_type,
+                                 creds, "yes"])
+        def nonmatching_url():
+            providers.enter_new(url, auth_types=["http_basic_auth"])
+        nonmatching_url()
+        ok_exists(op.join(providers_dir, "foo3.cfg"))

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -92,6 +92,7 @@ def test_get_downloader_class():
             Provider._get_downloader_class(url)
         assert_in("you need 'requests'", str(cmr.exception))
 
+
 @with_tree(tree={
   'providers': {'atest.cfg':"""\
 [provider:syscrcns]

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -38,7 +38,7 @@ skip_if_no_network()  # TODO: provide persistent vcr fixtures for the tests
 url_2versions_nonversioned1 = 's3://datalad-test0-versioned/2versions-nonversioned1.txt'
 url_2versions_nonversioned1_ver1 = url_2versions_nonversioned1 + '?versionId=null'
 url_2versions_nonversioned1_ver2 = url_2versions_nonversioned1 + '?versionId=V4Dqhu0QTEtxmvoNkCHGrjVZVomR1Ryo'
-
+url_1version_bucketwithdot = 's3://datalad.test1/version1.txt'
 
 @use_cassette('test_s3_download_basic')
 def test_s3_download_basic():
@@ -47,9 +47,9 @@ def test_s3_download_basic():
         (url_2versions_nonversioned1, 'version2', 'version1'),
         (url_2versions_nonversioned1_ver2, 'version2', 'version1'),
         (url_2versions_nonversioned1_ver1, 'version1', 'version2'),
+        (url_1version_bucketwithdot, 'version1', 'nothing')
     ]:
         yield check_download_external_url, url, failed_str, success_str
-
 
 # TODO: redo smart way with mocking, to avoid unnecessary CPU waste
 @use_cassette('test_s3_mtime')

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -527,6 +527,7 @@ def _ls_s3(loc, fast=False, recursive=False, all_=False, long_=False,
     from hashlib import md5
     from boto.s3.key import Key
     from boto.s3.prefix import Prefix
+    from boto.s3.connection import OrdinaryCallingFormat
     from boto.exception import S3ResponseError
     from ..support.configparserinc import SafeConfigParser  # provides PY2,3 imports
 
@@ -547,7 +548,10 @@ def _ls_s3(loc, fast=False, recursive=False, all_=False, long_=False,
         secret_key = config.get('default', 'secret_key')
 
         # TODO: remove duplication -- reuse logic within downloaders/s3.py to get connected
-        conn = boto.connect_s3(access_key, secret_key)
+        kwargs = {}
+        if '.' in bucket_name:
+            kwargs['calling_format']=OrdinaryCallingFormat()
+        conn = boto.connect_s3(access_key, secret_key, **kwargs)
         try:
             bucket = conn.get_bucket(bucket_name)
         except S3ResponseError as e:

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -310,7 +310,9 @@ class TargetFileAbsent(DownloadError):
 
 
 class AccessDeniedError(DownloadError):
-    pass
+    def __init__(self, msg=None, supported_types=None, **kwargs):
+        super(AccessDeniedError, self).__init__(msg, **kwargs)
+        self.supported_types = supported_types
 
 
 class AnonymousAccessDeniedError(AccessDeniedError):

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -313,6 +313,10 @@ class AccessDeniedError(DownloadError):
     pass
 
 
+class AnonymousAccessDeniedError(AccessDeniedError):
+    pass
+
+
 class AccessFailedError(DownloadError):
     pass
 

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -96,7 +96,9 @@ def get_bucket(conn, bucket_name):
             raise AnonymousAccessDeniedError(
                 "Access to the bucket %s did not succeed.  Requesting "
                 "'all buckets' for anonymous S3 connection makes "
-                "little sense and thus not supported." % bucket_name)
+                "little sense and thus not supported." % bucket_name,
+                supported_types=['aws-s3']
+            )
         all_buckets = []
         try:
             all_buckets = conn.get_all_buckets()

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1043,7 +1043,7 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
                 lgr.warning(
                     "%s changed cwd to %s. Mitigating and changing back to %s"
                     % (func, cwd_after, pwd_before))
-                # If there was already exception raised, we better re-raise
+                # If there was already exception raised, we better reraise
                 # that one since it must be more important, so not masking it
                 # here with our assertion
                 if exc_info is None:

--- a/datalad/ui/base.py
+++ b/datalad/ui/base.py
@@ -31,10 +31,21 @@ class InteractiveUI(object):
         pass
 
     def yesno(self, *args, **kwargs):
+        # Provide some default sugaring
+        default = kwargs.pop('default', None)
+        if default is not None:
+            if default in {True}:
+                default = 'yes'
+            elif default in {False}:
+                default = 'no'
+            kwargs['default'] = default
         response = self.question(*args, choices=['yes', 'no'], **kwargs).rstrip('\n')
         if response == 'yes':
             return True
         elif response == 'no':
             return False
         else:
-            raise RuntimeError("must not happen but did")
+            raise RuntimeError(
+                "must not happen but did, got %r response, whenever "
+                "expected only yes or no" % response
+            )

--- a/datalad/ui/base.py
+++ b/datalad/ui/base.py
@@ -40,12 +40,5 @@ class InteractiveUI(object):
                 default = 'no'
             kwargs['default'] = default
         response = self.question(*args, choices=['yes', 'no'], **kwargs).rstrip('\n')
-        if response == 'yes':
-            return True
-        elif response == 'no':
-            return False
-        else:
-            raise RuntimeError(
-                "must not happen but did, got %r response, whenever "
-                "expected only yes or no" % response
-            )
+        assert response in {'yes', 'no'}, "shouldn't happen; question() failed"
+        return response == 'yes'

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -118,7 +118,6 @@ class SilentConsoleLog(ConsoleLog):
 def getpass_echo(prompt='Password', stream=None):
     """Q&D workaround until we have proper 'centralized' UI -- just use getpass BUT enable echo
     """
-    prompt = '{}: '.format(prompt)
     if on_windows:
         # Can't do anything fancy yet, so just ask the one without echo
         return getpass.getpass(prompt=prompt, stream=stream)

--- a/datalad/ui/tests/test_base.py
+++ b/datalad/ui/tests/test_base.py
@@ -12,10 +12,13 @@ __docformat__ = 'restructuredtext'
 
 from .. import _UI_Switcher
 from ..dialog import DialogUI, ConsoleLog
-from ...tests.utils import assert_equal, assert_not_equal
-from ...tests.utils import assert_raises
-from ...tests.utils import assert_false
-from ...tests.utils import with_testsui
+from ...tests.utils import (
+    assert_equal, assert_not_equal,
+    assert_raises,
+    assert_false,
+    ok_,
+    with_testsui,
+)
 
 
 def test_ui_switcher():
@@ -85,3 +88,6 @@ def test_with_testsui():
     @with_testsui(responses='a')
     def ask():
         assert_equal(ui.question('what is a?'), 'a')
+
+
+    ask()

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -34,6 +34,16 @@ def patch_getpass(**kwargs):
     return patch('getpass.getpass', **kwargs)
 
 
+def test_yesno():
+    for expected_value, defaults in {True: ('yes', True),
+                                     False: ('no', False)}.items():
+        for d in defaults:
+            with patch_getpass(return_value=''):
+                out = StringIO()
+                response = DialogUI(out=out).yesno("?", default=d)
+                eq_(response, expected_value)
+
+
 def test_question_choices():
 
     # TODO: come up with a reusable fixture for testing here


### PR DESCRIPTION
- [x] Basic and Digest HTTP Auth should work now
- [x]  In interactive session would now allow to establish a new provider configuration for which would get saved into a user directory
- [x] unittests for `process_www_authenticate` etc
- [x] Test at least for the major portions of the UI to enter the new provider/credential
- [ ] may be would include or just be part of integration test above to test Basic and Digest auth on https://jigsaw.w3.org/HTTP/Basic and https://jigsaw.w3.org/HTTP/Digest
- [x] may be more RFing for credentials (allow to make new one persistent etc)
so marking WIP for now 