### PR TITLE
BF: annex_info - be robust to "unknown" size

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2588,7 +2588,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         info = json_records[0]
         for k in info:
             if k.endswith(' size') or k.endswith(' disk space') or k.startswith('size of '):
-                info[k] = int(info[k].split()[0])
+                size = info[k].split()[0]
+                if size.isdigit():
+                    info[k] = int(size)
+                else:
+                    lgr.debug("Size %r reported to be %s, setting to None", k, size)
+                    info[k] = None
         assert(info.pop('success'))
         assert(info.pop('command') == 'info')
         return info  # just as is for now


### PR DESCRIPTION
Reported in https://github.com/datalad/datalad/issues/2839
Local disk space might be "unknown" so we must not blindly
convert it to int.  I wondered if we should keep original value
("unknown") but because in other place we already get it as None
by default, I thought that it would be better just to log at debug
and assign a None

This pull request fixes #2839 
