### PR TITLE
ENH: Report detailed info on git-annex in `wtf` (fixes gh-2854)

### DIFF
--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -78,6 +78,24 @@ def _describe_datalad():
     }
 
 
+def _describe_annex():
+    from datalad.cmd import get_runner
+
+    runner = get_runner()
+    out, err = runner.run(['git', 'annex', 'version'])
+    info = {}
+    for line in out.split(os.linesep):
+        key = line.split(':')[0]
+        if not key:
+            continue
+        value = line[len(key) + 2:].strip()
+        key = key.replace('git-annex ', '')
+        if key.endswith('s'):
+            value = value.split()
+        info[key] = value
+    return info
+
+
 def _describe_system():
     import platform as pl
     from datalad import get_encoding_info
@@ -280,6 +298,7 @@ class WTF(Interface):
             infos=infos,
         )
         infos['datalad'] = _describe_datalad()
+        infos['git-annex'] = _describe_annex()
         infos['system'] = _describe_system()
         infos['environment'] = _describe_environment()
         infos['configuration'] = _describe_configuration(cfg, sensitive)
@@ -324,7 +343,7 @@ def _render_report(res):
                 text = _unwind(text, val[k], u'{}  '.format(top))
         elif isinstance(val, (list, tuple)):
             for i, v in enumerate(val):
-                text += u'\n{}{}. '.format(top, i + 1)
+                text += u'\n{}{} '.format(top, '-')
                 text = _unwind(text, v, u'{}  '.format(top))
         else:
             text += u'{}'.format(val)


### PR DESCRIPTION
A parsed variant of `git annex version` output. Looks like this:

```
% datalad wtf
# WTF
...
## git-annex 
  - build flags: 
    - Assistant
    - Webapp
    - Pairing
    - S3(multipartupload)(storageclasses)
    - WebDAV
    - Inotify
    - DBus
    - DesktopNotify
    - ConcurrentOutput
    - TorrentParser
    - MagicMime
    - Feeds
    - Testsuite
  - dependency versions: 
    - aws-0.19
    - bloomfilter-2.0.1.0
    - cryptonite-0.25
    - DAV-1.3.2
    - feed-1.0.0.0
    - ghc-8.2.2
    - http-client-0.5.12
    - persistent-sqlite-2.8.1.2
    - torrent-10000.1.1
    - uuid-1.3.13
    - yesod-1.6.0
  - key/value backends: 
    - SHA256E
    - SHA256
    - SHA512E
    - SHA512
    - SHA224E
    - SHA224
    - SHA384E
    - SHA384
    - SHA3_256E
    - SHA3_256
    - SHA3_512E
    - SHA3_512
    - SHA3_224E
    - SHA3_224
    - SHA3_384E
    - SHA3_384
    - SKEIN256E
    - SKEIN256
    - SKEIN512E
    - SKEIN512
    - BLAKE2B256E
    - BLAKE2B256
    - BLAKE2B512E
    - BLAKE2B512
    - BLAKE2B160E
    - BLAKE2B160
    - BLAKE2B224E
    - BLAKE2B224
    - BLAKE2B384E
    - BLAKE2B384
    - BLAKE2S256E
    - BLAKE2S256
    - BLAKE2S160E
    - BLAKE2S160
    - BLAKE2S224E
    - BLAKE2S224
    - BLAKE2SP256E
    - BLAKE2SP256
    - BLAKE2SP224E
    - BLAKE2SP224
    - SHA1E
    - SHA1
    - MD5E
    - MD5
    - WORM
    - URL
  - operating system: linux x86_64
  - remote types: 
    - git
    - gcrypt
    - p2p
    - S3
    - bup
    - directory
    - rsync
    - web
    - bittorrent
    - webdav
    - adb
    - tahoe
    - glacier
    - ddar
    - hook
    - external
  - supported repository versions: 
    - 3
    - 5
    - 6
  - upgrade supported from repository versions: 
    - 0
    - 1
    - 2
    - 3
    - 4
    - 5
  - version: 6.20180913+git33-g2cd5a723f-1~ndall+1
...
```