### PR TITLE
ENH progressbars for addurl

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1331,9 +1331,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         if len(fetch_files) != len(files):
             lgr.debug("Actually getting %d files", len(fetch_files))
 
-        # options  might be the '--key' which should go last
-        options = ['--json-progress'] + options
-
         # TODO: provide more meaningful message (possibly aggregating 'note'
         #  from annex failed ones
         # TODO: reproduce DK's bug on OSX, and either switch to
@@ -1348,6 +1345,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             # TODO: eventually make use of --batch mode
             jobs=jobs,
             expected_entries=expected_downloads,
+            progress=True,
             **kwargs
         )
         results_list = list(results)
@@ -2057,6 +2055,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             out_json = self._run_annex_command_json(
                 'addurl',
                 opts=options + [files_opt] + [url],
+                progress=True,
                 log_online=True, log_stderr=False,
                 **kwargs
             )
@@ -2271,6 +2270,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 jobs=None,
                                 files=None,
                                 expected_entries=None,
+                                progress=False,
                                 **kwargs):
         """Run an annex command with --json and load output results into a tuple of dicts
 
@@ -2279,6 +2279,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         expected_entries : dict, optional
           If provided `filename/key: size` dictionary, will be used to create
           ProcessAnnexProgressIndicators to display progress
+        progress: bool, optional
+          Either request/handle --json-progress
         """
         progress_indicators = None
         try:
@@ -2294,11 +2296,15 @@ class AnnexRepo(GitRepo, RepoInterface):
                 ))
             # TODO: refactor to account for possible --batch ones
             annex_options = ['--json']
+            if progress:
+                annex_options += ['--json-progress']
+
             if jobs == 'auto':
                 jobs = N_AUTO_JOBS
             if jobs and jobs != 1:
                 annex_options += ['-J%d' % jobs]
             if opts:
+                # opts might be the '--key' which should go last
                 annex_options += opts
 
             # TODO: RF to use --batch where possible instead of splitting
@@ -3048,7 +3054,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         if len(copy_files) != len(files):
             lgr.debug("Actually copying %d files", len(copy_files))
 
-        annex_options = ['--to=%s' % remote, '--json-progress']
+        annex_options = ['--to=%s' % remote]
         if options:
             annex_options.extend(shlex.split(options))
 
@@ -3059,7 +3065,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             opts=annex_options,
             files=files,  # copy_files,
             jobs=jobs,
-            expected_entries=expected_copys
+            expected_entries=expected_copys,
+            progress=True
             #log_stdout=True, log_stderr=not log_online,
             #log_online=log_online, expect_stderr=True
         )

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2059,8 +2059,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 opts=options + [files_opt] + [url],
                 progress=True,
                 expected_entries={file_: None},
-                #log_online=True,
-                #log_stderr=False,
                 **kwargs
             )
             if len(out_json) != 1:
@@ -2284,7 +2282,7 @@ class AnnexRepo(GitRepo, RepoInterface):
           If provided `filename/key: size` dictionary, will be used to create
           ProcessAnnexProgressIndicators to display progress
         progress: bool, optional
-          Either request/handle --json-progress
+          Whether to request/handle --json-progress
         """
         progress_indicators = None
         try:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3562,14 +3562,14 @@ class ProcessAnnexProgressIndicators(object):
                     label="Total", total=total)
                 self.total_pbar.start()
 
-    def __getitem__(self, download_id):
+    def __getitem__(self, id_):
         if self.pbars == 1:
             # regardless what it is, it is the one!
             # will happen e.g. in case of add_url_to_file since filename
             # is not even reported in the status and final msg just
             # reports the key which is not known before
             return self.pbars.items()[0]
-        return self.pbars[download_id]
+        return self.pbars[id_]
 
     def _update_pbar(self, pbar, new_value):
         """Updates pbar while also updating possibly total pbar"""
@@ -3627,9 +3627,9 @@ class ProcessAnnexProgressIndicators(object):
         target_size = None
         if 'command' in j and ('key' in j or 'file' in j):
             # might be the finish line message
-            download_item = j.get('key') or j.get('file')
-            j_download_id = (j['command'], download_item)
-            pbar = self.pbars.pop(j_download_id, None)
+            action_item = j.get('key') or j.get('file')
+            j_action_id = (j['command'], action_item)
+            pbar = self.pbars.pop(j_action_id, None)
             if pbar is None and len(self.pbars) == 1 and self.only_one_expected:
                 # it is the only one left - take it!
                 pbar = self.pbars.popitem()[1]
@@ -3641,7 +3641,7 @@ class ProcessAnnexProgressIndicators(object):
                     # we didn't have a pbar for this download, so total should
                     # get it all at once
                     try:
-                        target_size = self.expected[download_item]
+                        target_size = self.expected[action_item]
                     except:
                         target_size = None
                     if not target_size and 'key' in j:
@@ -3676,9 +3676,9 @@ class ProcessAnnexProgressIndicators(object):
 
         # so we have a progress indicator, let's deal with it
         action = j['action']
-        download_item = action.get('key') or action.get('file')
-        download_id = (action['command'], download_item)
-        if download_id not in self.pbars:
+        action_item = action.get('key') or action.get('file')
+        action_id = (action['command'], action_item)
+        if action_id not in self.pbars:
             # New download!
             from datalad.ui import ui
             from datalad.ui import utils as ui_utils
@@ -3697,25 +3697,25 @@ class ProcessAnnexProgressIndicators(object):
                     0
             w = ui_utils.get_console_width()
 
-            if not download_item and self.only_one_expected:
+            if not action_item and self.only_one_expected:
                 # must be the one!
-                download_item = list(self.expected)[0]
+                action_item = list(self.expected)[0]
 
-            title = str(action.get('file') or download_item)
+            title = str(action.get('file') or action_item)
 
             pbar_right = 50
             title_len = w - pbar_right - 4  # (4 for reserve)
             if len(title) > title_len:
                 half = title_len//2 - 2
                 title = '%s .. %s' % (title[:half], title[-half:])
-            pbar = self.pbars[download_id] = ui.get_progressbar(
+            pbar = self.pbars[action_id] = ui.get_progressbar(
                 label=title, total=target_size)
             pbar.start()
 
-        lgr.log(1, "Updating pbar for download_id=%s. annex: %s.\n",
-                download_id, j)
+        lgr.log(1, "Updating pbar for action_id=%s. annex: %s.\n",
+                action_id, j)
         self._update_pbar(
-            self[download_id],
+            self[action_id],
             int(j.get('byte-progress'))
         )
 

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -32,6 +32,8 @@ class ProgressBarBase(object):
         pass
 
     def update(self, size, increment=False):
+        if not size:
+            return
         if increment:
             self._current += size
         else:
@@ -106,6 +108,8 @@ try:
 
         def update(self, size, increment=False):
             self._create()
+            if not size:
+                return
             inc = size - self.current
             try:
                 self._pbar.update(size if increment else inc)


### PR DESCRIPTION
This pull request fixes https://github.com/datalad/datalad-container/issues/49

- It got even messier in there, and ideally requires some fixups on git-annex side: http://git-annex.branchable.com/todo/provide___39__file__39___in_--json-progress_record_for_addurl/
- I also disabled Total progress bar if we expect only one .  hopefully I didn't ruin something great ;-)

I guess would require manual testdriving since it is UI which we might not test very thoroughly automatically.  But on my attempts seems to be quite kosher.