### PR TITLE
BFing direct mode:  "git commit file(s)" etc

### DIFF
--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -323,6 +323,9 @@ def test_create_withprocedure(path):
     eq_(ds.config['datalad.metadata.nativetype'], ('xmp', 'datacite'))
 
 
+# Skipping on Windows due to lack of MagicMime support:
+# https://github.com/datalad/datalad/pull/2770#issuecomment-415842284
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 def test_create_text_no_annex(path):
     ds = create(path, text_no_annex=True)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -324,7 +324,6 @@ def test_create_withprocedure(path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_create_text_no_annex(path):
     ds = create(path, text_no_annex=True)
     ok_clean_git(path)

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -447,7 +447,6 @@ def test_failon_no_permissions(src_path, target_path):
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_replace_and_relative_sshpath(src_path, dst_path):
     # We need to come up with the path relative to our current home directory
     # https://github.com/datalad/datalad/issues/1653

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -8,7 +8,7 @@
 """Test create testdataset helpers
 
 """
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
 
 from glob import glob
 from os.path import join as opj
@@ -39,7 +39,7 @@ def test_parse_spec():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -52,7 +52,7 @@ def test_create_test_dataset():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -63,7 +63,7 @@ def test_create_1test_dataset():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
@@ -76,7 +76,7 @@ def test_new_relpath(topdir):
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -97,7 +97,6 @@ def test_get_flexible_source_candidates_for_submodule(t, t2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(content="doesntmatter")
-@known_failure_direct_mode  #FIXME
 def test_get_invalid_call(path, file_outside):
 
     # no argument at all:
@@ -160,7 +159,6 @@ def test_get_single_file(path):
                  'file4.txt': 'whatever 4'})
 @serve_path_via_http
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_get_multiple_files(path, url, ds_dir):
     from os import listdir
     from datalad.support.network import RI
@@ -208,7 +206,6 @@ def test_get_multiple_files(path, url, ds_dir):
                                 'file4.txt': 'something'
                             }}})
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -649,6 +649,7 @@ def test_reckless(path, top_path):
                            }
                  })
 @with_tempfile(mkdir=True)
+@skip_if_on_windows  # Due to "another process error" and buggy ok_clean_git
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -649,7 +649,6 @@ def test_reckless(path, top_path):
                            }
                  })
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_install_recursive_repeat(src, path):
     subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -391,7 +391,6 @@ def test_careless_subdataset_uninstall(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_kill(path):
     # nested datasets with load
     ds = Dataset(path).create()

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -535,6 +535,7 @@ def test_drop_nocrash_absent_subds(path):
         assert_status('notneeded', drop('.', recursive=True))
 
 
+@known_failure_direct_mode  #FIXME
 @with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
 def test_remove_more_than_one(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -80,7 +80,6 @@ def test_download_url_return(toppath, topurl, outdir):
 ])
 @serve_path_via_http
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_download_url_dataset(toppath, topurl, path):
     # Non-dataset directory.
     file1_fullpath = opj(path, "file1.txt")
@@ -123,7 +122,6 @@ def test_download_url_dataset(toppath, topurl, path):
 @with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})
 @serve_path_via_http
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_download_url_archive(toppath, topurl, path):
     ds = Dataset(path).create()
     ds.download_url([opj(topurl, "archive.tar.gz")], archive=True)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -102,19 +102,20 @@ def test_basics(path, nodspath):
         last_state = ds.repo.get_hexsha()
         # now run a command that will not alter the dataset
         res = ds.run('touch empty', message='NOOP_TEST')
-        assert_status('notneeded', res)
+        assert_result_count(res, 1, action='save', status='notneeded')
         eq_(last_state, ds.repo.get_hexsha())
         # We can also run the command via a single-item list because this is
         # what the CLI interface passes in for quoted commands.
         res = ds.run(['touch empty'], message='NOOP_TEST')
-        assert_status('notneeded', res)
+        assert_result_count(res, 1, action='save', status='notneeded')
 
     # run outside the dataset, should still work but with limitations
     with chpwd(nodspath), \
             swallow_outputs():
         res = ds.run(['touch', 'empty2'], message='TEST')
