### PR TITLE
Revert "RF: Remove funtion that has moved into the crawler extension"

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -683,3 +683,14 @@ class GitRunner(Runner):
         # All communication here will be returned as unicode
         # TODO: do that instead within the super's run!
         return assure_unicode(out), assure_unicode(err)
+
+
+# TODO: remove some time after datalad-crawler > 0.2 and datalad > 0.11.1 are out
+# left for compatibility with released datalad-crawler (0.2)
+def get_runner(*args, **kwargs):
+    # needs local import, because the ConfigManager itself needs the runner
+    from . import cfg
+    if cfg.obtain('datalad.crawl.dryrun', default=False):
+        kwargs = kwargs.copy()
+        kwargs['protocol'] = DryRunProtocol()
+    return Runner(*args, **kwargs)


### PR DESCRIPTION
This reverts commit fcccb489a9c3659bc10f43b62d90aef8e012782e.

Conflicts:
	datalad/cmd.py - adopted and left a comment on TODO remove

This PR should make current master usable/testable with current datalad-crawler.  Ref: https://github.com/datalad/datalad/pull/3104#discussion_r248306718
