### PR TITLE
RF: place all extracted metadata under git-annex

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -271,7 +271,7 @@ definitions = {
         'ui': ('question', {
                'title': 'Limit configuration annexing aggregated metadata in new dataset',
                'text': 'Git-annex large files expression (see https://git-annex.branchable.com/tips/largefiles; given expression will be wrapped in parentheses)'}),
-        'default': 'largerthan=20kb',
+        'default': 'anything',
     },
     'datalad.runtime.raiseonerror': {
         'ui': ('question', {


### PR DESCRIPTION
We have discussed it before, and decided to place small files directly under git.
But I was thinking about it and converging on placing all metadata under annex
control, so there is a better control over availability: we might need to remove
leaked sensitive metadata.

What do you think?

Not sure yet if any unittest would be effected
