### PR TITLE
BFs and RF (Windows): more precommits etc to avoid operation on held up files/directories

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -220,6 +220,8 @@ def teardown_package():
         os.environ['DATALAD_DATASETS_TOPURL'] = _test_states['DATASETS_TOPURL_ENV']
     consts.DATASETS_TOPURL = _test_states['DATASETS_TOPURL']
 
+    from datalad.support.cookies import cookies_db
+    cookies_db.close()
     from datalad.support.annexrepo import AnnexRepo
     AnnexRepo._ALLOW_LOCAL_URLS = False  # stay safe!
 

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -11,7 +11,7 @@
 
 from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 
 
 import os
@@ -304,7 +304,7 @@ def test_saving_prior(topdir):
     assert_in('ds2', ds1.subdatasets(result_xfm='relpaths'))
 
 
-@skip_if_on_windows  # https://github.com/datalad/datalad/issues/2606
+@known_failure_windows  # https://github.com/datalad/datalad/issues/2606
 @with_tempfile(mkdir=True)
 def test_create_withprocedure(path):
     # first without
@@ -325,7 +325,7 @@ def test_create_withprocedure(path):
 
 # Skipping on Windows due to lack of MagicMime support:
 # https://github.com/datalad/datalad/pull/2770#issuecomment-415842284
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_create_text_no_annex(path):
     ds = create(path, text_no_annex=True)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -30,7 +30,7 @@ from datalad.tests.utils import SkipTest
 from datalad.tests.utils import with_tempfile, assert_in, with_tree, with_testrepos
 from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import assert_raises
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import PathOutsideRepositoryError
 
@@ -151,7 +151,7 @@ def test_repo_cache(path):
     assert_true(isinstance(ds.repo, AnnexRepo))
 
 
-@skip_if_on_windows  # leaves modified .gitmodules behind
+@known_failure_windows  # leaves modified .gitmodules behind
 @with_tempfile(mkdir=True)
 def test_subdatasets(path):
     # from scratch

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -166,7 +166,7 @@ def _parse_git_diff(dspath, diff_thingie=None, paths=None,
                 status='impossible',
                 message=e.stderr.strip())
             return
-        raise e
+        raise
 
     ap = None
     for line in stdout.split('\0'):

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -394,6 +394,7 @@ class TestAddArchiveOptions():
 
     def teardown(self):
         assert_equal(self.pwd, getpwd())
+        self.annex.precommit()  # so we close any outstanding batch process etc
         rmtemp(self.annex.path)
 
     def test_add_delete(self):

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -25,7 +25,7 @@ from datalad.distribution.dataset import Dataset
 from datalad.api import diff
 from datalad.interface.diff import _parse_git_diff
 from datalad.consts import PRE_INIT_COMMIT_SHA
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
@@ -36,7 +36,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 
 
-@skip_if_on_windows
+@known_failure_windows
 def test_magic_number():
     # we hard code the magic SHA1 that represents the state of a Git repo
     # prior to the first commit -- used to diff from scratch to a specific

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -75,7 +75,8 @@ def test_fs_traverse(topdir):
     for recursive in [True, False]:
         # test fs_traverse in display mode
         with swallow_logs(new_level=logging.INFO) as log, swallow_outputs() as cmo:
-            fs = fs_traverse(topdir, AnnexRepo(topdir), recurse_directories=recursive, json='display')
+            repo = AnnexRepo(topdir)
+            fs = fs_traverse(topdir, repo, recurse_directories=recursive, json='display')
             if recursive:
                 # fs_traverse logs should contain all not ignored subdirectories
                 for subdir in [opj(topdir, 'dir'), opj(topdir, 'dir', 'subdir')]:
@@ -89,10 +90,12 @@ def test_fs_traverse(topdir):
             # dir type child's size currently has no metadata file for traverser to pick its size from
             # and would require a recursive traversal w/ write to child metadata file mode
             assert_equal(child['size']['total'], {True: '6 Bytes', False: '0 Bytes'}[recursive])