-        assert_status('ok', res)
-        assert_result_count(res, 1, action='add', path=opj(ds.path, 'empty2'), type='file')
+        assert_result_count(res, 1, action='add', path=opj(ds.path, 'empty2'), type='file',
+                            status='ok')
+        assert_result_count(res, 1, action='save', status='ok')
 
     # running without a command is a noop
     with chpwd(path):

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -78,6 +78,7 @@ def test_invalid_call(path):
 @with_tempfile(mkdir=True)
 def test_basics(path, nodspath):
     ds = Dataset(path).create()
+    direct_mode = ds.repo.is_direct_mode()
     last_state = ds.repo.get_hexsha()
     # run inside the dataset
     with chpwd(path), \
@@ -102,12 +103,17 @@ def test_basics(path, nodspath):
         last_state = ds.repo.get_hexsha()
         # now run a command that will not alter the dataset
         res = ds.run('touch empty', message='NOOP_TEST')
-        assert_result_count(res, 1, action='save', status='notneeded')
+        # When in direct mode, check at the level of save rather than add
+        # because the annex files show up as typechanges and adding them won't
+        # necessarily have a "notneeded" status.
+        assert_result_count(res, 1, action='save' if direct_mode else 'add',
+                            status='notneeded')
         eq_(last_state, ds.repo.get_hexsha())
         # We can also run the command via a single-item list because this is
         # what the CLI interface passes in for quoted commands.
         res = ds.run(['touch empty'], message='NOOP_TEST')
