### PR TITLE
TST+BF: download_url: Don't try to infer dataset if save=False

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -91,12 +91,14 @@ class DownloadURL(Interface):
 
         pwd, rel_pwd = get_dataset_pwds(dataset)
 
-        try:
-            ds = require_dataset(
-                dataset, check_installed=True,
-                purpose='downloading urls')
-        except NoDatasetArgumentFound:
-            ds = None
+        ds = None
+        if save or dataset:
+            try:
+                ds = require_dataset(
+                    dataset, check_installed=True,
+                    purpose='downloading urls')
+            except NoDatasetArgumentFound:
+                pass
 
         common_report = {"action": "download_url",
                          "ds": ds}
@@ -116,7 +118,7 @@ class DownloadURL(Interface):
 
         if dataset:  # A dataset was explicitly given.
             path = op.normpath(op.join(ds.path, path or op.curdir))
-        elif ds:
+        elif save and ds:
             path = op.normpath(op.join(ds.path, rel_pwd, path or op.curdir))
         elif not path:
             path = op.curdir

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -25,13 +25,15 @@ from ...tests.utils import serve_path_via_http
 
 
 def test_download_url_exceptions():
-    res0 = download_url(['url1', 'url2'], path=__file__, on_failure='ignore')
+    res0 = download_url(['url1', 'url2'], path=__file__,
+                        save=False, on_failure='ignore')
     assert_result_count(res0, 1, status='error')
     assert_message('When specifying multiple urls, --path should point to '
                    'an existing directory. Got %r',
                    res0)
 
-    res1 = download_url('http://example.com/bogus', on_failure='ignore')
+    res1 = download_url('http://example.com/bogus',
+                        save=False, on_failure='ignore')
     assert_result_count(res1, 1, status='error')
     msg = res1[0]['message']
     # when running under bogus proxy, on older systems we could get


### PR DESCRIPTION
When a dataset isn't explicitly specified, download_url will try to
infer one from the current directory.  However, if save is False,
there's no reason to do so.  Trying to infer the dataset in these
situations generally won't hurt, but doing so may unnecessarily
fail in the save=False case if the current directory is something
that may cause issues when used as a dataset (e.g., a git
worktree).

Note: This was prompted by a download_url test failing when ran from a
worktree (gh-3028).  The most direct solution is to use chpwd() to get
to a non-dataset directory in the cases that we call
api.download_url(dataset=None), but that wouldn't help for callers
outside the test.  Another would be to catch the repository exception
around the require_dataset() call, but I've found that, when calling
`datalad download-url` from a worktree, the exception may be raised
downstream rather than at the require_dataset() call.

Fixes #3028.