### PR TITLE
Adding config option to set superdataset root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This is a high level and scarce summary of the changes between releases.
 We would recommend to consult log of the 
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
+## 0.10.4 (??? ??, 2018) -- Soon-to-be-perfect
+
+### Major refactoring and deprecations
+
+- `datalad.consts.LOCAL_CENTRAL_PATH` constant was deprecated in favor
+  of `datalad.locations.default-dataset` [configuration] variable
+  (#2835)
+
 ## 0.10.3.1 (Sep 13, 2018) -- Nothing-is-perfect
 
 Emergency bugfix to address forgotten boost of version in
@@ -782,6 +790,7 @@ publishing
 [annotate-paths]: http://docs.datalad.org/en/latest/generated/man/datalad-annotate-paths.html
 [clean]: http://datalad.readthedocs.io/en/latest/generated/man/datalad-clean.html
 [clone]: http://datalad.readthedocs.io/en/latest/generated/man/datalad-clone.html
+[configuration]: http://docs.datalad.org/en/latest/config.html
 [copy_to]: http://docs.datalad.org/en/latest/_modules/datalad/support/annexrepo.html?highlight=%22copy_to%22
 [create-sibling-github]: http://datalad.readthedocs.io/en/latest/generated/man/datalad-create-sibling-github.html
 [create-sibling]: http://datalad.readthedocs.io/en/latest/generated/man/datalad-create-sibling.html

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,5 +19,6 @@ Michael Hanke
 Nell Hardcastle
 Taylor Olson
 Torsten Stoeter
+Vanessa Sochat
 Vicky C Lau
 Yaroslav Halchenko

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -43,9 +43,6 @@ DATASETS_TOPURL = os.environ.get("DATALAD_DATASETS_TOPURL", None) \
 if not DATASETS_TOPURL.endswith('/'):
     DATASETS_TOPURL += '/'
 
-# Centralized deployment
-LOCAL_CENTRAL_PATH = join(expanduser('~'), 'datalad')
-
 WEB_META_LOG = join(DATALAD_GIT_DIR, 'logs')
 WEB_META_DIR = join(DATALAD_GIT_DIR, 'metadata')
 WEB_HTML_DIR = join(DATALAD_GIT_DIR, 'web')

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -24,8 +24,8 @@ from six import string_types
 from six import add_metaclass
 import wrapt
 
+from datalad import cfg
 from datalad.config import ConfigManager
-from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.dochelpers import exc_str
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import Constraint
@@ -132,7 +132,7 @@ class Dataset(object):
         elif path == '///':
             # TODO: logic/UI on installing a central dataset could move here
             # from search?
-            path_ = LOCAL_CENTRAL_PATH
+            path_ = cfg.obtain('datalad.locations.local_central_path')
         if path != path_:
             lgr.debug("Resolved dataset alias %r to path %r", path, path_)
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -132,7 +132,7 @@ class Dataset(object):
         elif path == '///':
             # TODO: logic/UI on installing a central dataset could move here
             # from search?
-            path_ = cfg.obtain('datalad.locations.local_central_path')
+            path_ = cfg.obtain('datalad.locations.default-dataset')
         if path != path_:
             lgr.debug("Resolved dataset alias %r to path %r", path, path_)
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -130,7 +130,7 @@ class Dataset(object):
             # might have its ideas on what to do with ^, so better use as -d^
             path_ = Dataset(curdir).get_superdataset(topmost=True).path
         elif path == '///':
-            # TODO: logic/UI on installing a central dataset could move here
+            # TODO: logic/UI on installing a default dataset could move here
             # from search?
             path_ = cfg.obtain('datalad.locations.default-dataset')
         if path != path_:

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -14,10 +14,10 @@ import shutil
 from os.path import join as opj, abspath, normpath, relpath, exists
 
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
+from datalad import cfg
 from datalad.api import create
 from datalad.api import install
 from datalad.api import get
-from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.utils import chpwd, getpwd, rmtree
 from datalad.utils import _path_
 from datalad.utils import get_dataset_root
@@ -205,7 +205,8 @@ def test_subdatasets(path):
         eq_(dstop, subds)
         # and while in the dataset we still can resolve into central one
         dscentral = Dataset('///')
-        eq_(dscentral.path, LOCAL_CENTRAL_PATH)
+        eq_(dscentral.path,
+            cfg.obtain('datalad.locations.local_central_path'))
 
     with chpwd(ds.path):
         dstop = Dataset('^')

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -206,7 +206,7 @@ def test_subdatasets(path):
         # and while in the dataset we still can resolve into central one
         dscentral = Dataset('///')
         eq_(dscentral.path,
-            cfg.obtain('datalad.locations.local_central_path'))
+            cfg.obtain('datalad.locations.default-dataset'))
 
     with chpwd(ds.path):
         dstop = Dataset('^')

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -46,8 +46,9 @@ definitions = {
     },
     'datalad.locations.default-dataset': {
         'ui': ('question', {
-               'title': 'Superdataset local central path',
-               'text': 'Where should datalad install the dataset superdataset?'}),
+               'title': 'Default dataset path',
+               'text': 'Where should datalad should look for (or install) a '
+                       'default dataset?'}),
         'destination': 'global',
         'default': opj(expanduser('~'), 'datalad'),
     },

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -13,7 +13,7 @@
 __docformat__ = 'restructuredtext'
 
 from appdirs import AppDirs
