### PR TITLE
RF: Move get_git_dir() into GitRepo

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-from os.path import abspath
 from os.path import curdir
 from os.path import exists
 from os.path import join as opj
@@ -40,7 +39,6 @@ from datalad.utils import getpwd
 from datalad.utils import optional_args, expandpath, is_explicit_path
 from datalad.utils import get_dataset_root
 from datalad.utils import dlabspath
-from datalad.distribution.utils import get_git_dir
 
 
 lgr = logging.getLogger('datalad.dataset')

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -13,7 +13,8 @@ import os
 from os.path import join as opj
 
 from datalad.distribution.utils import _get_flexible_source_candidates
-from datalad.distribution.utils import get_git_dir
+
+from datalad.support.gitrepo import GitRepo
 
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import eq_
@@ -64,7 +65,7 @@ def test_get_flexible_source_candidates():
 @with_tempfile
 def test_get_git_dir(path):
     # minimal, only missing coverage
-    assert_raises(RuntimeError, get_git_dir, path)
+    assert_raises(RuntimeError, GitRepo.get_git_dir, path)
 
     srcpath = opj(path, 'src')
     targetpath = opj(path, 'target')
@@ -74,9 +75,9 @@ def test_get_git_dir(path):
     if not on_windows:
         # with PY3 would also work with Windows 6+
         os.symlink(srcpath, targetgitpath)
-        eq_(srcpath, get_git_dir(targetpath))
+        eq_(srcpath, GitRepo.get_git_dir(targetpath))
         # cleanup for following test
         unlink(targetgitpath)
     with open(targetgitpath, 'w') as f:
         f.write('gitdir: {}'.format(srcpath))
-    eq_(srcpath, get_git_dir(targetpath))
+    eq_(srcpath, GitRepo.get_git_dir(targetpath))

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -19,11 +19,11 @@ from ..consts import ARCHIVES_TEMP_DIR
 from ..consts import ANNEX_TEMP_DIR
 from ..consts import SEARCH_INDEX_DOTGITDIR
 
+from datalad.support.gitrepo import GitRepo
 from datalad.support.constraints import EnsureNone
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import datasetmethod
-from datalad.distribution.utils import get_git_dir
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
@@ -90,7 +90,7 @@ class Clean(Interface):
                 yield ap
                 continue
             d = ap['path']
-            gitdir = get_git_dir(d)
+            gitdir = GitRepo.get_git_dir(d)
             for dirpath, flag, msg, sing_pl in [
                 (ARCHIVES_TEMP_DIR, "cached-archives",
                  "temporary archive", ("directory", "directories")),

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -34,7 +34,7 @@ from datalad.interface.utils import eval_results
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     require_dataset
-from datalad.distribution.utils import get_git_dir
+from datalad.support.gitrepo import GitRepo
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureInt
@@ -263,7 +263,7 @@ class _WhooshSearch(_Search):
 
         self.idx_obj = None
         # where does the bunny have the eggs?
-        self.index_dir = opj(self.ds.path, get_git_dir(self.ds.path), SEARCH_INDEX_DOTGITDIR)
+        self.index_dir = opj(self.ds.path, GitRepo.get_git_dir(ds), SEARCH_INDEX_DOTGITDIR)
         self._mk_search_index(force_reindex)
 
     def show_keys(self, mode):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -802,6 +802,44 @@ class GitRepo(RepoInterface):
         """Returns if a given path points to a git repository"""
         return exists(opj(path, '.git'))
 
+    @staticmethod
+    def get_git_dir(repo):
+        """figure out a repo's gitdir
+
+        '.git' might be a  directory, a symlink or a file
+
+        Parameter
+        ---------
+        repo: path or Repo instance
+          currently expected to be the repos base dir
+
+        Returns
+        -------
+        str
+          relative path to the repo's git dir; So, default would be ".git"
+        """
+        if hasattr(repo, 'path'):
+            # repo instance like given
+            repo = repo.path
+        dot_git = op.join(repo, ".git")
+        if not op.exists(dot_git):
+            raise RuntimeError("Missing .git in %s." % repo)
+        elif op.islink(dot_git):
+            # readlink cannot be imported on windows, but there should also
+            # be no symlinks
+            from os import readlink
+            git_dir = readlink(dot_git)
+        elif op.isdir(dot_git):
+            git_dir = ".git"
+        elif op.isfile(dot_git):
+            with open(dot_git) as f:
+                git_dir = f.readline()
+                if git_dir.startswith("gitdir:"):
+                    git_dir = git_dir[7:]
+                git_dir = git_dir.strip()
+
+        return git_dir
+
     @property
     def config(self):
         """Get an instance of the parser for the persistent repository


### PR DESCRIPTION
Previously in datalad.distribution.utils, but such base functionality
should no be scattered around to prevent needless reinvention.

Kept the function static to avoid any cost of Repo instantiation,
given that this is the main usage pattern ATM.