### PR TITLE
Removing obstacles for generator behavior in low-level code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_DIRECT=yes
 ##1    - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5
 
@@ -153,14 +152,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  - python: 3.5
-    # test whether known direct mode failures still fail
-    env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
   - python: 3.5
     # test with extension datalad-crawler
@@ -196,13 +187,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  # test whether known direct mode failures still fail
-  - env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -279,11 +279,11 @@ class AutomagicIO(object):
         try:
             # might fail.  TODO: troubleshoot when it does e.g.
             # datalad/tests/test_auto.py:test_proxying_open_testrepobased
-            under_annex = annex.is_under_annex(filepath, batch=True)
+            under_annex = annex.is_under_annex(filepath, batch=True)[filepath]
         except:  # MIH: really? what if MemoryError
             under_annex = None
         # either it has content
-        if (under_annex or under_annex is None) and not annex.file_has_content(filepath):
+        if (under_annex or under_annex is None) and not annex.file_has_content(filepath)[0]:
             lgr.info("AutomagicIO: retrieving file content of %s", filepath)
             out = annex.get(filepath)
             if not out.get('success', False):

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -78,15 +78,15 @@ def test_basic_scenario(direct, d, d2):
     annex.add_url_to_file(fn_extracted, file_url, ['--relaxed'])
     annex.drop(fn_extracted)
 
-    list_of_remotes = annex.whereis(fn_extracted, output='descriptions')
+    list_of_remotes = annex.whereis(fn_extracted, output='descriptions')[0]
     in_('[%s]' % ARCHIVES_SPECIAL_REMOTE, list_of_remotes)
 
-    assert_false(annex.file_has_content(fn_extracted))
+    assert_false(annex.file_has_content(fn_extracted)[0])
     annex.get(fn_extracted)
-    assert_true(annex.file_has_content(fn_extracted))
+    assert_true(annex.file_has_content(fn_extracted)[0])
 
     annex.rm_url(fn_extracted, file_url)
-    assert_false(annex.drop(fn_extracted)['success'])
+    assert_false(annex.drop(fn_extracted)[0]['success'])
 
     annex.add_url_to_file(fn_extracted, file_url)
     annex.drop(fn_extracted)
@@ -100,12 +100,12 @@ def test_basic_scenario(direct, d, d2):
     # we still need to enable manually atm that special remote for archives
     # cloned_annex.enable_remote('annexed-archives')
 
-    assert_false(cloned_annex.file_has_content(fn_archive))
-    assert_false(cloned_annex.file_has_content(fn_extracted))
+    assert_false(cloned_annex.file_has_content(fn_archive)[0])
+    assert_false(cloned_annex.file_has_content(fn_extracted)[0])
     cloned_annex.get(fn_extracted)
-    assert_true(cloned_annex.file_has_content(fn_extracted))
+    assert_true(cloned_annex.file_has_content(fn_extracted)[0])
     # as a result it would also fetch tarball
-    assert_true(cloned_annex.file_has_content(fn_archive))
+    assert_true(cloned_annex.file_has_content(fn_archive)[0])
 
     # Check if protocol was collected
     if os.environ.get('DATALAD_TESTS_PROTOCOLREMOTE'):
@@ -138,9 +138,9 @@ def test_annex_get_from_subdir(topdir):
     with chpwd(opj(topdir, 'a', 'd')):
         runner = Runner()
         runner(['git', 'annex', 'drop', '--', fn_inarchive_obscure])  # run git annex drop
-        assert_false(annex.file_has_content(fpath))             # and verify if file deleted from directory
+        assert_false(annex.file_has_content(fpath)[0])             # and verify if file deleted from directory
         runner(['git', 'annex', 'get', '--', fn_inarchive_obscure])   # run git annex get
-        assert_true(annex.file_has_content(fpath))              # and verify if file got into directory
+        assert_true(annex.file_has_content(fpath)[0])              # and verify if file got into directory
 
 
 def test_get_git_environ_adjusted():

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -34,15 +34,16 @@ def check_basic_scenario(direct, url, d):
     with swallow_outputs() as cmo:
         annex.add_urls([url])
         annex.commit("committing")
-        whereis1 = annex.whereis('3versions_allversioned.txt', output='full')
+        testfilename = '3versions_allversioned.txt'
+        whereis1 = annex.whereis(testfilename, output='full')[testfilename]
         eq_(len(whereis1), 2)  # here and datalad
-        annex.drop('3versions_allversioned.txt')
+        annex.drop(testfilename)
         if PY2:
             pass  # stopped appearing within the test  TODO
             #assert_in('100%', cmo.err)  # we do provide our progress indicator
         else:
             pass  # TODO:  not sure what happened but started to fail for me on my laptop under tox
-    whereis2 = annex.whereis('3versions_allversioned.txt', output='full')
+    whereis2 = annex.whereis(testfilename, output='full')[testfilename]
     eq_(len(whereis2), 1)  # datalad
 
     # if we provide some bogus address which we can't access, we shouldn't pollute output

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -153,7 +153,7 @@ def test_clone_simple_local(src, path):
             {'test.dat', 'INFO.txt', 'test-annex.dat'})
         ok_clean_git(path, annex=True)
         # no content was installed:
-        ok_(not ds.repo.file_has_content('test-annex.dat'))
+        ok_(not ds.repo.file_has_content('test-annex.dat')[0])
         uuid_before = ds.repo.uuid
         eq_(ds.repo.get_description(), 'mydummy')
 

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -143,13 +143,13 @@ def test_get_single_file(path):
 
     ds = Dataset(path)
     ok_(ds.is_installed())
-    ok_(ds.repo.file_has_content('test-annex.dat') is False)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is False)
     result = ds.get("test-annex.dat")
     assert_result_count(result, 1)
     assert_status('ok', result)
     eq_(result[0]['path'], opj(ds.path, 'test-annex.dat'))
     eq_(result[0]['annexkey'], ds.repo.get_file_key('test-annex.dat'))
-    ok_(ds.repo.file_has_content('test-annex.dat') is True)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is True)
 
 
 @with_tree(tree={'file1.txt': 'whatever 1',
@@ -239,7 +239,7 @@ def test_get_recurse_dirs(o_path, c_path):
 
     # additionally got file1.txt silently, since it has the same content as
     # subdir/subsubdir/file4.txt:
-    ok_(ds.repo.file_has_content('file1.txt') is True)
+    ok_(ds.repo.file_has_content('file1.txt')[0] is True)
 
 
 @slow  # 15.1496s
@@ -267,9 +267,9 @@ def test_get_recurse_subdatasets(src, path):
                      rel_path_sub2}
 
     # None of them is currently present:
-    ok_(ds.repo.file_has_content('test-annex.dat') is False)
-    ok_(subds1.repo.file_has_content('test-annex.dat') is False)
-    ok_(subds2.repo.file_has_content('test-annex.dat') is False)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is False)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is False)
+    ok_(subds2.repo.file_has_content('test-annex.dat')[0] is False)
 
     ok_clean_git(subds1.path)
     # explicitly given path in subdataset => implicit recursion:
@@ -280,11 +280,11 @@ def test_get_recurse_subdatasets(src, path):
     assert_status('ok', result)
 
     assert_in_results(result, path=opj(ds.path, rel_path_sub1), status='ok')
-    ok_(subds1.repo.file_has_content('test-annex.dat') is True)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is True)
 
     # drop it:
     subds1.repo.drop('test-annex.dat')
