### PR TITLE
RF: Centralize submodule addition logic in GitRepo

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -41,11 +41,13 @@ from datalad.interface.utils import discover_dataset_trace_to_targets
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.save import Save
-from datalad.distribution.utils import _fixup_submodule_dotgit_setup
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
-from datalad.support.gitrepo import GitRepo
+from datalad.support.gitrepo import (
+    GitRepo,
+    InvalidGitRepositoryError,
+)
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import CommandError
@@ -355,24 +357,11 @@ class Add(Interface):
                         **dict(common_report, **ap))
                     continue
                 subds = Dataset(ap['path'])
-                # check that the subds has a commit, and refuse
-                # to operate on it otherwise, or we would get a bastard
-                # submodule that cripples git operations
-                if not subds.repo.get_hexsha():
-                    yield get_status_dict(
-                        ds=subds, status='impossible',
-                        message='cannot add subdataset with no commits',
-                        **dict(common_report, **ap))
-                    continue
                 subds_relpath = relpath(ap['path'], ds_path)
-                # make an attempt to configure a submodule source URL based on the
-                # discovered remote configuration
-                remote, branch = subds.repo.get_tracking_branch()
-                subds_url = subds.repo.get_remote_url(remote) if remote else None
                 # Register the repository in the repo tree as a submodule
                 try:
-                    ds.repo.add_submodule(subds_relpath, url=subds_url, name=None)
-                except CommandError as e:
+                    ds.repo.add_submodule(subds_relpath, url=None, name=None)
+                except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(
                         ds=subds, status='error', message=e.stderr,
                         **dict(common_report, **ap))
@@ -390,7 +379,6 @@ class Add(Interface):
                 # slow down
                 #ap['staged'] = True
                 to_save.append(ap)
-                _fixup_submodule_dotgit_setup(ds, subds_relpath)
                 # report added subdatasets -- `annex add` below won't do it
                 yield get_status_dict(
                     ds=subds,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -40,7 +40,10 @@ from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
-from datalad.support.gitrepo import GitRepo
+from datalad.support.gitrepo import (
+    GitRepo,
+    _fixup_submodule_dotgit_setup,
+)
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import InstallFailedError
 from datalad.support.exceptions import IncompleteResultsError
@@ -61,7 +64,6 @@ from .dataset import datasetmethod
 from .clone import Clone
 from .utils import _get_flexible_source_candidates
 from .utils import _get_tracking_source
-from .utils import _fixup_submodule_dotgit_setup
 
 __docformat__ = 'restructuredtext'
 

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -31,23 +31,6 @@ from datalad.utils import knows_annex
 lgr = logging.getLogger('datalad.distribution.utils')
 
 
-def _fixup_submodule_dotgit_setup(ds, relativepath):
-    """Implementation of our current of .git in a subdataset
-
-    Each subdataset/module has its own .git directory where a standalone
-    repository would have it. No gitdir files, no symlinks.
-    """
-    # move .git to superrepo's .git/modules, remove .git, create
-    # .git-file
-    path = opj(ds.path, relativepath)
-    src_dotgit = GitRepo.get_git_dir(path)
-
-    # at this point install always yields the desired result
-    # just make sure
-    assert(src_dotgit == '.git')
-
-
-
 def _get_git_url_from_source(source):
     """Return URL for cloning associated with a source specification
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2286,7 +2286,7 @@ class GitRepo(RepoInterface):
             # submodule that cripples git operations
             if not subm.get_hexsha():
                 raise InvalidGitRepositoryError(
-                    'cannot add subdataset %s with no commits', subm)
+                    'cannot add subdataset {} with no commits'.format(subm))
             # make an attempt to configure a submodule source URL based on the
             # discovered remote configuration
             remote, branch = subm.get_tracking_branch()

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1146,6 +1146,10 @@ def test_GitRepo_gitignore(path):
 
     gr = GitRepo(path, create=True)
     sub = GitRepo(op.join(path, 'ignore-sub.me'))
+    # we need to commit something, otherwise add_submodule
+    # will already refuse the submodule for having no commit
+    sub.add('a_file.txt')
+    sub.commit()
 
     from ..exceptions import GitIgnoreError
 


### PR DESCRIPTION
Essential verification check was only available in `add`

- [x] fix #2909
- [x] adjust Repo tests to handle the newly reported issues during submodule addition (prev. silent or different)