### PR TITLE
BF(workaround): switch to use os.getcwd if something odd detected with PWD env var

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -51,7 +51,10 @@ from .config import ConfigManager
 cfg = ConfigManager()
 
 from .log import lgr
-from datalad.utils import get_encoding_info, get_envvars_info
+from datalad.utils import get_encoding_info, get_envvars_info, getpwd
+
+# To analyze/initiate our decision making on what current directory to return
+getpwd()
 
 lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -326,18 +326,21 @@ def _test_assert_Xwd_unchanged_ok_chdir(func):
     @assert_cwd_unchanged(ok_to_chdir=True)
     def do_chdir_value_error():
         func(os.pardir)
+        return "a value"
 
     with swallow_logs() as cml:
-        do_chdir_value_error()
+        eq_(do_chdir_value_error(), "a value")
         eq_(orig_cwd, os.getcwd(),
             "assert_cwd_unchanged didn't return us back to cwd %s" % orig_cwd)
         eq_(orig_pwd, getpwd(),
             "assert_cwd_unchanged didn't return us back to cwd %s" % orig_pwd)
         assert_not_in("Mitigating and changing back", cml.out)
 
+
 def test_assert_Xwd_unchanged_ok_chdir():
     yield _test_assert_Xwd_unchanged_ok_chdir, os.chdir
     yield _test_assert_Xwd_unchanged_ok_chdir, chpwd
+
 
 def test_assert_cwd_unchanged_not_masking_exceptions():
     # Test that we are not masking out other "more important" exceptions

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -334,6 +334,23 @@ def test_getpwd_basic():
         assert_false(oschdir.called)
 
 
+@assert_cwd_unchanged(ok_to_chdir=True)
+@with_tempfile(mkdir=True)
+def test_getpwd_change_mode(tdir):
+    from datalad import utils
+    if utils._pwd_mode != 'PWD':
+        raise SkipTest("Makes sense to be tested only in PWD mode, "
+                       "but we seems to be beyond that already")
+    # The evil plain chdir call
+    os.chdir(tdir)
+    # Just testing the logic of switching to cwd mode and issuing a warning
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        pwd = getpwd()
+        eq_(pwd, os.path.realpath(pwd))  # might have symlinks, thus realpath
+    assert_in("symlinks in the paths will be resolved", cml.out)
+    eq_(utils._pwd_mode, 'cwd')
+
+
 @skip_if_on_windows
 @with_tempfile(mkdir=True)
 @assert_cwd_unchanged

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1066,7 +1066,7 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
         # record previous state of PWD handling
         utils_pwd_mode = utils._pwd_mode
         try:
-            func(*args, **kwargs)
+            ret = func(*args, **kwargs)
         except:
             exc_info = sys.exc_info()
         finally:
@@ -1095,6 +1095,8 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
 
         if exc_info is not None:
             reraise(*exc_info)
+
+        return ret
 
     return newfunc
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1079,6 +1079,9 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
 
         if cwd_after != cwd_before:
             chpwd(pwd_before)
