### PR TITLE
First batch of GitPython pruning

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -321,7 +321,7 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
     def skip_or_pick(hexsha, result, msg):
         pick = hexsha in to_pick
         result["rerun_action"] = "pick" if pick else "skip"
-        shortrev = dset.repo.repo.git.rev_parse("--short", hexsha)
+        shortrev = dset.repo.get_hexsha(hexsha, short=True)
         result["message"] = (
             "%s %s; %s",
             shortrev, msg, "cherry picking" if pick else "skipping")

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -562,6 +562,6 @@ def new_or_modified(diff_results):
 def commit_exists(dataset, commit):
     try:
         dataset.repo.repo.git.rev_parse("--verify", commit + "^{commit}")
-    except:
+    except GitCommandError:
         return False
     return True

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -313,12 +313,7 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
             status="ok")
 
     def rev_is_ancestor(rev):
-        try:
-            dset.repo.repo.git.merge_base("--is-ancestor", rev, start_point)
-        except GitCommandError:
-            # Revision is NOT an ancestor of the starting point.
-            return False
-        return True
+        return dset.repo.is_ancestor(rev, start_point)
 
     # We want to skip revs before the starting point and pick those after.
     to_pick = set(dropwhile(rev_is_ancestor, [r["commit"] for r in results]))

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -422,7 +422,7 @@ def _get_script_handler(script, since, revision):
         ofh.write(header.format(
             script=script,
             since="" if since is None else " --since=" + since,
-            revision=dset.repo.repo.git.rev_parse(revision),
+            revision=dset.repo.get_hexsha(revision),
             ds='dataset {} at '.format(dset.id) if dset.id else '',
             path=dset.path))
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -243,7 +243,7 @@ class Rerun(Interface):
 def _revs_as_results(dset, revs):
     for rev in revs:
         res = get_status_dict("run", ds=dset, commit=rev)
-        full_msg = dset.repo.repo.git.show(rev, "--format=%B", "--no-patch")
+        full_msg = dset.repo.format_commit("%B", rev)
         try:
             msg, info = get_run_info(dset, full_msg)
         except ValueError as exc:
@@ -401,8 +401,7 @@ def _report(dset, results):
                 res["diff"] = list(res["diff"])
                 # Add extra information that is useful in the report but not
                 # needed for the rerun.
-                out = dset.repo.repo.git.show(
-                    "--no-patch", "--format=%an%x00%aI", res["commit"])
+                out = dset.repo.format_commit("%an%x00%aI", res["commit"])
                 res["author"], res["date"] = out.split("\0")
         yield res
 

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -623,7 +623,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     msg = assure_bytes(msg)
 
     if not rerun_info and cmd_exitcode:
-        msg_path = opj(relpath(ds.repo.repo.git_dir), "COMMIT_EDITMSG")
+        msg_path = relpath(opj(ds.repo.path, ds.repo.get_git_dir(ds.repo),
+                               "COMMIT_EDITMSG"))
         with open(msg_path, "wb") as ofh:
             ofh.write(msg)
         lgr.info("The command had a non-zero exit code. "

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -262,16 +262,16 @@ def test_rerun_onto(path):
     # same (but detached) place.
     ds.rerun(revision="static", onto="static")
     ok_(ds.repo.get_active_branch() is None)
-    eq_(ds.repo.repo.git.rev_parse("HEAD"),
-        ds.repo.repo.git.rev_parse("static"))
+    eq_(ds.repo.get_hexsha(),
+        ds.repo.get_hexsha("static"))
 
     # If we run the "static" change from the same "base", we end up
     # with a new commit.
     ds.repo.checkout("master")
     ds.rerun(revision="static", onto="static^")
     ok_(ds.repo.get_active_branch() is None)
-    neq_(ds.repo.repo.git.rev_parse("HEAD"),
-         ds.repo.repo.git.rev_parse("static"))
+    neq_(ds.repo.get_hexsha(),
+         ds.repo.get_hexsha("static"))
     assert_result_count(ds.diff(revision="HEAD..static"), 0)
     for revrange in ["..static", "static.."]:
         assert_result_count(
@@ -282,8 +282,8 @@ def test_rerun_onto(path):
     ds.repo.checkout("master")
     ds.rerun(onto="HEAD")
     ok_(ds.repo.get_active_branch() is None)
-    neq_(ds.repo.repo.git.rev_parse("HEAD"),
-         ds.repo.repo.git.rev_parse("master"))
+    neq_(ds.repo.get_hexsha(),
+         ds.repo.get_hexsha("master"))
 
     # An empty `onto` means use the parent of the first revision.
     ds.repo.checkout("master")
@@ -300,7 +300,7 @@ def test_rerun_onto(path):
     eq_(ds.repo.get_active_branch(), "from-base")
     assert_result_count(ds.diff(revision="master..from-base"), 0)
     eq_(ds.repo.get_merge_base(["static", "from-base"]),
-        ds.repo.repo.git.rev_parse("static^"))
+        ds.repo.get_hexsha("static^"))
 
 
 @ignore_nose_capturing_stdout
@@ -449,7 +449,7 @@ def test_rerun_branch(path):
         assert_result_count(
             ds.repo.repo.git.rev_list(revrange).split(), 3)
     eq_(ds.repo.get_merge_base(["master", "rerun"]),
-        ds.repo.repo.git.rev_parse("prerun"))
+        ds.repo.get_hexsha("prerun"))
 
     # Start rerun branch at tip of current branch.
     ds.repo.checkout("master")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -391,7 +391,7 @@ def test_run_failure(path):
     eq_(hexsha_initial, ds.repo.get_hexsha())
     ok_(ds.repo.dirty)
 
