### PR TITLE
Improve support of IPython

### DIFF
--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -17,9 +17,14 @@ lgr = getLogger('datalad.ui')
 
 lgr.log(5, "Starting importing ui")
 
-from .dialog import ConsoleLog, DialogUI, UnderAnnexUI
+from .dialog import (
+    ConsoleLog,
+    DialogUI,
+    IPythonWebUI,
+    UnderAnnexUI,
+    UnderTestsUI,
+)
 from .dialog import SilentConsoleLog
-from .dialog import UnderTestsUI
 from ..utils import is_interactive
 
 # TODO: implement logic on selection of the ui based on the cfg and environment
@@ -48,6 +53,7 @@ class _UI_Switcher(object):
         self._ui = {
             'console': ConsoleLog,
             'dialog': DialogUI,
+            'ipython-web': IPythonWebUI,
             'annex': UnderAnnexUI,
             'tests': UnderTestsUI,
             'tests-noninteractive': SilentConsoleLog,

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -241,8 +241,16 @@ class DialogUI(ConsoleLog, InteractiveUI):
         return response
 
 
-class IPythonWebUI(DialogUI):
-    """Custom to IPython Web frontend UI implementation
+class IPythonUI(DialogUI):
+    """Custom to IPython frontend UI implementation
+
+    There is no way to discriminate between web notebook or qt console,
+    so we have just a single class for all.
+
+    TODO: investigate how to provide 'proper' displays for
+    IPython of progress bars so backend could choose the
+    appropriate one
+
     """
 
     _tqdm_frontend = "unknown"
@@ -275,7 +283,7 @@ class IPythonWebUI(DialogUI):
                 self.__class__._tqdm_frontend = None
         if self._tqdm_frontend:
             kwargs.update()
-        return super(IPythonWebUI, self).get_progressbar(
+        return super(IPythonUI, self).get_progressbar(
                 *args, frontend=self._tqdm_frontend, **kwargs)
 
 

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -27,6 +27,7 @@ import getpass
 # from mock import patch
 from collections import deque
 from copy import copy
+from six import PY2
 
 from ..utils import auto_repr
 from ..utils import on_windows
@@ -136,6 +137,10 @@ def getpass_echo(prompt='Password', stream=None):
             return getpass.getpass(prompt=prompt, stream=stream)
 
 
+def _get_value(value, hidden):
+    return "<hidden>" if hidden else value
+
+
 @auto_repr
 class DialogUI(ConsoleLog, InteractiveUI):
 
@@ -147,6 +152,26 @@ class DialogUI(ConsoleLog, InteractiveUI):
         self._prev_title = None
         self._prev_title_time = 0
 
+    def input(self, prompt, hidden=False):
+        """Request user input
+
+        Parameters
+        ----------
+        prompt: str
+          Prompt for the entry
+        """
+        # if not hidden:
+        #     self.out.write(msg + ": ")
+        #     self.out.flush()  # not effective for stderr for some reason under annex
+        #
+        #     # TODO: raw_input works only if stdin was not controlled by
+        #     # (e.g. if coming from annex).  So we might need to do the
+        #     # same trick as get_pass() does while directly dealing with /dev/pty
+        #     # and provide per-OS handling with stdin being override
+        #     response = (raw_input if PY2 else input)()
+        # else:
+        return (getpass.getpass if hidden else getpass_echo)(prompt)
+
     def question(self, text,
                  title=None, choices=None,
                  default=None,
@@ -154,7 +179,7 @@ class DialogUI(ConsoleLog, InteractiveUI):
         # Do initial checks first
         if default and choices and default not in choices:
             raise ValueError("default value %r is not among choices: %s"
-                             % (default, choices))
+                             % (_get_value(default, hidden), choices))
 
         msg = ''
         if title and not (title == self._prev_title and time.time() - self._prev_title_time < 5):
@@ -167,14 +192,6 @@ class DialogUI(ConsoleLog, InteractiveUI):
             return "[%s]" % x \
                 if default is not None and x == default \
                 else x
-
-        def ask_repetition_match(msg):
-            response = getpass.getpass('{}: '.format(msg))
-            response_r = getpass.getpass('{} (repeat): '.format(msg))
-            if response != response_r:
-                return None
-            else:
-                return response
 
         if choices is not None:
             msg += "%s (choices: %s)" % (text, ', '.join(map(mark_default, choices)))
@@ -192,21 +209,19 @@ class DialogUI(ConsoleLog, InteractiveUI):
             attempt += 1
             if attempt >= 100:
                 raise RuntimeError("This is 100th attempt. Something really went wrong")
-            # if not hidden:
-            #     self.out.write(msg + ": ")
-            #     self.out.flush()  # not effective for stderr for some reason under annex
-            #
-            #     # TODO: raw_input works only if stdin was not controlled by
-            #     # (e.g. if coming from annex).  So we might need to do the
-            #     # same trick as get_pass() does while directly dealing with /dev/pty
-            #     # and provide per-OS handling with stdin being override
-            #     response = (raw_input if PY2 else input)()
-            # else:
-            response = (ask_repetition_match if hidden else getpass_echo)(msg)
-            if response is None:
-                self.error("input mismatch, please start over")
-                continue
-            elif '\x03' in response:
+
+            response = self.input("{}: ".format(msg), hidden=hidden)
+            # TODO: dedicated option?  got annoyed by this one
+            # multiple times already, typically we are not defining
+            # new credentials where repetition would be needed.
+            repeat = hidden
+            if repeat:
+                response_r = self.input('{} (repeat): '.format(msg))
+                if response != response_r:
+                    self.error("input mismatch, please start over")
+                    continue
+
+            if response and '\x03' in response:
                 # Ctrl-C is part of the response -> clearly we should not pretend it's all good
                 raise KeyboardInterrupt
 
@@ -216,7 +231,7 @@ class DialogUI(ConsoleLog, InteractiveUI):
 
             if choices and response not in choices:
                 self.error("%r is not among choices: %s. Repeat your answer"
-                           % (response, choices))
+                           % (_get_value(response, hidden), choices))
                 continue
             break
 
@@ -224,6 +239,44 @@ class DialogUI(ConsoleLog, InteractiveUI):
         self._prev_title_time = time.time()
 
         return response
+
+
+class IPythonWebUI(DialogUI):
+    """Custom to IPython Web frontend UI implementation
+    """
+
+    _tqdm_frontend = "unknown"
+
+    def input(self, prompt, hidden=False):
+        # We cannot and probably do not need to "abuse" termios
+        if not hidden:
+            self.out.write(prompt)
+            self.out.flush()
+            return (raw_input if PY2 else input)()
+        else:
+            return getpass.getpass(prompt=prompt)
+
+    def get_progressbar(self, *args, **kwargs):
+        """Return a progressbar.  See e.g. `tqdmProgressBar` about the
+        interface
+
+        Additional parameter is backend to choose among available
+        """
+        backend = kwargs.pop('backend', None)
+        if self._tqdm_frontend == "unknown":
+            from .progressbars import tqdmProgressBar
+            try:
+                from tqdm import tqdm_notebook  # check if available etc
+                self.__class__._tqdm_frontend = 'ipython'
+            except Exception as exc:
+                lgr.warning(
+                    "Regular progressbar will be used -- cannot import tqdm_notebook: %s",
+                    exc_str(exc))
+                self.__class__._tqdm_frontend = None
+        if self._tqdm_frontend:
+            kwargs.update()
+        return super(IPythonWebUI, self).get_progressbar(
+                *args, frontend=self._tqdm_frontend, **kwargs)
 
 
 # poor man thingie for now

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -214,9 +214,9 @@ class DialogUI(ConsoleLog, InteractiveUI):
             # TODO: dedicated option?  got annoyed by this one
             # multiple times already, typically we are not defining
             # new credentials where repetition would be needed.
-            repeat = hidden
+            repeat = hidden and choices is None
             if repeat:
-                response_r = self.input('{} (repeat): '.format(msg))
+                response_r = self.input('{} (repeat): '.format(msg), hidden=hidden)
                 if response != response_r:
                     self.error("input mismatch, please start over")
                     continue

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -32,6 +32,7 @@ from six import PY2
 from ..utils import auto_repr
 from ..utils import on_windows
 from .base import InteractiveUI
+from ..dochelpers import exc_str
 
 # Example APIs which might be useful to look for "inspiration"
 #  man debconf-devel
@@ -279,7 +280,8 @@ class IPythonUI(DialogUI):
             except Exception as exc:
                 lgr.warning(
                     "Regular progressbar will be used -- cannot import tqdm_notebook: %s",
-                    exc_str(exc))
+                    exc_str(exc)
+                )
                 self.__class__._tqdm_frontend = None
         if self._tqdm_frontend:
             kwargs.update()

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -75,6 +75,10 @@ try:
         """Adapter for tqdm.ProgressBar"""
 
         backend = 'tqdm'
+        _frontends = {
+            None: tqdm,
+            'ipython': None  # to be loaded
+        }
 
         # TQDM behaved a bit suboptimally with older versions -- either was
         # completely resetting time/size in global pbar, or not updating
@@ -90,8 +94,41 @@ try:
             else dict(mininterval=0.1)
 
         def __init__(self, label='', fill_text=None,
-                     total=None, unit='B', out=sys.stdout, leave=False):
+                     total=None, unit='B', out=sys.stdout, leave=False,
+                     frontend=None):
+            """
+
+            Parameters
+            ----------
+            label
+            fill_text
+            total
+            unit
+            out
+            leave
+            frontend: (None, 'ipython'), optional
+              tqdm module to use.  Could be tqdm_notebook if under IPython
+            """
             super(tqdmProgressBar, self).__init__(total=total)
+
+            if frontend not in self._frontends:
+                raise ValueError(
+                    "Know only about following tqdm frontends: %s. Got %s"
+                    % (', '.join(map(str, self._frontends)),
+                       frontend))
+
+            tqdm_frontend = self._frontends[frontend]
+            if not tqdm_frontend:
+                if frontend == 'ipython':
+                    from tqdm import tqdm_notebook
+                    tqdm_frontend = self._frontends[frontend] = tqdm_notebook
+                else:
+                    lgr.error(
+                        "Something went wrong here, using default tqdm frontend for %s",
+                        frontend)
+                    tqdm_frontend = self._frontends[frontend] = self._frontends[None]
+
+            self._tqdm = tqdm_frontend
             self._pbar_params = updated(
                 self._default_pbar_params,
                 dict(desc=label, unit=unit,
@@ -102,7 +139,7 @@ try:
 
         def _create(self):
             if self._pbar is None:
-                self._pbar = tqdm(**self._pbar_params)
+                self._pbar = self._tqdm(**self._pbar_params)
 
         def update(self, size, increment=False):
             self._create()
@@ -124,7 +161,7 @@ try:
             super(tqdmProgressBar, self).refresh()
             # older tqdms might not have refresh yet but I think we can live
             # without it for a bit there
-            if hasattr(tqdm, 'refresh'):
+            if hasattr(self._tqdm, 'refresh'):
                 self._pbar.refresh()
 
         def finish(self, clear=False):

--- a/datalad/ui/tests/test_base.py
+++ b/datalad/ui/tests/test_base.py
@@ -11,12 +11,17 @@
 __docformat__ = 'restructuredtext'
 
 from .. import _UI_Switcher
-from ..dialog import DialogUI, ConsoleLog
+from ..dialog import (
+    ConsoleLog,
+    DialogUI,
+    IPythonUI,
+)
 from ...tests.utils import assert_equal, assert_not_equal
 from ...tests.utils import assert_raises
 from ...tests.utils import assert_false
 from ...tests.utils import with_testsui
 
+from mock import patch
 
 def test_ui_switcher():
     ui = _UI_Switcher('dialog')
@@ -32,6 +37,16 @@ def test_ui_switcher():
         ui.yesno
 
     ui.set_backend('annex')
+
+    # Let's pretend we are under IPython
+    class ZMQInteractiveShell(object):
+        pass
+
+    with patch('datalad.utils.get_ipython',
+               lambda: ZMQInteractiveShell(),
+               create=True):
+        ui = _UI_Switcher()
+        assert (isinstance(ui.ui, IPythonUI))
 
 
 def test_tests_ui():

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -62,7 +62,9 @@ def test_question_choices():
                         "prompt", choices=sorted(choices), default=default_value,
                         hidden=hidden
                     )
-                    gpcm.assert_called_once()  # should have not asked multiple times
+                    # .assert_called_once() is not available on older mock's
+                    # e.g. on  1.3.0 on nd16.04
+                    eq_(gpcm.call_count, 1)  # should have asked only once
                     eq_(response, expected_value)
                     # getpass doesn't use out -- goes straight to the terminal
                     eq_(out.getvalue(), '')

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -47,20 +47,23 @@ def test_question_choices():
         'cc': 'a, b, [cc]'
     }
 
-    for default_value in ['a', 'b']:
-        choices_str = choices[default_value]
-        for entered_value, expected_value in [(default_value, default_value),
-                                              ('', default_value),
-                                              ('cc', 'cc')]:
-            with patch_getpass(return_value=entered_value), \
-                patch_getpass(return_value=entered_value):
-                out = StringIO()
-                response = DialogUI(out=out).question("prompt", choices=sorted(choices), default=default_value)
-                eq_(response, expected_value)
-                # getpass doesn't use out -- goes straight to the terminal
-                eq_(out.getvalue(), '')
-                # TODO: may be test that the prompt was passed as a part of the getpass arg
-                #eq_(out.getvalue(), 'prompt (choices: %s): ' % choices_str)
+    for hidden in (True, False):
+        for default_value in ['a', 'b']:
+            choices_str = choices[default_value]
+            for entered_value, expected_value in [(default_value, default_value),
+                                                  ('', default_value),
+                                                  ('cc', 'cc')]:
+                with patch_getpass(return_value=entered_value):
+                    out = StringIO()
+                    response = DialogUI(out=out).question(
+                        "prompt", choices=sorted(choices), default=default_value,
+                        hidden=hidden
+                    )
+                    eq_(response, expected_value)
+                    # getpass doesn't use out -- goes straight to the terminal
+                    eq_(out.getvalue(), '')
+                    # TODO: may be test that the prompt was passed as a part of the getpass arg
+                    #eq_(out.getvalue(), 'prompt (choices: %s): ' % choices_str)
 
     # check some expected exceptions to be thrown
     out = StringIO()

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -21,7 +21,10 @@ from ...tests.utils import assert_re_in
 from ...tests.utils import assert_in
 from ...tests.utils import ok_startswith
 from ...tests.utils import ok_endswith
-from ..dialog import DialogUI
+from ..dialog import (
+    DialogUI,
+    IPythonUI,
+)
 from datalad.ui.progressbars import progressbars
 
 
@@ -105,3 +108,18 @@ def test_progress_bar():
         for l in 0, 4, 10, 1000:
             for increment in True, False:
                 yield _test_progress_bar, backend, l, increment
+
+
+def test_IPythonUI():
+    # largely just smoke tests to see if nothing is horribly bad
+    with patch_input(return_value='a'):
+        out = StringIO()
+        response = IPythonUI(out=out).question(
+            "prompt", choices=sorted(['b', 'a'])
+        )
+        eq_(response, 'a')
+        eq_(out.getvalue(), 'prompt (choices: a, b): ')
+
+    ui = IPythonUI()
+    pbar = ui.get_progressbar(total=10)
+    assert_in('notebook', str(pbar._tqdm))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -182,6 +182,17 @@ def is_interactive():
     return sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()
 
 
+def get_ipython_shell():
+    """Detect if running within IPython and returns its `ip` (shell) object
+
+    Returns None if not under ipython (no `get_ipython` function)
+    """
+    try:
+        return get_ipython()
+    except NameError:
+        return None
+
+
 def md5sum(filename):
     with open(filename, 'rb') as f:
         return hashlib.md5(f.read()).hexdigest()


### PR DESCRIPTION
This pull request fixes #2719 
- [x] sets custom progress bars in the ipython session
- it will not display any progress bars if ran under `ipython console` (still would work under regular `ipython` terminal) and we have no way to differentiate.
- [x] partially addresses #2721  to not ask twice at least the hidden ones with choices given
