### PR TITLE
NF: Field-selective search in egrep mode (fixes gh-2337)

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -95,9 +95,7 @@ def setup_parser(
     parts = {}
     # main parser
     parser = ArgumentParserDisableAbbrev(
-        # cannot use '@' because we need to input JSON-LD properties (which might come wit @ prefix)
-        # MH: question, do we need this at all?
-        fromfile_prefix_chars=':',
+        fromfile_prefix_chars=None,
         # usage="%(prog)s ...",
         description=dedent_docstring("""\
             Comprehensive data management solution

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -420,6 +420,10 @@ class _WhooshSearch(_Search):
         self.idx_obj = idx_obj
 
     def __call__(self, query, max_nresults=None, force_reindex=False, full_record=False):
+        if max_nresults is None:
+            # mode default
+            max_nresults = 20
+
         with self.idx_obj.searcher() as searcher:
             wquery = self.get_query(query)
 
@@ -622,6 +626,9 @@ class _EGrepSearch(_Search):
     # --consider_ucn - search through unique content properties of the dataset
     #    which might be more computationally demanding
     def __call__(self, query, max_nresults=None, consider_ucn=False, full_record=True):
+        if max_nresults is None:
+            # no limit by default
+            max_nresults = 0
         query = self.get_query(query)
 
         nhits = 0
@@ -965,9 +972,10 @@ class Search(Interface):
         max_nresults=Parameter(
             args=("--max-nresults",),
             doc="""maxmimum number of search results to report. Setting this
-            to 0 will report all search matches, and make searching substantially
-            slower on large metadata sets.""",
-            constraints=EnsureInt()),
+            to 0 will report all search matches. Depending on the mode this
+            can search substantially slower. If not specified, a
+            mode-specific default setting will be used.""",
+            constraints=EnsureInt() | EnsureNone()),
         mode=Parameter(
             args=("--mode",),
             choices=('egrep', 'textblob', 'autofield'),
@@ -1012,7 +1020,7 @@ class Search(Interface):
     def __call__(query=None,
                  dataset=None,
                  force_reindex=False,
-                 max_nresults=20,
+                 max_nresults=None,
                  mode=None,
                  full_record=False,
                  show_keys=None,

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -759,7 +759,7 @@ class _EGrepSearch(_Search):
 
     def get_query(self, query):
         query = assure_list(query)
-        simple_fieldspec = re.compile(r"(?P<field>\S+?):(?P<query>.*)")
+        simple_fieldspec = re.compile(r"(?P<field>\S*?):(?P<query>.*)")
         quoted_fieldspec = re.compile(r"'(?P<field>[^']+?)':(?P<query>.*)")
         query = [
             simple_fieldspec.match(q) or
@@ -771,6 +771,11 @@ class _EGrepSearch(_Search):
             {k: re.compile(v) for k, v in q.groupdict().items()}
             if hasattr(q, 'groupdict') else re.compile(q)
             for q in query]
+        # turn "empty" field specs into simple queries
+        # this is used to forcibly disable field-based search
+        # e.g. when searching for a value
+        query = [q['query'] if isinstance(q, dict) and q['field'].pattern == '' else q
+                 for q in query]
         return query
 
 

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -849,7 +849,7 @@ class Search(Interface):
     *Mode: egrep/egrepcs*
 
     These search modes are largely ignorant of the metadata structure, and
-    simply performs matching of a search pattern against a flat
+    simply perform matching of a search pattern against a flat
     string-representation of metadata. This is advantageous when the query is
     simple and the metadata structure is irrelevant, or precisely known.
     Moreover, it does not require a search index, hence results can be reported

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -171,8 +171,8 @@ def test_aggregation(path):
 
     # test search in search tests, not all over the place
     ## query smoke test
-    assert_result_count(clone.search('mother', mode='egrep'), 1)
-    assert_result_count(clone.search('MoTHER', mode='egrep'), 1)
+    assert_result_count(clone.search('(?i)mother', mode='egrep'), 1)
+    assert_result_count(clone.search('(?i)MoTHER', mode='egrep'), 1)
 
     child_res = clone.search('child', mode='egrep')
     assert_result_count(child_res, 2)

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -171,7 +171,7 @@ def test_aggregation(path):
 
     # test search in search tests, not all over the place
     ## query smoke test
-    assert_result_count(clone.search('(?i)mother', mode='egrep'), 1)
+    assert_result_count(clone.search('mother', mode='egrep'), 1)
     assert_result_count(clone.search('(?i)MoTHER', mode='egrep'), 1)
 
     child_res = clone.search('child', mode='egrep')

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -180,6 +180,11 @@ def test_within_ds_file_search(path):
     except ImportError:
         raise SkipTest
     ds = Dataset(path).create(force=True)
+    # override default and search for datasets and files for this test
+    for m in ('egrep', 'textblob', 'autofield'):
+        ds.config.add(
+            'datalad.search.index-{}-documenttype'.format(m), 'all',
+            where='dataset')
     ds.config.add('datalad.metadata.nativetype', 'audio', where='dataset')
     makedirs(opj(path, 'stim'))
     for src, dst in (
@@ -239,49 +244,68 @@ type
 
     assert_result_count(ds.search('blablob#'), 0)
     # now check that we can discover things from the aggregated metadata
-    for mode, query, hitpath, matched_key, matched_val in (
-            # random keyword query
-            ('textblob',
-             'mp3',
-             opj('stim', 'stim1.mp3'),
-             'meta', 'mp3'),
-            # report which field matched with auto-field
-            ('autofield',
-             'mp3',
-             opj('stim', 'stim1.mp3'),
-             'audio.format', 'mp3'),
-            # XXX next one is not supported by current text field analyser
-            # decomposes the mime type in [mime, audio, mp3]
-            # ('autofield',
-            # "'mime:audio/mp3'",
-            # opj('stim', 'stim1.mp3'),
-            # 'audio.format', 'mime:audio/mp3'),
-            # but this one works
-            ('autofield',
-             "'mime audio mp3'",
-             opj('stim', 'stim1.mp3'),
-             'audio.format', 'mp3'),
-            # TODO extend with more complex queries to test whoosh
-            # query language configuration
+    for mode, query, hitpath, matched in (
+        ('egrep',
+         'mp3',
+         opj('stim', 'stim1.mp3'),
+         {'audio.format': 'mp3'}),
+        # same as above, but with AND condition
+        # get both matches
+        ('egrep',
+         ['mp3', 'type:file'],
+         opj('stim', 'stim1.mp3'),
+         {'type': 'file', 'audio.format': 'mp3'}),
+        # case insensitive search
+        ('egrep',
+         '(?i)MP3',
+         opj('stim', 'stim1.mp3'),
+         {'audio.format': 'mp3'}),
+        # field selection by expression
+        ('egrep',
+         'audio\.+:mp3',
+         opj('stim', 'stim1.mp3'),
+         {'audio.format': 'mp3'}),
+        # random keyword query
+        ('textblob',
+         'mp3',
+         opj('stim', 'stim1.mp3'),
+         {'meta': 'mp3'}),
+        # report which field matched with auto-field
+        ('autofield',
+         'mp3',
+         opj('stim', 'stim1.mp3'),
+         {'audio.format': 'mp3'}),
+        # XXX next one is not supported by current text field analyser
+        # decomposes the mime type in [mime, audio, mp3]
+        # ('autofield',
+        # "'mime:audio/mp3'",
+        # opj('stim', 'stim1.mp3'),
+        # 'audio.format', 'mime:audio/mp3'),
+        # but this one works
+        ('autofield',
+         "'mime audio mp3'",
+         opj('stim', 'stim1.mp3'),
+         {'audio.format': 'mp3'}),
+        # TODO extend with more complex queries to test whoosh
+        # query language configuration
     ):
+        print('KKKKKKKKKKKKKKKKKK', query, mode)
         res = ds.search(query, mode=mode, full_record=True)
-        if mode == 'textblob':
-            # 'textblob' does datasets by default only (be could be configured otherwise
-            assert_result_count(res, 1)
-        else:
-            # the rest has always a file and the dataset, because they carry metadata in
-            # the same structure
-            assert_result_count(res, 2)
-            assert_result_count(
-                res, 1, type='file', path=opj(ds.path, hitpath),
-                # each file must report the ID of the dataset it is from, critical for
-                # discovering related content
-                dsid=ds.id)
         assert_result_count(
-            res, 1, type='dataset', path=ds.path, dsid=ds.id)
+            res, 1, type='file', path=opj(ds.path, hitpath),
+            # each file must report the ID of the dataset it is from, critical for
+            # discovering related content
+            dsid=ds.id)
+        # in egrep we currently do not search unique values
+        # and the queries above aim at files
+        assert_result_count(res, 1 if mode == 'egrep' else 2)
+        if mode != 'egrep':
+            assert_result_count(
+                res, 1, type='dataset', path=ds.path, dsid=ds.id)
         # test the key and specific value of the match
-        assert_in(matched_key, res[-1]['query_matched'])
-        assert_equal(res[-1]['query_matched'][matched_key], matched_val)
+        for matched_key, matched_val in matched.items():
+            assert_in(matched_key, res[-1]['query_matched'])
+            assert_equal(res[-1]['query_matched'][matched_key], matched_val)
 
 
 def test_listdict2dictlist():

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -262,7 +262,7 @@ type
          {'type': 'file', 'audio.format': 'mp3'}),
         # case insensitive search
         ('egrep',
-         '(?i)MP3',
+         'mp3',
          opj('stim', 'stim1.mp3'),
          {'audio.format': 'mp3'}),
         # field selection by expression

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -246,6 +246,11 @@ type
     # now check that we can discover things from the aggregated metadata
     for mode, query, hitpath, matched in (
         ('egrep',
+         ':mp3',
+         opj('stim', 'stim1.mp3'),
+         {'audio.format': 'mp3'}),
+        # same as above, leading : is stripped, in indicates "ALL FIELDS"
+        ('egrep',
          'mp3',
          opj('stim', 'stim1.mp3'),
          {'audio.format': 'mp3'}),
@@ -289,7 +294,6 @@ type
         # TODO extend with more complex queries to test whoosh
         # query language configuration
     ):
-        print('KKKKKKKKKKKKKKKKKK', query, mode)
         res = ds.search(query, mode=mode, full_record=True)
         assert_result_count(
             res, 1, type='file', path=opj(ds.path, hitpath),


### PR DESCRIPTION
This PR implements a number of changes for the `egrep` default search mode that should make it substantially more useful, without putting too much strain on novice users.

- [x] by default queries are case-sensitive now. An example documents how to change that in a query on a case-by-case basis.
- [x] search can be limited to specific keys, syntax described and documented in examples
- [x] multiple queries (list of expressions) are evaluated using AND to determine whether something is a hit
- [x] a single multi-field query (e.g. `pa*:findme`) is a hit, when any matching field matches the query
- [x] all matching key/value combinations across all (multi-field) queries are reported in the `query_matched` result field.
- [x] mode-specific search hit number limit: egrep has none now #2639 