### PR TITLE
run: Use 'datalad add' in failure instructions

### DIFF
--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -20,6 +20,7 @@ from os.path import normpath
 from os.path import pardir
 from os.path import relpath
 
+from datalad.utils import assure_unicode
 from datalad.utils import unique
 from datalad.utils import get_dataset_root
 from datalad.interface.base import Interface
@@ -29,6 +30,7 @@ from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
 from datalad.interface.common_opts import nosave_opt
 from datalad.interface.common_opts import save_message_opt
+from datalad.interface.common_opts import message_file_opt
 from datalad.interface.common_opts import git_opts
 from datalad.interface.common_opts import annex_opts
 from datalad.interface.common_opts import annex_add_opts
@@ -167,6 +169,7 @@ class Add(Interface):
             their respective datasets, regardless of this setting."""),
         save=nosave_opt,
         message=save_message_opt,
+        message_file=message_file_opt,
         git_opts=git_opts,
         annex_opts=annex_opts,
         annex_add_opts=annex_add_opts,
@@ -183,6 +186,7 @@ class Add(Interface):
             to_git=None,
             save=True,
             message=None,
+            message_file=None,
             recursive=False,
             recursion_limit=None,
             ds2super=False,
@@ -196,6 +200,13 @@ class Add(Interface):
                 "insufficient information for adding: requires at least a path")
         refds_path = Interface.get_refds_path(dataset)
         common_report = dict(action='add', logger=lgr, refds=refds_path)
+
+        if message and message_file:
+            raise ValueError("Both a message and message file were specified")
+
+        if message_file:
+            with open(message_file, "rb") as mfh:
+                message = assure_unicode(mfh.read())
 
         to_add = []
         subds_to_add = {}

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import eq_
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import assert_raises
+from datalad.tests.utils import assert_equal
 from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
@@ -60,6 +61,19 @@ def test_add_insufficient_args(path):
     with open(opj(path, 'outside'), 'w') as f:
         f.write('doesnt matter')
     assert_status('impossible', ds.add(opj(path, 'outside'), on_failure='ignore'))
+
+
+@with_tempfile
+def test_add_message_file(path):
+    ds = Dataset(path).create()
+    with assert_raises(ValueError):
+        ds.add("blah", message="me", message_file="and me")
+
+    create_tree(path, {"foo": "x",
+                       "msg": u"add β"})
+    ds.add("foo", message_file=opj(ds.path, "msg"))
+    assert_equal(ds.repo.format_commit("%s"),
+                 u"add β")
 
 
 tree_arg = dict(tree={'test.txt': 'some',

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -119,6 +119,12 @@ save_message_opt = Parameter(
     doc="""a description of the state or the changes made to a dataset.""",
     constraints=EnsureStr() | EnsureNone())
 
+message_file_opt = Parameter(
+    args=("-F", "--message-file"),
+    doc="""take the commit message from this file. This flag is
+    mutually exclusive with -m.""",
+    constraints=EnsureStr() | EnsureNone())
+
 reckless_opt = Parameter(
     args=("--reckless",),
     action="store_true",

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -611,7 +611,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 ofh.write(assure_bytes(msg))
             lgr.info("The command had a non-zero exit code. "
                      "If this is expected, you can save the changes with "
-                     "'datalad save -r -F %s .'",
+                     "'datalad add -d . -r -F %s .'",
                      msg_path)
         raise exc
     elif outputs_to_save:

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -19,6 +19,7 @@ from os.path import relpath
 from os.path import lexists
 
 
+from datalad.utils import assure_unicode
 from datalad.utils import unique
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureStr
@@ -233,8 +234,8 @@ class Save(Interface):
             return
 
         if message_file:
-            with open(message_file) as mfh:
-                message = mfh.read()
+            with open(message_file, "rb") as mfh:
+                message = assure_unicode(mfh.read())
 
         to_process = []
         got_nothing = True

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -34,6 +34,7 @@ from datalad.interface.annotate_paths import annotated2content_by_ds
 from datalad.interface.common_opts import recursion_limit, recursion_flag
 from datalad.interface.common_opts import super_datasets_flag
 from datalad.interface.common_opts import save_message_opt
+from datalad.interface.common_opts import message_file_opt
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
@@ -187,11 +188,7 @@ class Save(Interface):
             nargs='*',
             constraints=EnsureStr() | EnsureNone()),
         message=save_message_opt,
-        message_file=Parameter(
-            args=("-F", "--message-file"),
-            doc="""take the commit message from this file. This flag is
-            mutually exclusive with -m.""",
-            constraints=EnsureStr() | EnsureNone()),
+        message_file=message_file_opt,
         # switch not functional from cmdline: default True, action=store_true
         # TODO remove from API? all_updated=False is not used anywhere in the codebase
         all_updated=Parameter(

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -225,13 +225,7 @@ class Save(Interface):
         refds_path = Interface.get_refds_path(dataset)
 
         if message and message_file:
-            yield get_status_dict(
-                'save',
-                status='error',
-                path=refds_path,
-                message="Both a message and message file were specified",
-                logger=lgr)
-            return
+            raise ValueError("Both a message and message file were specified")
 
         if message_file:
             with open(message_file, "rb") as mfh:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -423,26 +423,27 @@ def test_rerun_just_one_commit(path):
 
 @ignore_nose_capturing_stdout
 @known_failure_windows
+@known_failure_direct_mode
 @with_tempfile(mkdir=True)
 def test_run_failure(path):
     ds = Dataset(path).create()
+    subds = ds.create("sub")
 
     hexsha_initial = ds.repo.get_hexsha()
 
     with assert_raises(CommandError):
-        ds.run("echo x$(cat grows) > grows && false")
+        ds.run("echo x$(cat sub/grows) > sub/grows && false")
     eq_(hexsha_initial, ds.repo.get_hexsha())
     ok_(ds.repo.dirty)
 
     msgfile = opj(path, ds.repo.get_git_dir(ds.repo), "COMMIT_EDITMSG")
     ok_exists(msgfile)
 
-    ds.add(".", save=False)
-    ds.save(message_file=msgfile)
+    ds.add(".", recursive=True, message_file=msgfile)
     ok_clean_git(ds.path)
     neq_(hexsha_initial, ds.repo.get_hexsha())
 
-    outfile = opj(ds.path, "grows")
+    outfile = opj(subds.path, "grows")
     eq_('x\n', open(outfile).read())
 
     # There is no CommandError on rerun if the non-zero error matches the

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -270,7 +270,7 @@ def test_recursive_save(path):
 @with_tempfile()
 def test_save_message_file(path):
     ds = Dataset(path).create()
-    with assert_raises(IncompleteResultsError):
+    with assert_raises(ValueError):
         ds.save("blah", message="me", message_file="and me")
 
     create_tree(path, {"foo": "x",

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -1,4 +1,5 @@
 # emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -273,11 +274,11 @@ def test_save_message_file(path):
         ds.save("blah", message="me", message_file="and me")
 
     create_tree(path, {"foo": "x",
-                       "msg": "add foo"})
+                       "msg": u"add β"})
     ds.add("foo", save=False)
     ds.save(message_file=opj(ds.path, "msg"))
     assert_equal(ds.repo.format_commit("%s"),
-                 "add foo")
+                 u"add β")
 
 
 def test_renamed_file():


### PR DESCRIPTION
  * Minor improvments `save`s `--message-file` handling

  * Update `add` to support `--message-file`

  * Update `run`s failure instructions to use `datalad add` (closes #3072)
