### PR TITLE
 BF: run: Support globbing in uninstalled datasets

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -267,7 +267,7 @@ class GlobbedPaths(object):
                     expanded.extend([pattern])
         return expanded
 
-    def expand(self, full=False, dot=True):
+    def expand(self, full=False, dot=True, refresh=False):
         """Return paths with the globs expanded.
 
         Parameters
@@ -276,12 +276,15 @@ class GlobbedPaths(object):
             Return full paths rather than paths relative to `pwd`.
         dot : bool, optional
             Include the "." pattern if it was specified.
+        refresh : bool, optional
+            Run glob regardless of whether there are cached values. This is
+            useful if there may have been changes on the file system.
         """
         maybe_dot = self._maybe_dot if dot else []
         if not self._paths["patterns"]:
             return maybe_dot + []
 
-        if "expanded" not in self._paths:
+        if refresh or "expanded" not in self._paths:
             paths = self._expand_globs()
             self._paths["expanded"] = paths
         else:

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -18,7 +18,6 @@ from argparse import REMAINDER
 from glob import glob
 import os.path as op
 from os.path import join as opj
-from os.path import curdir
 from os.path import normpath
 from os.path import relpath
 from os.path import isabs

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -34,6 +34,7 @@ from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.gitrepo import GitCommandError, GitRepo
 from datalad.tests.utils import ok_, assert_false, neq_
+from datalad.api import install
 from datalad.api import run
 from datalad.interface.run import GlobbedPaths
 from datalad.interface.rerun import get_run_info
@@ -653,11 +654,16 @@ def test_rerun_script(path):
 @slow  # ~10s
 @ignore_nose_capturing_stdout
 @skip_if_on_windows
-@with_testrepos('basic_annex', flavors=['clone'])
+@with_tree(tree={"test-annex.dat": "content"})
+@with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
-def test_run_inputs_outputs(path):
-    ds = Dataset(path)
+def test_run_inputs_outputs(src, path):
+    src_ds = Dataset(src).create(force=True)
+    src_ds.add(".", recursive=True)
+
+    ds = install(path, source=src,
+                 result_xfm='datasets', return_type='item-or-list')
 
     assert_false(ds.repo.file_has_content("test-annex.dat"))
 


### PR DESCRIPTION
```
In order to resolve globbed paths within a subdataset, the subdataset
needs to be installed.  To do so, use the following procedure: install
the subdirectories returned by the longest *matched* pattern and then
glob again, stopping when no new paths are globbed.

[...]
```

This pull request fixes #2789.
