### PR TITLE
RF+ENH: if search resulted in no hits due to wrong keys used, log an INFO msg with suggestions

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -31,9 +31,13 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
-from ..utils import setup_exceptionhook, chpwd
-from ..utils import assure_unicode
-from ..utils import on_msys_tainted_paths
+from ..utils import (
+    assure_unicode,
+    chpwd,
+    get_suggestions_msg,
+    on_msys_tainted_paths,
+    setup_exceptionhook,
+)
 from ..dochelpers import exc_str
 
 
@@ -355,12 +359,7 @@ def fail_with_short_help(parser=None,
             "datalad: Unknown %s %r.  See 'datalad --help'.\n\n"
             % (what, provided,))
         if provided not in known:
-            import difflib
-            suggestions = difflib.get_close_matches(provided, known)
-            if suggestions:
-                out.write(
-                    "Did you mean one of these?\n        %s\n"
-                    % "\n        ".join(suggestions))
+            out.write(get_suggestions_msg(provided, known))
         # Too noisy
         # sys.stderr.write(" All known %ss: %s\n"
         #                   % (what, ", ".join(sorted(known))))

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -268,7 +268,7 @@ def test_fail_with_short_help():
     assert_equal(out.getvalue(),
                  "error: Failed badly\n"
                  "datalad: Unknown parent 'muther'.  See 'datalad --help'.\n\n"
-                 "Did you mean one of these?\n"
+                 "Did you mean any of these?\n"
                  "        mutter\n"
                  "        mother\n"
                  "        father\n"

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -9,6 +9,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Some additional tests for search command (some are within test_base)"""
 
+import logging
 from shutil import copy
 from mock import patch
 from os import makedirs
@@ -16,8 +17,11 @@ from os.path import join as opj
 from os.path import dirname
 from datalad.api import Dataset, install
 from nose.tools import assert_equal, assert_raises
-from datalad.utils import chpwd
-from datalad.utils import swallow_outputs
+from datalad.utils import (
+    chpwd,
+    swallow_logs,
+    swallow_outputs,
+)
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_is_generator
@@ -324,6 +328,14 @@ type
         for matched_key, matched_val in matched.items():
             assert_in(matched_key, res[-1]['query_matched'])
             assert_equal(res[-1]['query_matched'][matched_key], matched_val)
+
+    # test a suggestion msg being logged if no hits and key is a bit off
+    with swallow_logs(new_level=logging.INFO) as cml:
+        res = ds.search('audio.formats:mp3 audio.bitsrate:1', mode='egrep')
+        assert not res
+        assert_in('Did you mean any of', cml.out)
+        assert_in('audio.format', cml.out)
+        assert_in('audio.bitrate', cml.out)
 
 
 def test_listdict2dictlist():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2142,4 +2142,24 @@ def create_tree(path, tree, archives_leading_dir=True, remove_existing=False):
             os.chmod(full_name, os.stat(full_name).st_mode | stat.S_IEXEC)
 
 
+def get_suggestions_msg(values, known, sep="\n        "):
+    """Return a formatted string with suggestions for values given the known ones
+    """
+    import difflib
+    suggestions = []
+    for value in assure_list(values):  # might not want to do it if we change presentation below
+        suggestions += difflib.get_close_matches(value, known)
+    suggestions = unique(suggestions)
+    msg = "Did you mean any of these?"
+    if suggestions:
+        if '\n' in sep:
+            # if separator includes new line - we add entire separator right away
+            msg += sep
+        else:
+            msg += ' '
+        return msg + "%s\n" % sep.join(suggestions)
+    return ''
+
+
+
 lgr.log(5, "Done importing datalad.utils")


### PR DESCRIPTION
Just kept hitting the situations where a key is mistyped and I get no results, and have no clue what went wrong - either there is no hits really or I mistyped something.  Now would look like

```shell
$> datalad -f '{path}' -c datalad.search.index-egrep-documenttype=files search --mode egrep paths:.*_rec-.* bids.subject.age:10 biids.subject.race:white du                                                                     
[INFO   ] No search hits, wrong query? See 'datalad search --show-keys name' for known keys and 'datalad search --help' on how to prepare your query. Following keys were not found in available metadata: bids.subject.age, biids.subject.race, paths.  Did you mean any of these?
|         bids.subject.race
|         bids.subject.scanage
|         bids.subject.sex
|         bids.subject.source
|         bids.subject.trial
|         path
|         parentds
|  
```
not ideal, but at least gives clues