### PR TITLE
BF: do not blow hard in python -O0 mode of operation

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -35,7 +35,8 @@ def _command_summary():
     return "\n".join(get_cmd_summaries(grp_short_descriptions, groups))
 
 
-__doc__ += "\n\n{}".format(_command_summary())
+if __debug__:
+    __doc__ += "\n\n{}".format(_command_summary())
 
 
 def _load_plugins():

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -487,7 +487,7 @@ def main(args=None):
         # run the function associated with the selected command
         run_via_pbs(args_, cmdlineargs.pbs_runner)
     elif has_func:
-        if cmdlineargs.common_debug or cmdlineargs.common_idebug:
+        if __debug__ and (cmdlineargs.common_debug or cmdlineargs.common_idebug):
             # so we could see/stop clearly at the point of failure
             setup_exceptionhook(ipython=cmdlineargs.common_idebug)
             from datalad.interface.base import Interface

--- a/datalad/cmdline/tests/test_formatters.py
+++ b/datalad/cmdline/tests/test_formatters.py
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover
 from ..main import setup_parser
 from datalad.tests.utils import ok_, assert_in, ok_startswith
 from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import assert_raises
 
 demo_example = """
 #!/bin/sh
@@ -96,8 +97,10 @@ def test_manpage_formatter():
 
     parsers = setup_parser(['datalad'], return_subparsers=True)
     for p in parsers:
-        mp = fmt.ManPageFormatter(
-            p, ext_sections=addonsections).format_man_page(parsers[p])
+        formatter = fmt.ManPageFormatter(p, ext_sections=addonsections)
+        if not __debug__:
+            continue
+        mp = formatter.format_man_page(parsers[p])
         for section in ('SYNOPSIS', 'NAME', 'OPTIONS', 'MYTEST'):
             assert_in('.SH {0}'.format(section), mp)
         assert_in('uniquedummystring', mp)
@@ -106,7 +109,10 @@ def test_manpage_formatter():
 def test_rstmanpage_formatter():
     parsers = setup_parser(['datalad'], return_subparsers=True)
     for p in parsers:
-        mp = fmt.RSTManPageFormatter(p).format_man_page(parsers[p])
+        formatter = fmt.RSTManPageFormatter(p)
+        if not __debug__:
+            continue
+        mp = formatter.format_man_page(parsers[p])
         for section in ('Synopsis', 'Description', 'Options'):
             assert_in('\n{0}'.format(section), mp)
         assert_in('{0}\n{1}'.format(p, '=' * len(p)), mp)

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -48,7 +48,8 @@ def get_git_version(runner):
 
 def _where_reload(obj):
     """Helper decorator to simplify providing repetitive docstring"""
-    obj.__doc__ = obj.__doc__ % _where_reload_doc
+    if __debug__:
+        obj.__doc__ = obj.__doc__ % _where_reload_doc
     return obj
 
 

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -124,6 +124,8 @@ def _split_out_parameters(initdoc):
     """
 
     # TODO: bind it to the only word in the line
+    if not initdoc:
+        return '', '', ''
     p_res = __parameters_str_re.search(initdoc)
     if p_res is None:
         return initdoc, "", ""

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -387,7 +387,7 @@ def build_doc(cls, **kwargs):
     lgr.debug("Building doc for {}".format(cls))
 
     cls_doc = cls.__doc__
-    if hasattr(cls, '_docs_'):
+    if hasattr(cls, '_docs_') and cls_doc:
         # expand docs
         cls_doc = cls_doc.format(**cls._docs_)
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -60,7 +60,8 @@ else:
         safe += '~'
         return _urlquote(url, safe=safe, **kwargs)
 
