### PR TITLE
RF: Do not force byte-encoding of commit message

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -713,14 +713,13 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     msg = msg.format(
         message if message is not None else _format_cmd_shorty(cmd),
         '"{}"'.format(record_id) if use_sidecar else record)
-    msg = assure_bytes(msg)
 
     outputs_to_save = outputs.expand(full=True) if explicit else '.'
     if not rerun_info and cmd_exitcode:
         if outputs_to_save:
             msg_path = relpath(opj(ds.repo.path, ds.repo.get_git_dir(ds.repo),
                                    "COMMIT_EDITMSG"))
-            with open(msg_path, "wb") as ofh:
+            with open(msg_path, "w") as ofh:
                 ofh.write(msg)
             lgr.info("The command had a non-zero exit code. "
                      "If this is expected, you can save the changes with "


### PR DESCRIPTION
This fails on windows, see #3030

This PR may be accumulating more changes.