### PR TITLE
ENH: run_command: Support injecting a detached command

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -438,9 +438,10 @@ def _get_script_handler(script, since, revision):
                 msg = ''
 
             expanded_cmd = format_command(
-                cmd, **dict(run_info,
-                            dspath=dset.path,
-                            pwd=op.join(dset.path, run_info["pwd"])))
+                dset, cmd,
+                **dict(run_info,
+                       dspath=dset.path,
+                       pwd=op.join(dset.path, run_info["pwd"])))
 
             ofh.write(
                 "\n" + "".join("# " + ln

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -492,6 +492,7 @@ def format_command(dset, command, **kwds):
 
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 explicit=False, message=None, sidecar=None,
+                extra_info=None,
                 rerun_info=None, rerun_outputs=None):
     """Run `cmd` in `dataset` and record the results.
 
@@ -502,6 +503,11 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
     Parameters
     ----------
+    extra_info : dict, optional
+        Additional information to dump with the json run record. Any value
+        given here will take precedence over the standard run key. Warning:
+        Callers should try to use fairly specific key names to avoid collisions
+        with future keys added by `run`.
     rerun_info : dict, optional
         Record from a previous run. This is used internally by `rerun`.
     rerun_outputs : list, optional
@@ -634,6 +640,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         run_info['pwd'] = rel_pwd
     if ds.id:
         run_info["dsid"] = ds.id
+    if extra_info:
+        run_info.update(extra_info)
 
     record = json.dumps(run_info, indent=1, sort_keys=True, ensure_ascii=False)
 

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -365,7 +365,7 @@ def _install_and_reglob(dset, gpaths):
     Parameters
     ----------
     dset : Dataset
-    gpaths : list of GlobbedPaths objects
+    gpaths : GlobbedPaths object
 
     Returns
     -------

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -490,10 +490,28 @@ def format_command(dset, command, **kwds):
     return sfmt.format(command, **kwds)
 
 
-# This helper function is used to add the rerun_info argument.
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 explicit=False, message=None, sidecar=None,
                 rerun_info=None, rerun_outputs=None):
+    """Run `cmd` in `dataset` and record the results.
+
+    `Run.__call__` is a simple wrapper over this function. Aside from backward
+    compatibility kludges, the only difference is that `Run.__call__` doesn't
+    expose all the parameters of this function. The unexposed parameters are
+    listed below.
+
+    Parameters
+    ----------
+    rerun_info : dict, optional
+        Record from a previous run. This is used internally by `rerun`.
+    rerun_outputs : list, optional
+        Outputs, in addition to those in `outputs`, determined automatically
+        from a previous run. This is used internally by `rerun`.
+
+    Yields
+    ------
+    Result records for the run.
+    """
     rel_pwd = rerun_info.get('pwd') if rerun_info else None
     if rel_pwd and dataset:
         # recording is relative to the dataset

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -526,7 +526,7 @@ def _execute_command(command, pwd, expected_exit=None):
             raise exc
 
     lgr.info("== Command exit (modification check follows) =====")
-    return cmd_exitcode, exc
+    return cmd_exitcode or 0, exc
 
 
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
@@ -634,7 +634,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     # - exit code of the command
     run_info = {
         'cmd': cmd,
-        'exit': cmd_exitcode if cmd_exitcode is not None else 0,
+        'exit': cmd_exitcode,
         'chain': rerun_info["chain"] if rerun_info else [],
         'inputs': inputs.paths,
         'outputs': outputs.paths,

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -545,9 +545,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     ----------
     extra_info : dict, optional
         Additional information to dump with the json run record. Any value
-        given here will take precedence over the standard run key. Warning:
-        Callers should try to use fairly specific key names to avoid collisions
-        with future keys added by `run`.
+        given here will take precedence over the standard run key. Warning: To
+        avoid collisions with future keys added by `run`, callers should try to
+        use fairly specific key names and are encouraged to nest fields under a
+        top-level "namespace" key (e.g., the project or extension name).
     rerun_info : dict, optional
         Record from a previous run. This is used internally by `rerun`.
     rerun_outputs : list, optional

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -591,11 +591,11 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
     inputs = GlobbedPaths(inputs, pwd=pwd,
                           expand=expand in ["inputs", "both"])
-    for res in prepare_inputs(ds, inputs):
-        yield res
-
     outputs = GlobbedPaths(outputs, pwd=pwd,
                            expand=expand in ["outputs", "both"])
+
+    for res in prepare_inputs(ds, inputs):
+        yield res
 
     if outputs:
         for res in _install_and_reglob(ds, outputs):

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -37,6 +37,7 @@ from datalad.tests.utils import ok_, assert_false, neq_
 from datalad.api import install
 from datalad.api import run
 from datalad.interface.run import GlobbedPaths
+from datalad.interface.run import run_command
 from datalad.interface.rerun import get_run_info
 from datalad.interface.rerun import diff_revision, new_or_modified
 from datalad.tests.utils import assert_raises
@@ -952,6 +953,21 @@ def test_inputs_quotes_needed(path):
     cmd_list = [sys.executable, "-c", cmd, "{inputs}", "{outputs[0]}"]
     ds.run(cmd_list, inputs=["*.txt"], outputs=["out0"])
     ok_file_has_content(opj(path, "out0"), "bar.txt foo!blah.txt!out0")
+
+
+@ignore_nose_capturing_stdout
+@known_failure_windows
+@with_tree(tree={"foo": "f", "bar": "b"})
+def test_inject(path):
+    ds = Dataset(path).create(force=True)
+    ok_(ds.repo.is_dirty())
+    list(run_command("nonsense command",
+                     dataset=ds,
+                     inject=True,
+                     extra_info={"custom_key": "custom_field"}))
+    msg = ds.repo.format_commit("%B")
+    assert_in("custom_key", msg)
+    assert_in("nonsense command", msg)
 
 
 def test_globbedpaths_get_sub_patterns():

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -921,6 +921,10 @@ def test_placeholders(path):
     ds.config.add("datalad.run.substitutions.license", "gpl3", where="local")
     ds.run("echo {license} >configured-license")
     ok_file_has_content(opj(path, "configured-license"), "gpl3", strip=True)
+    # --script handles configured placeholders.
+    with patch("sys.stdout", new_callable=StringIO) as cmout:
+        ds.rerun(script="-")
+        assert_in("gpl3", cmout.getvalue())
 
 
 @ignore_nose_capturing_stdout


### PR DESCRIPTION
Main changes:

-   New function `prepare_inputs` to help datalad-htcondor to avoid some duplicated code.

-   `format_command` now handles custom substitutions. This fixes `rerun --script` for commands that include substitutions and helps (a little bit) with code duplication in datalad-htcondor.

-   `run_command` accepts a new argument `extra_info` that allows arbitrary information to be added to the run record.

-   `run_command` accepts a new argument `inject` that means "take the current working tree state as the result of the command" (i.e., don't prepare inputs or outputs before the command and don't execute the command) (gh-2934).

---

@mih, will `inject=True` work for you wrt datalad-htcondor?