### PR TITLE
BF: external_versions: Make __contains__ work with non-primed items

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -225,7 +225,7 @@ class ExternalVersions(object):
         return self._versions.keys()
 
     def __contains__(self, item):
-        return item in self._versions
+        return bool(self[item])
 
     @property
     def versions(self):

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -85,6 +85,12 @@ def test_external_versions_basic():
     assert_equal(ev[our_module], __version__)
 
 
+def test_external_version_contains():
+    ev = ExternalVersions()
+    assert_true("datalad" in ev)
+    assert_false("does not exist" in ev)
+
+
 def test_external_versions_unknown():
     assert_equal(str(ExternalVersions.UNKNOWN), 'UNKNOWN')
 


### PR DESCRIPTION
```
Because ExternalVersions.__contains__ checks the cached _versions
attribute, it will return False for an item that hasn't been seen by
__getitem__.  This is misleading for cases where the __getitem__
return value isn't None.  To fix this, adjust __contains__ to use
__getitem__ instead.
```