### PR TITLE
ENH: Make core reporting ready for paths as pathlib objects

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -565,7 +565,8 @@ def _process_results(
                 {k: v for k, v in res.items()
                  if k not in ('message', 'logger')},
                 sort_keys=True,
-                indent=2 if result_renderer.endswith('_pp') else None))
+                indent=2 if result_renderer.endswith('_pp') else None,
+                default=lambda x: str(x)))
         elif result_renderer == 'tailored':
             if hasattr(cmd_class, 'custom_result_renderer'):
                 cmd_class.custom_result_renderer(res, **kwargs)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1189,7 +1189,7 @@ def assert_status(label, results):
                 i + 1,
                 len(results),
                 label,
-                dumps(results, indent=1, default=lambda x: str(x)")))
+                dumps(results, indent=1, default=lambda x: str(x))))
 
 
 def assert_message(message, results):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1189,7 +1189,7 @@ def assert_status(label, results):
                 i + 1,
                 len(results),
                 label,
-                dumps(results, indent=1, default=lambda x: "<not serializable>")))
+                dumps(results, indent=1, default=lambda x: str(x)")))
 
 
 def assert_message(message, results):
@@ -1220,7 +1220,7 @@ def assert_result_count(results, n, **kwargs):
                 n,
                 kwargs,
                 len(results),
-                dumps(results, indent=1, default=lambda x: "<not serializable>")))
+                dumps(results, indent=1, default=lambda x: str(x))))
 
 
 def assert_in_results(results, **kwargs):


### PR DESCRIPTION
Their str() is the path in it native representation.

This also adjusts test helpers that previously showed a relatively
uninformative message ("not serializable") where str() might
give some useful indication what is actually contained..