### PR TITLE
RF: show only the version, without license, upon --version

### DIFF
--- a/datalad/cmdline/common_args.py
+++ b/datalad/cmdline/common_args.py
@@ -29,7 +29,7 @@ help = (
 version = (
     'version', ('--version',),
     dict(action='version',
-         help="show the program's version and license information")
+         help="show the program's version")
 )
 
 _log_level_names = ['critical', 'error', 'warning', 'info', 'debug']

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -118,7 +118,7 @@ def setup_parser(
     helpers.parser_add_common_opt(
         parser,
         'version',
-        version='datalad %s\n\n%s' % (datalad.__version__, _license_info()))
+        version='datalad %s\n' % datalad.__version__)
     if __debug__:
         parser.add_argument(
             '--dbg', action='store_true', dest='common_debug',

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -81,8 +81,9 @@ def test_version():
     # https://hg.python.org/cpython/file/default/Doc/whatsnew/3.4.rst#l1952
     out = stdout if sys.version_info >= (3, 4) else stderr
     ok_startswith(out, 'datalad %s\n' % datalad.__version__)
-    in_("Copyright", out)
-    in_("Permission is hereby granted", out)
+    # since https://github.com/datalad/datalad/pull/2733 no license in --version
+    assert_not_in("Copyright", out)
+    assert_not_in("Permission is hereby granted", out)
 
 
 def test_help_np():


### PR DESCRIPTION
if user asks for `--version` I think we should just output the version. Similar behavior of the mighty git:
```shell
~datalad/datalad > git --version              
git version 2.18.0
~datalad/datalad > datalad --version
datalad 0.10.2.dev38
```
that makes it easier to cut/paste output from terminal without needing to strip stuff