### PR TITLE
ENH+BF: run-procedure

### DIFF
--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -63,9 +63,9 @@ def _get_configured_call_format(name, ds=None):
     cm = cfg if ds is None else ds.config
     v = cm.get('datalad.procedures.{}.call-format'.format(name), None)
     if isinstance(v, tuple):
-        # Note: This relies on the assumption, that ConfigManager returns
-        # values order from most general to most specific entries in case of
-        # multiple values (just like git-config)
+        # If multiple values are defined (at the same level), ConfigManager
+        # returns a tuple. Go with the last one.
+        # TODO: Should we issue a warning or fail entirely?
         return v[-1]
     else:
         return v

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -206,16 +206,15 @@ class RunProcedure(Interface):
       fully customizable format string to determine how to execute procedure
       NAME (see also datalad-run).
       It currently requires to include the following placeholders:
-      - '{script}'
-        will be replaced by the path to the procedure
-      - '{ds}'
-        will be replaced by the absolute path to the dataset the procedure
+
+      - '{script}': will be replaced by the path to the procedure
+      - '{ds}': will be replaced by the absolute path to the dataset the procedure
         shall operate on
-      - '{args}'
-        will be replaced by all additional arguments passed into run-procedure
-        after NAME
-      As an example the default format string for a call to a python script is:
-      "python {script} {ds} {args}"
+      - '{args}': will be replaced by [CMD: all additional arguments passed into
+        run-procedure after NAME CMD][PY: all but the first element of `spec` if
+        `spec` is a list or tuple PY]
+        As an example the default format string for a call to a python script is:
+        "python {script} {ds} {args}"
     - 'datalad.procedures.<NAME>.help'
       will be shown on `datalad run-procedure --help-proc NAME` to provide a
       description and/or usage info for procedure NAME

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -64,9 +64,10 @@ def _get_procedure_implementation(name='*', ds=None):
             for m in _get_file_match(op.join(ds.path, dir), name):
                 yield m
         # 1.1. check subdatasets recursively
-        # for subds in ds.subdatasets(return_type='generator',
-        #                             result_xfm='datasets'):
-        #     yield _get_procedure_implementation(name=name, ds=subds)
+        for subds in ds.subdatasets(return_type='generator',
+                                    result_xfm='datasets'):
+            for m in _get_procedure_implementation(name=name, ds=subds):
+                yield m
 
     # 2. check system and user account for procedure
     for loc in (cfg.obtain('datalad.locations.user-procedures'),

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -61,6 +61,9 @@ def _get_file_match(dir, name='*'):
 def _get_proc_config(name, ds=None):
     """get configuration of named procedure
 
+    Figures call format string and help message for a given procedure name,
+    based on dataset.
+
     Returns
     -------
     tuple
@@ -151,7 +154,7 @@ class RunProcedure(Interface):
 
     Implementations of some procedures are shipped together with DataLad,
     but additional procedures can be provided by 1) any DataLad extension,
-    2) any dataset, 3) a local user, or 4) a local system administrator.
+    2) any (sub-)dataset, 3) a local user, or 4) a local system administrator.
     DataLad will look for procedures in the following locations and order:
 
     Directories identified by the configuration settings
@@ -166,6 +169,14 @@ class RunProcedure(Interface):
 
     and subsequently in the 'resources/procedures/' directories of any
     installed extension, and, lastly, of the DataLad installation itself.
+
+    Please note, that a dataset that defines
+    'datalad.locations.dataset-procedures' provides its procedures to
+    any dataset it is a subdataset of. That way you can have a collection of
+    such procedures in a dedicated dataset and install it as a subdataset into
+    any dataset you want to use those procedures with. In case of a naming
+    conflict with such a dataset hierarchy, the dataset you're calling
+    run-procedures on will take precedence over its subdatasets and so on.
 
     Each configuration setting can occur multiple times to indicate multiple
     directories to be searched. If a procedure matching a given name is found
@@ -188,6 +199,26 @@ class RunProcedure(Interface):
     of taking at least one positional argument (the absolute path to the
     dataset they shall operate on).
 
+    For further customization there are two configuration settings per procedure
+    available:
+
+    - 'datalad.procedures.<NAME>.call-format'
+      fully customizable format string to determine how to execute procedure
+      NAME (see also datalad-run).
+      It currently requires to include the following placeholders:
+      - '{script}'
+        will be replaced by the path to the procedure
+      - '{ds}'
+        will be replaced by the absolute path to the dataset the procedure
+        shall operate on
+      - '{args}'
+        will be replaced by all additional arguments passed into run-procedure
+        after NAME
+      As an example the default format string for a call to a python script is:
+      "python {script} {ds} {args}"
+    - 'datalad.procedures.<NAME>.help'
+      will be shown on `datalad run-procedure --help-proc NAME` to provide a
+      description and/or usage info for procedure NAME
 
     *Customize other commands with procedures*
 

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -112,7 +112,6 @@ def _get_procedure_implementation(name='*', ds=None):
       path, format string, help message
     """
 
-
     ds = ds if isinstance(ds, Dataset) else Dataset(ds) if ds else None
 
     # 1. check system and user account for procedure
@@ -407,17 +406,31 @@ class RunProcedure(Interface):
             ex['template'] = cmd_tmpl
 
         if help_proc:
-            res = get_status_dict(
-                    action='procedure_help',
-                    path=procedure_file,
-                    type='file',
-                    logger=lgr,
-                    refds=ds.path if ds else None,
-                    status='ok',
-                    state=ex['state'],
-                    procedure_type=ex['type'],
-                    procedure_callfmt=ex['template'],
-                    message=cmd_help if cmd_help else "No help available")
+            if cmd_help:
+                res = get_status_dict(
+                        action='procedure_help',
+                        path=procedure_file,
+                        type='file',
+                        logger=lgr,
+                        refds=ds.path if ds else None,
+                        status='ok',
+                        state=ex['state'],
+                        procedure_type=ex['type'],
+                        procedure_callfmt=ex['template'],
+                        message=cmd_help)
+            else:
+                res = get_status_dict(
+                        action='procedure_help',
+                        path=procedure_file,
+                        type='file',
+                        logger=lgr,
+                        refds=ds.path if ds else None,
+                        status='impossible',
+                        state=ex['state'],
+                        procedure_type=ex['type'],
+                        procedure_callfmt=ex['template'],
+                        message="No help available for '%s'" % name)
+
             yield res
             return
 

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -241,6 +241,11 @@ def test_configs(path):
     ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'local\n')
 
     # 4. get configured help message:
+    r = ds.run_procedure('datalad_test_proc', help_proc=True,
+                         on_failure='ignore')
+    assert_true(len(r) == 1)
+    assert_in_results(r, status="impossible")
+
     ds.config.add(
         'datalad.procedures.datalad_test_proc.help',
         "This is a help message",

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -216,12 +216,12 @@ def test_configs(path):
         'code',
         where='dataset')
 
-    # run procedure based on execution guessing by run_procedure:
+    # 1. run procedure based on execution guessing by run_procedure:
     ds.run_procedure(spec=['datalad_test_proc', 'some_arg'])
     # look for traces
     ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'some_arg\n')
 
-    # now configure specific call format including usage of substitution config
+    # 2. now configure specific call format including usage of substitution config
     # for run:
     ds.config.add(
         'datalad.procedures.datalad_test_proc.call-format',
@@ -240,3 +240,16 @@ def test_configs(path):
     ds.run_procedure(spec=['datalad_test_proc', 'some_arg'])
     # look for traces
     ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'dataset-call-config\n')
+
+    # 3. have a conflicting config at user-level, which should override the
+    # config on dataset level:
+    ds.config.add(
+        'datalad.procedures.datalad_test_proc.call-format',
+        'python "{script}" "{ds}" local {args}',
+        where='local'
+    )
+    ds.unlock("fromproc.txt")
+    # run again:
+    ds.run_procedure(spec=['datalad_test_proc', 'some_arg'])
+    # look for traces
+    ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'local\n')

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -34,6 +34,9 @@ from datalad import cfg
 def test_invalid_call():
     # needs spec or discover
     assert_raises(InsufficientArgumentsError, run_procedure)
+    res = run_procedure('unknown', on_failure='ignore')
+    assert_true(len(res) == 1)
+    assert_in_results(res, status="impossible")
 
 
 # FIXME: For some reason fails to commit correctly if on windows and in direct
@@ -254,7 +257,7 @@ def test_configs(path):
     # look for traces
     ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'local\n')
 