-    urlquote.__doc__ = _urlquote.__doc__ + """
+    if __debug__:
+        urlquote.__doc__ = _urlquote.__doc__ + """
 
 This DataLad version of the function assumes ~ to be a safe character to be
 consistent with Python >= 3.7

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -242,7 +242,10 @@ def find_files(regex, topdir=curdir, exclude=None, exclude_vcs=True, exclude_dat
             if exclude_datalad and re.search(_DATALAD_REGEX, path):
                 continue
             yield path
-find_files.__doc__ %= (_VCS_REGEX, _DATALAD_REGEX)
+
+
+if __debug__:
+    find_files.__doc__ %= (_VCS_REGEX, _DATALAD_REGEX)
 
 
 def expandpath(path, force_absolute=True):
@@ -785,7 +788,10 @@ def generate_chunks(container, size):
     """Given a container, generate chunks from it with size up to `size`
     """
     # There could be a "smarter" solution but I think this would suffice
-    assert size > 0,  "Size should be non-0 positive"
+    # Explicit check, instead of assert statement, for correct operation in
+    # -OO mode
+    if not size:
+        raise AssertionError("Size should be non-0 positive")
     while container:
         yield container[:size]
         container = container[size:]

--- a/formatters.py
+++ b/formatters.py
@@ -84,6 +84,9 @@ class ManPageFormatter(argparse.HelpFormatter):
         return '.SH NAME\n%s \\- %s\n' % (self._bold(prog), desc)
 
     def _mk_description(self, parser):
+        if not __debug__:
+            raise RuntimeError(
+                "We cannot provide description in -OO mode")
         desc = parser.description
         desc = '\n'.join(desc.splitlines()[1:])
         if not desc:


### PR DESCRIPTION
This fix is not yet a complete set of changes to be done, but it does
fixes #2461  in that it would not blow on a basic import and otherwise
largely work

Outstanding failures would be (edit: removed two leading ones which are due to vcr tapes, not -O0 per se)

	======================================================================
	ERROR: Failure: TypeError (unsupported operand type(s) for +: 'NoneType' and 'str')
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 418, in loadTestsFromName
		addr.filename, addr.module)
	  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
		return self.importFromDir(dir_path, fqname)
	  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
		mod = load_module(part_fqname, fh, filename, desc)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/test_auto.py", line 37, in <module>
		import nibabel as nib
	  File "/usr/lib/python2.7/dist-packages/nibabel/__init__.py", line 41, in <module>
		from . import nifti1 as ni1
	  File "/usr/lib/python2.7/dist-packages/nibabel/nifti1.py", line 1750, in <module>
		class Nifti1Pair(analyze.AnalyzeImage):
	  File "/usr/lib/python2.7/dist-packages/nibabel/nifti1.py", line 1780, in Nifti1Pair
		<default-sform-qform-codes>` for more details.  '''
	TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

	======================================================================
	ERROR: datalad.tests.test_utils.test_import_module_from_file
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 418, in newfunc
		return t(*(arg + (d,)), **kw)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/test_utils.py", line 1029, in test_import_module_from_file
		import_module_from_file(op.join(topdir, 'dltestm2', 'dlsub1'))
	  File "/home/yoh/proj/datalad/datalad-master/datalad/utils.py", line 1881, in import_module_from_file
		"Failed to import module from %s: %s" % (modpath, exc_str(e)))
	RuntimeError: Failed to import module from /home/yoh/.tmp/datalad_temp_tree_test_import_module_from_filewcjvlE/dltestm2/dlsub1: No module named dls [utils.py:import_module_from_file:1872]

	======================================================================
	FAIL: datalad.downloaders.tests.test_http.test_docstring
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/downloaders/tests/test_http.py", line 76, in test_docstring
		assert_in("\ncredential: Credential", doc)
	AssertionError: '\ncredential: Credential' not found in ''

	======================================================================
	FAIL: datalad.interface.tests.test_add_archive_content.TestAddArchiveOptions.test_add_delete_after_and_drop
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/tests/test_add_archive_content.py", line 426, in test_add_delete_after_and_drop
		self.annex.whereis(key1, key=True, output='full')
	AssertionError: Exception not raised

	======================================================================
	FAIL: datalad.interface.tests.test_utils.test_eval_results_plus_build_doc
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/tests/test_utils.py", line 242, in test_eval_results_plus_build_doc
		assert_in("TestUtil's fake command", doc1)
	AssertionError: "TestUtil's fake command" not found in u'Parameters\n----------\nnumber : str or None\n  It\'s a number.\ndataset : Dataset or None, optional\n  "specify the dataset to update.  If no dataset is given, an attempt\n  is made to identify the dataset based on the input and/or the\n  current working directory. [Default: None]\non_failure : {\'ignore\', \'continue\', \'stop\'}, optional\n  behavior to perform on failure: \'ignore\' any failure is reported,\n  but does not cause an exception; \'continue\' if any failure occurs an\n  exception will be raised at the end, but processing other actions\n  will continue for as long as possible; \'stop\': processing will stop\n  on first failure and an exception is raised. A failure is any result\n  with status \'impossible\' or \'error\'. Raised exception is an\n  IncompleteResultsError that carries the result dictionaries of the\n  failures in its `failed` attribute. [Default: \'continue\']\nproc_post\n  Like `proc_pre`, but procedures are executed after the main command\n  has finished. [Default: None]\nproc_pre\n  DataLad procedure to run prior to the main command. The argument a\n  list of lists with procedure names and optional arguments.\n  Procedures are called in the order their are given in this list. It\n  is important to provide the respective target dataset to run a\n  procedure on as the `dataset` argument of the main command.\n  [Default: None]\nresult_filter : callable or None, optional\n  if given, each to-be-returned status dictionary is passed to this\n  callable, and is only returned if the callable\'s return value does\n  not evaluate to False or a ValueError exception is raised. If the\n  given callable supports `**kwargs` it will additionally be passed\n  the keyword arguments of the original API call. [Default: None]\nresult_renderer : {\'default\', \'json\', \'json_pp\', \'tailored\'} or None, optional\n  format of return value rendering on stdout. [Default: None]\nresult_xfm : {\'paths\', \'relpaths\', \'datasets\', \'successdatasets-or-none\', \'metadata\'} or callable or None, optional\n  if given, each to-be-returned result status dictionary is passed to\n  this callable, and its return value becomes the result instead. This\n  is different from `result_filter`, as it can perform arbitrary\n  transformation of the result value. This is mostly useful for top-\n  level command invocations that need to provide the results in a\n  particular format. Instead of a callable, a label for a pre-crafted\n  result transformation can be given. [Default: None]\nreturn_type : {\'generator\', \'list\', \'item-or-list\'}, optional\n  return value behavior switch. If \'item-or-list\' a single value is\n  returned instead of a one-item return value list, or a list in case\n  of multiple return values. `None` is return in case of an empty\n  list. [Default: \'list\']\n'
	-------------------- >> begin captured logging << --------------------
	datalad.interface.utils: DEBUG: Determined class of decorated function: <class 'datalad.interface.tests.test_utils.TestUtils'>
	--------------------- >> end captured logging << ---------------------

	======================================================================
	FAIL: datalad.support.tests.test_external_versions.test_custom_versions
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/support/tests/test_external_versions.py", line 133, in test_custom_versions
		assert_equal(set(ev.versions.keys()), {'cmd:annex'})
	AssertionError: Items in the second set but not the first:
	'cmd:annex'

	======================================================================
	FAIL: datalad.support.tests.test_external_versions.test_external_versions_rogue_module
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 591, in newfunc
		return t(*(arg + (filename,)), **kw)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/support/tests/test_external_versions.py", line 127, in test_external_versions_rogue_module
		assert_in('pickaboo', cml.out)
	AssertionError: 'pickaboo' not found in ''

	======================================================================
	FAIL: datalad.support.tests.test_gitrepo.test_split_remote_branch
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/support/tests/test_gitrepo.py", line 869, in test_split_remote_branch
		assert_raises(AssertionError, split_remote_branch, "NoSlashesAtAll")
	AssertionError: AssertionError not raised

	======================================================================
	FAIL: datalad.support.tests.test_locking.test_lock_if_check_fails
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 591, in newfunc
		return t(*(arg + (filename,)), **kw)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/support/tests/test_locking.py", line 81, in test_lock_if_check_fails
		ok_(q.get())
	AssertionError: None
	-------------------- >> begin captured logging << --------------------
	fasteners.process_lock: Level 5: Acquired file lock `/home/yoh/.tmp/datalad_temp_test_lock_if_check_failsapEa5w.lck` after waiting 0.000s [1 attempts were required]
	fasteners.process_lock: Level 5: Unlocked and closed file lock open on `/home/yoh/.tmp/datalad_temp_test_lock_if_check_failsapEa5w.lck`
	fasteners.process_lock: Level 5: Acquired file lock `/home/yoh/.tmp/datalad_temp_test_lock_if_check_failsapEa5w.get-lck` after waiting 0.000s [1 attempts were required]
	fasteners.process_lock: Level 5: Unlocked and closed file lock open on `/home/yoh/.tmp/datalad_temp_test_lock_if_check_failsapEa5w.get-lck`
	fasteners.process_lock: Level 5: Acquired file lock `/home/yoh/.tmp/datalad_temp_test_lock_if_check_failsapEa5w.lck` after waiting 0.000s [1 attempts were required]
	fasteners.process_lock: Level 5: Unlocked and closed file lock open on `/home/yoh/.tmp/datalad_temp_test_lock_if_check_failsapEa5w.lck`
	--------------------- >> end captured logging << ---------------------

	======================================================================
	FAIL: datalad.ui.tests.test_base.test_tests_ui
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/ui/tests/test_base.py", line 71, in test_tests_ui
		assert_equal(ui.question("text"), 'a')
	AssertionError: AssertionError not raised

	======================================================================
	FAIL: datalad.ui.tests.test_base.test_with_testsui
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/ui/tests/test_base.py", line 100, in test_with_testsui
		assert_raises(AssertionError, nothing, 1, k=2)
	AssertionError: AssertionError not raised

	======================================================================
	FAIL: datalad.tests.test_dochelpers.test_borrow_kwargs
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/test_dochelpers.py", line 119, in test_borrow_kwargs
		assert_true('B.met1 doc' in B.met1.__doc__)
	AssertionError: False is not true

	----------------------------------------------------------------------
	Ran 850 tests in 1671.522s

	FAILED (SKIP=52, errors=4, failures=10)
	python -OO -m nose -s -v datalad 2>&1  945.75s user 702.32s system 98% cpu 27:54.59 total

This pull request fixes #2461
