### PR TITLE
ENH: report absent fields reported as N/A in output instead of not rendering the record at all

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -326,6 +326,11 @@ class nagen(object):
     def __init__(self, missing=NA_STRING):
         self.missing = missing
 
+    def __repr__(self):
+        cls = self.__class__.__name__
+        args = str(self.missing) if self.missing != NA_STRING else ''
+        return '%s(%s)' % (cls, args)
+
     def __str__(self):
         return self.missing
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -19,7 +19,12 @@ import sys
 import re
 import textwrap
 import inspect
-from collections import OrderedDict
+import string
+from collections import (
+    defaultdict,
+    OrderedDict,
+)
+from six import iteritems
 
 from ..ui import ui
 from ..dochelpers import exc_str
@@ -307,6 +312,101 @@ def build_doc(cls, **kwargs):
     return cls
 
 
+NA_STRING = 'N/A'  # we might want to make it configurable via config
+
+
+class nagen(object):
+    """A helper to provide a desired missing value if no value is known
+
+    Usecases
+    - could be used as a generator for `defaultdict`
+    - since it returns itself upon getitem, should work even for complex
+      nested dictionaries/lists .format templates
+    """
+    def __init__(self, missing=NA_STRING):
+        self.missing = missing
+
+    def __str__(self):
+        return self.missing
+
+    def __getitem__(self, *args):
+        return self
+
+    def __getattr__(self, item):
+        return self
+
+
+def nadict(*items):
+    """A generator of default dictionary with the default nagen"""
+    dd = defaultdict(nagen)
+    dd.update(*items)
+    return dd
+
+
+class DefaultOutputFormatter(string.Formatter):
+    """A custom formatter for default output rendering using .format
+    """
+    # TODO: make missing configurable?
+    def __init__(self, missing=nagen()):
+        """
+        Parameters
+        ----------
+        missing: string, optional
+          What to output for the missing values
+        """
+        super(DefaultOutputFormatter, self).__init__()
+        self.missing = missing
+
+    def _d(self, msg, *args):
+        # print("   HERE %s" % (msg % args))
+        pass
+
+    def get_value(self, key, args, kwds):
+        assert not args
+        self._d("get_value: %r %r %r", key, args, kwds)
+        return kwds.get(key, self.missing)
+
+    # def get_field(self, field_name, args, kwds):
+    #     assert not args
+    #     self._d("get_field: %r args=%r kwds=%r" % (field_name, args, kwds))
+    #     try:
+    #         out = string.Formatter.get_field(self, field_name, args, kwds)
+    #     except Exception as exc:
+    #         # TODO needs more than just a value
+    #         return "!ERR %s" % exc
+
+
+class DefaultOutputRenderer(object):
+    """A default renderer for .format'ed output line
+    """
+    def __init__(self, format):
+        self.format = format
+        # We still need custom output formatter since at the "first level"
+        # within .format template all items there is no `nadict`
+        self.formatter = DefaultOutputFormatter()
+
+    @classmethod
+    def _dict_to_nadict(cls, v):
+        """Traverse datastructure and replace any regular dict with nadict"""
+        if isinstance(v, list):
+            return [cls._dict_to_nadict(x) for x in v]
+        elif isinstance(v, dict):
+            return nadict((k, cls._dict_to_nadict(x)) for k, x in iteritems(v))
+        else:
+            return v
+
+    def __call__(self, x, **kwargs):
+        dd = nadict(
+            (k, nadict({k_.replace(':', '#'): self._dict_to_nadict(v_)
+                for k_, v_ in v.items()})
+                if isinstance(v, dict) else v)
+            for k, v in x.items()
+        )
+
+        msg = self.formatter.format(self.format, **dd)
+        return ui.message(msg)
+
+
 class Interface(object):
     """Base class for interface implementations"""
 
@@ -404,11 +504,8 @@ class Interface(object):
                 else getattr(cls, 'result_renderer', args.common_output_format)
             if '{' in args.common_output_format:
                 # stupid hack, could and should become more powerful
-                kwargs['result_renderer'] = \
-                    lambda x, **kwargs: ui.message(args.common_output_format.format(
-                        **{k: {k_.replace(':', '#'): v_ for k_, v_ in v.items()}
-                           if isinstance(v, dict) else v
-                           for k, v in x.items()}))
+                kwargs['result_renderer'] = DefaultOutputRenderer(args.common_output_format)
+
             if args.common_on_failure:
                 kwargs['on_failure'] = args.common_on_failure
             # compose filter function from to be invented cmdline options

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -13,7 +13,12 @@
 import mock
 from datalad.tests.utils import *
 from datalad.utils import updated
-from ..base import Interface
+from ..base import (
+    Interface,
+    nadict,
+    nagen,
+    NA_STRING,
+)
 from argparse import Namespace
 
 
@@ -131,3 +136,19 @@ def test_get_result_filter_arg_vs_config():
         with patch_config({"datalad.runtime.report-status": "error"}):
             cargs_overload = f(_new_args(common_report_status=v))
         eq_(repr(cargs), repr(cargs_overload))
+
+
+def test_nagen():
+    na = nagen()
+    eq_(str(na), NA_STRING)
+    eq_(repr(na), 'nagen()')
+    assert na.unknown is na
+    assert na['unknown'] is na
+
+    eq_(str(nagen('-')), '-')
+
+
+def test_nadict():
+    d = nadict({1: 2})
+    eq_(d[1], 2)
+    eq_(str(d[2]), NA_STRING)


### PR DESCRIPTION
Since this one might controversial and still needs tests, filing it separately from #2724:
- [x] If result record is missing a value (absent field, or subfield in metadata), do not crash rendering it, but just print `N/A` for that value.  I wonder though if there should be config option to turn that behavior off since might be handy to see original crash at times
- [x] at least a basic test for the functionality

- shortened access syntax item moved the other into a separate issue https://github.com/datalad/datalad/issues/2760