### PR TITLE
[WIP] New query tools in *Repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_DIRECT=yes
 ##1    - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5
 
@@ -153,14 +152,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  - python: 3.5
-    # test whether known direct mode failures still fail
-    env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
   - python: 3.5
     # test with extension datalad-crawler
@@ -196,13 +187,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  # test whether known direct mode failures still fail
-  - env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda35
       DATALAD_TESTS_SSH: 1
+      DATALAD_REPO_VERSION: 6
 
 cache:
   # cache the pip cache
@@ -62,7 +63,6 @@ install:
   - pip install colorama
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"
-  - git config --global --add datalad.repo.version 6
 
 test_script:
   # establish baseline, if annex doesn't work, we are not even trying

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,6 @@ environment:
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda35
       DATALAD_TESTS_SSH: 1
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
-      DATALAD_TESTS_SSH: 1
-      DATALAD_REPO_VERSION: 6
 
 cache:
   # cache the pip cache
@@ -68,6 +62,7 @@ install:
   - pip install colorama
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"
+  - git config --global --add datalad.repo.version 6
 
 test_script:
   # establish baseline, if annex doesn't work, we are not even trying

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,7 +97,7 @@ test_script:
   # additional tests need module `dateutil`!!
   - python -m nose -s -v datalad.plugin.tests.test_check_dates
   # remaining fails: test_annexrepo test_digests test_gitrepo test_locking test_repodates test_sshrun 
-  - python -m nose -s -v datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_ 
+  - python -m nose -s -v datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_ datalad.support.tests.test_fileinfo
   # remaining fails: test__main__ test_archives test_cmd test_log  test_protocols test_test_utils test_utils test_auto
   - python -m nose -s -v datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos 
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-from os.path import abspath
 from os.path import curdir
 from os.path import exists
 from os.path import join as opj
@@ -40,7 +39,6 @@ from datalad.utils import getpwd
 from datalad.utils import optional_args, expandpath, is_explicit_path
 from datalad.utils import get_dataset_root
 from datalad.utils import dlabspath
-from datalad.distribution.utils import get_git_dir
 
 
 lgr = logging.getLogger('datalad.dataset')

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -91,7 +91,9 @@ def _parse_git_submodules(dspath):
         return
 
     ds = Dataset(dspath)
-
+    # get info on subdatasets, use GitRepo variant of the
+    # method directly to save some cycles, as we do not need
+    # any info from git-annex
     for p, props in iteritems(GitRepo.get_content_info(ds.repo)):
         if not props.get('type', None) == 'dataset':
             continue

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -19,6 +19,8 @@ from os.path import normpath
 from os.path import relpath
 from os.path import exists
 
+from six import iteritems
+
 from git import GitConfigParser
 
 from datalad.interface.base import Interface
@@ -29,6 +31,7 @@ from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
+from datalad.support.gitrepo import GitRepo
 from datalad.support.gitrepo import InvalidGitRepositoryError
 from datalad.support.exceptions import CommandError
 from datalad.interface.common_opts import recursion_flag
@@ -87,36 +90,16 @@ def _parse_git_submodules(dspath):
         # we cannot have (functional) subdatasets
         return
 
-    # this will not work in direct mode, need better way #1422
-    cmd = ['git', 'ls-files', '--stage', '-z']
+    ds = Dataset(dspath)
 
-    # need to go rogue  and cannot use proper helper in GitRepo
-    # as they also pull in all of GitPython's magic
-    try:
-        stdout, stderr = GitRunner(cwd=dspath).run(
-            cmd,
-            log_stderr=True,
-            log_stdout=True,
-            # not sure why exactly, but log_online has to be false!
-            log_online=False,
-            expect_stderr=False,
-            shell=False,
-            # we don't want it to scream on stdout
-            expect_fail=True)
-    except CommandError as e:
-        raise InvalidGitRepositoryError(exc_str(e))
-
-    for line in stdout.split('\0'):
-        if not line or not line.startswith('160000'):
+    for p, props in iteritems(GitRepo.get_content_info(ds.repo)):
+        if not props.get('type', None) == 'dataset':
             continue
-        sm = {}
-        props = submodule_full_props.match(line)
-        sm['revision'] = props.group(2)
-        subpath = _path_(dspath, props.group(4))
-        sm['path'] = subpath
+        subpath = _path_(dspath, p)
+        props['path'] = subpath
         if not exists(subpath) or not GitRepo.is_valid_repo(subpath):
