### PR TITLE
[WIP] ENH: Allow Git to talk to the caller in Repo.commit()

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1303,7 +1303,9 @@ class GitRepo(RepoInterface):
 
         try:
             self._git_custom_command(files, cmd,
-                                     expect_stderr=True, expect_fail=True,
+                                     log_stdout=not options or not '--edit' in options,
+                                     expect_stderr=True,
+                                     expect_fail=True,
                                      check_fake_dates=True,
                                      index_file=index_file)
         except CommandError as e:


### PR DESCRIPTION
- [x] let stdout through. Without this change, DataLad blocks any attempt to get Git to launch an editor to tailor commit messages.
- [x] RF handling of commit messages too (blocks more `git commit` features like message templates)
- [ ] catch error when `git commit` fails due to an unedited commit message (template) and issue a proper error instead of crashing with debug output

It turns out that the last point, and, even worse, acting on any error is tricky (or impossible) -- see below and #3103 