-    msgfile = opj(ds.repo.repo.git_dir, "COMMIT_EDITMSG")
+    msgfile = opj(path, ds.repo.get_git_dir(ds.repo), "COMMIT_EDITMSG")
     ok_exists(msgfile)
 
     ds.add(".", save=False)

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -276,7 +276,7 @@ def test_save_message_file(path):
                        "msg": "add foo"})
     ds.add("foo", save=False)
     ds.save(message_file=opj(ds.path, "msg"))
-    assert_equal(ds.repo.repo.git.show("--format=%s", "--no-patch"),
+    assert_equal(ds.repo.format_commit("%s"),
                  "add foo")
 
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1341,21 +1341,21 @@ class GitRepo(RepoInterface):
         return [x[0] for x in self.cmd_call_wrapper(
             self.repo.index.entries.keys)]
 
-    def get_hexsha(self, object=None):
-        """Return a hexsha for a given object. If None - of current HEAD
+    def get_hexsha(self, commitish=None):
+        """Return a hexsha for a given commitish.
 
         Parameters
         ----------
-        object: str, optional
-          Any type of Git object identifier. See `git show`.
+        commitish : str, optional
+          Any commit identifier (defaults to "HEAD").
 
         Returns
         -------
         str or, if there are not commits yet, None.
         """
         cmd = ['git', 'show', '--no-patch', "--format=%H"]
-        if object:
-            cmd.append(object)
+        if commitish:
+            cmd.append(commitish)
         # make sure Git takes our argument as a revision
         cmd.append('--')
         try:
@@ -1363,7 +1363,7 @@ class GitRepo(RepoInterface):
                 '', cmd, expect_stderr=True, expect_fail=True)
         except CommandError as e:
             if 'bad revision' in e.stderr:
-                raise ValueError("Unknown object identifier: %s" % object)
+                raise ValueError("Unknown commit identifier: %s" % commitish)
             elif 'does not have any commits yet' in e.stderr:
                 return None
             else:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1442,6 +1442,26 @@ class GitRepo(RepoInterface):
         assert(len(bases) == 1)  # we do not do 'all' yet
         return bases[0].hexsha
 
+    def is_ancestor(self, reva, revb):
+        """Is `reva` an ancestor of `revb`?
+
+        Parameters
+        ----------
+        reva, revb : str
+            Revisions.
+
+        Returns
+        -------
+        bool
+        """
+        try:
+            self._git_custom_command(
+                "", ["git", "merge-base", "--is-ancestor", reva, revb],
+                expect_fail=True)
+        except CommandError:
+            return False
+        return True
+
     def get_commit_date(self, branch=None, date='authored'):
         """Get the date stamp of the last commit (in a branch or head otherwise)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1384,6 +1384,29 @@ class GitRepo(RepoInterface):
                 return None
             raise
 
+    def commit_exists(self, commitish):
+        """Does `commitish` exist in the repo?
+
+        Parameters
+        ----------
+        commitish : str
+            A commit or an object that can be dereferenced to one.
+
+        Returns
+        -------
+        bool
+        """
+        try:
+            # Note: The peeling operator "^{commit}" is required so that
+            # rev-parse doesn't succeed if passed a full hexsha that is valid
+            # but doesn't exist.
+            self._git_custom_command(
+                "", ["git", "rev-parse", "--verify", commitish + "^{commit}"],
+                expect_fail=True)
+        except CommandError:
+            return False
+        return True
+
     def get_merge_base(self, commitishes):
         """Get a merge base hexsha
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1355,7 +1355,7 @@ class GitRepo(RepoInterface):
         """
         cmd = ['git', 'show', '--no-patch', "--format=%H"]
         if commitish:
-            cmd.append(commitish)
+            cmd.append(commitish + "^{commit}")
         # make sure Git takes our argument as a revision
         cmd.append('--')
         try:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1348,6 +1348,10 @@ class GitRepo(RepoInterface):
         ----------
         object: str, optional
           Any type of Git object identifier. See `git show`.
+
+        Returns
+        -------
+        str or, if there are not commits yet, None.
         """
         cmd = ['git', 'show', '--no-patch', "--format=%H"]
         if object:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1376,19 +1376,21 @@ class GitRepo(RepoInterface):
         # compatibility across platforms.
         return stdout.rsplit("\0", 1)[0]
 
-    def get_hexsha(self, commitish=None):
+    def get_hexsha(self, commitish=None, short=False):
         """Return a hexsha for a given commitish.
 
         Parameters
         ----------
         commitish : str, optional
           Any identifier that refers to a commit (defaults to "HEAD").
+        short : bool, optional
+          Return the abbreviated form of the hexsha.
 
         Returns
         -------
         str or, if there are not commits yet, None.
         """
-        stdout = self.format_commit("%H",
+        stdout = self.format_commit("%{}".format('h' if short else 'H'),
                                     commitish)
         if stdout is not None:
             stdout = stdout.splitlines()

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1242,6 +1242,15 @@ def test_gitattributes(path):
 
 
 @with_tempfile(mkdir=True)
+def test_get_hexsha_tag(path):
+    gr = GitRepo(path, create=True)
+    gr.commit(msg="msg", options=["--allow-empty"])
+    gr.tag("atag", message="atag msg")
+    # get_hexsha() dereferences a tag to a commit.
+    eq_(gr.get_hexsha("atag"), gr.get_hexsha())
+
+
+@with_tempfile(mkdir=True)
 def test_get_tags(path):
     from mock import patch
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1066,7 +1066,8 @@ def test_optimized_cloning(path):
         return dict(
             [(os.path.join(*o.split(os.sep)[-2:]),
               os.stat(o).st_ino)
-             for o in glob(os.path.join(repo.repo.git_dir,
+             for o in glob(os.path.join(repo.path,
+                                        repo.get_git_dir(repo),
                                         'objects', '*', '*'))])
 
     origin_inodes = _get_inodes(repo)

--- a/datalad/support/tests/test_repodates.py
+++ b/datalad/support/tests/test_repodates.py
@@ -35,7 +35,7 @@ def test_check_dates(path):
         ar.commit("add foo")
         ar.tag("foo-tag", "tag before refdate")
         # We can't use ar.get_tags because that returns the commit's hexsha,
-        # not the tag's.
+        # not the tag's, and ar.get_hexsha is limited to commit objects.
         foo_tag = ar.repo.git.rev_parse("foo-tag")
         # Make a lightweight tag to make sure `tag_dates` doesn't choke on it.
         ar.tag("light")


### PR DESCRIPTION
This eliminates some of the GitPython API calls mentioned in #2879.

-   Eliminates nearly all `repo.git.rev_parse` calls through use and extension of `GitRepo.get_hexsha` and through new `GitRepo.commit_exists`. (ece522998 explains the remaining two.)
-   Removes all `repo.git.show` calls with use of new `GitRepo.format_commit`.
-   Removes all `repo.git_dir` uses.
-   Add `GitRepo.is_ancestor` and drops `repo.git.merge_base`.

---

-   [X] This change is complete