### PR TITLE
BF: metadata aggregation - check also the "content" of metadata files

### DIFF
--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -750,7 +750,8 @@ class AggregateMetaData(Interface):
             metavar="PATH",
             doc="""path to datasets that shall be aggregated.
             When a given path is pointing into a dataset, the metadata of the
-            containing dataset will be aggregated.""",
+            containing dataset will be aggregated.  If no paths given, current
+            dataset metadata is aggregated.""",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()),
         recursive=recursion_flag,
@@ -795,9 +796,12 @@ class AggregateMetaData(Interface):
         # it really doesn't work without a dataset
         ds = require_dataset(
             dataset, check_installed=True, purpose='metadata aggregation')
-        # always include the reference dataset
         path = assure_list(path)
-        path.append(ds.path)
+        if not path:
+            # then current/reference dataset is "aggregated"
+            # We should not add ds.path always since then --recursive would
+            # also recurse current even if paths are given
+            path.append(ds.path)
 
         agginfo_db = _load_agginfo_db(ds.path)
 

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -366,6 +366,16 @@ def test_partial_aggregation(path):
     sub1 = ds.create('sub1', force=True)
     sub2 = ds.create('sub2', force=True)
     ds.add('.', recursive=True)
+
+    # if we aggregate a path(s) and say to recurse, we must not recurse into
+    # the dataset itself and aggregate others
+    ds.aggregate_metadata(path='sub1', recursive=True)
+    res = ds.metadata(get_aggregates=True)
+    assert_result_count(res, 1, path=ds.path)
+    assert_result_count(res, 1, path=sub1.path)
+    # so no metadata aggregates for sub2 yet
+    assert_result_count(res, 0, path=sub2.path)
+
     ds.aggregate_metadata(recursive=True)
     # baseline, recursive aggregation gets us something for all three datasets
     res = ds.metadata(get_aggregates=True)

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -11,7 +11,6 @@
 
 from collections import Mapping
 from functools import partial
-from itertools import dropwhile
 import logging
 import os
 import re
@@ -28,6 +27,7 @@ from datalad.interface.results import annexjson2result, get_status_dict
 from datalad.interface.common_opts import nosave_opt
 from datalad.support.exceptions import AnnexBatchCommandError
 from datalad.support.network import get_url_filename
+from datalad.support.path import split_ext
 from datalad.support.s3 import get_versioned_url
 from datalad.utils import (
     assure_list,
@@ -277,41 +277,6 @@ def _format_filenames(format_fn, rows, row_infos):
         info["filename"] = filename
         info["subpath"] = spaths[-1] if spaths else None
     return subpaths
-
-
-def split_ext(filename):
-    """Use git-annex's splitShortExtensions rule for splitting extensions.
-
-    Parameters
-    ----------
-    filename : str
-
-    Returns
-    -------
-    A tuple with (root, extension)
-
-    Examples
-    --------
-    >>> from datalad.plugin.addurls import split_ext
-    >>> split_ext("filename.py")
-    ('filename', '.py')
-
-    >>> split_ext("filename.tar.gz")
-    ('filename', '.tar.gz')
-
-    >>> split_ext("filename.above4chars.ext")
-    ('filename.above4chars', '.ext')
-    """
-    parts = filename.split(".")
-    if len(parts) == 1:
-        return filename, ""
-
-    tail = list(dropwhile(lambda x: len(x) < 5,
-                          reversed(parts[1:])))
-
-    file_parts = parts[:1] + tail[::-1]
-    ext_parts = parts[1+len(tail):]
-    return ".".join(file_parts), "." + ".".join(ext_parts)
 
 
 def get_file_parts(filename, prefix="name"):
@@ -727,8 +692,6 @@ class Addurls(Interface):
 
         from requests.exceptions import RequestException
 
-        from datalad.distribution.add import Add
-        from datalad.distribution.create import Create
         from datalad.distribution.dataset import Dataset, require_dataset
         from datalad.interface.results import get_status_dict
         from datalad.support.annexrepo import AnnexRepo

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -151,20 +151,6 @@ def test_fmt_to_name():
     assert_false(au.fmt_to_name("{}", {}))
 
 
-def test_split_ext():
-    eq_(au.split_ext("file"), ("file", ""))
-
-    eq_(au.split_ext("file.py"), ("file", ".py"))
-    eq_(au.split_ext("file.tar.gz"), ("file", ".tar.gz"))
-    eq_(au.split_ext("file.toolong.gz"), ("file.toolong", ".gz"))
-
-    eq_(au.split_ext("file.a.b.c.d"), ("file", ".a.b.c.d"))
-    eq_(au.split_ext("file.a.b.cccc.d"), ("file", ".a.b.cccc.d"))
-    eq_(au.split_ext("file.a.b.ccccc.d"), ("file.a.b.ccccc", ".d"))
-
-    eq_(au.split_ext("file.a.b..c"), ("file", ".a.b..c"))
-
-
 def test_get_file_parts():
     assert_dict_equal(au.get_file_parts("file.tar.gz", "prefix"),
                       {"prefix": "file.tar.gz",

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3143,6 +3143,11 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 annex_options=files,
                                 backend=backend)
 
+    @classmethod
+    def get_key_backend(cls, key):
+        """Get the backend from a given key"""
+        return key.split('-', 1)[0]
+
     @normalize_paths
     def get_file_backend(self, files):
         """Get the backend currently used for file(s).