-    ok_(subds1.repo.file_has_content('test-annex.dat') is False)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is False)
 
     # now, with a path not explicitly pointing within a
     # subdataset, but recursive option:
@@ -295,17 +295,17 @@ def test_get_recurse_subdatasets(src, path):
     eq_(set([item.get('path')[len(ds.path) + 1:] for item in result
              if item['type'] == 'file']),
         annexed_files)
-    ok_(ds.repo.file_has_content('test-annex.dat') is True)
-    ok_(subds1.repo.file_has_content('test-annex.dat') is True)
-    ok_(subds2.repo.file_has_content('test-annex.dat') is True)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is True)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is True)
+    ok_(subds2.repo.file_has_content('test-annex.dat')[0] is True)
 
     # drop them:
     ds.repo.drop('test-annex.dat')
     subds1.repo.drop('test-annex.dat')
     subds2.repo.drop('test-annex.dat')
-    ok_(ds.repo.file_has_content('test-annex.dat') is False)
-    ok_(subds1.repo.file_has_content('test-annex.dat') is False)
-    ok_(subds2.repo.file_has_content('test-annex.dat') is False)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is False)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is False)
+    ok_(subds2.repo.file_has_content('test-annex.dat')[0] is False)
 
     # now, the very same call, but without recursive:
     result = ds.get('.', recursive=False)
@@ -314,9 +314,9 @@ def test_get_recurse_subdatasets(src, path):
     eq_(len(result) - 1, 1)
     assert_result_count(
         result, 1, path=opj(ds.path, 'test-annex.dat'), status='ok')
-    ok_(ds.repo.file_has_content('test-annex.dat') is True)
-    ok_(subds1.repo.file_has_content('test-annex.dat') is False)
-    ok_(subds2.repo.file_has_content('test-annex.dat') is False)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is True)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is False)
+    ok_(subds2.repo.file_has_content('test-annex.dat')[0] is False)
 
 
 @with_testrepos('submodule_annex', flavors='local')
@@ -332,9 +332,9 @@ def test_get_greedy_recurse_subdatasets(src, path):
 
     # We got all content in the subdatasets
     subds1, subds2 = ds.subdatasets(result_xfm='datasets')
-    ok_(ds.repo.file_has_content('test-annex.dat') is False)
-    ok_(subds1.repo.file_has_content('test-annex.dat') is True)
-    ok_(subds2.repo.file_has_content('test-annex.dat') is True)
+    ok_(ds.repo.file_has_content('test-annex.dat')[0] is False)
+    ok_(subds1.repo.file_has_content('test-annex.dat')[0] is True)
+    ok_(subds2.repo.file_has_content('test-annex.dat')[0] is True)
 
 
 @with_testrepos('submodule_annex', flavors='local')
@@ -357,7 +357,7 @@ def test_get_install_missing_subdataset(src, path):
     file_ = opj(subs[0].path, 'test-annex.dat')
     ds.get(file_)
     ok_(subs[0].is_installed())
-    ok_(subs[0].repo.file_has_content('test-annex.dat') is True)
+    ok_(subs[0].repo.file_has_content('test-annex.dat')[0] is True)
 
     # but we fulfill any handles, and dataset handles too
     ds.get(curdir, recursive=True)
@@ -386,7 +386,7 @@ def test_get_mixed_hierarchy(src, path):
     ds, subds = install(
         path, source=src, recursive=True,
         result_xfm='datasets', return_type='item-or-list', result_filter=None)
-    ok_(subds.repo.file_has_content("file_in_annex.txt") is False)
+    ok_(subds.repo.file_has_content("file_in_annex.txt")[0] is False)
 
     # and get:
     result = ds.get(curdir, recursive=True)
@@ -394,7 +394,7 @@ def test_get_mixed_hierarchy(src, path):
     assert_status(['ok', 'notneeded'], result)
     assert_result_count(
         result, 1, path=opj(subds.path, "file_in_annex.txt"), status='ok')
-    ok_(subds.repo.file_has_content("file_in_annex.txt") is True)
+    ok_(subds.repo.file_has_content("file_in_annex.txt")[0] is True)
 
 
 @with_testrepos('submodule_annex', flavors='local')
@@ -410,8 +410,8 @@ def test_autoresolve_multiple_datasets(src, path):
         results = get([opj('ds1', 'test-annex.dat')] + glob(opj('ds2', '*.dat')))
         # each ds has one file
         assert_result_count(results, 2, type='file', action='get', status='ok')
-        ok_(ds1.repo.file_has_content('test-annex.dat') is True)
-        ok_(ds2.repo.file_has_content('test-annex.dat') is True)
+        ok_(ds1.repo.file_has_content('test-annex.dat')[0] is True)
+        ok_(ds2.repo.file_has_content('test-annex.dat')[0] is True)
 
 
 @slow  # 20 sec
@@ -438,7 +438,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     assert_in(subsub, results)
     # all file handles are fulfilled by default
     ok_(Dataset(opj(ds.path, 'sub', 'subsub')).repo.file_has_content(
-        "file_in_annex.txt") is True)
+        "file_in_annex.txt")[0] is True)
 
 
 @slow  # 92sec
@@ -461,7 +461,7 @@ def test_recurse_existing(src, path):
     root, sub1, sub2 = install(
         path, source=src, recursive=True, recursion_limit=2,
         result_xfm='datasets', result_filter=None)
-    ok_(sub2.repo.file_has_content('file_in_annex.txt') is False)
+    ok_(sub2.repo.file_has_content('file_in_annex.txt')[0] is False)
     sub3 = Dataset(opj(sub2.path, 'sub3'))
     ok_(not sub3.is_installed())
     # now get all content in all existing datasets, no new datasets installed
@@ -469,18 +469,18 @@ def test_recurse_existing(src, path):
     files = root.get(curdir, recursive=True, recursion_limit='existing')
     assert_not_in_results(files, type='dataset', status='ok')
     assert_result_count(files, 1, type='file', status='ok')
-    ok_(sub2.repo.file_has_content('file_in_annex.txt') is True)
+    ok_(sub2.repo.file_has_content('file_in_annex.txt')[0] is True)
     ok_(not sub3.is_installed())
     # now pull down all remaining datasets, no data
     sub3, sub4 = root.get(
         curdir, recursive=True, get_data=False,
         result_xfm='datasets', result_filter=lambda x: x['status'] == 'ok')
     ok_(sub4.is_installed())
-    ok_(sub3.repo.file_has_content('file_in_annex.txt') is False)
+    ok_(sub3.repo.file_has_content('file_in_annex.txt')[0] is False)
     # aaannd all data
     files = root.get(curdir, recursive=True, result_filter=lambda x: x['status'] == 'ok' and x['type'] == 'file')
     eq_(len(files), 1)
-    ok_(sub3.repo.file_has_content('file_in_annex.txt') is True)
+    ok_(sub3.repo.file_has_content('file_in_annex.txt')[0] is True)
 
 
 @slow  # 33sec
@@ -504,5 +504,5 @@ def test_get_in_unavailable_subdataset(src, path):
     # we got the dataset, and its immediate content, but nothing below
     sub2 = Dataset(targetabspath)
     ok_(sub2.is_installed())
-    ok_(sub2.repo.file_has_content('file_in_annex.txt') is True)
+    ok_(sub2.repo.file_has_content('file_in_annex.txt')[0] is True)
     ok_(not Dataset(opj(targetabspath, 'sub3')).is_installed())

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -269,7 +269,7 @@ def test_install_simple_local(src, path):
             {'test.dat', 'INFO.txt', 'test-annex.dat'})
         ok_clean_git(path, annex=True)
         # no content was installed:
