### PR TITLE
 RF: Move GlobbedPaths from run.py to a support module

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -224,7 +224,7 @@ class Run(Interface):
 
 
 class GlobbedPaths(object):
-    """Helper for inputs and outputs.
+    """Helper for globbing paths.
 
     Parameters
     ----------

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -20,7 +20,6 @@ import os.path as op
 from os.path import join as opj
 from os.path import normpath
 from os.path import relpath
-from os.path import isabs
 
 from six.moves import map
 from six.moves import shlex_quote
@@ -252,7 +251,7 @@ class GlobbedPaths(object):
             patterns, dots = partition(patterns, lambda i: i.strip() == ".")
             self._maybe_dot = ["."] if list(dots) else []
             self._paths = {
-                "patterns": [relpath(p, start=pwd) if isabs(p) else p
+                "patterns": [op.relpath(p, start=pwd) if op.isabs(p) else p
                              for p in patterns],
                 "sub_patterns": {}}
 
@@ -293,7 +292,7 @@ class GlobbedPaths(object):
 
     def _expand_globs(self):
         def normalize_hit(h):
-            normalized = relpath(h) + ("" if op.basename(h) else op.sep)
+            normalized = op.relpath(h) + ("" if op.basename(h) else op.sep)
             if h == op.curdir + op.sep + normalized:
                 # Don't let relpath prune "./fname" (gh-3034).
                 return h
@@ -347,7 +346,7 @@ class GlobbedPaths(object):
 
         if full:
             if refresh or "expanded_full" not in self._paths:
-                paths = [opj(self.pwd, p) for p in paths]
+                paths = [op.join(self.pwd, p) for p in paths]
                 self._paths["expanded_full"] = paths
             else:
                 paths = self._paths["expanded_full"]

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -15,7 +15,6 @@ import logging
 import json
 
 from argparse import REMAINDER
-import glob
 import os.path as op
 from os.path import join as opj
 from os.path import normpath
@@ -36,6 +35,7 @@ from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureBool
 from datalad.support.exceptions import CommandError
+from datalad.support.globbedpaths import GlobbedPaths
 from datalad.support.param import Parameter
 from datalad.support.json_py import dump2stream
 
@@ -50,11 +50,8 @@ from datalad.interface.unlock import Unlock
 
 from datalad.utils import assure_bytes
 from datalad.utils import assure_unicode
-from datalad.utils import chpwd
 # Rename get_dataset_pwds for the benefit of containers_run.
 from datalad.utils import get_dataset_pwds as get_command_pwds
-from datalad.utils import getpwd
-from datalad.utils import partition
 from datalad.utils import SequenceFormatter
 
 lgr = logging.getLogger('datalad.interface.run')
@@ -221,147 +218,6 @@ class Run(Interface):
                                  message=message,
                                  sidecar=sidecar):
                 yield r
