### PR TITLE
BF: Don't crash on no reported percentage

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3665,7 +3665,7 @@ def _get_size_from_perc_complete(count, perc):
     try:
         portion = (float(perc) / 100.)
     except ValueError:
-        return None
+        portion = None
     return int(math.ceil(int(count) / portion)) \
         if portion else 0
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2112,8 +2112,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                     % str(out_json))
             # Make the output's structure match bcmd's.
             out_json = out_json[0]
-            # Don't capture stderr, since download progress provided by wget uses
-            # stderr.
+            # Don't capture stderr, since download progress provided by wget
+            # uses stderr.
         else:
             options += ['--with-files']
             if backend:
@@ -3661,7 +3661,11 @@ class BatchedAnnex(object):
 
 def _get_size_from_perc_complete(count, perc):
     """A helper to get full size if know % and corresponding size"""
-    portion = (float(perc) / 100.)
+
+    try:
+        portion = (float(perc) / 100.)
+    except ValueError:
+        return None
     return int(math.ceil(int(count) / portion)) \
         if portion else 0
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2358,8 +2358,8 @@ def test_get_size_from_perc_complete():
     eq_(f(0, '0'), 0)
     eq_(f(100, '0'), 0)  # we do not know better
     eq_(f(1, '1'), 100)
-	# with no percentage info, we don't know better either:
-	eq_(f(1, ''), 0)
+    # with no percentage info, we don't know better either:
+    eq_(f(1, ''), 0)
 
 
 # to prevent regression

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2358,8 +2358,8 @@ def test_get_size_from_perc_complete():
     eq_(f(0, '0'), 0)
     eq_(f(100, '0'), 0)  # we do not know better
     eq_(f(1, '1'), 100)
-    # with no percentage info, we know nothing at all:
-    eq_(f(1, ''), None)
+	# with no percentage info, we don't know better either:
+	eq_(f(1, ''), 0)
 
 
 # to prevent regression

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2358,6 +2358,8 @@ def test_get_size_from_perc_complete():
     eq_(f(0, '0'), 0)
     eq_(f(100, '0'), 0)  # we do not know better
     eq_(f(1, '1'), 100)
+    # with no percentage info, we know nothing at all:
+    eq_(f(1, ''), None)
 
 
 # to prevent regression


### PR DESCRIPTION
This pull request fixes a failure discovered in https://github.com/datalad/datalad-container. Test was failing in https://travis-ci.org/datalad/datalad-container/jobs/436153807, because `annex-addurl` didn't report progress in the JSON report. Therefore `ProcessAnnexProgressIndicators` set the reported percentage to default to an empty string, which was then casted to a `float`, yielding a `ValueError`.

Independently on why exactly `addurl` doesn't report it (seems to just take a while for the first report to contain a field "percent-progress"), WE are setting the default to an empty string and therefore have to be able to deal with that value in the function we pass it to.

This pull request proposes to just catch the `ValueError` and return `None` in `AnnexRepo._get_size_from_perc_complete()`. 

### Changes
- [x] This change is complete

Please have a look @datalad/developers
