### PR TITLE
run: Resolve some py2 unicode issues

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -530,7 +530,7 @@ class Runner(object):
                            "" if log_online else " out=%s" % out[0],
                            "" if log_online else " err=%s" % out[1])
                     lgr.log(9 if expect_fail else 11, msg)
-                    raise CommandError(str(cmd), msg, status, out[0], out[1])
+                    raise CommandError(text_type(cmd), msg, status, out[0], out[1])
                 else:
                     self.log("Finished running %r with status %s" % (cmd, status),
                              level=8)

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -63,7 +63,7 @@ lgr = logging.getLogger('datalad.interface.run')
 def _format_cmd_shorty(cmd):
     """Get short string representation from a cmd argument list"""
     cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
-    cmd_shorty = '{}{}'.format(
+    cmd_shorty = u'{}{}'.format(
         cmd_shorty[:40],
         '...' if len(cmd_shorty) > 40 else '')
     return cmd_shorty

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -49,6 +49,7 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.interface.unlock import Unlock
 
 from datalad.utils import assure_bytes
+from datalad.utils import assure_unicode
 from datalad.utils import chpwd
 # Rename get_dataset_pwds for the benefit of containers_run.
 from datalad.utils import get_dataset_pwds as get_command_pwds
@@ -249,6 +250,7 @@ class GlobbedPaths(object):
             self._maybe_dot = []
             self._paths = {"patterns": [], "sub_patterns": {}}
         else:
+            patterns = list(map(assure_unicode, patterns))
             patterns, dots = partition(patterns, lambda i: i.strip() == ".")
             self._maybe_dot = ["."] if list(dots) else []
             self._paths = {

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -958,7 +958,7 @@ def test_inputs_quotes_needed(path):
     # spaces ...
     cmd_str = "{} -c \"{}\" {{inputs}} {{outputs[0]}}".format(
         sys.executable, cmd)
-    ds.run(cmd_str, inputs=["*.t*"], outputs=["out0"])
+    ds.run(cmd_str, inputs=["*.t*"], outputs=["out0"], expand="inputs")
     expected = u"!".join(
         list(sorted([OBSCURE_FILENAME + u".t", "bar.txt", "foo blah.txt"])) +
         ["out0"])

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -295,6 +295,14 @@ def test_runner_failure(dir_):
 
 
 @with_tempfile(mkdir=True)
+def test_runner_failure_unicode(path):
+    # Avoid OBSCURE_FILENAME in hopes of windows-compatibility (gh-2929).
+    runner = Runner()
+    with assert_raises(CommandError), swallow_logs():
+        runner.run(u"β-command-doesnt-exist", cwd=path)
+
+
+@with_tempfile(mkdir=True)
 def test_git_path(dir_):
     from ..support.gitrepo import GitRepo
     # As soon as we use any GitRepo we should get _GIT_PATH set in the Runner


### PR DESCRIPTION
This pull request supersedes gh-3033, fixing the py2 issue there as well as other py2 unicode issues in cmd.py and run.py.

---

@mih: One of the tests added (`test_run:test_py2_unicode_command`) triggers a case where the patch from #3031 (e3d2af7e6, RF: Do not force byte-encoding of commit message) fails under Python 2.

```
======================================================================
ERROR: datalad.interface.tests.test_run.test_py2_unicode_command
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kyle/src/python/venvs/datalad-py2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/kyle/src/python/datalad/datalad/tests/utils.py", line 596, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/kyle/src/python/datalad/datalad/interface/tests/test_run.py", line 151, in test_py2_unicode_command
    ds.run(u"bβ2.dat")
  File "/home/kyle/src/python/datalad/datalad/distribution/dataset.py", line 494, in apply_func
    return f(**kwargs)
  File "/home/kyle/src/python/datalad/datalad/interface/utils.py", line 479, in eval_func
    return return_func(generator_func)(*args, **kwargs)
  File "/home/kyle/src/python/datalad/datalad/interface/utils.py", line 467, in return_func
    results = list(results)
  File "/home/kyle/src/python/datalad/datalad/interface/utils.py", line 422, in generator_func
    result_renderer, result_xfm, _result_filter, **_kwargs):
  File "/home/kyle/src/python/datalad/datalad/interface/utils.py", line 509, in _process_results
    for res in results:
  File "/home/kyle/src/python/datalad/datalad/interface/run.py", line 223, in __call__
    sidecar=sidecar):
  File "/home/kyle/src/python/datalad/datalad/interface/run.py", line 725, in run_command
    ofh.write(msg)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u03b2' in position 18: ordinal not in range(128)
```