### PR TITLE
BF: rerun: Widen "onto commit exists" check

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 import logging
 from itertools import dropwhile
 import json
-import os
 import os.path as op
 import re
 import sys

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -295,7 +295,7 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
         if not dset.repo.commit_exists(onto):
             # This is unlikely to happen in the wild because it means that the
             # first commit is a datalad run commit. Just abort rather than
-            # trying to checkout on orphan branch or something like that.
+            # trying to checkout an orphan branch or something like that.
             yield get_status_dict(
                 "run", ds=dset, status="error",
                 message="Commit for --onto does not exist.")

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -292,14 +292,18 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
         # that, regardless of if and how --since is specified, the effective
         # value for --since is the parent of the first revision.
         onto = results[0]["commit"] + "^"
-        if not dset.repo.commit_exists(onto):
-            # This is unlikely to happen in the wild because it means that the
-            # first commit is a datalad run commit. Just abort rather than
-            # trying to checkout an orphan branch or something like that.
-            yield get_status_dict(
-                "run", ds=dset, status="error",
-                message="Commit for --onto does not exist.")
-            return
+
+    if onto and not dset.repo.commit_exists(onto):
+        # This happens either because the user specifies a value that doesn't
+        # exists or the results first parent doesn't exist. The latter is
+        # unlikely to happen in the wild because it means that the first commit
+        # is a datalad run commit. Just abort rather than trying to checkout an
+        # orphan branch or something like that.
+        yield get_status_dict(
+            "run", ds=dset, status="error",
+            message=("Revision specified for --onto (%s) does not exist.",
+                     onto))
+        return
 
     start_point = onto or "HEAD"
     if branch or onto:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -32,7 +32,7 @@ from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import NoDatasetArgumentFound
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import IncompleteResultsError
-from datalad.support.gitrepo import GitCommandError, GitRepo
+from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import ok_, assert_false, neq_
 from datalad.api import install
 from datalad.api import run

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -312,6 +312,13 @@ def test_rerun_onto(path):
     eq_(ds.repo.get_merge_base(["static", "from-base"]),
         ds.repo.get_hexsha("static^"))
 
+    # We give abort when an explicitly specified onto doesn't exists.
+    ds.repo.checkout("master")
+    assert_result_count(
+        ds.rerun(since="", onto="doesnotexist", branch="from-base",
+                 on_failure="ignore"),
+        1, status="error", action="run")
+
 
 @ignore_nose_capturing_stdout
 @known_failure_windows


### PR DESCRIPTION
```
We check that the commit specified for --onto exists when we
automatically set onto in the --onto='' case.  We should do the same
when an --onto value is explicitly given because it may not exist,
which leads to 'git checkout' failing with an unclear message:

  fatal: git checkout: --detach does not take a path argument '<onto value>'
```

Fixes #3019.