### PR TITLE
ENH: wtf returns structured data (fixes gh-2415, gh-2734)

### DIFF
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -59,6 +59,7 @@ _group_metadata = (
 _group_misc = (
     'Miscellaneous commands',
     [
+        ('datalad.plugin.wtf', 'WTF'),
         ('datalad.interface.test', 'Test'),
         ('datalad.interface.ls', 'Ls'),
         ('datalad.interface.clean', 'Clean'),

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -63,21 +63,21 @@ def test_wtf(path):
     # smoke test for now
     with swallow_outputs() as cmo:
         wtf(dataset=path)
-        assert_not_in('Dataset information', cmo.out)
-        assert_in('Configuration', cmo.out)
+        assert_not_in('## dataset', cmo.out)
+        assert_in('## configuration', cmo.out)
         # Those sections get sensored out by default now
         assert_not_in('user.name: ', cmo.out)
     with chpwd(path):
         with swallow_outputs() as cmo:
             wtf()
-            assert_not_in('Dataset information', cmo.out)
-            assert_in('Configuration', cmo.out)
+            assert_not_in('## dataset', cmo.out)
+            assert_in('## configuration', cmo.out)
     # now with a dataset
     ds = create(path)
     with swallow_outputs() as cmo:
         wtf(dataset=ds.path)
-        assert_in('Configuration', cmo.out)
-        assert_in('Dataset information', cmo.out)
+        assert_in('## configuration', cmo.out)
+        assert_in('## dataset', cmo.out)
         assert_in('path: {}'.format(ds.path), cmo.out)
 
     # and if we run with all sensitive
@@ -113,7 +113,7 @@ def test_wtf(path):
                 "Pyperclip seems to be not functioning here correctly")
         assert_not_in('user.name', pyperclip.paste())
         assert_in(_HIDDEN, pyperclip.paste())  # by default no sensitive info
-        assert_in("cmd:annex=", pyperclip.paste())  # but the content is there
+        assert_in("cmd:annex:", pyperclip.paste())  # but the content is there
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -10,6 +10,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import logging
 import os
 import os.path as op
 from datalad.interface.base import Interface
@@ -18,6 +19,9 @@ from datalad.utils import getpwd
 from datalad.utils import assure_unicode
 from datalad.dochelpers import exc_str
 from datalad.support.external_versions import external_versions
+
+lgr = logging.getLogger('datalad.plugin.wtf')
+
 
 # wording to use for items which were considered sensitive and thus not shown
 _HIDDEN = "<SENSITIVE, report disabled by configuration>"
@@ -268,9 +272,10 @@ class WTF(Interface):
         infos = {}
         res = get_status_dict(
             action='wtf',
-            ds=dataset,
             path=ds.path if ds else op.abspath(op.curdir),
+            type='dataset' if ds else 'directory',
             status='ok',
+            logger=lgr,
             infos=infos,
         )
         infos['datalad'] = _describe_datalad()

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -269,7 +269,7 @@ class WTF(Interface):
         res = get_status_dict(
             action='wtf',
             ds=dataset,
-            path=dataset.path if dataset else op.abspath(op.curdir),
+            path=ds.path if ds else op.abspath(op.curdir),
             status='ok',
             infos=infos,
         )


### PR DESCRIPTION
The report now looks different, but is much easier to extend and work with. Besides the default human-focused rendering, our common infrastructure can also return JSON, so the output of `wtf` can now
be worked with programmatically.

Moreover, version info has been added to the extension report (gh-2734), and versions are now also reported for metadata extractors (although none of them have any yet).

Here is an example report with the default rendering (which is now in simplistic markdown):

# WTF
- path: /tmp/mikey
## configuration 
  - alias.co: checkout
  - alias.glog: log --pretty=format:'%h %ad %s (%an)' --date=short --graph
  - alias.st: status
  - alias.wdiff: diff --color-words
  - alias.wshow: show --color-words
  - annex.backends: MD5E
  - annex.uuid: 2400a411-ee6a-4332-b60d-af931a851496
  - annex.version: 5
  - color.diff: auto
  - color.status: true
  - core.bare: false
  - core.editor: vim
  - core.filemode: true
  - core.logallrefupdates: true
  - core.repositoryformatversion: 0
  - datalad.dataset.id: 3cce70ba-9725-11e8-a851-f0d5bf7b5561
  - datalad.hirni.import.acquisition-format: {PatientID}
  - datalad.log.timestamp: false
  - diff.ignoresubmodule: true
  - hub.oauthtoken: <SENSITIVE, report disabled by configuration>
  - hub.username: <SENSITIVE, report disabled by configuration>
  - push.default: simple
  - url.git@github.com:.insteadof: github:
  - user.email: <SENSITIVE, report disabled by configuration>
  - user.name: <SENSITIVE, report disabled by configuration>
  - user.signingkey: <SENSITIVE, report disabled by configuration>
## datalad 
  - full_version: 0.10.1.dev70-gcce8cf-dirty
  - version: 0.10.1.dev70
## dataset 
  - metadata: 
    - @context: 
      - @vocab: http://docs.datalad.org/schema_v2.0.json
    - datalad_core: 
      - @id: 3cce70ba-9725-11e8-a851-f0d5bf7b5561
      - refcommit: 4f7d5af8ab2b57eeca73872704ec5cd661d74f19
  - path: /tmp/mikey
  - repo: AnnexRepo
## dependencies 
  - appdirs: 1.4.3
  - boto: 2.44.0
  - cmd:annex: 6.20180626+gitg12cd64369-1~ndall+1
  - cmd:git: 2.18.0
  - cmd:system-git: 2.18.0
  - cmd:system-ssh: 7.7p1
  - exifread: 2.1.2
  - git: 2.1.8
  - gitdb: 2.0.3
  - humanize: 0.5.1
  - iso8601: 0.1.11
  - msgpack: 0.5.6
  - mutagen: 1.40.0
  - requests: 2.18.4
  - scrapy: 1.5.0
  - six: 1.11.0
  - tqdm: 4.20.0
  - wrapt: 1.10.11
## environment 
  - GIT_EDITOR: vim
  - GIT_PYTHON_GIT_EXECUTABLE: /usr/lib/git-annex.linux/git
  - LANG: en_US.UTF-8
  - LANGUAGE: en_US:en
  - LC_CTYPE: en_US.UTF-8
  - PATH: /home/mih/env/datalad3-dev/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/home/mih/bin:/home/mih/bin/pycharm/bin
## extentions 
  - container: 
    - description: Containerized environments
    - entrypoints: 
      - datalad_container.containers_add.ContainersAdd: 
        - class: ContainersAdd
        - load_error: None
        - module: datalad_container.containers_add
        - names: 
          1. containers-add
          2. containers_add
      - datalad_container.containers_list.ContainersList: 
        - class: ContainersList
        - load_error: None
        - module: datalad_container.containers_list
        - names: 
          1. containers-list
          2. containers_list
      - datalad_container.containers_remove.ContainersRemove: 
        - class: ContainersRemove
        - load_error: None
        - module: datalad_container.containers_remove
        - names: 
          1. containers-remove
          2. containers_remove
      - datalad_container.containers_run.ContainersRun: 
        - class: ContainersRun
        - load_error: None
        - module: datalad_container.containers_run
        - names: 
          1. containers-run
          2. containers_run
    - load_error: None
    - module: datalad_container
    - version: 0.2.1
  - crawler: 
    - description: Crawl web resources
    - entrypoints: 
      - datalad_crawler.crawl.Crawl: 
        - class: Crawl
        - load_error: None
        - module: datalad_crawler.crawl
        - names: 
          1. crawl
      - datalad_crawler.crawl_init.CrawlInit: 
        - class: CrawlInit
        - load_error: None
        - module: datalad_crawler.crawl_init
        - names: 
          1. crawl-init
          2. crawl_init
    - load_error: None
    - module: datalad_crawler
    - version: 0.1
  - hirni: 
    - description: HIRNI workflows
    - entrypoints: 
      - datalad_hirni.commands.create_study.CreateStudy: 
        - class: CreateStudy
        - load_error: None
        - module: datalad_hirni.commands.create_study
        - names: 
          1. hirni-create-study
          2. hirni_create_study
      - datalad_hirni.commands.dicom2spec.Dicom2Spec: 
        - class: Dicom2Spec
        - load_error: None
        - module: datalad_hirni.commands.dicom2spec
        - names: 
          1. hirni-dicom2spec
          2. hirni_dicom2spec
      - datalad_hirni.commands.import_dicoms.ImportDicoms: 
        - class: ImportDicoms
        - load_error: None
        - module: datalad_hirni.commands.import_dicoms
        - names: 
          1. hirni-import-dcm
          2. hirni_import_dcm
      - datalad_hirni.commands.spec2bids.Spec2Bids: 
        - class: Spec2Bids
        - load_error: None
        - module: datalad_hirni.commands.spec2bids
        - names: 
          1. hirni-spec2bids
          2. hirni_spec2bids
      - datalad_hirni.commands.spec4anything.Spec4Anything: 
        - class: Spec4Anything
        - load_error: None
        - module: datalad_hirni.commands.spec4anything
        - names: 
          1. hirni-spec4anything
          2. hirni_spec4anything
      - datalad_hirni.commands.validate_spec.ValidateSpec: 
        - class: ValidateSpec
        - load_error: None
        - module: datalad_hirni.commands.validate_spec
        - names: 
          1. hirni-validate-spec
          2. hirni_validate_spec
    - load_error: None
    - module: datalad_hirni
    - version: None
  - neuroimaging: 
    - description: Neuroimaging tools
    - entrypoints: 
      - datalad_neuroimaging.bids2scidata.BIDS2Scidata: 
        - class: BIDS2Scidata
        - load_error: None
        - module: datalad_neuroimaging.bids2scidata
        - names: 
          1. bids2scidata
    - load_error: None
    - module: datalad_neuroimaging
    - version: 0.1.1
  - webapp: 
    - description: Generic web app support
    - entrypoints: 
      - datalad_webapp.WebApp: 
        - class: WebApp
        - load_error: None
        - module: datalad_webapp
        - names: 
          1. webapp
          2. webapp
    - load_error: None
    - module: datalad_webapp
    - version: None
## metadata_extractors 
  - annex: 
    - load_error: None
    - module: datalad.metadata.extractors.annex
    - version: None
  - audio: 
    - load_error: None
    - module: datalad.metadata.extractors.audio
    - version: None
  - bids: 
    - load_error: None
    - module: datalad_neuroimaging.extractors.bids
    - version: None
  - datacite: 
    - load_error: None
    - module: datalad.metadata.extractors.datacite
    - version: None
  - datalad_core: 
    - load_error: None
    - module: datalad.metadata.extractors.datalad_core
    - version: None
  - datalad_rfc822: 
    - load_error: None
    - module: datalad.metadata.extractors.datalad_rfc822
    - version: None
  - dicom: 
    - load_error: None
    - module: datalad_neuroimaging.extractors.dicom
    - version: None
  - exif: 
    - load_error: None
    - module: datalad.metadata.extractors.exif
    - version: None
  - frictionless_datapackage: 
    - load_error: None
    - module: datalad.metadata.extractors.frictionless_datapackage
    - version: None
  - image: 
    - load_error: None
    - module: datalad.metadata.extractors.image
    - version: None
  - nidm: 
    - load_error: None
    - module: datalad_neuroimaging.extractors.nidm
    - version: None
  - nifti1: 
    - load_error: None
    - module: datalad_neuroimaging.extractors.nifti1
    - version: None
  - xmp: 
    - load_error: None
    - module: datalad.metadata.extractors.xmp
    - version: None
## system 
  - distribution: debian/buster/sid
  - encoding: 
    - default: utf-8
    - filesystem: utf-8
    - locale.prefered: UTF-8
  - max_path_length: 266
  - name: Linux
  - release: 4.16.0-2-amd64
  - type: posix
  - version: #1 SMP Debian 4.16.16-2 (2018-06-22)