### PR TITLE
TST: run: Unmark two tests as known direct mode failures

### DIFF
--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -344,7 +344,6 @@ def test_rerun_old_flag_compatibility(path):
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_rerun_just_one_commit(path):
     ds = Dataset(path).create()
@@ -523,7 +522,6 @@ def test_rerun_ambiguous_revision_file(path):
 
 
 @ignore_nose_capturing_stdout
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 @with_tree(tree={"subdir": {}})
 def test_rerun_subdir(path):


### PR DESCRIPTION
These pass following 98039ccf5 from gh-2770.

Note that gh-2782 reported that test_create_1test_dataset now passes
in direct mode, but this is because the test doesn't fail
consistently, not because it was fixed by gh-2770.