### PR TITLE
Minor improvements on run/run-procedure

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -501,6 +501,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                           expand=expand in ["inputs", "both"])
 
     if inputs:
+        lgr.info('Making sure inputs are available (this may take some time)')
         for res in _install_and_reglob(ds, inputs):
             yield res
         for res in ds.get(inputs.expand(full=True), on_failure="ignore"):

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -453,5 +453,6 @@ class RunProcedure(Interface):
                 outputs=None,
                 # pass through here
                 on_failure='ignore',
+                return_type='generator'
         ):
             yield r


### PR DESCRIPTION
This pull request fixes two minor issues.
1. `run` might be surprisingly silent for quite some time when `get` figures what inputs it needs to get. When I was using it on a dataset with a lot of DICOMS, I noticed it looks as if it was hanging until the actual downloads started. This time was even needed if the DICOMS were actually present, suggesting that it's probably annex just checking what it needs to get, only to conclude: nothing. So, I added a message on info level here

2. `run-procedure` didn't call `run` explicitly with `return_type='generator'`. This resulted in yielding and rendering the results from `run` only after everything was done. So the `get` for inputs is done before the execution of the procedure, but it's silent and yields the result only after the output of the procedure. Changed that to yield in a timely fashion.

### Changes
- let `run` be slightly more talkative
- `run-procedure` yields results and output in time and in order
- [x] This change is complete

Please have a look @datalad/developers
