### PR TITLE
WiP: annihilation of direct mode support for the sake of the revolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_DIRECT=yes
 ##1    - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5
 
@@ -159,14 +158,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  - python: 3.5
-    # test whether known direct mode failures still fail
-    env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
   - python: 3.5
     # test with extension datalad-crawler
@@ -210,13 +201,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  # test whether known direct mode failures still fail
-  - env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test functioning of the datalad main cmdline utility """
 
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import on_windows
 
 

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for customremotes archives providing dl+archive URLs handling"""
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 from ..archives import ArchiveAnnexCustomRemote
@@ -126,7 +125,6 @@ def test_basic_scenario(direct, d, d2):
 @with_tree(
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
-@known_failure_direct_mode  #FIXME
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -32,16 +32,15 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 
 # TODO: with_tree ATM for archives creates this nested top directory
 # matching archive name, so it will be a/d/test.dat ... we don't want that probably
-@with_direct
 @with_tree(
     tree=(('a.tar.gz', {'d': {fn_inarchive_obscure: '123'}}),
           ('simple.txt', '123'),
           (fn_archive_obscure, (('d', ((fn_inarchive_obscure, '123'),)),)),
           (fn_extracted_obscure, '123')))
 @with_tempfile()
-def test_basic_scenario(direct, d, d2):
+def test_basic_scenario(d, d2):
     fn_archive, fn_extracted = fn_archive_obscure, fn_extracted_obscure
-    annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
+    annex = AnnexRepo(d, runner=_get_custom_runner(d))
     annex.init_remote(
         ARCHIVES_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % ARCHIVES_SPECIAL_REMOTE,
@@ -93,9 +92,7 @@ def test_basic_scenario(direct, d, d2):
     annex.drop(fn_extracted)  # so we don't get from this one next
 
     # Let's create a clone and verify chain of getting file through the tarball
-    cloned_annex = AnnexRepo.clone(d, d2,
-                                   runner=_get_custom_runner(d2),
-                                   direct=direct)
+    cloned_annex = AnnexRepo.clone(d, d2, runner=_get_custom_runner(d2))
     # we still need to enable manually atm that special remote for archives
     # cloned_annex.enable_remote('annexed-archives')
 

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for the base of our custom remotes"""
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from os.path import isabs
 
@@ -19,7 +18,6 @@ from ..base import AnnexCustomRemote, DEFAULT_AVAILABILITY, DEFAULT_COST
 from datalad.tests.utils import eq_
 
 @with_tree(tree={'file.dat': ''})
-@known_failure_direct_mode  #FIXME
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)
     repo.add('file.dat')

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -20,8 +20,8 @@ from ..datalad import DataladAnnexCustomRemote
 
 @with_tempfile()
 @skip_if_no_network
-def check_basic_scenario(direct, url, d):
-    annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
+def check_basic_scenario(url, d):
+    annex = AnnexRepo(d, runner=_get_custom_runner(d))
     annex.init_remote(
         DATALAD_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % DATALAD_SPECIAL_REMOTE,
@@ -58,16 +58,14 @@ def check_basic_scenario(direct, url, d):
 
 # unfortunately with_tree etc decorators aren't generators friendly thus
 # this little adapters to test both on local and s3 urls
-@with_direct
 @with_tree(tree={'3versions-allversioned.txt': "somefile"})
 @serve_path_via_http
-def test_basic_scenario_local_url(direct, p, local_url):
-    check_basic_scenario(direct, "%s3versions-allversioned.txt" % local_url)
+def test_basic_scenario_local_url(p, local_url):
+    check_basic_scenario("%s3versions-allversioned.txt" % local_url)
 
 
-@with_direct
-def test_basic_scenario_s3(direct):
-    check_basic_scenario(direct, 's3://datalad-test0-versioned/3versions-allversioned.txt')
+def test_basic_scenario_s3():
+    check_basic_scenario('s3://datalad-test0-versioned/3versions-allversioned.txt')
 
 
 

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -10,7 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import logging
 import os
@@ -124,7 +123,6 @@ def test_add_files(path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_known_submodule(path):
     def get_baseline(p):
         ds = Dataset(p).create()
@@ -145,7 +143,6 @@ def test_update_known_submodule(path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_recursive(path):
     # make simple hierarchy
     parent = Dataset(path).create()
@@ -177,7 +174,6 @@ def test_add_recursive(path):
 
 
 @with_tree(**tree_arg)
-@known_failure_direct_mode  #FIXME
 def test_add_dirty_tree(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
@@ -334,7 +330,6 @@ def test_add_source(path, url, ds_dir):
 
 @with_tree(**tree_arg)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_subdataset(path, other):
     subds = create(opj(path, 'dir'), force=True)
     ds = create(path, force=True)
@@ -371,7 +366,6 @@ def test_add_subdataset(path, other):
     'file2.txt': 'some text to go to annex',
     '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
 )
-@known_failure_direct_mode  #FIXME
 def test_add_mimetypes(path):
     # XXX apparently there is symlinks dereferencing going on while deducing repo
     #    type there!!!! so can't use following invocation  -- TODO separately
@@ -412,7 +406,6 @@ def test_gh1597_simpler(path):
 
 
 # Failed to run ['git', '--work-tree=.', 'diff', '--raw', '-z', '--ignore-submodules=none', '--abbrev=40', 'HEAD', '--'] This operation must be run in a work tree
-@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_gh1597(path):
     ds = Dataset(path).create()

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -229,10 +229,7 @@ def test_clone_into_dataset(source, top_path):
 
     subds = ds.clone(source, "sub",
                      result_xfm='datasets', return_type='item-or-list')
-    if isinstance(subds.repo, AnnexRepo) and subds.repo.is_direct_mode():
-        ok_(exists(opj(subds.path, '.git')))
-    else:
-        ok_(isdir(opj(subds.path, '.git')))
+    ok_(isdir(opj(subds.path, '.git')))
     ok_(subds.is_installed())
     assert_in('sub', ds.subdatasets(fulfilled=True, result_xfm='relpaths'))
     # sub is clean:

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -138,6 +138,7 @@ def test_create(path):
         ('bim', 'bam', 'bum'))
 
 
+@known_failure_windows  #FIXME
 @with_tempfile
 def test_create_sub(path):
 
@@ -200,6 +201,8 @@ def test_create_sub_nosave(path):
     # Just the annex subdataset is recognized.
     eq_(ds.subdatasets(result_xfm="relpaths"), ["sub_annex"])
 
+
+@known_failure_windows
 @with_tree(tree=_dataset_hierarchy_template)
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import known_failure_windows
 
 
@@ -140,7 +139,6 @@ def test_create(path):
 
 
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_create_sub(path):
 
     ds = Dataset(path)
@@ -178,7 +176,6 @@ def test_create_sub(path):
 
 
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_create_sub_nosave(path):
     ds = Dataset(path)
     ds.create()
@@ -204,7 +201,6 @@ def test_create_sub_nosave(path):
     eq_(ds.subdatasets(result_xfm="relpaths"), ["sub_annex"])
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto
     # an existing directory tree
@@ -233,7 +229,6 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_nested_create(path):
     # to document some more organic usage pattern
     ds = Dataset(path).create()

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import os
@@ -308,7 +307,6 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
@@ -380,7 +378,6 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
     source = install(src_path, source=origin, recursive=True)
@@ -558,4 +555,4 @@ def test_target_ssh_inherit():
     #   https://github.com/datalad/datalad/issues/1274
     #yield _test_target_ssh_inherit, None      # no wanted etc
     #yield _test_target_ssh_inherit, 'manual'  # manual -- no load should be annex copied
-    yield known_failure_direct_mode(_test_target_ssh_inherit), 'backup'  # backup -- all data files  #FIXME
+    yield _test_target_ssh_inherit, 'backup'  # backup -- all data files  #FIXME

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -37,7 +37,6 @@ def test_parse_spec():
     eq_(_parse_spec(''), [])
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -49,7 +48,6 @@ def test_create_test_dataset():
         ok_(len(glob(opj(ds, 'file*'))))
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -59,7 +57,6 @@ def test_create_1test_dataset():
     ok_clean_git(dss[0], annex=False)
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 @with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
@@ -71,7 +68,6 @@ def test_new_relpath(topdir):
         ok_clean_git(ds, annex=False)
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -8,7 +8,6 @@
 """Test create testdataset helpers
 
 """
-from datalad.tests.utils import known_failure_direct_mode
 
 from glob import glob
 from os.path import join as opj
@@ -39,7 +38,6 @@ def test_parse_spec():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -52,7 +50,6 @@ def test_create_test_dataset():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -63,7 +60,6 @@ def test_create_1test_dataset():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
@@ -76,7 +72,6 @@ def test_new_relpath(topdir):
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -10,7 +10,6 @@
 """
 
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from os import curdir
 from os.path import join as opj, basename
@@ -369,7 +368,6 @@ def test_get_install_missing_subdataset(src, path):
 #                  'subds': {'file_in_annex.txt': 'content'}})
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_get_mixed_hierarchy(src, path):
 
     origin = Dataset(src).create(no_annex=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -443,10 +443,7 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(ds.path)
 
     subds = ds.install("sub", source=source, save=False)
-    if isinstance(subds.repo, AnnexRepo) and subds.repo.is_direct_mode():
-        ok_(exists(opj(subds.path, '.git')))
-    else:
-        ok_(isdir(opj(subds.path, '.git')))
+    ok_(isdir(opj(subds.path, '.git')))
     ok_(subds.is_installed())
     assert_in('sub', ds.subdatasets(result_xfm='relpaths'))
     # sub is clean:

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import logging
@@ -425,11 +424,6 @@ def test_install_recursive_with_data(src, path):
             ok_(all(subds.repo.file_has_content(subds.repo.get_annexed_files())))
 
 
-# @known_failure_direct_mode  #FIXME:
-# If we use all testrepos, we get a mixed hierarchy. Therefore ok_clean_git
-# fails if we are in direct mode and run into a plain git beneath an annex, due
-# to currently impossible recursion of `AnnexRepo._submodules_dirty_direct_mode`
-
 @slow  # 88.0869s  because of going through multiple test repos, ~8sec each time
 @with_testrepos('.*annex.*', flavors=['local'])
 # 'local-url', 'network'
@@ -475,7 +469,6 @@ def test_install_into_dataset(source, top_path):
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_failed_install_multiple(top_path):
     ds = create(top_path)
 
@@ -533,7 +526,6 @@ def test_install_known_subdataset(src, path):
 @slow  # 46.3650s
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_implicit_install(src, dst):
 
     origin_top = create(src)
@@ -795,7 +787,6 @@ def test_install_source_relpath(src, dest):
 @with_tempfile
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_install_consistent_state(src, dest, dest2, dest3):
     # if we install a dataset, where sub-dataset "went ahead" in that branch,
     # while super-dataset was not yet updated (e.g. we installed super before)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -72,6 +72,7 @@ from datalad.tests.utils import slow
 from datalad.tests.utils import usecase
 from datalad.tests.utils import get_datasets_topdir
 from datalad.tests.utils import SkipTest
+from datalad.tests.utils import known_failure_windows
 from datalad.utils import _path_
 from datalad.utils import rmtree
 
@@ -465,6 +466,7 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
+@known_failure_windows  #FIXME
 @usecase  # 39.3074s
 @skip_if_no_network
 @use_cassette('test_install_crcns')
@@ -782,6 +784,7 @@ def test_install_source_relpath(src, dest):
         ds2 = install(dest, source=src_)
 
 
+@known_failure_windows  #FIXME
 @integration  # 41.2043s
 @with_tempfile
 @with_tempfile

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -46,6 +46,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 
 
 @with_testrepos('submodule_annex', flavors=['local'])
@@ -564,6 +565,7 @@ def test_publish_depends(
         ok_file_has_content(opj(p, 'probe1'), 'probe1')
 
 
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_gh1426(origin_path, target_path):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import logging
@@ -105,7 +104,6 @@ def test_smth_about_not_supported(p1, p2):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -230,7 +228,6 @@ def test_publish_plain_git(origin, src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
     # we will be publishing back to origin, so to not alter testrepo
@@ -397,7 +394,6 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
 
     # prepare src
@@ -491,7 +487,6 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 @with_tempfile()
 @with_tempfile()
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_publish_depends(
         origin,
         src_path,
@@ -571,7 +566,6 @@ def test_publish_depends(
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_gh1426(origin_path, target_path):
     # set up a pair of repos, one the published copy of the other
     origin = create(origin_path)
@@ -633,7 +627,6 @@ def test_publish_gh1691(origin, src_path, dst_path):
 @with_tree(tree={'1': '123'})
 @with_tempfile(mkdir=True)
 @serve_path_via_http
-@known_failure_direct_mode  #FIXME
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
@@ -651,7 +644,6 @@ def test_publish_target_url(src, desttop, desturl):
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_gh1763(src, target1, target2):
     # this test is very similar to test_publish_depends, but more
     # comprehensible, and directly tests issue 1763

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -7,7 +7,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test subdataset command"""
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os
 from os.path import join as opj
@@ -25,10 +24,8 @@ from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_status
-from datalad.tests.utils import known_failure_direct_mode
 
 
-@known_failure_direct_mode  #FIXME
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
 def test_get_subdatasets(path):
     ds = Dataset(path)
@@ -195,7 +192,6 @@ def test_state(path):
         ds.subdatasets(), 1, path=sub.path, state='absent')
 
 
-@known_failure_direct_mode  #FIXME same issue as gh-2113
 @with_tempfile
 def test_get_subdatasets_types(path):
     from datalad.api import create

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import os
@@ -74,7 +73,6 @@ def test_uninstall_uninstalled(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
@@ -224,7 +222,6 @@ def test_uninstall_subdataset(src, dst):
             'keep': 'keep1', 'kill': 'kill1'}},
     'keep': 'keep2',
     'kill': 'kill2'})
-@known_failure_direct_mode  #FIXME
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
     subds = ds.create('deep', force=True)
@@ -274,7 +271,6 @@ def test_uninstall_dataset(path):
 
 
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
-@known_failure_direct_mode  #FIXME
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
     ds.add(os.curdir)
@@ -304,7 +300,6 @@ def test_remove_file_handle_only(path):
 
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
-@known_failure_direct_mode  #FIXME
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
@@ -369,7 +364,6 @@ def test_remove_dataset_hierarchy(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_careless_subdataset_uninstall(path):
     # nested datasets
     ds = Dataset(path).create()
@@ -469,7 +463,6 @@ def test_remove_recursive_2(tdir):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_failon_nodrop(path):
     # test to make sure that we do not wipe out data when checks are enabled
     # despite the general error behavior mode
@@ -531,7 +524,6 @@ def test_drop_nocrash_absent_subds(path):
         assert_status('notneeded', drop('.', recursive=True))
 
 
-@known_failure_direct_mode  #FIXME
 @with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
 def test_remove_more_than_one(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -37,6 +37,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import slow
+from datalad.tests.utils import known_failure_windows
 
 
 @slow
@@ -207,6 +208,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
     eq_([False], ds.repo.file_has_content(["first.txt"]))
 
 
+@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_newthings_coming_down(originpath, destpath):
@@ -263,6 +265,7 @@ def test_newthings_coming_down(originpath, destpath):
     eq_(ds.repo.get_tags(output='name')[-1], 'second!')
 
 
+@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -343,6 +346,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     ok_clean_git(ds.path)
 
 
+@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_reobtain_data(originpath, destpath):

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import os
@@ -44,7 +43,6 @@ from datalad.tests.utils import slow
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -151,7 +149,6 @@ def test_update_git_smoke(src_path, dst_path):
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_fetch_all(src, remote_1, remote_2):
     rmt1 = AnnexRepo.clone(src, remote_1)
     rmt2 = AnnexRepo.clone(src, remote_2)
@@ -212,7 +209,6 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
@@ -270,7 +266,6 @@ def test_newthings_coming_down(originpath, destpath):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_volatile_subds(originpath, otherpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -350,7 +345,6 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_reobtain_data(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -392,7 +386,6 @@ def test_reobtain_data(originpath, destpath):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  # use of bare repos in the test
 def test_multiway_merge(path):
     # prepare ds with two siblings, but no tracking branch
     ds = Dataset(op.join(path, 'ds_orig')).create()

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -77,7 +77,7 @@ def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     with chpwd(repo_path):
         # create annex repo
-        repo = AnnexRepo(repo_path, create=True, direct=False)
+        repo = AnnexRepo(repo_path, create=True)
 
         # add archive to the repo so we could test
         with swallow_outputs():
@@ -166,13 +166,12 @@ tree4uargs = dict(
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 def test_add_archive_content(path_orig, url, repo_path):
-    direct = False  # TODO: test on undirect, but too long ATM
     with chpwd(repo_path):
         # TODO we need to be able to pass path into add_archive_content
         # We could mock but I mean for the API
         assert_raises(RuntimeError, add_archive_content, "nonexisting.tar.gz") # no repo yet
 
-        repo = AnnexRepo(repo_path, create=True, direct=direct)
+        repo = AnnexRepo(repo_path, create=True)
         assert_raises(ValueError, add_archive_content, "nonexisting.tar.gz")
         # we can't add a file from outside the repo ATM
         assert_raises(FileNotInRepositoryError, add_archive_content, opj(path_orig, '1.tar.gz'))
@@ -305,9 +304,8 @@ def test_add_archive_content(path_orig, url, repo_path):
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
-    direct = False  # TODO: test on undirect, but too long ATM
     with chpwd(repo_path):
-        repo = AnnexRepo(repo_path, create=True, direct=direct)
+        repo = AnnexRepo(repo_path, create=True)
 
         # Let's add first archive to the repo so we could test
         with swallow_outputs():
@@ -338,8 +336,7 @@ def test_add_archive_content_zip(repo_path):
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 def test_add_archive_use_archive_dir(repo_path):
-    direct = False  # TODO: test on undirect, but too long ATM
-    repo = AnnexRepo(repo_path, create=True, direct=direct)
+    repo = AnnexRepo(repo_path, create=True)
     with chpwd(repo_path):
         # Let's add first archive to the repo with default setting
         archive_path = opj('4u', '1.tar.gz')
@@ -378,8 +375,7 @@ class TestAddArchiveOptions():
                delete=False)
     def setup(self, repo_path):
         self.pwd = getpwd()
-        direct = False  # TODO: test on undirect, but too long ATM
-        self.annex = annex = AnnexRepo(repo_path, create=True, direct=direct)
+        self.annex = annex = AnnexRepo(repo_path, create=True)
         # Let's add first archive to the annex so we could test
         annex.add('1.tar')
         annex.commit(msg="added 1.tar")

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -10,7 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from copy import deepcopy
 
@@ -224,7 +223,6 @@ def test_annotate_paths(dspath, nodspath):
 
 @slow  # 11.0891s
 @with_tree(demo_hierarchy['b'])
-@known_failure_direct_mode  #FIXME
 def test_get_modified_subpaths(path):
     ds = Dataset(path).create(force=True)
     suba = ds.create('ba', force=True)
@@ -330,7 +328,6 @@ def test_get_modified_subpaths(path):
 @slow  # 41.5367s
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 from os.path import join as opj
@@ -146,7 +145,6 @@ def test_diff(path, norepo):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')
@@ -203,7 +201,6 @@ def test_diff_recursive(path):
     'modified': 'original_content',
     'untracked': 'dirt',
 })
-@known_failure_direct_mode  #FIXME
 def test_diff_helper(path):
     # make test dataset components of interesting states
     ds = Dataset.create(path, force=True)

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -23,7 +23,6 @@ from datalad.interface.ls_webui import machinesize, ignored, fs_traverse, \
     _ls_json, UNKNOWN_SIZE
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import with_tree
 from datalad.utils import swallow_logs, swallow_outputs, _path_
 # needed below as bound dataset method
@@ -134,7 +133,6 @@ def test_fs_traverse(topdir):
             assert_equal(brokenlink['size']['total'], '3 Bytes')
 
 
-@known_failure_direct_mode  #FIXME
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '123',

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -80,7 +80,6 @@ def test_invalid_call(path):
 @with_tempfile(mkdir=True)
 def test_basics(path, nodspath):
     ds = Dataset(path).create()
-    direct_mode = ds.repo.is_direct_mode()
     last_state = ds.repo.get_hexsha()
     # run inside the dataset
     with chpwd(path), \
@@ -108,14 +107,12 @@ def test_basics(path, nodspath):
         # When in direct mode, check at the level of save rather than add
         # because the annex files show up as typechanges and adding them won't
         # necessarily have a "notneeded" status.
-        assert_result_count(res, 1, action='save' if direct_mode else 'add',
-                            status='notneeded')
+        assert_result_count(res, 1, action='add', status='notneeded')
         eq_(last_state, ds.repo.get_hexsha())
         # We can also run the command via a single-item list because this is
         # what the CLI interface passes in for quoted commands.
         res = ds.run(['touch empty'], message='NOOP_TEST')
-        assert_result_count(res, 1, action='save' if direct_mode else 'add',
-                            status='notneeded')
+        assert_result_count(res, 1, action='add', status='notneeded')
 
     # run outside the dataset, should still work but with limitations
     with chpwd(nodspath), \

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -103,9 +103,6 @@ def test_basics(path, nodspath):
         last_state = ds.repo.get_hexsha()
         # now run a command that will not alter the dataset
         res = ds.run('touch empty', message='NOOP_TEST')
-        # When in direct mode, check at the level of save rather than add
-        # because the annex files show up as typechanges and adding them won't
-        # necessarily have a "notneeded" status.
         assert_result_count(res, 1, action='add', status='notneeded')
         eq_(last_state, ds.repo.get_hexsha())
         # We can also run the command via a single-item list because this is

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os.path as op
 from os.path import join as opj
@@ -184,7 +183,6 @@ def test_sidecar(path):
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun(path, nodspath):
     ds = Dataset(path).create()
     sub = ds.create('sub')
@@ -272,7 +270,6 @@ def test_rerun_empty_branch(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_onto(path):
     ds = Dataset(path).create()
 
@@ -464,7 +461,6 @@ def test_run_failure(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_branch(path):
     ds = Dataset(path).create()
 
@@ -517,7 +513,6 @@ def test_rerun_branch(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()
 
@@ -704,7 +699,6 @@ def test_rerun_script(path):
                                         "d.txt": "d"}},
                         "ss": {"e.dat": "e"}}})
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_run_inputs_outputs(src, path):
     for subds in [("s0", "s1_0", "s2"),
                   ("s0", "s1_1", "s2"),

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in_results
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import on_windows
+from datalad.tests.utils import known_failure_windows
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.api import run_procedure
@@ -41,7 +42,7 @@ def test_invalid_call():
     assert_in_results(res, status="impossible")
 
 
-@skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
+@known_failure_windows  #FIXME
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -41,8 +41,6 @@ def test_invalid_call():
     assert_in_results(res, status="impossible")
 
 
-# FIXME: For some reason fails to commit correctly if on windows and in direct
-# mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
@@ -95,8 +93,6 @@ def test_basics(path, super_path):
     ok_clean_git(super.path, index_modified=[op.join('.datalad', 'config')])
 
 
-# FIXME: For some reason fails to commit correctly if on windows and in direct
-# mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
@@ -192,8 +188,6 @@ def test_procedure_discovery(path, super_path):
                                                'unknwon_broken_link'))
 
 
-# FIXME: For some reason fails to commit correctly if on windows and in direct
-# mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -26,7 +26,6 @@ from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in_results
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import on_windows
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.api import run_procedure
@@ -45,7 +44,6 @@ def test_invalid_call():
 # FIXME: For some reason fails to commit correctly if on windows and in direct
 # mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
-@known_failure_direct_mode  #FIXME
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os
 from os.path import pardir
@@ -46,7 +45,6 @@ from datalad.tests.utils import known_failure_windows
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
-@known_failure_direct_mode  #FIXME
 def test_save(path):
 
     ds = Dataset(path)
@@ -118,7 +116,6 @@ def test_save(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_recursive_save(path):
     ds = Dataset(path).create()
     # nothing to save
@@ -296,7 +293,6 @@ def test_renamed_file():
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_subdataset_save(path):
     parent = Dataset(path).create()
     sub = parent.create('sub')
@@ -372,7 +368,6 @@ def test_symlinked_relpath(path):
 
 
 # two subdatasets not possible in direct mode
-@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_bf1886(path):
     parent = Dataset(path).create()

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -367,7 +367,6 @@ def test_symlinked_relpath(path):
     ok_clean_git(dspath)
 
 
-# two subdatasets not possible in direct mode
 @with_tempfile(mkdir=True)
 def test_bf1886(path):
     parent = Dataset(path).create()

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -77,12 +77,6 @@ def test_unlock(path):
     # TODO: use get_annexed_files instead of hardcoded filename
     assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
-    # in direct mode there is no unlock:
-    if ds.repo.is_direct_mode():
-        res = ds.unlock()
-        assert_result_count(res, 1)
-        assert_status('notneeded', res)
-
     # in V6+ we can unlock even if the file's content isn't present:
     elif ds.repo.supports_unlocked_pointers:
         res = ds.unlock()
@@ -98,10 +92,7 @@ def test_unlock(path):
     ds.repo.get('test-annex.dat')
     result = ds.unlock()
     assert_result_count(result, 1)
-    if ds.repo.is_direct_mode():
-        assert_status('notneeded', result)
-    else:
-        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
+    assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
 
     with open(opj(path, 'test-annex.dat'), "w") as f:
         f.write("change content")
@@ -114,9 +105,8 @@ def test_unlock(path):
         ds.repo._git_custom_command('test-annex.dat', ['git', 'annex', 'lock'])
     ds.repo.commit("edit 'test-annex.dat' via unlock and lock it again")
 
-    if not ds.repo.is_direct_mode():
-        # after commit, file is locked again:
-        assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
+    # after commit, file is locked again:
+    assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
     # content was changed:
     with open(opj(path, 'test-annex.dat'), "r") as f:
@@ -126,10 +116,7 @@ def test_unlock(path):
     result = ds.unlock(path='test-annex.dat')
     assert_result_count(result, 1)
 
-    if ds.repo.is_direct_mode():
-        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='notneeded')
-    else:
-        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
+    assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
 
     with open(opj(path, 'test-annex.dat'), "w") as f:
         f.write("change content again")
@@ -148,9 +135,8 @@ def test_unlock(path):
     # and locked it again?
     # Also: After opening the file is empty.
 
-    if not ds.repo.is_direct_mode():
-        # after commit, file is locked again:
-        assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
+    # after commit, file is locked again:
+    assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
     # content was changed:
     with open(opj(path, 'test-annex.dat'), "r") as f:

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -78,7 +78,7 @@ def test_unlock(path):
     assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
     # in V6+ we can unlock even if the file's content isn't present:
-    elif ds.repo.supports_unlocked_pointers:
+    if ds.repo.supports_unlocked_pointers:
         res = ds.unlock()
         assert_result_count(res, 1)
         assert_status('ok', res)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -10,7 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os
 import logging
@@ -138,7 +137,6 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 
 @slow  # 74.4509s
 @with_tree(demo_hierarchy)
-@known_failure_direct_mode  #FIXME
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -119,15 +119,6 @@ class Unlock(Interface):
                     yield ap
                 continue
 
-            # direct mode, no unlock:
-            elif ds.repo.is_direct_mode():
-                for ap in content:
-                    ap['status'] = 'notneeded'
-                    ap['message'] = "direct mode, nothing to unlock"
-                    ap.update(res_kwargs)
-                    yield ap
-                continue
-
             # only files in annex with their content present:
             files = [ap['path'] for ap in content]
             to_unlock = []

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -14,7 +14,6 @@ from datalad.api import Dataset
 from datalad.utils import on_osx
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import known_failure_direct_mode
 
 from nose import SkipTest
 from nose.tools import assert_equal

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -26,7 +26,6 @@ from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import skip_if_on_windows
 
 
@@ -56,7 +55,6 @@ _dataset_hierarchy_template = {
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_basic_aggregate(path):
     # TODO give datasets some more metadata to actually aggregate stuff
     base = Dataset(opj(path, 'origin')).create(force=True)
@@ -146,7 +144,6 @@ def test_aggregate_query(path):
 
 # this is for gh-1971
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_reaggregate_with_unavailable_objects(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -181,7 +178,6 @@ def test_reaggregate_with_unavailable_objects(path):
 
 @with_tree(tree=_dataset_hierarchy_template)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_aggregate_with_unavailable_objects_from_subds(path, target):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -217,7 +213,6 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_publish_aggregated(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -264,7 +259,6 @@ def _get_referenced_objs(ds):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_aggregate_removal(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -300,7 +294,6 @@ def test_aggregate_removal(path):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_update_strategy(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -356,7 +349,6 @@ def test_update_strategy(path):
 
 
 # needs two subdatasets, no possible in direct mode
-@known_failure_direct_mode  #FIXME
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -348,7 +348,6 @@ def test_update_strategy(path):
     eq_(target_meta, base.metadata(return_type='list'))
 
 
-# needs two subdatasets, no possible in direct mode
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -238,10 +238,8 @@ def test_bf2458(src, dst):
 
     # no clone (empty) into new dst
     clone = install(source=ds.path, path=dst)
-    # XXX whereis says nothing in direct mode
     # content is not here
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
     # check that plain metadata access does not `get` stuff
     clone.metadata('.', on_failure='ignore')
-    # XXX whereis says nothing in direct mode
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -32,7 +32,6 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_direct_mode
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_
 from datalad.tests.utils import swallow_logs
@@ -94,7 +93,6 @@ def _compare_metadata_helper(origres, compds):
                 eq_(ores[i], cres[i])
 
 
-@known_failure_direct_mode  #FIXME
 @slow  # ~16s
 @with_tree(tree=_dataset_hierarchy_template)
 def test_aggregation(path):

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -31,7 +31,6 @@ from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import skip_direct_mode
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_
 from datalad.tests.utils import swallow_logs

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -195,10 +195,6 @@ def test_within_ds_file_search(path):
             opj(dirname(dirname(__file__)), 'tests', 'data', src),
             opj(path, dst))
     ds.add('.')
-    # yoh: CANNOT FIGURE IT OUT since in direct mode it gets added to git
-    # directly BUT
-    #  - output reports key, so seems to be added to annex!
-    #  - when I do manually in cmdline - goes to annex
     ok_file_under_git(path, opj('stim', 'stim1.mp3'), annexed=True)
     # If it is not under annex, below addition of metadata silently does
     # not do anything

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -21,7 +21,6 @@ from datalad.utils import swallow_outputs
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_is_generator
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_testsui
 from datalad.tests.utils import ok_clean_git

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -87,12 +87,6 @@ def test_archive(path):
     check_contents(custom_outname, 'myexport')
 
     # now loose some content
-    if ds.repo.is_direct_mode():
-        # in direct mode the add() aove commited directly to the annex/direct/master
-        # branch, hence drop will have no effect (notneeded)
-        # this might be undesired behavior (or not), but this is not the place to test
-        # for it
-        return
     ds.drop('file_up', check=False)
     assert_raises(IOError, ds.export_archive, filename=opj(path, 'my'))
     ds.export_archive(filename=opj(path, 'partial'), missing_content='ignore')

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -10,7 +10,6 @@
 """Test plugin interface mechanics"""
 
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from os.path import join as opj
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -87,6 +87,7 @@ from .exceptions import IncompleteResultsError
 from .exceptions import AccessDeniedError
 from .exceptions import AccessFailedError
 from .exceptions import InvalidAnnexRepositoryError
+from .exceptions import DirectModeNoLongerSupportedError
 
 lgr = logging.getLogger('datalad.annex')
 
@@ -261,12 +262,14 @@ class AnnexRepo(GitRepo, RepoInterface):
         # Could happen in case we didn't specify anything, but annex forced
         # direct mode due to FS or an already existing repo was in direct mode,
         if self._is_direct_mode_from_config():
-            self._fail_direct_mode(
+            raise DirectModeNoLongerSupportedError(
+                self,
                 "Git configuration reports repository being in direct mode"
             )
 
         if self.config.getbool("datalad", "repo.direct", default=False):
-            self._fail_direct_mode(
+            raise DirectModeNoLongerSupportedError(
+                self,
                 "datalad.repo.direct configuration instructs to use direct mode"
             )
 
@@ -282,14 +285,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         if self._ALLOW_LOCAL_URLS:
             self._allow_local_urls()
 
-    def _fail_direct_mode(self, msg=None):
-        raise RuntimeError(
-            ("direct mode of operation is no longer supported.  "
-            "Please use 'git annex upgrade' under %s to upgrade your direct "
-            "mode repository to annex v6 (or later) which should provide a "
-            "better operation on your system." % self.path) +
-            msg if msg else ''
-        )
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
 
@@ -1056,7 +1051,11 @@ class AnnexRepo(GitRepo, RepoInterface):
     #       migration to v6+ mode and testing. For now is made protected to
     #       avoid use by users
     def _set_direct_mode(self, enable_direct_mode=True):
-        """Switch to direct or indirect mode (to be used only internally)
+        """Switch to direct or indirect mode
+
+        WARNING!  To be used only for internal development purposes.
+                  We no longer support direct mode and thus setting it in a
+                  repository would render it unusable for DataLad
 
         Parameters
         ----------

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -266,6 +266,21 @@ class InvalidAnnexRepositoryError(RuntimeError):
     without init=True"""
 
 
+class DirectModeNoLongerSupportedError(NotImplementedError):
+    """direct mode is no longer supported"""
+
+    def __init__(self, repo, msg=None):
+        super(DirectModeNoLongerSupportedError, self).__init__(
+            ((" " + msg + ", but ") if msg else '')
+            +
+             "direct mode of operation is being deprecated in git-annex and "
+             "no longer supported by DataLad. "
+             "Please use 'git annex upgrade' under %s to upgrade your direct "
+             "mode repository to annex v6 (or later)." % repo.path
+            )
+        self.repo = repo  # might come handy
+
+
 class IncompleteResultsError(RuntimeError):
     """Exception to be raised whenever results are incomplete.
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -198,50 +198,6 @@ def test_AnnexRepo_is_direct_mode_gitrepo(path):
 
 
 @assert_cwd_unchanged
-@with_testrepos('.*annex.*')
-@with_tempfile
-def test_AnnexRepo_set_direct_mode(src, dst):
-
-    ar = AnnexRepo.clone(src, dst)
-
-    if ar.supports_unlocked_pointers:
-        # there's no direct mode available:
-        assert_raises(CommandError, ar.set_direct_mode, True)
-        raise SkipTest("Test not applicable in repository version >= 6")
-
-    ar.set_direct_mode(True)
-    ok_(ar.is_direct_mode(), "Switching to direct mode failed.")
-    if ar.is_crippled_fs():
-        assert_raises(CommandNotAvailableError, ar.set_direct_mode, False)
-        ok_(
-            ar.is_direct_mode(),
-            "Indirect mode on crippled fs detected. Shouldn't be possible.")
-    else:
-        ar.set_direct_mode(False)
-        assert_false(ar.is_direct_mode(), "Switching to indirect mode failed.")
-
-
-@assert_cwd_unchanged
-@with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
-@with_tempfile
-def test_AnnexRepo_annex_proxy(src, annex_path):
-    ar = AnnexRepo.clone(src, annex_path)
-    if ar.supports_unlocked_pointers:
-        # there's no direct mode available and therefore no 'annex proxy':
-        assert_raises(CommandError, ar.proxy, ['git', 'status'])
-        raise SkipTest("Test not applicable in repository version >= 6")
-    ar.set_direct_mode(True)
-
-    # annex proxy raises in indirect mode:
-    try:
-        ar.set_direct_mode(False)
-        assert_raises(CommandNotAvailableError, ar.proxy, ['git', 'status'])
-    except CommandNotAvailableError:
-        # we can't switch to indirect
-        pass
-
-
-@assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
 def test_AnnexRepo_get_file_key(src, annex_path):
@@ -596,18 +552,13 @@ def test_AnnexRepo_migrating_backends(src, dst):
     # migrating will only do, if file is present
     ok_annex_get(ar, 'test-annex.dat')
 
-    if ar.is_direct_mode():
-        # No migration in direct mode
-        assert_raises(CommandNotAvailableError, ar.migrate_backend,
-                      'test-annex.dat')
-    else:
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
-        ar.migrate_backend('test-annex.dat')
-        eq_(ar.get_file_backend('test-annex.dat'), 'MD5')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+    ar.migrate_backend('test-annex.dat')
+    eq_(ar.get_file_backend('test-annex.dat'), 'MD5')
 
-        ar.migrate_backend('', backend='SHA1')
-        eq_(ar.get_file_backend(filename), 'SHA1')
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
+    ar.migrate_backend('', backend='SHA1')
+    eq_(ar.get_file_backend(filename), 'SHA1')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
 
 
 tree1args = dict(
@@ -691,14 +642,10 @@ def test_AnnexRepo_get_file_backend(src, dst):
     ar = AnnexRepo.clone(src, dst)
 
     eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
-    if not ar.is_direct_mode():
-        # no migration in direct mode
-        ok_annex_get(ar, 'test-annex.dat', network=False)
-        ar.migrate_backend('test-annex.dat', backend='SHA1')
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
-    else:
-        assert_raises(CommandNotAvailableError, ar.migrate_backend,
-                      'test-annex.dat', backend='SHA1')
+    # no migration
+    ok_annex_get(ar, 'test-annex.dat', network=False)
+    ar.migrate_backend('test-annex.dat', backend='SHA1')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
 
 
 @with_tempfile
@@ -828,12 +775,8 @@ def test_AnnexRepo_add_to_annex(path):
 
     out_json = repo.add(filename)
     # file is known to annex:
-    if not repo.is_direct_mode():
-        assert_true(os.path.islink(filename_abs),
-                    "Annexed file is not a link.")
-    else:
-        assert_false(os.path.islink(filename_abs),
-                     "Annexed file is link in direct mode.")
+    assert_true(os.path.islink(filename_abs),
+                "Annexed file is not a link.")
     assert_in('key', out_json)
     key = repo.get_file_key(filename)
     assert_false(key == '')
@@ -841,11 +784,7 @@ def test_AnnexRepo_add_to_annex(path):
     ok_(repo.file_has_content(filename))
 
     # uncommitted:
-    # but not in direct mode branch
-    if repo.is_direct_mode():
-        ok_(not repo.is_dirty(submodules=False))
-    else:
-        ok_(repo.is_dirty(submodules=False))
+    ok_(repo.is_dirty(submodules=False))
 
     repo.commit("Added file to annex.")
     ok_clean_git(repo, annex=True, ignore_submodules=True)
@@ -900,30 +839,6 @@ def test_AnnexRepo_add_to_git(path):
 
     # and committed:
     ok_clean_git(repo, annex=True, ignore_submodules=True)
-
-
-@with_testrepos('submodule_annex', flavors=['clone'])
-def test_AnnexRepo_add_unexpected_direct_mode(path):
-    # tests a special case where a submodule is in direct mode, while it's
-    # superproject is not.
-    # There is no point in this test, if direct mode was enforced in the
-    # superproject already (either by test run configuration or FS) or if the
-    # repositories are in V6+ by default (where there is no direct mode)
-
-    top = AnnexRepo(path)
-
-    if top.is_direct_mode() or top.supports_unlocked_pointers:
-        raise SkipTest("Nothing to test for")
-
-    top.update_submodule('subm 1', init=True)
-    sub = AnnexRepo(opj(path, 'subm 1'))
-    sub.set_direct_mode(True)
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        top.add('.')
-        cml.assert_logged(msg="Known bug in direct mode.",
-                          level="WARNING",
-                          regex=False)
-
 
 
 @ignore_nose_capturing_stdout
@@ -1047,11 +962,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     eq_(info['size'], 14)
     assert(info['key'])
     # not even added to index yet since we this repo is with default batch_size
-    # but: in direct mode it is added!
-    if ar.is_direct_mode():
-        assert_in(ar.WEB_UUID, ar.whereis(testfile))
-    else:
-        assert_not_in(ar.WEB_UUID, ar.whereis(testfile))
+    assert_not_in(ar.WEB_UUID, ar.whereis(testfile))
 
     # TODO: none of the below should re-initiate the batch process
 
@@ -1097,9 +1008,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     assert_in(filename, ar2.get_files())
     assert_in(ar.WEB_UUID, ar2.whereis(filename))
 
-    if not ar.is_direct_mode():
-        # in direct mode there's nothing to commit
-        ar.commit("actually committing new files")
+    ar.commit("actually committing new files")
     assert_in(filename, ar.get_files())
     assert_in(ar.WEB_UUID, ar.whereis(filename))
     # this poor bugger still wasn't added since we used default batch_size=0 on him
@@ -1247,37 +1156,36 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ok_(exists(socket_2))
     ssh_manager.close(ctrl_path=[socket_1, socket_2])
 
+
 @with_testrepos('basic_annex', flavors=['clone'])
 @with_tempfile(mkdir=True)
 def test_annex_remove(path1, path2):
-    ar1 = AnnexRepo(path1, create=False)
-    ar2 = AnnexRepo.clone(path1, path2, create=True, direct=True)
+    repo = AnnexRepo(path1, create=False)
 
-    for repo in (ar1, ar2):
-        file_list = repo.get_annexed_files()
-        assert len(file_list) >= 1
-        # remove a single file
-        out = repo.remove(file_list[0])
-        assert_not_in(file_list[0], repo.get_annexed_files())
-        eq_(out[0], file_list[0])
+    file_list = repo.get_annexed_files()
+    assert len(file_list) >= 1
+    # remove a single file
+    out = repo.remove(file_list[0])
+    assert_not_in(file_list[0], repo.get_annexed_files())
+    eq_(out[0], file_list[0])
 
-        with open(opj(repo.path, "rm-test.dat"), "w") as f:
-            f.write("whatever")
+    with open(opj(repo.path, "rm-test.dat"), "w") as f:
+        f.write("whatever")
 
-        # add it
-        repo.add("rm-test.dat")
+    # add it
+    repo.add("rm-test.dat")
 
-        # remove without '--force' should fail, due to staged changes:
-        if repo.is_direct_mode():
-            assert_raises(CommandError, repo.remove, "rm-test.dat")
-        else:
-            assert_raises(GitCommandError, repo.remove, "rm-test.dat")
-        assert_in("rm-test.dat", repo.get_annexed_files())
+    # remove without '--force' should fail, due to staged changes:
+    if repo.is_direct_mode():
+        assert_raises(CommandError, repo.remove, "rm-test.dat")
+    else:
+        assert_raises(GitCommandError, repo.remove, "rm-test.dat")
+    assert_in("rm-test.dat", repo.get_annexed_files())
 
-        # now force:
-        out = repo.remove("rm-test.dat", force=True)
-        assert_not_in("rm-test.dat", repo.get_annexed_files())
-        eq_(out[0], "rm-test.dat")
+    # now force:
+    out = repo.remove("rm-test.dat", force=True)
+    assert_not_in("rm-test.dat", repo.get_annexed_files())
+    eq_(out[0], "rm-test.dat")
 
 
 @with_tempfile
@@ -1825,11 +1733,9 @@ def test_AnnexRepo_dirty(path):
     ok_(repo.dirty)
     # annexed file
     repo.add('file2.txt', git=False)
-    if not repo.is_direct_mode():
-        # in direct mode 'annex add' results in a clean repo
-        ok_(repo.dirty)
-        # commit
-        repo.commit("file2.txt annexed")
+    ok_(repo.dirty)
+    # commit
+    repo.commit("file2.txt annexed")
     ok_(not repo.dirty)
 
     # TODO: unlock/modify
@@ -1899,9 +1805,7 @@ def _test_status(ar):
     ar.add('second')
     sync_wrapper()
     stat['untracked'].remove('second')
-    if not ar.is_direct_mode():
-        # in direct mode annex-status doesn't report an added file 'added'
-        stat['added'].append('second')
+    stat['added'].append('second')
     eq_(stat, ar.get_status())
 
     # commit to be clean again:
@@ -1941,18 +1845,16 @@ def _test_status(ar):
     eq_(stat, ar.get_status())
 
     # modify an annexed file:
-    if not ar.is_direct_mode():
-        # actually: if 'second' isn't locked, which is the case in direct mode
-        ar.unlock('second')
-        if not ar.get_active_branch().endswith('(unlocked)'):
-            stat['type_changed'].append('second')
-        eq_(stat, ar.get_status())
+    ar.unlock('second')
+    if not ar.get_active_branch().endswith('(unlocked)'):
+        stat['type_changed'].append('second')
+    eq_(stat, ar.get_status())
+
     with open(opj(ar.path, 'second'), 'w') as f:
         f.write("Needed to unlock first. Sad!")
-    if not ar.is_direct_mode():
-        ar.add('second')  # => modified
-        if not ar.get_active_branch().endswith('(unlocked)'):
-            stat['type_changed'].remove('second')
+    ar.add('second')  # => modified
+    if not ar.get_active_branch().endswith('(unlocked)'):
+        stat['type_changed'].remove('second')
     stat['modified'].append('second')
     sync_wrapper()
     eq_(stat, ar.get_status())
@@ -2034,15 +1936,6 @@ def _test_status(ar):
     eq_(stat, ar.get_status(submodules=False))
 
     # commit the submodule
-    # in direct mode, commit of a removed submodule fails with:
-    #  error: unable to index file submod
-    #  fatal: updating files failed
-    #
-    # - this happens, when commit is called with -c core.bare=False
-    # - it works when called via annex proxy
-    # - if we add a submodule instead of removing one, it's vice versa with
-    #   the very same error message
-
     ar.commit(msg="submodule added", files=['.gitmodules', 'submod'])
 
     stat['added'].remove('.gitmodules')
@@ -2308,9 +2201,7 @@ def test_AnnexRepo_get_corresponding_branch(path):
 
     ar = AnnexRepo(path)
 
-    # we should be on master or a corresponding branch like annex/direct/master
-    # respectively if ran in direct mode build.
-    # We want to get 'master' in any case
+    # we should be on master.
     eq_('master', ar.get_corresponding_branch())
 
     # special case v6 adjusted branch is not provided by a dedicated build:
@@ -2327,8 +2218,7 @@ def test_AnnexRepo_get_tracking_branch(path):
 
     ar = AnnexRepo(path)
 
-    # we want the relation to original branch, especially in direct mode
-    # or even in v6 adjusted branch
+    # we want the relation to original branch, e.g. in v6+ adjusted branch
     eq_(('origin', 'refs/heads/master'), ar.get_tracking_branch())
 
 
@@ -2337,13 +2227,11 @@ def test_AnnexRepo_is_managed_branch(path):
 
     ar = AnnexRepo(path)
 
-    if ar.is_direct_mode():
-        ok_(ar.is_managed_branch())
-    else:
-        # ATM only direct mode and v6+ adjusted branches should return True.
-        # Adjusted branch requires a call of git-annex-adjust and shouldn't
-        # be the state of a fresh clone
-        ok_(not ar.is_managed_branch())
+    # ATM only v6+ adjusted branches should return True.
+    # Adjusted branch requires a call of git-annex-adjust and shouldn't
+    # be the state of a fresh clone
+    ok_(not ar.is_managed_branch())
+
     if ar.supports_unlocked_pointers:
         ar.adjust()
         ok_(ar.is_managed_branch())
@@ -2487,8 +2375,7 @@ def check_commit_annex_commit_changed(unlock, path):
         , untracked=['untracked']
     )
     ok_file_under_git(path, 'tobechanged-git', annexed=False)
-    # TODO: direct mode gotcha!!!
-    ok_file_under_git(path, 'tobechanged-annex', annexed=not ar.is_direct_mode())
+    ok_file_under_git(path, 'tobechanged-annex', annexed=True)
 
 
 def test_commit_annex_commit_changed():

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1822,14 +1822,7 @@ def _test_status(ar):
 
     ar.add('fifth')
     sync_wrapper()
-    # TODO:
-    # Note: For some reason this seems to be the only place, where we actually
-    # need to call commit via annex-proxy. If called via '-c core.bare=False'
-    # and/or '--work-tree=.' the file ends up in git instead of annex.
-    # Note 2: This is only if we explicitly pass a path. Otherwise it works
-    # without annex-proxy.
-    ar.commit(msg="fifth to be unannexed", files='fifth',
-              proxy=ar.is_direct_mode())
+    ar.commit(msg="fifth to be unannexed", files='fifth')
     eq_(stat, ar.get_status())
 
     ar.unannex('fifth')
@@ -2015,9 +2008,6 @@ def _test_status(ar):
     stat['modified'].append('.gitmodules')
     eq_(stat, ar.get_status())
 
-    # Note: Here again we need to use annex-proxy; This contradicts the addition
-    # of the very same submodule, which we needed to commit via
-    # -c core.bare=False instead. Otherwise the very same failure happens.
     # Just vice versa. See above where 'submod' is added.
     ar.commit("submod removed", files=['submod', '.gitmodules'])
     stat['modified'].remove('.gitmodules')

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -54,7 +54,7 @@ from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import create_tree
-from datalad.tests.utils import with_batch_direct
+from datalad.tests.utils import with_parametric_batch
 from datalad.tests.utils import assert_dict_equal as deq_
 from datalad.tests.utils import assert_is_instance
 from datalad.tests.utils import assert_false
@@ -310,11 +310,11 @@ def test_AnnexRepo_get_remote_na(path):
 
 
 # 1 is enough to test file_has_content
-@with_batch_direct
+@with_parametric_batch
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
-def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
-    ar = AnnexRepo.clone(src, annex_path, direct=direct)
+def test_AnnexRepo_file_has_content(batch, src, annex_path):
+    ar = AnnexRepo.clone(src, annex_path)
     testfiles = ["test-annex.dat", "test.dat"]
 
     eq_(ar.file_has_content(testfiles), [False, False])
@@ -329,22 +329,21 @@ def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     assert_false(ar.file_has_content("bogus.txt", batch=batch))
     ok_(ar.file_has_content("test-annex.dat", batch=batch))
 
-    if not direct:  # There's no unlock in direct mode.
-        ar.unlock(["test-annex.dat"])
-        eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
-            [ar.supports_unlocked_pointers])
-        with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
-            ofh.write("more")
-        eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
-            [False])
+    ar.unlock(["test-annex.dat"])
+    eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
+        [ar.supports_unlocked_pointers])
+    with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
+        ofh.write("more")
+    eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
+        [False])
 
 
 # 1 is enough to test
-@with_batch_direct
+@with_parametric_batch
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
-def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
-    ar = AnnexRepo.clone(src, annex_path, direct=direct)
+def test_AnnexRepo_is_under_annex(batch, src, annex_path):
+    ar = AnnexRepo.clone(src, annex_path)
 
     with open(opj(annex_path, 'not-committed.txt'), 'w') as f:
         f.write("aaa")
@@ -365,14 +364,13 @@ def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
     assert_false(ar.is_under_annex("bogus.txt", batch=batch))
     ok_(ar.is_under_annex("test-annex.dat", batch=batch))
 
-    if not direct:  # There's no unlock in direct mode.
-        ar.unlock(["test-annex.dat"])
-        eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
-            [ar.supports_unlocked_pointers])
-        with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
-            ofh.write("more")
-        eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
-            [False])
+    ar.unlock(["test-annex.dat"])
+    eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
+        [ar.supports_unlocked_pointers])
+    with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
+        ofh.write("more")
+    eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
+        [False])
 
 
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
@@ -639,11 +637,11 @@ def __test_get_md5s(path):
     print({f: annex.get_file_key(f) for f in files})
 
 
-@with_batch_direct
+@with_parametric_batch
 @with_tree(**tree1args)
-def test_dropkey(batch, direct, path):
+def test_dropkey(batch, path):
     kw = {'batch': batch}
-    annex = AnnexRepo(path, init=True, backend='MD5E', direct=direct)
+    annex = AnnexRepo(path, init=True, backend='MD5E')
     files = list(tree1_md5e_keys)
     annex.add(files)
     annex.commit()
@@ -1477,9 +1475,9 @@ def test_annex_remove(path):
     eq_(out[0], "rm-test.dat")
 
 
-@with_batch_direct
+@with_parametric_batch
 @with_testrepos('basic_annex', flavors=['clone'], count=1)
-def test_is_available(batch, direct, p):
+def test_is_available(batch, p):
     annex = AnnexRepo(p)
 
     # bkw = {'batch': batch}

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -70,7 +70,7 @@ def test_direct_cfg(path1, path2):
     # check if we somehow didn't reset the flag
     assert not ar.is_direct_mode()
 
-    if ar.config.get("datalad.repo.version", 5) >= 6:
+    if ar.config.obtain("datalad.repo.version") >= 6:
         raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
     # and if repo existed before and was in direct mode, we fail too
     # Since direct= option was deprecated entirely, we use protected method now

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -81,6 +81,9 @@ def test_direct_cfg(path1, path2):
         with assert_raises(DirectModeNoLongerSupportedError) as cme:
             AnnexRepo(path1, create=False)
 
+
+    # TODO: RM DIRECT decide what should we here -- should we test/blow?
+    #   ATM both tests below just pass
     ar2 = AnnexRepo(path2, create=True)
     # happily can do it since it doesn't need a worktree to do the clone
     ar2.add_submodule('sub1', url=path1)
@@ -89,7 +92,13 @@ def test_direct_cfg(path1, path2):
     assert not ar2sub1.is_direct_mode()
     ar2sub1._set_direct_mode(True)
     assert ar2sub1.is_direct_mode()
+    del ar2; del ar2sub1; AnnexRepo._unique_instances.clear()  # fight flyweight
+
+    ar2 = AnnexRepo(path2)
     ar2.get_submodules()
 
-    # TODO: RM DIRECT decide what should we here -- should we test/blow?
-    #   ATM just passes
+    # And what if we are trying to add pre-cloned repo in direct mode?
+    ar2sub2 = AnnexRepo.clone(path1, op.join(path2, 'sub2'))
+    ar2sub2._set_direct_mode(True)
+    del ar2sub2; AnnexRepo._unique_instances.clear()  # fight flyweight
+    ar2.add('sub2')

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -26,80 +26,70 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import swallow_logs
 from datalad.distribution.dataset import Dataset
 
+from ..support.exceptions import DirectModeNoLongerSupportedError
+from ..support import path as op
+
 from .utils import with_tempfile
 from .utils import skip_if_no_network
 from .utils import with_testrepos
 from .utils import on_windows
 from .utils import SkipTest
+from .utils import assert_raises
+from .utils import assert_in
+from .utils import eq_
 
 
-if on_windows:
-    raise SkipTest("Can't test direct mode switch, "
-                   "if direct mode is forced by OS anyway.")
-
-repo_version = cfg.get("datalad.repo.version", None)
-if repo_version and int(repo_version) >= 6:
-    raise SkipTest("Can't test direct mode switch, "
-                   "if repository version 6 or later is enforced.")
+# if on_windows:
+#     raise SkipTest("Can't test direct mode switch, "
+#                    "if direct mode is forced by OS anyway.")
+#
+# repo_version = cfg.get("datalad.repo.version", None)
+# if repo_version and int(repo_version) >= 6:
+#     raise SkipTest("Can't test direct mode switch, "
+#                    "if repository version 6 or later is enforced.")
 
 
 @with_tempfile
 @with_tempfile
-@with_tempfile
-@with_tempfile
-def test_direct_cfg(path1, path2, path3, path4):
+def test_direct_cfg(path1, path2):
+    # and if repo already exists and we have env var - we fail too
+    # Adding backend so we get some commit into the repo
+    ar = AnnexRepo(path1, create=True, backend='MD5E')
+    del ar;  AnnexRepo._unique_instances.clear()  # fight flyweight
+    for path in (path1, path2):
+        with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
+            # try to create annex repo in direct mode as see how it fails
+            with assert_raises(DirectModeNoLongerSupportedError) as cme:
+                AnnexRepo(path, create=True)
+            assert_in("no longer supported by DataLad", str(cme.exception)) # we have generic part
+            assert_in("datalad.repo.direct configuration", str(cme.exception)) # situation specific part
+    # assert not op.exists(path2)   # that we didn't create it - we do!
+    #   fixing for that would be too cumbersome since we first call GitRepo.__init__
+    #   with create
+    ar = AnnexRepo(path1)
+    # check if we somehow didn't reset the flag
+    assert not ar.is_direct_mode()
+
+    if ar.config.get("datalad.repo.version", 5) >= 6:
+        raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
+    # and if repo existed before and was in direct mode, we fail too
+    # Since direct= option was deprecated entirely, we use protected method now
+    ar._set_direct_mode(True)
+    assert ar.is_direct_mode()
+    del ar  # but we would need to disable somehow the flywheel
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
-        # create annex repo in direct mode:
-        with swallow_logs(new_level=logging.DEBUG) as cml:
-            ar = AnnexRepo(path1, create=True)
-            cml.assert_logged("Switching to direct mode",
-                              regex=False, level='DEBUG')
-            ok_(ar.is_direct_mode())
+        with assert_raises(DirectModeNoLongerSupportedError) as cme:
+            AnnexRepo(path1, create=False)
 
-        # but don't if repo version is 6 (actually, 6 or above):
-        with swallow_logs(new_level=logging.WARNING) as cml:
-            ar = AnnexRepo(path2, create=True, version=6)
-            ok_(not ar.is_direct_mode())
-            cml.assert_logged("direct mode not available", regex=False,
-                              level='WARNING')
+    ar2 = AnnexRepo(path2, create=True)
+    # happily can do it since it doesn't need a worktree to do the clone
+    ar2.add_submodule('sub1', url=path1)
+    ar2sub1 = AnnexRepo(op.join(path2, 'sub1'))
+    # but now let's convert that sub1 to direct mode
+    assert not ar2sub1.is_direct_mode()
+    ar2sub1._set_direct_mode(True)
+    assert ar2sub1.is_direct_mode()
+    ar2.get_submodules()
 
-        # explicit parameter `direct` has priority:
-        ar = AnnexRepo(path3, create=True, direct=False)
-        if not ar.is_crippled_fs():  # otherwise forced direct mode
-            ok_(not ar.is_direct_mode())
-
-        # don't touch existing repo:
-        ar = AnnexRepo(path2, create=True)
-        if not ar.is_crippled_fs():  # otherwise forced direct mode
-            ok_(not ar.is_direct_mode())
-
-    # make sure, value is relevant:
-    with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': '0'}):
-        # don't use direct mode
-        ar = AnnexRepo(path4, create=True)
-        if not ar.is_crippled_fs():  # otherwise forced direct mode
-            ok_(not ar.is_direct_mode())
-
-
-@with_tempfile
-def test_direct_create(path):
-    with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
-        ds = Dataset(path).create()
-        if not ds.repo.is_crippled_fs():  # otherwise forced direct mode
-            ok_(ds.repo.is_direct_mode())
-
-
-# Note/TODO: Currently flavor 'network' only, since creation of local testrepos
-# fails otherwise ATM. (git submodule add without needed git options to work in
-# direct mode)
-@skip_if_no_network
-@with_testrepos('basic_annex', flavors=['network'])
-@with_tempfile
-def test_direct_install(url, path):
-
-    with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
-        ds = datalad.api.install(
-            path=path, source=url,
-            result_xfm='datasets', return_type='item-or-list')
-        if not ds.repo.is_crippled_fs():  # otherwise forced direct mode
-            ok_(ds.repo.is_direct_mode(), "Not in direct mode: %s" % ds)
+    # TODO: RM DIRECT decide what should we here -- should we test/blow?
+    #   ATM just passes

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -7,7 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import git
 import os
@@ -56,7 +55,6 @@ def test_clone(src, tempdir):
 
 @usecase
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_make_studyforrest_mockup(path):
     # smoke test
     make_studyforrest_mockup(path)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -91,7 +91,7 @@ from .utils import ok_startswith
 from .utils import skip_if_no_module
 from .utils import (
     probe_known_failure, skip_known_failure, known_failure, known_failure_v6,
-    known_failure_direct_mode, skip_if
+    skip_if
 )
 
 
@@ -960,34 +960,6 @@ def test_known_failure_v6():
     probe = cfg.obtain("datalad.tests.knownfailures.probe")
 
     if v6:
-        if skip:
-            # skipping takes precedence over probing
-            failing()
-        elif probe:
-            # if we probe a known failure it's okay to fail:
-            failing()
-        else:
-            # not skipping and not probing results in the original failure:
-            assert_raises(AssertionError, failing)
-
-    else:
-        # behaves as if it wasn't decorated at all, no matter what
-        assert_raises(AssertionError, failing)
-
-
-def test_known_failure_direct_mode():
-
-    @known_failure_direct_mode
-    def failing():
-        raise AssertionError("Failed")
-
-    from datalad import cfg
-
-    direct = cfg.obtain("datalad.repo.direct")
-    skip = cfg.obtain("datalad.tests.knownfailures.skip")
-    probe = cfg.obtain("datalad.tests.knownfailures.probe")
-
-    if direct:
         if skip:
             # skipping takes precedence over probing
             failing()

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -978,6 +978,22 @@ def test_known_failure_v6():
 from datalad.utils import read_csv_lines
 
 
+def test_known_failure_direct_mode():
+    # Decorator is deprecated now and that is what we check
+    from .utils import known_failure_direct_mode
+
+    x = []
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        @known_failure_direct_mode
+        def failing():
+            x.append('ok')
+            raise AssertionError("Failed")
+
+        assert_raises(AssertionError, failing)  # nothing is swallowed
+        eq_(x, ['ok'])  # everything runs
+        assert_in("Direct mode support is deprecated", cml.out)
+
+
 @with_tempfile(content="h1 h2\nv1 2\nv2 3")
 def test_read_csv_lines_basic(infile):
     # Just a basic test, next one with unicode

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -21,6 +21,7 @@ import multiprocessing
 import logging
 import random
 import socket
+import warnings
 from six import PY2, text_type, iteritems
 from six import binary_type
 from six import string_types
@@ -957,6 +958,26 @@ def known_failure_v6_or_later(func):
 
 # TODO: Remove once the released version of datalad-crawler no longer uses it.
 known_failure_v6 = known_failure_v6_or_later
+
+
+def known_failure_direct_mode(func):
+    """DEPRECATED.  Stop using.  Does nothing
+
+    Test decorator marking a test as known to fail in a direct mode test run
+
+    If datalad.repo.direct is set to True behaves like `known_failure`.
+    Otherwise the original (undecorated) function is returned.
+    """
+    # TODO: consider adopting   nibabel/deprecated.py  nibabel/deprecator.py
+    # mechanism to consistently deprecate functionality and ensure they are
+    # displayed.
+    # Since 2.7 Deprecation warnings aren't displayed by default
+    # and thus kinda pointless to issue a warning here, so we will just log
+    msg = "Direct mode support is deprecated, so no point in using " \
+          "@known_failure_direct_mode for %r since glorious future " \
+          "DataLad 0.12" % func.__name__
+    lgr.warning(msg)
+    return func
 
 
 def known_failure_windows(func):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1363,29 +1363,6 @@ def with_testsui(t, responses=None, interactive=True):
 with_testsui.__test__ = False
 
 
-@optional_args
-def with_direct(func):
-    """To test functions under both direct and indirect mode
-
-    Unlike fancy generators would just fail on the first failure
-    """
-    @wraps(func)
-    @attr('direct_mode')
-    def newfunc(*args, **kwargs):
-        if on_windows or on_travis:
-            # since on windows would become indirect anyways
-            # on travis -- we have a dedicated matrix run
-            # which would select one or another based on config
-            # if we specify None
-            directs = [None]
-        else:
-            # otherwise we assume that we have to test both modes
-            directs = [True, False]
-        for direct in directs:
-            func(*(args + (direct,)), **kwargs)
-    return newfunc
-
-
 def assert_no_errors_logged(func, skip_re=None):
     """Decorator around function to assert that no errors logged during its execution"""
     @wraps(func)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1323,14 +1323,13 @@ def skip_httpretty_on_problematic_pythons(func):
 
 
 @optional_args
-def with_batch_direct(t):
+def with_parametric_batch(t):
     """Helper to run parametric test with possible combinations of batch and direct
     """
     @wraps(t)
     def newfunc():
         for batch in (False, True):
-            for direct in (False, True) if not on_windows else (True,):
-                yield t, batch, direct
+                yield t, batch
 
     return newfunc
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -184,39 +184,27 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
 
     eq_(sorted(r.untracked_files), sorted(untracked))
 
-    if annex and r.is_direct_mode():
-        if head_modified or index_modified:
-            lgr.warning("head_modified and index_modified are not supported "
-                        "for direct mode repositories!")
+    repo = r.repo
+
+    if repo.index.entries.keys():
+        ok_(repo.head.is_valid())
+
+        if not head_modified and not index_modified:
+            # get string representations of diffs with index to ease
+            # troubleshooting
+            head_diffs = [str(d) for d in repo.index.diff(repo.head.commit)]
+            index_diffs = [str(d) for d in repo.index.diff(None)]
+            eq_(head_diffs, [])
+            eq_(index_diffs, [])
         else:
-            test_untracked = not untracked
-            test_submodules = not ignore_submodules
-            ok_(not r.is_dirty(untracked_files=test_untracked,
-                               submodules=test_submodules),
-                msg="Repo unexpectedly dirty (tested for: untracked({}), submodules({})".format(
-                    test_untracked, test_submodules))
-    else:
-        repo = r.repo
-
-        if repo.index.entries.keys():
-            ok_(repo.head.is_valid())
-
-            if not head_modified and not index_modified:
-                # get string representations of diffs with index to ease
-                # troubleshooting
-                head_diffs = [str(d) for d in repo.index.diff(repo.head.commit)]
-                index_diffs = [str(d) for d in repo.index.diff(None)]
-                eq_(head_diffs, [])
-                eq_(index_diffs, [])
-            else:
-                # TODO: These names are confusing/non-descriptive.  REDO
-                if head_modified:
-                    # we did ask for interrogating changes
-                    head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
-                    eq_(sorted(head_modified_), sorted(head_modified))
-                if index_modified:
-                    index_modified_ = [d.a_path for d in repo.index.diff(None)]
-                    eq_(sorted(index_modified_), sorted(index_modified))
+            # TODO: These names are confusing/non-descriptive.  REDO
+            if head_modified:
+                # we did ask for interrogating changes
+                head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
+                eq_(sorted(head_modified_), sorted(head_modified))
+            if index_modified:
+                index_modified_ = [d.a_path for d in repo.index.diff(None)]
+                eq_(sorted(index_modified_), sorted(index_modified))
 
 
 def ok_file_under_git(path, filename=None, annexed=False):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -959,30 +959,6 @@ def known_failure_v6_or_later(func):
 known_failure_v6 = known_failure_v6_or_later
 
 
-def known_failure_direct_mode(func):
-    """Test decorator marking a test as known to fail in a direct mode test run
-
-    If datalad.repo.direct is set to True behaves like `known_failure`.
-    Otherwise the original (undecorated) function is returned.
-    """
-
-    from datalad import cfg
-
-    direct = cfg.obtain("datalad.repo.direct") or on_windows
-    if direct:
-
-        @known_failure
-        @wraps(func)
-        @attr('known_failure_direct_mode')
-        @attr('direct_mode')
-        def dm_func(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return dm_func
-
-    return func
-
-
 def known_failure_windows(func):
     """Test decorator marking a test as known to fail on windows
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1001,25 +1001,6 @@ def skip_v6_or_later(func, method='raise'):
 
 
 @optional_args
-def skip_direct_mode(func, method='raise'):
-    """Skips tests if datalad is configured to use direct mode
-    (set DATALAD_REPO_DIRECT)
-    """
-
-    from datalad import cfg
-
-    @skip_if(cfg.obtain("datalad.repo.direct"),
-             msg="Skip test in direct mode test run",
-             method=method)
-    @wraps(func)
-    @attr('skip_direct_mode')
-    @attr('direct_mode')
-    def newfunc(*args, **kwargs):
-        return func(*args, **kwargs)
-    return newfunc
-
-
-@optional_args
 def assert_cwd_unchanged(func, ok_to_chdir=False):
     """Decorator to test whether the current working directory remains unchanged
 


### PR DESCRIPTION
A can remove so good

Removed:
- `direct=` option from AnnexRepo interface
- `AnnexRepo._submodules_dirty_direct_mode` - not even sure if was used
- `AnnexRepo._git_custom_command` and `AnnexRepo.proxy` - no longer needed

RFed:
- `set_direct_mode` -> `_set_direct_mode` which just calls `git annex direct`.  To be used internally for testing

Kept for now (but might go as well):
- `is_direct_mode()`

Behavior:
- encountering `DATALAD_REPO_DIRECT=` env var (well -- datalad config) set to True causes `DirectModeNoLongerSupportedError` (but happens only after possibly repo got created)
- encountering AnnexRepo in direct mode also causes `DirectModeNoLongerSupportedError` with a different message for reason .
- Both `DirectModeNoLongerSupportedError` provide instruction to upgrade corresponding repo using direct git-annex upgrade -- we might want to provide auto-upgrade convenience or not?

- [x] adjust AnnexRepo class to remove any custom direct mode handling (WiP) while announcing absent direct mode handling
- [x] update minimal annex requirement to `7` for more uniform handling and remove other related craft
- [x] reintroduce `@known_failure_direct_mode` as a shim which just merely issues a deprecation warning when executed. This way we could keep extensions compatible with new datalad core and allow them to deprecate usage of this decorator, without requiring them all to release a new version.  That should prevent [breakage of travis](https://travis-ci.org/datalad/datalad/jobs/462619117) while testing datalad-crawler
- [x] make sure tests pass