### PR TITLE
RF: Consolidate various aggregate metadata accessors into a single function

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -106,13 +106,6 @@ def get_metadata_type(ds):
     return []
 
 
-class MetadataDict(dict):
-    """Metadata dict helper class"""
-    # TODO no longer needed ATM, but keeping for now, avoiding the
-    # big diff
-    pass
-
-
 def _load_json_object(fpath, cache=None):
     if cache is None:
         cache = {}
@@ -367,7 +360,7 @@ def _query_aggregated_metadata_singlepath(
                   if rparentpath == op.curdir or
                   path_startswith(f, rparentpath)]:
         # we might be onto something here, prepare result
-        metadata = MetadataDict(contentmeta.get(fpath, {}))
+        metadata = contentmeta.get(fpath, {})
 
         # we have to pull out the context for each extractor from the dataset
         # metadata
@@ -441,8 +434,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
     types : list
     """
     errored = False
-    dsmeta = MetadataDict()
-    # each item in here will be a MetadataDict, but not the whole thing
+    dsmeta = dict()
     contentmeta = {}
 
     if global_meta is not None and content_meta is not None and \
@@ -597,7 +589,6 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
             #elif not meta:
             #    continue
 
-            meta = MetadataDict(meta)
             # apply filters
             meta = _filter_metadata_fields(
                 meta,

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -134,22 +134,26 @@ def _get_metadatarelevant_paths(ds, subds_relpaths):
                        for ex in list(exclude_from_metadata) + subds_relpaths))
 
 
-# TODO must work with abspath or relpath, no reason not to have that -> test
 def _get_containingds_from_agginfo(info, rpath):
-    """Return the relative path of a dataset that contains a relative query path
+    """Return the path of a dataset that contains a query path
+
+    If a query path matches a dataset path directly, the matching dataset path
+    is return -- not the parent dataset!
 
     Parameters
     ----------
     info : dict
-      Content of aggregate.json (dict with relative subdataset paths as keys)
+      Content of aggregate.json (dict with (relative) subdataset paths as keys)
     rpath : str
-      Relative query path
+      Query path can be absolute or relative, but must match the convention
+      used in the info dict.
 
     Returns
     -------
     str or None
-      None is returned if the is no match, the relative path of the closest
-      containing subdataset otherwise.
+      None is returned if there is no match, the path of the closest
+      containing subdataset otherwise (in the convention used in the
+      info dict).
     """
     if rpath in info:
         dspath = rpath

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -321,9 +321,10 @@ class _WhooshSearch(_Search):
         `meta2doc` - must return dict for index document from result input
         """
         from whoosh import index as widx
-        from .metadata import agginfo_relpath
+        from .metadata import get_ds_aggregate_db_locations
+        dbloc, db_base_path = get_ds_aggregate_db_locations(self.ds)
         # what is the lastest state of aggregated metadata
-        metadata_state = self.ds.repo.get_last_commit_hash(agginfo_relpath)
+        metadata_state = self.ds.repo.get_last_commit_hash(relpath(dbloc, start=self.ds.path))
         # use location common to all index types, they would all invalidate
         # simultaneously
         stamp_fname = opj(self.index_dir, 'datalad_metadata_state')

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -10,6 +10,7 @@
 """Test metadata aggregation"""
 
 
+import os.path as op
 from os.path import join as opj
 
 from datalad.api import metadata
@@ -258,9 +259,9 @@ def _get_contained_objs(ds):
 
 
 def _get_referenced_objs(ds):
-    return set([opj('.datalad', 'metadata', r[f])
-               for r in ds.metadata(get_aggregates=True)
-               for f in ('content_info', 'dataset_info')])
+    return set([op.relpath(r[f], start=ds.path)
+                for r in ds.metadata(get_aggregates=True)
+                for f in ('content_info', 'dataset_info')])
 
 
 @with_tree(tree=_dataset_hierarchy_template)
@@ -383,7 +384,7 @@ def test_partial_aggregation(path):
     # now let's do partial aggregation from just one subdataset
     # we should not loose information on the other datasets
     # as this would be a problem any time anything in a dataset
-    # subtree is missing: no installed, too expensive to reaggregate, ...
+    # subtree is missing: not installed, too expensive to reaggregate, ...
     ds.aggregate_metadata(path='sub1', incremental=True)
     res = ds.metadata(get_aggregates=True)
     assert_result_count(res, 3)


### PR DESCRIPTION
...which even comes with a docstring.

Pave the way for a future support of a different aggregate metadata layout.

Ping #3110 

The only failure is a crawler test that depended on private info which is now no longer available. The Crawler PR is https://github.com/datalad/datalad-crawler/pull/31, which of course cannot run cleanly until this PR is merged (no need to keep transition code in tests IMHO).

Will merge this ASAP.

Well, as stated in https://github.com/datalad/datalad/issues/3112 a quick merge will not help to resolve this without a release of -crawler. Hence I'll keep working on this (semi-ignoring crawler for now), and either merge when its done, or when a crawler release is imminent.