### PR TITLE
BF: V6: Fix file_has_content and is_under_annex for unlocked files

### DIFF
--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -161,7 +161,7 @@ def test_reaggregate_with_unavailable_objects(path):
     ok_clean_git(base.path)
     objpath = opj('.datalad', 'metadata', 'objects')
     # weird that it comes out as a string...
-    objs = [o for o in sorted(base.repo.find(objpath).split('\n')) if o]
+    objs = [o for o in sorted(base.repo.find(objpath).split('\0')) if o]
     # we have 3x2 metadata sets (dataset/files) under annex
     eq_(len(objs), 6)
     eq_(all(base.repo.file_has_content(objs)), True)
@@ -176,7 +176,7 @@ def test_reaggregate_with_unavailable_objects(path):
     # and there are no new objects
     eq_(
         objs,
-        [o for o in sorted(base.repo.find(objpath).split('\n')) if o]
+        [o for o in sorted(base.repo.find(objpath).split('\0')) if o]
     )
 
 
@@ -240,7 +240,7 @@ def test_publish_aggregated(path):
     base.publish('.', to='local_target', transfer_data='all')
     remote = Dataset(spath)
     objpath = opj('.datalad', 'metadata', 'objects')
-    objs = [o for o in sorted(base.repo.find(objpath).split('\n')) if o]
+    objs = [o for o in sorted(base.repo.find(objpath).split('\0')) if o]
     # all object files a present in both datasets
     eq_(all(base.repo.file_has_content(objs)), True)
     eq_(all(remote.repo.file_has_content(objs)), True)

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -160,8 +160,7 @@ def test_reaggregate_with_unavailable_objects(path):
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
     objpath = opj('.datalad', 'metadata', 'objects')
-    # weird that it comes out as a string...
-    objs = [o for o in sorted(base.repo.find(objpath).split('\0')) if o]
+    objs = list(sorted(base.repo.find(objpath)))
     # we have 3x2 metadata sets (dataset/files) under annex
     eq_(len(objs), 6)
     eq_(all(base.repo.file_has_content(objs)), True)
@@ -176,7 +175,7 @@ def test_reaggregate_with_unavailable_objects(path):
     # and there are no new objects
     eq_(
         objs,
-        [o for o in sorted(base.repo.find(objpath).split('\0')) if o]
+        list(sorted(base.repo.find(objpath)))
     )
 
 
@@ -240,7 +239,7 @@ def test_publish_aggregated(path):
     base.publish('.', to='local_target', transfer_data='all')
     remote = Dataset(spath)
     objpath = opj('.datalad', 'metadata', 'objects')