-        ok_(not ds.repo.file_has_content('test-annex.dat'))
+        ok_(not ds.repo.file_has_content('test-annex.dat')[0])
         uuid_before = ds.repo.uuid
         eq_(ds.repo.get_description(), 'mydummy')
 
@@ -515,11 +515,11 @@ def test_install_known_subdataset(src, path):
     assert_in('subm 1', ds.subdatasets(fulfilled=True, result_xfm='relpaths'))
 
     # now, get the data by reinstalling with -g:
-    ok_(subds.repo.file_has_content('test-annex.dat') is False)
+    ok_(subds.repo.file_has_content('test-annex.dat')[0] is False)
     with chpwd(ds.path):
         result = get(path='subm 1', dataset=os.curdir)
         assert_in_results(result, path=opj(subds.path, 'test-annex.dat'))
-        ok_(subds.repo.file_has_content('test-annex.dat') is True)
+        ok_(subds.repo.file_has_content('test-annex.dat')[0] is True)
         ok_(subds.is_installed())
 
 
@@ -670,14 +670,14 @@ def test_install_recursive_repeat(src, path):
     assert_in(sub1, result)
     assert_in(sub2, result)
     assert_not_in(subsub, result)
-    ok_(top_ds.repo.file_has_content('top_file.txt') is True)
-    ok_(sub1.repo.file_has_content('sub1file.txt') is True)
-    ok_(sub2.repo.file_has_content('sub2file.txt') is True)
+    ok_(top_ds.repo.file_has_content('top_file.txt')[0] is True)
+    ok_(sub1.repo.file_has_content('sub1file.txt')[0] is True)
+    ok_(sub2.repo.file_has_content('sub2file.txt')[0] is True)
 
     # install sub1 again, recursively and with data
     top_ds.install('sub 1', recursive=True, get_data=True)
     ok_(subsub.is_installed())
-    ok_(subsub.repo.file_has_content('subsubfile.txt'))
+    ok_(subsub.repo.file_has_content('subsubfile.txt')[0])
 
 
 @with_testrepos('submodule_annex', flavors=['local'])

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -365,7 +365,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 
     # and the file itself was transferred
     ok_(lexists(opj(sub2_target.path, 'file.dat')))
-    nok_(sub2_target.file_has_content('file.dat'))
+    nok_(sub2_target.file_has_content('file.dat')[0])
 
     ## but now we can redo publish recursively, with explicitly requested data transfer
     res_ = publish(
@@ -373,7 +373,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
         recursive=True,
         transfer_data='all'
     )
-    ok_(sub2_target.file_has_content('file.dat'))
+    ok_(sub2_target.file_has_content('file.dat')[0])
     assert_result_count(
         res_, 1, status='ok', path=opj(sub2.path, 'file.dat'))
 
@@ -443,15 +443,15 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 
     # we need compare target/master:
     target.checkout("master")
-    ok_(target.file_has_content('test-annex.dat'))
+    ok_(target.file_has_content('test-annex.dat')[0])
 
     # make sure that whatever we published is actually consumable
     dst_clone = install(
         dst_clone_path, source=dst_path,
         result_xfm='datasets', return_type='item-or-list')
-    nok_(dst_clone.repo.file_has_content('test-annex.dat'))
+    nok_(dst_clone.repo.file_has_content('test-annex.dat')[0])
     res = dst_clone.get('test-annex.dat')
-    ok_(dst_clone.repo.file_has_content('test-annex.dat'))
+    ok_(dst_clone.repo.file_has_content('test-annex.dat')[0])
 
     res = publish(dataset=source, to="target", path=['.'])
     # there is nothing to publish on 2nd attempt
@@ -553,7 +553,7 @@ def test_publish_depends(
     ok_(lexists(opj(target3_path, 'probe1')))
     # but it has no data copied
     target3 = Dataset(target3_path)
-    nok_(target3.repo.file_has_content('probe1'))
+    nok_(target3.repo.file_has_content('probe1')[0])
 
     # but if we publish specifying its path, it gets copied
     source.publish('probe1', to='target3')

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -127,12 +127,12 @@ def test_uninstall_annex_file(path):
     ok_(ds.is_installed())
     ok_file_under_git(ds.repo.path, 'test-annex.dat', annexed=True)
     ds.repo.get('test-annex.dat')
-    ok_(ds.repo.file_has_content('test-annex.dat'))
+    ok_(ds.repo.file_has_content('test-annex.dat')[0])
 
     # remove file's content:
     res = ds.drop(path='test-annex.dat', result_xfm='paths')
     # test it happened:
-    ok_(not ds.repo.file_has_content('test-annex.dat'))
+    ok_(not ds.repo.file_has_content('test-annex.dat')[0])
     ok_file_under_git(ds.repo.path, 'test-annex.dat', annexed=True)
     # test result:
     eq_(res, [opj(ds.path, 'test-annex.dat')])
@@ -242,8 +242,8 @@ def test_uninstall_multiple_paths(path):
     ok_clean_git(ds.path)
     files_left = glob(opj(ds.path, '*', '*', '*')) + glob(opj(ds.path, '*'))
     ok_(all([f.endswith('keep') for f in files_left if exists(f) and not isdir(f)]))
-    ok_(not ds.repo.file_has_content(topfile))
-    ok_(not subds.repo.file_has_content(opj(*psplit(deepfile)[1:])))
+    ok_(not ds.repo.file_has_content(topfile)[0])
+    ok_(not subds.repo.file_has_content(opj(*psplit(deepfile)[1:]))[0])
     # remove handles for all 'kill' files
     ds.remove([topfile, deepfile], check=False)
     ok_clean_git(ds.path)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -238,7 +238,7 @@ def test_newthings_coming_down(originpath, destpath):
     assert_is_instance(ds.repo, AnnexRepo)
     # should be fully functional
     testfname = opj(ds.path, 'load.dat')
-    assert_false(ds.repo.file_has_content(testfname))
+    assert_false(ds.repo.file_has_content(testfname)[0])
     ds.get('.')
     ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')
     # check that a new tag comes down
@@ -364,7 +364,7 @@ def test_reobtain_data(originpath, destpath):
     # update does not bring data automatically
     assert_result_count(ds.update(merge=True, reobtain_data=True), 1)
     assert_in('load.dat', ds.repo.get_annexed_files())
-    assert_false(ds.repo.file_has_content('load.dat'))
+    assert_false(ds.repo.file_has_content('load.dat')[0])
     # now get data
     ds.get('load.dat')
     ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')
@@ -377,7 +377,7 @@ def test_reobtain_data(originpath, destpath):
 
     ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')
     assert_in('novel', ds.repo.get_annexed_files())
-    assert_false(ds.repo.file_has_content('novel'))
+    assert_false(ds.repo.file_has_content('novel')[0])
     # modify content at origin
     os.remove(opj(origin.path, 'load.dat'))
     create_tree(origin.path, {'load.dat': 'light'})
@@ -388,7 +388,7 @@ def test_reobtain_data(originpath, destpath):
     assert_result_count(res, 1, status='ok', type='dataset', action='update')
     assert_result_count(res, 1, status='ok', type='file', action='get')
     ok_file_has_content(opj(ds.path, 'load.dat'), 'light')
-    assert_false(ds.repo.file_has_content('novel'))
+    assert_false(ds.repo.file_has_content('novel')[0])
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -326,10 +326,10 @@ class FsModel(AnnexModel):
 
         if type_ in ['file', 'link', 'link-broken']:
             # if node is under annex, ask annex for node size, ondisk_size
-            if isinstance(self.repo, AnnexRepo) and self.repo.is_under_annex(self._path):
-                size = self.repo.info(self._path, batch=True)['size']
+            if isinstance(self.repo, AnnexRepo) and self.repo.is_under_annex(self._path)[0]:
+                size = self.repo.info(self._path, batch=True)[self._path]['size']
                 ondisk_size = size \
-                    if self.repo.file_has_content(self._path) \
+                    if self.repo.file_has_content(self._path)[0] \
                     else 0
             # else ask fs for node size (= ondisk_size)
             else:

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -103,7 +103,7 @@ def test_download_url_dataset(toppath, topurl, path):
         [urls_tosave[1]])
 
     ds.download_url([opj(topurl, "file3.txt")], save=False)
