### PR TITLE
TST: appveyor: Explicitly specify direct mode for run

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda35
       DATALAD_TESTS_SSH: 1
+      DATALAD_REPO_DIRECT: yes
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"


### PR DESCRIPTION
As of git-annex 7.20181031, git-annex defaults to v7 on crippled file
systems.  Force direct mode in the first run by setting
DATALAD_REPO_DIRECT.

Re: #2976