-            sm['state'] = 'absent'
-        yield sm
+            props['state'] = 'absent'
+        yield props
 
 
 @build_doc

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -39,7 +39,6 @@ from datalad.interface.common_opts import recursion_limit
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import require_dataset
 from datalad.cmd import GitRunner
-from datalad.support.gitrepo import GitRepo
 from datalad.utils import _path_
 from datalad.utils import path_startswith
 from datalad.utils import assure_list
@@ -94,7 +93,7 @@ def _parse_git_submodules(dspath):
     # get info on subdatasets, use GitRepo variant of the
     # method directly to save some cycles, as we do not need
     # any info from git-annex
-    for p, props in iteritems(GitRepo.get_content_info(ds.repo)):
+    for p, props in iteritems(ds.repo.get_content_info()):
         if not props.get('type', None) == 'dataset':
             continue
         subpath = _path_(dspath, p)

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -92,7 +92,7 @@ def test_get_subdatasets(path):
     assert_status('ok', res)
     for r in res:
         #for prop in ('gitmodule_url', 'state', 'revision', 'gitmodule_name'):
-        for prop in ('gitmodule_url', 'revision', 'gitmodule_name'):
+        for prop in ('gitmodule_url', 'gitshasum', 'gitmodule_name'):
             assert_in(prop, r)
         # random property is unknown
         assert_not_in('mike', r)

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -13,7 +13,8 @@ import os
 from os.path import join as opj
 
 from datalad.distribution.utils import _get_flexible_source_candidates
-from datalad.distribution.utils import get_git_dir
+
+from datalad.support.gitrepo import GitRepo
 
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import eq_
@@ -64,7 +65,7 @@ def test_get_flexible_source_candidates():
 @with_tempfile
 def test_get_git_dir(path):
     # minimal, only missing coverage
-    assert_raises(RuntimeError, get_git_dir, path)
+    assert_raises(RuntimeError, GitRepo.get_git_dir, path)
 
     srcpath = opj(path, 'src')
     targetpath = opj(path, 'target')
@@ -74,9 +75,9 @@ def test_get_git_dir(path):
     if not on_windows:
         # with PY3 would also work with Windows 6+
         os.symlink(srcpath, targetgitpath)
-        eq_(srcpath, get_git_dir(targetpath))
+        eq_(srcpath, GitRepo.get_git_dir(targetpath))
         # cleanup for following test
         unlink(targetgitpath)
     with open(targetgitpath, 'w') as f:
         f.write('gitdir: {}'.format(srcpath))
-    eq_(srcpath, get_git_dir(targetpath))
+    eq_(srcpath, GitRepo.get_git_dir(targetpath))

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -19,11 +19,11 @@ from ..consts import ARCHIVES_TEMP_DIR
 from ..consts import ANNEX_TEMP_DIR
 from ..consts import SEARCH_INDEX_DOTGITDIR
 
+from datalad.support.gitrepo import GitRepo
 from datalad.support.constraints import EnsureNone
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import datasetmethod
-from datalad.distribution.utils import get_git_dir
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
@@ -90,7 +90,7 @@ class Clean(Interface):
                 yield ap
                 continue
             d = ap['path']
