### PR TITLE
ENH: initial Singularity recipe to provide an image to build git-annex for bisection

### DIFF
--- a/tools/Singularity.git-annex-dev
+++ b/tools/Singularity.git-annex-dev
@@ -1,0 +1,25 @@
+Bootstrap:docker
+From:neurodebian:buster
+
+%post
+    echo "Configuring the environment"
+    apt-get -y update
+
+    # setup the container sources themselves
+    apt-get -y install eatmydata vim less devscripts
+
+    sed -i -e 's,^deb \(.*\),deb \1\ndeb-src \1,g' /etc/apt/sources.list /etc/apt/*.d/*.list \
+     && apt-get -y update \
+     && eatmydata apt-get -y build-dep git git-annex git-annex-standalone
+
+    # we need a UTF locale for DataLad to work properly
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+     && locale-gen
+
+    # clean up
+    apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
+
+
+%environments
+    unset PYTHONPATH


### PR DESCRIPTION
Should provide a build environment to deploy on some other box (e.g. CentOS) so we could build and bisect git-annex

TODOs:
- [ ] supplement with the bisection script, which would mimic `git bisect` in API but would use this singularity image to `make standalone install DESTDIR=somewhere`  first and make that built version available for the bisection script run

"inspiration": http://git-annex.branchable.com/bugs/multiple_ssh_prompts__44___and_thread_blocked_indefinitely_in_an___63____63____63___transaction/#comment-89f62985af5dd49438a578851e4d541f

Attn @joeyh 