### PR TITLE
BF: ls_webui - do not blow if file size is not available from the annex

### DIFF
--- a/datalad/interface/ls_webui.py
+++ b/datalad/interface/ls_webui.py
@@ -11,6 +11,7 @@
 __docformat__ = 'restructuredtext'
 
 import hashlib
+import numbers
 import humanize
 import json as js
 import time
@@ -25,9 +26,15 @@ from datalad.interface.ls import FsModel, lgr, GitModel
 from datalad.support.network import is_datalad_compat_ri
 from datalad.utils import safe_print, with_pathsep
 
+# A string to use to depict unknown size of the annexed dataset, e.g.
+# whenever all the keys are "relaxed" urls
+UNKNOWN_SIZE = "?"
+
 
 def machinesize(humansize):
     """convert human-size string to machine-size"""
+    if humansize == UNKNOWN_SIZE:
+        return 0
     try:
         size_str, size_unit = humansize.split(" ")
     except AttributeError:
@@ -112,8 +119,11 @@ def fs_extract(nodepath, repo, basepath='/'):
     """
     # Create FsModel from filesystem nodepath and its associated parent repository
     node = FsModel(nodepath, repo)
-    pretty_size = {stype: humanize.naturalsize(svalue)
-                   for stype, svalue in node.size.items()}
+    pretty_size = {
+        stype: humanize.naturalsize(svalue)
+            if isinstance(svalue, numbers.Number) else UNKNOWN_SIZE
+        for stype, svalue in node.size.items()
+    }
     pretty_date = time.strftime(u"%Y-%m-%d %H:%M:%S", time.localtime(node.date))
     name = leaf_name(node._path) \
         if leaf_name(node._path) != "" \


### PR DESCRIPTION
  It happens if a file added as addurl --relaxed, so there is no information about its size whatsoever.
  Motivation is to add to our distribution such datasets as
  https://github.com/ntnn/ccc-media-annex
  etc which are already out there as git-annex repos
