### PR TITLE
CLN+TST: run_procedure: Remove stale to-dos

### DIFF
--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -58,9 +58,6 @@ add(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 @with_tempfile
 def test_basics(path, super_path):
     ds = Dataset(path).create(force=True)
-    # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
-    # input yet, so manual for now
-    ds.add('code', to_git=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder
@@ -126,9 +123,6 @@ def test_procedure_discovery(path, super_path):
 
     # set up dataset with registered procedure (c&p from test_basics):
     ds = Dataset(path).create(force=True)
-    # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
-    # input yet, so manual for now
-    ds.add('code', to_git=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder
@@ -215,9 +209,6 @@ def test_configs(path):
 
     # set up dataset with registered procedure (c&p from test_basics):
     ds = Dataset(path).create(force=True)
-    # TODO: this procedure would leave a clean dataset, but `run` cannot handle dirty
-    # input yet, so manual for now
-    ds.add('code', to_git=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder


### PR DESCRIPTION
This was taken care of with e1a58b001 (NF: run: Add --explicit flag,
2018-06-04) and 1e10a1874 (ENH: `run-procedure` does not require clean
datasets anymore, 2018-06-15).

---

Re: https://github.com/datalad/datalad/pull/2905#discussion_r224868031

