### PR TITLE
ENH: download_url: Normalize reported destination path 

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -115,9 +115,9 @@ class DownloadURL(Interface):
             return
 
         if dataset:  # A dataset was explicitly given.
-            path = op.join(ds.path, path or op.curdir)
+            path = op.normpath(op.join(ds.path, path or op.curdir))
         elif ds:
-            path = op.join(ds.path, rel_pwd, path or op.curdir)
+            path = op.normpath(op.join(ds.path, rel_pwd, path or op.curdir))
         elif not path:
             path = op.curdir
 

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -22,7 +22,6 @@ from ...tests.utils import ok_, ok_exists, eq_, assert_cwd_unchanged, \
     with_tempfile
 from ...tests.utils import with_tree
 from ...tests.utils import serve_path_via_http
-from ...tests.utils import known_failure_direct_mode
 
 
 def test_download_url_exceptions():


### PR DESCRIPTION
```
Avoid the ugly "path/." and "path/./." that can happen when rel_pwd
and op.curdir are ".".
```

Closes #2802.
