### PR TITLE
BF: setup_yoda_dataset: Avoid conjoined lines

### DIFF
--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -21,6 +21,7 @@ from datalad.tests.utils import with_tree
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_true
+from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in_results
 from datalad.tests.utils import skip_if
@@ -60,6 +61,7 @@ def test_basics(path, super_path):
     ds = Dataset(path).create(force=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
+    assert_false(ds.repo.is_under_annex("README.md"))
     # configure dataset to look for procedures in its code folder
     ds.config.add(
         'datalad.locations.dataset-procedures',

--- a/datalad/resources/procedures/setup_yoda_dataset.py
+++ b/datalad/resources/procedures/setup_yoda_dataset.py
@@ -37,8 +37,6 @@ README_top = """\
 tmpl = {
     'code': {
         'README.md': README_code,
-        # all code goes into Git
-        '.gitattributes': '** annex.largefiles=nothing',
     },
     'README.md': README_top,
     'CHANGELOG.md': '',  # TODO
@@ -56,15 +54,13 @@ force_in_git = [
 # actually dump everything into the dataset
 create_tree(ds.path, tmpl)
 
+# all code goes into Git
+ds.repo.set_gitattributes([('*', {'annex.largefiles': 'nothing'})],
+                          op.join('code', '.gitattributes'))
+
 # amend gitattributes
-for path in force_in_git:
-    abspath = op.join(ds.path, path)
-    d = op.dirname(abspath)
-    ga_path = op.join(d, '.gitattributes') \
-        if op.exists(d) else op.join(ds.path, '.gitattributes')
-    with open(ga_path, 'a') as gaf:
-        gaf.write('{} annex.largefiles=nothing\n'.format(
-            op.relpath(abspath, start=d) if op.exists(d) else path))
+ds.repo.set_gitattributes(
+    [(p, {'annex.largefiles': 'nothing'}) for p in force_in_git])
 
 # leave clean
 # TODO only commit actually changed/added files


### PR DESCRIPTION
Similar to the cfg_text2git new line issue (gh-2954, fixed by
eed1cacee), setup_yoda_dataset creates a malformed attribute line:

    **/.git* annex.largefiles=nothingREADME.md annex.largefiles=nothing

Use GitRepo.set_gitattributes() so that new lines are properly
handled.  Don't bother checking if the attribute exists since the
procedure is documented as assuming a just-create dataset.

---

I'm a bit unsure about the fix because I don't quite get what the path handling is about here:

https://github.com/datalad/datalad/blob/5f69cfe961f91c8add6bd15db5abde5757f3d969/datalad/resources/procedures/setup_yoda_dataset.py#L66-L67

<details>
<summary>script/demo</summary>

```shell
#!/bin/sh

set -eu

tmpdir=$(mktemp -d)
datalad --proc-post setup_yoda_dataset --cmd create -d $tmpdir
cd $tmpdir
git cat-file -p :README.md
```

Before:

```
[INFO   ] Creating a new annex repo at /tmp/tmp.L4qC12yQs2 
create(ok): . (dataset)
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) ===== 
.git/annex/objects/XK/72/MD5E-s171--eea84c4597886872ef74589f0fc293c5.md/MD5E-s171--eea84c4597886872ef74589f0fc293c5.md%   
```

After:

```
[INFO   ] Creating a new annex repo at /tmp/tmp.BjFXyUndYu 
create(ok): . (dataset)
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) ===== 
# Project <insert name>

## Dataset structure

- All inputs (i.e. building blocks from other sources) are located in
  `inputs/`.
- All custom code is located in `code/`.
```

</details>