-    assert_false(ds.repo.file_has_content("file3.txt"))
+    assert_false(ds.repo.file_has_content("file3.txt")[0])
 
     subdir_path = opj(path, "subdir")
     os.mkdir(subdir_path)

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -241,8 +241,8 @@ def test_bf2458(src, dst):
     clone = install(source=ds.path, path=dst)
     # XXX whereis says nothing in direct mode
     # content is not here
-    eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
+    eq_(clone.repo.whereis('dummy'), [[ds.config.get('annex.uuid')]])
     # check that plain metadata access does not `get` stuff
     clone.metadata('.', on_failure='ignore')
     # XXX whereis says nothing in direct mode
-    eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
+    eq_(clone.repo.whereis('dummy'), [[ds.config.get('annex.uuid')]])

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -67,7 +67,6 @@ from .gitrepo import GitRepo
 from .gitrepo import NoSuchPathError
 from .gitrepo import _normalize_path
 from .gitrepo import normalize_path
-from .gitrepo import normalize_paths
 from .gitrepo import GitCommandError
 from .gitrepo import to_options
 from . import ansi_colors
@@ -1294,7 +1293,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         # on crippled filesystem for example (think so)?
         self.config.reload()
 
-    @normalize_paths
     def get(self, files, remote=None, options=None, jobs=None, key=False):
         """Get the actual content of files
 
@@ -1417,7 +1415,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 unknown_sizes.append(j['file'])
         return expected_files, fetch_files
 
-    @normalize_paths
     def add(self, files, git=None, backend=None, options=None, jobs=None,
             git_options=None, annex_options=None, update=False):
         """Add file(s) to the repository.
@@ -1599,7 +1596,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                                        annex_options=['--'] + git_cmd,
                                        **kwargs)
 
-    @normalize_paths
     def get_file_key(self, files):
         """Get key of an annexed file.
 
@@ -1615,6 +1611,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             in case of a list an empty string is returned if there was no key
             for that file
         """
+        files = assure_list(files)
 
         if len(files) > 1:
             return self._batched.get('lookupkey', path=self.path)(files)
@@ -1663,7 +1660,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 raise FileNotInAnnexError("Could not get a key for a file(s) %s -- empty output" % files)
             return entries[0]
 
-    @normalize_paths
     def lock(self, files, options=None):
         """undo unlock
 
@@ -1680,7 +1676,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._run_annex_command('lock', annex_options=options, files=files)
         # note: there seems to be no output by annex if success.
 
-    @normalize_paths
     def unlock(self, files, options=None):
         """unlock files for modification
 
@@ -1753,7 +1748,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         options = options[:] if options else to_options(unlock=True)
         self._run_annex_command('adjust', annex_options=options)
 
-    @normalize_paths
     def unannex(self, files, options=None):
         """undo accidental add command
 
@@ -1780,7 +1774,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         return [line.split()[1] for line in std_out.splitlines()
                 if line.split()[0] == 'unannex' and line.split()[-1] == 'ok']
 
-    @normalize_paths(map_filenames_back=True)
     def find(self, files, batch=False):
         """Run `git annex find` on file(s).
 
@@ -1832,14 +1825,13 @@ class AnnexRepo(GitRepo, RepoInterface):
             # `find` returns an empty string for unlocked files, and in direct
             # mode everything looks modified, so we don't even bother.
             modified = self.get_changed_files() if is_v6 else []
-            annex_res = fn(files, normalize_paths=False, batch=batch)
+            annex_res = fn(files, batch=batch)
             return [bool(annex_res.get(f) and
                          not (is_v6 and normpath(f) in modified))
                     for f in files]
         else:  # ad-hoc check which should be faster than call into annex
             return [quick_fn(f) for f in files]
 
-    @normalize_paths
     def file_has_content(self, files, allow_quick=True, batch=False):
         """Check whether files have their content present under annex.
 
@@ -1874,7 +1866,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         return self._check_files(self.find, quick_check,
                                  files, allow_quick, batch)
 
-    @normalize_paths
     def is_under_annex(self, files, allow_quick=True, batch=False):
         """Check whether files are under annex control
 
@@ -2202,7 +2193,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         return self.whereis(file_, output='full', batch=batch)[AnnexRepo.WEB_UUID]['urls']
 
-    @normalize_paths
     def drop(self, files, options=None, key=False, jobs=None):
         """Drops the content of annexed files from this repository.
 
@@ -2477,7 +2467,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         return json_objects
 
     # TODO: reconsider having any magic at all and maybe just return a list/dict always
-    @normalize_paths
     def whereis(self, files, output='uuids', key=False, options=None, batch=False):
         """Lists repositories that have actual content of file(s).
 
@@ -2556,7 +2545,6 @@ class AnnexRepo(GitRepo, RepoInterface):
     # then returned filenames would not need to be mapped, so we could easily work on dirs
     # and globs.
     # OR if explicit filenames list - return list of matching entries, if globs/dirs -- return dict?
-    @normalize_paths(map_filenames_back=True)
     def info(self, files, batch=False, fast=False):
         """Provide annex info for file(s).
 
@@ -2927,7 +2915,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 if alt_index_file and os.path.exists(alt_index_file):
                     unlink(alt_index_file)
 
-    @normalize_paths(match_return_type=False)
     def remove(self, files, force=False, **kwargs):
         """Remove files from git/annex (works in direct mode as well)
 
@@ -2941,7 +2928,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         self.precommit()  # since might interfere
 
         return super(AnnexRepo, self).remove(files, force=force,
-                                             normalize_paths=False,
                                              **kwargs)
 
     def get_contentlocation(self, key, batch=False):
@@ -2980,7 +2966,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return self._batched.get('contentlocation', path=self.path)(key)
 
-    @normalize_paths(serialize=True)
     def is_available(self, file_, remote=None, key=False, batch=False):
         """Check if file or key is available (from a remote)
 
@@ -3044,7 +3029,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                     "Received output %r from annex, whenever expect 0 or 1" % out
                 )
 
-    @normalize_paths(match_return_type=False)
     def _annex_custom_command(
             self, files, cmd_str, log_stdout=True, log_stderr=True,
             log_online=False, expect_stderr=False, cwd=None, env=None,
@@ -3077,7 +3061,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             expect_stderr=expect_stderr,
             cwd=cwd, env=env, shell=shell, expect_fail=expect_fail)
 
-    @normalize_paths
     def migrate_backend(self, files, backend=None):
         """Changes the backend used for `file`.
 
@@ -3103,7 +3086,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 annex_options=files,
                                 backend=backend)
 
