### PR TITLE
BF: run: Fix expansion of cached full paths

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -339,9 +339,12 @@ class GlobbedPaths(object):
         else:
             paths = self._paths["expanded"]
 
-        if full and "expanded_full" not in self._paths:
-            paths = [opj(self.pwd, p) for p in paths]
-            self._paths["expanded_full"] = paths
+        if full:
+            if refresh or "expanded_full" not in self._paths:
+                paths = [opj(self.pwd, p) for p in paths]
+                self._paths["expanded_full"] = paths
+            else:
+                paths = self._paths["expanded_full"]
 
         return maybe_dot + paths
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -852,6 +852,13 @@ def test_run_explicit(path):
     ok_(ds.repo.is_dirty(path="dirt_modified"))
     neq_(hexsha_initial, ds.repo.get_hexsha())
 
+    # Saving explicit outputs works from subdirectories.
+    subdir = opj(path, "subdir")
+    mkdir(subdir)
+    with chpwd(subdir):
+        run("echo insubdir >foo", explicit=True, outputs=["foo"])
+    ok_(ds.repo.file_has_content(opj("subdir", "foo")))
+
 
 @ignore_nose_capturing_stdout
 @known_failure_windows


### PR DESCRIPTION
To avoid unnecessary re-globbing, GlobbedPaths.expand() stores the
glob results, which are relative paths.  When full=True, it also
converts these paths to absolute paths and stores that result.
However, since its introduction, the "full path, already stored" logic
has been incorrect and returns relative paths.  Update expand() to
actually use the cached full paths.

With the current run implementation, the way to trigger this codepath
is to call run *from a subdirectory* with explicit=True.

Fixes #2916.