### PR TITLE
ENH: add annex key to the extracted "annex" metadata record

### DIFF
--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -54,6 +54,16 @@ def check_api(no_annex, path):
         # precious file
         if extractor_ep.name == 'datalad_core':
             assert 'file.dat' in cm
+        elif extractor_ep.name == 'annex':
+            if not no_annex:
+                # verify correct key, which is the same for all files of 0 size
+                assert_equal(
+                    cm['file.dat']['key'],
+                    'MD5E-s0--d41d8cd98f00b204e9800998ecf8427e.dat'
+                )
+            else:
+                # no metadata on that file
+                assert not cm
         processed_extractors.append(extractor_ep.name)
     assert "datalad_core" in processed_extractors, \
         "Should have managed to find at least the core extractor extractor"

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -137,8 +137,9 @@ def test_aggregation(path):
     # store clean direct result
     origres = ds.metadata(recursive=True)
     # basic sanity check
-    assert_result_count(origres, 3)
+    assert_result_count(origres, 6)
     assert_result_count(origres, 3, type='dataset')
+    assert_result_count(origres, 3, type='file')  # Now that we have annex.key
     # three different IDs
     assert_equal(3, len(set([s['dsid'] for s in origres if s['type'] == 'dataset'])))
     # and we know about all three datasets
@@ -158,8 +159,9 @@ def test_aggregation(path):
     # get fresh metadata
     cloneres = clone.metadata()
     # basic sanity check
-    assert_result_count(cloneres, 1)
+    assert_result_count(cloneres, 2)
     assert_result_count(cloneres, 1, type='dataset')
+    assert_result_count(cloneres, 1, type='file')
 
     # now loop over the previous results from the direct metadata query of
     # origin and make sure we get the extact same stuff from the clone

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -231,6 +231,7 @@ type
 
     target_out = """\
 annex.importance
+annex.key
 audio.bitrate
 audio.duration(s)
 audio.format

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1599,13 +1599,19 @@ class AnnexRepo(GitRepo, RepoInterface):
                                        **kwargs)
 
     @normalize_paths
-    def get_file_key(self, files):
+    def get_file_key(self, files, batch=None):
         """Get key of an annexed file.
 
         Parameters
         ----------
         files: str or list
             file(s) to look up
+        batch: None or bool, optional
+            If True, `lookupkey --batch` process will be used, which would
+            not crash even if provided file is not under annex (but directly
+            under git), but rather just return an empty string. If False,
+            invokes without --batch. If None, use batch mode if more than a
+            single file is provided.
 
         Returns
         -------
@@ -1613,9 +1619,16 @@ class AnnexRepo(GitRepo, RepoInterface):
             keys used by git-annex for each of the files;
             in case of a list an empty string is returned if there was no key
             for that file
+
+        Raises
+        ------
+        FileInGitError
+             If running in non-batch mode and a file is under git, not annex
+        FileNotInAnnexError
+             If running in non-batch mode and a file is not under git at all
         """
 
-        if len(files) > 1:
+        if batch or (batch is None and len(files) > 1):
             return self._batched.get('lookupkey', path=self.path)(files)
         else:
             files = files[0]

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -246,15 +246,16 @@ def test_AnnexRepo_get_file_key(src, annex_path):
     ar = AnnexRepo.clone(src, annex_path)
 
     # test-annex.dat should return the correct key:
-    eq_(
-        ar.get_file_key("test-annex.dat"),
-        'SHA256E-s28--2795fb26981c5a687b9bf44930cc220029223f472cea0f0b17274f4473181e7b.dat')
+    test_annex_key = \
+        'SHA256E-s28' \
+        '--2795fb26981c5a687b9bf44930cc220029223f472cea0f0b17274f4473181e7b.dat'
+    eq_(ar.get_file_key("test-annex.dat"), test_annex_key)
 
     # and should take a list with an empty string as result, if a file wasn't
     # in annex:
     eq_(
         ar.get_file_key(["filenotpresent.wtf", "test-annex.dat"]),
-        ['', 'SHA256E-s28--2795fb26981c5a687b9bf44930cc220029223f472cea0f0b17274f4473181e7b.dat']
+        ['', test_annex_key]
     )
 
     # test.dat is actually in git
@@ -265,6 +266,12 @@ def test_AnnexRepo_get_file_key(src, annex_path):
 
     # filenotpresent.wtf doesn't even exist
     assert_raises(IOError, ar.get_file_key, "filenotpresent.wtf")
+
+    # if we force batch mode, no failure for not present or not annexed files
+    eq_(ar.get_file_key("filenotpresent.wtf", batch=True), '')
+    eq_(ar.get_file_key("test.dat", batch=True), '')
+    eq_(ar.get_file_key("test-annex.dat", batch=True), test_annex_key)
+
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
- Replaces #2950 with more native placement of key record
- adjusts `AnnexRepo.get_file_key` with explicit `batch=None` option to trigger batch mode of operation

cons: with this change (and as test fixups show) now all annexed files will get some metadata record within "annex" section.  Time will show if any notable impact on size/performance