### PR TITLE
NF: git-show frontend to replace a bunch of other helpers ￼…

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1670,7 +1670,7 @@ class GitRepo(RepoInterface):
             ]
         return remotes
 
-    def get_files(self, branch=None, tree=None):
+    def get_files(self, branch=None):
         """Get a list of files in git.
 
         Lists the files in the (remote) branch.
@@ -1685,18 +1685,18 @@ class GitRepo(RepoInterface):
         [str]
           list of files.
         """
-        branch = 'HEAD' if branch is None else branch
-        tree = '' if tree is None else tree
-        files = []
-        for f in self.get_object('{}:{}'.format(
-                branch, tree)):
-            if f.endswith('/'):
-                files.extend(
-                    (tree + s) if tree else s for s in self.get_files(
-                        branch, '{}{}'.format(tree, f)))
-            else:
-                files.append(f)
-        return files
+        # XXX this is `git ls-tree` and implemented in
+        # -revolution as get_content_info()
+
+        # TODO: RF codes base and melt get_indexed_files() in
+
+        if branch is None:
+            # active branch can be queried way faster:
+            return self.get_indexed_files()
+        else:
+            return [item.path for item in self.repo.tree(branch).traverse()
+                    if isinstance(item, Blob)]
+
 
     def get_file_content(self, file_, branch='HEAD'):
         """

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1701,17 +1701,7 @@ class GitRepo(RepoInterface):
         [str]
           content of file_ as a list of lines.
         """
