### PR TITLE
ENH: added initial .zenodo.json, and its mentioning in PR template and CONTRIBUTING

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,6 @@ This pull request proposes
 
 ### Changes
 - [ ] This change is complete
+- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
 
 Please have a look @datalad/developers

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,93 @@
+{
+  "creators": [
+    {
+      "affiliation": "Dartmouth College",
+      "name": "Visconti di Oleggio Castello, Matteo",
+      "orcid": "0000-0001-7931-5272"
+    },
+    {
+      "affiliation": "Dartmouth College: Hanover, NH, United States",
+      "name": "Halchenko, Yaroslav O.",
+      "orcid": "0000-0003-3456-2493"
+    },
+    {
+      "affiliation": "Otto-von-Guericke-University Magdeburg, Germany",
+      "name": "Hanke, Michael",
+      "orcid": "0000-0001-6398-6370"
+    },
+    { 
+      "name": "Poldrack, Benjamin"
+    },
+    { 
+      "name": "Meyer, Kyle"
+    },
+    { 
+      "name": "Solanky, Debanjum Singh"
+    },
+    { 
+      "name": "Alteva, Gergana"
+    },
+    { 
+      "name": "Gors, Jason"
+    },
+    { 
+      "name": "MacFarlane, Dave"
+    },
+    { 
+      "name": "Olaf Häusler, Christian"
+    },
+    { 
+      "name": "Olson, Taylor"
+    },
+    { 
+      "name": "Waite, Alex"
+    },
+    { 
+      "name": "de la Vega, Alejandro"
+    },
+    { 
+      "name": "Sochat, Vanessa"
+    },
+    { 
+      "name": "Keshavan, Anisha"
+    },
+    { 
+      "name": "Yarchael"
+    },
+    { 
+      "name": "Ma, Feilong"
+    },
+    { 
+      "name": "Christian, Horea"
+    },
+    { 
+      "name": "Poelen, Jorrit"
+    },
+    { 
+      "name": "Skytén, Kusti"
+    },
+    { 
+      "name": "Visconti dOC, Matteo"
+    },
+    { 
+      "name": "Hardcastle, Nell"
+    },
+    { 
+      "name": "Stoeter, Torsten"
+    },
+    { 
+      "name": "C Lau, Vicky"
+    }
+  ],
+  "grants": [
+    {"id": "10.13039/501100000925"}
+  ],
+  "keywords": [
+    "data version control",
+    "data distribution",
+    "execution provenance tracking"
+  ],
+  "access_right": "open",
+  "license": "MIT",
+  "upload_type": "software"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -431,6 +431,21 @@ without much prior knowledge.  Your assistance in this area will be greatly
 appreciated by the more experienced developers as it helps free up their time to
 concentrate on other issues.
 
+Recognizing contributions
+-------------------------
+
+We welcome and recognize all contributions from documentation to testing to code development.
+
+You can see a list of current contributors in our [zenodo file][link_zenodo].
+If you are new to the project, don't forget to add your name and affiliation there!
+
+Thank you!
+----------
+
+You're awesome. :wave::smiley:
+
+
+
 Various hints for developers
 ----------------------------
 
@@ -545,3 +560,5 @@ bet we will fix some bugs and make a world even a better place.
 
 ?
 
+
+[link_zenodo]: https://github.com/datalad/datalad/blob/master/.zenodo.json


### PR DESCRIPTION
For format of the file: http://developers.zenodo.org/

So far I have failed to
- find DOI for BMBF (in grants)
- clear description on either we could put spectific grant # after :: in grants
  entries, or just expand those entries with some other fields to point to
  the specific grant(s0

[ci: skip]

Dear @datalad/contributors  and @datalad/developers - please add/adjust/review your entries in .zenodo.json and push your changes into this PR