### PR TITLE
BF(TST): realpath path before figuring out which repo it belongs to

### DIFF
--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -34,15 +34,17 @@ from nose import SkipTest
 from ..utils import getpwd, chpwd
 
 from . import utils
-from .utils import eq_, ok_, assert_false, ok_startswith, nok_startswith, \
-    with_tempfile, with_testrepos, with_tree, \
-    rmtemp, \
-    OBSCURE_PREFIX, OBSCURE_FILENAMES,\
-    get_most_obscure_supported_name, \
-    swallow_outputs, swallow_logs, \
-    on_windows, assert_raises, assert_cwd_unchanged, serve_path_via_http, \
-    ok_symlink, assert_true, ok_good_symlink, ok_broken_symlink
-
+from .utils import (
+    eq_, ok_, assert_false, ok_startswith, nok_startswith,
+    with_tempfile, with_testrepos, with_tree,
+    rmtemp,
+    OBSCURE_PREFIX, OBSCURE_FILENAMES,
+    get_most_obscure_supported_name,
+    swallow_outputs, swallow_logs,
+    on_windows, assert_raises, assert_cwd_unchanged, serve_path_via_http,
+    ok_symlink, assert_true, ok_good_symlink, ok_broken_symlink,
+    ok_file_under_git
+)
 from .utils import ok_generator
 from .utils import assert_dict_equal
 from .utils import assert_str_equal
@@ -50,6 +52,7 @@ from .utils import assert_re_in
 from .utils import local_testrepo_flavors
 from .utils import skip_if_no_network
 from .utils import skip_if_no_module
+from .utils import skip_if_on_windows
 from .utils import run_under_dir
 from .utils import skip_if
 from .utils import ok_file_has_content
@@ -60,6 +63,8 @@ from .utils import probe_known_failure
 from .utils import patch_config
 from .utils import ignore_nose_capturing_stdout
 
+from ..support.gitrepo import GitRepo
+from ..support import path as op
 #
 # Test with_tempfile, especially nested invocations
 #
@@ -634,3 +639,23 @@ def test_ignore_nose_capturing_stdout():
                              'StringIO and fileno')
     with assert_raises(SkipTest):
         ignore_nose_capturing_stdout(raise_exc)()
+
+
+@skip_if_on_windows  # no symlinks. may be skip if not hasattr(os, "symlink")
+@with_tree(tree={'ingit': '', 'staged': 'staged', 'notingit': ''})
+def test_ok_file_under_git_symlinks(path):
+    # Test that works correctly under symlinked path
+    orepo = GitRepo(path)
+    orepo.add('ingit')
+    orepo.commit('msg')
+    orepo.add('staged')
+    lpath = path + "-symlink"  # will also be removed AFAIK by our tempfile handling
+    os.symlink(path, lpath)
+    ok_symlink(lpath)
+    ok_file_under_git(op.join(path, 'ingit'))
+    ok_file_under_git(op.join(lpath, 'ingit'))
+    ok_file_under_git(op.join(lpath, 'staged'))
+    with assert_raises(AssertionError):
+        ok_file_under_git(op.join(lpath, 'notingit'))
+    with assert_raises(AssertionError):
+        ok_file_under_git(op.join(lpath, 'nonexisting'))

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -280,7 +280,7 @@ def _prep_file_under_git(path, filename):
 
     # path to the file within the repository
     # repo.path is a "realpath" so to get relpath working correctly
-    # we need to relpath our path as well
+    # we need to realpath our path as well
     path = op.realpath(path)  # intentional realpath to match GitRepo behavior
     file_repo_dir = op.relpath(path, repo.path)
     file_repo_path = filename if file_repo_dir == curdir else opj(file_repo_dir, filename)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -279,7 +279,10 @@ def _prep_file_under_git(path, filename):
             raise
 
     # path to the file within the repository
-    file_repo_dir = os.path.relpath(path, repo.path)
+    # repo.path is a "realpath" so to get relpath working correctly
+    # we need to relpath our path as well
+    path = op.realpath(path)  # intentional realpath to match GitRepo behavior
+    file_repo_dir = op.relpath(path, repo.path)
     file_repo_path = filename if file_repo_dir == curdir else opj(file_repo_dir, filename)
     return annex, file_repo_path, filename, path, repo
 


### PR DESCRIPTION
Surprisingly, I ran into it only within https://github.com/datalad/datalad/pull/2898
despite all our testing with symlinked `TMPDIR`s on travis.  This time I have added
a dedicated unittest to trigger that failure.

The rationale for using realpath there is because GitRepo already realpath"ing
the path to be able to return the singleton Repo for the same path

This pull request fixes #2961 