### PR TITLE
ENH+BF(TST): create-sibling --group option

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -204,10 +204,10 @@ def _create_dataset_sibling(
             delayed_super, name, ssh)
 
     if group:
-        # Either it existed before or a new directory for a repo, set its
-        # group to a desired one if was provided
+        # Either repository existed before or a new directory was created for it,
+        # set its group to a desired one if was provided with the same chgrp
         ssh("chgrp -R {} {}".format(
-            group,
+            sh_quote(group),
             sh_quote(remoteds_path)))
     # don't (re-)initialize dataset if existing == reconfigure
     if not only_reconfigure:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -389,8 +389,9 @@ class CreateSibling(Interface):
         group=Parameter(
             args=("--group",),
             metavar="GROUP",
-            doc="""Filesystem group for the repository. Important in particular
-            when --shared=group""",
+            doc="""Filesystem group for the repository. Specifying the group is
+            particularly important when [CMD: --shared=group CMD][PY:
+            shared="group" PY]""",
             constraints=EnsureStr() | EnsureNone()
         ),
         ui=Parameter(

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -207,7 +207,7 @@ def _create_dataset_sibling(
         # Either repository existed before or a new directory was created for it,
         # set its group to a desired one if was provided with the same chgrp
         ssh("chgrp -R {} {}".format(
-            sh_quote(group),
+            sh_quote(text_type(group)),
             sh_quote(remoteds_path)))
     # don't (re-)initialize dataset if existing == reconfigure
     if not only_reconfigure:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -70,6 +70,7 @@ def _create_dataset_sibling(
         target_pushurl,
         existing,
         shared,
+        group,
         publish_depends,
         publish_by_default,
         as_common_datasrc,
@@ -202,6 +203,12 @@ def _create_dataset_sibling(
         shared = CreateSibling._get_ds_remote_shared_setting(
             delayed_super, name, ssh)
 
+    if group:
+        # Either it existed before or a new directory for a repo, set its
+        # group to a desired one if was provided
+        ssh("chgrp -R {} {}".format(
+            group,
+            sh_quote(remoteds_path)))
     # don't (re-)initialize dataset if existing == reconfigure
     if not only_reconfigure:
         # init git and possibly annex repo
@@ -379,6 +386,13 @@ class CreateSibling(Interface):
             Possible values for this option are identical to those of
             `git init --shared` and are described in its documentation.""",
             constraints=EnsureStr() | EnsureBool() | EnsureNone()),
+        group=Parameter(
+            args=("--group",),
+            metavar="GROUP",
+            doc="""Filesystem group for the repository. Important in particular
+            when --shared=group""",
+            constraints=EnsureStr() | EnsureNone()
+        ),
         ui=Parameter(
             args=("--ui",),
             metavar='false|true|html_filename',
@@ -408,7 +422,10 @@ class CreateSibling(Interface):
                  dataset=None,
                  recursive=False,
                  recursion_limit=None,
-                 existing='error', shared=None, ui=False,
+                 existing='error',
+                 shared=None,
+                 group=None,
+                 ui=False,
                  as_common_datasrc=None,
                  publish_by_default=None,
                  publish_depends=None,
@@ -587,6 +604,7 @@ class CreateSibling(Interface):
                 target_pushurl,
                 existing,
                 shared,
+                group,
                 publish_depends,
                 publish_by_default,
                 as_common_datasrc,

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -497,6 +497,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     eq_(len(logs_post), len(logs_prior) + 1)
 
 
+@known_failure_direct_mode  #FIXME
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)
@@ -556,8 +557,9 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
 
 def test_target_ssh_inherit():
     skip_if_on_windows()  # create_sibling incompatible with win servers
-    # TODO: waits for resolution on
+    # TODO: was waiting for resolution on
     #   https://github.com/datalad/datalad/issues/1274
-    #yield _test_target_ssh_inherit, None      # no wanted etc
-    #yield _test_target_ssh_inherit, 'manual'  # manual -- no load should be annex copied
-    yield known_failure_direct_mode(_test_target_ssh_inherit), 'backup'  # backup -- all data files  #FIXME
+    # which is now closed but this one is failing ATM, thus leaving as TODO
+    # yield _test_target_ssh_inherit, None      # no wanted etc
+    yield _test_target_ssh_inherit, 'manual'  # manual -- no load should be annex copied
+    yield _test_target_ssh_inherit, 'backup'  # backup -- all data files

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -554,8 +554,8 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
         assert_false(target_sub.repo.file_has_content('sub.dat'))
 
 
-@skip_if_on_windows  # create_sibling incompatible with win servers
 def test_target_ssh_inherit():
+    skip_if_on_windows()  # create_sibling incompatible with win servers
     # TODO: waits for resolution on
     #   https://github.com/datalad/datalad/issues/1274
     #yield _test_target_ssh_inherit, None      # no wanted etc

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -505,7 +505,9 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
     ds = Dataset(src_path).create()
     target_url = 'localhost:%s' % target_path
     remote = "magical"
-    ds.create_sibling(target_url, name=remote, shared='group')  # not doing recursively
+    # for the test of setting a group, will just smoke test while using current
+    # user's group
+    ds.create_sibling(target_url, name=remote, shared='group', group=os.getgid())  # not doing recursively
     if standardgroup:
         ds.repo.set_preferred_content('wanted', 'standard', remote)
         ds.repo.set_preferred_content('group', standardgroup, remote)

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -286,9 +286,9 @@ def check_download_external_url(url, failed_str, success_str, d, url_final=None)
     # TODO -- more and more specific
 
 
-@skip_if_no_network
 @use_cassette('test_authenticate_external_portals', record_mode='once')
 def test_authenticate_external_portals():
+    skip_if_no_network()
     yield check_download_external_url, \
           "https://portal.nersc.gov/project/crcns/download/alm-1/checksums.md5", \
           "<form action=", \
@@ -305,8 +305,8 @@ def test_authenticate_external_portals():
 test_authenticate_external_portals.tags = ['external-portal', 'network']
 
 
-@skip_if_no_network
 def test_download_ftp():
+    skip_if_no_network()
     try:
         import requests_ftp
     except ImportError:

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -315,7 +315,7 @@ def test_download_ftp():
           "ftp://ftp.gnu.org/README", \
           None, \
           "This is ftp.gnu.org"
-test_authenticate_external_portals.tags = ['external-portal', 'network']
+test_download_ftp.tags = ['network']
 
 
 # TODO: redo smart way with mocking, to avoid unnecessary CPU waste

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -311,10 +311,16 @@ def test_download_ftp():
         import requests_ftp
     except ImportError:
         raise SkipTest("need requests_ftp")  # TODO - make it not ad-hoc
-    yield check_download_external_url, \
-          "ftp://ftp.gnu.org/README", \
-          None, \
-          "This is ftp.gnu.org"
+    # Started to throw 504 when on travis
+    try:
+        yield check_download_external_url, \
+              "ftp://ftp.gnu.org/README", \
+              None, \
+              "This is ftp.gnu.org"
+    except AccessFailedError as exc:
+        if 'status code 503' in str(exc):
+            raise SkipTest("ftp.gnu.org throws 503 when on travis (only?)")
+        raise
 test_download_ftp.tags = ['network']
 
 

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -315,6 +315,7 @@ def test_download_ftp():
           "ftp://ftp.gnu.org/README", \
           None, \
           "This is ftp.gnu.org"
+test_authenticate_external_portals.tags = ['external-portal', 'network']
 
 
 # TODO: redo smart way with mocking, to avoid unnecessary CPU waste

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -305,23 +305,22 @@ def test_authenticate_external_portals():
 test_authenticate_external_portals.tags = ['external-portal', 'network']
 
 
+@skip_if_no_network
 def test_download_ftp():
-    skip_if_no_network()
     try:
         import requests_ftp
     except ImportError:
         raise SkipTest("need requests_ftp")  # TODO - make it not ad-hoc
-    # Started to throw 504 when on travis
     try:
-        yield check_download_external_url, \
-              "ftp://ftp.gnu.org/README", \
-              None, \
-              "This is ftp.gnu.org"
+        check_download_external_url(
+                  "ftp://ftp.gnu.org/README",
+                  None,
+                  "This is ftp.gnu.org"
+        )
     except AccessFailedError as exc:
         if 'status code 503' in str(exc):
             raise SkipTest("ftp.gnu.org throws 503 when on travis (only?)")
         raise
-test_download_ftp.tags = ['network']
 
 
 # TODO: redo smart way with mocking, to avoid unnecessary CPU waste

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -222,8 +222,8 @@ def check_runner_heavy_output(log_online):
         assert not ret[0], "all messages went into `logged`"
 
 
-@skip_if_on_windows  # much too slow to finish in any reaosnable time on windows
 def test_runner_heavy_output():
+    skip_if_on_windows()
     for log_online in [False, True]:
         yield check_runner_heavy_output, log_online
 


### PR DESCRIPTION
1.
    ENH: create-sibling --group option
    
    When needing to create a group shared remote sibling, we need to be able
    to specify which group actually should it be (if directories setup does not
    enforce it).

2.
    BF+RF: @skip_ decorators must not be used on generator tests
    
    Apparently some tests were simply not ran because decorated to be skipped,
    but our decorators do not work nicely with those generatorfunctions tests,
    so we must use them via their functional counterparts.
    
    Ideally those @skip_ helpers should be refactored since there is a repeating
    pattern and only the check is different.  But I kept it "minimal" for now,
    and made them usable as functions within tests in such cases.
    
    There might now be test failures detected where they are still not used
    appropriately
