### PR TITLE
BF: correct location for ")" + RF: use os.sysconf('SC_ARG_MAX')

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2388,8 +2388,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                      - sum((len(x) + 3) for x in annex_options)
                      - 4   # for '--' below
                      - 50  # for safety since we are to add more options
-                    // (maxl + 3)  # +3 for possible quotes and a space
-                    )
+                     ) // (maxl + 3)  # +3 for possible quotes and a space
                 )
                 file_chunks = generate_chunks(files, chunk_size)
             out, err = "", ""

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -88,12 +88,13 @@ CMD_MAX_ARG_HARDCODED = 2097152 if on_linux else 262144 if on_osx else 32767
 try:
     CMD_MAX_ARG = os.sysconf('SC_ARG_MAX') or CMD_MAX_ARG_HARDCODED
 except Exception as exc:
-    # yoh: do not know when it might/will fail but I would prefer to play
-    # safe while querying `sysconf`
+    # ATM (20181005) SC_ARG_MAX available only on POSIX systems
+    # so exception would be thrown e.g. on Windows.
+    CMD_MAX_ARG = CMD_MAX_ARG_HARDCODED
     lgr.debug(
         "Failed to query SC_ARG_MAX sysconf, will use hardcoded value: %s",
         exc)
-    CMD_MAX_ARG = CMD_MAX_ARG_HARDCODED
+lgr.debug("Maximal length of cmdline string: %d", CMD_MAX_ARG)
 
 #
 # Little helpers

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -81,10 +81,19 @@ except:  # pragma: no cover
     linux_distribution_name = linux_distribution_release = None
 
 # Maximal length of cmdline string
-# Did not find anything in Python which could tell at run time and
+# Query the system and use hardcoded "knowledge" if None
 # probably   getconf ARG_MAX   might not be available
 # The last one would be the most conservative/Windows
-CMD_MAX_ARG = 2097152 if on_linux else 262144 if on_osx else 32767
+CMD_MAX_ARG_HARDCODED = 2097152 if on_linux else 262144 if on_osx else 32767
+try:
+    CMD_MAX_ARG = os.sysconf('SC_ARG_MAX') or CMD_MAX_ARG_HARDCODED
+except Exception as exc:
+    # yoh: do not know when it might/will fail but I would prefer to play
+    # safe while querying `sysconf`
+    lgr.debug(
+        "Failed to query SC_ARG_MAX sysconf, will use hardcoded value: %s",
+        exc)
+    CMD_MAX_ARG = CMD_MAX_ARG_HARDCODED
 
 #
 # Little helpers


### PR DESCRIPTION
Originally discovered by reviewing current code while at 
https://github.com/datalad/datalad/issues/1883#issuecomment-435932579