-from os.path import join as opj
+from os.path import join as opj, expanduser
 from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureInt
 from datalad.support.constraints import EnsureNone
@@ -43,6 +43,13 @@ definitions = {
                'text': 'Where should datalad cache files?'}),
         'destination': 'global',
         'default': dirs.user_cache_dir,
+    },
+    'datalad.locations.local_central_path': {
+        'ui': ('question', {
+               'title': 'Superdataset local central path',
+               'text': 'Where should datalad install the superdataset?'}),
+        'destination': 'global',
+        'default': opj(expanduser('~'), 'datalad'),
     },
     'datalad.locations.system-plugins': {
         'ui': ('question', {

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -44,10 +44,10 @@ definitions = {
         'destination': 'global',
         'default': dirs.user_cache_dir,
     },
-    'datalad.locations.local_central_path': {
+    'datalad.locations.default-dataset': {
         'ui': ('question', {
                'title': 'Superdataset local central path',
-               'text': 'Where should datalad install the superdataset?'}),
+               'text': 'Where should datalad install the dataset superdataset?'}),
         'destination': 'global',
         'default': opj(expanduser('~'), 'datalad'),
     },

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -175,15 +175,15 @@ def _search_from_virgin_install(dataset, query):
         # none was provided so we could ask user either he possibly wants
         # to install our beautiful mega-duper-super-dataset?
         # TODO: following logic could possibly benefit other actions.
-        LOCAL_CENTRAL_PATH = cfg.obtain('datalad.locations.default-dataset')
-        if os.path.exists(LOCAL_CENTRAL_PATH):
-            central_ds = Dataset(LOCAL_CENTRAL_PATH)
-            if central_ds.is_installed():
+        DEFAULT_DATASET_PATH = cfg.obtain('datalad.locations.default-dataset')
+        if os.path.exists(DEFAULT_DATASET_PATH):
+            default_ds = Dataset(DEFAULT_DATASET_PATH)
+            if default_ds.is_installed():
                 if ui.yesno(
                     title="No DataLad dataset found at current location",
                     text="Would you like to search the DataLad "
                          "superdataset at %r?"
-                          % LOCAL_CENTRAL_PATH):
+                          % DEFAULT_DATASET_PATH):
                     pass
                 else:
                     reraise(*exc_info)
@@ -192,14 +192,14 @@ def _search_from_virgin_install(dataset, query):
                     "No DataLad dataset found at current location. "
                     "The DataLad superdataset location %r exists, "
                     "but does not contain an dataset."
-                    % LOCAL_CENTRAL_PATH)
+                    % DEFAULT_DATASET_PATH)
         elif ui.yesno(
                 title="No DataLad dataset found at current location",
                 text="Would you like to install the DataLad "
                      "superdataset at %r?"
-                     % LOCAL_CENTRAL_PATH):
+                     % DEFAULT_DATASET_PATH):
             from datalad.api import install
