### PR TITLE
BF: downloaders: Add guard against unset credential object

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -284,7 +284,7 @@ class BaseDownloader(object):
         else:
             action_msg = "enter other credentials in case they were updated?"
 
-            if ui.yesno(
+            if self.credential and ui.yesno(
                     title=title,
                     text="Do you want to %s" % action_msg):
                 self.credential.enter_new()


### PR DESCRIPTION
If access is denied and the Authenticator's requires_authentication
and allows_anonymous attributes are both True, we can hit the case
where BaseDownloader.credential is None when _enter_credentials is
called with new_provider=False.

There is nothing to update in this case, so raise the download error.

Fixes #3090.