### PR TITLE
Towards add/save sanity

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -417,7 +417,7 @@ class Add(Interface):
             lgr.debug('Adding content to repo %s: %s', ds.repo, torepoadd)
             is_annex = isinstance(ds.repo, AnnexRepo)
             add_kw = {'jobs': jobs} if is_annex and jobs else {}
-            added = ds.repo.add(
+            added = ds.repo.add_(
                 list(torepoadd.keys()),
                 git=to_git if is_annex else True,
                 **add_kw

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -257,10 +257,6 @@ class Add(Interface):
             if not ap['path'] in ds_to_annotate_from_recursion:
                 # if it was somehow already discovered
                 to_add.append(ap)
-            # TODO check if next isn't covered by discover_dataset_trace_to_targets already??
-            if dataset and ap.get('type', None) == 'dataset':
-                # duplicates not possible, annotated_paths returns unique paths
-                subds_to_add[ap['path']] = ap
         if got_nothing:
             # path annotation yielded nothing, most likely cause is that nothing
             # was found modified, we need to say something about the reference

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -108,11 +108,13 @@ def save_dataset(
 
     if to_gitadd or save_entire_ds:
         lgr.debug('Adding files straight to Git at %s: %s', ds, to_gitadd)
+        # TODO this swallows status message, yield properly
         ds.repo.add(to_gitadd, git=True,
                     # this makes sure that pending submodule updates are added too
                     update=save_entire_ds)
     if to_annexadd:
         lgr.debug('Adding files to annex at %s: %s', ds, to_annexadd)
+        # TODO this swallows status message, yield properly
         ds.repo.add(to_annexadd)
 
     _datalad_msg = False

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1407,7 +1407,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     @normalize_paths
     def add(self, files, git=None, backend=None, options=None,
             jobs=None,
-            git_options=None, annex_options=None, _datalad_msg=False,
+            git_options=None, annex_options=None,
             update=False):
         """Add file(s) to the repository.
 
@@ -1532,7 +1532,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                                            files,
                                            git=True,
                                            git_options=git_options,
-                                           _datalad_msg=_datalad_msg,
                                            update=update)
             finally:
                 if self.is_direct_mode() and not files:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -896,8 +896,10 @@ class GitRepo(RepoInterface):
         list
           Of status dicts.
         """
-        return list(self.add_(
-            files, git=git, git_options=git_options, update=update))
+        # under all circumstances call this class' add_ (otherwise
+        # AnnexRepo.add would go into a loop
+        return list(GitRepo.add_(self, files, git=git, git_options=git_options,
+                    update=update))
 
     def add_(self, files, git=True, git_options=None, update=False):
         """Like `add`, but returns a generator"""

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -154,10 +154,10 @@ def _normalize_path(base_dir, path):
 
     Parameters
     ----------
-    path: str
-        path to be normalized
     base_dir: str
         directory to serve as base to normalized, relative paths
+    path: str
+        path to be normalized
 
     Returns
     -------
@@ -870,8 +870,7 @@ class GitRepo(RepoInterface):
         return msg + '\n\nFiles:\n' + '\n'.join(files)
 
     @normalize_paths
-    def add(self, files, git=True, git_options=None,
-            _datalad_msg=False, update=False):
+    def add(self, files, git=True, git_options=None, update=False):
         """Adds file(s) to the repository.
 
         Parameters

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -135,8 +135,6 @@ def test_GitRepo_add(src, path):
     filename = "another.txt"
     with open(opj(path, filename), 'w') as f:
         f.write("Another file to add to git")
-    assert_raises(AssertionError, gr.add, filename, git=False)
-    assert_raises(AssertionError, gr.add, filename, git=None)
 
     # include committing:
     added2 = gr.add(filename)


### PR DESCRIPTION
So far this is just the result of killing some time on a flight:

- [x] sister functions for *Repo.add() that are generators
- [x] big test RF to kill `import *` madness
- [x] some minor cleanup

After staring at the code for a while I think we should RF to make `save` use `add` and not vice versa. That should compact the code quite a bit, and make the presently observable differences in behavior go away.