### PR TITLE
ENH(TST): test that we can install/get from datasets.datalad.org (or its -tests brother)

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -921,7 +921,14 @@ def check_datasets_datalad_org(suffix, tdir):
     # smart HTTP backend for apache2 etc
     ds = install(tdir, source='///dicoms/dartmouth-phantoms/bids_test6-PD+T2w' + suffix)
     eq_(ds.config.get('remote.origin.annex-ignore', None), None)
-    assert_status('ok', ds.get(op.join('001-anat-scout_ses-{date}', '000001.dcm')))
+    # assert_result_count and not just assert_status since for some reason on
+    # Windows we get two records due to a duplicate attempt (as res[1]) to get it
+    # again, which is reported as "notneeded".  For the purpose of this test
+    # it doesn't make a difference.
+    assert_result_count(
+        ds.get(op.join('001-anat-scout_ses-{date}', '000001.dcm')),
+        1,
+        status='ok')
     assert_status('ok', ds.remove())
 
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -907,3 +907,16 @@ def test_install_subds_from_another_remote(topdir):
         clone1.update(merge=True, sibling=clone2_)
         # print("Installing within updated dataset -- should be able to install from clone2")
         clone1.install('subds1')
+
+# Takes > 2 sec
+# Do not use cassette
+@skip_if_no_network
+@with_tempfile
+def test_datasets_datalad_org(tdir):
+    # Test that git annex / datalad install, get work correctly on our datasets.datalad.org
+    # Apparently things can break, especially with introduction of the
+    # smart HTTP backend for apache2 etc
+    ds = install(tdir, source='///dicoms/dartmouth-phantoms/bids_test6-PD+T2w')
+    eq_(ds.config.get('remote.origin.annex-ignore', None), None)
+    out = ds.get('001-anat-scout_ses-{date}/000001.dcm')
+    eq_(out[0]['status'], 'ok')

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -33,6 +33,7 @@ from datalad.api import get
 from datalad import consts
 from datalad.utils import chpwd
 from datalad.utils import on_windows
+from datalad.support import path as op
 from datalad.interface.results import YieldDatasets
 from datalad.interface.results import YieldRelativePaths
 from datalad.support.exceptions import InsufficientArgumentsError
@@ -920,7 +921,7 @@ def check_datasets_datalad_org(suffix, tdir):
     # smart HTTP backend for apache2 etc
     ds = install(tdir, source='///dicoms/dartmouth-phantoms/bids_test6-PD+T2w' + suffix)
     eq_(ds.config.get('remote.origin.annex-ignore', None), None)
-    assert_status('ok', ds.get('001-anat-scout_ses-{date}/000001.dcm'))
+    assert_status('ok', ds.get(op.join('001-anat-scout_ses-{date}', '000001.dcm')))
     assert_status('ok', ds.remove())
 
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -28,6 +28,7 @@ from datalad.utils import getpwd
 
 from datalad.api import create
 from datalad.api import install
+from datalad.api import remove
 from datalad.api import get
 from datalad import consts
 from datalad.utils import chpwd
@@ -908,15 +909,21 @@ def test_install_subds_from_another_remote(topdir):
         # print("Installing within updated dataset -- should be able to install from clone2")
         clone1.install('subds1')
 
+
 # Takes > 2 sec
 # Do not use cassette
 @skip_if_no_network
 @with_tempfile
-def test_datasets_datalad_org(tdir):
+def check_datasets_datalad_org(suffix, tdir):
     # Test that git annex / datalad install, get work correctly on our datasets.datalad.org
     # Apparently things can break, especially with introduction of the
     # smart HTTP backend for apache2 etc
-    ds = install(tdir, source='///dicoms/dartmouth-phantoms/bids_test6-PD+T2w')
+    ds = install(tdir, source='///dicoms/dartmouth-phantoms/bids_test6-PD+T2w' + suffix)
     eq_(ds.config.get('remote.origin.annex-ignore', None), None)
-    out = ds.get('001-anat-scout_ses-{date}/000001.dcm')
-    eq_(out[0]['status'], 'ok')
+    assert_status('ok', ds.get('001-anat-scout_ses-{date}/000001.dcm'))
+    assert_status('ok', ds.remove())
+
+
+def test_datasets_datalad_org():
+    yield check_datasets_datalad_org, ''
+    yield check_datasets_datalad_org, '/.git'


### PR DESCRIPTION
I am not sure how it went unnoticed for weeks
- detected initially while running heudiconv tests which were skipped due to inability to get the data
This test should guarantee that our datasets.datalad.org performs at least somewhat correctly