### PR TITLE
Revert "This (expensive) approach is not needed in v6+"

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2896,7 +2896,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 direct_mode = self.is_direct_mode()
                 # we might need to avoid explicit paths
                 files_to_commit = None if direct_mode else files
-                if files and self.config.getint("annex", "version") < 6:
+                if files:
                     # In direct mode, if we commit file(s) they would get
                     # committed directly into git ignoring possibly being
                     # staged by annex.  So, if not all files are committed, and


### PR DESCRIPTION
This reverts commit f5d6a6f5cecb85ab6bee5d4fe11e09ec8555d3aa.

Apparently there is some bug, I guess in git-annex, which requires either a
sleep before the commit in the test, or to apply the same procedure as we
do in v5.  As a result it also changes the effect - files do get
committed locked (as regular symlinks).

Closes #3023

Someone could/should track the issue down to proper resolution, so this is not an ideal resolution.