### PR TITLE
RF: Do not consider a symlink to the root of a dataset as the root of a dataset

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1546,10 +1546,17 @@ def get_dataset_root(path):
     The root path is returned in the same absolute or relative form
     as the input argument. If no associated dataset exists, or the
     input path doesn't exist, None is returned.
+
+    If `path` is a symlink or something other than a directory, the root dataset
+    containing its parent directory will be reported.  If none can be found, and
+    a symlink at `path` is pointing to a dataset, `path` itself will be
+    reported as the root.
     """
     suffix = '.git'
-    if not isdir(path):
-        path = dirname(path)
+    altered = None
+    if op.islink(path) or not op.isdir(path):
+        altered = path
+        path = op.dirname(path)
     apath = abspath(path)
     # while we can still go up
     while psplit(apath)[1]:
@@ -1559,6 +1566,12 @@ def get_dataset_root(path):
         path = normpath(opj(path, os.pardir))
         # no luck, next round
         apath = abspath(path)
+    # if we applied dirname() at the top, we give it another go with
+    # the actual path, if it was itself a symlink, it could be the
+    # top-level dataset itself
+    if altered and op.exists(op.join(altered, suffix)):
+        return altered
+
     return None
 
 


### PR DESCRIPTION
I don't feel strongly about merging this PR, but in my exploration of symlink behavior I found this one problematic in -core. It is worked around in some places, and this PR merely want to see what would break.

Specifically one would see a change in behavior when looking to `add` a symlink that is pointing to the root of a subdirectory. With this change the parent of the symlink is the root, without this change it would be the root of the dataset that the symlink is pointing too. In the latter case (the present behavior) such a symlink is essentially transparent to datalad -- which is suboptimal IMHO.