### PR TITLE
TST: test_annex_ssh: swallow_output in another spot

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1166,8 +1166,9 @@ def test_annex_backends(path):
 def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     from datalad import ssh_manager
     # create remotes:
-    rm1 = AnnexRepo(remote_1_path, create=False)
-    rm2 = AnnexRepo(remote_2_path, create=False)
+    with swallow_outputs():  # Avoid stalling on Travis (gh-3041).
+        rm1 = AnnexRepo(remote_1_path, create=False)
+        rm2 = AnnexRepo(remote_2_path, create=False)
 
     # check whether we are the first to use these sockets:
     socket_1 = opj(ssh_manager.socket_dir, get_connection_hash('datalad-test'))


### PR DESCRIPTION
As of abed6efad (ENH: annexrepo: Inform users about repo version
auto-upgrades, 2018-11-28), test_annex_ssh is stalling on Travis.
Blindly apply the same workaround from 7c0742298 (BF: use
swallow_output in 2 failing spots whenever nosetests ran without -s,
2017-03-10).

~Fixes #3041.~