### PR TITLE
ENH: annexrepo: Inform users about repo version auto-upgrades

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -93,6 +93,13 @@ lgr = logging.getLogger('datalad.annex')
 # Limit to # of CPUs and up to 8, but at least 3 to start with
 N_AUTO_JOBS = min(8, max(3, cpu_count()))
 
+# This is a map between an auto-upgradeable version and the version that it
+# upgrades to. It should track autoUpgradeableVersions in Annex.Version.
+_AUTO_UPGRADEABLE_VERSIONS = {3: 5, 4: 5}
+# TODO: Adjust once GIT_ANNEX_VERSION is at least 7.20181031.
+if external_versions['cmd:annex'] >= '7.20181031':
+    _AUTO_UPGRADEABLE_VERSIONS[6] = 7
+
 
 class AnnexRepo(GitRepo, RepoInterface):
     """Representation of an git-annex repository.
@@ -1276,6 +1283,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         if description is not None:
             opts += [description]
         if version is not None:
+            upgraded_version = _AUTO_UPGRADEABLE_VERSIONS.get(version)
+            if upgraded_version:
+                lgr.info("Annex repository version %s will be upgraded to %s",
+                         version, upgraded_version)
             opts += ['--version', '{0}'.format(version)]
         if not len(opts):
             opts = None

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1286,13 +1286,16 @@ def test_annex_remove(path1, path2):
 @with_tempfile
 @with_tempfile
 def test_repo_version(path1, path2, path3):
-    annex = AnnexRepo(path1, create=True, version=6)
-    ok_clean_git(path1, annex=True)
-    version = annex.repo.config_reader().get_value('annex', 'version')
-    # TODO: Since git-annex 7.20181031, v6 repos upgrade to v7. Once that
-    # version or later is our minimum required version, update this test and
-    # the one below to eq_(version, 7).
-    assert_in(version, [6, 7])
+    with swallow_logs(new_level=logging.INFO) as cm:
+        annex = AnnexRepo(path1, create=True, version=6)
+        ok_clean_git(path1, annex=True)
+        version = annex.repo.config_reader().get_value('annex', 'version')
+        # TODO: Since git-annex 7.20181031, v6 repos upgrade to v7. Once that
+        # version or later is our minimum required version, update this test and
+        # the one below to eq_(version, 7).
+        assert_in(version, [6, 7])
+        if external_versions['cmd:annex'] >= '7.20181031':
+            assert_in("will be upgraded to 7", cm.out)
 
     # default from config item (via env var):
     with patch.dict('os.environ', {'DATALAD_REPO_VERSION': '6'}):


### PR DESCRIPTION
An attempt to address an [issue] raised by @bpoldrack:
> ATM we happily accept datalad.repo.version = 6, while silently creating a v7 repository. This is misleading. 

[issue]: https://github.com/datalad/datalad/issues/2969#issuecomment-441051936