-            central_ds = install(LOCAL_CENTRAL_PATH, source='///')
+            default_ds = install(DEFAULT_DATASET_PATH, source='///')
             ui.message(
                 "From now on you can refer to this dataset using the "
                 "label '///'"
@@ -209,9 +209,9 @@ def _search_from_virgin_install(dataset, query):
 
         lgr.info(
             "Performing search using DataLad superdataset %r",
-            central_ds.path
+            default_ds.path
         )
-        for res in central_ds.search(query):
+        for res in default_ds.search(query):
             yield res
         return
     else:

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -177,7 +177,7 @@ def _search_from_virgin_install(dataset, query):
         # to install our beautiful mega-duper-super-dataset?
         # TODO: following logic could possibly benefit other actions.
         LOCAL_CENTRAL_PATH = cfg.obtain('datalad.locations.local_central_path')
-        if os.path.exists(local_central_path):
+        if os.path.exists(LOCAL_CENTRAL_PATH):
             central_ds = Dataset(LOCAL_CENTRAL_PATH)
             if central_ds.is_installed():
                 if ui.yesno(

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -175,7 +175,7 @@ def _search_from_virgin_install(dataset, query):
         # none was provided so we could ask user either he possibly wants
         # to install our beautiful mega-duper-super-dataset?
         # TODO: following logic could possibly benefit other actions.
-        LOCAL_CENTRAL_PATH = cfg.obtain('datalad.locations.local_central_path')
+        LOCAL_CENTRAL_PATH = cfg.obtain('datalad.locations.default-dataset')
         if os.path.exists(LOCAL_CENTRAL_PATH):
             central_ds = Dataset(LOCAL_CENTRAL_PATH)
             if central_ds.is_installed():

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -39,7 +39,6 @@ from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureInt
 
-from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
 from datalad.utils import assure_list, assure_iter, unicode_srctypes, as_unicode
 from datalad.utils import assure_unicode

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -39,6 +39,7 @@ from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureInt
 
+from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
 from datalad.utils import assure_list, assure_iter, unicode_srctypes, as_unicode
 from datalad.utils import assure_unicode

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -39,7 +39,6 @@ from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureInt
 
-from datalad.consts import LOCAL_CENTRAL_PATH
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
 from datalad.utils import assure_list, assure_iter, unicode_srctypes, as_unicode
 from datalad.utils import assure_unicode
@@ -176,7 +175,8 @@ def _search_from_virgin_install(dataset, query):
         # none was provided so we could ask user either he possibly wants
         # to install our beautiful mega-duper-super-dataset?
         # TODO: following logic could possibly benefit other actions.
-        if os.path.exists(LOCAL_CENTRAL_PATH):
+        LOCAL_CENTRAL_PATH = cfg.obtain('datalad.locations.local_central_path')
+        if os.path.exists(local_central_path):
             central_ds = Dataset(LOCAL_CENTRAL_PATH)
             if central_ds.is_installed():
                 if ui.yesno(

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -54,7 +54,7 @@ def test_search_outside1(tdir, newhome):
     with chpwd(tdir):
         # should fail since directory exists, but not a dataset
         # should not even waste our response ;)
-        with patch_config({'datalad.locations.local_central_path': newhome}):
+        with patch_config({'datalad.locations.default-dataset': newhome}):
             gen = search("bu", return_type='generator')
             assert_is_generator(gen)
             assert_raises(NoDatasetArgumentFound, next, gen)
@@ -71,7 +71,7 @@ def test_search_outside1_install_central_ds(tdir, central_dspath):
     with chpwd(tdir):
         # let's mock out even actual install/search calls
         with \
-            patch_config({'datalad.locations.local_central_path': central_dspath}), \
+            patch_config({'datalad.locations.default-dataset': central_dspath}), \
             patch('datalad.api.install',
                   return_value=Dataset(central_dspath)) as mock_install, \
             patch('datalad.distribution.dataset.Dataset.search',

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_testsui
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import ok_file_under_git
+from datalad.tests.utils import patch_config
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import eq_
 from datalad.support.exceptions import NoDatasetArgumentFound
@@ -53,7 +54,7 @@ def test_search_outside1(tdir, newhome):
     with chpwd(tdir):
         # should fail since directory exists, but not a dataset
         # should not even waste our response ;)
-        with patch.object(search_mod, 'LOCAL_CENTRAL_PATH', newhome):
+        with patch_config({'datalad.locations.local_central_path': newhome}):
             gen = search("bu", return_type='generator')
             assert_is_generator(gen)
             assert_raises(NoDatasetArgumentFound, next, gen)
@@ -70,7 +71,7 @@ def test_search_outside1_install_central_ds(tdir, central_dspath):
     with chpwd(tdir):
         # let's mock out even actual install/search calls
         with \
-            patch.object(search_mod, 'LOCAL_CENTRAL_PATH', central_dspath), \
+            patch_config({'datalad.locations.local_central_path': central_dspath}), \
             patch('datalad.api.install',
                   return_value=Dataset(central_dspath)) as mock_install, \
             patch('datalad.distribution.dataset.Dataset.search',

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -67,16 +67,16 @@ def test_search_outside1(tdir, newhome):
 @with_testsui(responses='yes')
 @with_tempfile(mkdir=True)
 @with_tempfile()
-def test_search_outside1_install_central_ds(tdir, central_dspath):
+def test_search_outside1_install_default_ds(tdir, default_dspath):
     with chpwd(tdir):
         # let's mock out even actual install/search calls
         with \
-            patch_config({'datalad.locations.default-dataset': central_dspath}), \
+            patch_config({'datalad.locations.default-dataset': default_dspath}), \
             patch('datalad.api.install',
-                  return_value=Dataset(central_dspath)) as mock_install, \
+                  return_value=Dataset(default_dspath)) as mock_install, \
             patch('datalad.distribution.dataset.Dataset.search',
                   new_callable=_mock_search):
-            _check_mocked_install(central_dspath, mock_install)
+            _check_mocked_install(default_dspath, mock_install)
 
             # now on subsequent run, we want to mock as if dataset already exists
             # at central location and then do search again
@@ -86,7 +86,7 @@ def test_search_outside1_install_central_ds(tdir, central_dspath):
             with patch(
                     'datalad.distribution.dataset.Dataset.is_installed',
                     True):
-                _check_mocked_install(central_dspath, mock_install)
+                _check_mocked_install(default_dspath, mock_install)
 
             # and what if we say "no" to install?
             ui.add_responses('no')
@@ -95,7 +95,7 @@ def test_search_outside1_install_central_ds(tdir, central_dspath):
                 list(search("."))
 
             # and if path exists and is a valid dataset and we say "no"
-            Dataset(central_dspath).create()
+            Dataset(default_dspath).create()
             ui.add_responses('no')
             mock_install.reset_mock()
             with assert_raises(NoDatasetArgumentFound):
@@ -124,7 +124,7 @@ class _mock_search(object):
             yield report
 
 
-def _check_mocked_install(central_dspath, mock_install):
+def _check_mocked_install(default_dspath, mock_install):
     gen = search(".", return_type='generator')
     assert_is_generator(gen)
     # we no longer do any custom path tune up from the one returned by search
@@ -132,7 +132,7 @@ def _check_mocked_install(central_dspath, mock_install):
     assert_equal(
         list(gen), [report
                     for report in _mocked_search_results])
-    mock_install.assert_called_once_with(central_dspath, source='///')
+    mock_install.assert_called_once_with(default_dspath, source='///')
 
 
 @with_tempfile

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -775,7 +775,7 @@ class SSHRI(RI, RegexBasedURLMixin):
 
 
 class DataLadRI(RI, RegexBasedURLMixin):
-    """RI pointing to datasets within central DataLad super-dataset"""
+    """RI pointing to datasets within default DataLad super-dataset"""
 
     _FIELDS = RI._FIELDS + (
         'remote',

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -114,19 +114,21 @@ API principles
 
 You can use DataLad's ``install`` command to download datasets. The command accepts
 URLs of different protocols (``http``, ``ssh``) as an argument. Nevertheless, the easiest way
-to obtain a first dataset is downloading the canonical :term:`superdataset` from
+to obtain a first dataset is downloading the default :term:`superdataset` from
 http://datasets.datalad.org/ using a shortcut.
 
-Downloading DataLad's canonical superdataset
+Downloading DataLad's default superdataset
 --------------------------------------------
 
-DataLad's canonical :term:`superdataset` provides an automated collection of datasets
-from various portals and sites. The argument ``///`` can be used 
+http://datasets.datalad.org provides a super-dataset consisting of datasets
+from various portals and sites.  Many of them were crawled, and periodically
+updated, using `datalad-crawler <https://github.com/datalad/datalad-crawler>`__
+extension.  The argument ``///`` can be used
 as a shortcut that points to the superdataset located at http://datasets.datalad.org/. 
 Here are three common examples in command line notation:
 
 ``datalad install ///``
-    installs the canonical superdataset (metadata without subdatasets) in a
+    installs this superdataset (metadata without subdatasets) in a
     `datasets.datalad.org/` subdirectory under the current directory
 ``datalad install -r ///openfmri``
     installs the openfmri superdataset into an `openfmri/` subdirectory.
@@ -136,6 +138,11 @@ Here are three common examples in command line notation:
     installs the superdataset of datasets released by the lab of Dr. James V. Haxby
     and all subdatasets' metadata. The ``-g`` flag indicates getting the actual data, too.
     It does so by using 3 parallel download processes (``-J3`` flag).
+
+:ref:`datalad search <man_datalad-search>` command, if ran outside of any dataset,
+will install this default superdataset under a path specified in
+``datalad.locations.default-dataset`` :ref:`configuration <configuration>`
+variable (by default ``$HOME/datalad``).
 
 Downloading datasets via http
 -----------------------------
@@ -169,7 +176,7 @@ relative to the current directory.
 There are also some useful pre-defined "shortcut" values for dataset arguments:
 
 ``///``
-   refers to the "canonical" dataset located under `$HOME/datalad/`.
+   refers to the "default" dataset located under `$HOME/datalad/`.
    So running ``datalad install -d/// crcns`` will install the ``crcns`` subdataset
    under ``$HOME/datalad/crcns``.  This is the same as running
    ``datalad install $HOME/datalad/crcns``.


### PR DESCRIPTION
This pull request will close https://github.com/datalad/datalad/issues/2792 by adding a configuration value, `datasets.locations.local_central_path`

![image](https://user-images.githubusercontent.com/814322/45588124-914fa800-b8dd-11e8-85d2-a6caae781470.png)

### Notes
 - **naming** I would have called it `superdataset_root` or similar, but to be consistent I named it equivalently to the current variable `LOCAL_CENTRAL_PATH` --> `datasets.locations.local_central_path`.
 - **The path defined in confs.py might still be useful for testing.** I noticed that this default is set in the confs.py, and then used in testing. Since testing may be a different use case / invocation pathway than when it's actually being used, I left it here and didn't change the imports in testing. 
 - **docs** my life was very easy! The change appeared there automatically :)

### Changes
- [x] This change is complete

Please have a look @datalad/developers and thank you in advance for help with fine tuning. I'm still unfamiliar with the code base and using datalad.