### PR TITLE
BF: rstrip before checking if trailing period is needed

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -558,8 +558,8 @@ class Interface(object):
             if defaults_idx >= 0:
                 parser_kwargs['default'] = defaults[defaults_idx]
             help = alter_interface_docs_for_cmdline(param._doc)
-            if help and help[-1] != '.':
-                help += '.'
+            if help and help.rstrip()[-1] != '.':
+                help = help.rstrip() + '.'
             if param.constraints is not None:
                 parser_kwargs['type'] = param.constraints
                 # include value constraint description and default

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -1091,8 +1091,7 @@ class Search(Interface):
             args=("--mode",),
             choices=('egrep', 'textblob', 'autofield'),
             doc="""Mode of search index structure and content. See section
-            SEARCH MODES for details.
-            """),
+            SEARCH MODES for details."""),
         full_record=Parameter(
             args=("--full-record", '-f'),
             action='store_true',


### PR DESCRIPTION
Spotted odd docstring
```
  --mode {egrep,textblob,autofield}
                        Mode of search index structure and content. See
                        section SEARCH MODES for details. . [Default: None]
```
