### PR TITLE
BF: remove trailing period while matching a mesage from git

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1189,7 +1189,7 @@ class GitRepo(RepoInterface):
                               "Ignored.".format(self))
                 else:
                     raise
-            elif "did not match any file(s) known to git." in e.stderr:
+            elif "did not match any file(s) known to git" in e.stderr:
                 # TODO: Improve FileNotInXXXXError classes to better deal with
                 # multiple files; Also consider PathOutsideRepositoryError
                 raise FileNotInRepositoryError(cmd=e.cmd,


### PR DESCRIPTION
with git 2.19 there is no trailing period in "did not match any file(s)"
