### PR TITLE
BF: rerun: Guard against empty result list

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -341,12 +341,10 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
 
 def _rerun(dset, results):
     for res in results:
-        if res["status"] == "error":
-            yield res
-            return
-
         rerun_action = res.get("rerun_action")
-        if rerun_action == "skip":
+        if not rerun_action:
+            yield res
+        elif rerun_action == "skip":
             yield res
         elif rerun_action == "checkout":
             if res.get("branch"):
@@ -360,7 +358,7 @@ def _rerun(dset, results):
                 None, ["git", "cherry-pick", res["commit"]],
                 check_fake_dates=True)
             yield res
-        else:
+        elif rerun_action == "run":
             hexsha = res["commit"]
             run_info = res["run_info"]
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -275,8 +275,18 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
         # For --since='', drop any leading commits that don't have
         # a run command.
         results = list(dropwhile(lambda r: "run_info" not in r, results))
+        if not results:
+            yield get_status_dict(
+                "run", status="impossible", ds=dset,
+                message=("No run commits found in history of %s", revrange))
+            return
     else:
         results = list(results)
+        if not results:
+            yield get_status_dict(
+                "run", status="impossible", ds=dset,
+                message=("No commits found in %s", revrange))
+            return
 
     if onto is not None and onto.strip() == "":
         # Special case: --onto='' is the value of --since. Because we're

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -238,6 +238,12 @@ def test_rerun_onto(path):
 
     grow_file = opj(path, "grows")
 
+    # Make sure we can handle range-specifications that yield no results.
+    for since in ["", "HEAD"]:
+        assert_result_count(
+            ds.rerun("HEAD", onto="", since=since, on_failure="ignore"),
+            1, status="impossible", action="run")
+
     ds.run('echo static-content > static')
     ds.repo.tag("static")
     ds.run('echo x$(cat grows) > grows')


### PR DESCRIPTION
```
There are two cases where we can end up with an empty list of
results: (1) the user specifies --since='' but there are no run
commits in REVISION's history and (2) the user specifies a range
A..B (i.e., --since=A B) that doesn't have any commits.

In most cases, the downstream code will process an empty result list
fine, but, if --onto is specified, we'll fail with an index error.
Abort if we encounter an empty list to prevent the index error as well
as provide more useful feedback to the user.
```
