### PR TITLE
ENH: Add the ability for custom result summary rendering

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -414,6 +414,12 @@ def eval_results(func):
                             **_kwargs):
                         yield r
 
+            # if a custom summary is to be provided, collect the results
+            # of the command execution
+            results = []
+            do_custom_result_summary = result_renderer == 'tailored' \
+                and hasattr(_func_class, 'custom_result_summary_renderer')
+
             # process main results
             for r in _process_results(
                     wrapped(*_args, **_kwargs),
@@ -421,6 +427,9 @@ def eval_results(func):
                     on_failure, incomplete_results,
                     result_renderer, result_xfm, _result_filter, **_kwargs):
                 yield r
+                # collect if summary is desired
+                if do_custom_result_summary:
+                    results.append(r)
 
             if proc_post and cmdline_name != 'run-procedure':
                 from datalad.interface.run_procedure import RunProcedure
@@ -438,7 +447,10 @@ def eval_results(func):
                         yield r
 
             # result summary before a potential exception
-            if result_renderer == 'default' and action_summary and \
+            # custom first
+            if do_custom_result_summary:
+                _func_class.custom_result_summary_renderer(results)
+            elif result_renderer == 'default' and action_summary and \
                     sum(sum(s.values()) for s in action_summary.values()) > 1:
                 # give a summary in default mode, when there was more than one
                 # action performed


### PR DESCRIPTION
Now each class could provide its own idea of how results can be summarized, and override the default action counter that is sometimes rather uninformative.

Instrumental in addressing situations like https://github.com/datalad/datalad-revolution/issues/56

Let's see if it breaks anything existing. Demo PR: https://github.com/datalad/datalad-revolution/pull/57