### PR TITLE
WIP: Removing some "failing in v6" tests

### DIFF
--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -219,7 +219,6 @@ def test_clone_isnot_recursive(src, path_nr, path_r):
 
 
 @slow  # 23.1478s
-@known_failure_v6   #FIXME
 @with_testrepos(flavors=['local'])
 # 'local-url', 'network'
 # TODO: Somehow annex gets confused while initializing installed ds, whose

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -426,7 +426,6 @@ def test_install_recursive_with_data(src, path):
 # to currently impossible recursion of `AnnexRepo._submodules_dirty_direct_mode`
 
 @slow  # 88.0869s  because of going through multiple test repos, ~8sec each time
-@known_failure_v6  # https://github.com/datalad/datalad/pull/2391#issuecomment-379414293
 @with_testrepos('.*annex.*', flavors=['local'])
 # 'local-url', 'network'
 # TODO: Somehow annex gets confused while initializing installed ds, whose

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -164,7 +164,6 @@ tree4uargs = dict(
 
 
 @slow  # 29.4293s
-@known_failure_v6   # FIXME
 #  apparently fails only sometimes in PY3, but in a way that's common in V6
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree1args)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -298,7 +298,6 @@ def test_rerun_onto(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_rerun_chain(path):
     ds = Dataset(path).create()
     commits = []
@@ -376,7 +375,6 @@ def test_rerun_just_one_commit(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_run_failure(path):
     ds = Dataset(path).create()
 


### PR DESCRIPTION
Should pass on that run (temporarily enabled) where we use devel annex and now test on v6