-    @normalize_paths
     def get_file_backend(self, files):
         """Get the backend currently used for file(s).
 
@@ -3136,7 +3118,6 @@ class AnnexRepo(GitRepo, RepoInterface):
     # symlink's target instead of the actual content.
 
     # We need --auto and --fast having exposed  TODO
-    @normalize_paths(match_return_type=False)  # get a list even in case of a single item
     def copy_to(self, files, remote, options=None, jobs=None):
         """Copy the actual content of `files` to `remote`
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -207,9 +207,6 @@ def _normalize_path(base_dir, path):
 def normalize_path(func):
     """Decorator to provide unified path conversion for a single file
 
-    Unlike normalize_paths, intended to be used for functions dealing with a
-    single filename at a time
-
     Note
     ----
     This is intended to be used within the repository classes and therefore
@@ -224,113 +221,6 @@ def normalize_path(func):
     def newfunc(self, file_, *args, **kwargs):
         file_new = _normalize_path(self.path, file_)
         return func(self, file_new, *args, **kwargs)
-
-    return newfunc
-
-
-@optional_args
-def normalize_paths(func, match_return_type=True, map_filenames_back=False,
-                    serialize=False):
-    """Decorator to provide unified path conversions.
-
-    Note
-    ----
-    This is intended to be used within the repository classes and therefore
-    returns a class method!
-
-    The decorated function is expected to take a path or a list of paths at
-    first positional argument (after 'self'). Additionally the class `func`
-    is a member of, is expected to have an attribute 'path'.
-
-    Accepts either a list of paths or a single path in a str. Passes a list
-    to decorated function either way, but would return based on the value of
-    match_return_type and possibly input argument.
-
-    If a call to the wrapped function includes normalize_path and it is False
-    no normalization happens for that function call (used for calls to wrapped
-    functions within wrapped functions, while possible CWD is within a
-    repository)
-
-    Parameters
-    ----------
-    match_return_type : bool, optional
-      If True, and a single string was passed in, it would return the first
-      element of the output (after verifying that it is a list of length 1).
-      It makes easier to work with single files input.
-    map_filenames_back : bool, optional
-      If True and returned value is a dictionary, it assumes to carry entries
-      one per file, and then filenames are mapped back to as provided from the
-      normalized (from the root of the repo) paths
-    serialize : bool, optional
-      Loop through files giving only a single one to the function one at a time.
-      This allows to simplify implementation and interface to annex commands
-      which do not take multiple args in the same call (e.g. checkpresentkey)
-    """
-
-    @wraps(func)
-    def newfunc(self, files, *args, **kwargs):
-
-        normalize = _normalize_path if kwargs.pop('normalize_paths', True) \
-            else lambda rpath, filepath: filepath
-
-        if files:
-            if isinstance(files, string_types) or not files:
-                files_new = [normalize(self.path, files)]
-                single_file = True
-            elif isinstance(files, list):
-                files_new = [normalize(self.path, path) for path in files]
-                single_file = False
-            else:
-                raise ValueError("_files_decorator: Don't know how to handle "
-                                 "instance of %s." % type(files))
-        else:
-            single_file = None
-            files_new = []
-
-        if map_filenames_back:
-            def remap_filenames(out):
-                """Helper to map files back to non-normalized paths"""
-                if isinstance(out, dict):
-                    assert(len(out) == len(files_new))
-                    files_ = [files] if single_file else files
-                    mapped = out.__class__()
-                    for fin, fout in zip(files_, files_new):
-                        mapped[fin] = out[fout]
-                    return mapped
-                else:
-                    return out
-        else:
-            remap_filenames = lambda x: x
-
-        if serialize:  # and not single_file:
-            result = [
-                func(self, f, *args, **kwargs)
-                for f in files_new
-            ]
-        else:
-            result = func(self, files_new, *args, **kwargs)
-
-        if single_file is None:
-            # no files were provided, nothing we can do really
-            return result
-        elif (result is None) or not match_return_type or not single_file:
-            # If function doesn't return anything or no denormalization
-            # was requested or it was not a single file
-            return remap_filenames(result)
-        elif single_file:
-            if len(result) != 1:
-                # Magic doesn't apply
-                return remap_filenames(result)
-            elif isinstance(result, (list, tuple)):
-                return result[0]
-            elif isinstance(result, dict) and tuple(result)[0] == files_new[0]:
-                # assume that returned dictionary has files as keys.
-                return tuple(result.values())[0]
-            else:
-                # no magic can apply
-                return remap_filenames(result)
-        else:
-            return RuntimeError("should have not got here... check logic")
 
     return newfunc
 
@@ -888,7 +778,6 @@ class GitRepo(RepoInterface):
             msg += "s"
         return msg + '\n\nFiles:\n' + '\n'.join(files)
 
-    @normalize_paths
     def add(self, files, git=True, git_options=None, update=False):
         """Adds file(s) to the repository.
 
@@ -990,7 +879,6 @@ class GitRepo(RepoInterface):
         return [{u'file': f, u'success': True}
                 for f in re.findall("'(.*)'[\n$]", assure_unicode(stdout))]
 
