### PR TITLE
BF:  be able to commit annexed changed files which potentially jump between git/annex

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2896,7 +2896,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 direct_mode = self.is_direct_mode()
                 # we might need to avoid explicit paths
                 files_to_commit = None if direct_mode else files
-                if direct_mode and files:
+                if files:
                     # In direct mode, if we commit file(s) they would get
                     # committed directly into git ignoring possibly being
                     # staged by annex.  So, if not all files are committed, and
@@ -2905,45 +2905,47 @@ class AnnexRepo(GitRepo, RepoInterface):
                     # commit without specifying any paths
                     changed_files = {
                         staged: set(self.get_changed_files(staged=staged))
-                        for staged in (True,) #  False}
+                        for staged in (True, False)
                     }
                     files_set = {
                         _normalize_path(self.path, f) if isabs(f) else f
-                        for f in files}
-                    files_notstaged = files_set.difference(changed_files[True])
-                    # Lazy .add('.') results in ALL (performance?) files listed
-                    # here even if they are not changed at all and could be ignored
-                    #files_changed_notstaged = files_notstaged.difference(changed_files[False])
-                    # if files_changed_notstaged:
-                    #     # To be safe(r), let's just blow for now!
-                    #     # We could be smart(er) and do all the git or annex add
-                    #     # but let's see if we run into those cases first
-                    #     import pdb; pdb.set_trace()
-                    #     raise RuntimeError(
-                    #         "To commit files in direct mode, please first git "
-                    #         "or git-annex add them first!  Files: %s"
-                    #         % ', '.join(files_changed_notstaged)
-                    #     )
+                        for f in files
+                    }
+                    # files_notstaged = files_set.difference(changed_files[True])
+                    files_changed_notstaged = files_set.intersection(changed_files[False])
+
                     # Files which were staged but not among files
                     staged_not_to_commit = changed_files[True].difference(files_set)
-                    if staged_not_to_commit:
+                    if staged_not_to_commit or files_changed_notstaged:
                         # Need an alternative index_file
                         with make_tempfile() as index_file:
+                            # First add those which were changed but not staged yet
+                            if files_changed_notstaged:
+                                self.add(files=list(files_changed_notstaged))
+
                             alt_index_file = index_file
                             index_tree = self.repo.git.write_tree()
                             self.repo.git.read_tree(index_tree,
                                                     index_output=index_file)
                             # Reset the files we are not to be committed
-                            self._git_custom_command(
-                                list(staged_not_to_commit),
-                                ['git', 'reset'],
-                                index_file=alt_index_file)
+                            if staged_not_to_commit:
+                                self._git_custom_command(
+                                    list(staged_not_to_commit),
+                                    ['git', 'reset'],
+                                    index_file=alt_index_file)
 
                             super(AnnexRepo, self).commit(
                                 msg, options,
                                 _datalad_msg=_datalad_msg,
-                                careless=careless,
+                                careless=False, # careless,
                                 index_file=alt_index_file)
+
+                            if files_changed_notstaged:
+                                # reset current index to reflect the changes annex might have done
+                                self._git_custom_command(
+                                    list(files_changed_notstaged),
+                                    ['git', 'reset']
+                                )
 
                     # in any case we will not specify files explicitly
                     files_to_commit = None

--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -40,6 +40,7 @@ def _get_unicode_robust_version(f):
 
 
 abspath = op.abspath
+basename = op.basename
 curdir = op.curdir
 dirname = op.dirname
 exists = _get_unicode_robust_version(op.exists)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2431,7 +2431,7 @@ def test_error_reporting(path):
     'tobechanged-git': 'a',
     'tobechanged-annex': 'a'*10,
 })
-def test_commit_annex_commit_changed(path):
+def check_commit_annex_commit_changed(unlock, path):
     # Here we test commit working correctly if file was just removed
     # (not unlocked), edited and committed back
     ar = AnnexRepo(path, create=True)
@@ -2441,7 +2441,8 @@ def test_commit_annex_commit_changed(path):
     ok_clean_git(path)
     # Now let's change all but commit only some
     files = [op.basename(p) for p in glob(op.join(path, '*'))]
-    # os.unlink(files)
+    if unlock:
+        ar.unlock(files)
     create_tree(
         path
         , {
@@ -2478,3 +2479,8 @@ def test_commit_annex_commit_changed(path):
     ok_file_under_git(path, 'tobechanged-git', annexed=False)
     # TODO: direct mode gotcha!!!
     ok_file_under_git(path, 'tobechanged-annex', annexed=not ar.is_direct_mode())
+
+
+def test_commit_annex_commit_changed():
+    yield check_commit_annex_commit_changed, False
+    yield check_commit_annex_commit_changed, True

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -209,13 +209,14 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
                 eq_(head_diffs, [])
                 eq_(index_diffs, [])
             else:
+                # TODO: These names are confusing/non-descriptive.  REDO
                 if head_modified:
                     # we did ask for interrogating changes
                     head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
-                    eq_(head_modified_, head_modified)
+                    eq_(sorted(head_modified_), sorted(head_modified))
                 if index_modified:
                     index_modified_ = [d.a_path for d in repo.index.diff(None)]
-                    eq_(index_modified_, index_modified)
+                    eq_(sorted(index_modified_), sorted(index_modified))
 
 
 def ok_file_under_git(path, filename=None, annexed=False):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2074,7 +2074,7 @@ def create_tree_archive(path, name, load, overwrite=False, archives_leading_dir=
     rmtree(full_dirname)
 
 
-def create_tree(path, tree, archives_leading_dir=True):
+def create_tree(path, tree, archives_leading_dir=True, remove_existing=False):
     """Given a list of tuples (name, load) create such a tree
 
     if load is a tuple itself -- that would create either a subtree or an archive
@@ -2095,11 +2095,18 @@ def create_tree(path, tree, archives_leading_dir=True):
             executable = False
             name = file_
         full_name = op.join(path, name)
+        if remove_existing and op.lexists(full_name):
+            rmtree(full_name, chmod_files=True)
         if isinstance(load, (tuple, list, dict)):
             if name.endswith('.tar.gz') or name.endswith('.tar') or name.endswith('.zip'):
-                create_tree_archive(path, name, load, archives_leading_dir=archives_leading_dir)
+                create_tree_archive(
+                    path, name, load,
+                    archives_leading_dir=archives_leading_dir)
             else:
-                create_tree(full_name, load, archives_leading_dir=archives_leading_dir)
+                create_tree(
+                    full_name, load,
+                    archives_leading_dir=archives_leading_dir,
+                    remove_existing=remove_existing)
         else:
             if PY2:
                 open_kwargs = {'mode': "w"}


### PR DESCRIPTION
This pull request might be fixing #1651 and #2752. Ran into it again in the course of preparing PR for #3007 

- includes some minor refactoring and BFing around the code

- overall it boils down to adopting our "hack" for direct mode to be applied generally when we are working with a commit for specific subset of files.  All the files listed to be committed and which were not staged, would get first `annex add`-ed, index would be copied into a temporary one, staged files which are not to be committed, reset from that index, we commit, and if we added some files explicitly - we reset original index to match the committed state.

What is more "useful" in this PR is actually the unittest which triggers original failure.  Now I am testing only with first optionally unlocking of the files to be edited, but we should test also with "unannex"ing first (left TODO for the future or revolution).
