### PR TITLE
BF: GitRepo.commit to work correctly on directory paths (Fixes #3087)

### DIFF
--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -460,3 +460,25 @@ def test_bf2043p2(path):
     with chpwd(path):
         save()
     ok_clean_git(ds.path, untracked=['untracked'])
+
+
+# https://github.com/datalad/datalad/issues/3087
+@with_tree({
+    'sdir1': {'foo': 'foo'},
+    'sdir2': {'foo': 'foo'},
+    'sdir3': {'sdir': {'subsub': {'foo': 'foo'}}},
+})
+def test_save_directory(path):
+    # Sequence of save invocations on subdirectories.
+    ds = Dataset(path).create(force=True)
+    ds.save(path='sdir1')
+    ok_clean_git(ds.path, untracked=['sdir2/foo', 'sdir3/sdir/subsub/foo'])
+
+    # There is also difference from
+    with chpwd(path):
+        save(path='sdir2')
+    ok_clean_git(ds.path, untracked=['sdir3/sdir/subsub/foo'])
+
+    with chpwd(opj(path, 'sdir3')):
+        save(path='sdir')
+    ok_clean_git(ds.path)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2926,10 +2926,25 @@ class AnnexRepo(GitRepo, RepoInterface):
                         if direct_mode \
                         else set(self.get_changed_files(staged=False))
 
-                    files_set = {
+                    files_normalized = [
                         _normalize_path(self.path, f) if isabs(f) else f
                         for f in files
-                    }
+                    ]
+                    # Some paths might be directories, so we should expand
+                    # them to the actual set of files known to git/index. Here
+                    # we are not aiming to add untracked files, so should be good
+                    # XXXX? submodules?
+                    files_set = set(
+                        filter(
+                            bool,
+                            self._git_custom_command(
+                                files=files_normalized,
+                                cmd_str=['git', 'ls-files', '-z'])
+                                [0]
+                                .split('\0')
+                        )
+                    )
+
                     # files_notstaged = files_set.difference(changed_files_staged)
                     files_changed_notstaged = files_set.intersection(changed_files_notstaged)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2601,7 +2601,8 @@ class GitRepo(RepoInterface):
                                     if len(item.split(': ')) == 2]}
         return count
 
-    def get_changed_files(self, staged=False, diff_filter='', index_file=None):
+    def get_changed_files(self, staged=False, diff_filter='', index_file=None,
+                          files=None):
         """Return files that have changed between the index and working tree.
 
         Parameters
@@ -2624,6 +2625,9 @@ class GitRepo(RepoInterface):
             opts.append('--diff-filter=%s' % diff_filter)
         if index_file:
             kwargs['env'] = {'GIT_INDEX_FILE': index_file}
+        if files:
+            opts.append('--')
+            opts += assure_list(files)
         return [normpath(f)  # Call normpath to convert separators on Windows.
                 for f in self.repo.git.diff(*opts, **kwargs).split('\0') if f]
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2609,7 +2609,7 @@ class GitRepo(RepoInterface):
             opts.append('--diff-filter=%s' % diff_filter)
         if index_file:
             kwargs['env'] = {'GIT_INDEX_FILE': index_file}
-        if files:
+        if files is not None:
             opts.append('--')
             # might be too many, need to chunk up
             optss = (

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1063,6 +1063,11 @@ def test_get_missing(path):
         {'test1', op.join('deep', 'test2')})
     eq_(set(repo.get_changed_files(staged=True, diff_filter='AD')),
         {'test1', op.join('deep', 'test2')})
+    eq_(set(repo.get_changed_files(staged=True, diff_filter='AD', files=['test1'])),
+        {'test1'})
+    # providing 'files' pointing to subdirectory lists files within
+    eq_(set(repo.get_changed_files(staged=True, diff_filter='AD', files=['deep'])),
+        {op.join('deep', 'test2')})
     eq_(repo.get_changed_files(staged=True, diff_filter='D'), [])
     repo.commit()
     eq_(repo.get_changed_files(), [])

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1068,6 +1068,9 @@ def test_get_missing(path):
     # providing 'files' pointing to subdirectory lists files within
     eq_(set(repo.get_changed_files(staged=True, diff_filter='AD', files=['deep'])),
         {op.join('deep', 'test2')})
+    # empty list should cause no files being reported in either scenario
+    eq_(repo.get_changed_files(staged=True, files=[]), [])
+    eq_(repo.get_changed_files(staged=False, files=[]), [])
     eq_(repo.get_changed_files(staged=True, diff_filter='D'), [])
     repo.commit()
     eq_(repo.get_changed_files(), [])

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -871,7 +871,7 @@ def generate_file_chunks(files, cmd=None):
     files = assure_list(files)
     cmd = assure_list(cmd)
 
-    maxl = max(map(len, files))
+    maxl = max(map(len, files)) if files else 0
     chunk_size = max(
         1,  # should at least be 1. If blows then - not our fault
         (CMD_MAX_ARG

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -858,6 +858,37 @@ def generate_chunks(container, size):
         yield container[:size]
         container = container[size:]
 
+
+def generate_file_chunks(files, cmd=None):
+    """Given a list of files, generate chunks of them to avoid exceding cmdline length
+
+    Parameters
+    ----------
+    files: list of str
+    cmd: str or list of str, optional
+      Command to account for as well
+    """
+    files = assure_list(files)
+    cmd = assure_list(cmd)
+
+    maxl = max(map(len, files))
+    chunk_size = max(
+        1,  # should at least be 1. If blows then - not our fault
+        (CMD_MAX_ARG
+         - sum((len(x) + 3) for x in cmd)
+         - 4  # for '--' below
+         ) // (maxl + 3)  # +3 for possible quotes and a space
+    )
+    # TODO: additional treatment for "too many arguments"? although
+    # as https://github.com/datalad/datalad/issues/1883#issuecomment
+    # -436272758
+    # shows there seems to be no hardcoded limit on # of arguments,
+    # but may be we decide to go for smth like follow to be on safe side
+    # chunk_size = min(10240 - len(cmd), chunk_size)
+    file_chunks = generate_chunks(files, chunk_size)
+    return file_chunks
+
+
 #
 # Generators helpers
 #


### PR DESCRIPTION
This pull request fixes #3087 through comparing to the `git diff` for the files provided to the commit call, so should behave properly in case of directories etc.

### Changes
- [x] Needs fixing since breaks the tests
- Make checks optional for the `rev-` functionality since it cares not about staged or not and about direct mode, so I guess a plain `commit(files)` should suffice in that case - probably should better be done in master upon merge