### PR TITLE
RF: Allow for customization of change recording in `run`

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -572,7 +572,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     saver : callable, optional
         Must take a dataset instance, a list of paths to save, and a
         message string as arguments and must record any changes done
-        to any content matching an entry in the path list.
+        to any content matching an entry in the path list. Must yield
+        result dictionaries as a generator.
 
     Yields
     ------


### PR DESCRIPTION
This is admittedly a bit clunky. An alternative way of doing this would be to RF the `add()` call into the main command class, and have a helper method deal with it. In this scenario, it could simply be overwritten in a derived class, instead of having to introduce another argument. What would you prefer @kyleam?

Why is this needed? ATM `run` performs a hard-coded `add(recursive)`, and this adds the flexibility to tailor this behavior (non-recursive add, or more than just adding).