### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+datalad (0.10.3-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 16:24:27 +0100
+
 datalad (0.10.3-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,7 @@ Build-Depends:
  python3-wrapt,
 Standards-Version: 4.1.4
 Homepage: http://datalad.org
-Vcs-Git: git://github.com/datalad/datalad -b debian
+Vcs-Git: https://github.com/datalad/datalad -b debian
 Vcs-Browser: https://github.com/datalad/datalad/
 
 Package: datalad


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
