### PR TITLE
RF(BF): credential defined in environment vars takes precedence

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -125,6 +125,8 @@ class ExternalVersions(object):
         'gitdb',
         'humanize',
         'iso8601',
+        'keyring',
+        'keyrings.alt',
         'msgpack',
         'mutagen',
         'patool',

--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -44,11 +44,11 @@ class Keyring(object):
 
     # proxy few methods of interest explicitly, to be rebound to the module's
     def get(self, name, field):
-        # consult environment, might be provided there
-        val = self._keyring.get_password(self._get_service_name(name), field)
-        if val is None:
-            val = os.environ.get(('DATALAD_%s_%s' % (name, field)).replace('-', '_'), None)
-        return val
+        # consult environment, might be provided there and should take precedence
+        env_var = ('DATALAD_%s_%s' % (name, field)).replace('-', '_')
+        if env_var in os.environ:
+            return os.environ[env_var]
+        return self._keyring.get_password(self._get_service_name(name), field)
 
     def set(self, name, field, value):
         return self._keyring.set_password(self._get_service_name(name), field, value)


### PR DESCRIPTION
This pull request fixes #2959

This is potentially to overcome a not yet reproduced
https://github.com/datalad/datalad/issues/2959
which came to life with 16.0.0 version of keyring.
And this change otherwise makes sense since we typically treat env vars
as overriding what is stored in configuration