-    objs = [o for o in sorted(base.repo.find(objpath).split('\0')) if o]
+    objs = list(sorted(base.repo.find(objpath)))
     # all object files a present in both datasets
     eq_(all(base.repo.file_has_content(objs)), True)
     eq_(all(remote.repo.file_has_content(objs)), True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1806,7 +1806,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         objects = []
         if batch:
-            objects = self._batched.get('find', path=self.path)(files)
+            find = self._batched.get('find', json=True, path=self.path)
+            objects = [d.get("file", "") for d in find(files)]
         else:
             for f in files:
                 try:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1830,6 +1830,23 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         return objects
 
+    def _check_files(self, fn, quick_fn, files, allow_quick, batch):
+        # Helper that isolates the common logic in `file_has_content` and
+        # `is_under_annex`. `fn` is the annex command used to do the check, and
+        # `quick_fn` is the non-annex variant.
+        is_v6 = self.config.get("annex.version") == "6"
+        if is_v6 or self.is_direct_mode() or batch or not allow_quick:
+            # We're only concerned about modified files in V6 mode. In V5
+            # `find` returns an empty string for unlocked files, and in direct
+            # mode everything looks modified, so we don't even bother.
+            modified = self.get_changed_files() if is_v6 else []
+            annex_res = fn(files, normalize_paths=False, batch=batch)
+            return [bool(annex_res.get(f) and
+                         not (is_v6 and normpath(f) in modified))
+                    for f in files]
+        else:  # ad-hoc check which should be faster than call into annex
+            return [quick_fn(f) for f in files]
+
     @normalize_paths
     def file_has_content(self, files, allow_quick=True, batch=False):
         """Check whether files have their content present under annex.
@@ -1849,32 +1866,21 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         # TODO: Also provide option to look for key instead of path
 
-        is_v6 = self.config.get("annex.version") == "6"
-        if is_v6 or self.is_direct_mode() or batch or not allow_quick:  # TODO: thin mode
-            # We're only concerned about modified files in V6 mode. In V5
-            # `find` returns an empty string for unlocked files, and in direct
-            # mode everything looks modified, so we don't even bother.
-            modified = self.get_changed_files() if is_v6 else []
-            # TODO: Also provide option to look for key instead of path
-            find = self.find(files, normalize_paths=False, batch=batch)
-            return [bool(find[f] and not (is_v6 and f in modified))
-                    for f in files]
-        else:  # ad-hoc check which should be faster than call into annex
-            out = []
-            for f in files:
-                filepath = opj(self.path, f)
-                if islink(filepath):                    # if symlink
-                    # find abspath of node pointed to by symlink
-                    target_path = realpath(filepath)  # realpath OK
-                    # TODO: checks for being not outside of this repository
-                    # Note: ben removed '.git/' from '.git/annex/objects',
-                    # since it is not true for submodules, whose '.git' is a
-                    # symlink and being resolved to some
-                    # '.git/modules/.../annex/objects'
-                    out.append(exists(target_path) and 'annex/objects' in str(target_path))
-                else:
-                    out.append(False)
-            return out
+        def quick_check(filename):
+            filepath = opj(self.path, filename)
+            if islink(filepath):                    # if symlink
+                # find abspath of node pointed to by symlink
+                target_path = realpath(filepath)  # realpath OK
+                # TODO: checks for being not outside of this repository
+                # Note: ben removed '.git/' from '.git/annex/objects',
+                # since it is not true for submodules, whose '.git' is a
+                # symlink and being resolved to some
+                # '.git/modules/.../annex/objects'
+                return exists(target_path) and 'annex/objects' in str(target_path)
+            return False
+
+        return self._check_files(self.find, quick_check,
+                                 files, allow_quick, batch)
 
     @normalize_paths
     def is_under_annex(self, files, allow_quick=True, batch=False):
@@ -1893,41 +1899,35 @@ class AnnexRepo(GitRepo, RepoInterface):
         list of bool
             For each input file states either file is under annex
         """
-        is_v6 = self.config.get("annex.version") == "6"
         # theoretically in direct mode files without content would also be
         # broken symlinks on the FSs which support it, but that would complicate
         # the matters
-        if is_v6 or self.is_direct_mode() or batch or not allow_quick:  # TODO: thin mode
-            # This is an ugly hack to prevent files from being treated as
-            # remotes by `git annex info`. See annex's `nameToUUID'`.
-            files = [opj(curdir, f) for f in files]
-            # We're only concerned about modified files in V6 mode. In V5
-            # `find` returns an empty string for unlocked files, and in direct
-            # mode everything looks modified, so we don't even bother.
-            modified = self.get_changed_files() if is_v6 else []
+
+        # This is an ugly hack to prevent files from being treated as
+        # remotes by `git annex info`. See annex's `nameToUUID'`.
+        files = [opj(curdir, f) for f in files]
+
+        def check(files, **kwargs):
             # Filter out directories because it doesn't make sense to ask if
             # they are under annex control and `info` can only handle
             # non-directories.
-            info = self.info([f for f in files if not isdir(f)],
-                             normalize_paths=False, batch=batch, fast=True)
-            # info is a dict... khe khe -- "thanks" Yarik! ;)
-            return [bool(info.get(f) and
-                         not (is_v6 and normpath(f) in modified))
-                    for f in files]
-        else:  # ad-hoc check which should be faster than call into annex
-            out = []
-            for f in files:
-                filepath = opj(self.path, f)
-                # todo checks for being not outside of this repository
-                # Note: ben removed '.git/' from '.git/annex/objects',
-                # since it is not true for submodules, whose '.git' is a
-                # symlink and being resolved to some
-                # '.git/modules/.../annex/objects'
-                out.append(
-                    islink(filepath)
-                    and 'annex/objects' in str(realpath(filepath))  # realpath OK
-                )
-            return out
+            return self.info([f for f in files if not isdir(f)],
+                             fast=True, **kwargs)
+
+        def quick_check(filename):
+            filepath = opj(self.path, filename)
+            # todo checks for being not outside of this repository
+            # Note: ben removed '.git/' from '.git/annex/objects',
+            # since it is not true for submodules, whose '.git' is a
+            # symlink and being resolved to some
+            # '.git/modules/.../annex/objects'
+            return (
+                islink(filepath)
+                and 'annex/objects' in str(realpath(filepath))  # realpath OK
+            )
+
+        return self._check_files(check, quick_check,
+                                 files, allow_quick, batch)
 
     def init_remote(self, name, options):
         """Creates a new special remote

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -23,6 +23,7 @@ import time
 
 from itertools import chain
 from os import linesep
+from os.path import curdir
 from os.path import join as opj
 from os.path import exists
 from os.path import islink
@@ -1896,6 +1897,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         # broken symlinks on the FSs which support it, but that would complicate
         # the matters
         if self.is_direct_mode() or batch or not allow_quick:  # TODO: thin mode
+            # This is an ugly hack to prevent files from being treated as
+            # remotes by `git annex info`. See annex's `nameToUUID'`.
+            files = [opj(curdir, f) for f in files]
             info = self.info(files, normalize_paths=False, batch=batch)
             # info is a dict... khe khe -- "thanks" Yarik! ;)
             return [bool(info[f]) for f in files]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3469,7 +3469,8 @@ def readlines_until_ok_or_failed(stdout, maxlines=100):
 
 
 def readline_json(stdout):
-    return json_loads(stdout.readline().strip())
+    toload = stdout.readline().strip()
+    return json_loads(toload) if toload else {}
 
 
 @auto_repr

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1797,7 +1797,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             files to find under annex
         batch: bool, optional
             initiate or continue with a batched run of annex find, instead of just
-            calling a single git annex find command
+            calling a single git annex find command. If any items in `files`
+            are directories, this value is treated as False.
 
         Returns
         -------
@@ -1805,7 +1806,9 @@ class AnnexRepo(GitRepo, RepoInterface):
           list with filename if file found else empty string
         """
         objects = []
-        if batch:
+        # Ignore batch=True if any path is a directory because `git annex find
+        # --batch` always returns an empty string for directories.
+        if batch and not any(isdir(opj(self.path, f)) for f in files):
             find = self._batched.get('find', json=True, path=self.path)
             objects = [d.get("file", "") for d in find(files)]
         else:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1812,9 +1812,11 @@ class AnnexRepo(GitRepo, RepoInterface):
             for f in files:
                 try:
                     obj, er = self._run_annex_command(
-                        'find', files=[f], expect_fail=True
+                        'find', files=[f],
+                        annex_options=["--print0"],
+                        expect_fail=True
                     )
-                    objects.append(obj)
+                    objects.append(obj.rstrip("\0"))
                 except CommandError:
                     objects.append('')
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1789,7 +1789,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
     @normalize_paths(map_filenames_back=True)
     def find(self, files, batch=False):
-        """Provide annex info for file(s).
+        """Run `git annex find` on file(s).
 
         Parameters
         ----------

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1909,7 +1909,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             # they are under annex control and `info` can only handle
             # non-directories.
             info = self.info([f for f in files if not isdir(f)],
-                             normalize_paths=False, batch=batch)
+                             normalize_paths=False, batch=batch, fast=True)
             # info is a dict... khe khe -- "thanks" Yarik! ;)
             return [bool(info.get(f) and
                          not (is_v6 and normpath(f) in modified))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1890,7 +1890,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         # broken symlinks on the FSs which support it, but that would complicate
         # the matters
         if self.is_direct_mode() or batch or not allow_quick:  # TODO: thin mode
-            # no other way but to call whereis and if anything returned for it
             info = self.info(files, normalize_paths=False, batch=batch)
             # info is a dict... khe khe -- "thanks" Yarik! ;)
             return [bool(info[f]) for f in files]

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -503,9 +503,12 @@ def test_find_batch_equivalence(path):
     ar.add(files + ["subdir"])
     ar.commit("add files")
     query = ["not-there"] + files
-    expected = [""] + files
+    expected = {f: f for f in files}
+    expected.update({"not-there": ""})
     eq_(expected, ar.find(query, batch=True))
     eq_(expected, ar.find(query))
+    # If we give a subdirectory, we split that output.
+    eq_(set(ar.find(["subdir"])["subdir"]), {"subdir/d", "subdir/e"})
     eq_(ar.find(["subdir"]), ar.find(["subdir"], batch=True))
 
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -496,7 +496,7 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
 @with_tree(tree={"a.txt": "a",
                  "b": "b",
                  OBSCURE_FILENAME: "c"})
-def test_find_batch_obscure(path):
+def test_find_batch_equivalence(path):
     ar = AnnexRepo(path)
     files = ["a.txt", "b", OBSCURE_FILENAME]
     ar.add(files)
@@ -504,6 +504,7 @@ def test_find_batch_obscure(path):
     query = ["not-there"] + files
     expected = [""] + files
     eq_(expected, ar.find(query, batch=True))
+    eq_(expected, ar.find(query))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -355,6 +355,15 @@ def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
     assert_false(ar.is_under_annex("bogus.txt", batch=batch))
     ok_(ar.is_under_annex("test-annex.dat", batch=batch))
 
+    if not direct:  # There's no unlock in direct mode.
+        ar.unlock(["test-annex.dat"])
+        eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
+            [ar.config.get("annex.version") == "6"])
+        with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
+            ofh.write("more")
+        eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
+            [False])
+
 
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
                  ('about2.txt', 'more abouts'),

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -495,16 +495,18 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
 
 @with_tree(tree={"a.txt": "a",
                  "b": "b",
-                 OBSCURE_FILENAME: "c"})
+                 OBSCURE_FILENAME: "c",
+                 "subdir": {"d": "d", "e": "e"}})
 def test_find_batch_equivalence(path):
     ar = AnnexRepo(path)
     files = ["a.txt", "b", OBSCURE_FILENAME]
