### PR TITLE
CLN: providers: Remove unused resolve_url_to_name()

### DIFF
--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -59,18 +59,6 @@ AUTHENTICATION_TYPES = {
 
 from .credentials import CREDENTIAL_TYPES
 
-def resolve_url_to_name(d, url):
-    """Given a directory (e.g. of SiteInformation._items or Credential._items)
-    go through url_re and find the corresponding item and returns its key (i.e. name)
-    """
-
-    for k, rec in iteritems(d):
-        for url_re in rec.get('url_re', '').split('\n'):
-            if url_re:
-                if re.search(url_re, url):
-                    return k
-    return None
-
 
 @auto_repr
 class Provider(object):


### PR DESCRIPTION
The last call to it was dropped in 3514063c7 (RF: more of configs for
providers/credentials, reading and some cruel testing, 2015-11-18).