-    @normalize_paths(match_return_type=False)
     def remove(self, files, recursive=False, **kwargs):
         """Remove files.
 
@@ -1235,7 +1123,6 @@ class GitRepo(RepoInterface):
         assert(len(stdout) == 1)
         return stdout[0]
 
-    @normalize_paths(match_return_type=False)
     def get_last_commit_hash(self, files):
         """Return the hash of the last commit the modified any of the given
         paths"""
@@ -1570,7 +1457,6 @@ class GitRepo(RepoInterface):
 
         return std_out, std_err
 
-    @normalize_paths(match_return_type=False)
     def _git_custom_command(self, files, cmd_str,
                             log_stdout=True, log_stderr=True, log_online=False,
                             expect_stderr=True, cwd=None, env=None,
@@ -1602,6 +1488,10 @@ class GitRepo(RepoInterface):
         else:
             if files and cmd_str[-1] != '--':
                 cmd_str.append('--')
+
+        # little dance, because our own code frequently
+        # uses the pattern of giving an empty string as `files`
+        files = assure_list(files if files else [])
 
         cmd = cmd_str + files
 
@@ -2414,7 +2304,7 @@ class GitRepo(RepoInterface):
         stdout, stderr = self._git_custom_command(path, cmd)
         # make sure we have one entry for each query path to
         # simplify work with the result
-        attributes = {_normalize_path(self.path, p): {} for p in path}
+        attributes = {p: {} for p in path}
         attr = []
         for item in stdout.split('\0'):
             attr.append(item)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -38,62 +38,65 @@ from datalad.support.external_versions import external_versions
 
 from datalad.support.sshconnector import get_connection_hash
 
-from datalad.utils import on_windows
-from datalad.utils import chpwd
-from datalad.utils import rmtree
-from datalad.utils import linux_distribution_name
-from datalad.utils import unlink
+from datalad.utils import (
+    on_windows,
+    chpwd,
+    rmtree,
+    linux_distribution_name,
+    unlink,
+)
 
 from datalad.tests.utils import (
     assert_result_count,
+    ignore_nose_capturing_stdout,
+    assert_cwd_unchanged,
+    with_testrepos,
+    with_tempfile,
+    with_tree,
+    create_tree,
+    with_batch_direct,
+    assert_dict_equal as deq_,
+    assert_is_instance,
+    assert_false,
+    assert_in,
+    assert_is,
+    assert_not_in,
+    assert_re_in,
+    assert_raises,
+    assert_not_equal,
+    assert_equal,
+    assert_true,
+    eq_,
+    ok_,
+    ok_git_config_not_empty,
+    ok_annex_get,
+    ok_clean_git,
+    ok_file_has_content,
+    swallow_logs,
+    swallow_outputs,
+    local_testrepo_flavors,
+    serve_path_via_http,
+    get_most_obscure_supported_name,
+    OBSCURE_FILENAME,
+    SkipTest,
+    skip_ssh,
+    find_files,
 )
 
-from datalad.tests.utils import ignore_nose_capturing_stdout
-from datalad.tests.utils import assert_cwd_unchanged
-from datalad.tests.utils import with_testrepos
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import create_tree
-from datalad.tests.utils import with_batch_direct
-from datalad.tests.utils import assert_dict_equal as deq_
-from datalad.tests.utils import assert_is_instance
-from datalad.tests.utils import assert_false
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_is
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import assert_re_in
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import assert_not_equal
-from datalad.tests.utils import assert_equal
-from datalad.tests.utils import assert_true
-from datalad.tests.utils import eq_
-from datalad.tests.utils import ok_
-from datalad.tests.utils import ok_git_config_not_empty
-from datalad.tests.utils import ok_annex_get
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import swallow_logs
-from datalad.tests.utils import swallow_outputs
-from datalad.tests.utils import local_testrepo_flavors
-from datalad.tests.utils import serve_path_via_http
-from datalad.tests.utils import get_most_obscure_supported_name
-from datalad.tests.utils import OBSCURE_FILENAME
-from datalad.tests.utils import SkipTest
-from datalad.tests.utils import skip_ssh
-from datalad.tests.utils import find_files
-
-from datalad.support.exceptions import CommandError
-from datalad.support.exceptions import CommandNotAvailableError
-from datalad.support.exceptions import FileNotInRepositoryError
-from datalad.support.exceptions import FileNotInAnnexError
-from datalad.support.exceptions import FileInGitError
-from datalad.support.exceptions import OutOfSpaceError
-from datalad.support.exceptions import RemoteNotAvailableError
-from datalad.support.exceptions import OutdatedExternalDependency
-from datalad.support.exceptions import MissingExternalDependency
-from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import AnnexBatchCommandError
-from datalad.support.exceptions import IncompleteResultsError
+from datalad.support.exceptions import (
+    CommandError,
+    CommandNotAvailableError,
+    FileNotInRepositoryError,
+    FileNotInAnnexError,
+    FileInGitError,
+    OutOfSpaceError,
+    RemoteNotAvailableError,
+    OutdatedExternalDependency,
+    MissingExternalDependency,
+    InsufficientArgumentsError,
+    AnnexBatchCommandError,
+    IncompleteResultsError,
+)
 
 from datalad.support.gitrepo import GitRepo
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,8 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
-
 import logging
 from functools import partial
 import os
@@ -45,6 +43,10 @@ from datalad.utils import chpwd
 from datalad.utils import rmtree
 from datalad.utils import linux_distribution_name
 from datalad.utils import unlink
+
+from datalad.tests.utils import (
+    assert_result_count,
+)
 
 from datalad.tests.utils import ignore_nose_capturing_stdout
 from datalad.tests.utils import assert_cwd_unchanged
@@ -316,7 +318,7 @@ def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     eq_(ar.file_has_content(testfiles + ["bogus.txt"], batch=batch),
         [True, False, False])
 
-    assert_false(ar.file_has_content("bogus.txt", batch=batch))
+    assert_false(ar.file_has_content("bogus.txt", batch=batch)[0])
     ok_(ar.file_has_content("test-annex.dat", batch=batch))
 
     if not direct:  # There's no unlock in direct mode.
@@ -352,8 +354,8 @@ def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
     eq_(ar.is_under_annex(testfiles + ["bogus.txt"], batch=batch),
                  target_value + [False])
 
-    assert_false(ar.is_under_annex("bogus.txt", batch=batch))
-    ok_(ar.is_under_annex("test-annex.dat", batch=batch))
+    assert_false(ar.is_under_annex("bogus.txt", batch=batch)[0])
+    ok_(ar.is_under_annex("test-annex.dat", batch=batch)[0])
 
     if not direct:  # There's no unlock in direct mode.
         ar.unlock(["test-annex.dat"])
@@ -384,13 +386,13 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     # get the file from remote
     with swallow_outputs() as cmo:
         ar.add_urls([testurl])
-    l = ar.whereis(testfile)
+    l = ar.whereis(testfile)[0]
     assert_in(ar.WEB_UUID, l)
     eq_(len(l), 2)
     ok_(ar.file_has_content(testfile))
 
     # output='full'
-    lfull = ar.whereis(testfile, output='full')
+    lfull = ar.whereis(testfile, output='full')[testfile]
     eq_(set(lfull), set(l))  # the same entries
     non_web_remote = l[1 - l.index(ar.WEB_UUID)]
     assert_in('urls', lfull[non_web_remote])
@@ -402,20 +404,20 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     assert_raises(CommandError, ar.whereis, [], options='--all', output='full', key=True)
 
     # output='descriptions'
-    ldesc = ar.whereis(testfile, output='descriptions')
+    ldesc = ar.whereis(testfile, output='descriptions')[0]
     eq_(set(ldesc), set([v['description'] for v in lfull.values()]))
 
     # info w/ and w/o fast mode
     for fast in [True, False]:
-        info = ar.info(testfile, fast=fast)
+        info = ar.info(testfile, fast=fast)[testfile]
         eq_(info['size'], 14)
         assert(info['key'])  # that it is there
-        info_batched = ar.info(testfile, batch=True, fast=fast)
+        info_batched = ar.info(testfile, batch=True, fast=fast)[testfile]
         eq_(info, info_batched)
         # while at it ;)
         with swallow_outputs() as cmo:
-            eq_(ar.info('nonexistent', batch=False), None)
-            eq_(ar.info('nonexistent-batch', batch=True), None)
+            eq_(ar.info('nonexistent', batch=False)['nonexistent'], None)
+            eq_(ar.info('nonexistent-batch', batch=True)['nonexistent-batch'], None)
             eq_(cmo.out, '')
             eq_(cmo.err, '')
             ar.precommit()  # to stop all the batched processes for swallow_outputs
@@ -428,8 +430,6 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     repo_info_fast = ar.repo_info(fast=True)
     # doesn't give much testable info, so just comparing a subset for match with repo_info info
     eq_(repo_info_fast['semitrusted repositories'], repo_info['semitrusted repositories'])
-    #import pprint; pprint.pprint(repo_info)
-
     # remove the remote
     ar.rm_url(testfile, testurl)
     l = ar.whereis(testfile)
@@ -437,25 +437,25 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     eq_(len(l), 1)
 
     # now only 1 copy; drop should fail
-    res = ar.drop(testfile)
+    res = ar.drop(testfile)[0]
     eq_(res['command'], 'drop')
     eq_(res['success'], False)
     assert_in('adjust numcopies', res['note'])
 
     # read the url using different method
     ar.add_url_to_file(testfile, testurl)
-    l = ar.whereis(testfile)
+    l = ar.whereis(testfile)[0]
     assert_in(ar.WEB_UUID, l)
     eq_(len(l), 2)
     ok_(ar.file_has_content(testfile))
 
     # 2 known copies now; drop should succeed
     ar.drop(testfile)
-    l = ar.whereis(testfile)
+    l = ar.whereis(testfile)[0]
     assert_in(ar.WEB_UUID, l)
     eq_(len(l), 1)
-    assert_false(ar.file_has_content(testfile))
-    lfull = ar.whereis(testfile, output='full')
+    assert_false(ar.file_has_content(testfile)[0])
+    lfull = ar.whereis(testfile, output='full')[testfile]
     assert_not_in(non_web_remote, lfull) # not present -- so not even listed
 
     # multiple files/urls
@@ -478,7 +478,7 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
 
     someurl = "http://example.com/someurl"
     ar.add_url_to_file(testfile, someurl, options=['--relaxed'])
-    lfull = ar.whereis(testfile, output='full')
+    lfull = ar.whereis(testfile, output='full')[testfile]
     eq_(set(lfull[ar.WEB_UUID]['urls']), {testurl, someurl})
 
     # and now test with a file in subdirectory
@@ -487,8 +487,8 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     with swallow_outputs() as cmo:
         ar.add_url_to_file(testfile3, url=testurl3)
     ok_file_has_content(opj(dst, testfile3), 'more stuff')
-    eq_(set(ar.whereis(testfile3)), {ar.WEB_UUID, non_web_remote})
-    eq_(set(ar.whereis(testfile3, output='full').keys()), {ar.WEB_UUID, non_web_remote})
+    eq_(set(ar.whereis(testfile3)[0]), {ar.WEB_UUID, non_web_remote})
+    eq_(set(ar.whereis(testfile3, output='full')[testfile3].keys()), {ar.WEB_UUID, non_web_remote})
 
     # and if we ask for both files
     info2 = ar.info([testfile, testfile3])
@@ -498,17 +498,6 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     full = ar.whereis([], options='--all', output='full')
     eq_(len(full.keys()), 3)  # we asked for all files -- got 3 keys
     assert_in(ar.WEB_UUID, full['SHA256E-s10--a978713ea759207f7a6f9ebc9eaebd1b40a69ae408410ddf544463f6d33a30e1.txt'])
-
-    # which would work even if we cd to that subdir, but then we should use explicit curdir
-    with chpwd(subdir):
-        cur_subfile = opj(curdir, 'sub.txt')
-        eq_(set(ar.whereis(cur_subfile)), {ar.WEB_UUID, non_web_remote})
-        eq_(set(ar.whereis(cur_subfile, output='full').keys()), {ar.WEB_UUID, non_web_remote})
-        testfiles = [cur_subfile, opj(pardir, testfile)]
-        info2_ = ar.info(testfiles)
-        # Should maintain original relative file names
-        eq_(set(info2_), set(testfiles))
-        eq_(info2_[cur_subfile]['size'], 10)
 
 
 @with_tree(tree={"a.txt": "a",
@@ -582,8 +571,8 @@ def test_AnnexRepo_migrating_backends(src, dst):
     f.close()
 
     ar.add(filename, backend='MD5')
-    eq_(ar.get_file_backend(filename), 'MD5')
-    eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+    eq_(ar.get_file_backend(filename), ['MD5'])
+    eq_(ar.get_file_backend('test-annex.dat'), ['SHA256E'])
 
     # migrating will only do, if file is present
     ok_annex_get(ar, 'test-annex.dat')
@@ -593,13 +582,13 @@ def test_AnnexRepo_migrating_backends(src, dst):
         assert_raises(CommandNotAvailableError, ar.migrate_backend,
                       'test-annex.dat')
     else:
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+        eq_(ar.get_file_backend('test-annex.dat'), ['SHA256E'])
         ar.migrate_backend('test-annex.dat')
-        eq_(ar.get_file_backend('test-annex.dat'), 'MD5')
+        eq_(ar.get_file_backend('test-annex.dat'), ['MD5'])
 
         ar.migrate_backend('', backend='SHA1')
-        eq_(ar.get_file_backend(filename), 'SHA1')
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
+        eq_(ar.get_file_backend(filename), ['SHA1'])
+        eq_(ar.get_file_backend('test-annex.dat'), ['SHA1'])
 
 
 tree1args = dict(
@@ -626,7 +615,6 @@ def __test_get_md5s(path):
     files = [basename(f) for f in find_files('.*', path)]
     annex.add(files)
     annex.commit()
-    print({f: annex.get_file_key(f) for f in files})
 
 
 @with_batch_direct
@@ -658,13 +646,13 @@ def test_AnnexRepo_backend_option(path, url):
 
     ar.add('firstfile', backend='SHA1')
     ar.add('secondfile')
-    eq_(ar.get_file_backend('firstfile'), 'SHA1')
-    eq_(ar.get_file_backend('secondfile'), 'MD5')
+    eq_(ar.get_file_backend('firstfile'), ['SHA1'])
+    eq_(ar.get_file_backend('secondfile'), ['MD5'])
 
     with swallow_outputs() as cmo:
         # must be added under different name since annex 20160114
         ar.add_url_to_file('remotefile2', url + 'remotefile', backend='SHA1')
-    eq_(ar.get_file_backend('remotefile2'), 'SHA1')
+    eq_(ar.get_file_backend('remotefile2'), ['SHA1'])
 
     with swallow_outputs() as cmo:
         ar.add_urls([url + 'faraway'], backend='SHA1')
@@ -682,12 +670,12 @@ def test_AnnexRepo_get_file_backend(src, dst):
 
     ar = AnnexRepo.clone(src, dst)
 
-    eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+    eq_(ar.get_file_backend('test-annex.dat'), ['SHA256E'])
     if not ar.is_direct_mode():
         # no migration in direct mode
         ok_annex_get(ar, 'test-annex.dat', network=False)
         ar.migrate_backend('test-annex.dat', backend='SHA1')
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
+        eq_(ar.get_file_backend('test-annex.dat'), ['SHA1'])
     else:
         assert_raises(CommandNotAvailableError, ar.migrate_backend,
                       'test-annex.dat', backend='SHA1')
@@ -769,10 +757,10 @@ def test_AnnexRepo_on_uninited_annex(origin, path):
     assert_false(exists(opj(path, '.git', 'annex'))) # must not be there for this test to be valid
     annex = AnnexRepo(path, create=False, init=False)  # so we can initialize without
     # and still can get our things
-    assert_false(annex.file_has_content('test-annex.dat'))
+    assert_false(annex.file_has_content('test-annex.dat')[0])
     with swallow_outputs():
         annex.get('test-annex.dat')
-        ok_(annex.file_has_content('test-annex.dat'))
+        ok_(annex.file_has_content('test-annex.dat')[0])
 
 
 @assert_cwd_unchanged
@@ -826,10 +814,8 @@ def test_AnnexRepo_add_to_annex(path):
     else:
         assert_false(os.path.islink(filename_abs),
                      "Annexed file is link in direct mode.")
-    assert_in('key', out_json)
     key = repo.get_file_key(filename)
-    assert_false(key == '')
-    assert_equal(key, out_json['key'])
+    assert_result_count(out_json, 1, key=key)
     ok_(repo.file_has_content(filename))
 
     # uncommitted:
@@ -928,7 +914,7 @@ def test_AnnexRepo_get(src, dst):
     assert_is_instance(annex, AnnexRepo, "AnnexRepo was not created.")
     testfile = 'test-annex.dat'
     testfile_abs = opj(dst, testfile)
-    assert_false(annex.file_has_content("test-annex.dat"))
+    assert_false(annex.file_has_content("test-annex.dat")[0])
     with swallow_outputs():
         annex.get(testfile)
     ok_(annex.file_has_content("test-annex.dat"))
@@ -1035,7 +1021,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     unlink(opj(dst, testfile))
     ar.add_url_to_file(testfile, testurl, batch=True)
 
-    info = ar.info(testfile)
+    info = ar.info(testfile)[testfile]
     eq_(info['size'], 14)
     assert(info['key'])
     # not even added to index yet since we this repo is with default batch_size
@@ -1064,11 +1050,11 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
         assert_not_in(ar.WEB_UUID, ar.whereis(testfile))
     ar.commit("added about2_.txt and there was about2.txt lingering around")
     # commit causes closing all batched annexes, so testfile gets committed
-    assert_in(ar.WEB_UUID, ar.whereis(testfile))
+    assert_in(ar.WEB_UUID, ar.whereis(testfile)[0])
     assert(not ar.dirty)
     ar.add_url_to_file(testfile2_, testurl2_, batch=True)
     assert(ar.info(testfile2_))
-    assert_in(ar.WEB_UUID, ar.whereis(testfile2_))
+    assert_in(ar.WEB_UUID, ar.whereis(testfile2_)[0])
 
     # add into a new file
     # filename = 'newfile.dat'
@@ -1087,13 +1073,13 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
         ar2.precommit()  # to possibly stop batch process occupying the stdout
     ar2.commit("added new file")  # would do nothing ATM, but also doesn't fail
     assert_in(filename, ar2.get_files())
-    assert_in(ar.WEB_UUID, ar2.whereis(filename))
+    assert_in(ar.WEB_UUID, ar2.whereis(filename)[0])
 
     if not ar.is_direct_mode():
         # in direct mode there's nothing to commit
         ar.commit("actually committing new files")
     assert_in(filename, ar.get_files())
-    assert_in(ar.WEB_UUID, ar.whereis(filename))
+    assert_in(ar.WEB_UUID, ar.whereis(filename)[0])
     # this poor bugger still wasn't added since we used default batch_size=0 on him
 
     # and closing the pipes now shoudn't anyhow affect things
@@ -1372,13 +1358,13 @@ def test_annex_copy_to(origin, clone):
 def test_annex_drop(src, dst):
     ar = AnnexRepo.clone(src, dst)
     testfile = 'test-annex.dat'
-    assert_false(ar.file_has_content(testfile))
+    assert_false(ar.file_has_content(testfile)[0])
     ar.get(testfile)
-    ok_(ar.file_has_content(testfile))
+    ok_(ar.file_has_content(testfile)[0])
 
     # drop file by name:
     result = ar.drop([testfile])
-    assert_false(ar.file_has_content(testfile))
+    assert_false(ar.file_has_content(testfile)[0])
     ok_(isinstance(result, list))
     eq_(len(result), 1)
     eq_(result[0]['command'], 'drop')
@@ -1390,7 +1376,7 @@ def test_annex_drop(src, dst):
     # drop file by key:
     testkey = ar.get_file_key(testfile)
     result = ar.drop([testkey], key=True)
-    assert_false(ar.file_has_content(testfile))
+    assert_false(ar.file_has_content(testfile)[0])
     ok_(isinstance(result, list))
     eq_(len(result), 1)
     eq_(result[0]['command'], 'drop')
@@ -1501,7 +1487,6 @@ def test_is_available(batch, direct, p):
 @with_tempfile(mkdir=True)
 def test_annex_add_no_dotfiles(path):
     ar = AnnexRepo(path, create=True)
-    print(ar.path)
     assert_true(os.path.exists(ar.path))
     assert_false(ar.dirty)
     os.makedirs(opj(ar.path, '.datalad'))
@@ -1526,7 +1511,7 @@ def test_annex_add_no_dotfiles(path):
     # all committed
     assert_false(ar.dirty)
     # not known to annex
-    assert_false(ar.is_under_annex(opj(ar.path, '.datalad', 'somefile')))
+    assert_false(ar.is_under_annex(opj(ar.path, '.datalad', 'somefile'))[0])
 
 
 @with_tempfile
@@ -1759,7 +1744,6 @@ def test_AnnexRepo_update_submodule():
     raise SkipTest("TODO")
 
 
-@known_failure_v6  #FIXME
 def test_AnnexRepo_get_submodules():
     raise SkipTest("TODO")
 

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -137,21 +137,21 @@ def _test_proxying_open(generate_load, verify_load, repo):
         verify_load(fpath2_2)
         # and even if we drop it -- we still can get it no problem
         annex2.drop(fpath2_2)
-        assert_false(annex2.file_has_content(fpath2_2))
+        assert_false(annex2.file_has_content(fpath2_2)[0])
         verify_load(fpath2_2)
-        assert_true(annex2.file_has_content(fpath2_2))
+        assert_true(annex2.file_has_content(fpath2_2)[0])
         annex2.drop(fpath2_2)
-        assert_false(annex2.file_has_content(fpath2_2))
+        assert_false(annex2.file_has_content(fpath2_2)[0])
         assert_true(os.path.isfile(fpath2_2))
 
     # In check_once mode, if we drop it, it wouldn't be considered again
     annex2.drop(fpath2_2)
-    assert_false(annex2.file_has_content(fpath2_2))
+    assert_false(annex2.file_has_content(fpath2_2)[0])
     with AutomagicIO(check_once=True):
         verify_load(fpath2_2)
-        assert_true(annex2.file_has_content(fpath2_2))
+        assert_true(annex2.file_has_content(fpath2_2)[0])
         annex2.drop(fpath2_2)
-        assert_false(annex2.file_has_content(fpath2_2))
+        assert_false(annex2.file_has_content(fpath2_2)[0])
         assert_false(os.path.isfile(fpath2_2))
 
 
@@ -166,9 +166,9 @@ def _test_proxying_open(generate_load, verify_load, repo):
     with patch('sys.stdout', new_callable=StringIOfileno), \
          patch('sys.stderr', new_callable=StringIOfileno):
         with AutomagicIO():
-            assert_false(annex2.file_has_content(fpath2_2))
+            assert_false(annex2.file_has_content(fpath2_2)[0])
             verify_load(fpath2_2)
-            assert_true(annex2.file_has_content(fpath2_2))
+            assert_true(annex2.file_has_content(fpath2_2)[0])
 
 
 def test_proxying_open_h5py():

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -30,10 +30,10 @@ def _test_BasicAnnexTestRepo(repodir):
     ok_file_under_git(trepo.path, 'test.dat')
     ok_file_under_git(trepo.path, 'INFO.txt')
     ok_file_under_git(trepo.path, 'test-annex.dat', annexed=True)
-    ok_(trepo.repo.file_has_content('test-annex.dat') is False)
+    ok_(trepo.repo.file_has_content('test-annex.dat')[0] is False)
     with swallow_outputs():
         trepo.repo.get('test-annex.dat')
-    ok_(trepo.repo.file_has_content('test-annex.dat'))
+    ok_(trepo.repo.file_has_content('test-annex.dat')[0])
 
 
 # Use of @with_tempfile() apparently is not friendly to test generators yet


### PR DESCRIPTION
This pull request shall eventually fix #2488

Current status of RF:
- [x] low level code and its own tests
- [ ]  usage of low-level code in high-level tests

Goal:
- Remove any magic file path handling, including:
  - magic conversion of list return values into single items when input path was a single item
  - resolution of paths relative to the curdir
- for now keep the ability to supply a single path as input, when a list is actually expected further in, but eventually this should be removed, to clearly see what code is capable/optimized for processing multiple inputs vs a single one

Rational:
All look-ups and conversions should be done by top-level code, once.