-    #
+    # 4. get configured help message:
     ds.config.add(
         'datalad.procedures.datalad_test_proc.help',
         "This is a help message",

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -17,17 +17,18 @@ import os.path as op
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_true
 from datalad.tests.utils import assert_in_results
-from datalad.tests.utils import known_failure_direct_mode
+from datalad.tests.utils import skip_if
+from datalad.tests.utils import on_windows
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.api import run_procedure
 from datalad.api import clean
+from datalad import cfg
 
 
 def test_invalid_call():
@@ -35,8 +36,9 @@ def test_invalid_call():
     assert_raises(InsufficientArgumentsError, run_procedure)
 
 
-@known_failure_windows
-#@ignore_nose_capturing_stdout
+# FIXME: For some reason fails to commit correctly if on windows and in direct
+# mode. However, direct mode on linux works
+@skip_if(cond=on_windows and cfg.get("datalad.repo.version", None) != 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys
@@ -96,6 +98,9 @@ def test_basics(path, super_path):
     ok_clean_git(super.path, index_modified=[op.join('.datalad', 'config')])
 
 
+# FIXME: For some reason fails to commit correctly if on windows and in direct
+# mode. However, direct mode on linux works
+@skip_if(cond=on_windows and cfg.get("datalad.repo.version", None) != 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys
@@ -178,6 +183,9 @@ def test_procedure_discovery(path, super_path):
                                        'datalad_test_proc.py'))
 
 
+# FIXME: For some reason fails to commit correctly if on windows and in direct
+# mode. However, direct mode on linux works
+@skip_if(cond=on_windows and cfg.get("datalad.repo.version", None) != 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys
@@ -188,8 +196,7 @@ with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('{}\\n'.format(sys.argv[2]))
 add(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 """}})
-@with_tempfile
-def test_configs(path, super_path):
+def test_configs(path):
 
     # set up dataset with registered procedure (c&p from test_basics):
     ds = Dataset(path).create(force=True)

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -67,7 +67,7 @@ def test_basics(path, super_path):
         'code',
         where='dataset')
     # commit this procedure config for later use in a clone:
-    ds.save()
+    ds.add(op.join('.datalad', 'config'))
     # configure dataset to run the demo procedure prior to the clean command
     ds.config.add(
         'datalad.clean.proc-pre',
@@ -96,10 +96,6 @@ def test_basics(path, super_path):
     ok_clean_git(super.path, index_modified=[op.join('.datalad', 'config')])
 
 
-
-
-
-@known_failure_direct_mode
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys
@@ -146,7 +142,7 @@ def test_procedure_discovery(path, super_path):
         'datalad.clean.proc-pre',
         'datalad_test_proc',
         where='dataset')
-    ds.save()
+    ds.add(op.join('.datalad', 'config'))
 
     # run discovery on the dataset:
     ps = ds.run_procedure(discover=True)

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -57,13 +57,7 @@ def test_basics(path, super_path):
     ds = Dataset(path).create(force=True)
     # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
     # input yet, so manual for now
-    # V6FACT: this leaves the file staged, but not committed
     ds.add('code', to_git=True)
-    # V6FACT: even this leaves it staged
-    ds.add('.')
-    # V6FACT: but this finally commits it
-    ds.save()
-    # TODO remove above two lines
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder
@@ -131,13 +125,7 @@ def test_procedure_discovery(path, super_path):
     ds = Dataset(path).create(force=True)
     # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
     # input yet, so manual for now
-    # V6FACT: this leaves the file staged, but not committed
     ds.add('code', to_git=True)
-    # V6FACT: even this leaves it staged
-    ds.add('.')
-    # V6FACT: but this finally commits it
-    ds.save()
-    # TODO remove above two lines
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder
@@ -205,12 +193,7 @@ def test_configs(path):
     ds = Dataset(path).create(force=True)
     # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
     # input yet, so manual for now
-    # V6FACT: this leaves the file staged, but not committed
     ds.add('code', to_git=True)
-    # V6FACT: even this leaves it staged
-    ds.add('.')
-    # V6FACT: but this finally commits it
-    ds.save()
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -253,3 +253,14 @@ def test_configs(path):
     ds.run_procedure(spec=['datalad_test_proc', 'some_arg'])
     # look for traces
     ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'local\n')
+
+    #
+    ds.config.add(
+        'datalad.procedures.datalad_test_proc.help',
+        "This is a help message",
+        where='dataset'
+    )
+
+    r = ds.run_procedure('datalad_test_proc', help_proc=True)
+    assert_true(len(r) == 1)
+    assert_in_results(r, message="This is a help message", status='ok')


### PR DESCRIPTION
Fixes and additions to `run-procedure`:

- `run-procedure` required the `-d` parameter to discover procedures within a dataset even if called from within the dataset. That's not intuitive and I changed that. When called from within a dataset it will use it (except when passing in sth else via `-d` of course).
- BF: files that are neither executable nor end with `.py` or `.sh` but are in a configured look up location for procedures caused the command to crash. Fixed that.
- procedures can now recursively be discovered in subdatasets as well. The uppermost has highest priority
- added two configs for procedures: `datalad.procedures.NAME.call-format` and `datalad.procedures.NAME.help`. The former replaces (if given) the default, which is based on discovered file type. This allows not only for changing order or even execute different scripts than just python and bash, but also for usage of `run` substitutions.
The latter is queried by `datalad run-procedure --help-proc NAME`, which yields the value of this config as `message`. So we can provide description, usage info etc. on a procedure.
- proper 'impossible' result when procedure not found (instead of `ValueError`)

Please have a look @datalad/developers
