### PR TITLE
ENH: download_url: Pass add_archive_content a path relative to dataset

### DIFF
--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -41,6 +41,7 @@ from ..cmdline.helpers import get_repo_instance
 from ..utils import getpwd, rmtree, file_basename
 from ..utils import md5sum
 from ..utils import assure_tuple_or_list
+from ..utils import get_dataset_root
 
 from datalad.customremotes.base import init_datalad_remote
 
@@ -227,7 +228,11 @@ class AddArchiveContent(Interface):
         annex_path = annex.path
 
         # _rpath below should depict paths relative to the top of the annex
-        archive_rpath = relpath(archive_path, annex_path)
+        archive_rpath = relpath(
+            archive_path,
+            # Use `get_dataset_root` to avoid resolving the leading path. If no
+            # repo is found, downstream code will raise FileNotInRepositoryError.
+            get_dataset_root(archive_path) or ".")
 
         if archive in annex.untracked_files:
             raise RuntimeError(

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -514,7 +514,7 @@ class AddArchiveContent(Interface):
                 if annex.is_dirty(untracked_files=False):
                     annex.commit(
                         "Added content extracted from %s %s\n\n%s" %
-                        (origin, archive, commit_stats.as_str(mode='full')),
+                        (origin, archive_rpath, commit_stats.as_str(mode='full')),
                         _datalad_msg=True
                     )
                     commit_stats.reset()

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -335,6 +335,23 @@ def test_add_archive_content_zip(repo_path):
         ok_archives_caches(repo.path, 0)
 
 
+@with_tree(tree={"ds": {"1.tar.gz": {"foo": "abc"}},
+                 "notds": {"2.tar.gz": {"bar": "def"}}})
+def test_add_archive_content_absolute_path(path):
+    repo = AnnexRepo(opj(path, "ds"), create=True)
+    repo.add(["1.tar.gz"])
+    repo.commit("1.tar.gz")
+    abs_tar_gz = opj(path, "ds", "1.tar.gz")
+    add_archive_content(abs_tar_gz, annex=repo)
+    ok_file_under_git(opj(path, "ds", "1", "foo"), annexed=True)
+    commit_msg = repo.format_commit("%B")
+    assert_in("1.tar.gz", commit_msg)
+
+    with assert_raises(FileNotInRepositoryError):
+        add_archive_content(opj(path, "notds", "2.tar.gz"),
+                            annex=repo)
+
+
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 def test_add_archive_use_archive_dir(repo_path):

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -22,6 +22,7 @@ from ...tests.utils import ok_, eq_, assert_cwd_unchanged, assert_raises, \
     with_tempfile, assert_in
 from ...tests.utils import assert_equal, assert_not_equal
 from ...tests.utils import assert_false
+from ...tests.utils import assert_not_in
 from ...tests.utils import assert_true
 from ...tests.utils import ok_archives_caches
 from ...tests.utils import slow
@@ -345,6 +346,8 @@ def test_add_archive_content_absolute_path(path):
     add_archive_content(abs_tar_gz, annex=repo)
     ok_file_under_git(opj(path, "ds", "1", "foo"), annexed=True)
     commit_msg = repo.format_commit("%B")
+    # The commit message uses relative paths.
+    assert_not_in(abs_tar_gz, commit_msg)
     assert_in("1.tar.gz", commit_msg)
 
     with assert_raises(FileNotInRepositoryError):

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -20,6 +20,7 @@ from ...utils import chpwd
 from ...tests.utils import ok_, ok_exists, eq_, assert_cwd_unchanged, \
     assert_in, assert_false, assert_message, assert_result_count, \
     with_tempfile
+from ...tests.utils import assert_not_in
 from ...tests.utils import with_tree
 from ...tests.utils import serve_path_via_http
 
@@ -127,3 +128,5 @@ def test_download_url_archive(toppath, topurl, path):
     ds = Dataset(path).create()
     ds.download_url([opj(topurl, "archive.tar.gz")], archive=True)
     ok_(ds.repo.file_has_content(opj("archive", "file1.txt")))
+    assert_not_in(opj(ds.path, "archive.tar.gz"),
+                  ds.repo.format_commit("%B"))


### PR DESCRIPTION
Otherwise the archive's absolute path is shown in the commit message.