-
-
-class GlobbedPaths(object):
-    """Helper for globbing paths.
-
-    Parameters
-    ----------
-    patterns : list of str
-        Call `glob.glob` with each of these patterns. "." is considered as
-        datalad's special "." path argument; it is not passed to glob and is
-        always left unexpanded. Each set of glob results is sorted
-        alphabetically.
-    pwd : str, optional
-        Glob in this directory.
-    expand : bool, optional
-       Whether the `paths` property returns unexpanded or expanded paths.
-    """
-
-    def __init__(self, patterns, pwd=None, expand=False):
-        self.pwd = pwd or getpwd()
-        self._expand = expand
-
-        if patterns is None:
-            self._maybe_dot = []
-            self._paths = {"patterns": [], "sub_patterns": {}}
-        else:
-            patterns = list(map(assure_unicode, patterns))
-            patterns, dots = partition(patterns, lambda i: i.strip() == ".")
-            self._maybe_dot = ["."] if list(dots) else []
-            self._paths = {
-                "patterns": [op.relpath(p, start=pwd) if op.isabs(p) else p
-                             for p in patterns],
-                "sub_patterns": {}}
-
-    def __bool__(self):
-        return bool(self._maybe_dot or self.expand())
-
-    __nonzero__ = __bool__  # py2
-
-    def _get_sub_patterns(self, pattern):
-        """Extract sub-patterns from the leading path of `pattern`.
-
-        The right-most path component is successively peeled off until there
-        are no patterns left.
-        """
-        if pattern in self._paths["sub_patterns"]:
-            return self._paths["sub_patterns"][pattern]
-
-        head, tail = op.split(pattern)
-        if not tail:
-            # Pattern ended with a separator. Take the first directory as the
-            # base.
-            head, tail = op.split(head)
-
-        sub_patterns = []
-        seen_magic = glob.has_magic(tail)
-        while head:
-            new_head, tail = op.split(head)
-            if seen_magic and not glob.has_magic(head):
-                break
-            elif not seen_magic and glob.has_magic(tail):
-                seen_magic = True
-
-            if seen_magic:
-                sub_patterns.append(head + op.sep)
-            head = new_head
-        self._paths["sub_patterns"][pattern] = sub_patterns
-        return sub_patterns
-
-    def _expand_globs(self):
-        def normalize_hit(h):
-            normalized = op.relpath(h) + ("" if op.basename(h) else op.sep)
-            if h == op.curdir + op.sep + normalized:
-                # Don't let relpath prune "./fname" (gh-3034).
-                return h
-            return normalized
-
-        expanded = []
-        with chpwd(self.pwd):
-            for pattern in self._paths["patterns"]:
-                hits = glob.glob(pattern)
-                if hits:
-                    expanded.extend(sorted(map(normalize_hit, hits)))
-                else:
-                    lgr.debug("No matching files found for '%s'", pattern)
-                    # We didn't find a hit for the complete pattern. If we find
-                    # a sub-pattern hit, that may mean we have an uninstalled
-                    # subdataset.
-                    for sub_pattern in self._get_sub_patterns(pattern):
-                        sub_hits = glob.glob(sub_pattern)
-                        if sub_hits:
-                            expanded.extend(
-                                sorted(map(normalize_hit, sub_hits)))
-                            break
-                    # ... but we still want to retain the original pattern
-                    # because we don't know for sure at this point, and it
-                    # won't bother the "install, reglob" routine.
-                    expanded.extend([pattern])
-        return expanded
-
-    def expand(self, full=False, dot=True, refresh=False):
-        """Return paths with the globs expanded.
-
-        Parameters
-        ----------
-        full : bool, optional
-            Return full paths rather than paths relative to `pwd`.
-        dot : bool, optional
-            Include the "." pattern if it was specified.
-        refresh : bool, optional
-            Run glob regardless of whether there are cached values. This is
-            useful if there may have been changes on the file system.
-        """
-        maybe_dot = self._maybe_dot if dot else []
-        if not self._paths["patterns"]:
-            return maybe_dot + []
-
-        if refresh or "expanded" not in self._paths:
-            paths = self._expand_globs()
-            self._paths["expanded"] = paths
-        else:
-            paths = self._paths["expanded"]
-
-        if full:
-            if refresh or "expanded_full" not in self._paths:
-                paths = [op.join(self.pwd, p) for p in paths]
-                self._paths["expanded_full"] = paths
-            else:
-                paths = self._paths["expanded_full"]
-
-        return maybe_dot + paths
-
-    @property
-    def paths(self):
-        """Return paths relative to `pwd`.
-
-        Globs are expanded if `expand` was set to true during instantiation.
-        """
-        if self._expand:
-            return self.expand()
-        return self._maybe_dot + self._paths["patterns"]
 
 
 def _install_and_reglob(dset, gpaths):

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -1070,7 +1070,7 @@ def test_globbedpaths(path):
         gp = GlobbedPaths(patterns, pwd=path)
         eq_(set(gp.expand()), expected)
         eq_(set(gp.expand(full=True)),
-            {opj(path, p) for p in expected})
+            {op.join(path, p) for p in expected})
 
     pardir = op.pardir + op.sep
     subdir_path = op.join(path, "subdir")
@@ -1084,10 +1084,10 @@ def test_globbedpaths(path):
         gp = GlobbedPaths(patterns, pwd=subdir_path)
         eq_(set(gp.expand()), expected)
         eq_(set(gp.expand(full=True)),
-            {opj(subdir_path, p) for p in expected})
+            {op.join(subdir_path, p) for p in expected})
 
     # Full patterns still get returned as relative to pwd.
