### PR TITLE
ENH: channel output from annex init into our logger

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1288,8 +1288,10 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 value=new_value,
                                 where='local',
                                 reload=False)
-
-        self._run_annex_command('init', annex_options=opts)
+        self._run_annex_command(
+            'init',
+            log_stderr=lambda s: lgr.info(s.rstrip()), log_online=True,
+            annex_options=opts)
         # TODO: When to expect stderr?
         # on crippled filesystem for example (think so)?
         self.config.reload()


### PR DESCRIPTION
This pull request partially fixes #2844 and replaces #2868 

Partially, because whenever we do consume/redirect stderr, `git` no longer outputs progress information.  Here is the function it decides upon  https://git.kernel.org/pub/scm/git/git.git/tree/progress.c#n75

To force it to provide progress output, checkout/pull/push have additional `--progress` option to force it. there is no config setting (according to IRC chat). But just from a few days back, https://public-inbox.org/git/20180921222454.GD11177@sigill.intra.peff.net/ points to a proposal to be able to pipe progress information to any process to provide custom progress rendering without needing to parse etc. Might come handy in the future

So, for now I am offering to get following:
```shell
$> tools/eval_under_testloopfs DATALAD_REPO_VERSION=6 /usr/bin/time datalad install -s https://github.com/psychoinformatics-de/studyforrest-data-structural.git studyforrest-data-structural_alt                            I: vfat of 10:  /home/yoh/.tmp/datalad-fs-6wyWm
10+0 records in
10+0 records out
10321920 bytes (10 MB, 9.8 MiB) copied, 0.00474188 s, 2.2 GB/s
mkfs.fat 4.1 (2017-01-24)
I: running DATALAD_REPO_VERSION=6 /usr/bin/time datalad install -s https://github.com/psychoinformatics-de/studyforrest-data-structural.git studyforrest-data-structural_alt
[INFO   ] Cloning https://github.com/psychoinformatics-de/studyforrest-data-structural.git [1 other candidates] into '/home/yoh/.tmp/datalad-fs-6wyWm/studyforrest-data-structural_alt' 
[INFO   ]   Detected a filesystem without fifo support. 
[INFO   ]   Disabling ssh connection caching. 
[INFO   ]   Detected a crippled filesystem. 
[INFO   ]   Entering an adjusted branch where files are unlocked as this filesystem does not support locked files. 
[INFO   ] Switched to branch 'adjusted/master(unlocked)' 
[INFO   ] download failed: Not Found 
[INFO   ]   Remote origin not usable by git-annex; setting annex-ignore 
install(ok): /home/yoh/.tmp/datalad-fs-6wyWm/studyforrest-data-structural_alt (dataset)
6.74user 3.51system 0:15.83elapsed 64%CPU (0avgtext+0avgdata 54752maxresident)k
8inputs+18768outputs (0major+847758minor)pagefaults 0swaps
/home/yoh/.tmp/datalad-fs-6wyWm
tools/eval_under_testloopfs DATALAD_REPO_VERSION=6 /usr/bin/time datalad  -s   6.79s user 3.55s system 64% cpu 16.003 total
```
IMHO it is already good enough to inform user about ongoing activities... not yet sure about `download failed: Not Found` message there.

As for progress, which as some of you already discovered first hand is not really "logging/CI friendly" if just dumped to stderr filling up the logs,  I would wait for us to be able to get and handle it.
