### PR TITLE
TST: run: Include OBSCURE_FILENAME within a commit message

### DIFF
--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -958,7 +958,7 @@ def test_inputs_quotes_needed(path):
     # spaces ...
     cmd_str = "{} -c \"{}\" {{inputs}} {{outputs[0]}}".format(
         sys.executable, cmd)
-    ds.run(cmd_str, inputs=["*.t*"], outputs=["out0"])
+    ds.run(cmd_str, inputs=["*.t*"], outputs=["out0"], expand="inputs")
     expected = u"!".join(
         list(sorted([OBSCURE_FILENAME + u".t", "bar.txt", "foo blah.txt"])) +
         ["out0"])


### PR DESCRIPTION
This test is focused on input quoting, but we might was well expand
the inputs in the commit message to make sure that dumping the obscure
name to the commit message doesn't fail.

Re: #3031