@@ -3158,7 +3163,10 @@ class AnnexRepo(GitRepo, RepoInterface):
             like "SHA256E" or "MD5".
         """
 
-        return [self.get_file_key(f).split('-')[0] for f in files]
+        return [
+            self.get_key_backend(self.get_file_key(f))
+            for f in files
+        ]
 
     @property
     def default_backends(self):

--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -16,6 +16,8 @@ import os
 import os.path as op
 
 from functools import wraps
+from itertools import dropwhile
+
 from ..utils import (
     assure_bytes,
     getpwd,
@@ -73,3 +75,38 @@ def robust_abspath(p):
             except:
                 return normpath(join(getpwd(), p))
         raise
+
+
+def split_ext(filename):
+    """Use git-annex's splitShortExtensions rule for splitting extensions.
+
+    Parameters
+    ----------
+    filename : str
+
+    Returns
+    -------
+    A tuple with (root, extension)
+
+    Examples
+    --------
+    >>> from datalad.plugin.addurls import split_ext
+    >>> split_ext("filename.py")
+    ('filename', '.py')
+
+    >>> split_ext("filename.tar.gz")
+    ('filename', '.tar.gz')
+
+    >>> split_ext("filename.above4chars.ext")
+    ('filename.above4chars', '.ext')
+    """
+    parts = filename.split(".")
+    if len(parts) == 1:
+        return filename, ""
+
+    tail = list(dropwhile(lambda x: len(x) < 5,
+                          reversed(parts[1:])))
+
+    file_parts = parts[:1] + tail[::-1]
+    ext_parts = parts[1+len(tail):]
+    return ".".join(file_parts), "." + ".".join(ext_parts)

--- a/datalad/support/tests/test_path.py
+++ b/datalad/support/tests/test_path.py
@@ -12,6 +12,7 @@ from ..path import (
     abspath,
     curdir,
     robust_abspath,
+    split_ext,
 )
 from ...dochelpers import exc_str
 from ...utils import (
@@ -41,3 +42,17 @@ def test_robust_abspath(tdir):
 
         assert_raises(OSError, abspath, curdir)
         eq_(robust_abspath(curdir), tdir)
+
+
+def test_split_ext():
+    eq_(split_ext("file"), ("file", ""))
+
+    eq_(split_ext("file.py"), ("file", ".py"))
+    eq_(split_ext("file.tar.gz"), ("file", ".tar.gz"))
+    eq_(split_ext("file.toolong.gz"), ("file.toolong", ".gz"))
+
+    eq_(split_ext("file.a.b.c.d"), ("file", ".a.b.c.d"))
+    eq_(split_ext("file.a.b.cccc.d"), ("file", ".a.b.cccc.d"))
+    eq_(split_ext("file.a.b.ccccc.d"), ("file.a.b.ccccc", ".d"))
+
+    eq_(split_ext("file.a.b..c"), ("file", ".a.b..c"))


### PR DESCRIPTION
This pull hopefully addresses #2841

This pull request proposes to not rely solely on the "state" of the repo in the ID of the metadata file, but also verify that actual content is the same across two datasets.

`_the_same_across_datasets` might be a bit over-engineered, but thought to make it work for >= 2 datasets just because logic should be generic.  

Sits on top of #3002 

### TODOs
- [ ] Check if actually addresses usecase of #2841
- [ ] Unit-test

Please have a look @datalad/developers
