### PR TITLE
Prepare 0.11.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,14 @@ TODO
 
 - The logic for setting the maximum command line length now works
   around Python 3.4 returning an unreasonably high value for
-  `SC_ARG_MAX` on Debian systems (#3165).
+  `SC_ARG_MAX` on Debian systems ([#3165]).
 
 - DataLad commands that are conceptually "read-only", such as
   `datalad ls -L`, can fail when the caller lacks write permissions
   because git-annex tries merging remote git-annex branches to update
   information about availability. DataLad now disables
   `annex.merge-annex-branches` in some common "read-only" scenarios to
-  avoid these failures. (#3164)
+  avoid these failures. ([#3164])
 
 ### Enhancements and new features
 
@@ -32,10 +32,10 @@ TODO
   necessary module rather than requiring an explicit import from the
   Python caller. For example, calling `Dataset.add` no longer needs to
   be preceded by `from datalad.distribution.add import Add` or an
-  import of `datalad.api`. (#3156)
+  import of `datalad.api`. ([#3156])
 
 - Configuring the new variable `datalad.ssh.identityfile` instructs
-  DataLad to pass a value to the `-i` option of `ssh`. (#3149)
+  DataLad to pass a value to the `-i` option of `ssh`. ([#3149])
 
 ## 0.11.2 (Feb 07, 2019) -- live-long-and-prosper
 
@@ -1142,3 +1142,7 @@ publishing
 [#3138]: https://github.com/datalad/datalad/issues/3138
 [#3141]: https://github.com/datalad/datalad/issues/3141
 [#3146]: https://github.com/datalad/datalad/issues/3146
+[#3149]: https://github.com/datalad/datalad/issues/3149
+[#3156]: https://github.com/datalad/datalad/issues/3156
+[#3164]: https://github.com/datalad/datalad/issues/3164
+[#3165]: https://github.com/datalad/datalad/issues/3165

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ TODO
 
 - Configuring the new variable `datalad.ssh.identityfile` instructs
   DataLad to pass a value to the `-i` option of `ssh`. ([#3149])
-  (#3168)
+  ([#3168])
 
 ## 0.11.2 (Feb 07, 2019) -- live-long-and-prosper
 
@@ -1147,3 +1147,4 @@ publishing
 [#3156]: https://github.com/datalad/datalad/issues/3156
 [#3164]: https://github.com/datalad/datalad/issues/3164
 [#3165]: https://github.com/datalad/datalad/issues/3165
+[#3168]: https://github.com/datalad/datalad/issues/3168

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ TODO
 
 - Configuring the new variable `datalad.ssh.identityfile` instructs
   DataLad to pass a value to the `-i` option of `ssh`. ([#3149])
+  (#3168)
 
 ## 0.11.2 (Feb 07, 2019) -- live-long-and-prosper
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,31 @@ We would recommend to consult log of the
 
 ## 0.11.3 (??? ??, 2019) -- will be better than ever
 
-bet we will fix some bugs and make a world even a better place.
-
-### Major refactoring and deprecations
-
-- hopefully none
+TODO
 
 ### Fixes
 
-?
+- The logic for setting the maximum command line length now works
+  around Python 3.4 returning an unreasonably high value for
+  `SC_ARG_MAX` on Debian systems (#3165).
+
+- DataLad commands that are conceptually "read-only", such as
+  `datalad ls -L`, can fail when the caller lacks write permissions
+  because git-annex tries merging remote git-annex branches to update
+  information about availability. DataLad now disables
+  `annex.merge-annex-branches` in some common "read-only" scenarios to
+  avoid these failures. (#3164)
 
 ### Enhancements and new features
 
-?
+- Accessing an "unbound" dataset method now automatically imports the
+  necessary module rather than requiring an explicit import from the
+  Python caller. For example, calling `Dataset.add` no longer needs to
+  be preceded by `from datalad.distribution.add import Add` or an
+  import of `datalad.api`. (#3156)
 
+- Configuring the new variable `datalad.ssh.identityfile` instructs
+  DataLad to pass a value to the `-i` option of `ssh`. (#3149)
 
 ## 0.11.2 (Feb 07, 2019) -- live-long-and-prosper
 


### PR DESCRIPTION
- [X] Update CHANGELOG
- [ ] CHANGELOG touch-ups by @yarikoptic 
- [x] Wait on #3168 (follow-up to #3149)

<details>
<summary>Since 0.11.2</summary>

```
# Generated with
#   git log --format="?  %s%n   %h^-1" --reverse --first-parent 0.11.2..origin/master
#
#
# ?  = unprocessed and undecided
# -  = decided not to include
# +  = included
# +* = included, but might still be bits that should be added

-  Merge remote-tracking branch 'gh-yarikoptic/rel-0.11.2'
   c797f719c^-1
-  Show must go on
   ca3225e66^-1
-  Merge pull request #3145 from kyleam/tst-protocol-callable
   137da7087^-1
-  Merge pull request #3160 from yarikoptic/bf-tests
   f1ebdac30^-1
+  Merge pull request #3156 from yarikoptic/bf-delayed-datasetmethod
   81bfe17a7^-1
+  Merge pull request #3165 from yarikoptic/bf-python34-long
   9c6f6ab82^-1
-  Merge pull request #3166 from yarikoptic/bf-disable-appveyor-installtest
   95ac85b42^-1
+  BF: Allow datalad commands not requiring git-annex changes to operate on read-only filesystem
   4eff996c8^-1
+  ENH: ssh: Support specifying identity file via datalad.ssh.identityfile config variable
   cf3f899e5^-1

```

</details>
