### PR TITLE
 ENH: run: Use expanded command for commit summary

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -437,15 +437,16 @@ def _get_script_handler(script, since, revision):
 
             run_info = res["run_info"]
             cmd = run_info["cmd"]
-            msg = res["run_message"]
-            if msg == _format_cmd_shorty(cmd):
-                msg = ''
 
             expanded_cmd = format_command(
                 dset, cmd,
                 **dict(run_info,
                        dspath=dset.path,
                        pwd=op.join(dset.path, run_info["pwd"])))
+
+            msg = res["run_message"]
+            if msg == _format_cmd_shorty(expanded_cmd):
+                msg = ''
 
             ofh.write(
                 "\n" + "".join("# " + ln

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -599,7 +599,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 ^^^ Do not change lines above ^^^
 """
     msg = msg.format(
-        message if message is not None else _format_cmd_shorty(cmd),
+        message if message is not None else _format_cmd_shorty(cmd_expanded),
         '"{}"'.format(record_id) if use_sidecar else record)
 
     outputs_to_save = outputs.expand(full=True) if explicit else '.'


### PR DESCRIPTION
The unexpanded form can be pretty uninformative (e.g., "python {input}").