### PR TITLE
TST: Work around some worktree-related failures

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -113,13 +113,18 @@ assert_create_sshwebserver = (
 
 @with_tempfile(mkdir=True)
 def test_invalid_call(path):
-    # needs a SSH URL
-    assert_raises(InsufficientArgumentsError, create_sibling, '')
-    assert_raises(ValueError, create_sibling, 'http://ignore.me')
-    # needs an actual dataset
-    assert_raises(
-        ValueError,
-        create_sibling, 'localhost:/tmp/somewhere', dataset='/nothere')
+    with chpwd(path):
+        # ^ Change directory so that we don't fail with an
+        # InvalidGitRepositoryError if the test is executed from a git
+        # worktree.
+
+        # needs a SSH URL
+        assert_raises(InsufficientArgumentsError, create_sibling, '')
+        assert_raises(ValueError, create_sibling, 'http://ignore.me')
+        # needs an actual dataset
+        assert_raises(
+            ValueError,
+            create_sibling, 'localhost:/tmp/somewhere', dataset='/nothere')
     # pre-configure a bogus remote
     ds = Dataset(path).create()
     ds.repo.add_remote('bogus', 'http://bogus.url.com')

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -21,6 +21,7 @@ from datalad.utils import unlink
 from datalad.dochelpers import exc_str
 from datalad.support.external_versions import external_versions
 from datalad.support.exceptions import CommandError
+from datalad.support.gitrepo import InvalidGitRepositoryError
 
 
 lgr = logging.getLogger('datalad.plugin.wtf')
@@ -314,7 +315,10 @@ class WTF(Interface):
         infos['metadata_extractors'] = _describe_metadata_extractors()
         infos['dependencies'] = _describe_dependencies()
         if ds:
-            infos['dataset'] = _describe_dataset(ds, sensitive)
+            try:
+                infos['dataset'] = _describe_dataset(ds, sensitive)
+            except InvalidGitRepositoryError as e:
+                infos['dataset'] = {"invalid": exc_str(e)}
 
         if clipboard:
             external_versions.check(


### PR DESCRIPTION
Based on local testing, three tests fail with an
InvalidGitRepositoryError when executed from within a git worktree of
the codebase: test_create_sibling.test_invalid_call,
test_run_procedure.test_invalid_call (gh-3052), and
test_run_procedure.test_procedure_discovery.

Avoid these errors by switching to a temporary, non-repo directory
before running the tests.

Re: #3029
Fixes #3052.

---

The last commit adjusts Travis so that the tests are executed from a worktree.  This is intended as a temporary check for additional failures because I don't think it's worth adding another dedicated Travis run to check for worktree testing issues.