-    ar.add(files)
+    ar.add(files + ["subdir"])
     ar.commit("add files")
     query = ["not-there"] + files
     expected = [""] + files
     eq_(expected, ar.find(query, batch=True))
     eq_(expected, ar.find(query))
+    eq_(ar.find(["subdir"]), ar.find(["subdir"], batch=True))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -75,6 +75,7 @@ from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import local_testrepo_flavors
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import get_most_obscure_supported_name
+from datalad.tests.utils import OBSCURE_FILENAME
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import find_files
@@ -490,6 +491,19 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
         # Should maintain original relative file names
         eq_(set(info2_), set(testfiles))
         eq_(info2_[cur_subfile]['size'], 10)
+
+
+@with_tree(tree={"a.txt": "a",
+                 "b": "b",
+                 OBSCURE_FILENAME: "c"})
+def test_find_batch_obscure(path):
+    ar = AnnexRepo(path)
+    files = ["a.txt", "b", OBSCURE_FILENAME]
+    ar.add(files)
+    ar.commit("add files")
+    query = ["not-there"] + files
+    expected = [""] + files
+    eq_(expected, ar.find(query, batch=True))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -319,6 +319,15 @@ def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     assert_false(ar.file_has_content("bogus.txt", batch=batch))
     ok_(ar.file_has_content("test-annex.dat", batch=batch))
 
