### PR TITLE
BF: run: Escape each input/output before formatting command string

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -103,7 +103,9 @@ class Run(Interface):
     the command is given as a list but not when it is given as a string. This
     means that the string form is required if you need to pass each input as a
     separate argument to a preceding script (i.e., write the command as
-    "./script {inputs}", quotes included).
+    "./script {inputs}", quotes included). The string form should also be used
+    if the input or output paths contain spaces or other characters that need
+    to be escaped.
     << REFLOW ||
 
     To escape a brace character, double it (i.e., "{{" or "}}").
@@ -372,7 +374,7 @@ def format_command(command, **kwds):
         io_val = kwds.pop(name, None)
         if not isinstance(io_val, GlobbedPaths):
             io_val = GlobbedPaths(io_val, pwd=kwds.get("pwd"))
-        kwds[name] = io_val.expand(dot=False)
+        kwds[name] = list(map(shlex_quote, io_val.expand(dot=False)))
     return sfmt.format(command, **kwds)
 
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -898,13 +898,11 @@ def test_inputs_spaces(path):
     cmd_str = "{} -c \"{}\" {{inputs}} {{outputs[0]}}".format(
         sys.executable, cmd)
     ds.run(cmd_str, inputs=["*.txt"], outputs=["out0"])
-    ok_file_has_content(opj(path, "out0"), "bar.txt!foo blah.txt!out0",
-                        strip=True)
+    ok_file_has_content(opj(path, "out0"), "bar.txt!foo blah.txt!out0")
     # ... but the list form of a command does not.
     cmd_list = [sys.executable, "-c", cmd, "{inputs}", "{outputs[0]}"]
     ds.run(cmd_list, inputs=["*.txt"], outputs=["out0"])
-    ok_file_has_content(opj(path, "out0"), "bar.txt foo!blah.txt!out0",
-                        strip=True)
+    ok_file_has_content(opj(path, "out0"), "bar.txt foo!blah.txt!out0")
 
 
 @with_tree(tree={"1.txt": "",


### PR DESCRIPTION
```
Our processing of inputs and outputs is broken for paths with
spaces.  Take the inputs "foo blah.txt" and "bar.txt", and the run

  $ datalad run --input="a" --input="b c" CMD

If CMD is a string (e.g., "./script {inputs}"), then the formatted run
command is ultimately "./script a b c" rather than "./script a 'b c'"
because the individual inputs aren't quoted.

On the other hand, if CMD is a list (no quotes), the list is first
converted to the string form of "./script '{inputs}'" (see 9c3a65e3d)
and ultimately "./script 'a b c'".

Quote each input and output so that paths with spaces work with the
string form.  This won't work with the list form because {inputs} is
surrounded by quotes, but at least one form will work reliably.
```

Note: This has a trivial merge conflict with #2796.
