### PR TITLE
BF: run: Preserve current directory prefix for inputs/outputs

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -293,7 +293,11 @@ class GlobbedPaths(object):
 
     def _expand_globs(self):
         def normalize_hit(h):
-            return relpath(h) + ("" if op.basename(h) else op.sep)
+            normalized = relpath(h) + ("" if op.basename(h) else op.sep)
+            if h == op.curdir + op.sep + normalized:
+                # Don't let relpath prune "./fname" (gh-3034).
+                return h
+            return normalized
 
         expanded = []
         with chpwd(self.pwd):

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -292,16 +292,15 @@ class GlobbedPaths(object):
         return sub_patterns
 
     def _expand_globs(self):
-        def normalize_hits(hs):
-            return [relpath(h) + ("" if op.basename(h) else op.sep)
-                    for h in sorted(hs)]
+        def normalize_hit(h):
+            return relpath(h) + ("" if op.basename(h) else op.sep)
 
         expanded = []
         with chpwd(self.pwd):
             for pattern in self._paths["patterns"]:
                 hits = glob.glob(pattern)
                 if hits:
-                    expanded.extend(normalize_hits(hits))
+                    expanded.extend(sorted(map(normalize_hit, hits)))
                 else:
                     lgr.debug("No matching files found for '%s'", pattern)
                     # We didn't find a hit for the complete pattern. If we find
@@ -310,7 +309,8 @@ class GlobbedPaths(object):
                     for sub_pattern in self._get_sub_patterns(pattern):
                         sub_hits = glob.glob(sub_pattern)
                         if sub_hits:
-                            expanded.extend(normalize_hits(sub_hits))
+                            expanded.extend(
+                                sorted(map(normalize_hit, sub_hits)))
                             break
                     # ... but we still want to retain the original pattern
                     # because we don't know for sure at this point, and it

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -1017,10 +1017,17 @@ def test_globbedpaths_get_sub_patterns():
                  "3.txt": "",
                  "subdir": {"1.txt": "", "2.txt": ""}})
 def test_globbedpaths(path):
+    dotdir = op.curdir + op.sep
+
     for patterns, expected in [
             (["1.txt", "2.dat"], {"1.txt", "2.dat"}),
+            ([dotdir + "1.txt", "2.dat"], {dotdir + "1.txt", "2.dat"}),
             (["*.txt", "*.dat"], {"1.txt", "2.dat", "3.txt"}),
+            ([dotdir + "*.txt", "*.dat"],
+             {dotdir + "1.txt", "2.dat", dotdir + "3.txt"}),
             (["subdir/*.txt"], {"subdir/1.txt", "subdir/2.txt"}),
+            ([dotdir + "subdir/*.txt"],
+             {dotdir + p for p in ["subdir/1.txt", "subdir/2.txt"]}),
             (["*.txt"], {"1.txt", "3.txt"})]:
         gp = GlobbedPaths(patterns, pwd=path)
         eq_(set(gp.expand()), expected)
@@ -1031,7 +1038,10 @@ def test_globbedpaths(path):
     subdir_path = op.join(path, "subdir")
     for patterns, expected in [
             (["*.txt"], {"1.txt", "2.txt"}),
+            ([dotdir + "*.txt"], {dotdir + p for p in ["1.txt", "2.txt"]}),
             ([pardir + "*.txt"], {pardir + p for p in ["1.txt", "3.txt"]}),
+            ([dotdir + pardir + "*.txt"],
+             {dotdir + pardir + p for p in ["1.txt", "3.txt"]}),
             (["subdir/"], {"subdir/"})]:
         gp = GlobbedPaths(patterns, pwd=subdir_path)
         eq_(set(gp.expand()), expected)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -1014,16 +1014,29 @@ def test_globbedpaths_get_sub_patterns():
 
 @with_tree(tree={"1.txt": "",
                  "2.dat": "",
-                 "3.txt": ""})
+                 "3.txt": "",
+                 "subdir": {"1.txt": "", "2.txt": ""}})
 def test_globbedpaths(path):
     for patterns, expected in [
             (["1.txt", "2.dat"], {"1.txt", "2.dat"}),
             (["*.txt", "*.dat"], {"1.txt", "2.dat", "3.txt"}),
+            (["subdir/*.txt"], {"subdir/1.txt", "subdir/2.txt"}),
             (["*.txt"], {"1.txt", "3.txt"})]:
         gp = GlobbedPaths(patterns, pwd=path)
         eq_(set(gp.expand()), expected)
         eq_(set(gp.expand(full=True)),
             {opj(path, p) for p in expected})
+
+    pardir = op.pardir + op.sep
+    subdir_path = op.join(path, "subdir")
+    for patterns, expected in [
+            (["*.txt"], {"1.txt", "2.txt"}),
+            ([pardir + "*.txt"], {pardir + p for p in ["1.txt", "3.txt"]}),
+            (["subdir/"], {"subdir/"})]:
+        gp = GlobbedPaths(patterns, pwd=subdir_path)
+        eq_(set(gp.expand()), expected)
+        eq_(set(gp.expand(full=True)),
+            {opj(subdir_path, p) for p in expected})
 
     # Full patterns still get returned as relative to pwd.
     gp = GlobbedPaths([opj(path, "*.dat")], pwd=path)


### PR DESCRIPTION
Prevent `os.path.relpath` from converting "./input" to "input".

Fixes  #3034.