### PR TITLE
TST: protocols: Don't assume GitRepo runs a callable

### DIFF
--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -65,6 +65,7 @@ from datalad.support.gitrepo import guard_BadName
 from datalad.support.exceptions import DeprecatedError
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import FileNotInRepositoryError
+from datalad.support.protocol import ExecutionTimeProtocol
 from .utils import check_repo_deals_with_inode_change
 
 
@@ -1371,3 +1372,18 @@ def test_guard_BadName():
     v = Vulnerable()
     eq_(v(1, y=3), 4)
     eq_(calls, [1, 'precommit'])
+
+
+@with_tree(tree={"foo": "foo content"})
+def test_custom_runner_protocol(path):
+    # Check that a runner with a non-default protocol gets wired up correctly.
+    prot = ExecutionTimeProtocol()
+    gr = GitRepo(path, runner=Runner(cwd=path, protocol=prot), create=True)
+    eq_(len(prot), 1)
+    ok_(prot[0]['duration'] >= 0)
+    gr.add("foo")
+    eq_(len(prot), 2)
+    assert_in("add", prot[1]["command"])
+    gr.commit("commit foo")
+    eq_(len(prot), 3)
+    assert_in("commit", prot[2]["command"])


### PR DESCRIPTION
protocols.py distinguishes between external commands and callables.
To test the "callable" case, we create a GitRepo, assuming that this
will lead to gitpy.Repo.init() being executed through the runner.
This is problematic because it depends on internal details of GitRepo
and a reader has to dig into the GitRepo class to understand why we
expect a callable to be used.

And with -revolution, those internal details change. RevolutionGitRepo
overrides _create_empty_repo() and uses the external command 'git
init' as of 8b9d65a (ENH: Expose git-init options, create without
GitPython, 2018-10-29).  As a result, these protocol tests fail if we
substitute RevolutionGitRepo for GitRepo.

Use os.mkdir as the callable to simplify these tests and prepare for
the absorption of RevolutionGitRepo into GitRepo.