### PR TITLE
TST: travis: Pin Sphinx to v1.7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -247,7 +247,8 @@ install:
   - git config --global user.name "Travis Almighty"
   - cd ..; pip install -q codecov; cd -
   - pip install -r requirements-devel.txt
-  - pip install 'sphinx>=1.6.2'
+  # Avoid Sphinx v1.7.7, which fails with spurious warnings.  See gh-2774.
+  - pip install 'sphinx==1.7.6'
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
   # TMPDIRs


### PR DESCRIPTION
With Sphinx v1.7.7, Travis runs are currently failing with

    /home/travis/build/datalad/datalad/docs/source/generated/cfginfo/dataset.rst:document isn't included in any toctree

This appears to be a spurious warning rather than a real issue
uncovered by the newer Sphinx.  Pin Sphinx to the previous version
until the issue is resolved.

Re: #2774