### PR TITLE
BF: cmdline: Restore handling of short options

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -67,9 +67,15 @@ class ArgumentParserDisableAbbrev(argparse.ArgumentParser):
     # Don't accept abbreviations for long options. With py3.5 and above, we
     # could just use allow_abbrev=False.
     #
-    # See https://bugs.python.org/issue14910#msg204678
+    # Modified from the solution posted at
+    # https://bugs.python.org/issue14910#msg204678
     def _get_option_tuples(self, option_string):
-        return []
+        chars = self.prefix_chars
+        if option_string[0] in chars and option_string[1] in chars:
+            # option_string is a long flag. Disable abbreviation.
+            return []
+        return super(ArgumentParserDisableAbbrev, self)._get_option_tuples(
+            option_string)
 
 
 # TODO:  OPT look into making setup_parser smarter to become faster

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -131,6 +131,12 @@ def test_subcmd_usage_on_unknown_args():
     in_('get', stdout)
 
 
+def test_combined_short_option():
+    stdout, stderr = run_main(['-fjson'], exit_code=2, expect_stderr=True)
+    assert_not_in("unrecognized argument", stderr)
+    assert_in("too few arguments", stderr)
+
+
 def check_incorrect_option(opts, err_str):
     # The first line used to be:
     # stdout, stderr = run_main((sys.argv[0],) + opts, expect_stderr=True, exit_code=2)


### PR DESCRIPTION
```
We fail to parse combined short options (e.g., 'datalad -ar') and
short option/value pairs with no space (e.g., 'datalad -l1 ...) as of
be49a95dd (ENH: cmdline: Disable abbreviations for long options,
2018-05-24).  That commit overrides _get_option_tuples so that it
unconditionally returns an empty list.  Unfortunately, in addition to
disabling abbreviations, that swallows combined short options.
Instead, perform the same check that ArgumentParser._get_option_tuples
does to distinguish long flags from combined short options, and only
return an empty list in the long flag case.
```

Fixes #2709.