+            # Above chpwd could also trigger the change of _pwd_mode, so we
+            # would need to reset it again since we know that it is all kosher
+            utils._pwd_mode = utils_pwd_mode
             if not ok_to_chdir:
                 lgr.warning(
                     "%s changed cwd to %s. Mitigating and changing back to %s"

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -50,6 +50,7 @@ from nose.tools import assert_is_instance
 from nose import SkipTest
 
 from ..cmd import Runner
+from .. import utils
 from ..utils import *
 from ..support.exceptions import CommandNotAvailableError
 from ..support.vcr_ import *
@@ -1062,11 +1063,14 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
         cwd_before = os.getcwd()
         pwd_before = getpwd()
         exc_info = None
+        # record previous state of PWD handling
+        utils_pwd_mode = utils._pwd_mode
         try:
             func(*args, **kwargs)
         except:
             exc_info = sys.exc_info()
         finally:
+            utils._pwd_mode = utils_pwd_mode
             try:
                 cwd_after = os.getcwd()
             except OSError as e:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1216,25 +1216,90 @@ def updated(d, update):
     return d
 
 
+_pwd_mode = None
+
+
+def _switch_to_getcwd(msg, *args):
+    global _pwd_mode
+    _pwd_mode = 'cwd'
+    lgr.warning(
+        msg + ". From now on will be returning os.getcwd(). Directory"
+               " symlinks in the paths will be resolved",
+        *args
+    )
+    # TODO:  we might want to mitigate by going through all flywheighted
+    # repos and tuning up their .paths to be resolved?
+
+
 def getpwd():
     """Try to return a CWD without dereferencing possible symlinks
 
-    If no PWD found in the env, output of getcwd() is returned
+    This function will try to use PWD environment variable to provide a current
+    working directory, possibly with some directories along the path being
+    symlinks to other directories.  Unfortunately, PWD is used/set only by the
+    shell and such functions as `os.chdir` and `os.getcwd` nohow use or modify
+    it, thus `os.getcwd()` returns path with links dereferenced.
+
+    While returning current working directory based on PWD env variable we
+    verify that the directory is the same as `os.getcwd()` after resolving all
+    symlinks.  If that verification fails, we fall back to always use
+    `os.getcwd()`.
+
+    Initial decision to either use PWD env variable or os.getcwd() is done upon
+    the first call of this function.
     """
-    try:
-        pwd = os.environ['PWD']
-        if on_windows and pwd and pwd.startswith('/'):
-            # It should be a path from MSYS.
-            # - it might start with a drive letter or not
-            # - it seems to be "illegal" to have a single letter directories
-            #   under / path, i.e. if created - they aren't found
-            # - 'ln -s' does not fail to create a "symlink" but it just copies!
-            #   so we are not likely to need original PWD purpose on those systems
-            # Verdict:
-            return os.getcwd()
-        return pwd
-    except KeyError:
+    global _pwd_mode
+    if _pwd_mode is None:
+        # we need to decide!
+        try:
+            pwd = os.environ['PWD']
+            if on_windows and pwd and pwd.startswith('/'):
+                # It should be a path from MSYS.
+                # - it might start with a drive letter or not
+                # - it seems to be "illegal" to have a single letter directories
+                #   under / path, i.e. if created - they aren't found
+                # - 'ln -s' does not fail to create a "symlink" but it just
+                # copies!
+                #   so we are not likely to need original PWD purpose on
+                # those systems
+                # Verdict:
+                _pwd_mode = 'cwd'
+            else:
+                _pwd_mode = 'PWD'
+        except KeyError:
+            _pwd_mode = 'cwd'
+
+    if _pwd_mode == 'cwd':
         return os.getcwd()
+    elif _pwd_mode == 'PWD':
+        cwd = os.getcwd()
+        try:
+            pwd = os.environ['PWD']
+            pwd_real = op.realpath(pwd)
+            # This logic would fail to catch the case where chdir did happen
+            # to the directory where current PWD is pointing to, e.g.
+            # $> ls -ld $PWD
+            # lrwxrwxrwx 1 yoh yoh 5 Oct 11 13:27 /home/yoh/.tmp/tmp -> /tmp//
+            # hopa:~/.tmp/tmp
+            # $> python -c 'import os; os.chdir("/tmp"); from datalad.utils import getpwd; print(getpwd(), os.getcwd())'
+            # ('/home/yoh/.tmp/tmp', '/tmp')
+            # but I guess that should not be too harmful
+            if pwd_real != cwd:
+                _switch_to_getcwd(
+                    "realpath of PWD=%s is %s whenever os.getcwd()=%s",
+                    pwd, pwd_real, cwd
+                )
+                return cwd
+            return pwd
+        except KeyError:
+            _switch_to_getcwd("PWD env variable is no longer available")
+            return cwd  # Must not happen, but may be someone
+                        # evil purges PWD from environ?
+    else:
+        raise RuntimeError(
+            "Must have not got here. "
+            "pwd_mode must be either cwd or PWD. And it is now %r" % (_pwd_mode,)
+        )
 
 
 class chpwd(object):


### PR DESCRIPTION
This pull request might help to address  #2910 but in an odd ad-hoc ugly fashion.  See description in patch/code

If we decide to adopt this at least as a temporary stop-gap measure, then  TODOs
- [x] tests

Testing locally with smth like
```shell
$> python -c 'import os; os.chdir("/tmp"); from datalad.utils import getpwd; print(getpwd(), os.getcwd())'
[WARNING] realpath of PWD=/home/yoh/proj/datalad/datalad-master is /home/yoh/proj/datalad/datalad-master whenever os.getcwd()=/tmp. From now on will be returning os.getcwd(). Directory symlinks in the paths will be resolved 
('/tmp', '/tmp')
```