-            gitdir = get_git_dir(d)
+            gitdir = GitRepo.get_git_dir(d)
             for dirpath, flag, msg, sing_pl in [
                 (ARCHIVES_TEMP_DIR, "cached-archives",
                  "temporary archive", ("directory", "directories")),

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -33,6 +33,7 @@ from datalad.support.param import Parameter
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 from datalad.cmd import GitRunner
+from datalad.utils import _posixpath_
 
 from datalad.distribution.dataset import (
     Dataset,
@@ -142,7 +143,7 @@ def _parse_git_diff(dspath, diff_thingie=None, paths=None,
             # a filename
             if 'path' in ap:
                 ap['path_src'] = ap['path']
-            ap['path'] = opj(dspath, line)
+            ap['path'] = _posixpath_(dspath, line)
     if ap:
         yield ap
 

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -13,11 +13,11 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import stat
+import os.path as op
 from os.path import join as opj
 from os.path import curdir
-from os.path import isdir
 from os.path import relpath
-from os.path import normpath
+from six import iteritems
 
 
 from datalad.interface.annotate_paths import AnnotatePaths
@@ -34,11 +34,12 @@ from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 from datalad.cmd import GitRunner
 
-from datalad.distribution.dataset import EnsureDataset
-from datalad.distribution.dataset import datasetmethod
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+)
 
-from datalad.utils import with_pathsep as _with_sep
-from datalad.utils import path_startswith
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
 
@@ -76,59 +77,6 @@ def _translate_type(mode, ap, prop):
         ap[prop] = 'directory'
     else:
         ap[prop] = 'file'
-
-
-def _get_untracked_content(dspath, report_untracked, paths=None):
-    cmd = ['git', '--work-tree=.', 'status', '--porcelain',
-           # file names NULL terminated
-           '-z',
-           # we never want to touch submodules, they cannot be untracked
-           '--ignore-submodules=all',
-           # fully untracked dirs as such, the rest as files
-           '--untracked={}'.format(report_untracked)]
-    try:
-        stdout, stderr = GitRunner(cwd=dspath).run(
-            cmd,
-            log_stderr=True,
-            log_stdout=True,
-            log_online=False,
-            expect_stderr=False,
-            shell=False,
-            expect_fail=True)
-    except CommandError as e:
-        # TODO should we catch any and handle them in here?
-        raise e
-
-    if paths:
-        paths = [r['path'] for r in paths]
-        if len(paths) == 1 and paths[0] == dspath:
-            # nothing to filter
-            paths = None
-
-    from datalad.utils import assure_unicode
-
-    for line in stdout.split('\0'):
-        if not line:
-            continue
-        line = assure_unicode(line)
-        if not line.startswith('?? '):
-            # nothing untracked, ignore, task of `diff`
-            continue
-        apath = opj(
-            dspath,
-            # strip state marker
-            line[3:])
-        norm_apath = normpath(apath)
-        if paths and not any(norm_apath == p or path_startswith(apath, p)
-                             for p in paths):
-            # we got a whitelist for paths, don't report any other
-            continue
-        ap = dict(
-            path=norm_apath,
-            parentds=dspath,
-            state='untracked',
-            type='directory' if isdir(apath) else 'file')
-        yield ap
 
 
 def _parse_git_diff(dspath, diff_thingie=None, paths=None,
@@ -388,11 +336,16 @@ class Diff(Interface):
             if (revision and '..' in revision) or report_untracked == 'no':
                 # don't look for untracked content, we got a revision range
                 continue
-            for r in _get_untracked_content(
-                    ds_path,
-                    report_untracked,
-                    paths=content_paths):
+            # report untracked content
+            for p, r in iteritems(Dataset(ds_path).repo.status(
+                    paths=[c['path'] for c in content_paths]
+                    if content_paths else None,
+                    untracked=report_untracked)):
+                if r.get('state', None) != 'untracked':
+                    continue
                 r.update(dict(
+                    path=op.join(ds_path, p),
+                    parentds=ds_path,
                     action='diff',
                     logger=lgr))
                 if refds_path:

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -34,7 +34,7 @@ from datalad.interface.utils import eval_results
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     require_dataset
-from datalad.distribution.utils import get_git_dir
+from datalad.support.gitrepo import GitRepo
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureInt
@@ -241,7 +241,7 @@ class _WhooshSearch(_Search):
 
         self.idx_obj = None
         # where does the bunny have the eggs?
-        self.index_dir = opj(self.ds.path, get_git_dir(self.ds.path), SEARCH_INDEX_DOTGITDIR)
+        self.index_dir = opj(self.ds.path, GitRepo.get_git_dir(ds), SEARCH_INDEX_DOTGITDIR)
         self._mk_search_index(force_reindex)
 
     def show_keys(self, mode):

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -77,13 +77,10 @@ class ExportArchive(Interface):
         import tarfile
         import zipfile
         from mock import patch
-        from os.path import join as opj, dirname, normpath, isabs
         import os.path as op
 
         from datalad.distribution.dataset import require_dataset
         from datalad.utils import file_basename
-        from datalad.support.annexrepo import AnnexRepo
-        from datalad.dochelpers import exc_str
 
         import logging
         lgr = logging.getLogger('datalad.plugin.export_archive')
@@ -136,7 +133,7 @@ class ExportArchive(Interface):
             add_method = archive.add if archivetype == 'tar' else archive.write
             repo_files = getattr(repo, 'annexstatus', repo.status)(untracked='no')
             for rpath, record in iteritems(repo_files):
-                fpath = opj(root, rpath)
+                fpath = op.join(root, rpath)
                 if 'key' in record:
                     if not record.get('has_content', None):
                         if missing_content in ('ignore', 'continue'):
@@ -147,14 +144,14 @@ class ExportArchive(Interface):
                             raise IOError('File %s has no content available' % fpath)
                     fpath = record['objloc']
                 # name in the archive
-                aname = normpath(opj(leading_dir, rpath))
+                aname = op.normpath(op.join(leading_dir, rpath))
                 add_method(
                     fpath,
                     arcname=aname,
                     **(tar_args if archivetype == 'tar' else {}))
 
-        if not isabs(filename):
-            filename = opj(os.getcwd(), filename)
+        if not op.isabs(filename):
+            filename = op.join(os.getcwd(), filename)
 
         yield dict(
             status='ok',

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3490,9 +3490,16 @@ class AnnexRepo(GitRepo, RepoInterface):
             # which be a more frequent target
             # TODO optimize order based on some check that reveals
             # what scheme is used in a given annex
-            r['has_content'] = \
-                op.exists(op.join(objectstore, r['hashdirmixed'], r['key'])) or \
-                op.exists(op.join(objectstore, r['hashdirlower'], r['key']))
+            r['has_content'] = False
+            for testpath in (
+                    op.join(objectstore, r['hashdirmixed'], r['key']),
+                    op.join(objectstore, r['hashdirlower'], r['key'])):
+                if op.exists(testpath):
+                    r.pop('hashdirlower', None)
+                    r.pop('hashdirmixed', None)
+                    r['objloc'] = testpath
+                    r['has_content'] = True
+                    break
         # TODO RF == end ==
         for f, r in iteritems(self.status(paths=paths)):
             info[f].update(r)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3469,6 +3469,14 @@ class AnnexRepo(GitRepo, RepoInterface):
             info[path].update({k: j[k] for k in j if k != 'file'})
         return info
 
+    def annexstatus(self, paths=None, untracked='all'):
+        info = self.get_content_annexinfo(
+            init=self.get_content_annexinfo(
+                ref='HEAD'))
+        for f, r in iteritems(self.status()):
+            info[f].update(r)
+        return info
+
     @staticmethod
     def _is_annex_work_tree_message(out):
         return re.match(

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2546,7 +2546,7 @@ class GitRepo(RepoInterface):
         props_re = re.compile(r'([0-9]+) (.*) (.*)\t(.*)$')
 
         stdout, stderr = self._git_custom_command(
-            [_normalize_path(self.path, p) for p in paths] if paths else [],
+            paths if paths else [],
             cmd,
             log_stderr=True,
             log_stdout=True,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2585,7 +2585,7 @@ class GitRepo(RepoInterface):
             info[path] = inf
         return info
 
-    def status(self, paths=None):
+    def status(self, paths=None, untracked='all'):
         """Simplified `git status` equivalent.
 
         Performs a comparison of a get_content_info(stat_wt=True) with a
@@ -2594,6 +2594,14 @@ class GitRepo(RepoInterface):
         Importantly, this function will not detect modified subdatasets.
         This would require recursion into present subdatasets and query
         their status. This is left to higher-level commands.
+
+        Parameters
+        ----------
+        untracked : {'no', 'normal', 'all'}
+          If and how untracked content is reported when no `ref` was given:
+          'no': no untracked files are reported; 'normal': untracked files
+          and entire untracked directories are reported as such; 'all': report
+          individual files even in fully untracked directories.
 
         Returns
         -------
@@ -2612,7 +2620,8 @@ class GitRepo(RepoInterface):
         # we need three calls to git
         # 1. everything we know about the worktree, including os.stat
         # for each file
-        wt = self.get_content_info(paths=paths, ref=None, stat_wt=True)
+        wt = self.get_content_info(
+            paths=paths, ref=None, stat_wt=True, untracked=untracked)
         # 2. the last committed state
         head = self.get_content_info(paths=paths, ref='HEAD', stat_wt=False)
         # 3. we want Git to tell us what it considers modified and avoid

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -35,6 +35,7 @@ from os.path import sep
 import posixpath
 from functools import wraps
 from weakref import WeakValueDictionary
+from collections import OrderedDict
 
 
 from six import string_types
@@ -2474,6 +2475,9 @@ class GitRepo(RepoInterface):
 
     def get_content_info(self, paths=None, wtmode=False):
         """
+        Calling without any options given will always give the fastest
+        performance.
+
         Parameters
         ----------
         paths : list
@@ -2496,7 +2500,7 @@ class GitRepo(RepoInterface):
             tracked.
         """
         # TODO limit by file type to replace code in subdatasets command
-        info = {}
+        info = OrderedDict()
 
         mode_type_map = {
             '100644': 'file',

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2495,9 +2495,10 @@ class GitRepo(RepoInterface):
 
           `type`
             Can be 'file', 'symlink', 'dataset', 'directory'
-          `revision`
-            SHASUM is last commit affecting the item, or None, if not
-            tracked.
+          `gitshasum`
+            SHASUM of the item as tracked by Git, or None, if not
+            tracked. This could be different from the SHASUM of the file
+            in the worktree, if it was modified.
         """
         # TODO limit by file type to replace code in subdatasets command
         info = OrderedDict()
@@ -2535,10 +2536,10 @@ class GitRepo(RepoInterface):
             if not props:
                 # not known to Git
                 path = line
-                inf['revision'] = None
+                inf['gitshasum'] = None
             else:
                 path = props.group(4)
-                inf['revision'] = props.group(2)
+                inf['gitshasum'] = props.group(2)
                 inf['type'] = mode_type_map.get(
                     props.group(1), props.group(1))
             abspath_ = op.join(self.path, path)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -185,6 +185,11 @@ def _normalize_path(base_dir, path):
         # so realpath only its directory, to get "inline" with
         # realpath(base_dir) above
         path = opj(realpath(dirname(path)), basename(path))  # realpath OK
+        # deal with the specific situation described in #2885
+        # this is not a general solution, which would investigate whether we
+        # are actually dealing with an annexed file in a locked state
+        if realpath(path) == base_dir:  # realpath OK
+            path = base_dir
     # Executive decision was made to not do this kind of magic!
     #
     # elif commonprefix([realpath(getpwd()), base_dir]) == base_dir:

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -9,7 +9,7 @@
 
 import os
 import os.path as op
-import shutil
+import posixpath
 
 from datalad.tests.utils import (
     with_tempfile,
@@ -168,12 +168,12 @@ def test_get_content_info(path):
     res = ds.repo.get_content_info(
         [op.join(ds.path, 'subdir', 'file_clean')])
     assert_equal(len(res), 1)
-    assert_in(op.join('subdir', 'file_clean'), res)
+    assert_in(posixpath.join('subdir', 'file_clean'), res)
 
     status = ds.repo.status()
     for t in ('subds', 'file'):
         for s in ('untracked', 'added', 'deleted', 'clean', 'modified'):
-            for l in ('', op.join('subdir', '')):
+            for l in ('', posixpath.join('subdir', '')):
                 if t == 'subds' and s == 'deleted':
                     # same as subds_unavailable -> clean
                     continue

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -120,18 +120,18 @@ def test_get_content_info(path):
                 ref='HEAD',
                 wtmode=True)).items():
         if f.endswith('untracked'):
-            assert(r['revision'] is None)
+            assert(r['gitshasum'] is None)
         if f.endswith('deleted'):
             assert(r['stat_wt'] is None)
         if 'subds_' in f:
-                assert(r['type'] == 'dataset' if r['revision'] else 'directory')
+                assert(r['type'] == 'dataset' if r['gitshasum'] else 'directory')
         if 'file_' in f:
             # which one exactly depends on many things
             assert_in(r['type'], ('file', 'symlink'))
         if 'file_ingit' in f:
             assert(r['type'] == 'file')
         elif 'datalad' not in f and 'git' not in f and \
-                r['revision'] and 'subds' not in f:
+                r['gitshasum'] and 'subds' not in f:
             # this should be known to annex, one way or another
             # regardless of whether things add deleted or staged
             # or anything inbetween

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -1,0 +1,113 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test file info getters"""
+
+import os
+import os.path as op
+import shutil
+
+from datalad.tests.utils import (
+    with_tempfile,
+    create_tree,
+    assert_equal,
+    assert_in,
+    ok_clean_git,
+)
+
+from datalad.api import (
+    Dataset,
+    create,
+)
+
+from datalad.support.gitrepo import GitRepo
+
+
+def _get_convoluted_situation(path):
+    ds = Dataset(path).create(force=True)
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_normal': 'file_normal',
+                'file_deleted': 'file_deleted',
+            },
+            'file_normal': 'file_normal',
+            'file_deleted': 'file_deleted',
+        }
+    )
+    ds.add('.')
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_ingit': 'file_ingit',
+            },
+            'file_ingit': 'file_ingit',
+        }
+    )
+    ds.add('.', to_git=True)
+    ds.create('subds_available')
+    ds.create(op.join('subdir', 'subds_available'))
+    ds.create('subds_unavailable')
+    ds.create(op.join('subdir', 'subds_unavailable'))
+    ds.create('subds_deleted')
+    ds.create(op.join('subdir', 'subds_deleted'))
+    ds.uninstall([
+        'subds_unavailable',
+        op.join('subdir', 'subds_unavailable')],
+        check=False)
+    ok_clean_git(ds.path)
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_untracked': 'file_untracked',
+            },
+            'file_untracked': 'file_untracked',
+            'dir_untracked': {
+                'file_untracked': 'file_untracked',
+            }
+        }
+    )
+    create(op.join(ds.path, 'subds_untracked'))
+    create(op.join(ds.path, 'subdir', 'subds_untracked'))
+    os.remove(op.join(ds.path, 'file_deleted'))
+    os.remove(op.join(ds.path, 'subdir', 'file_deleted'))
+    shutil.rmtree(op.join(ds.path, 'subds_deleted'))
+    shutil.rmtree(op.join(ds.path, 'subdir', 'subds_deleted'))
+    return ds
+
+
+@with_tempfile
+def test_get_content_info(path):
+    repo = GitRepo(path)
+    assert_equal(repo.get_content_info(), {})
+
+    ds = _get_convoluted_situation(path)
+
+    # verify general rules
+    for f, r in ds.repo.get_content_info(wtmode=True).items():
+        if f.endswith('untracked'):
+            assert(r['revision'] is None)
+        if f.endswith('deleted'):
+            assert(r['stat_wt'] is None)
+        if 'subds_' in f:
+                assert(r['type'] == 'dataset' if r['revision'] else 'directory')
+        if 'file_' in f:
+            # which one exactly depends on many things
+            assert_in(r['type'], ('file', 'symlink'))
+        if 'file_ingit' in f:
+            assert(r['type'] == 'file')
+
+    # query a single absolute path
+    res = ds.repo.get_content_info(
+        [op.join(ds.path, 'subdir', 'file_normal')])
+    assert_equal(len(res), 1)
+    assert_in(op.join('subdir', 'file_normal'), res)
+
+

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -61,6 +61,10 @@ def _get_convoluted_situation(path):
         }
     )
     ds.add('.', to_git=True)
+    ds.drop([
+        'file_dropped_clean',
+        op.join('subdir', 'file_dropped_clean')],
+        check=False)
     # clean and proper subdatasets
     ds.create('subds_clean')
     ds.create(op.join('subdir', 'subds_clean'))
@@ -70,10 +74,6 @@ def _get_convoluted_situation(path):
     ds.uninstall([
         'subds_unavailable_clean',
         op.join('subdir', 'subds_unavailable_clean')],
-        check=False)
-    ds.drop([
-        'file_dropped_clean',
-        op.join('subdir', 'file_dropped_clean')],
         check=False)
     ok_clean_git(ds.path)
     # staged subds, and files

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -170,6 +170,19 @@ def test_get_content_info(path):
     assert_equal(len(res), 1)
     assert_in(posixpath.join('subdir', 'file_clean'), res)
 
+    # query full untracked report
+    res = ds.repo.get_content_info()
+    assert_in(posixpath.join('dir_untracked', 'file_untracked'), res)
+    assert_not_in('dir_untracked', res)
+    # query for compact untracked report
+    res = ds.repo.get_content_info(untracked='normal')
+    assert_not_in(posixpath.join('dir_untracked', 'file_untracked'), res)
+    assert_in('dir_untracked', res)
+    # query no untracked report
+    res = ds.repo.get_content_info(untracked='no')
+    assert_not_in(posixpath.join('dir_untracked', 'file_untracked'), res)
+    assert_not_in('dir_untracked', res)
+
     status = ds.repo.status()
     for t in ('subds', 'file'):
         for s in ('untracked', 'added', 'deleted', 'clean', 'modified'):

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -16,6 +16,7 @@ from datalad.tests.utils import (
     create_tree,
     assert_equal,
     assert_in,
+    assert_not_in,
     ok_clean_git,
 )
 
@@ -103,6 +104,15 @@ def test_get_content_info(path):
             assert_in(r['type'], ('file', 'symlink'))
         if 'file_ingit' in f:
             assert(r['type'] == 'file')
+        elif 'datalad' not in f and 'git' not in f and \
+                r['revision'] and 'subds' not in f:
+            # this should be known to annex, one way or another
+            assert_in('key', r)
+            assert_in('keyname', r)
+            assert_in('backend', r)
+            assert_in('bytesize', r)
+            # no duplication with path
+            assert_not_in('file', r)
 
     # query a single absolute path
     res = ds.repo.get_content_info(

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -63,18 +63,25 @@ def _get_convoluted_situation(path):
         op.join('subdir', 'subds_unavailable')],
         check=False)
     ok_clean_git(ds.path)
+    create(op.join(ds.path, 'subds_added'))
+    ds.repo.add_submodule('subds_added')
+    create(op.join(ds.path, 'subdir', 'subds_added'))
+    ds.repo.add_submodule(op.join('subdir', 'subds_added'))
     create_tree(
         ds.path,
         {
             'subdir': {
                 'file_untracked': 'file_untracked',
+                'file_added': 'file_added',
             },
             'file_untracked': 'file_untracked',
+            'file_added': 'file_added',
             'dir_untracked': {
                 'file_untracked': 'file_untracked',
             }
         }
     )
+    ds.repo.add(['file_added', op.join('subdir', 'file_added')])
     create(op.join(ds.path, 'subds_untracked'))
     create(op.join(ds.path, 'subdir', 'subds_untracked'))
     os.remove(op.join(ds.path, 'file_deleted'))
@@ -91,8 +98,27 @@ def test_get_content_info(path):
 
     ds = _get_convoluted_situation(path)
 
-    # verify general rules
-    for f, r in ds.repo.get_content_info(wtmode=True).items():
+    # with no reference, the worktree is the reference, hence no deleted
+    # files are reported
+    for f in ds.repo.get_content_annexinfo(init={}, ref=None):
+        assert_not_in('deleted', f)
+    # with a Git reference, nothing staged can be reported
+    for f in ds.repo.get_content_annexinfo(init={}, ref='HEAD'):
+        assert_not_in('added', f)
+
+    # verify general rules on fused info records that are incrementally
+    # assembled: for git content info, ammended with annex info on 'HEAD'
+    # (to get the last commited stage and with it possibly vanished
+    # content), and lastly annex info wrt to the present worktree, to
+    # also get info on added/staged content
+    # this fuses the info reported from
+    # - git ls-files
+    # - git annex findref HEAD
+    # - git annex find --include '*'
+    for f, r in ds.repo.get_content_annexinfo(
+            init=ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                wtmode=True)).items():
         if f.endswith('untracked'):
             assert(r['revision'] is None)
         if f.endswith('deleted'):
@@ -107,12 +133,14 @@ def test_get_content_info(path):
         elif 'datalad' not in f and 'git' not in f and \
                 r['revision'] and 'subds' not in f:
             # this should be known to annex, one way or another
-            assert_in('key', r)
-            assert_in('keyname', r)
-            assert_in('backend', r)
-            assert_in('bytesize', r)
+            # regardless of whether things add deleted or staged
+            # or anything inbetween
+            assert_in('key', r, f)
+            assert_in('keyname', r, f)
+            assert_in('backend', r, f)
+            assert_in('bytesize', r, f)
             # no duplication with path
-            assert_not_in('file', r)
+            assert_not_in('file', r, f)
 
     # query a single absolute path
     res = ds.repo.get_content_info(

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -15,6 +15,7 @@ from datalad.tests.utils import (
     with_tempfile,
     create_tree,
     assert_equal,
+    assert_dict_equal,
     assert_in,
     assert_not_in,
     ok_clean_git,
@@ -118,7 +119,7 @@ def test_get_content_info(path):
     for f, r in ds.repo.get_content_annexinfo(
             init=ds.repo.get_content_annexinfo(
                 ref='HEAD',
-                wtmode=True)).items():
+                stat_wt=True)).items():
         if f.endswith('untracked'):
             assert(r['gitshasum'] is None)
         if f.endswith('deleted'):
@@ -149,3 +150,11 @@ def test_get_content_info(path):
     assert_in(op.join('subdir', 'file_normal'), res)
 
 
+@with_tempfile
+def test_compare_content_info(path):
+    ds = Dataset(path).create()
+    ok_clean_git(path)
+
+    # for a clean repo HEAD and worktree query should yield identical results
+    wt = ds.repo.get_content_info(ref=None)
+    assert_dict_equal(wt, ds.repo.get_content_info(ref='HEAD'))


### PR DESCRIPTION
Not worth looking at ATM. But eventually will offer a more convenient way to get info on repository content, without having to invent queries and data structures for each scenario.

### Problem being addressed

ATM we have low-level helpers that can query individual aspects of dataset content properties (`is_under_annex`, `file_has_content`, ...). Moroever, we never had a general purpose `status()` for Git repositories. Both aspects combined lead to a particular way of processing: We limits the paths that need attention in a particular case to the smallest possible subset through a series of queries, and then act upon them (path annotation approach etc...). Queries tend to be expensive (frequently lead to a dedicated git/annex call per aspect or sometimes even per path). This has the potential to be slow.

### Core idea

Implement a minimum number of helpers that can extract a maximum number of information from git/annex with the least number of git calls. The theme being to get as much in one go as possible that has no significant penalties in terms of file system access. It should become possible to get a tailored view on the state of a *single* repository without having to invent approaches and data structures for each use case. In this concept, one would err on the side of getting too much information, rather then too little. This would them allow for RFs of commands where tracking state information across various levels is crucial (i.e. `save`) and the present implementation do a good job of confusing users and authors ;-)

In terms of v6 compatibility, emphasis is put on only using Git/annex API calls that work in all scenarios and perform test of filesystem representation only for a few select aspects that generalize well.

### Major changes
- [x] `GitRepo.get_content_info()` as a frontend for `ls-files/tree` to get type, shasum and path of anything known to git, or detectable by its change-detection mechanism (incl. untracked content)
- [x] `AnnexRepo.get_content_annexinfo()` as a frontend for `find/findref` to get basic annex properties for anything known to annex
- [x] `GitRepo.status()` to report the difference between `HEAD` and the worktree. Possible states can be: 'added', 'untracked', 'clean', 'deleted', 'modified'
- [x] `AnnexRepo.annexstatus()` to amend `GitRepo.status()` with info on local content availability of annex'ed files.
- [x] RF'ed `subdatasets` to remove custom Git call and replace with `GitRepo.get_content_info()`
- [x] RF'ed `diff` to remove custom Git call to detect untracked files and replace with `GitRepo.status()`

### Open issues

- [ ] make annex content availability accessible without a call to `status()` for enhanced speed
- [ ] `ls` computes file sizes with dedicated code, but those could be taken from Repo.annexstatus()
- [ ] NFS server tests fail, because it seems files aren't dropped as fast as they should be, e.g. https://travis-ci.org/datalad/datalad/jobs/435532533
```
======================================================================
FAIL: datalad.support.tests.test_fileinfo.test_get_content_info
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/tests/utils.py", line 591, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/support/tests/test_fileinfo.py", line 226, in test_get_content_info
    assert_equal(annexstatus[p]['has_content'], 'dropped' not in s)
AssertionError: True != False

Traceback (most recent call last):
  File "/opt/python/3.5.6/lib/python3.5/multiprocessing/util.py", line 262, in _run_finalizers
    finalizer()
  File "/opt/python/3.5.6/lib/python3.5/multiprocessing/util.py", line 186, in __call__
    res = self._callback(*self._args, **self._kwargs)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/shutil.py", line 480, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/shutil.py", line 438, in _rmtree_safe_fd
    onerror(os.unlink, fullname, sys.exc_info())
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/shutil.py", line 436, in _rmtree_safe_fd
    os.unlink(name, dir_fd=topfd)
OSError: [Errno 16] Device or resource busy: '.nfs00000000000411f700000001'
```

### Notes

- status functions are not called `get_*status()` yet, because there is `AnnexRepo.get_status()` that does one aspect of the proposed functionality in a different way. It should likely be removed, but at present `GitRepo.status()` does not (and does not want to) detect subdataset modification, as it requires dataset traversal and is better done in top-level code IMHO.