### PR TITLE
Revert "BF(TMP): declare check_datasets_datalad_org failing on windows"

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,10 +9,7 @@
 
 """
 
-from datalad.tests.utils import (
-    known_failure_direct_mode,
-    known_failure_windows,
-)
+from datalad.tests.utils import known_failure_direct_mode
 
 
 import logging
@@ -923,7 +920,6 @@ def test_install_subds_from_another_remote(topdir):
 
 # Takes > 2 sec
 # Do not use cassette
-@known_failure_windows
 @skip_if_no_network
 @with_tempfile
 def check_datasets_datalad_org(suffix, tdir):


### PR DESCRIPTION
This reverts commit 076c6a05d48a91f944c2b3842a1249671541c433.
since presumably was fixed in git-annex
see https://github.com/datalad/datalad/issues/3130 and http://git-annex.branchable.com/bugs/windows_support_totally_bitrotted/#comment-2bf69c9e5095ba74727cd1892c2d2f66