### PR TITLE
BF: Assume 50% safety margin for max cmdline length

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2399,7 +2399,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                      - len(command)
                      - sum((len(x) + 3) for x in annex_options)
                      - 4   # for '--' below
-                     - 50  # for safety since we are to add more options
                      ) // (maxl + 3)  # +3 for possible quotes and a space
                 )
                 file_chunks = generate_chunks(files, chunk_size)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -94,7 +94,15 @@ except Exception as exc:
     lgr.debug(
         "Failed to query SC_ARG_MAX sysconf, will use hardcoded value: %s",
         exc)
-lgr.debug("Maximal length of cmdline string: %d", CMD_MAX_ARG)
+# Even with all careful computations we do, due to necessity to account for
+# environment and what not, we still could not figure out "exact" way to
+# estimate it, but it was shown that 300k safety margin on linux was sufficient.
+# https://github.com/datalad/datalad/pull/2977#issuecomment-436264710
+# 300k is ~15%, so to be safe, we will just use up to 80% of the length
+CMD_MAX_ARG = int(0.8 * CMD_MAX_ARG)
+lgr.debug(
+    "Maximal length of cmdline string (adjusted for safety margin): %d",
+    CMD_MAX_ARG)
 
 #
 # Little helpers

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -98,8 +98,10 @@ except Exception as exc:
 # environment and what not, we still could not figure out "exact" way to
 # estimate it, but it was shown that 300k safety margin on linux was sufficient.
 # https://github.com/datalad/datalad/pull/2977#issuecomment-436264710
-# 300k is ~15%, so to be safe, we will just use up to 80% of the length
-CMD_MAX_ARG = int(0.8 * CMD_MAX_ARG)
+# 300k is ~15%, so to be safe, and for paranoid us we will just use up to 50%
+# of the length for "safety margin".  We might probably still blow due to
+# env vars, unicode, etc...  so any hard limit imho is not a proper solution
+CMD_MAX_ARG = int(0.5 * CMD_MAX_ARG)
 lgr.debug(
     "Maximal length of cmdline string (adjusted for safety margin): %d",
     CMD_MAX_ARG)


### PR DESCRIPTION
Hit it again with current master ... not sure if this would have resolved it but it should ;)