### PR TITLE
TST: Remove more @known_failure_v6

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test functioning of the datalad main cmdline utility """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import on_windows
 

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for customremotes archives providing dl+archive URLs handling"""
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -11,7 +11,6 @@
 
 
 from datalad.tests.utils import (
-    known_failure_v6,
     get_datasets_topdir,
     integration,
     slow

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import known_failure_windows
 
@@ -235,7 +234,6 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_nested_create(path):
     # to document some more organic usage pattern
     ds = Dataset(path).create()
@@ -271,7 +269,9 @@ def test_nested_create(path):
     # only way to make it work is to unannex the content upfront
     ds.repo._run_annex_command('unannex', annex_options=[opj(lvl2relpath, 'file')])
     # nothing to save, git-annex commits the unannex itself
-    assert_status('notneeded', ds.save())
+    assert_status(
+        'ok' if ds.repo.config.getint("annex", "version") == 6 else 'notneeded',
+        ds.save())
     # still nothing without force
     # "err='lvl1/lvl2' already exists in the index"
     assert_in_results(

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -10,7 +10,6 @@
 """
 
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 from os import curdir

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -246,7 +246,6 @@ def test_get_recurse_dirs(o_path, c_path):
 @slow  # 15.1496s
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_get_recurse_subdatasets(src, path):
 
     ds = install(

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -458,7 +458,6 @@ def test_remove_nowhining(path):
 
 
 @usecase
-@known_failure_v6  # https://github.com/datalad/datalad/pull/2391#issuecomment-379414293
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 @use_cassette('test_remove_recursive_2')

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -41,7 +41,6 @@ from datalad.tests.utils import slow
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -12,9 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_v6
-
-
 import logging
 import os
 from os import unlink

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -666,7 +666,6 @@ def test_rerun_script(path):
                         "ss": {"e.dat": "e"}}})
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_run_inputs_outputs(src, path):
     for subds in [("s0", "s1_0", "s2"),
                   ("s0", "s1_1", "s2"),

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -14,10 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-from datalad.tests.utils import (
-    known_failure_direct_mode,
-    known_failure_v6,
-)
+from datalad.tests.utils import known_failure_direct_mode
 
 import os.path as op
 from os.path import join as opj
@@ -244,7 +241,6 @@ def test_rerun_empty_branch(path):
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_rerun_onto(path):
     ds = Dataset(path).create()
 
@@ -349,7 +345,6 @@ def test_rerun_old_flag_compatibility(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_rerun_just_one_commit(path):
     ds = Dataset(path).create()
 
@@ -477,7 +472,6 @@ def test_rerun_branch(path):
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()
 
@@ -514,7 +508,6 @@ def test_rerun_outofdate_tree(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_v6  #FIXME
 def test_rerun_ambiguous_revision_file(path):
     ds = Dataset(path).create()
     ds.run('echo ambig > ambig')
@@ -526,7 +519,6 @@ def test_rerun_ambiguous_revision_file(path):
 
 
 @ignore_nose_capturing_stdout
-@known_failure_v6  #FIXME
 @with_tree(tree={"subdir": {}})
 def test_rerun_subdir(path):
     # Note: Using with_tree rather than with_tempfile is matters. The latter
@@ -863,7 +855,6 @@ def test_run_explicit(path):
 
 @ignore_nose_capturing_stdout
 @known_failure_windows
-@known_failure_v6  #FIXME
 @with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c",
                  "subdir": {}})
 def test_placeholders(path):

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -29,7 +29,6 @@ from datalad.tests.utils import chpwd
 from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import on_windows, skip_if
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import assert_status, assert_result_count, assert_in_results
 
 
@@ -66,7 +65,6 @@ def test_unlock_raises(path, path2, path3):
     chpwd(_cwd)
 
 
-@known_failure_v6  # FIXME: See TODOs in the comments below
 # Note: As root there is no actual lock/unlock.
 #       Therefore don't know what to test for yet.
 @skip_if(cond=not on_windows and os.geteuid() == 0)  # uid not available on windows


### PR DESCRIPTION
This follows up on the remaining V6 failues listed in https://github.com/datalad/datalad/pull/2782#issuecomment-417763061

The only remaining one is

https://github.com/datalad/datalad/blob/e8dfb0fdadbe16f24f381b963153e06831e7a4ac/datalad/support/tests/test_annexrepo.py#L1689-L1691

---

- [x] This change is complete
       Yes, but we should wait for the latest git-annex to be uploaded to neurodebian (~released and bump our dependency~ --- not necessary the issues are limited to v6).