### PR TITLE
Revert "ENH: annexrepo: Inform users about repo version auto-upgrades"

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -93,13 +93,6 @@ lgr = logging.getLogger('datalad.annex')
 # Limit to # of CPUs and up to 8, but at least 3 to start with
 N_AUTO_JOBS = min(8, max(3, cpu_count()))
 
-# This is a map between an auto-upgradeable version and the version that it
-# upgrades to. It should track autoUpgradeableVersions in Annex.Version.
-_AUTO_UPGRADEABLE_VERSIONS = {3: 5, 4: 5}
-# TODO: Adjust once GIT_ANNEX_VERSION is at least 7.20181031.
-if external_versions['cmd:annex'] >= '7.20181031':
-    _AUTO_UPGRADEABLE_VERSIONS[6] = 7
-
 
 class AnnexRepo(GitRepo, RepoInterface):
     """Representation of an git-annex repository.
@@ -1283,10 +1276,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         if description is not None:
             opts += [description]
         if version is not None:
-            upgraded_version = _AUTO_UPGRADEABLE_VERSIONS.get(version)
-            if upgraded_version:
-                lgr.info("Annex repository version %s will be upgraded to %s",
-                         version, upgraded_version)
             opts += ['--version', '{0}'.format(version)]
         if not len(opts):
             opts = None

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1286,16 +1286,13 @@ def test_annex_remove(path1, path2):
 @with_tempfile
 @with_tempfile
 def test_repo_version(path1, path2, path3):
-    with swallow_logs(new_level=logging.INFO) as cm:
-        annex = AnnexRepo(path1, create=True, version=6)
-        ok_clean_git(path1, annex=True)
-        version = annex.repo.config_reader().get_value('annex', 'version')
-        # TODO: Since git-annex 7.20181031, v6 repos upgrade to v7. Once that
-        # version or later is our minimum required version, update this test and
-        # the one below to eq_(version, 7).
-        assert_in(version, [6, 7])
-        if external_versions['cmd:annex'] >= '7.20181031':
-            assert_in("will be upgraded to 7", cm.out)
+    annex = AnnexRepo(path1, create=True, version=6)
+    ok_clean_git(path1, annex=True)
+    version = annex.repo.config_reader().get_value('annex', 'version')
+    # TODO: Since git-annex 7.20181031, v6 repos upgrade to v7. Once that
+    # version or later is our minimum required version, update this test and
+    # the one below to eq_(version, 7).
+    assert_in(version, [6, 7])
 
     # default from config item (via env var):
     with patch.dict('os.environ', {'DATALAD_REPO_VERSION': '6'}):


### PR DESCRIPTION
This reverts commit abed6efad890eb421b4548b45de2dfabb86565ba.

As of that commit, test_annex_ssh is stalling on Travis for unclear
reasons.  Revert those changes until we figure out why.

Closes #3041.