### PR TITLE
 ENH: run: Support "extra inputs"

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -388,6 +388,7 @@ def _rerun(dset, results):
             for r in run_command(run_info['cmd'],
                                  dataset=dset,
                                  inputs=run_info.get("inputs", []),
+                                 extra_inputs=run_info.get("extra_inputs", []),
                                  outputs=outputs,
                                  rerun_outputs=auto_outputs,
                                  message=message,

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -213,16 +213,13 @@ class Run(Interface):
             for r in Rerun.__call__(dataset=dataset, message=message):
                 yield r
         else:
-            if cmd:
-                for r in run_command(cmd, dataset=dataset,
-                                     inputs=inputs, outputs=outputs,
-                                     expand=expand,
-                                     explicit=explicit,
-                                     message=message,
-                                     sidecar=sidecar):
-                    yield r
-            else:
-                lgr.warning("No command given")
+            for r in run_command(cmd, dataset=dataset,
+                                 inputs=inputs, outputs=outputs,
+                                 expand=expand,
+                                 explicit=explicit,
+                                 message=message,
+                                 sidecar=sidecar):
+                yield r
 
 
 class GlobbedPaths(object):
@@ -581,6 +578,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     ------
     Result records for the run.
     """
+    if not cmd:
+        lgr.warning("No command given")
+        return
+
     rel_pwd = rerun_info.get('pwd') if rerun_info else None
     if rel_pwd and dataset:
         # recording is relative to the dataset


### PR DESCRIPTION
```
To let run interface wrappers (like containers-run) specify inputs
without surprising users (who did not explicitly specify those
inputs), add an "extra_inputs" argument to run_command().  There's no
reason we couldn't add it to Run.__call__ along with a command-line
switch and format field, but let's avoid doing so exposing another
user-facing option until a clear use case arises.
```

Re: datalad/datalad-container#38 