### PR TITLE
BF: install default value for jobs should be "auto" not None

### DIFF
--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -156,7 +156,7 @@ class Install(Interface):
             # git_clone_opts=None,
             # annex_opts=None,
             # annex_init_opts=None,
-            jobs=None):
+            jobs="auto"):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`


### PR DESCRIPTION
   Otherwise  install -g  was not triggering parallel downloads.
   Kudos to the problem solver @kyleam