### PR TITLE
BF(PY3): workaround for python3.4 on debian returning obnoxious SC_ARG_MAX

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -89,6 +89,10 @@ CMD_MAX_ARG_HARDCODED = 2097152 if on_linux else 262144 if on_osx else 32767
 try:
     CMD_MAX_ARG = os.sysconf('SC_ARG_MAX')
     assert CMD_MAX_ARG > 0
+    if sys.version_info[:2] == (3, 4):
+        # workaround for some kind of a bug which comes up with python 3.4
+        # see https://github.com/datalad/datalad/issues/3150
+        CMD_MAX_ARG = min(CMD_MAX_ARG, CMD_MAX_ARG_HARDCODED)
 except Exception as exc:
     # ATM (20181005) SC_ARG_MAX available only on POSIX systems
     # so exception would be thrown e.g. on Windows, or


### PR DESCRIPTION
it returns 2**62 number when running the package build.

Closes #3150