+            repo.precommit()  # to possibly stop batch process occupying the stdout
 
     for recursive in [True, False]:
         # run fs_traverse in write to json 'file' mode
-        fs = fs_traverse(topdir, AnnexRepo(topdir), recurse_directories=recursive, json='file')
+        repo = AnnexRepo(topdir)
+        fs = fs_traverse(topdir, repo, recurse_directories=recursive, json='file')
         # fs_traverse should return a dictionary
         assert_equal(isinstance(fs, dict), True)
         # not including git and annex folders

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -59,7 +59,7 @@ from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import assert_in_results
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import ignore_nose_capturing_stdout
 from datalad.tests.utils import slow
 from datalad.tests.utils import with_testrepos
@@ -78,7 +78,7 @@ def test_invalid_call(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_basics(path, nodspath):
@@ -152,7 +152,7 @@ def test_basics(path, nodspath):
 
 @slow  # 17.1880s
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
@@ -241,7 +241,7 @@ def test_rerun_empty_branch(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
@@ -308,7 +308,7 @@ def test_rerun_onto(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_chain(path):
     ds = Dataset(path).create()
@@ -330,7 +330,7 @@ def test_rerun_chain(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_old_flag_compatibility(path):
     ds = Dataset(path).create()
@@ -347,7 +347,7 @@ def test_rerun_old_flag_compatibility(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_v6  #FIXME
 def test_rerun_just_one_commit(path):
@@ -384,7 +384,7 @@ def test_rerun_just_one_commit(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_run_failure(path):
     ds = Dataset(path).create()
@@ -421,7 +421,7 @@ def test_run_failure(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 def test_rerun_branch(path):
@@ -474,7 +474,7 @@ def test_rerun_branch(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
@@ -493,7 +493,7 @@ def test_rerun_cherry_pick(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_outofdate_tree(path):
     ds = Dataset(path).create()
@@ -512,7 +512,7 @@ def test_rerun_outofdate_tree(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_v6  #FIXME
 def test_rerun_ambiguous_revision_file(path):
@@ -617,7 +617,7 @@ def test_new_or_modified(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_script(path):
     ds = Dataset(path).create()
@@ -657,7 +657,7 @@ def test_rerun_script(path):
 
 @slow  # ~10s
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tree(tree={"test-annex.dat": "content",
                  "s0": {"s1_0": {"s2": {"a.dat": "a",
                                         "b.txt": "b"}},
@@ -805,7 +805,7 @@ def test_run_inputs_outputs(src, path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_run_inputs_no_annex_repo(path):
     ds = Dataset(path).create(no_annex=True)
@@ -817,7 +817,7 @@ def test_run_inputs_no_annex_repo(path):
 
 @slow  # ~10s
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_run_explicit(path):
     ds = Dataset(path)
@@ -863,7 +863,7 @@ def test_run_explicit(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @known_failure_v6  #FIXME
 @with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c",
                  "subdir": {}})
@@ -921,7 +921,7 @@ def test_placeholders(path):
 
 
 @ignore_nose_capturing_stdout
-@skip_if_on_windows
+@known_failure_windows
 @with_tree(tree={OBSCURE_FILENAME + u".t": "obscure",
                  "bar.txt": "b",
                  "foo blah.txt": "f"})

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -17,7 +17,7 @@ import os.path as op
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_true
@@ -33,7 +33,7 @@ def test_invalid_call():
     assert_raises(InsufficientArgumentsError, run_procedure)
 
 
-@skip_if_on_windows
+@known_failure_windows
 #@ignore_nose_capturing_stdout
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -42,7 +42,7 @@ from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_values_equal
 from datalad.tests.utils import skip_v6
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
@@ -338,7 +338,7 @@ def test_subdataset_save(path):
     ok_clean_git(parent.path, untracked=['untracked'])
 
 
-@skip_if_on_windows  # gh-2536
+@known_failure_windows  # gh-2536
 @with_tempfile(mkdir=True)
 def test_symlinked_relpath(path):
     # initially ran into on OSX https://github.com/datalad/datalad/issues/2406

--- a/datalad/support/cookies.py
+++ b/datalad/support/cookies.py
@@ -57,6 +57,10 @@ class CookiesDB(object):
         except Exception as exc:
             lgr.warning("Failed to open cookies DB %s: %s", filename, exc_str(exc))
 
+    def close(self):
+        if self._cookies_db:
+            self._cookies_db.close()
+
     def _get_provider(self, url):
         if self._cookies_db is None:
             self._load()

--- a/datalad/support/locking.py
+++ b/datalad/support/locking.py
@@ -98,6 +98,6 @@ def lock_if_check_fails(
     finally:
         if lock.acquired:
             lgr.debug("Releasing lock %s", lock_filename)
+            lock.release()
             if exists(lock_filename):
                 unlink(lock_filename)
-            lock.release()

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -446,7 +446,7 @@ class SSHManager(object):
             self._connections[ctrl_path] = c
             return c
 
-    def close(self, allow_fail=True):
+    def close(self, allow_fail=True, ctrl_path=None):
         """Closes all connections, known to this instance.
 
         Parameters
@@ -454,13 +454,19 @@ class SSHManager(object):
         allow_fail: bool, optional
           If True, swallow exceptions which might be thrown during
           connection.close, and just log them at DEBUG level
+        ctrl_path: str or list of str, optional
+          If specified, only the path(s) provided would be considered
         """
         if self._connections:
+            from datalad.utils import assure_list
+            ctrl_paths = assure_list(ctrl_path)
             to_close = [c for c in self._connections
                         # don't close if connection wasn't opened by SSHManager
                         if self._connections[c].ctrl_path
                         not in self._prev_connections and
-                        exists(self._connections[c].ctrl_path)]
+                        exists(self._connections[c].ctrl_path)
+                        and (not ctrl_paths
+                             or self._connections[c].ctrl_path in ctrl_paths)]
             if to_close:
                 lgr.debug("Closing %d SSH connections..." % len(to_close))
             for cnct in to_close:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2010,7 +2010,7 @@ def _test_status(ar):
 
     # remove a submodule:
     # rm; git rm; git commit
-    sub.precommit()  # Do precommit so there is not active batched processes etc
+    sub.precommit()  # Do precommit so there are not active batched processes etc
     from datalad.utils import rmtree
     rmtree(opj(ar.path, 'submod'))
     stat['deleted'].append('submod')

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -399,6 +399,7 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
             eq_(ar.info('nonexistent-batch', batch=True), None)
             eq_(cmo.out, '')
             eq_(cmo.err, '')
+            ar.precommit()  # to stop all the batched processes for swallow_outputs
 
     # annex repo info
     repo_info = ar.repo_info(fast=False)
@@ -1010,6 +1011,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
         eq_(len(ar2._batched), 0)
         ar2.add_url_to_file(filename, testurl, batch=True)
         eq_(len(ar2._batched), 1)  # we added one more with batch_size=1
+        ar2.precommit()  # to possibly stop batch process occupying the stdout
     ar2.commit("added new file")  # would do nothing ATM, but also doesn't fail
     assert_in(filename, ar2.get_files())
     assert_in(ar.WEB_UUID, ar2.whereis(filename))

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1111,7 +1111,6 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
         ok_(not exists(socket_1))
 
     from datalad import lgr
-    lgr.debug("HERE")
     # remote interaction causes socket to be created:
     try:
         # Note: For some reason, it hangs if log_stdout/err True
@@ -1165,7 +1164,7 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
             pass
 
     ok_(exists(socket_2))
-
+    ssh_manager.close(ctrl_path=[socket_1, socket_2])
 
 @with_testrepos('basic_annex', flavors=['clone'])
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2010,6 +2010,7 @@ def _test_status(ar):
 
     # remove a submodule:
     # rm; git rm; git commit
+    sub.precommit()  # Do precommit so there is not active batched processes etc
     from datalad.utils import rmtree
     rmtree(opj(ar.path, 'submod'))
     stat['deleted'].append('submod')

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -855,7 +855,7 @@ def test_GitRepo_git_get_branch_commits(src):
     eq_([commits[0].hexsha], commits_hexsha)
     # our unittest is rudimentary ;-)
     eq_(commits_hexsha_left, commits_hexsha)
-
+    repo.precommit()  # to stop all the batched processes for swallow_outputs
     raise SkipTest("TODO: Was more of a smoke test -- improve testing")
 
 

--- a/datalad/support/tests/test_path.py
+++ b/datalad/support/tests/test_path.py
@@ -7,11 +7,13 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+import os
 from ..path import (
     abspath,
     curdir,
     robust_abspath,
 )
+from ...dochelpers import exc_str
 from ...utils import (
     chpwd,
     rmtree,
@@ -20,6 +22,7 @@ from ...tests.utils import (
     assert_raises,
     eq_,
     with_tempfile,
+    SkipTest,
 )
 
 
@@ -27,6 +30,14 @@ from ...tests.utils import (
 def test_robust_abspath(tdir):
     with chpwd(tdir):
         eq_(robust_abspath(curdir), tdir)
-        rmtree(tdir)
+        try:
+            if os.environ.get('DATALAD_ASSERT_NO_OPEN_FILES'):
+                raise Exception("cannot test under such pressure")
+            rmtree(tdir)
+        except Exception as exc:
+            # probably windows or above exception
+            raise SkipTest(
+                "Cannot test in current environment: %s" % exc_str(exc))
+
         assert_raises(OSError, abspath, curdir)
         eq_(robust_abspath(curdir), tdir)

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -82,6 +82,7 @@ def test_proxying_open_testrepobased(repo):
         # DATALAD_ASSERT_NO_OPEN_FILES mode on.  Reason is not 100% clear
         # on why underlying git-annex process would be dumping to stdout or err
         #with swallow_outputs():
+
         # now we should be able just to request to open this file
         with open(fpath2) as f:
             content = f.read()

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -78,11 +78,14 @@ def test_proxying_open_testrepobased(repo):
     with AutomagicIO() as aio:
         ok_(isinstance(aio, AutomagicIO))
         ok_(aio.active)
-        with swallow_outputs():
-            # now we should be able just to request to open this file
-            with open(fpath2) as f:
-                content = f.read()
-                eq_(content, TEST_CONTENT)
+        # swallowing output would cause trouble while testing with
+        # DATALAD_ASSERT_NO_OPEN_FILES mode on.  Reason is not 100% clear
+        # on why underlying git-annex process would be dumping to stdout or err
+        #with swallow_outputs():
+        # now we should be able just to request to open this file
+        with open(fpath2) as f:
+            content = f.read()
+            eq_(content, TEST_CONTENT)
 
     annex.drop(fpath2)
     assert_raises(IOError, open, fpath2)

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -63,6 +63,9 @@ def test_logging_to_a_file(dst):
         regex += ' RSS/VMS: \S+/\S+( \S+)?\s*'
     regex += "(\s+\S+\s*)? " + msg
     assert_re_in(regex, line, match=True)
+    # Close all handlers so windows is happy -- apparently not closed fast enough
+    for handler in lgr.handlers:
+        handler.close()
 
 
 @with_tempfile

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -92,6 +92,9 @@ def test_mutliple_targets(dst1, dst2):
             lines = f.readlines()
         assert_equal(len(lines), 1, "Read more than a single log line: %s" %  lines)
         ok_(msg in lines[0])
+    # Close all handlers so windows is happy -- apparently not closed fast enough
+    for handler in lgr.handlers:
+        handler.close()
 
 
 def check_filters(name):

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -142,7 +142,7 @@ def test_rotree(d):
     # so explicit 'or'
     if not (ar.is_crippled_fs() or (os.getuid() == 0)):
         assert_raises(OSError, os.unlink, f)          # OK to use os.unlink
-        assert_raises(OSError, unlink, f, ntimes=10)  # and even with waiting and trying!
+        assert_raises(OSError, unlink, f)   # and even with waiting and trying!
         assert_raises(OSError, shutil.rmtree, d)
         # but file should still be accessible
         with open(f) as f_:

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -986,6 +986,24 @@ def known_failure_direct_mode(func):
     return func
 
 
+def known_failure_windows(func):
+    """Test decorator marking a test as known to fail on windows
+
+    On Windows behaves like `known_failure`.
+    Otherwise the original (undecorated) function is returned.
+    """
+    if on_windows:
+
+        @known_failure
+        @wraps(func)
+        @attr('known_failure_windows')
+        @attr('windows')
+        def dm_func(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return dm_func
+    return func
+
 # ### ###
 # END known failure decorators
 # ### ###

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1623,6 +1623,7 @@ def try_multiple_dec(f, ntrials=None, duration=0.1, exceptions=None, increment_t
     ----------
     ntrials: int, optional
     duration: float, optional
+      Seconds to sleep before retrying.
     increment_type: {None, 'exponential'}
       Note that if it is exponential, duration should typically be > 1.0
       so it grows with higher power

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -338,7 +338,7 @@ def rmtree(path, chmod_files='auto', children_only=False, *args, **kwargs):
         return
     if not (os.path.islink(path) or not os.path.isdir(path)):
         rotree(path, ro=False, chmod_files=chmod_files)
-        shutil.rmtree(path, *args, **kwargs)
+        _rmtree(path, *args, **kwargs)
     else:
         # just remove the symlink
         unlink(path)
@@ -1672,6 +1672,17 @@ def unlink(f):
     return os.unlink(f)
 
 
+@try_multiple_dec
+def _rmtree(*args, **kwargs):
+    """Just a helper to decorate solely shutil.rmtree.
+
+    rmtree defined above does more and ideally should not itself be decorated
+    since a recursive definition and does checks for open files inside etc -
+    might be too runtime expensive
+    """
+    return shutil.rmtree(*args, **kwargs)
+
+
 def slash_join(base, extension):
     """Join two strings with a '/', avoiding duplicate slashes
 
@@ -1962,7 +1973,7 @@ def create_tree_archive(path, name, load, overwrite=False, archives_leading_dir=
                        path=op.join(path, dirname),
                        overwrite=overwrite)
     # remove original tree
-    shutil.rmtree(full_dirname)
+    rmtree(full_dirname)
 
 
 def create_tree(path, tree, archives_leading_dir=True):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -326,7 +326,10 @@ def rmtree(path, chmod_files='auto', children_only=False, *args, **kwargs):
     # Give W permissions back only to directories, no need to bother with files
     if chmod_files == 'auto':
         chmod_files = on_windows
-
+    # TODO:  yoh thinks that if we could quickly check our Flyweight for
+    #        repos if any of them is under the path, and could call .precommit
+    #        on those to possibly stop batched processes etc, we did not have
+    #        to do it on case by case
     # Check for open files
     assert_no_open_files(path)
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1677,7 +1677,7 @@ def unlink(f):
 
 @try_multiple_dec
 def _rmtree(*args, **kwargs):
-    """Just a helper to decorate solely shutil.rmtree.
+    """Just a helper to decorate shutil.rmtree.
 
     rmtree defined above does more and ideally should not itself be decorated
     since a recursive definition and does checks for open files inside etc -

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -432,34 +432,6 @@ def rmtemp(f, *args, **kwargs):
         lgr.info("Keeping temp file: %s" % f)
 
 
-def unlink(f, ntimes=None, sleep_duration=0.1):
-    """'Robust' unlink.  Would try multiple times
-
-    On windows boxes there is evidence for a latency of more than a second
-    until a file is considered no longer "in-use".
-    WindowsError is not known on Linux, and if IOError or any other exception
-    is thrown then if except statement has WindowsError in it -- NameError
-    also see gh-2533
-    """
-    exceptions = (OSError, WindowsError, PermissionError) \
-        if on_windows else OSError
-    if not ntimes:
-        # Life goes fast on proper systems, no need to delay it much
-        ntimes = 50 if on_windows else 3
-    # Check for open files
-    assert_no_open_files(f)
-    for i in range(ntimes):
-        try:
-            os.unlink(f)
-        except exceptions:
-            if i < ntimes - 1:
-                sleep(sleep_duration)
-                continue
-            else:
-                raise
-        break
-
-
 def file_basename(name, return_ext=False):
     """
     Strips up to 2 extensions of length up to 4 characters and starting with alpha
@@ -1620,6 +1592,7 @@ def get_dataset_pwds(dataset):
     return pwd, rel_pwd
 
 
+# ATM used in datalad_crawler extension, so do not remove yet
 def try_multiple(ntrials, exception, base, f, *args, **kwargs):
     """Call f multiple times making exponentially growing delay between the calls"""
     from .dochelpers import exc_str
@@ -1633,6 +1606,70 @@ def try_multiple(ntrials, exception, base, f, *args, **kwargs):
             lgr.warning("Caught %s on trial #%d. Sleeping %f and retrying",
                         exc_str(exc), trial, t)
             sleep(t)
+
+
+@optional_args
+def try_multiple_dec(f, ntrials=None, duration=0.1, exceptions=None, increment_type=None):
+    """Decorator to try function multiple times.
+
+    Main purpose is to decorate functions dealing with removal of files/directories
+    and which might need a few seconds to work correctly on Windows which takes
+    its time to release files/directories.
+
+    Parameters
+    ----------
+    ntrials: int, optional
+    duration: float, optional
+    increment_type: {None, 'exponential'}
+      Note that if it is exponential, duration should typically be > 1.0
+      so it grows with higher power
+
+    """
+    from .dochelpers import exc_str
+    if not exceptions:
+        exceptions = (OSError, WindowsError, PermissionError) \
+            if on_windows else OSError
+    if not ntrials:
+        # Life goes fast on proper systems, no need to delay it much
+        ntrials = 50 if on_windows else 3
+
+    assert increment_type in {None, 'exponential'}
+
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        t = duration
+        for trial in range(ntrials):
+            try:
+                return f(*args, **kwargs)
+            except exceptions as exc:
+                if increment_type == 'exponential':
+                    t = duration ** (trial + 1)
+                lgr.log(
+                    5,
+                    "Caught %s on trial #%d. Sleeping %f and retrying",
+                    exc_str(exc), trial, t)
+                if trial < ntrials - 1:
+                    sleep(t)
+                else:
+                    raise
+
+    return wrapped
+
+
+@try_multiple_dec
+def unlink(f):
+    """'Robust' unlink.  Would try multiple times
+
+    On windows boxes there is evidence for a latency of more than a second
+    until a file is considered no longer "in-use".
+    WindowsError is not known on Linux, and if IOError or any other
+    exception
+    is thrown then if except statement has WindowsError in it -- NameError
+    also see gh-2533
+    """
+    # Check for open files
+    assert_no_open_files(f)
+    return os.unlink(f)
 
 
 def slash_join(base, extension):


### PR DESCRIPTION
This is absorbed from #2791 which keeps running all the tests under windows.

Notable change is that we should start using `@known_failure_windows` for the tests which potentially should work on Windows.
