### PR TITLE
BF: do not even check with hasattr, go straight for _repo

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -867,8 +867,7 @@ class GitRepo(RepoInterface):
         # Make sure to flush pending changes, especially close batch processes
         # (internal `git cat-file --batch` by GitPython)
         try:
-            if hasattr(self, 'repo') and exists(self.path) \
-                    and self._repo is not None:
+            if getattr(self, '_repo', None) is not None and exists(self.path):
                 # gc might be late, so the (temporary)
                 # repo doesn't exist on FS anymore
                 self._repo.git.clear_cache()


### PR DESCRIPTION
This should complete the fix in 15573223c5e765e0e711672166b6717b6ad0382f .
Apparently hasattr would also trigger property value computation, at least according
to this traceback I was receiving if using python3:

    [INFO   ] Cloning http://datasets-dev.datalad.org/openfmri/ds000002 [1 other candidates] into '/tmp/ds000002'
    [INFO   ]   Remote origin not usable by git-annex; setting annex-ignore
    [INFO   ] Exception ignored in: <bound method AnnexRepo.__del__ of <AnnexRepo path=/tmp/ds000002 (<class 'datalad.support.annexrepo.AnnexRepo'>)>>
    [INFO   ] Traceback (most recent call last):
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/annexrepo.py, line 365, in __del__
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py, line 870, in __del__
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py, line 743, in repo
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/cmd.py, line 189, in __call__
    [INFO   ] Exception ignored in: <bound method AnnexRepo.__del__ of <AnnexRepo path=/tmp/ds000002 (<class 'datalad.support.annexrepo.AnnexRepo'>)>>
    [INFO   ] Traceback (most recent call last):
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/annexrepo.py, line 365, in __del__
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py, line 870, in __del__
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py, line 743, in repo
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/cmd.py, line 189, in __call__
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/cmd.py, line 570, in call
    [INFO   ]   File /home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py, line 402, in Repo
    [INFO   ]   File /usr/lib/python3/dist-packages/git/repo/base.py, line 178, in __init__
    [INFO   ] NameError: name 'open' is not defined
    [INFO   ] access to dataset sibling datalad not auto-enabled, enable with:
    | 		datalad siblings -d /tmp/ds000002 enable -s datalad
    install(ok): /tmp/ds000002 (dataset)

