### PR TITLE
ENH: add annex key to the extracted datalad-core metadata record

### DIFF
--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -126,7 +126,7 @@ class MetadataExtractor(BaseMetadataExtractor):
             # just first one.  `add_key` was added to avoid separate call to
             # get_file_key which would need to be ran separately
             if whereis:
-                meta['annex-key'] = list(whereis.values())[0]['key']
+                meta['annex_key'] = list(whereis.values())[0]['key']
             yield (file, meta)
         log_progress(
             lgr.info,

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -102,7 +102,9 @@ class MetadataExtractor(BaseMetadataExtractor):
         # Availability information
         for file, whereis in self.ds.repo.whereis(
                 self.paths if self.paths and valid_paths is None else '.',
-                output='full').items():
+                output='full',
+                add_key=True
+            ).items():
             if file.startswith('.datalad') or valid_paths and file not in valid_paths:
                 # do not report on our own internal annexed files (e.g. metadata blobs)
                 continue
@@ -119,6 +121,12 @@ class MetadataExtractor(BaseMetadataExtractor):
                     # "web" remote
                     if remote == "00000000-0000-0000-0000-000000000001" and
                     whereis[remote].get('urls', None)}
+            # Also record its key.  Since we used `add_key` above, key
+            # should be present in a record for each remote, so we will take
+            # just first one.  `add_key` was added to avoid separate call to
+            # get_file_key which would need to be ran separately
+            if whereis:
+                meta['annex-key'] = list(whereis.values())[0]['key']
             yield (file, meta)
         log_progress(
             lgr.info,

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -57,10 +57,10 @@ def check_api(no_annex, path):
             if not no_annex:
                 # verify correct key, which is the same for all files of 0 size
                 assert_equal(
-                    cm['file.dat']['annex-key'],
+                    cm['file.dat']['annex_key'],
                     'MD5E-s0--d41d8cd98f00b204e9800998ecf8427e.dat')
             else:
-                assert 'annex-key' not in cm['file.dat']
+                assert 'annex_key' not in cm['file.dat']
         processed_extractors.append(extractor_ep.name)
     assert "datalad_core" in processed_extractors, \
         "Should have managed to find at least the core extractor extractor"

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -54,6 +54,13 @@ def check_api(no_annex, path):
         # precious file
         if extractor_ep.name == 'datalad_core':
             assert 'file.dat' in cm
+            if not no_annex:
+                # verify correct key, which is the same for all files of 0 size
+                assert_equal(
+                    cm['file.dat']['annex-key'],
+                    'MD5E-s0--d41d8cd98f00b204e9800998ecf8427e.dat')
+            else:
+                assert 'annex-key' not in cm['file.dat']
         processed_extractors.append(extractor_ep.name)
     assert "datalad_core" in processed_extractors, \
         "Should have managed to find at least the core extractor extractor"

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -241,6 +241,7 @@ audio.music-channels
 audio.music-sample_rate
 audio.name
 audio.tracknumber
+datalad_core.annex_key
 datalad_core.id
 datalad_core.refcommit
 id


### PR DESCRIPTION
This is to possibly facilitate additional search functionality such as requested in
  https://neurostars.org/t/return-hash-and-url-for-every-nifti-file-in-datalad-super-dataset/2733
in case if a known checksum matches the backend used by git annex

I bet it is done better in the rev- version of the universe.  Here I chose to provide an ugly hack to avoid secondary call to lookup key for a file.

Should break some tests, possibly in datalad-neuroimaging since output record is extended now.

- [x] may be it should be just a `key` or `annex_key` since I think `-` is not used in the metadata fields