### PR TITLE
BF: Stop running that failing test on appveyor - needs fix in git-annex

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,7 +9,10 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
+from datalad.tests.utils import (
+    known_failure_direct_mode,
+    known_failure_windows,
+)
 
 
 import logging
@@ -920,6 +923,7 @@ def test_install_subds_from_another_remote(topdir):
 
 # Takes > 2 sec
 # Do not use cassette
+@known_failure_windows
 @skip_if_no_network
 @with_tempfile
 def check_datasets_datalad_org(suffix, tdir):


### PR DESCRIPTION
This makes all the appveyor runs a useless red mark - hiding away possibly new
bugs we would introduce.  So, I think it is better to disable that test on
appveyor for now

This is a temporary workaround for #3130 