### PR TITLE
BF(py2): Fix unicode/bytestring mismatch

### DIFF
--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -66,6 +66,7 @@ tree_arg = dict(tree={'test.txt': 'some',
                       'test_annex.txt': 'some annex',
                       'test1.dat': 'test file 1',
                       'test2.dat': 'test file 2',
+                      OBSCURE_FILENAME: 'blobert',
                       'dir': {'testindir': 'someother',
                               OBSCURE_FILENAME: 'none'},
                       'dir2': {'testindir3': 'someother3'}})

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -35,6 +35,7 @@ import json
 from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
 from datalad.utils import path_startswith
 from datalad.utils import path_is_subpath
+from datalad.utils import assure_unicode
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import IncompleteResultsError
 from datalad import cfg as dlcfg
@@ -217,7 +218,7 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
     filematch = False
     if isdir(basepath):
         for p in listdir(basepath):
-            p = opj(basepath, p)
+            p = assure_unicode(opj(basepath, p))
             if not isdir(p):
                 if p in targetpaths:
                     filematch = True


### PR DESCRIPTION
```
Under Python 2, running the new test---where OBSCURE_FILENAME is in
the top-level rather than a subdirectory---will trigger the following
warning:

   [...]/interface/utils.py:222: UnicodeWarning: Unicode equal
   comparison failed to convert both arguments to Unicode -
   interpreting them as being unequal
     if p in targetpaths:

This happens because os.listdir returns a list of bytestrings on
Python 2, but targetpaths is a list of unicode strings.
(discover_dataset_trace_to_targets has three callers, add.py, save.py,
and aggregate.py, and they all pass a list of unicode strings for
targetpaths.)
```

This pull request fixes the issue mentioned in 48d3b09d7 (TST: run: Extend test_inputs_spaces with OBSCURE_FILENAME, 2018-09-07).
