### PR TITLE
BF: account for possible decorations around filenames while chunking cmdline

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2328,7 +2328,16 @@ class AnnexRepo(GitRepo, RepoInterface):
             else:
                 files = assure_list(files)
                 maxl = max(map(len, files))
-                chunk_size = CMD_MAX_ARG // maxl
+                chunk_size = max(
+                    1,  # should at least be 1. If blows then - not our fault
+                    (CMD_MAX_ARG
+                     - len(command)
+                     - sum((len(x) + 3) for x in annex_options)
+                     - 4   # for '--' below
+                     - 50  # for safety since we are to add more options
+                    // (maxl + 3)  # +3 for possible quotes and a space
+                    )
+                )
                 file_chunks = generate_chunks(files, chunk_size)
             out, err = "", ""
             for file_chunk in file_chunks:


### PR DESCRIPTION
Discovered on Windows, see https://github.com/datalad/datalad/issues/2863 ,
where error message was suggesting just getting over the maximum filename
size, but it was not it.  Accounting with at least +3 resolved the issue.
Here we do more to account for all the rest to be even safer

Fixes #2863 