### PR TITLE
BF(RF?): do not aggregate dataset itself if paths for aggregation provided

### DIFF
--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -750,7 +750,8 @@ class AggregateMetaData(Interface):
             metavar="PATH",
             doc="""path to datasets that shall be aggregated.
             When a given path is pointing into a dataset, the metadata of the
-            containing dataset will be aggregated.""",
+            containing dataset will be aggregated.  If no paths given, current
+            dataset metadata is aggregated.""",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()),
         recursive=recursion_flag,
@@ -795,9 +796,12 @@ class AggregateMetaData(Interface):
         # it really doesn't work without a dataset
         ds = require_dataset(
             dataset, check_installed=True, purpose='metadata aggregation')
-        # always include the reference dataset
         path = assure_list(path)
-        path.append(ds.path)
+        if not path:
+            # then current/reference dataset is "aggregated"
+            # We should not add ds.path always since then --recursive would
+            # also recurse current even if paths are given
+            path.append(ds.path)
 
         agginfo_db = _load_agginfo_db(ds.path)
 

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -366,6 +366,16 @@ def test_partial_aggregation(path):
     sub1 = ds.create('sub1', force=True)
     sub2 = ds.create('sub2', force=True)
     ds.add('.', recursive=True)
+
+    # if we aggregate a path(s) and say to recurse, we must not recurse into
+    # the dataset itself and aggregate others
+    ds.aggregate_metadata(path='sub1', recursive=True)
+    res = ds.metadata(get_aggregates=True)
+    assert_result_count(res, 1, path=ds.path)
+    assert_result_count(res, 1, path=sub1.path)
+    # so no metadata aggregates for sub2 yet
+    assert_result_count(res, 0, path=sub2.path)
+
     ds.aggregate_metadata(recursive=True)
     # baseline, recursive aggregation gets us something for all three datasets
     res = ds.metadata(get_aggregates=True)


### PR DESCRIPTION
Otherwise it causes negative side effect in --recursive mode that it would start
recursing all subdatasets.

This issue was mentioned in
https://github.com/datalad/datalad/issues/2841

Aggregation of current dataset could always be forced by providing '.' or just not providing paths.
If this PR causes some ideological breakage, it is not visible since no tests seems to get broken.