-        assert_result_count(res, 1, action='save', status='notneeded')
+        assert_result_count(res, 1, action='save' if direct_mode else 'add',
+                            status='notneeded')
 
     # run outside the dataset, should still work but with limitations
     with chpwd(nodspath), \

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -462,6 +462,7 @@ def test_rerun_branch(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
+@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -773,7 +773,6 @@ def test_run_inputs_no_annex_repo(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_testrepos('basic_annex', flavors=['clone'])
-@known_failure_direct_mode  #FIXME
 def test_run_explicit(path):
     ds = Dataset(path)
 

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -68,6 +68,5 @@ def test_api_git():
     yield check_api, True
 
 
-@known_failure_direct_mode
 def test_api_annex():
     yield check_api, False

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -26,7 +26,7 @@ from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import skip_direct_mode
+from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import skip_if_on_windows
 
 
@@ -56,7 +56,7 @@ _dataset_hierarchy_template = {
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_basic_aggregate(path):
     # TODO give datasets some more metadata to actually aggregate stuff
     base = Dataset(opj(path, 'origin')).create(force=True)
@@ -146,7 +146,7 @@ def test_aggregate_query(path):
 
 # this is for gh-1971
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_reaggregate_with_unavailable_objects(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -182,7 +182,7 @@ def test_reaggregate_with_unavailable_objects(path):
 
 @with_tree(tree=_dataset_hierarchy_template)
 @with_tempfile(mkdir=True)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_aggregate_with_unavailable_objects_from_subds(path, target):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -218,7 +218,7 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_publish_aggregated(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -265,7 +265,7 @@ def _get_referenced_objs(ds):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_aggregate_removal(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -301,7 +301,7 @@ def test_aggregate_removal(path):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 def test_update_strategy(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -357,7 +357,7 @@ def test_update_strategy(path):
 
 
 # needs two subdatasets, no possible in direct mode
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -231,11 +231,6 @@ def test_get_aggregates_fails(path):
     assert_result_count(res, 1, path=ds.path, status='impossible')
 
 
-# XXX MIH knows of no way to test if the content of a file is NOT
-# available in a local clone that works in direct mode
-# tried whereis() -- no output
-# is_under_annex -- also fails
-@known_failure_direct_mode
 @with_tree({'dummy': 'content'})
 @with_tempfile(mkdir=True)
 def test_bf2458(src, dst):

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -94,7 +94,7 @@ def _compare_metadata_helper(origres, compds):
                 eq_(ores[i], cres[i])
 
 
-@skip_direct_mode  #FIXME
+@known_failure_direct_mode  #FIXME
 @slow  # ~16s
 @with_tree(tree=_dataset_hierarchy_template)
 def test_aggregation(path):

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -176,7 +176,6 @@ def test_search_non_dataset(tdir):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_within_ds_file_search(path):
     try:
         import mutagen

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -74,6 +74,7 @@ class ExportArchive(Interface):
         import zipfile
         from mock import patch
         from os.path import join as opj, dirname, normpath, isabs
+        import os.path as op
 
         from datalad.distribution.dataset import require_dataset
         from datalad.utils import file_basename
@@ -148,10 +149,11 @@ class ExportArchive(Interface):
                             raise IOError('File %s has no content available' % fpath)
 
                     # resolve to possible link target
-                    link_target = os.readlink(fpath)
-                    if not isabs(link_target):
-                        link_target = normpath(opj(dirname(fpath), link_target))
-                    fpath = link_target
+                    if op.islink(fpath):
+                        link_target = os.readlink(fpath)
+                        if not isabs(link_target):
+                            link_target = normpath(opj(dirname(fpath), link_target))
+                        fpath = link_target
                 # name in the archive
                 aname = normpath(opj(leading_dir, rpath))
                 add_method(

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -117,7 +117,6 @@ def test_wtf(path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_no_annex(path):
     ds = create(path)
     ok_clean_git(ds.path)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2702,6 +2702,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                careless=True, files=None, proxy=False):
         self.precommit()
 
+        if files:
+            files = assure_list(files)
+
         # Note: `proxy` is for explicitly enforcing the use of git-annex-proxy
         #       in direct mode. This is needed in very special cases, which
         #       might go away once we figured out a better way. In any case, it
@@ -2727,7 +2730,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 # used to fail, because absolute paths are used. Using annex
                 # proxy this leads to an error (path outside repository)
                 if files:
-                    files = assure_list(files)
                     if options is None:
                         options = []
                     for i in range(len(files)):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -56,6 +56,7 @@ from datalad.utils import _path_
 from datalad.utils import generate_chunks
 from datalad.utils import CMD_MAX_ARG
 from datalad.utils import assure_unicode, assure_bytes
+from datalad.utils import make_tempfile
 from datalad.support.json_py import loads as json_loads
 from datalad.cmd import GitRunner
 
@@ -198,6 +199,14 @@ class AnnexRepo(GitRepo, RepoInterface):
             else:
                 raise e
 
+        # Below while setting for direct mode workaround, we change
+        # _GIT_COMMON_OPTIONS.
+        # But we should not pass workarounds such as --worktree=.
+        # -c core.bare=False to git annex commands, so for their
+        # invocation we will keep and use pristine version of the
+        # common options
+        self._ANNEX_GIT_COMMON_OPTIONS = self._GIT_COMMON_OPTIONS[:]
+
         # check for possible SSH URLs of the remotes in order to set up
         # shared connections:
         for r in self.get_remotes():
@@ -267,7 +276,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 # to use 'git annex unlock' instead.
                 lgr.warning("direct mode not available for %s. Ignored." % self)
 
-        self._batched = BatchedAnnexes(batch_size=batch_size)
+        self._batched = BatchedAnnexes(
+            batch_size=batch_size, git_options=self._ANNEX_GIT_COMMON_OPTIONS)
 
         # set default backend for future annex commands:
         # TODO: Should the backend option of __init__() also migrate
@@ -1039,7 +1049,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         debug = ['--debug'] if lgr.getEffectiveLevel() <= 8 else []
         backend = ['--backend=%s' % backend] if backend else []
 
-        git_options = (git_options[:] if git_options else []) + self._GIT_COMMON_OPTIONS
+        git_options = (git_options[:] if git_options else []) + self._ANNEX_GIT_COMMON_OPTIONS
         annex_options = annex_options[:] if annex_options else []
         if self._annex_common_options:
             annex_options = self._annex_common_options + annex_options
@@ -1601,9 +1611,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
 
         if len(files) > 1:
-            return self._batched.get('lookupkey',
-                                     git_options=self._GIT_COMMON_OPTIONS,
-                                     path=self.path)(files)
+            return self._batched.get('lookupkey', path=self.path)(files)
         else:
             files = files[0]
             # single file
@@ -1785,7 +1793,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         objects = []
         if batch:
-            objects = self._batched.get('find', git_options=self._GIT_COMMON_OPTIONS, path=self.path)(files)
+            objects = self._batched.get('find', path=self.path)(files)
         else:
             for f in files:
                 try:
@@ -2077,7 +2085,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 # Since backend will be critical for non-existing files
                 'addurl_to_file_backend:%s' % backend,
                 annex_cmd='addurl',
-                git_options=self._GIT_COMMON_OPTIONS + git_options,
+                git_options=git_options,
                 annex_options=options,  # --raw ?
                 path=self.path,
                 json=True
@@ -2246,7 +2254,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             json_objects = self._batched.get(
                 'dropkey',
-                git_options=self._GIT_COMMON_OPTIONS,
                 annex_options=options, json=True, path=self.path
             )(keys)
         for j in json_objects:
@@ -2520,7 +2527,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             json_objects = self._batched.get(
                 'info',
-                git_options=self._GIT_COMMON_OPTIONS,
                 annex_options=options, json=True, path=self.path
             )(files)
 
@@ -2770,10 +2776,57 @@ class AnnexRepo(GitRepo, RepoInterface):
             #       example.
 
             try:
-                super(AnnexRepo, self).commit(msg, options,
-                                              _datalad_msg=_datalad_msg,
-                                              careless=careless, files=files)
+                alt_index_file = None
+                files_to_commit = None  # we might need to avoid explicit paths
+                if self.is_direct_mode() and files:
+                    # In direct mode, if we commit file(s) they would get
+                    # committed directly into git ignoring possibly being
+                    # staged by annex.  So, if not all files are committed, and
+                    # assuming that what is to be committed is staged (!could be
+                    # wrong assumption), we need to prepare a custom index, and
+                    # commit without specifying any paths
+                    all_staged_files = {
+                        opj(self.path, p)
+                        for p in self.get_changed_files(staged=True)
+                    }
+                    files_set = set(files)
+                    files_notstaged = files_set.difference(all_staged_files)
+                    if files_notstaged:
+                        # To be safe(r), let's just blow for now!
+                        # We could be smart(er) and do all the git or annex add
+                        # but let's see if we run into those cases first
+                        raise RuntimeError(
+                            "To commit files in direct mode, please first git "
+                            "or git-annex add them first!  Files: %s"
+                            % ', '.join(files_notstaged)
+                        )
+                    # Files which were staged but not among files
+                    staged_not_to_commit = all_staged_files.difference(files_set)
+                    if staged_not_to_commit:
+                        # Need an alternative index_file
+                        with make_tempfile() as index_file:
+                            alt_index_file = index_file
+                            # Reset the files we are not to be committed
+                            self._git_custom_command(
+                                list(staged_not_to_commit),
+                                ['git', 'reset'],
+                                index_file=alt_index_file)
+
+                            super(AnnexRepo, self).commit(
+                                msg, options,
+                                _datalad_msg=_datalad_msg,
+                                careless=careless,
+                                index_file=alt_index_file)
+
+                    # in any case we will not specify files explicitly
+                    files_to_commit = None
+                if not alt_index_file:
+                    super(AnnexRepo, self).commit(msg, options,
+                                                  _datalad_msg=_datalad_msg,
+                                                  careless=careless,
+                                                  files=files_to_commit)
             except CommandError as e:
+                # TODO: just remove this???
                 if self.is_direct_mode() and \
                     AnnexRepo._is_annex_work_tree_message(e.stderr):
                     lgr.debug("Commit failed. "
@@ -2782,6 +2835,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 careless=careless, files=files, proxy=True)
                 else:
                     raise
+            finally:
+                if alt_index_file and os.path.exists(alt_index_file):
+                    os.unlink(alt_index_file)
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, force=False, **kwargs):
@@ -2834,7 +2890,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             except CommandError:
                 return ''
         else:
-            return self._batched.get('contentlocation', git_options=self._GIT_COMMON_OPTIONS, path=self.path)(key)
+            return self._batched.get('contentlocation', path=self.path)(key)
 
     @normalize_paths(serialize=True)
     def is_available(self, file_, remote=None, key=False, batch=False):
@@ -2881,7 +2937,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             annex_cmd = ["checkpresentkey"] + ([remote] if remote else [])
             out = self._batched.get(
                 ':'.join(annex_cmd), annex_cmd,
-                git_options=self._GIT_COMMON_OPTIONS,
                 path=self.path)(key_)
             try:
                 return {
@@ -3282,15 +3337,16 @@ class BatchedAnnexes(dict):
     """Class to contain the registry of active batch'ed instances of annex for
     a repository
     """
-    def __init__(self, batch_size=0):
+    def __init__(self, batch_size=0, git_options=None):
         self.batch_size = batch_size
+        self.git_options = git_options or []
         super(BatchedAnnexes, self).__init__()
 
     def get(self, codename, annex_cmd=None, **kwargs):
         if annex_cmd is None:
             annex_cmd = codename
 
-        git_options = kwargs.pop('git_options', [])
+        git_options = self.git_options + kwargs.pop('git_options', [])
         if self.batch_size:
             git_options += ['-c', 'annex.queuesize=%d' % self.batch_size]
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2777,8 +2777,10 @@ class AnnexRepo(GitRepo, RepoInterface):
 
             try:
                 alt_index_file = None
-                files_to_commit = None  # we might need to avoid explicit paths
-                if self.is_direct_mode() and files:
+                direct_mode = self.is_direct_mode()
+                # we might need to avoid explicit paths
+                files_to_commit = None if direct_mode else files
+                if direct_mode and files:
                     # In direct mode, if we commit file(s) they would get
                     # committed directly into git ignoring possibly being
                     # staged by annex.  So, if not all files are committed, and

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2812,6 +2812,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                         # Need an alternative index_file
                         with make_tempfile() as index_file:
                             alt_index_file = index_file
+                            index_tree = self.repo.git.write_tree()
+                            self.repo.git.read_tree(index_tree,
+                                                    index_output=index_file)
                             # Reset the files we are not to be committed
                             self._git_custom_command(
                                 list(staged_not_to_commit),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -64,6 +64,7 @@ from datalad.cmd import GitRunner
 from .repo import RepoInterface
 from .gitrepo import GitRepo
 from .gitrepo import NoSuchPathError
+from .gitrepo import _normalize_path
 from .gitrepo import normalize_path
 from .gitrepo import normalize_paths
 from .gitrepo import GitCommandError
@@ -2808,12 +2809,12 @@ class AnnexRepo(GitRepo, RepoInterface):
                     # wrong assumption), we need to prepare a custom index, and
                     # commit without specifying any paths
                     changed_files = {
-                        staged: {
-                            opj(self.path, p)
-                            for p in self.get_changed_files(staged=staged)
-                        } for staged in (True,) #  False}
+                        staged: set(self.get_changed_files(staged=staged))
+                        for staged in (True,) #  False}
                     }
-                    files_set = set(files)
+                    files_set = {
+                        _normalize_path(self.path, f) if isabs(f) else f
+                        for f in files}
                     files_notstaged = files_set.difference(changed_files[True])
                     # Lazy .add('.') results in ALL (performance?) files listed
                     # here even if they are not changed at all and could be ignored

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2325,8 +2325,9 @@ class GitRepo(RepoInterface):
         staged: bool, optional
           Either operate on staged (index) files instead of workdir
         diff_filter: str, optional
-          Status codes (from ACDMRTUXB) if only specific changes should be
-          considered.  See `--diff-filter` within the `git-diff` for more info
+          Any value accepted by the `--diff-filter` option of `git diff`.
+          Common ones include "A", "D", "M" for add, deleted, and modified
+          files, respectively.
         index_file: str, optional
           Alternative index file for git to use
         """

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2338,7 +2338,7 @@ class GitRepo(RepoInterface):
             opts.append('--diff-filter=%s' % diff_filter)
         if index_file:
             kwargs['env'] = {'GIT_INDEX_FILE': index_file}
-        return [f
+        return [normpath(f)  # Call normpath to convert separators on Windows.
                 for f in self.repo.git.diff(*opts, **kwargs).split('\0') if f]
 
     def get_missing_files(self):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2315,7 +2315,7 @@ class GitRepo(RepoInterface):
                                     if len(item.split(': ')) == 2]}
         return count
 
-    def get_changed_files(self, staged=False, filter='', index_file=None):
+    def get_changed_files(self, staged=False, diff_filter='', index_file=None):
         """Return a dictionary with files and their status code
 
         See `git diff --help` for more information about codes
@@ -2324,7 +2324,7 @@ class GitRepo(RepoInterface):
         ----------
         staged: bool, optional
           Either operate on staged (index) files instead of workdir
-        filter: str, optional
+        diff_filter: str, optional
           Status codes (from ACDMRTUXB) if only specific changes should be
           considered.  See `--diff-filter` within the `git-diff` for more info
         index_file: str, optional
@@ -2334,8 +2334,8 @@ class GitRepo(RepoInterface):
         kwargs = {}
         if staged:
             opts.append('--staged')
-        if filter:
-            opts.append('--diff-filter=%s' % filter)
+        if diff_filter:
+            opts.append('--diff-filter=%s' % diff_filter)
         if index_file:
             kwargs['env'] = {'GIT_INDEX_FILE': index_file}
         diff_output = self.repo.git.diff(*opts, **kwargs)
@@ -2347,11 +2347,11 @@ class GitRepo(RepoInterface):
 
     def get_missing_files(self):
         """Return a list of paths with missing files (and no staged deletion)"""
-        return list(self.get_changed_files(filter='D'))
+        return list(self.get_changed_files(diff_filter='D'))
 
     def get_deleted_files(self):
         """Return a list of paths with deleted files (staged deletion)"""
-        return list(self.get_changed_files(staged=True, filter='D'))
+        return list(self.get_changed_files(staged=True, diff_filter='D'))
 
     def get_git_attributes(self):
         """Check git attribute for the current repository (not per-file support for now)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1580,6 +1580,7 @@ class GitRepo(RepoInterface):
             env = self.add_fake_dates(env)
 
         if index_file:
+            env = (env if env is not None else os.environ).copy()
             env['GIT_INDEX_FILE'] = index_file
 
         try:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2331,7 +2331,7 @@ class GitRepo(RepoInterface):
         index_file: str, optional
           Alternative index file for git to use
         """
-        opts = ['--raw', '--name-status']
+        opts = ['--name-status']
         kwargs = {}
         if staged:
             opts.append('--staged')

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1054,8 +1054,9 @@ def test_get_missing(path):
     # still no differences between worktree and staged
     eq_(repo.get_changed_files(), {})
     eq_(repo.get_changed_files(staged=True), {'test1': 'A', 'deep/test2': 'A'})
-    eq_(repo.get_changed_files(staged=True, filter='AD'), {'test1': 'A', 'deep/test2': 'A'})
-    eq_(repo.get_changed_files(staged=True, filter='D'), {})
+    eq_(repo.get_changed_files(staged=True, diff_filter='AD'),
+        {'test1': 'A', 'deep/test2': 'A'})
+    eq_(repo.get_changed_files(staged=True, diff_filter='D'), {})
     repo.commit()
     eq_(repo.get_changed_files(), {})
     eq_(repo.get_changed_files(staged=True), {})

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1048,8 +1048,17 @@ def test_get_missing(path):
         f.write('some')
     with open(opj(path, 'deep', 'test2'), 'w') as f:
         f.write('some more')
+    # no files tracked yet, so nothing changed
+    eq_(repo.get_changed_files(), {})
     repo.add('.')
+    # still no differences between worktree and staged
+    eq_(repo.get_changed_files(), {})
+    eq_(repo.get_changed_files(staged=True), {'test1': 'A', 'deep/test2': 'A'})
+    eq_(repo.get_changed_files(staged=True, filter='AD'), {'test1': 'A', 'deep/test2': 'A'})
+    eq_(repo.get_changed_files(staged=True, filter='D'), {})
     repo.commit()
+    eq_(repo.get_changed_files(), {})
+    eq_(repo.get_changed_files(staged=True), {})
     ok_clean_git(path, annex=False)
     os.unlink(opj(path, 'test1'))
     eq_(repo.get_missing_files(), ['test1'])

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1053,9 +1053,10 @@ def test_get_missing(path):
     repo.add('.')
     # still no differences between worktree and staged
     eq_(repo.get_changed_files(), [])
-    eq_(set(repo.get_changed_files(staged=True)), {'test1', 'deep/test2'})
+    eq_(set(repo.get_changed_files(staged=True)),
+        {'test1', opj('deep', 'test2')})
     eq_(set(repo.get_changed_files(staged=True, diff_filter='AD')),
-        {'test1', 'deep/test2'})
+        {'test1', opj('deep', 'test2')})
     eq_(repo.get_changed_files(staged=True, diff_filter='D'), [])
     repo.commit()
     eq_(repo.get_changed_files(), [])

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1049,17 +1049,17 @@ def test_get_missing(path):
     with open(opj(path, 'deep', 'test2'), 'w') as f:
         f.write('some more')
     # no files tracked yet, so nothing changed
-    eq_(repo.get_changed_files(), {})
+    eq_(repo.get_changed_files(), [])
     repo.add('.')
     # still no differences between worktree and staged
-    eq_(repo.get_changed_files(), {})
-    eq_(repo.get_changed_files(staged=True), {'test1': 'A', 'deep/test2': 'A'})
-    eq_(repo.get_changed_files(staged=True, diff_filter='AD'),
-        {'test1': 'A', 'deep/test2': 'A'})
-    eq_(repo.get_changed_files(staged=True, diff_filter='D'), {})
+    eq_(repo.get_changed_files(), [])
+    eq_(set(repo.get_changed_files(staged=True)), {'test1', 'deep/test2'})
+    eq_(set(repo.get_changed_files(staged=True, diff_filter='AD')),
+        {'test1', 'deep/test2'})
+    eq_(repo.get_changed_files(staged=True, diff_filter='D'), [])
     repo.commit()
-    eq_(repo.get_changed_files(), {})
-    eq_(repo.get_changed_files(staged=True), {})
+    eq_(repo.get_changed_files(), [])
+    eq_(repo.get_changed_files(staged=True), [])
     ok_clean_git(path, annex=False)
     os.unlink(opj(path, 'test1'))
     eq_(repo.get_missing_files(), ['test1'])

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -492,7 +492,7 @@ def test_skip_if_no_network():
         @skip_if_no_network
         def somefunc(a1):
             return a1
-        eq_(somefunc.tags, ['network'])
+        ok_(hasattr(somefunc, "network"))
         with patch.dict('os.environ', {'DATALAD_TESTS_NONETWORK': '1'}):
             assert_raises(SkipTest, somefunc, 1)
         with patch.dict('os.environ', {}):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -39,6 +39,7 @@ from functools import wraps
 from os.path import exists, realpath, join as opj, pardir, split as pathsplit, curdir
 from os.path import relpath
 
+from nose.plugins.attrib import attr
 from nose.tools import \
     assert_equal, assert_not_equal, assert_raises, assert_greater, assert_true, assert_false, \
     assert_in, assert_not_in, assert_in as in_, assert_is, \
@@ -512,6 +513,7 @@ def serve_path_via_http(tfunc, *targs):
     """
 
     @wraps(tfunc)
+    @attr('serve_path_via_http')
     def newfunc(*args, **kwargs):
 
         if targs:
@@ -534,6 +536,7 @@ def with_memory_keyring(t):
     """Decorator to use non-persistant MemoryKeyring instance
     """
     @wraps(t)
+    @attr('with_memory_keyring')
     def newfunc(*args, **kwargs):
         keyring = MemoryKeyring()
         with patch("datalad.downloaders.credentials.keyring_", keyring):
@@ -548,6 +551,7 @@ def without_http_proxy(tfunc):
     """
 
     @wraps(tfunc)
+    @attr('without_http_proxy')
     def newfunc(*args, **kwargs):
         # Such tests don't require real network so if http_proxy settings were
         # provided, we remove them from the env for the duration of this run
@@ -733,6 +737,7 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
 
     """
     @wraps(t)
+    @attr('with_testrepos')
     def newfunc(*arg, **kw):
         if on_windows:
             raise SkipTest("Testrepo setup is broken on Windows")
@@ -782,6 +787,7 @@ def with_fake_cookies_db(func, cookies={}):
     from ..support.cookies import cookies_db
 
     @wraps(func)
+    @attr('with_fake_cookies_db')
     def newfunc(*args, **kwargs):
         try:
             orig_cookies_db = cookies_db._cookies_db
@@ -804,12 +810,11 @@ def skip_if_no_network(func=None):
 
     if func:
         @wraps(func)
+        @attr('network')
+        @attr('skip_if_no_network')
         def newfunc(*args, **kwargs):
             check_and_raise()
             return func(*args, **kwargs)
-        # right away tag the test as a networked test
-        tags = getattr(newfunc, 'tags', [])
-        newfunc.tags = tags + ['network']
         return newfunc
     else:
         check_and_raise()
@@ -819,6 +824,7 @@ def skip_if_on_windows(func):
     """Skip test completely under Windows
     """
     @wraps(func)
+    @attr('skip_if_on_windows')
     def newfunc(*args, **kwargs):
         if on_windows:
             raise SkipTest("Skipping on Windows")
@@ -860,6 +866,7 @@ def skip_ssh(func):
     DATALAD_TESTS_SSH was not set
     """
     @wraps(func)
+    @attr('skip_ssh')
     def newfunc(*args, **kwargs):
         from datalad import cfg
         test_ssh = cfg.get("datalad.tests.ssh", '')
@@ -882,6 +889,7 @@ def probe_known_failure(func):
     """
 
     @wraps(func)
+    @attr('probe_known_failure')
     def newfunc(*args, **kwargs):
         from datalad import cfg
         if cfg.obtain("datalad.tests.knownfailures.probe"):
@@ -908,6 +916,7 @@ def skip_known_failure(func, method='raise'):
              msg="Skip test known to fail",
              method=method)
     @wraps(func)
+    @attr('skip_known_failure')
     def newfunc(*args, **kwargs):
         return func(*args, **kwargs)
     return newfunc
@@ -923,6 +932,7 @@ def known_failure(func):
     @skip_known_failure
     @probe_known_failure
     @wraps(func)
+    @attr('known_failure')
     def newfunc(*args, **kwargs):
         return func(*args, **kwargs)
     return newfunc
@@ -942,6 +952,8 @@ def known_failure_v6(func):
 
         @known_failure
         @wraps(func)
+        @attr('known_failure_v6')
+        @attr('v6')
         def v6_func(*args, **kwargs):
             return func(*args, **kwargs)
 
@@ -964,6 +976,8 @@ def known_failure_direct_mode(func):
 
         @known_failure
         @wraps(func)
+        @attr('known_failure_direct_mode')
+        @attr('direct_mode')
         def dm_func(*args, **kwargs):
             return func(*args, **kwargs)
 
@@ -988,6 +1002,8 @@ def skip_v6(func, method='raise'):
 
     @skip_if(version == 6, msg="Skip test in v6 test run", method=method)
     @wraps(func)
+    @attr('skip_v6')
+    @attr('v6')
     def newfunc(*args, **kwargs):
         return func(*args, **kwargs)
     return newfunc
@@ -1005,6 +1021,8 @@ def skip_direct_mode(func, method='raise'):
              msg="Skip test in direct mode test run",
              method=method)
     @wraps(func)
+    @attr('skip_direct_mode')
+    @attr('direct_mode')
     def newfunc(*args, **kwargs):
         return func(*args, **kwargs)
     return newfunc
@@ -1373,6 +1391,7 @@ def with_direct(func):
     Unlike fancy generators would just fail on the first failure
     """
     @wraps(func)
+    @attr('direct_mode')
     def newfunc(*args, **kwargs):
         if on_windows or on_travis:
             # since on windows would become indirect anyways


### PR DESCRIPTION
Disclaimer - sits on top of #2724 which I intend to merge if tests pass

This pull request fixes # ... TODO ... there might be a few
- [x] (nearly all) test decorators now carry identical to their name attributes for nose, so you can easily run only a subset of those decorated tests.  Some are decorated further, e.g. `direct_mode` would point to tests somehow related to direct mode - either explicitly testing in direct mode, known to fail, or ignored. etc
- [x] `git annex` invocations do not get ` -c core.bare=False --work-tree=.` since they shouldn't/mustn't!
- [x] in direct mode:  for `git commit file(s)` under direct mode, we resort to `git commit` while first analyzing `file(s)` given:
   - if any is not staged - we puke
   - if some staged aren't among `file(s)` - we prepare a new index file, where we reset those which aren't to be committed
   - **gotcha/shortcoming** if there is a modified file, which is staged but in some previous shape (so there are newer changes in worktree), they would not get committed.  We could have analyzed index regarding either staged version is annexified or git - and then do `git add` or `git annex add` accordingly, but not sure if worth the hassle ATM.  At least this fix/behavior would get us those 95% of correct functionality in direct mode ;)
    - This current "index" trick workaround could later be superseded by git supporting `git commit --cached file(s)` invocation.  but that wouldn't eliminate the need for the analysis if we decide to do regarding files which aren't yet staged (thus might needing `git annex add`)
- [x] redecorate `@skip_direct_mode` into `@known_failure_direct_mode`
- [x] undecorate tests which no longer fail in direct mode (there should be a few)
- [ ] possibly a dedicated test for `git commit file(s)` (`datalad save file(s)`) behavior in the case of some files being staged and some not... but might not do it if coverage would indicate that all possible lines are tested now

Please have a look @datalad/developers
