### PR TITLE
CHANGELOG.md: Start adding entries for v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ This is a high level and scarce summary of the changes between releases.
 We would recommend to consult log of the 
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
+## master (unreleased)
+
+### Fixes
+
+- The `datalad save` instructions shown by `datalad run` for a command
+  with a non-zero exit were incorrectly formatted. (#2692)
+- Decompression of zip files (e.g., through `datalad
+  add-archive-content`) failed on Python 3.  (#2702)
+- On Windows, colored log output was not being processed by colorama.  (#2707)
+- Parsing of combined short options has been broken since DataLad
+  v0.10.0. (#2710)
+- Internal git fetch calls have been updated to work around a
+  GitPython issue.  (#2712, #2794)
+- The progess bar for annex file transferring was unable to handle an
+  empty file.  (#2717)
+- `datalad add-readme` halted when no aggregated metadata was found
+  rather than displaying a warning.  (#2731)
+- `datalad rerun` failed if `--onto` was specified and the history
+  contained no run commits.  (#2761)
+- Processing of a command's results failed on a result record with a
+  missing value (e.g., absent field or subfield in metadata).  Now the
+  missing value is rendered as "N/A".  (#2725).
+- A couple of documentation links in the "Delineation from related
+  solutions" were misformatted.  (#2773)
+- With the latest git-annex, several known V6 failures are no longer
+  an issue.  (#2777)
+- In direct mode, commit changes would often commit annexed content as
+  regular Git files.  A new approach fixes this and resolves a good
+  number of known failures.  (#2770)
+- The reporting of command results failed if the current working
+  directory was removed (e.g., after an unsuccessful `install`). (#2788)
+- When installing into an existing empty directory, `datalad install`
+  removed the directory after a failed clone.  (#2788)
+- `datalad run` incorrectly handled inputs and outputs for paths with
+  spaces and other characters that require shell escaping.  (#2798)
+- Globbing inputs and outputs for `datalad run` didn't work correctly
+  if a subdataset wasn't installed.  (#2796)
+
+### Enhancements and new features
+
+- The documentation on how to format commands for `datalad run` has
+  been improved.  (#2703)
+- The method for determining the current working directory on Windows
+  has been improved.  (#2707)
+- `datalad --version` now simply shows the version without the
+  license.  (#2733)
+- `datalad export-archive` learned to export under an existing
+  directory via its `--filename` option.  (#2723)
+- `datalad export-to-figshare` now generates the zip archive in the
+  root of the dataset unless `--filename` is specified.  (#2723)
+- After importing `datalad.api`, `help(datalad.api)` (or
+  `datalad.api?` in IPython) now shows a summary of the available
+  DataLad commands.  (#2728)
+- Support for using `datalad` from IPython has been improved.  (#2722)
+- `datalad wtf` now returns structured data and reports the version of
+  each extension.  (#2741)
+- Metadata: changes to egrep mode search  (#2735)
+  - Queries in egrep mode are now case-sensitive when the query
+    contains any uppercase letters and are case-insensitive otherwise.
+    The new mode egrepcs can be used to perform a case-sensitive query
+    with all lower-case letters.
+  - Search can now be limited to a specific key.
+  - Multiple queries (list of expressions) are evaluated using AND to
+    determine whether something is a hit.
+  - A single multi-field query (e.g., `pa*:findme`) is a hit, when any
+    matching field matches the query.
+  - All matching key/value combinations across all (multi-field)
+    queries are reported in the query_matched result field.
+  - egrep mode now shows all hits rather than limiting the results to
+    the top 20 hits.
+- The internal handling of gitattributes information has been
+  improved.  A user-visible consequence is that `datalad create
+  --force` no longer duplicates existing attributes.  (#2744)
+- The "annex" metadata extractor can now be used even when no content
+  is present.  (#2724)
+- The `add_url_to_file` method (called by commands like `datalad
+  download-url` and `datalad add-archive-content`) learned how to
+  display a progress bar.  (#2738)
+- Anonymous access is now supported for S3 and other downloaders.  (#2708)
+- A new interface is available to ease setting up new providers.  (#2708)
+- More codepaths now try multiple times when removing a file to deal
+  with latency and locking issues on Windows.  (#2795)
+
 ## 0.10.2 (Jul 09, 2018) -- Thesecuriestever
 
 Primarily a bugfix release to accommodate recent git-annex release


### PR DESCRIPTION
There are still some missing entries or at least entries that should be consider (look for `?` below) or entries that have been added to some degree but may be incomplete (look for `+*` below).  Please add or tweak as you see fit.

```
# Generated with
#   git log --format="?  %s%n   %h^-1" --reverse --first-parent 0.10.2..origin/master
#
#
# ?  = unprocessed and undecided
# -  = decided not to include
# +  = included
# +* = included, but might still be bits that should be added

---

-  Merge branch 'bf-py37'
   db6bb0dd7^-1
+  Merge pull request #2692 from kyleam/bf-run-failmsg
   3108eb90b^-1
-  Merge pull request #2686 from kyleam/enh-commanderror-rendering
   64f6e5bca^-1
-  Bump Singularity container version
   e6750ec7f^-1
-  Merge pull request #2697 from yarikoptic/enh-cleanup
   cf78c1880^-1
-  Merge pull request #2674 from kyleam/doc-revise-remove
   79df5a442^-1
+  Merge pull request #2702 from kyleam/bf-archive-zip
   8540bb22e^-1
+  Merge pull request #2703 from kyleam/doc-run-cmd-str
   b29581e7c^-1
+* Merge pull request #2707 from yarikoptic/bf-win
   1e1336f34^-1
+  Merge pull request #2710 from kyleam/bf-short-opt
   36853566a^-1
+  Merge pull request #2712 from yarikoptic/enh-gitpy-debug
   7fd9e00ef^-1
+  Merge pull request #2717 from yarikoptic/bf-zerofile
   cce8cf509^-1
+  Merge pull request #2733 from yarikoptic/rf-nolicense
   4b294fef0^-1
+  Merge pull request #2723 from yarikoptic/bf-export
   55881e747^-1
-  DOC: Fix a docstring typo
   cdb223390^-1
+  Merge pull request #2728 from kyleam/doc-api-commands
   dc68aca0a^-1
+* Merge pull request #2722 from yarikoptic/bf-ipython
   ca8dfdd52^-1
+  Merge pull request #2731 from mih/bf-errorhandling
   0690615c8^-1
+  Merge pull request #2741 from mih/enh-wtf
   9c8a9a184^-1
-  Merge pull request #2748 from kyleam/tst-pin-grunt
   2ef86ea74^-1
-  travis: Add a comment about grunt-contrib-qunit pinning
   cd6e2b424^-1
+* Merge pull request #2735 from mih/enh-search
   fcaac41fc^-1
+  Merge pull request #2744 from mih/enh-attributes
   3bcc58fa4^-1
-  Merge pull request #2751 from mih/bf-deprecation
   d0d332c9b^-1
?  Merge pull request #2756 from mih/master
   aaf0a36c3^-1
?  Merge pull request #2757 from akeshavan/css_fix
   063b03b37^-1
-  Merge pull request #2758 from mih/master
   90d18e325^-1
+  Merge pull request #2761 from kyleam/bf-rerun-empty-results
   61ce1c1f4^-1
+  Merge pull request #2724 from yarikoptic/enh-search2
   559b69495^-1
+  Merge pull request #2725 from yarikoptic/enh-format-output
   7a3ead793^-1
+  Merge pull request #2738 from yarikoptic/enh-progress-addurl
   0287e70fd^-1
-  Merge pull request #2749 from mih/rf-generator
   2517f6146^-1
?  Merge pull request #2759 from mih/enh-metadata
   41a663cb3^-1
+  Merge pull request #2773 from jhpoelen/patch-1
   1a5f167d7^-1
-  Merge pull request #2775 from kyleam/tst-pin-sphinx
   4f01e5841^-1
-  Merge pull request #2776 from kyleam/tst-unpin-grunt-contrib-qunit
   e33aa3a08^-1
+  Merge pull request #2777 from yarikoptic/enh-direct
   410f20a7f^-1
+* Merge pull request #2770 from yarikoptic/bf-direct-mode
   2ebfddde0^-1
-  Merge pull request #2785 from kyleam/tst-unpin-sphinx
   8dd4a6db1^-1
-  Merge pull request #2784 from kyleam/tst-unskip-more-direct
   7ce110089^-1
+*  Merge pull request #2708 from yarikoptic/enh-s3
   adb83d1d2^-1
-  ENH(TST): remove @known_failure_v6 which were resolved by 6.20180807+git142-g1a08a8613-1~ndall+1
   6b8295270^-1
+  Merge pull request #2788 from yarikoptic/bf-subdirinstall
   f93c5c09f^-1
-  Merge pull request #2790 from yarikoptic/enh-v6-appveyor
   1d0d0cbc5^-1
+  Merge pull request #2794 from yarikoptic/bf-badname
   5e5967775^-1
+*  Merge pull request #2795 from yarikoptic/bf-windows
   6dbfe309a^-1
-  ENH(TST): a disabled test to demonstrate compat issue between old git and new annex in v6
   9fa564c5f^-1
-  TST: Fix a typo in ok_clean_git's message
   e17fe5900^-1
-  Merge pull request #2804 from kyleam/enh-download-url-normalize
   e360812e9^-1
-  Merge pull request #2803 from kyleam/bf-listdirs-unicode
   a56fd101d^-1
+  Merge pull request #2798 from kyleam/bf-run-io-quote
   3a9945ac8^-1
+  Merge pull request #2796 from kyleam/bf-run-subds-glob
   3471a9bca^-1
-  ENH: tune up .mailmap and mkcontrib, adjust CONTRIBUTORS
   fb9bbe2a0^-1
-  ENH: add .noannex to avoid accidental git annex initification
   512441817^-1
```
