### PR TITLE
ENH+BF: make it possible to export_to_figshare without cd'ing

### DIFF
--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -108,11 +108,11 @@ class ExportArchive(Interface):
                 '.' if compression else '',
                 compression) if archivetype == 'tar' else '')
 
-        filename_tmpl = "datalad_{.id}".format(dataset)
+        default_filename = "datalad_{.id}".format(dataset)
         if filename is None:
-            filename = filename_tmpl  # in current directory
+            filename = default_filename  # in current directory
         elif path.exists(filename) and path.isdir(filename):
-            filename = path.join(filename, filename_tmpl) # under given directory
+            filename = path.join(filename, default_filename) # under given directory
         if not filename.endswith(file_extension):
             filename += file_extension
 

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -37,9 +37,9 @@ class ExportArchive(Interface):
             nargs='?',
             doc="""File name of the generated TAR archive. If no file name is
             given the archive will be generated in the current directory and
-            will be named: datalad_<dataset_uuid>.(tar.*|zip).  If an existing
-            directory provided as filename, such file will be generated under 
-            that directory.""",
+            will be named: datalad_<dataset_uuid>.(tar.*|zip). To generate that
+            file in a different directory, provide an existing directory as the
+            file name.""",
             constraints=EnsureStr() | EnsureNone()),
         archivetype=Parameter(
             args=("-t", "--archivetype"),

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -12,7 +12,7 @@ __docformat__ = 'restructuredtext'
 
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
-
+from datalad.support import path
 
 @build_doc
 class ExportArchive(Interface):
@@ -37,7 +37,9 @@ class ExportArchive(Interface):
             nargs='?',
             doc="""File name of the generated TAR archive. If no file name is
             given the archive will be generated in the current directory and
-            will be named: datalad_<dataset_uuid>.(tar.*|zip).""",
+            will be named: datalad_<dataset_uuid>.(tar.*|zip).  If an existing
+            directory provided as filename, such file will be generated under 
+            that directory.""",
             constraints=EnsureStr() | EnsureNone()),
         archivetype=Parameter(
             args=("-t", "--archivetype"),
@@ -106,8 +108,11 @@ class ExportArchive(Interface):
                 '.' if compression else '',
                 compression) if archivetype == 'tar' else '')
 
+        filename_tmpl = "datalad_{.id}".format(dataset)
         if filename is None:
-            filename = "datalad_{}".format(dataset.id)
+            filename = filename_tmpl  # in current directory
+        elif path.exists(filename) and path.isdir(filename):
+            filename = path.join(filename, filename_tmpl) # under given directory
         if not filename.endswith(file_extension):
             filename += file_extension
 

--- a/datalad/plugin/export_to_figshare.py
+++ b/datalad/plugin/export_to_figshare.py
@@ -273,7 +273,7 @@ class ExportToFigshare(Interface):
                 else:
                     article_id = int(ui.question(
                         "Which of the articles should we upload to.",
-                        choices=map(str, figshare.get_article_ids())
+                        choices=list(map(str, figshare.get_article_ids()))
                     ))
             if not article_id:
                 raise ValueError("We need an article to upload to.")

--- a/datalad/plugin/export_to_figshare.py
+++ b/datalad/plugin/export_to_figshare.py
@@ -230,11 +230,13 @@ class ExportToFigshare(Interface):
             raise RuntimeError(
                 "Paranoid authors of DataLad refuse to proceed in a dirty repository"
             )
-        lgr.info(
-            "Exporting current tree as an archive since figshare "
-            "does not support directories")
         if filename is None:
             filename = dataset.path
+        lgr.info(
+            "Exporting current tree as an archive under %s since figshare "
+            "does not support directories",
+            filename
+        )
         archive_out = next(
             export_archive(
                 dataset,

--- a/datalad/plugin/export_to_figshare.py
+++ b/datalad/plugin/export_to_figshare.py
@@ -165,8 +165,8 @@ class ExportToFigshare(Interface):
             metavar="PATH",
             nargs='?',
             doc="""File name of the generated ZIP archive. If no file name is
-            given the archive will be generated in the current directory and
-            will be named: datalad_<dataset_uuid>.zip.""",
+            given the archive will be generated in the top directory
+            of the dataset and will be named: datalad_<dataset_uuid>.zip.""",
             constraints=EnsureStr() | EnsureNone()),
         no_annex=Parameter(
             args=("--no-annex",),
@@ -230,7 +230,11 @@ class ExportToFigshare(Interface):
             raise RuntimeError(
                 "Paranoid authors of DataLad refuse to proceed in a dirty repository"
             )
-        lgr.info("Exporting current tree as an archive since figshare does not support directories")
+        lgr.info(
+            "Exporting current tree as an archive since figshare "
+            "does not support directories")
+        if filename is None:
+            filename = dataset.path
         archive_out = next(
             export_archive(
                 dataset,

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -110,3 +110,8 @@ def test_zip_archive(path):
         time.sleep(1.1)
         ds.export_archive(filename='my', archivetype='zip')
         assert_equal(md5sum('my.zip'), custom1_md5)
+
+    # should be able to export without us cd'ing to that ds directory
+    ds.export_archive(filename=ds.path, archivetype='zip')
+    default_name = 'datalad_{}.zip'.format(ds.id)
+    assert_true(os.path.exists(os.path.join(ds.path, default_name)))


### PR DESCRIPTION
Done by allowing export-archive --filename=directorypath/ so we could
point to the directory where the tarball could be located
