### PR TITLE
TST: travis: Pin grunt-contrib-qunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -258,7 +258,7 @@ install:
   - if [ ! -z "$UNSET_S3_SECRETS" ]; then echo "usetting"; unset DATALAD_datalad_test_s3_key_id DATALAD_datalad_test_s3_secret_id; fi
   # Install grunt to test run javascript frontend tests
   - npm install grunt
-  - npm install grunt-contrib-qunit
+  - npm install grunt-contrib-qunit@2.0.0
   - if [ "${BUILD_DATALAD_EXTENSION:-}"x = "datalad-container"x ]; then travis_retry sudo eatmydata apt-get install singularity-container; fi
 
 script:


### PR DESCRIPTION
The grunt tests are now consistently failing (gh-2742).  Comparing a
recently passing Travis log to the failing ones shows that the
grunt-contrib-qunit version has changed from 2.0.0 to 3.0.0.  Assuming
that this change triggered the failure, let's pin grunt-contrib-qunit
at the old version until someone provides a proper fix.

---

This is a shot in the dark.  Let's see if the tests pass.
