### PR TITLE
SSH: Support URLs with ports

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -674,6 +674,7 @@ class GitRunner(Runner):
 
         if 'GIT_SSH_COMMAND' not in git_env:
             git_env['GIT_SSH_COMMAND'] = GIT_SSH_COMMAND
+            git_env['GIT_SSH_VARIANT'] = 'ssh'
 
         return git_env
 

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -157,7 +157,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         create_sibling(
             dataset=source,
             name="local_target",
-            sshurl="ssh://localhost",
+            sshurl="ssh://localhost:22",
             target_dir=target_path,
             ui=True)
         assert_not_in('enableremote local_target failed', cml.out)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -543,7 +543,8 @@ class GitRepo(RepoInterface):
     """
 
     # We use our sshrun helper
-    GIT_SSH_ENV = {'GIT_SSH_COMMAND': GIT_SSH_COMMAND}
+    GIT_SSH_ENV = {'GIT_SSH_COMMAND': GIT_SSH_COMMAND,
+                   'GIT_SSH_VARIANT': 'ssh'}
 
     # We must check git config to have name and email set, but
     # should do it once

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -265,9 +265,10 @@ class SSHConnection(object):
         str
           stdout, stderr of the copy operation.
         """
-
+        # Convert ssh's port flag (-p) to scp's (-P).
+        scp_options = ["-P" if x == "-p" else x for x in self._ctrl_options]
         # add recursive, preserve_attributes flag if recursive, preserve_attrs set and create scp command
-        scp_options = self._ctrl_options + ["-r"] if recursive else self._ctrl_options
+        scp_options += ["-r"] if recursive else []
         scp_options += ["-p"] if preserve_attrs else []
         scp_cmd = ["scp"] + scp_options
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -22,12 +22,7 @@ from os.path import join as opj
 from subprocess import Popen
 # importing the quote function here so it can always be imported from this
 # module
-try:
-    # from Python 3.3 onwards
-    from shlex import quote as sh_quote
-except ImportError:
-    # deprecated since Python 2.7
-    from pipes import quote as sh_quote
+from six.moves import shlex_quote as sh_quote
 
 # !!! Do not import network here -- delay import, allows to shave off 50ms or so
 # on initial import datalad time

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -165,7 +165,7 @@ def test_ssh_manager_close_no_throw(bogus_socket):
 @with_tempfile(content="two")
 def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
 
-    remote_url = 'ssh://localhost'
+    remote_url = 'ssh://localhost:22'
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
     ssh.open()


### PR DESCRIPTION
This is mainly for the benefit of the ReproMan project.  There we are managing SSH resources that the user may not have configured in .ssh/config, so we need to call `create-sibling` with an SSH URL that includes port.  Without these changes, doing that results in an error like

```
stderr: 'fatal: ssh variant 'simple' does not support setting port' [cmd.py:wait:415] (GitCommandError)
```

Just for reference, here is the ssh.variant part of `man git-config`:

```
ssh.variant
    By default, Git determines the command line arguments to use based on the basename of the configured SSH
    command (configured using the environment variable GIT_SSH or GIT_SSH_COMMAND or the config setting
    core.sshCommand). If the basename is unrecognized, Git will attempt to detect support of OpenSSH options
    by first invoking the configured SSH command with the -G (print configuration) option and will
    subsequently use OpenSSH options (if that is successful) or no options besides the host and remote
    command (if it fails).

    The config variable ssh.variant can be set to override this detection. Valid values are ssh (to use
    OpenSSH options), plink, putty, tortoiseplink, simple (no options except the host and remote command).
    The default auto-detection can be explicitly requested using the value auto. Any other value is treated
    as ssh. This setting can also be overridden via the environment variable GIT_SSH_VARIANT.

    The current command-line parameters used for each variant are as follows:

    ·   ssh - [-p port] [-4] [-6] [-o option] [username@]host command

    ·   simple - [username@]host command

    ·   plink or putty - [-P port] [-4] [-6] [username@]host command

    ·   tortoiseplink - [-P port] [-4] [-6] -batch [username@]host command

    Except for the simple variant, command-line parameters are likely to change as git gains new features.
```

---

- [x] Add test for `create-sibling` that uses port in URL.


