### PR TITLE
ENH: ssh: Support specifying identity file via environment variable

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -220,6 +220,12 @@ definitions = {
         'ui': ('question', {
                'title': 'Sets a prefix to add before the command call times are noted by DATALAD_CMD_PROTOCOL.'}),
     },
+    'datalad.ssh.identityfile': {
+        'ui': ('question', {
+               'title': "If set, pass this file as ssh's -i option."}),
+        'destination': 'global',
+        'default': None,
+    },
     'datalad.repo.direct': {
         'ui': ('yesno', {
                'title': 'Direct Mode for git-annex repositories',

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -37,13 +37,16 @@ from datalad.cmd import Runner
 lgr = logging.getLogger('datalad.support.sshconnector')
 
 
-def get_connection_hash(hostname, port='', username=''):
+def get_connection_hash(hostname, port='', username='', identity_file=''):
     """Generate a hash based on SSH connection properties
 
     This can be used for generating filenames that are unique
     to a connection from and to a particular machine (with
     port and login username). The hash also contains the local
     host name.
+
+    Identity file corresponds to a file that will be passed via ssh's -i
+    option.
     """
     # returning only first 8 characters to minimize our chance
     # of hitting a limit on the max path length for the Unix socket.
@@ -52,10 +55,11 @@ def get_connection_hash(hostname, port='', username=''):
     #  https://github.com/ansible/ansible/issues/11536#issuecomment-153030743
     #  https://github.com/datalad/datalad/pull/1377
     return md5(
-        '{lhost}{rhost}{port}{username}'.format(
+        '{lhost}{rhost}{port}{identity_file}{username}'.format(
             lhost=gethostname(),
             rhost=hostname,
             port=port,
+            identity_file=identity_file,
             username=username).encode('utf-8')).hexdigest()[:8]
 
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -68,7 +68,7 @@ class SSHConnection(object):
     """Representation of a (shared) ssh connection.
     """
 
-    def __init__(self, ctrl_path, sshri):
+    def __init__(self, ctrl_path, sshri, identity_file=None):
         """Create a connection handler
 
         The actual opening of the connection is performed on-demand.
@@ -80,6 +80,8 @@ class SSHConnection(object):
         sshri: SSHRI
           SSH resource identifier (contains all connection-relevant info),
           or another resource identifier that can be converted into an SSHRI.
+        identity_file : str or None
+          Value to pass to ssh's -i option.
         """
         self._runner = None
 
@@ -94,6 +96,8 @@ class SSHConnection(object):
         self._ctrl_options = ["-o", "ControlPath=\"%s\"" % self.ctrl_path]
         if self.sshri.port:
             self._ctrl_options += ['-p', '{}'.format(self.sshri.port)]
+
+        self._identity_file = identity_file
 
         # essential properties of the remote system
         self._remote_props = {}
@@ -211,6 +215,8 @@ class SSHConnection(object):
         ctrl_options = ["-fN",
                         "-o", "ControlMaster=auto",
                         "-o", "ControlPersist=15m"] + self._ctrl_options
+        if self._identity_file:
+            ctrl_options.extend(["-i", self._identity_file])
         # create ssh control master command
         cmd = ["ssh"] + ctrl_options + [self.sshri.as_str()]
 

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -36,6 +36,8 @@ class SSHRun(Interface):
     In addition to SSH alone, this command can make use of datalad's SSH
     connection management. Its primary use case is to be used with Git
     as 'core.sshCommand' or via "GIT_SSH_COMMAND".
+
+    Configure `datalad.ssh.identityfile` to pass a file to the ssh's -i option.
     """
     # prevent common args from being added to the docstring
     _no_eval_results = True

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -108,8 +108,10 @@ def test_ssh_manager_close():
     manager = SSHManager()
 
     # check for previously existing sockets:
-    existed_before_1 = exists(opj(manager.socket_dir, 'localhost'))
-    existed_before_2 = exists(opj(manager.socket_dir, 'datalad-test'))
+    existed_before_1 = exists(opj(manager.socket_dir,
+                                  get_connection_hash('localhost')))
+    existed_before_2 = exists(opj(manager.socket_dir,
+                                  get_connection_hash('datalad-test')))
 
     manager.get_connection('ssh://localhost').open()
     manager.get_connection('ssh://datalad-test').open()
@@ -125,8 +127,10 @@ def test_ssh_manager_close():
 
     manager.close()
 
-    still_exists_1 = exists(opj(manager.socket_dir, 'localhost'))
-    still_exists_2 = exists(opj(manager.socket_dir, 'datalad-test'))
+    still_exists_1 = exists(opj(manager.socket_dir,
+                                get_connection_hash('localhost')))
+    still_exists_2 = exists(opj(manager.socket_dir,
+                                get_connection_hash('datalad-test')))
 
     eq_(existed_before_1, still_exists_1)
     eq_(existed_before_2, still_exists_2)


### PR DESCRIPTION
This enables callers to use sshrun with non-standard identity files.
For example, in the ReproMan project, we want to use DataLad commands
with an AWS EC2 instance.  In this case, the host will not be in
.ssh/config, and the key files are usually not in the default
location.