-    gp = GlobbedPaths([opj(path, "*.dat")], pwd=path)
+    gp = GlobbedPaths([op.join(path, "*.dat")], pwd=path)
     eq_(gp.expand(), ["2.dat", u"bβ.dat"])
 
     # "." gets special treatment.

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -36,7 +36,6 @@ from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import ok_, assert_false, neq_
 from datalad.api import install
 from datalad.api import run
-from datalad.interface.run import GlobbedPaths
 from datalad.interface.run import run_command
 from datalad.interface.rerun import get_run_info
 from datalad.interface.rerun import diff_revision, new_or_modified
@@ -1021,99 +1020,6 @@ def test_inject(path):
     msg = ds.repo.format_commit("%B")
     assert_in("custom_key", msg)
     assert_in("nonsense command", msg)
-
-
-def test_globbedpaths_get_sub_patterns():
-    gp = GlobbedPaths([], "doesn't matter")
-    for pat, expected in [
-            # If there are no patterns in the directory component, we get no
-            # sub-patterns.
-            ("", []),
-            ("nodir", []),
-            (op.join("nomagic", "path"), []),
-            (op.join("nomagic", "path*"), []),
-            # Create sub-patterns from leading path, successively dropping the
-            # right-most component.
-            (op.join("s*", "path"), ["s*" + op.sep]),
-            (op.join("s", "ss*", "path"), [op.join("s", "ss*") + op.sep]),
-            (op.join("s", "ss*", "path*"), [op.join("s", "ss*") + op.sep]),
-            (op.join("s", "ss*" + op.sep), []),
-            (op.join("s*", "ss", "path*"),
-             [op.join("s*", "ss") + op.sep,
-              "s*" + op.sep]),
-            (op.join("s?", "ss", "sss*", "path*"),
-             [op.join("s?", "ss", "sss*") + op.sep,
-              op.join("s?", "ss") + op.sep,
-              "s?" + op.sep])]:
-        eq_(gp._get_sub_patterns(pat), expected)
-
-
-@with_tree(tree={"1.txt": "",
-                 "2.dat": "",
-                 "3.txt": "",
-                 # Avoid OBSCURE_FILENAME to avoid windows-breakage (gh-2929).
-                 u"bβ.dat": "",
-                 "subdir": {"1.txt": "", "2.txt": ""}})
-def test_globbedpaths(path):
-    dotdir = op.curdir + op.sep
-
-    for patterns, expected in [
-            (["1.txt", "2.dat"], {"1.txt", "2.dat"}),
-            ([dotdir + "1.txt", "2.dat"], {dotdir + "1.txt", "2.dat"}),
-            (["*.txt", "*.dat"], {"1.txt", "2.dat", u"bβ.dat", "3.txt"}),
-            ([dotdir + "*.txt", "*.dat"],
-             {dotdir + "1.txt", "2.dat", u"bβ.dat", dotdir + "3.txt"}),
-            (["subdir/*.txt"], {"subdir/1.txt", "subdir/2.txt"}),
-            ([dotdir + "subdir/*.txt"],
-             {dotdir + p for p in ["subdir/1.txt", "subdir/2.txt"]}),
-            (["*.txt"], {"1.txt", "3.txt"})]:
-        gp = GlobbedPaths(patterns, pwd=path)
-        eq_(set(gp.expand()), expected)
-        eq_(set(gp.expand(full=True)),
-            {op.join(path, p) for p in expected})
-
-    pardir = op.pardir + op.sep
-    subdir_path = op.join(path, "subdir")
-    for patterns, expected in [
-            (["*.txt"], {"1.txt", "2.txt"}),
-            ([dotdir + "*.txt"], {dotdir + p for p in ["1.txt", "2.txt"]}),
-            ([pardir + "*.txt"], {pardir + p for p in ["1.txt", "3.txt"]}),
-            ([dotdir + pardir + "*.txt"],
-             {dotdir + pardir + p for p in ["1.txt", "3.txt"]}),
-            (["subdir/"], {"subdir/"})]:
-        gp = GlobbedPaths(patterns, pwd=subdir_path)
-        eq_(set(gp.expand()), expected)
-        eq_(set(gp.expand(full=True)),
-            {op.join(subdir_path, p) for p in expected})
-
-    # Full patterns still get returned as relative to pwd.
-    gp = GlobbedPaths([op.join(path, "*.dat")], pwd=path)
-    eq_(gp.expand(), ["2.dat", u"bβ.dat"])
-
-    # "." gets special treatment.
-    gp = GlobbedPaths([".", "*.dat"], pwd=path)
-    eq_(set(gp.expand()), {"2.dat", u"bβ.dat", "."})
-    eq_(gp.expand(dot=False), ["2.dat", u"bβ.dat"])
-    gp = GlobbedPaths(["."], pwd=path, expand=False)
-    eq_(gp.expand(), ["."])
-    eq_(gp.paths, ["."])
-
-    # We can the glob outputs.
-    glob_results = {"z": "z",
-                    "a": ["x", "d", "b"]}
-    with patch('glob.glob', glob_results.get):
-        gp = GlobbedPaths(["z", "a"])
-        eq_(gp.expand(), ["z", "b", "d", "x"])
-
-    # glob expansion for paths property is determined by expand argument.
-    for expand, expected in [(True, ["2.dat", u"bβ.dat"]),
-                             (False, ["*.dat"])]:
-        gp = GlobbedPaths(["*.dat"], pwd=path, expand=expand)
-        eq_(gp.paths, expected)
-
-    with swallow_logs(new_level=logging.DEBUG) as cml:
-        GlobbedPaths(["not here"], pwd=path).expand()
-        assert_in("No matching files found for 'not here'", cml.out)
 
 
 def test_rerun_commit_message_check():

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -1,0 +1,162 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Wrapper for globbing paths.
+"""
+
+import glob
+import logging
+import os.path as op
+
+from datalad.utils import assure_unicode
+from datalad.utils import chpwd
+from datalad.utils import getpwd
+from datalad.utils import partition
+
+lgr = logging.getLogger('datalad.support.globbedpaths')
+
+
+class GlobbedPaths(object):
+    """Helper for globbing paths.
+
+    Parameters
+    ----------
+    patterns : list of str
+        Call `glob.glob` with each of these patterns. "." is considered as
+        datalad's special "." path argument; it is not passed to glob and is
+        always left unexpanded. Each set of glob results is sorted
+        alphabetically.
+    pwd : str, optional
+        Glob in this directory.
+    expand : bool, optional
+       Whether the `paths` property returns unexpanded or expanded paths.
+    """
+
+    def __init__(self, patterns, pwd=None, expand=False):
+        self.pwd = pwd or getpwd()
+        self._expand = expand
+
+        if patterns is None:
+            self._maybe_dot = []
+            self._paths = {"patterns": [], "sub_patterns": {}}
+        else:
+            patterns = list(map(assure_unicode, patterns))
+            patterns, dots = partition(patterns, lambda i: i.strip() == ".")
+            self._maybe_dot = ["."] if list(dots) else []
+            self._paths = {
+                "patterns": [op.relpath(p, start=pwd) if op.isabs(p) else p
+                             for p in patterns],
+                "sub_patterns": {}}
+
+    def __bool__(self):
+        return bool(self._maybe_dot or self.expand())
+
+    __nonzero__ = __bool__  # py2
+
+    def _get_sub_patterns(self, pattern):
+        """Extract sub-patterns from the leading path of `pattern`.
+
+        The right-most path component is successively peeled off until there
+        are no patterns left.
+        """
+        if pattern in self._paths["sub_patterns"]:
+            return self._paths["sub_patterns"][pattern]
+
+        head, tail = op.split(pattern)
+        if not tail:
+            # Pattern ended with a separator. Take the first directory as the
+            # base.
+            head, tail = op.split(head)
+
+        sub_patterns = []
+        seen_magic = glob.has_magic(tail)
+        while head:
+            new_head, tail = op.split(head)
+            if seen_magic and not glob.has_magic(head):
+                break
+            elif not seen_magic and glob.has_magic(tail):
+                seen_magic = True
+
+            if seen_magic:
+                sub_patterns.append(head + op.sep)
+            head = new_head
+        self._paths["sub_patterns"][pattern] = sub_patterns
+        return sub_patterns
+
+    def _expand_globs(self):
+        def normalize_hit(h):
+            normalized = op.relpath(h) + ("" if op.basename(h) else op.sep)
+            if h == op.curdir + op.sep + normalized:
+                # Don't let relpath prune "./fname" (gh-3034).
+                return h
+            return normalized
+
+        expanded = []
+        with chpwd(self.pwd):
+            for pattern in self._paths["patterns"]:
+                hits = glob.glob(pattern)
+                if hits:
+                    expanded.extend(sorted(map(normalize_hit, hits)))
+                else:
+                    lgr.debug("No matching files found for '%s'", pattern)
+                    # We didn't find a hit for the complete pattern. If we find
+                    # a sub-pattern hit, that may mean we have an uninstalled
+                    # subdataset.
+                    for sub_pattern in self._get_sub_patterns(pattern):
+                        sub_hits = glob.glob(sub_pattern)
+                        if sub_hits:
+                            expanded.extend(
+                                sorted(map(normalize_hit, sub_hits)))
+                            break
+                    # ... but we still want to retain the original pattern
+                    # because we don't know for sure at this point, and it
+                    # won't bother the "install, reglob" routine.
+                    expanded.extend([pattern])
+        return expanded
+
+    def expand(self, full=False, dot=True, refresh=False):
+        """Return paths with the globs expanded.
+
+        Parameters
+        ----------
+        full : bool, optional
+            Return full paths rather than paths relative to `pwd`.
+        dot : bool, optional
+            Include the "." pattern if it was specified.
+        refresh : bool, optional
+            Run glob regardless of whether there are cached values. This is
+            useful if there may have been changes on the file system.
+        """
+        maybe_dot = self._maybe_dot if dot else []
+        if not self._paths["patterns"]:
+            return maybe_dot + []
+
+        if refresh or "expanded" not in self._paths:
+            paths = self._expand_globs()
+            self._paths["expanded"] = paths
+        else:
+            paths = self._paths["expanded"]
+
+        if full:
+            if refresh or "expanded_full" not in self._paths:
+                paths = [op.join(self.pwd, p) for p in paths]
+                self._paths["expanded_full"] = paths
+            else:
+                paths = self._paths["expanded_full"]
+
+        return maybe_dot + paths
+
+    @property
+    def paths(self):
+        """Return paths relative to `pwd`.
+
+        Globs are expanded if `expand` was set to true during instantiation.
+        """
+        if self._expand:
+            return self.expand()
+        return self._maybe_dot + self._paths["patterns"]

--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -1,0 +1,115 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""test GlobbedPaths
+"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from mock import patch
+import os.path as op
+
+from datalad.support.globbedpaths import GlobbedPaths
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import eq_
+from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import with_tree
+
+
+def test_globbedpaths_get_sub_patterns():
+    gp = GlobbedPaths([], "doesn't matter")
+    for pat, expected in [
+            # If there are no patterns in the directory component, we get no
+            # sub-patterns.
+            ("", []),
+            ("nodir", []),
+            (op.join("nomagic", "path"), []),
+            (op.join("nomagic", "path*"), []),
+            # Create sub-patterns from leading path, successively dropping the
+            # right-most component.
+            (op.join("s*", "path"), ["s*" + op.sep]),
+            (op.join("s", "ss*", "path"), [op.join("s", "ss*") + op.sep]),
+            (op.join("s", "ss*", "path*"), [op.join("s", "ss*") + op.sep]),
+            (op.join("s", "ss*" + op.sep), []),
+            (op.join("s*", "ss", "path*"),
+             [op.join("s*", "ss") + op.sep,
+              "s*" + op.sep]),
+            (op.join("s?", "ss", "sss*", "path*"),
+             [op.join("s?", "ss", "sss*") + op.sep,
+              op.join("s?", "ss") + op.sep,
+              "s?" + op.sep])]:
+        eq_(gp._get_sub_patterns(pat), expected)
+
+
+@with_tree(tree={"1.txt": "",
+                 "2.dat": "",
+                 "3.txt": "",
+                 # Avoid OBSCURE_FILENAME to avoid windows-breakage (gh-2929).
+                 u"bβ.dat": "",
+                 "subdir": {"1.txt": "", "2.txt": ""}})
+def test_globbedpaths(path):
+    dotdir = op.curdir + op.sep
+
+    for patterns, expected in [
+            (["1.txt", "2.dat"], {"1.txt", "2.dat"}),
+            ([dotdir + "1.txt", "2.dat"], {dotdir + "1.txt", "2.dat"}),
+            (["*.txt", "*.dat"], {"1.txt", "2.dat", u"bβ.dat", "3.txt"}),
+            ([dotdir + "*.txt", "*.dat"],
+             {dotdir + "1.txt", "2.dat", u"bβ.dat", dotdir + "3.txt"}),
+            (["subdir/*.txt"], {"subdir/1.txt", "subdir/2.txt"}),
+            ([dotdir + "subdir/*.txt"],
+             {dotdir + p for p in ["subdir/1.txt", "subdir/2.txt"]}),
+            (["*.txt"], {"1.txt", "3.txt"})]:
+        gp = GlobbedPaths(patterns, pwd=path)
+        eq_(set(gp.expand()), expected)
+        eq_(set(gp.expand(full=True)),
+            {op.join(path, p) for p in expected})
+
+    pardir = op.pardir + op.sep
+    subdir_path = op.join(path, "subdir")
+    for patterns, expected in [
+            (["*.txt"], {"1.txt", "2.txt"}),
+            ([dotdir + "*.txt"], {dotdir + p for p in ["1.txt", "2.txt"]}),
+            ([pardir + "*.txt"], {pardir + p for p in ["1.txt", "3.txt"]}),
+            ([dotdir + pardir + "*.txt"],
+             {dotdir + pardir + p for p in ["1.txt", "3.txt"]}),
+            (["subdir/"], {"subdir/"})]:
+        gp = GlobbedPaths(patterns, pwd=subdir_path)
+        eq_(set(gp.expand()), expected)
+        eq_(set(gp.expand(full=True)),
+            {op.join(subdir_path, p) for p in expected})
+
+    # Full patterns still get returned as relative to pwd.
+    gp = GlobbedPaths([op.join(path, "*.dat")], pwd=path)
+    eq_(gp.expand(), ["2.dat", u"bβ.dat"])
+
+    # "." gets special treatment.
+    gp = GlobbedPaths([".", "*.dat"], pwd=path)
+    eq_(set(gp.expand()), {"2.dat", u"bβ.dat", "."})
+    eq_(gp.expand(dot=False), ["2.dat", u"bβ.dat"])
+    gp = GlobbedPaths(["."], pwd=path, expand=False)
+    eq_(gp.expand(), ["."])
+    eq_(gp.paths, ["."])
+
+    # We can the glob outputs.
+    glob_results = {"z": "z",
+                    "a": ["x", "d", "b"]}
+    with patch('glob.glob', glob_results.get):
+        gp = GlobbedPaths(["z", "a"])
+        eq_(gp.expand(), ["z", "b", "d", "x"])
+
+    # glob expansion for paths property is determined by expand argument.
+    for expand, expected in [(True, ["2.dat", u"bβ.dat"]),
+                             (False, ["*.dat"])]:
+        gp = GlobbedPaths(["*.dat"], pwd=path, expand=expand)
+        eq_(gp.paths, expected)
+
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        GlobbedPaths(["not here"], pwd=path).expand()
+        assert_in("No matching files found for 'not here'", cml.out)


### PR DESCRIPTION

GlobbedPaths is currently used only in run.py (and extensions that
wrap datalad run), but its logic isn't tied to run and it contributes
bloat to both run.py and test_run.py.

The practical motivation for moving this functionality to a separate
module is to be able to more easily absorb it as third-party code into
the source tree of NICEMAN, which isn't a DataLad extension and
doesn't require DataLad.  It's not a pretty solution, but NICEMAN
already includes a substantial amount of code from DataLad, and
GlobbedPaths isn't worth the effort of distributing as a separate
module.

DataLad extensions that use GlobbedPaths won't be affected by this
because GlobbedPaths is still available under the datalad.run
namespace. 