### PR TITLE
BF: run: Don't show save instructions when "no commit" runs fail

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -627,14 +627,15 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
     outputs_to_save = outputs.expand(full=True) if explicit else '.'
     if not rerun_info and cmd_exitcode:
-        msg_path = relpath(opj(ds.repo.path, ds.repo.get_git_dir(ds.repo),
-                               "COMMIT_EDITMSG"))
-        with open(msg_path, "wb") as ofh:
-            ofh.write(msg)
-        lgr.info("The command had a non-zero exit code. "
-                 "If this is expected, you can save the changes with "
-                 "'datalad save -r -F %s .'",
-                 msg_path)
+        if outputs_to_save:
+            msg_path = relpath(opj(ds.repo.path, ds.repo.get_git_dir(ds.repo),
+                                   "COMMIT_EDITMSG"))
+            with open(msg_path, "wb") as ofh:
+                ofh.write(msg)
+            lgr.info("The command had a non-zero exit code. "
+                     "If this is expected, you can save the changes with "
+                     "'datalad save -r -F %s .'",
+                     msg_path)
         raise exc
     elif outputs_to_save:
         for r in ds.add(outputs_to_save, recursive=True, message=msg):

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -625,6 +625,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         '"{}"'.format(record_id) if use_sidecar else record)
     msg = assure_bytes(msg)
 
+    outputs_to_save = outputs.expand(full=True) if explicit else '.'
     if not rerun_info and cmd_exitcode:
         msg_path = relpath(opj(ds.repo.path, ds.repo.get_git_dir(ds.repo),
                                "COMMIT_EDITMSG"))
@@ -635,8 +636,6 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                  "'datalad save -r -F %s .'",
                  msg_path)
         raise exc
-    else:
-        outputs_to_save = outputs.expand(full=True) if explicit else '.'
-        if outputs_to_save:
-            for r in ds.add(outputs_to_save, recursive=True, message=msg):
-                yield r
+    elif outputs_to_save:
+        for r in ds.add(outputs_to_save, recursive=True, message=msg):
+            yield r

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -414,6 +414,12 @@ def test_run_failure(path):
     with assert_raises(CommandError):
         ds.rerun()
 
+    # We don't show instructions if the caller specified us not to save.
+    remove(msgfile)
+    with assert_raises(CommandError):
+        ds.run("false", explicit=True, outputs=None)
+    assert_false(op.exists(msgfile))
+
 
 @ignore_nose_capturing_stdout
 @known_failure_windows


### PR DESCRIPTION
If a caller specifies explicit=True and outputs=None (as run_procedure
does), the caller is telling us not to commit, so it doesn't make
sense for us to write COMMIT_EDITMSG and display "how to commit"
instructions if the command fails.
