### PR TITLE
BF: Prevent issue with dangling batch processes

### DIFF
--- a/datalad/metadata/extractors/annex.py
+++ b/datalad/metadata/extractors/annex.py
@@ -65,6 +65,9 @@ class MetadataExtractor(BaseMetadataExtractor):
             if key:
                 meta['key'] = key
             yield (file, meta)
+        # we need to make sure that batch processes are terminated
+        # otherwise they might cause trouble on windows
+        repo.precommit()
         log_progress(
             lgr.info,
             'extractorannex',


### PR DESCRIPTION
It might be more useful to execute `precommit()` on a higher level, maybe at the end of aggregation...