+    if not direct:  # There's no unlock in direct mode.
+        ar.unlock(["test-annex.dat"])
+        eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
+            [ar.config.get("annex.version") == "6"])
+        with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
+            ofh.write("more")
+        eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
+            [False])
+
 
 # 1 is enough to test
 @with_batch_direct


### PR DESCRIPTION
`AnnexRepo.{file_has_content,is_under_annex}` get confused on unlocked files in V6. In V5, both these functions return false for unlocked files (i.e. we don't trust that the content in the working tree that replaced the symlink is unmodified). In V6, being unlocked isn't necessarily a transient state and doesn't mean that the content isn't in annex/objects, so we need a different check. This PR changes the "return false for unlocked" bit of the check to a more specific "return false if the file has unstaged modifications" in V6. The focus is on **unstaged** changes because any staged files will have already had their content added to the annex.

Commits ad8525b18 and 5dc2eb495 are the ones that actually change the checks. Most of the others fix other issues in these methods (and their helpers) and aren't specific for V6.

Fixes #2845.

---


- [x] base is #2811 rather than master, but that was for my local testing and shouldn't be necessary
- [x] might fail on tests outside of the limited ones I tested locally (edit: passing now)
- [ ] doesn't address requested [change in sematics](https://github.com/datalad/datalad/issues/2845#issuecomment-422834346)
      IMO this should be done in a separate PR.
