### PR TITLE
WiP: `datalad.coreapi.open`

### DIFF
--- a/datalad/coreapi.py
+++ b/datalad/coreapi.py
@@ -35,3 +35,5 @@ _generate_func_api()
 
 # Be nice and clean up the namespace properly
 del _generate_func_api
+
+from .interface.open import open

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -53,7 +53,7 @@ def resolve_path(path, ds=None):
     Any explicit path (absolute or relative) is returned as an absolute path.
     In case of an explicit relative path, the current working directory is
     used as a reference. Any non-explicit relative path is resolved against
-    as dataset location, i.e. considered relative to the location of the
+    dataset location, i.e. considered relative to the location of the
     dataset. If no dataset is provided, the current working directory is
     used.
 

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -69,6 +69,7 @@ _group_misc = (
         ('datalad.interface.run', 'Run', 'run'),
         ('datalad.interface.rerun', 'Rerun', 'rerun'),
         ('datalad.interface.run_procedure', 'RunProcedure', 'run-procedure'),
+        ('datalad.interface.open', 'Open', 'open'),
     ])
 
 _group_plumbing = (

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -69,7 +69,6 @@ _group_misc = (
         ('datalad.interface.run', 'Run', 'run'),
         ('datalad.interface.rerun', 'Rerun', 'rerun'),
         ('datalad.interface.run_procedure', 'RunProcedure', 'run-procedure'),
-        ('datalad.interface.open', 'Open', 'open'),
     ])
 
 _group_plumbing = (

--- a/datalad/interface/open.py
+++ b/datalad/interface/open.py
@@ -10,7 +10,7 @@
 
 __docformat__ = 'restructuredtext'
 
-
+import os
 import logging
 from contextlib import contextmanager
 
@@ -100,83 +100,139 @@ lgr = logging.getLogger('datalad.interface.open')
 
 _builtin_open = open
 
-if True:
-    @datasetmethod(name='open')
-    def open(
-            path=None,
-            mode=None,
-            buffering=None,
-            dataset=None,
-            save=True,
-            message=None
-            # , if_dirty='save-before'
-        ):
-        """TODO"""
-        # Pre-treat open parameters first
-        if mode is not None:
-            if mode[0] not in 'rwa':
-                raise ValueError("Mode must be either None or start with r, w, or a")
+@datasetmethod(name='open')
+def open(
+        path,
+        mode=None,
+        buffering=None,
+        dataset=None,
+        save=True,
+        message=None
+        # , if_dirty='save-before'
+    ):
+    """TODO"""
+    # Pre-treat open parameters first
+    if mode is not None:
+        if mode[0] not in 'rwa':
+            raise ValueError("Mode must be either None or start with r, w, or a")
 
-        open_args = []
-        if mode is not None:
-            open_args.append(mode)
-            if buffering is not None:
-                open_args.append(buffering)
-        elif buffering is not None:
-            # Do not bother messing with it
-            raise ValueError("When specifying buffering, provide mode for open")
+    open_args = []
+    if mode is not None:
+        open_args.append(mode)
+        if buffering is not None:
+            open_args.append(buffering)
+    elif buffering is not None:
+        # Do not bother messing with it
+        raise ValueError("When specifying buffering, provide mode for open")
 
-        # Probably will be useless in Python mode since we cannot return a
-        # context manager an yield all the result records at the same time.
-        # But if we make it into a class, we could store them in the instance
-        # so they could be inspected later on if desired?
-        all_results = []
-        path = assure_list(path)
-        resolved_paths = [resolve_path(p, dataset) for p in path] \
-            if dataset is not None else path
+    # Probably will be useless in Python mode since we cannot return a
+    # context manager an yield all the result records at the same time.
+    # But if we make it into a class, we could store them in the instance
+    # so they could be inspected later on if desired?
+    path = assure_list(path)
+    resolved_paths = [resolve_path(p, dataset) for p in path] \
+        if dataset is not None else path
 
-        import datalad.api as dl  # heavy import so delayed
+    import datalad.api as dl  # heavy import so delayed
 
-        @contextmanager
-        def open_read():
-            # TODO cannot yield all those wonderful reports here since it would
-            # be a context manager... nothing to be yielded into the Python code
-            res = dl.get(path, dataset=dataset
-                         # TODO: what should we do with files not under git at all?
-                         # here on_failure is not effective - fails during "rendering"
-                         # , on_failure='continue'
-            )
-            all_results.extend(res)
-            files = []
+    class OpenBase(object):
+        def __init__(self):
+            self.all_results = []
+            self.files = None
+
+        def __enter__(self):
+            pre_open = self.pre_open()
+            if pre_open:
+                self.all_results.extend(pre_open)
+
+            self.files = []
             for p in resolved_paths:
                 # TODO: actually do all that full path deduction here probably
                 # since we allow for ds.open
-                files.append(_builtin_open(p, *open_args))
-                all_results.append({
+                self.files.append(_builtin_open(p, *open_args))
+                self.all_results.append({
                     'status': 'ok',
                     'action': 'open',
+                    'mode': mode,
                     'path': p,
                     'type': 'file'
                 })
+            return self.files if len(self.files) > 1 else self.files[0]
 
-            yield files if len(files) > 1 else files[0]
-
-            # Nothing more to do for reading operation besides closing those
-            for f in files:
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            # TODO: handle if exception happened - I think we should "abort"
+            for f in self.files:
                 if not f.closed:
                     f.close()
-                    all_results.append({
-                        'status': 'ok',
-                        'action': 'close',
-                        'path': f.name,
-                        'type': 'file'
-                    })
+                    self.all_results.append(
+                        {
+                            'status': 'ok',
+                            'action': 'close',
+                            'path': f.name,
+                            'type': 'file'
+                        }
+                    )
+
+            post_close = self.post_close()
+            if post_close:
+                self.all_results.extend(post_close)
+
+        def pre_open(self):
+            raise NotImplementedError
+
+        def post_close(self):
+            raise NotImplementedError
+
+    class OpenRead(OpenBase):
+        def pre_open(self):
+            return dl.get(resolved_paths,
+                 # TODO: what should we do with files not under git at all?
+                 # here on_failure is not effective - fails during "rendering"
+                 # , on_failure='continue'
+            )
+
+        def post_close(self):
+            pass
 
 
-        mode_base = mode[0] if mode is not None else 'r'
-        res = {
-            'r': open_read,
-            #'w': open_write(),
-        }[mode_base]()
+    class OpenRewrite(OpenBase):
+        def pre_open(self):
+            for p in resolved_paths:
+                # TODO: do we need to store/apply to the new files anything?
+                # If file is under git - the only thing we could (re)store is
+                # executable bit
+                # If file is outside of git/annex control - we might better even
+                # not remove it at all
+                os.unlink(p)
 
-        return res
+        def post_close(self):
+            # add would crash in case file jumps between git and annex
+            # due to .gitattributes settings.
+            # .save seems to be more resilient BUT! retains git/annex so
+            # there would be no auto migrations
+            # TODO, see https://github.com/datalad/datalad/issues/1651
+            if save:
+                # mneh -- even this one (may be due to paths specification?)
+                # doesn't work if file jumps between git and annex
+                self.all_results.extend(
+                    dl.save(path=resolved_paths, message=message)
+                )
+
+
+    class OpenAppend(OpenRewrite):
+        def pre_open(self):
+            res = OpenRead.pre_open(self)
+            res.extend(dl.unlock(resolved_paths))
+            return res
+
+        # TODO: might need to track what was actually unlocked (v6) and do more
+        # in post_close here
+
+    mode_base = mode[0] if mode is not None else 'r'
+    res = {
+        'r': OpenRead,
+        'w': OpenRewrite,
+        'a': OpenAppend,
+    }[mode_base]()
+
+    return res

--- a/datalad/interface/open.py
+++ b/datalad/interface/open.py
@@ -125,7 +125,6 @@ def open(
             return self.files if len(self.files) > 1 else self.files[0]
 
         def __exit__(self, exc_type, exc_val, exc_tb):
-            # TODO: handle if exception happened - I think we should "abort"
             for f in self.files:
                 if not f.closed:
                     f.close()
@@ -137,10 +136,20 @@ def open(
                             'type': 'file'
                         }
                     )
-
-            post_close = self.post_close()
-            if post_close:
-                self.all_results.extend(post_close)
+            if exc_type:
+                self.all_results.append(
+                    {
+                        'status': 'error',
+                        'action': 'open',
+                        'path': None,
+                        # TODO: "proper" way to channel exeption into results
+                        'exception': (exc_type, exc_val, exc_tb)
+                    }
+                )
+            else:
+                post_close = self.post_close()
+                if post_close:
+                    self.all_results.extend(post_close)
 
         def pre_open(self):
             raise NotImplementedError

--- a/datalad/interface/open.py
+++ b/datalad/interface/open.py
@@ -210,6 +210,9 @@ def open(
             # due to .gitattributes settings.
             # .save seems to be more resilient BUT! retains git/annex so
             # there would be no auto migrations
+            # self.all_results.extend(
+            #     dl.add(path=resolved_paths, save=save, message=message)
+            # )
             # TODO, see https://github.com/datalad/datalad/issues/1651
             if save:
                 # mneh -- even this one (may be due to paths specification?)
@@ -221,7 +224,12 @@ def open(
 
     class OpenAppend(OpenRewrite):
         def pre_open(self):
-            res = OpenRead.pre_open(self)
+            # Copy from OpenRead,
+            res = dl.get(resolved_paths,
+                 # TODO: what should we do with files not under git at all?
+                 # here on_failure is not effective - fails during "rendering"
+                 # , on_failure='continue'
+            )
             res.extend(dl.unlock(resolved_paths))
             return res
 

--- a/datalad/interface/open.py
+++ b/datalad/interface/open.py
@@ -10,6 +10,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import io
 import os
 import logging
 
@@ -20,18 +21,24 @@ from datalad.utils import assure_list
 
 lgr = logging.getLogger('datalad.interface.open')
 
-_builtin_open = open
 
 @datasetmethod(name='open')
 def open(
         path,
         mode=None,
-        buffering=None,
         dataset=None,
         save=True,
-        message=None
+        message=None,
+        **open_kwargs
     ):
-    """TODO"""
+    """TODO
+
+    Parameters
+    ----------
+
+    **kwargs:
+      Passed to io.open as is
+    """
     # Pre-treat open parameters first
     if mode is not None:
         if mode[0] not in 'rwa':
@@ -40,11 +47,6 @@ def open(
     open_args = []
     if mode is not None:
         open_args.append(mode)
-        if buffering is not None:
-            open_args.append(buffering)
-    elif buffering is not None:
-        # Do not bother messing with it
-        raise ValueError("When specifying buffering, provide mode for open")
 
     # Probably will be useless in Python mode since we cannot return a
     # context manager an yield all the result records at the same time.
@@ -79,7 +81,7 @@ def open(
             for p in resolved_paths:
                 # TODO: actually do all that full path deduction here probably
                 # since we allow for ds.open
-                self.files.append(_builtin_open(p, *open_args))
+                self.files.append(io.open(p, *open_args, **open_kwargs))
                 self.all_results.append({
                     'status': 'ok',
                     'action': 'open',

--- a/datalad/interface/open.py
+++ b/datalad/interface/open.py
@@ -1,0 +1,215 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A context manager to assist with annexed files access (i.e. read/write)"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+
+
+import json
+
+from argparse import REMAINDER
+import glob
+import os.path as op
+from os.path import join as opj
+from os.path import normpath
+from os.path import relpath
+from os.path import isabs
+
+from six.moves import shlex_quote
+
+from datalad.interface.annotate_paths import AnnotatePaths
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
+from datalad.interface.common_opts import save_message_opt
+from datalad.interface.common_opts import if_dirty_opt
+from datalad.interface.common_opts import nosave_opt
+# TODO should be moved to common_opts may be?
+from datalad.distribution.drop import dataset_argument
+
+from datalad.support.constraints import EnsureChoice
+from datalad.support.constraints import EnsureInt
+from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureBool
+from datalad.support.exceptions import CommandError
+from datalad.support.param import Parameter
+from datalad.support.json_py import dump2stream
+
+from datalad.distribution.add import Add
+from datalad.distribution.get import Get
+from datalad.distribution.install import Install
+from datalad.distribution.remove import Remove
+from datalad.distribution.dataset import require_dataset
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import datasetmethod
+from datalad.interface.unlock import Unlock
+
+from datalad.utils import assure_bytes
+from datalad.utils import chpwd
+# Rename get_dataset_pwds for the benefit of containers_run.
+from datalad.utils import get_dataset_pwds as get_command_pwds
+from datalad.utils import getpwd
+from datalad.utils import partition
+from datalad.utils import SequenceFormatter
+
+lgr = logging.getLogger('datalad.interface.open')
+
+
+@build_doc
+class Open(Interface):
+    """Open files for reading or writing performing necessary git-annex actions.
+
+    TODO
+    """
+    _params_ = dict(
+        dataset=dataset_argument,
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="path to the file to be opened",
+            nargs="+",
+            constraints=EnsureStr() | EnsureNone(),
+        ),
+        mode=Parameter(
+            default=None,
+            doc="Mode as passed (if specified) to `open` call",
+            constraints=EnsureStr() | EnsureNone(),
+        ),
+        buffering=Parameter(
+            default=None,
+            doc="Buffering argument as passed (if specified) to `open` call",
+            constraints=EnsureInt() | EnsureNone(),
+        ),
+        save=nosave_opt,
+        message=save_message_opt,
+        # TODO: should we worry/bother eg checking dirtiness for those
+        # specified files
+        # if_dirty=if_dirty_opt,
+    )
+
+    @staticmethod
+    @datasetmethod(name='open')
+    @eval_results
+    def __call__(
+            path=None,
+            mode=None,
+            buffering=None,
+            dataset=None,
+            save=True,
+            message=None
+            # , if_dirty='save-before'
+        ):
+        if mode is not None:
+            if mode[0] not in 'rwa':
+                raise ValueError("Mode must be either None or start with r, w, or a")
+        # refds_path = Interface.get_refds_path(dataset)
+        # to_process = []
+        # for ap in AnnotatePaths.__call__(
+        #         path=path,
+        #         dataset=refds_path,
+        #         action='open',
+        #         unavailable_path_status='unavailable',
+        #         nondataset_path_status='',
+        #         return_type='generator',
+        #         on_failure='error'):
+        #     # if ap.get('status', None):
+        #     #     # this is done
+        #     #     yield ap
+        #     #     continue
+        #     # if ap.get('state', None) == 'absent' and \
+        #     #         ap.get('parentds', None) is None:
+        #     #     # nothing exists at location, and there is no parent to
+        #     #     # remove from
+        #     #     ap['status'] = 'notneeded'
+        #     #     ap['message'] = "path does not exist and is not in a dataset"
+        #     #     yield ap
+        #     #     continue
+        #     # if ap.get('raw_input', False) and ap.get('type', None) == 'dataset':
+        #     #     # make sure dataset sorting yields a dedicted entry for this one
+        #     #     ap['process_content'] = True
+        #     to_process.append(ap)
+        #
+        # if not to_process:
+        #     # nothing left to do, potentially all errored before
+        #     raise RuntimeError(
+        #         "There should have been something to do for paths %s" % (path,))
+
+        open_args = []
+        if mode is not None:
+            open_args.append(mode)
+            if buffering is not None:
+                open_args.append(buffering)
+        elif buffering is not None:
+            # Do not bother messing with it
+            raise ValueError("When specifying buffering, provide mode for open")
+
+        # Probably will be useless in Python mode since we cannot return a
+        # context manager an yield all the result records at the same time
+        all_results = []
+
+        from contextlib import contextmanager
+        import datalad.api as dl
+        @contextmanager
+        def open_read():
+            # TODO cannot yield all those wonderful reports here since it would
+            # be a context manager... nothing to be yielded into the Python code
+            res = dl.get(path, dataset=dataset
+                         # TODO: what should we do with files not under git at all?
+                         # here on_failure is not effective - fails during "rendering"
+                         # , on_failure='continue'
+            )
+            all_results.extend(res)
+            files = []
+            for p in path:
+                # TODO: actually do all that full path deduction here probably
+                # since we allow for ds.open
+                files.append(open(p, *open_args))
+                all_results.append({
+                    'status': 'ok',
+                    'action': 'open',
+                    'path': p,
+                    'type': 'file'
+                })
+
+            yield files
+
+            # Nothing more to do for reading operation besides closing those
+            for f in files:
+                if not f.closed:
+                    f.close()
+                    all_results.append({
+                        'status': 'ok',
+                        'action': 'close',
+                        'path': f.name,
+                        'type': 'file'
+                    })
+
+
+        mode_base = mode[0] if mode is not None else 'r'
+        res = {
+            'r': open_read,
+            #'w': open_write(),
+        }[mode_base]()
+
+        cmdline_mode = True
+        return res
+        # TODO: in cmdline mode we should use it as a context manager here.
+        # In Python - we just need to return it I guess?
+        # with res as files:
+        #   # TODO: cmdline - start a shell?
+        #   print("files are: %s" % str(files))
+        # Since we are to use it as an actual context manager, and not as a
+        # generator of result records
+        #for r in all_results:
+        #    yield r

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -36,25 +36,45 @@ from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import on_windows, skip_if
 from datalad.tests.utils import assert_status, assert_result_count, assert_in_results
-from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import (
+    ok_file_has_content,
+    ok_file_under_git,
+    ok_clean_git,
+)
 from datalad.support.path import exists, join as opj
 
+from functools import wraps
 
-@assert_cwd_unchanged
-@with_tree(tree={
-    'ds': {
-        'in-annex': '',
-        'in-git': 'text',
-        'untracked': 'buga',  # TODO: 'untracked' and 'outside' aren't supported yet
-    },
-    'outside': 'content'
-})
-def test_open_read(path):
-    ds_orig = Dataset(opj(path, 'ds')).create(text_no_annex=True, force=True)
-    ds_orig.add(['in-annex', 'in-git'])
-    # bleh -- clone in Python API we return the records, even with return_type
-    # ds = clone(path, path + '-clone', return_type='item-or-list')
-    ds = install(ds_orig.path + '-clone', source=ds_orig)
+
+def with_sample_ds(t):
+    """A "fixture" for the tests to provide a sample dataset
+    """
+    @wraps(t)
+    @assert_cwd_unchanged
+    @with_tree(tree={
+        'ds': {
+            'in-annex': '',
+            'in-git': 'text',
+            'untracked': 'buga',
+        # TODO: 'untracked' and 'outside' aren't supported yet
+        },
+        'outside': 'content'
+    })
+    def wrapped(path):
+        ds_orig = Dataset(opj(path, 'ds')).create(text_no_annex=True,
+                                                  force=True)
+        ds_orig.add(['in-annex', 'in-git'])
+        # bleh -- clone in Python API we return the records, even with
+        # return_type
+        # ds = clone(path, path + '-clone', return_type='item-or-list')
+        ds = install(ds_orig.path + '-clone', source=ds_orig)
+
+        return t(ds)
+    return wrapped
+
+
+@with_sample_ds
+def test_read(ds):
     in_annex = opj(ds.path, 'in-annex')
 
     assert not exists(in_annex)
@@ -78,3 +98,35 @@ def test_open_read(path):
         with open((in_annex, 'in-git'), 'r', buffering=1) as (f1, f2):
             eq_(f1.read(), '')
             eq_(f2.read(), 'text')
+
+
+@with_sample_ds
+def test_rewrite(ds):
+    in_annex = opj(ds.path, 'in-annex')
+
+    assert not exists(in_annex)
+    with ds.open('in-annex', 'w') as f:
+        f.write("stuff")
+    ok_file_has_content(in_annex, "stuff")
+    ok_file_under_git(in_annex, annexed=True)
+    ok_clean_git(ds, untracked=['untracked'])
+
+    with ds.open('in-git', 'w') as f:
+        f.write("1")
+        f.write("2")
+
+    # ds.drop('in-annex')
+    # assert not exists(in_annex)  # never know for sure with all those generators etc
+    # # multiple at once, including untracked
+    # with ds.open(['in-annex', 'in-git']) as (f1, f2):
+    #     eq_(f1.read(), '')
+    #     eq_(f2.read(), 'text')
+    # ds.drop('in-annex')
+    #
+    # # TODO: make code work also with 'untracked' and 'outside'
+    #
+    # # Let's test with full and local paths and also explicit mode and buffering
+    # with chpwd(ds.path):
+    #     with open((in_annex, 'in-git'), 'r', buffering=1) as (f1, f2):
+    #         eq_(f1.read(), '')
+    #         eq_(f2.read(), 'text')

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -32,6 +32,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import eq_
 from datalad.tests.utils import getpwd
 from datalad.tests.utils import chpwd
+from datalad.tests.utils import create_tree
 from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import on_windows, skip_if
@@ -55,20 +56,23 @@ def with_sample_ds(t):
         'ds': {
             'in-annex': '',
             'in-git': 'text',
-            'untracked': 'buga',
-        # TODO: 'untracked' and 'outside' aren't supported yet
+            'untracked': 'untracked',
+        # TODO: open of 'untracked' and 'outside' aren't "supported" yet
         },
         'outside': 'content'
     })
     def wrapped(path):
-        ds_orig = Dataset(opj(path, 'ds')).create(text_no_annex=True,
-                                                  force=True)
-        ds_orig.add(['in-annex', 'in-git'])
+        ds_orig = Dataset(opj(path, 'ds')).create(
+            # Causes BK TODO https://github.com/datalad/datalad/issues/1651
+            # text_no_annex=True,
+            force=True)
+        ds_orig.add('in-annex')
+        ds_orig.add('in-git', to_git=True)
         # bleh -- clone in Python API we return the records, even with
         # return_type
         # ds = clone(path, path + '-clone', return_type='item-or-list')
         ds = install(ds_orig.path + '-clone', source=ds_orig)
-
+        create_tree(ds.path, {'untracked': 'untracked'})
         return t(ds)
     return wrapped
 
@@ -103,30 +107,61 @@ def test_read(ds):
 @with_sample_ds
 def test_rewrite(ds):
     in_annex = opj(ds.path, 'in-annex')
+    in_git = opj(ds.path, 'in-git')
+    ok_clean_git(ds.repo, untracked=['untracked'])
 
     assert not exists(in_annex)
     with ds.open('in-annex', 'w') as f:
         f.write("stuff")
     ok_file_has_content(in_annex, "stuff")
     ok_file_under_git(in_annex, annexed=True)
-    ok_clean_git(ds, untracked=['untracked'])
+    ok_clean_git(ds.repo, untracked=['untracked'])
+
+    # We cannot drop since modified
+    with ds.open('in-annex', 'w') as f:
+        f.write("1")
+        f.write("2")
+    ok_file_under_git(in_annex, annexed=True)
+    ok_file_has_content(in_annex, "12")
+    ok_clean_git(ds.repo, untracked=['untracked'])
 
     with ds.open('in-git', 'w') as f:
         f.write("1")
-        f.write("2")
+    ok_file_under_git(in_git, annexed=True) # Automigrates to annex! both with add or save
+    ok_file_has_content(in_git, "1")
+    ok_clean_git(ds.repo, untracked=['untracked'])
 
-    # ds.drop('in-annex')
-    # assert not exists(in_annex)  # never know for sure with all those generators etc
-    # # multiple at once, including untracked
-    # with ds.open(['in-annex', 'in-git']) as (f1, f2):
-    #     eq_(f1.read(), '')
-    #     eq_(f2.read(), 'text')
-    # ds.drop('in-annex')
-    #
+    # TODO: test that commit messages could be passed and save=False
+    #  could be of effect
     # # TODO: make code work also with 'untracked' and 'outside'
-    #
-    # # Let's test with full and local paths and also explicit mode and buffering
-    # with chpwd(ds.path):
-    #     with open((in_annex, 'in-git'), 'r', buffering=1) as (f1, f2):
-    #         eq_(f1.read(), '')
-    #         eq_(f2.read(), 'text')
+
+
+# TODO: RF - a copy of the above with only mode and content difference
+@with_sample_ds
+def test_append(ds):
+    in_annex = opj(ds.path, 'in-annex')
+    in_git = opj(ds.path, 'in-git')
+    ok_clean_git(ds.repo, untracked=['untracked'])
+
+    assert not exists(in_annex)
+    with ds.open('in-annex', 'a') as f:
+        f.write("stuff")
+    ok_file_has_content(in_annex, "stuff")
+    ok_file_under_git(in_annex, annexed=True)
+    ok_clean_git(ds.repo, untracked=['untracked'])
+
+    # We cannot drop since modified
+    with ds.open('in-annex', 'a') as f:
+        f.write("1")
+        f.write("2")
+    ok_file_under_git(in_annex, annexed=True)
+    ok_file_has_content(in_annex, "stuff12")
+    ok_clean_git(ds.repo, untracked=['untracked'])
+
+    with ds.open('in-git', 'a') as f:
+        f.write("1")
+    ok_file_under_git(in_git, annexed=True) # Automigrates to annex! both with add or save
+    ok_file_has_content(in_git, "text1")
+    ok_clean_git(ds.repo, untracked=['untracked'])
+
+    # # TODO: make code work also with 'untracked' and 'outside'

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -9,6 +9,7 @@
 """test command datalad open
 
 """
+from __future__ import unicode_literals
 
 __docformat__ = 'restructuredtext'
 

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -17,10 +17,15 @@ from os.path import join as opj
 
 from datalad.distribution.dataset import Dataset
 import datalad.api as dl
-from datalad.api import unlock
+from datalad.api import (
+    clone,
+    install,
+    open,
+)
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import CommandError
 from datalad.support.annexrepo import AnnexRepo
+from datalad.utils import chpwd
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_raises
@@ -31,18 +36,45 @@ from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import on_windows, skip_if
 from datalad.tests.utils import assert_status, assert_result_count, assert_in_results
+from datalad.tests.utils import ok_file_has_content
+from datalad.support.path import exists, join as opj
 
 
 @assert_cwd_unchanged
 @with_tree(tree={
-    'in-annex': '',
-    'in-git': 'text',
-    'untracked': 'buga'
+    'ds': {
+        'in-annex': '',
+        'in-git': 'text',
+        'untracked': 'buga',  # TODO: 'untracked' and 'outside' aren't supported yet
+    },
+    'outside': 'content'
 })
 def test_open_read(path):
-    ds = Dataset(path).create(text_no_annex=True, force=True)
-    ds.add(['in-annex', 'in-git'])
-    with dl.open('in-annex', return_type='generator') as f:
+    ds_orig = Dataset(opj(path, 'ds')).create(text_no_annex=True, force=True)
+    ds_orig.add(['in-annex', 'in-git'])
+    # bleh -- clone in Python API we return the records, even with return_type
+    # ds = clone(path, path + '-clone', return_type='item-or-list')
+    ds = install(ds_orig.path + '-clone', source=ds_orig)
+    in_annex = opj(ds.path, 'in-annex')
+
+    assert not exists(in_annex)
+    with ds.open('in-annex') as f:
         eq_(f.read(), '')
-    with dl.open('in-git') as f:
+    with ds.open('in-git') as f:
         eq_(f.read(), 'text')
+
+    ds.drop('in-annex')
+    assert not exists(in_annex)  # never know for sure with all those generators etc
+    # multiple at once, including untracked
+    with ds.open(['in-annex', 'in-git']) as (f1, f2):
+        eq_(f1.read(), '')
+        eq_(f2.read(), 'text')
+    ds.drop('in-annex')
+
+    # TODO: make code work also with 'untracked' and 'outside'
+
+    # Let's test with full and local paths and also explicit mode and buffering
+    with chpwd(ds.path):
+        with open((in_annex, 'in-git'), 'r', buffering=1) as (f1, f2):
+            eq_(f1.read(), '')
+            eq_(f2.read(), 'text')

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -97,6 +97,16 @@ def test_read(ds):
             eq_(f1.read(), '')
             eq_(f2.read(), 'text')
 
+    # Let's test for error being "handled" separately
+    cm = ds.open("in-git")
+    try:
+        with cm as f:
+            raise RuntimeError("Evil exception which should abort everything")
+    except RuntimeError:
+        pass
+    eq_(cm.all_results[-1]['status'], 'error')
+    eq_(len(cm.all_results[-1]['exception']), 3)  # all details of the exception
+
 
 @with_sample_ds
 def test_rewrite(ds):

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -1,0 +1,48 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""test command datalad open
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import os
+from os.path import join as opj
+
+from datalad.distribution.dataset import Dataset
+import datalad.api as dl
+from datalad.api import unlock
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.exceptions import CommandError
+from datalad.support.annexrepo import AnnexRepo
+from datalad.tests.utils import with_tree
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import assert_raises
+from datalad.tests.utils import eq_
+from datalad.tests.utils import getpwd
+from datalad.tests.utils import chpwd
+from datalad.tests.utils import assert_cwd_unchanged
+from datalad.tests.utils import with_testrepos
+from datalad.tests.utils import on_windows, skip_if
+from datalad.tests.utils import assert_status, assert_result_count, assert_in_results
+
+
+@assert_cwd_unchanged
+@with_tree(tree={
+    'in-annex': '',
+    'in-git': 'text',
+    'untracked': 'buga'
+})
+def test_open_read(path):
+    ds = Dataset(path).create(text_no_annex=True, force=True)
+    ds.add(['in-annex', 'in-git'])
+    with dl.open('in-annex', return_type='generator') as f:
+        eq_(f.read(), '')
+    with dl.open('in-git') as f:
+        eq_(f.read(), 'text')

--- a/datalad/interface/tests/test_open.py
+++ b/datalad/interface/tests/test_open.py
@@ -12,37 +12,28 @@
 
 __docformat__ = 'restructuredtext'
 
-import os
 from os.path import join as opj
 
 from datalad.distribution.dataset import Dataset
-import datalad.api as dl
 from datalad.api import (
     clone,
     install,
     open,
 )
-from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import CommandError
-from datalad.support.annexrepo import AnnexRepo
-from datalad.utils import chpwd
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import eq_
-from datalad.tests.utils import getpwd
-from datalad.tests.utils import chpwd
-from datalad.tests.utils import create_tree
-from datalad.tests.utils import assert_cwd_unchanged
-from datalad.tests.utils import with_testrepos
-from datalad.tests.utils import on_windows, skip_if
-from datalad.tests.utils import assert_status, assert_result_count, assert_in_results
+from datalad.support.path import (
+    exists,
+    join as opj,
+)
 from datalad.tests.utils import (
+    assert_cwd_unchanged,
+    chpwd,
+    create_tree,
+    eq_,
+    ok_clean_git,
     ok_file_has_content,
     ok_file_under_git,
-    ok_clean_git,
+    with_tree,
 )
-from datalad.support.path import exists, join as opj
 
 from functools import wraps
 
@@ -57,7 +48,7 @@ def with_sample_ds(t):
             'in-annex': '',
             'in-git': 'text',
             'untracked': 'untracked',
-        # TODO: open of 'untracked' and 'outside' aren't "supported" yet
+            # TODO: open of 'untracked' and 'outside' aren't "supported" yet
         },
         'outside': 'content'
     })

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -172,9 +172,10 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
             # Instantiation failed => no annex
             try:
                 r = GitRepo(path, init=False, create=False)
-            except Exception:
-                raise AssertionError("Couldn't find an annex or a git "
-                                     "repository at {}.".format(path))
+            except Exception as exc:
+                raise AssertionError(
+                    "Failed to find an annex or a git "
+                    "repository at {}. Exception was: {}".format(path, exc_str(exc)))
             if annex is None:
                 annex = False
             # explicitly given GitRepo instance doesn't make sense with


### PR DESCRIPTION
This pull request fixes #2890

In current state it is more of a tech preview (although not that "revolutionary")

### Changes
- [x] Decide if `open` is a good name (overloads built-in)
- [ ] Address numerous TODOs left around in the code and tests
    - [x] Docstrings
    - [ ] Decide if any custom handling of exception is needed, or actually we should just avoid doing any post_close altogether if exception happened
    - [ ] Upon `w`, transfer file permissions (executability, group writeability) and ownership
    - [ ] Extend testing
    - [ ] Custom handling of "unlocked" files in V6
- [ ] Decide on the destiny of https://github.com/datalad/datalad/issues/1651 although largely independent of this issue which shouldn't care (but initial test was failing due to #1651)