-        content_str = self.repo.commit(branch).tree[file_].data_stream.read()
-
-        # in python3 a byte string is returned. Need to convert it:
-        from six import PY3
-        if PY3:
-            conv_str = u''
-            for b in bytes(content_str):
-                conv_str += chr(b)
-            return conv_str.splitlines()
-        else:
-            return content_str.splitlines()
+        return self.get_object('{}:{}'.format(branch, file_)).splitlines()
         # TODO: keep splitlines?
 
     def _get_files_history(self, files, branch='HEAD'):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1580,15 +1580,12 @@ class GitRepo(RepoInterface):
           None if no commit
         """
         try:
-            if branch:
-                commit = next(self.get_branch_commits(branch))
-            else:
-                commit = self.repo.head.commit
+            obj = self.get_object(branch if branch else 'HEAD')
         except Exception as exc:
             lgr.debug("Got exception while trying to get last commit: %s",
                       exc_str(exc))
             return None
-        return getattr(commit, "%s_date" % date)
+        return int(obj['author' if date == 'authored' else 'committed']['date'])
 
     def get_active_branch(self):
         try:


### PR DESCRIPTION
...that are GitPython-based, like:

- `get_commit_date()`
- `get_files()`
- `get_file_content()`

There are no tests yet. Please comment on whether you would like to see such RF being done in core. If that is the case, I'll do the tests with the tooling in -core.

Demos:

```
# commit
% python -c 'from pprint import pprint; from datalad.support.gitrepo import GitRepo; r=GitRepo("."); pprint(r.get_object("HEAD")); '
{u'author': {'date': u'1541053938',
             'name': u'Michael Hanke <michael.hanke@gmail.com>',
             'timezone': u'+0100'},
 u'commit': u'ad8e2bb8154e1f5faf3b12809f93332969a35e64',
 u'committer': {'date': u'1541053938',
                'name': u'Michael Hanke <michael.hanke@gmail.com>',
                'timezone': u'+0100'},
 'diff': [{'mode': 33188,
           'mode_src': 33188,
           'path': u'datalad_revolution/version.py',
           'revision': u'abeeedbf5b31f38290f2d3efa67b715259d4a4f6',
           'revision_src': u'0404d81037f66e8dfa8fa4e18458619876f083bc',
           'state': 'modified',
           'type': 'file',
           'type_src': 'file'}],
 'message': u'Release\n',
 u'parent': u'44370c8b5611fb6cf698e1aed0e839eb283d56f2',
 u'tree': u'70d678c757ba51f98bb963c5e514d6d3c7b5bf18'}

# tag
% python -c 'from pprint import pprint; from datalad.support.gitrepo import GitRepo; r=GitRepo("."); pprint(r.get_object("0.3.0")); '                  
{u'author': {'date': u'1540879302',
             'name': u'Michael Hanke <michael.hanke@gmail.com>',
             'timezone': u'+0100'},
 u'commit': u'140982cf97379a46d35fc2aa28db73fb392dcbb4',
 u'committer': {'date': u'1540879302',
                'name': u'Michael Hanke <michael.hanke@gmail.com>',
                'timezone': u'+0100'},
 'diff': [{'mode': 33188,
           'mode_src': 33188,
           'path': u'datalad_revolution/version.py',
           'revision': u'0404d81037f66e8dfa8fa4e18458619876f083bc',
           'revision_src': u'd93b5b24297cfd540ea837e02e1b6c4dedf0819d',
           'state': 'modified',
           'type': 'file',
           'type_src': 'file'}],
 'message': u'Version bump\n',
 u'parent': u'cf7ae482261d2e3c7ee110d721996f47c1df7793',
 u'tag': {'message': u'\nTagger: Michael Hanke <michael.hanke@gmail.com>\n\nRelease 0.3.0\n-----BEGIN PGP SIGNATURE-----\n\niQIzBAABCAAdFiEEVwHx0NGLh+Yaox89wHPSKH/7npsFAlvX8+sACgkQwHPSKH/7\nnpuImg//Y1OEmIISfcllxkssuYrwer/7cOQ4XJzewPkbU8Duf4GcoUb+P7zkHtiQ\npxJ1+9yuJSgQKTUOm9muW2xWeBFT0XkU1L/5ZayQKkdyk3ejuyjZGbkCR5GKGjuA\nXLURAl3QCLr3X0ojAVJuWLyCaJO3snw5Gj0EMOpbAYlFf3k4mf53UdS7eU0dRN4Z\nI+GVA1ZpopvffxifqlP46/0G0GGr6/ghKv2Yd+kh2rAwArUNK4/VOsZQM9NCIGAt\nh66UM5bQjjO/gmAYC7D0VvNb+jxPyaVqFHEgv7Ho7E9yvLngAlAIB1WK00aCtLCH\nKA8aepFsxYpNtWUo/wgcJ7lxKfnT52ekSAxEJqDV9mUvLftYOZwOiaFUFW4OfeLJ\njFU1++dPLHTe4XxNaP6lZnGD7PtmKyH13IK2irhU/KX+xvYAMVhn82+bE366pCsC\nqSq6yrwIHt5Ymlxt9TdF8G9O6zFu/E2pccX0RlQk2cjQJpQEF20bp1/9XlJeg/ib\n6YrDR80NhVEKGHbxo0z7W7x81ovZlm2fRAAJsjGMgdao1JOxYUXl6J7nsxOUwTDP\nm6gTpJKCUXtx5edHDvZhZm5EfmmyaIcnHbSXlV/N2UuJQmnWjWBX6kY6aB8V+6QK\ng0qgyUzyrNhumzIopaBT4QMoHROZ+ws/sef6dPlw5aHL1w/SbcE=\n=tM+l\n-----END PGP SIGNATURE-----',
          'name': u'0.3.0'},
 u'tree': u'c74286c382d63e7f7fc739fece2b3e32736b7c0c'}

# tree
% python -c 'from pprint import pprint; from datalad.support.gitrepo import GitRepo; r=GitRepo("."); pprint(r.get_object("master:")); '
[u'.gitignore',
 u'.travis.yml',
 u'CONTRIBUTORS',
 u'COPYING',
 u'Makefile',
 u'README.md',
 u'appveyor.yml',
 u'datalad_revolution/',
 u'requirements.txt',
 u'setup.py']

# blob
% python -c 'from pprint import pprint; from datalad.support.gitrepo import GitRepo; r=GitRepo("."); pprint(r.get_object("master:requirements.txt")); '
u'# If you want to develop, use requirements-devel.txt\ngit+https://github.com/datalad/datalad.git\ncoverage\n'
```
