### PR TITLE
RF: Remove direct mode support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_DIRECT=yes
 ##1    - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5
 
@@ -159,14 +158,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  - python: 3.5
-    # test whether known direct mode failures still fail
-    env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
   - python: 3.5
     # test with extension datalad-crawler
@@ -210,13 +201,6 @@ matrix:
 #    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
 #    - DATALAD_TESTS_SSH=1
 #    - _DL_CRON=1
-  # test whether known direct mode failures still fail
-  - env:
-    - DATALAD_REPO_DIRECT=yes
-    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-    - DATALAD_TESTS_SSH=1
-    - _DL_CRON=1
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test functioning of the datalad main cmdline utility """
 
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import on_windows
 
 

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -17,9 +17,6 @@ import logging
 import glob
 from time import sleep
 
-from datalad.tests.utils import known_failure_direct_mode
-
-
 from ..archives import (
     ArchiveAnnexCustomRemote,
     link_file_load,
@@ -167,7 +164,6 @@ def test_basic_scenario(direct, d, d2):
 @with_tree(
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
-@known_failure_direct_mode  #FIXME
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
     annex = AnnexRepo(topdir, init=True)

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -32,7 +32,6 @@ from ...tests.utils import (
     abspath,
     chpwd,
     get_most_obscure_supported_name,
-    with_direct,
     with_tempfile,
     with_tree,
     eq_,
@@ -71,16 +70,15 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 
 # TODO: with_tree ATM for archives creates this nested top directory
 # matching archive name, so it will be a/d/test.dat ... we don't want that probably
-@with_direct
 @with_tree(
     tree=(('a.tar.gz', {'d': {fn_inarchive_obscure: '123'}}),
           ('simple.txt', '123'),
           (fn_archive_obscure, (('d', ((fn_inarchive_obscure, '123'),)),)),
           (fn_extracted_obscure, '123')))
 @with_tempfile()
-def test_basic_scenario(direct, d, d2):
+def test_basic_scenario(d, d2):
     fn_archive, fn_extracted = fn_archive_obscure, fn_extracted_obscure
-    annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
+    annex = AnnexRepo(d, runner=_get_custom_runner(d))
     annex.init_remote(
         ARCHIVES_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % ARCHIVES_SPECIAL_REMOTE,
@@ -132,9 +130,7 @@ def test_basic_scenario(direct, d, d2):
     annex.drop(fn_extracted)  # so we don't get from this one next
 
     # Let's create a clone and verify chain of getting file through the tarball
-    cloned_annex = AnnexRepo.clone(d, d2,
-                                   runner=_get_custom_runner(d2),
-                                   direct=direct)
+    cloned_annex = AnnexRepo.clone(d, d2, runner=_get_custom_runner(d2))
     # we still need to enable manually atm that special remote for archives
     # cloned_annex.enable_remote('annexed-archives')
 

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for the base of our custom remotes"""
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from os.path import isabs
 
@@ -19,7 +18,6 @@ from ..base import AnnexCustomRemote, DEFAULT_AVAILABILITY, DEFAULT_COST
 from datalad.tests.utils import eq_
 
 @with_tree(tree={'file.dat': ''})
-@known_failure_direct_mode  #FIXME
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)
     repo.add('file.dat')

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -20,8 +20,8 @@ from ..datalad import DataladAnnexCustomRemote
 
 @with_tempfile()
 @skip_if_no_network
-def check_basic_scenario(direct, url, d):
-    annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
+def check_basic_scenario(url, d):
+    annex = AnnexRepo(d, runner=_get_custom_runner(d))
     annex.init_remote(
         DATALAD_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % DATALAD_SPECIAL_REMOTE,
@@ -58,16 +58,14 @@ def check_basic_scenario(direct, url, d):
 
 # unfortunately with_tree etc decorators aren't generators friendly thus
 # this little adapters to test both on local and s3 urls
-@with_direct
 @with_tree(tree={'3versions-allversioned.txt': "somefile"})
 @serve_path_via_http
-def test_basic_scenario_local_url(direct, p, local_url):
-    check_basic_scenario(direct, "%s3versions-allversioned.txt" % local_url)
+def test_basic_scenario_local_url(p, local_url):
+    check_basic_scenario("%s3versions-allversioned.txt" % local_url)
 
 
-@with_direct
-def test_basic_scenario_s3(direct):
-    check_basic_scenario(direct, 's3://datalad-test0-versioned/3versions-allversioned.txt')
+def test_basic_scenario_s3():
+    check_basic_scenario('s3://datalad-test0-versioned/3versions-allversioned.txt')
 
 
 

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -10,7 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import logging
 import os
@@ -138,7 +137,6 @@ def test_add_files(path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_known_submodule(path):
     def get_baseline(p):
         ds = Dataset(p).create()
@@ -159,7 +157,6 @@ def test_update_known_submodule(path):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_recursive(path):
     # make simple hierarchy
     parent = Dataset(path).create()
@@ -191,7 +188,6 @@ def test_add_recursive(path):
 
 
 @with_tree(**tree_arg)
-@known_failure_direct_mode  #FIXME
 def test_add_dirty_tree(path):
     ds = Dataset(path)
     ds.create(force=True, save=False)
@@ -348,7 +344,6 @@ def test_add_source(path, url, ds_dir):
 
 @with_tree(**tree_arg)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_add_subdataset(path, other):
     subds = create(opj(path, 'dir'), force=True)
     ds = create(path, force=True)
@@ -385,7 +380,6 @@ def test_add_subdataset(path, other):
     'file2.txt': 'some text to go to annex',
     '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
 )
-@known_failure_direct_mode  #FIXME
 def test_add_mimetypes(path):
     # XXX apparently there is symlinks dereferencing going on while deducing repo
     #    type there!!!! so can't use following invocation  -- TODO separately
@@ -426,7 +420,6 @@ def test_gh1597_simpler(path):
 
 
 # Failed to run ['git', '--work-tree=.', 'diff', '--raw', '-z', '--ignore-submodules=none', '--abbrev=40', 'HEAD', '--'] This operation must be run in a work tree
-@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_gh1597(path):
     ds = Dataset(path).create()

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -229,10 +229,7 @@ def test_clone_into_dataset(source, top_path):
 
     subds = ds.clone(source, "sub",
                      result_xfm='datasets', return_type='item-or-list')
-    if isinstance(subds.repo, AnnexRepo) and subds.repo.is_direct_mode():
-        ok_(exists(opj(subds.path, '.git')))
-    else:
-        ok_(isdir(opj(subds.path, '.git')))
+    ok_(isdir(opj(subds.path, '.git')))
     ok_(subds.is_installed())
     assert_in('sub', ds.subdatasets(fulfilled=True, result_xfm='relpaths'))
     # sub is clean:

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -138,6 +138,7 @@ def test_create(path):
         ('bim', 'bam', 'bum'))
 
 
+@known_failure_windows  #FIXME
 @with_tempfile
 def test_create_sub(path):
 
@@ -200,6 +201,8 @@ def test_create_sub_nosave(path):
     # Just the annex subdataset is recognized.
     eq_(ds.subdatasets(result_xfm="relpaths"), ["sub_annex"])
 
+
+@known_failure_windows
 @with_tree(tree=_dataset_hierarchy_template)
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import known_failure_windows
 
 
@@ -140,7 +139,6 @@ def test_create(path):
 
 
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_create_sub(path):
 
     ds = Dataset(path)
@@ -178,7 +176,6 @@ def test_create_sub(path):
 
 
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_create_sub_nosave(path):
     ds = Dataset(path)
     ds.create()
@@ -204,7 +201,6 @@ def test_create_sub_nosave(path):
     eq_(ds.subdatasets(result_xfm="relpaths"), ["sub_annex"])
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_create_subdataset_hierarchy_from_top(path):
     # how it would look like to overlay a subdataset hierarchy onto
     # an existing directory tree
@@ -233,7 +229,6 @@ def test_create_subdataset_hierarchy_from_top(path):
 
 
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_nested_create(path):
     # to document some more organic usage pattern
     ds = Dataset(path).create()

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import os
@@ -313,7 +312,6 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_target_ssh_recursive(origin, src_path, target_path):
 
     # prepare src
@@ -385,7 +383,6 @@ def test_target_ssh_recursive(origin, src_path, target_path):
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_target_ssh_since(origin, src_path, target_path):
     # prepare src
     source = install(src_path, source=origin, recursive=True)
@@ -502,7 +499,6 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     eq_(len(logs_post), len(logs_prior) + 1)
 
 
-@known_failure_direct_mode  #FIXME
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -37,7 +37,6 @@ def test_parse_spec():
     eq_(_parse_spec(''), [])
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -49,7 +48,6 @@ def test_create_test_dataset():
         ok_(len(glob(opj(ds, 'file*'))))
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -59,7 +57,6 @@ def test_create_1test_dataset():
     ok_clean_git(dss[0], annex=False)
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 @with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
@@ -71,7 +68,6 @@ def test_new_relpath(topdir):
         ok_clean_git(ds, annex=False)
 
 
-# Note: This randomly fails in direct mode due to gh-issue #1852
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -8,7 +8,6 @@
 """Test create testdataset helpers
 
 """
-from datalad.tests.utils import known_failure_direct_mode
 
 from glob import glob
 from os.path import join as opj
@@ -39,7 +38,6 @@ def test_parse_spec():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 def test_create_test_dataset():
     # rudimentary smoke test
     from datalad.api import create_test_dataset
@@ -52,7 +50,6 @@ def test_create_test_dataset():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 def test_create_1test_dataset():
     # and just a single dataset
     from datalad.api import create_test_dataset
@@ -63,7 +60,6 @@ def test_create_1test_dataset():
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_new_relpath(topdir):
     from datalad.api import create_test_dataset
@@ -76,7 +72,6 @@ def test_new_relpath(topdir):
 
 
 # Note: This randomly fails in direct mode due to gh-issue #1852
-@known_failure_direct_mode  #FIXME
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -10,7 +10,6 @@
 """
 
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from os import curdir
 from os.path import join as opj, basename
@@ -369,7 +368,6 @@ def test_get_install_missing_subdataset(src, path):
 #                  'subds': {'file_in_annex.txt': 'content'}})
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_get_mixed_hierarchy(src, path):
 
     origin = Dataset(src).create(no_annex=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -69,6 +69,7 @@ from datalad.tests.utils import slow
 from datalad.tests.utils import usecase
 from datalad.tests.utils import get_datasets_topdir
 from datalad.tests.utils import SkipTest
+from datalad.tests.utils import known_failure_windows
 from datalad.utils import _path_
 from datalad.utils import rmtree
 
@@ -462,6 +463,7 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
+@known_failure_windows  #FIXME
 @usecase  # 39.3074s
 @skip_if_no_network
 @use_cassette('test_install_crcns')
@@ -779,6 +781,7 @@ def test_install_source_relpath(src, dest):
         ds2 = install(dest, source=src_)
 
 
+@known_failure_windows  #FIXME
 @integration  # 41.2043s
 @with_tempfile
 @with_tempfile

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -442,10 +442,7 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(ds.path)
 
     subds = ds.install("sub", source=source, save=False)
-    if isinstance(subds.repo, AnnexRepo) and subds.repo.is_direct_mode():
-        ok_(exists(opj(subds.path, '.git')))
-    else:
-        ok_(isdir(opj(subds.path, '.git')))
+    ok_(isdir(opj(subds.path, '.git')))
     ok_(subds.is_installed())
     assert_in('sub', ds.subdatasets(result_xfm='relpaths'))
     # sub is clean:

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -9,9 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
-
-
 import logging
 import os
 
@@ -424,11 +421,6 @@ def test_install_recursive_with_data(src, path):
             ok_(all(subds.repo.file_has_content(subds.repo.get_annexed_files())))
 
 
-# @known_failure_direct_mode  #FIXME:
-# If we use all testrepos, we get a mixed hierarchy. Therefore ok_clean_git
-# fails if we are in direct mode and run into a plain git beneath an annex, due
-# to currently impossible recursion of `AnnexRepo._submodules_dirty_direct_mode`
-
 @slow  # 88.0869s  because of going through multiple test repos, ~8sec each time
 @with_testrepos('.*annex.*', flavors=['local'])
 # 'local-url', 'network'
@@ -474,7 +466,6 @@ def test_install_into_dataset(source, top_path):
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_failed_install_multiple(top_path):
     ds = create(top_path)
 
@@ -532,7 +523,6 @@ def test_install_known_subdataset(src, path):
 @slow  # 46.3650s
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_implicit_install(src, dst):
 
     origin_top = create(src)
@@ -794,7 +784,6 @@ def test_install_source_relpath(src, dest):
 @with_tempfile
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_install_consistent_state(src, dest, dest2, dest3):
     # if we install a dataset, where sub-dataset "went ahead" in that branch,
     # while super-dataset was not yet updated (e.g. we installed super before)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -46,6 +46,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_windows
 
 
 @with_testrepos('submodule_annex', flavors=['local'])
@@ -564,6 +565,7 @@ def test_publish_depends(
         ok_file_has_content(opj(p, 'probe1'), 'probe1')
 
 
+@known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_gh1426(origin_path, target_path):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import logging
@@ -105,7 +104,6 @@ def test_smth_about_not_supported(p1, p2):
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -230,7 +228,6 @@ def test_publish_plain_git(origin, src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
 
     # we will be publishing back to origin, so to not alter testrepo
@@ -397,7 +394,6 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
 
     # prepare src
@@ -491,7 +487,6 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 @with_tempfile()
 @with_tempfile()
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_publish_depends(
         origin,
         src_path,
@@ -571,7 +566,6 @@ def test_publish_depends(
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_gh1426(origin_path, target_path):
     # set up a pair of repos, one the published copy of the other
     origin = create(origin_path)
@@ -633,7 +627,6 @@ def test_publish_gh1691(origin, src_path, dst_path):
 @with_tree(tree={'1': '123'})
 @with_tempfile(mkdir=True)
 @serve_path_via_http
-@known_failure_direct_mode  #FIXME
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
@@ -651,7 +644,6 @@ def test_publish_target_url(src, desttop, desturl):
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_gh1763(src, target1, target2):
     # this test is very similar to test_publish_depends, but more
     # comprehensible, and directly tests issue 1763

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -7,7 +7,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test subdataset command"""
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os
 from os.path import join as opj
@@ -25,10 +24,8 @@ from datalad.tests.utils import assert_false
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_status
-from datalad.tests.utils import known_failure_direct_mode
 
 
-@known_failure_direct_mode  #FIXME
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
 def test_get_subdatasets(path):
     ds = Dataset(path)
@@ -195,7 +192,6 @@ def test_state(path):
         ds.subdatasets(), 1, path=sub.path, state='absent')
 
 
-@known_failure_direct_mode  #FIXME same issue as gh-2113
 @with_tempfile
 def test_get_subdatasets_types(path):
     from datalad.api import create

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import os
@@ -74,7 +73,6 @@ def test_uninstall_uninstalled(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_clean_subds_removal(path):
     ds = Dataset(path).create()
     subds1 = ds.create('one')
@@ -224,7 +222,6 @@ def test_uninstall_subdataset(src, dst):
             'keep': 'keep1', 'kill': 'kill1'}},
     'keep': 'keep2',
     'kill': 'kill2'})
-@known_failure_direct_mode  #FIXME
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
     subds = ds.create('deep', force=True)
@@ -274,7 +271,6 @@ def test_uninstall_dataset(path):
 
 
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
-@known_failure_direct_mode  #FIXME
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
     ds.add(os.curdir)
@@ -304,7 +300,6 @@ def test_remove_file_handle_only(path):
 
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
-@known_failure_direct_mode  #FIXME
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
@@ -369,7 +364,6 @@ def test_remove_dataset_hierarchy(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_careless_subdataset_uninstall(path):
     # nested datasets
     ds = Dataset(path).create()
@@ -469,7 +463,6 @@ def test_remove_recursive_2(tdir):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_failon_nodrop(path):
     # test to make sure that we do not wipe out data when checks are enabled
     # despite the general error behavior mode
@@ -531,7 +524,6 @@ def test_drop_nocrash_absent_subds(path):
         assert_status('notneeded', drop('.', recursive=True))
 
 
-@known_failure_direct_mode  #FIXME
 @with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
 def test_remove_more_than_one(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -37,6 +37,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import slow
+from datalad.tests.utils import known_failure_windows
 
 
 @slow
@@ -207,6 +208,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
     eq_([False], ds.repo.file_has_content(["first.txt"]))
 
 
+@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_newthings_coming_down(originpath, destpath):
@@ -263,6 +265,7 @@ def test_newthings_coming_down(originpath, destpath):
     eq_(ds.repo.get_tags(output='name')[-1], 'second!')
 
 
+@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -343,6 +346,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     ok_clean_git(ds.path)
 
 
+@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_reobtain_data(originpath, destpath):

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -9,7 +9,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 import os
@@ -44,7 +43,6 @@ from datalad.tests.utils import slow
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
@@ -151,7 +149,6 @@ def test_update_git_smoke(src_path, dst_path):
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_fetch_all(src, remote_1, remote_2):
     rmt1 = AnnexRepo.clone(src, remote_1)
     rmt2 = AnnexRepo.clone(src, remote_2)
@@ -212,7 +209,6 @@ def test_update_fetch_all(src, remote_1, remote_2):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
@@ -270,7 +266,6 @@ def test_newthings_coming_down(originpath, destpath):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_update_volatile_subds(originpath, otherpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -350,7 +345,6 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_reobtain_data(originpath, destpath):
     origin = Dataset(originpath).create()
     ds = install(
@@ -392,7 +386,6 @@ def test_reobtain_data(originpath, destpath):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  # use of bare repos in the test
 def test_multiway_merge(path):
     # prepare ds with two siblings, but no tracking branch
     ds = Dataset(op.join(path, 'ds_orig')).create()

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -78,7 +78,7 @@ def test_add_archive_dirs(path_orig, url, repo_path):
     # change to repo_path
     with chpwd(repo_path):
         # create annex repo
-        repo = AnnexRepo(repo_path, create=True, direct=False)
+        repo = AnnexRepo(repo_path, create=True)
 
         # add archive to the repo so we could test
         with swallow_outputs():
@@ -167,13 +167,12 @@ tree4uargs = dict(
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 def test_add_archive_content(path_orig, url, repo_path):
-    direct = False  # TODO: test on undirect, but too long ATM
     with chpwd(repo_path):
         # TODO we need to be able to pass path into add_archive_content
         # We could mock but I mean for the API
         assert_raises(RuntimeError, add_archive_content, "nonexisting.tar.gz") # no repo yet
 
-        repo = AnnexRepo(repo_path, create=True, direct=direct)
+        repo = AnnexRepo(repo_path, create=True)
         assert_raises(ValueError, add_archive_content, "nonexisting.tar.gz")
         # we can't add a file from outside the repo ATM
         assert_raises(FileNotInRepositoryError, add_archive_content, opj(path_orig, '1.tar.gz'))
@@ -306,9 +305,8 @@ def test_add_archive_content(path_orig, url, repo_path):
 @serve_path_via_http()
 @with_tempfile(mkdir=True)
 def test_add_archive_content_strip_leading(path_orig, url, repo_path):
-    direct = False  # TODO: test on undirect, but too long ATM
     with chpwd(repo_path):
-        repo = AnnexRepo(repo_path, create=True, direct=direct)
+        repo = AnnexRepo(repo_path, create=True)
 
         # Let's add first archive to the repo so we could test
         with swallow_outputs():
@@ -358,8 +356,7 @@ def test_add_archive_content_absolute_path(path):
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 def test_add_archive_use_archive_dir(repo_path):
-    direct = False  # TODO: test on undirect, but too long ATM
-    repo = AnnexRepo(repo_path, create=True, direct=direct)
+    repo = AnnexRepo(repo_path, create=True)
     with chpwd(repo_path):
         # Let's add first archive to the repo with default setting
         archive_path = opj('4u', '1.tar.gz')
@@ -398,8 +395,7 @@ class TestAddArchiveOptions():
                delete=False)
     def setup(self, repo_path):
         self.pwd = getpwd()
-        direct = False  # TODO: test on undirect, but too long ATM
-        self.annex = annex = AnnexRepo(repo_path, create=True, direct=direct)
+        self.annex = annex = AnnexRepo(repo_path, create=True)
         # Let's add first archive to the annex so we could test
         annex.add('1.tar')
         annex.commit(msg="added 1.tar")

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -10,7 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from copy import deepcopy
 
@@ -224,7 +223,6 @@ def test_annotate_paths(dspath, nodspath):
 
 @slow  # 11.0891s
 @with_tree(demo_hierarchy['b'])
-@known_failure_direct_mode  #FIXME
 def test_get_modified_subpaths(path):
     ds = Dataset(path).create(force=True)
     suba = ds.create('ba', force=True)
@@ -330,7 +328,6 @@ def test_get_modified_subpaths(path):
 @slow  # 41.5367s
 @with_tree(demo_hierarchy)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_direct_mode
 
 
 from os.path import join as opj
@@ -146,7 +145,6 @@ def test_diff(path, norepo):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')
@@ -203,7 +201,6 @@ def test_diff_recursive(path):
     'modified': 'original_content',
     'untracked': 'dirt',
 })
-@known_failure_direct_mode  #FIXME
 def test_diff_helper(path):
     # make test dataset components of interesting states
     ds = Dataset.create(path, force=True)

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -23,7 +23,6 @@ from datalad.interface.ls_webui import machinesize, ignored, fs_traverse, \
     _ls_json, UNKNOWN_SIZE
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import with_tree
 from datalad.utils import swallow_logs, swallow_outputs, _path_
 
@@ -132,7 +131,6 @@ def test_fs_traverse(topdir):
             assert_equal(brokenlink['size']['total'], '3 Bytes')
 
 
-@known_failure_direct_mode  #FIXME
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '123',

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os.path as op
 from os.path import join as opj
@@ -187,7 +186,6 @@ def test_sidecar(path):
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun(path, nodspath):
     ds = Dataset(path).create()
     sub = ds.create('sub')
@@ -275,7 +273,6 @@ def test_rerun_empty_branch(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_onto(path):
     ds = Dataset(path).create()
 
@@ -423,7 +420,6 @@ def test_rerun_just_one_commit(path):
 
 @ignore_nose_capturing_stdout
 @known_failure_windows
-@known_failure_direct_mode
 @with_tempfile(mkdir=True)
 def test_run_failure(path):
     ds = Dataset(path).create()
@@ -468,7 +464,6 @@ def test_run_failure(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_branch(path):
     ds = Dataset(path).create()
 
@@ -521,7 +516,6 @@ def test_rerun_branch(path):
 @ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()
 
@@ -708,7 +702,6 @@ def test_rerun_script(path):
                                         "d.txt": "d"}},
                         "ss": {"e.dat": "e"}}})
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_run_inputs_outputs(src, path):
     for subds in [("s0", "s1_0", "s2"),
                   ("s0", "s1_1", "s2"),

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -106,9 +106,6 @@ def test_basics(path, nodspath):
         last_state = ds.repo.get_hexsha()
         # now run a command that will not alter the dataset
         res = ds.run('touch empty', message='NOOP_TEST')
-        # When in direct mode, check at the level of save rather than add
-        # because the annex files show up as typechanges and adding them won't
-        # necessarily have a "notneeded" status.
         assert_result_count(res, 1, action='add', status='notneeded')
         eq_(last_state, ds.repo.get_hexsha())
         # We can also run the command via a single-item list because this is

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -83,7 +83,6 @@ def test_invalid_call(path):
 @with_tempfile(mkdir=True)
 def test_basics(path, nodspath):
     ds = Dataset(path).create()
-    direct_mode = ds.repo.is_direct_mode()
     last_state = ds.repo.get_hexsha()
     # run inside the dataset
     with chpwd(path), \
@@ -111,14 +110,12 @@ def test_basics(path, nodspath):
         # When in direct mode, check at the level of save rather than add
         # because the annex files show up as typechanges and adding them won't
         # necessarily have a "notneeded" status.
-        assert_result_count(res, 1, action='save' if direct_mode else 'add',
-                            status='notneeded')
+        assert_result_count(res, 1, action='add', status='notneeded')
         eq_(last_state, ds.repo.get_hexsha())
         # We can also run the command via a single-item list because this is
         # what the CLI interface passes in for quoted commands.
         res = ds.run(['touch empty'], message='NOOP_TEST')
-        assert_result_count(res, 1, action='save' if direct_mode else 'add',
-                            status='notneeded')
+        assert_result_count(res, 1, action='add', status='notneeded')
 
     # run outside the dataset, should still work but with limitations
     with chpwd(nodspath), \

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -27,6 +27,7 @@ from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in_results
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import on_windows
+from datalad.tests.utils import known_failure_windows
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.api import run_procedure
@@ -47,7 +48,7 @@ def test_invalid_call(path):
         assert_in_results(res, status="impossible")
 
 
-@skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
+@known_failure_windows  #FIXME
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -27,7 +27,6 @@ from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in_results
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import on_windows
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.api import run_procedure
@@ -51,7 +50,6 @@ def test_invalid_call(path):
 # FIXME: For some reason fails to commit correctly if on windows and in direct
 # mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
-@known_failure_direct_mode  #FIXME
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -47,8 +47,6 @@ def test_invalid_call(path):
         assert_in_results(res, status="impossible")
 
 
-# FIXME: For some reason fails to commit correctly if on windows and in direct
-# mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
@@ -101,8 +99,6 @@ def test_basics(path, super_path):
     ok_clean_git(super.path, index_modified=[op.join('.datalad', 'config')])
 
 
-# FIXME: For some reason fails to commit correctly if on windows and in direct
-# mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
@@ -202,8 +198,6 @@ def test_procedure_discovery(path, super_path):
                                                'unknwon_broken_link'))
 
 
-# FIXME: For some reason fails to commit correctly if on windows and in direct
-# mode. However, direct mode on linux works
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -13,7 +13,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os
 from os.path import pardir
@@ -47,7 +46,6 @@ from datalad.tests.utils import known_failure_windows
 
 
 @with_testrepos('.*git.*', flavors=['clone'])
-@known_failure_direct_mode  #FIXME
 def test_save(path):
 
     ds = Dataset(path)
@@ -119,7 +117,6 @@ def test_save(path):
 
 
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_recursive_save(path):
     ds = Dataset(path).create()
     # nothing to save
@@ -297,7 +294,6 @@ def test_renamed_file():
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_subdataset_save(path):
     parent = Dataset(path).create()
     sub = parent.create('sub')
@@ -373,7 +369,6 @@ def test_symlinked_relpath(path):
 
 
 # two subdatasets not possible in direct mode
-@known_failure_direct_mode  #FIXME
 @with_tempfile(mkdir=True)
 def test_bf1886(path):
     parent = Dataset(path).create()

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -368,7 +368,6 @@ def test_symlinked_relpath(path):
     ok_clean_git(dspath)
 
 
-# two subdatasets not possible in direct mode
 @with_tempfile(mkdir=True)
 def test_bf1886(path):
     parent = Dataset(path).create()

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -77,12 +77,6 @@ def test_unlock(path):
     # TODO: use get_annexed_files instead of hardcoded filename
     assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
-    # in direct mode there is no unlock:
-    if ds.repo.is_direct_mode():
-        res = ds.unlock()
-        assert_result_count(res, 1)
-        assert_status('notneeded', res)
-
     # in V6+ we can unlock even if the file's content isn't present:
     elif ds.repo.supports_unlocked_pointers:
         res = ds.unlock()
@@ -98,10 +92,7 @@ def test_unlock(path):
     ds.repo.get('test-annex.dat')
     result = ds.unlock()
     assert_result_count(result, 1)
-    if ds.repo.is_direct_mode():
-        assert_status('notneeded', result)
-    else:
-        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
+    assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
 
     with open(opj(path, 'test-annex.dat'), "w") as f:
         f.write("change content")
@@ -114,9 +105,8 @@ def test_unlock(path):
         ds.repo._git_custom_command('test-annex.dat', ['git', 'annex', 'lock'])
     ds.repo.commit("edit 'test-annex.dat' via unlock and lock it again")
 
-    if not ds.repo.is_direct_mode():
-        # after commit, file is locked again:
-        assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
+    # after commit, file is locked again:
+    assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
     # content was changed:
     with open(opj(path, 'test-annex.dat'), "r") as f:
@@ -126,10 +116,7 @@ def test_unlock(path):
     result = ds.unlock(path='test-annex.dat')
     assert_result_count(result, 1)
 
-    if ds.repo.is_direct_mode():
-        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='notneeded')
-    else:
-        assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
+    assert_in_results(result, path=opj(ds.path, 'test-annex.dat'), status='ok')
 
     with open(opj(path, 'test-annex.dat'), "w") as f:
         f.write("change content again")
@@ -148,9 +135,8 @@ def test_unlock(path):
     # and locked it again?
     # Also: After opening the file is empty.
 
-    if not ds.repo.is_direct_mode():
-        # after commit, file is locked again:
-        assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
+    # after commit, file is locked again:
+    assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
     # content was changed:
     with open(opj(path, 'test-annex.dat'), "r") as f:

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -78,7 +78,7 @@ def test_unlock(path):
     assert_raises(IOError, open, opj(path, 'test-annex.dat'), "w")
 
     # in V6+ we can unlock even if the file's content isn't present:
-    elif ds.repo.supports_unlocked_pointers:
+    if ds.repo.supports_unlocked_pointers:
         res = ds.unlock()
         assert_result_count(res, 1)
         assert_status('ok', res)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -10,7 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import os
 import logging
@@ -137,7 +136,6 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 
 @slow  # 74.4509s
 @with_tree(demo_hierarchy)
-@known_failure_direct_mode  #FIXME
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -119,15 +119,6 @@ class Unlock(Interface):
                     yield ap
                 continue
 
-            # direct mode, no unlock:
-            elif ds.repo.is_direct_mode():
-                for ap in content:
-                    ap['status'] = 'notneeded'
-                    ap['message'] = "direct mode, nothing to unlock"
-                    ap.update(res_kwargs)
-                    yield ap
-                continue
-
             # only files in annex with their content present:
             files = [ap['path'] for ap in content]
             to_unlock = []

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -14,7 +14,6 @@ from datalad.api import Dataset
 from datalad.utils import on_osx
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import known_failure_direct_mode
 
 from nose import SkipTest
 from nose.tools import assert_equal

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -26,7 +26,6 @@ from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import skip_if_on_windows
 
 
@@ -56,7 +55,6 @@ _dataset_hierarchy_template = {
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_basic_aggregate(path):
     # TODO give datasets some more metadata to actually aggregate stuff
     base = Dataset(opj(path, 'origin')).create(force=True)
@@ -146,7 +144,6 @@ def test_aggregate_query(path):
 
 # this is for gh-1971
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_reaggregate_with_unavailable_objects(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -181,7 +178,6 @@ def test_reaggregate_with_unavailable_objects(path):
 
 @with_tree(tree=_dataset_hierarchy_template)
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_aggregate_with_unavailable_objects_from_subds(path, target):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -217,7 +213,6 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_publish_aggregated(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -264,7 +259,6 @@ def _get_referenced_objs(ds):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_aggregate_removal(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -300,7 +294,6 @@ def test_aggregate_removal(path):
 
 
 @with_tree(tree=_dataset_hierarchy_template)
-@known_failure_direct_mode  #FIXME
 def test_update_strategy(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
     # force all metadata objects into the annex
@@ -356,7 +349,6 @@ def test_update_strategy(path):
 
 
 # needs two subdatasets, no possible in direct mode
-@known_failure_direct_mode  #FIXME
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -348,7 +348,6 @@ def test_update_strategy(path):
     eq_(target_meta, base.metadata(return_type='list'))
 
 
-# needs two subdatasets, no possible in direct mode
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -241,12 +241,10 @@ def test_bf2458(src, dst):
 
     # no clone (empty) into new dst
     clone = install(source=ds.path, path=dst)
-    # XXX whereis says nothing in direct mode
     # content is not here
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
     # check that plain metadata access does not `get` stuff
     clone.metadata('.', on_failure='ignore')
-    # XXX whereis says nothing in direct mode
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
 
 

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -35,7 +35,6 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_direct_mode
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_
 from datalad.tests.utils import swallow_logs
@@ -97,7 +96,6 @@ def _compare_metadata_helper(origres, compds):
                 eq_(ores[i], cres[i])
 
 
-@known_failure_direct_mode  #FIXME
 @slow  # ~16s
 @with_tree(tree=_dataset_hierarchy_template)
 def test_aggregation(path):

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -34,7 +34,6 @@ from datalad.tests.utils import assert_dict_equal
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import skip_direct_mode
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_
 from datalad.tests.utils import swallow_logs

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -25,7 +25,6 @@ from datalad.utils import (
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_is_generator
-from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_testsui
 from datalad.tests.utils import ok_clean_git

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -198,10 +198,6 @@ def test_within_ds_file_search(path):
             opj(dirname(dirname(__file__)), 'tests', 'data', src),
             opj(path, dst))
     ds.add('.')
-    # yoh: CANNOT FIGURE IT OUT since in direct mode it gets added to git
-    # directly BUT
-    #  - output reports key, so seems to be added to annex!
-    #  - when I do manually in cmdline - goes to annex
     ok_file_under_git(path, opj('stim', 'stim1.mp3'), annexed=True)
     # If it is not under annex, below addition of metadata silently does
     # not do anything

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -87,12 +87,6 @@ def test_archive(path):
     check_contents(custom_outname, 'myexport')
 
     # now loose some content
-    if ds.repo.is_direct_mode():
-        # in direct mode the add() aove commited directly to the annex/direct/master
-        # branch, hence drop will have no effect (notneeded)
-        # this might be undesired behavior (or not), but this is not the place to test
-        # for it
-        return
     ds.drop('file_up', check=False)
     assert_raises(IOError, ds.export_archive, filename=opj(path, 'my'))
     ds.export_archive(filename=opj(path, 'partial'), missing_content='ignore')

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -10,7 +10,6 @@
 """Test plugin interface mechanics"""
 
 
-from datalad.tests.utils import known_failure_direct_mode
 
 from os.path import join as opj
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -116,7 +116,8 @@ class AnnexRepo(GitRepo, RepoInterface):
     # 6.20170220 -- annex status provides --ignore-submodules
     # 6.20180416 -- annex handles unicode filenames more uniformly
     # 6.20180913 -- annex fixes all known to us issues for v6
-    GIT_ANNEX_MIN_VERSION = '6.20180913'
+    # 7          -- annex makes v7 mode default on crippled systems. We demand it for consistent operation
+    GIT_ANNEX_MIN_VERSION = '7'
     git_annex_version = None
 
     # Class wide setting to allow insecure URLs. Used during testing, since
@@ -125,7 +126,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     _ALLOW_LOCAL_URLS = False
 
     def __init__(self, path, url=None, runner=None,
-                 direct=None, backend=None, always_commit=True, create=True,
+                 backend=None, always_commit=True, create=True,
                  init=False, batch_size=None, version=None, description=None,
                  git_opts=None, annex_opts=None, annex_init_opts=None,
                  repo=None, fake_dates=False):
@@ -147,8 +148,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         runner: Runner, optional
           Provide a Runner in case AnnexRepo shall not create it's own.
           This is especially needed in case of desired dry runs.
-        direct: bool, optional
-          If True, force git-annex to use direct mode
         backend: str, optional
           Set default backend used by this annex. This does NOT affect files,
           that are already annexed nor will it automatically migrate files,
@@ -177,9 +176,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         # initialize
         self._uuid = None
         self._annex_common_options = []
-        # Workaround for per-call config issue with git 2.11.0
-        self.GIT_DIRECT_MODE_WRAPPER_ACTIVE = False
-        self.GIT_DIRECT_MODE_PROXY = False
 
         if annex_opts or annex_init_opts:
             lgr.warning("TODO: options passed to git-annex and/or "
@@ -202,8 +198,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             else:
                 raise e
 
-        # Below while setting for direct mode workaround, we change
-        # _GIT_COMMON_OPTIONS.
+        # Below was initially introduced for setting for direct mode workaround,
+        # where we changed _GIT_COMMON_OPTIONS.
         # But we should not pass workarounds such as --worktree=.
         # -c core.bare=False to git annex commands, so for their
         # invocation we will keep and use pristine version of the
@@ -255,34 +251,23 @@ class AnnexRepo(GitRepo, RepoInterface):
             else:
                 raise InvalidAnnexRepositoryError("No annex found at %s." % self.path)
 
-        self._direct_mode = None  # we don't know yet
+        # TODO: RM DIRECT  eventually, but should remain while we have is_direct_mode
+        # and _set_direct_mode
+        self._direct_mode = None
 
-        # If we are in direct mode already, we need to make
-        # this instance aware of that. This especially means, that we need to
-        # adapt self._GIT_COMMON_OPTIONS by calling set_direct_mode().
+        # Handle cases of detecting repositories with no longer supported
+        # direct mode.
         # Could happen in case we didn't specify anything, but annex forced
         # direct mode due to FS or an already existing repo was in direct mode,
         if self._is_direct_mode_from_config():
-            self.set_direct_mode()
+            self._fail_direct_mode(
+                "Git configuration reports repository being in direct mode"
+            )
 
-        # - only force direct mode; don't force indirect mode
-        # - parameter `direct` has priority over config
-        if direct is None:
-            direct = (create or init) and \
-                     self.config.getbool("datalad", "repo.direct", default=False)
-        self._direct_mode = None  # we don't know yet
-        if direct and not self.is_direct_mode():
-            # direct mode is available below version 6 repos only.
-            # Note: If 'annex.version' is missing in .git/config for some
-            # reason, we need to try to set direct mode:
-            repo_version = self.config.getint("annex", "version")
-            if (repo_version is None) or (repo_version < 6):
-                lgr.debug("Switching to direct mode (%s)." % self)
-                self.set_direct_mode()
-            else:
-                # TODO: This may change to either not being a warning and/or
-                # to use 'git annex unlock' instead.
-                lgr.warning("direct mode not available for %s. Ignored." % self)
+        if self.config.getbool("datalad", "repo.direct", default=False):
+            self._fail_direct_mode(
+                "datalad.repo.direct configuration instructs to use direct mode"
+            )
 
         self._batched = BatchedAnnexes(
             batch_size=batch_size, git_options=self._ANNEX_GIT_COMMON_OPTIONS)
@@ -296,6 +281,14 @@ class AnnexRepo(GitRepo, RepoInterface):
         if self._ALLOW_LOCAL_URLS:
             self._allow_local_urls()
 
+    def _fail_direct_mode(self, msg=None):
+        raise RuntimeError(
+            ("direct mode of operation is no longer supported.  "
+            "Please use 'git annex upgrade' under %s to upgrade your direct "
+            "mode repository to annex v6 (or later) which should provide a "
+            "better operation on your system." % self.path) +
+            msg if msg else ''
+        )
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
 
@@ -520,96 +513,11 @@ class AnnexRepo(GitRepo, RepoInterface):
                         branch=self.get_corresponding_branch(branch)
                         if corresponding else branch)
 
-    def _submodules_dirty_direct_mode(self,
-            untracked=True, deleted=True, modified=True, added=True,
-            type_changed=True, path=None):
-        """Get modified submodules
-
-        Workaround for http://git-annex.branchable.com/bugs/git_annex_status_fails_with_submodule_in_direct_mode/
-
-        This is using git-annex-status with --ignore-submodules to not let
-        git-status try to recurse into annex submodules without a working tree.
-        Therefore we need to do the recursion on our own.
-
-        Note, that added submodules will just be reported dirty. It's at very
-        least difficult to distinguish whether a submodule in direct mode was
-        just added or modified. ATM not worth the effort, I think.
-        This is leads to a bit inconsistent reportings by AnnexRepo.status()
-        whenever it needs to call this subroutine and there are added submodules.
-
-        Intended to be used by AnnexRepo.status() internally.
-        """
-
-        # Note: We do a lazy recursion. The only thing we need to know is
-        # whether or not a submodule is to be reported dirty. Once we already
-        # know it is, there's no need to go any deeper in the hierarchy.
-        # Apart from better performance, this also allows us to inspect each
-        # submodule separately, and therefore be able to deal with mixed
-        # hierarchies of git and annex submodules!
-
-        modified_subs = []
-        for sm in self.get_submodules():
-            sm_dirty = False
-
-            # First check for changes committed in the submodule, using
-            # git submodule summary -- path,
-            # since this can't be detected from within the submodule.
-            if self.is_submodule_modified(sm.name):
-                sm_dirty = True
-
-            # check state of annex submodules, that might be in direct mode
-            elif AnnexRepo.is_valid_repo(opj(self.path, sm.path),
-                                         allow_noninitialized=False):
-
-                sm_repo = AnnexRepo(opj(self.path, sm.path),
-                                    create=False, init=False)
-
-                sm_status = sm_repo.get_status(untracked=untracked, deleted=deleted,
-                                               modified=modified, added=added,
-                                               type_changed=type_changed,
-                                               submodules=False, path=path)
-                if any([bool(sm_status[i]) for i in sm_status]):
-                    sm_dirty = True
-
-            # check state of submodule, that is a plain git or not an
-            # initialized annex, which we can safely treat as a plain git, too.
-            elif GitRepo.is_valid_repo(opj(self.path, sm.path)):
-                sm_repo = GitRepo(opj(self.path, sm.path))
-
-                # TODO: Clarify issue: GitRepo.is_dirty() doesn't fit our parameters
-                if sm_repo.is_dirty(index=deleted or modified or added or type_changed,
-                                    working_tree=deleted or modified or added or type_changed,
-                                    untracked_files=untracked,
-                                    submodules=False, path=path):
-                    sm_dirty = True
-            else:
-                # uninitialized submodule
-                # it can't be dirty and we can't recurse any deeper:
-                continue
-
-            if sm_dirty:
-                # the submodule itself is dirty
-                modified_subs.append(sm.path)
-            else:
-                # the submodule itself is clean, recurse:
-                # TODO: This fails ATM with AttributeError, if sm is a GitRepo.
-                # we need get_status and this recursion method to be available
-                # to both classes. Issue: We need to be able to come back to
-                # AnnexRepo from GitRepo if there's again an annex beneath. But
-                # we can't import AnnexRepo in gitrepo.py.
-                modified_subs.extend(
-                    sm_repo._submodules_dirty_direct_mode(
-                        untracked=untracked, deleted=deleted,
-                        modified=modified, added=added,
-                        type_changed=type_changed, path=path
-                    ))
-
-        return modified_subs
-
     def get_status(self, untracked=True, deleted=True, modified=True, added=True,
                    type_changed=True, submodules=True, path=None):
         """Return various aspects of the status of the annex repository
 
+        # TODO: RM DIRECT?
         Note: Under certain circumstances newly added submodules might be
         reported as 'modified' rather tha 'added'.
         See `AnnexRepo._submodules_dirty_direct_mode` for details.
@@ -635,6 +543,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         if not submodules:
             options.extend(to_options(ignore_submodules='all'))
 
+        # TODO: RM DIRECT? _submodules_dirty_direct_mode is now removed,
+        #   git-annex is >= 7
         # BEGIN workaround bug (see self._submodules_dirty_direct_mode)
         # internal call to 'git status' by 'git annex status' will fail
         # in submodules without a working tree (direct mode)
@@ -667,37 +577,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                                    msg=cml.out, stderr=cml.out)
             return json_list
 
-        try:
-            if self.git_annex_version < '6.20170307':
-                json_list = _fake_exception_wrapper(self, options_=options)
-            else:
-                json_list = \
-                    list(self._run_annex_command_json(
-                        'status', opts=options, expect_stderr=False))
-        except CommandError as e:
-            if submodules and AnnexRepo._is_annex_work_tree_message(e.stderr):
-                lgr.debug("git-annex-status failed probably due to submodule in"
-                          " direct mode. Trying to workaround.")
-                # try again, ignoring submodules:
-                options = [path] if path else []
-                options.extend(to_options(ignore_submodules='all'))
-                json_list = list(
-                    self._run_annex_command_json('status', opts=options)
-                )
-                # separately get modified submodules:
-                m_subs = \
-                    self._submodules_dirty_direct_mode(untracked=untracked,
-                                                       deleted=deleted,
-                                                       modified=modified,
-                                                       added=added,
-                                                       type_changed=type_changed,
-                                                       path=path)
-                json_list.extend({'file': p, 'status': 'M'} for p in m_subs)
-            else:
-                # not the known bug we want to catch
-                raise e
-
-        # END workaround
+        json_list = \
+            list(self._run_annex_command_json(
+                'status', opts=options, expect_stderr=False))
 
         key_mapping = [(untracked, 'untracked', '?'),
                        (deleted, 'deleted', 'D'),
@@ -718,6 +600,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # TODO: Add doc on how this differs from GitRepo.is_dirty()
         # Parameter working_tree exists to meet the signature of GitRepo.is_dirty()
 
+        # TODO: RM DIRECT?
         if working_tree:
             # Note: annex repos don't always have a git working tree and the
             # behaviour in direct mode or V6+ repos is fundamentally different
@@ -1182,8 +1065,11 @@ class AnnexRepo(GitRepo, RepoInterface):
             # that unlocked pointers aren't supported.
             return False
 
-    def set_direct_mode(self, enable_direct_mode=True):
-        """Switch to direct or indirect mode
+    # TODO: RM DIRECT  might be gone but pieces might be useful for establishing
+    #       migration to v6+ mode and testing. For now is made protected to
+    #       avoid use by users
+    def _set_direct_mode(self, enable_direct_mode=True):
+        """Switch to direct or indirect mode (to be used only internally)
 
         Parameters
         ----------
@@ -1197,6 +1083,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             in case you try to switch to indirect mode on a crippled filesystem
         """
         if self.is_crippled_fs() and not enable_direct_mode:
+            # TODO: ?? DIRECT - should we call git annex upgrade?
             raise CommandNotAvailableError(
                 cmd="git-annex indirect",
                 msg="Can't switch to indirect mode on that filesystem.")
@@ -1209,64 +1096,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._direct_mode = None
         assert(self.is_direct_mode() == enable_direct_mode)
 
-        if self.is_direct_mode():
-            # adjust git options for plain git calls on this repo:
-            # Note: Not sure yet, whether this solves the issue entirely or we
-            # still need 'annex proxy' in some cases ...
-
-            lgr.debug("detected git version: %s" % external_versions['cmd:git'])
-
-            if external_versions['cmd:git'] >= '2.9.0':
-                # workaround for git 2.9.0, which for some reason ignores the
-                # per-call config "-c core.bare=False", but respects the value
-                # if it is set in .git/config
-                self.GIT_DIRECT_MODE_WRAPPER_ACTIVE = True
-
-            # TEMP: nevertheless use this option to inject it into gitpython
-            # TODO: Solve it and change to "elif"
-            if 'core.bare=False' not in self._GIT_COMMON_OPTIONS:
-                # standard direct mode procedure part I:
-                self._GIT_COMMON_OPTIONS.extend(['-c', 'core.bare=False'])
-            if '--work-tree=' not in self._GIT_COMMON_OPTIONS:
-                # standard direct mode procedure part II:
-                self._GIT_COMMON_OPTIONS.append('--work-tree=.')
-
-    def _git_custom_command(self, *args, **kwargs):
-
-        if self.GIT_DIRECT_MODE_PROXY:
-            proxy_str = "git annex proxy -- "
-            proxy_list = ['git', 'annex', 'proxy', '--']
-            cmd = kwargs.pop("cmd_str", None)
-            if not cmd:
-                cmd = args[1]
-            assert(cmd is not None)
-
-            if isinstance(cmd, string_types):
-                cmd = proxy_str + cmd
-            else:
-                cmd = proxy_list + cmd
-
-            args = (args[0], cmd) + args[2:]
-            return super(AnnexRepo, self)._git_custom_command(*args, **kwargs)
-
-        elif self.GIT_DIRECT_MODE_WRAPPER_ACTIVE:
-            old = self.config.get('core.bare')
-            lgr.debug("old config: %s(%s)" % (old, type(old)))
-            if old is not False:
-                self.config.set('core.bare', 'False', where='local')
-
-            try:
-                out, err = super(AnnexRepo, self)._git_custom_command(
-                    *args, **kwargs)
-            finally:
-                if old is None:
-                    self.config.unset('core.bare', where='local')
-                elif old:
-                    self.config.set('core.bare', old, where='local')
-            return out, err
-
-        else:
-            return super(AnnexRepo, self)._git_custom_command(*args, **kwargs)
+        # All further workarounds were stripped - no direct mode is supported
 
     def _init(self, version=None, description=None):
         """Initializes an annex repository.
@@ -1283,8 +1113,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         # will keep leading underscore in the name for know, but this is
         # not private
         # TODO: provide git and git-annex options.
-        # TODO: Document (or implement respectively) behaviour in special cases
-        # like direct mode (if it's different), not existing paths, etc.
         opts = []
         if description is not None:
             opts += [description]
@@ -1293,6 +1121,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         if not len(opts):
             opts = None
 
+        # TODO: RM DIRECT?  or RF at least ?
         # Note: git-annex-init kills a possible tracking branch for
         # 'annex/direct/my_branch', if we just cloned from a repo in direct
         # mode. We want to preserve the information about the tracking branch,
@@ -1511,43 +1340,36 @@ class AnnexRepo(GitRepo, RepoInterface):
             This is used for progress information
             """
 
-            if self.is_direct_mode():
-                # we already know we can't use --dry-run
-                for r in self._process_git_get_output(
-                        linesep.join(["'{}'".format(p.encode('utf-8'))
-                        for p in paths])):
+            # TODO: RM DIRECT? might remain useful to detect submods left in direct mode
+            # Note: if a path involves a submodule in direct mode, while we
+            # are not in direct mode at current level, we might still fail.
+            # Hence the except clause is still needed. However, this is
+            # unlikely, since direct mode usually should be used only, if it
+            # was enforced by FS and/or OS and therefore concerns the entire
+            # hierarchy.
+            _git_options = ['--dry-run', '-N', '--ignore-missing']
+            try:
+                for r in super(AnnexRepo, self).add_(
+                        files, git_options=_git_options, update=update):
                     yield r
                     return
-            else:
-                # Note: if a path involves a submodule in direct mode, while we
-                # are not in direct mode at current level, we might still fail.
-                # Hence the except clause is still needed. However, this is
-                # unlikely, since direct mode usually should be used only, if it
-                # was enforced by FS and/or OS and therefore concerns the entire
-                # hierarchy.
-                _git_options = ['--dry-run', '-N', '--ignore-missing']
-                try:
-                    for r in super(AnnexRepo, self).add_(
-                            files, git_options=_git_options, update=update):
+            except CommandError as e:
+                if AnnexRepo._is_annex_work_tree_message(e.stderr):
+                    lgr.warning(
+                        "Known bug in direct mode."
+                        "We can't use --dry-run when there are submodules in "
+                        "direct mode, because the internal call to git status "
+                        "fails. To be resolved by using (Dataset's) status "
+                        "instead of a git-add --dry-run altogether.")
+                    # fake the return for now
+                    for r in self._process_git_get_output(
+                            linesep.join(["'{}'".format(f)
+                            for f in files])):
                         yield r
                         return
-                except CommandError as e:
-                    if AnnexRepo._is_annex_work_tree_message(e.stderr):
-                        lgr.warning(
-                            "Known bug in direct mode."
-                            "We can't use --dry-run when there are submodules in "
-                            "direct mode, because the internal call to git status "
-                            "fails. To be resolved by using (Dataset's) status "
-                            "instead of a git-add --dry-run altogether.")
-                        # fake the return for now
-                        for r in self._process_git_get_output(
-                                linesep.join(["'{}'".format(f)
-                                for f in files])):
-                            yield r
-                            return
-                    else:
-                        # unexpected failure
-                        raise e
+                else:
+                    # unexpected failure
+                    raise e
 
         # Theoretically we could have done for git as well, if it could have
         # been batched
@@ -1575,20 +1397,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             # explicitly use git-add with --update instead of git-annex-add
             # TODO: This might still need some work, when --update AND files
             # are specified!
-            if self.is_direct_mode() and not files:
-                self.GIT_DIRECT_MODE_PROXY = True
-            try:
-                for r in super(AnnexRepo, self).add(
-                        files,
-                        git=True,
-                        git_options=git_options,
-                        update=update):
-                    yield r
-            finally:
-                if self.is_direct_mode() and not files:
-                    # don't accidentally cause other git calls to be done
-                    # via annex-proxy
-                    self.GIT_DIRECT_MODE_PROXY = False
+            for r in super(AnnexRepo, self).add(
+                    files,
+                    git=True,
+                    git_options=git_options,
+                    update=update):
+                yield r
 
         else:
             for r in self._run_annex_command_json(
@@ -1601,35 +1415,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                     expected_entries=expected_additions,
                     expect_stderr=True):
                 yield r
-
-    def proxy(self, git_cmd, **kwargs):
-        """Use git-annex as a proxy to git
-
-        This is needed in case we are in direct mode, since there's no git
-        working tree, that git can handle.
-
-        Parameters
-        ----------
-        git_cmd: list of str
-            the actual git command
-        `**kwargs`: dict, optional
-            passed to _run_annex_command
-
-        Returns
-        -------
-        (stdout, stderr)
-            output of the command call
-        """
-        # TODO: We probably don't need it anymore
-
-        if not self.is_direct_mode():
-            lgr.warning("proxy() called in indirect mode: %s" % git_cmd)
-            raise CommandNotAvailableError(cmd="git annex proxy",
-                                           msg="Proxy doesn't make sense"
-                                               " if not in direct mode.")
-        return self._run_annex_command('proxy',
-                                       annex_options=['--'] + git_cmd,
-                                       **kwargs)
 
     @normalize_paths
     def get_file_key(self, files, batch=None):
@@ -1742,37 +1527,15 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         options = options[:] if options else []
 
-        if self.is_direct_mode():
+        # TODO: catch and parse output if failed (missing content ...)
+        std_out, std_err = \
+            self._run_annex_command(
+                'unlock', annex_options=options, files=files
+            )
 
-            # TODO:
-            # If anything there should be a CommandNotAvailableError now:
-            lgr.debug("'%s' is in direct mode, "
-                      "'annex unlock' not available", self)
-            lgr.warning("In direct mode there is no 'unlock'. However if "
-                        "the file's content is present, it is kind of "
-                        "unlocked. Therefore just checking whether this is "
-                        "the case.")
-            # TODO/FIXME:
-            # Note: the following isn't exactly nice, if `files` is a dir.
-            # For a "correct" result we would need to report all files within
-            # potential dir(s) in `files`, that are annexed and have content.
-            # Also note, that even now files in git might be reported "unlocked",
-            # since they have content. This might be a confusing result.
-            # On the other hand, this is solved on the level of Dataset.unlock
-            # by annotating those paths 'notneeded' beforehand.
-            return [f for f in files if self.file_has_content(f)]
-
-        else:
-
-            # TODO: catch and parse output if failed (missing content ...)
-            std_out, std_err = \
-                self._run_annex_command(
-                    'unlock', annex_options=options, files=files
-                )
-
-            return [line.split()[1]
-                    for line in std_out.splitlines()
-                    if line.split()[0] == 'unlock' and line.split()[-1] == 'ok']
+        return [line.split()[1]
+                for line in std_out.splitlines()
+                if line.split()[0] == 'unlock' and line.split()[-1] == 'ok']
 
     def adjust(self, options=None):
         """enter an adjusted branch
@@ -1878,10 +1641,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         # `is_under_annex`. `fn` is the annex command used to do the check, and
         # `quick_fn` is the non-annex variant.
         pointers = self.supports_unlocked_pointers
-        if pointers or self.is_direct_mode() or batch or not allow_quick:
+        if pointers or batch or not allow_quick:
             # We're only concerned about modified files in V6+ mode. In V5
-            # `find` returns an empty string for unlocked files, and in direct
-            # mode everything looks modified, so we don't even bother.
+            # `find` returns an empty string for unlocked files.
             modified = self.get_changed_files() if pointers else []
             annex_res = fn(files, normalize_paths=False, batch=batch)
             return [bool(annex_res.get(f) and
@@ -2056,26 +1818,6 @@ class AnnexRepo(GitRepo, RepoInterface):
           Only sync with the remotes with the lowest annex-cost value
           configured
         """
-        # In direct mode annex-sync fails, if commit=True
-        # apparently sync is calling git status internally, which then fails
-        # in the submodule. (As we already know)
-        # stdout:
-        # commit  add second ok
-        # (recording state in git...)
-        #
-        # failed
-        # (recording state in git...)
-        #
-        # stderr:
-        # fatal: This operation must be run in a work tree
-        # fatal: 'git status --porcelain' failed in submodule submod
-        # git-annex: user error (xargs ["-0","git","--git-dir=.git","--work-tree=.","--literal-pathspecs","add","-f"] exited 123)
-        # fatal: This operation must be run in a work tree
-        # fatal: 'git status --porcelain' failed in submodule submod
-        # git-annex: user error (xargs ["-0","git","--git-dir=.git","--work-tree=.","--literal-pathspecs","add","-f"] exited 123)
-
-        # TODO: Workaround
-
         args = []
         args.extend(to_options(push=push, no_push=not push,
                                # means: '--push' if push else '--no-push'
@@ -2807,189 +2549,85 @@ class AnnexRepo(GitRepo, RepoInterface):
 
     @borrowdoc(GitRepo)
     def commit(self, msg=None, options=None, _datalad_msg=False,
-               careless=True, files=None, proxy=False):
+               careless=True, files=None):
         self.precommit()
 
         if files:
             files = assure_list(files)
 
-        # Note: `proxy` is for explicitly enforcing the use of git-annex-proxy
-        #       in direct mode. This is needed in very special cases, which
-        #       might go away once we figured out a better way. In any case, it
-        #       should turn into something that is automatically considered and
-        #       not done by the caller of this method.
+            # Raise FileNotInRepositoryError if `files` aren't tracked.
+            super(AnnexRepo, self).commit(
+                "dryrun", options=["--dry-run", "--no-status"],
+                files=files)
 
-        if proxy:
-            if not self.is_direct_mode():
-                raise CommandNotAvailableError(
-                    cmd="git-annex-proxy",
-                    msg="git-annex-proxy is available in direct mode only")
-            else:
-                if _datalad_msg:
-                    msg = self._get_prefixed_commit_msg(msg)
-                if not msg:
-                    if options:
-                        if "--allow-empty-message" not in options:
-                            options.append("--allow-empty-message")
-                    else:
-                        options = ["--allow-empty-message"]
-
-                # committing explicitly given paths in direct mode via proxy
-                # used to fail, because absolute paths are used. Using annex
-                # proxy this leads to an error (path outside repository)
-                if files:
-                    if options is None:
-                        options = []
-                    for i in range(len(files)):
-                        if isabs(files[i]):
-                            options.append(normpath(relpath(files[i],
-                                                            start=self.path)))
-                        else:
-                            options.append(files[i])
-                try:
-                    self.proxy(['git', 'commit'] + (['-m', msg] if msg else []) +
-                               (options if options else []),
-                               expect_stderr=True, expect_fail=True)
-                except CommandError as e:
-                    if 'nothing to commit' in e.stdout:
-                        if careless:
-                            lgr.debug("nothing to commit in {}. "
-                                      "Ignored.".format(self))
-                        else:
-                            raise
-                    elif 'no changes added to commit' in e.stdout or \
-                            'nothing added to commit' in e.stdout:
-                        if careless:
-                            lgr.debug("no changes added to commit in {}. "
-                                      "Ignored.".format(self))
-                        else:
-                            raise
-                    elif "did not match any file(s) known to git." in e.stderr:
-                        # TODO:
-                        # Improve FileNotInXXXXError classes to better deal with
-                        # multiple files; Also consider PathOutsideRepositoryError
-                        raise FileNotInRepositoryError(cmd=e.cmd,
-                                                       msg="File(s) unknown to git",
-                                                       code=e.code,
-                                                       filename=linesep.join(
-                                                    [l for l in e.stderr.splitlines()
-                                                     if l.startswith("pathspec")]))
-                    else:
-                        raise
-        else:
-
-            # Note: See the note on `proxy` parameter at the top of this method.
-            #       Trying to automatically use git-annex-proxy, whenever we
-            #       fail to commit the usual way via options to git in direct
-            #       mode. In particular this can happen if sth was staged via
-            #       git-annex-proxy, which is needed for --update option for
-            #       example.
-
+        alt_index_file = None
+        try:
+            # we might need to avoid explicit paths
+            files_to_commit = files
             if files:
-                # Raise FileNotInRepositoryError if `files` aren't tracked.
-                try:
-                    super(AnnexRepo, self).commit(
-                        "dryrun", options=["--dry-run", "--no-status"],
-                        files=files)
-                except CommandError as e:
-                    if not (self.is_direct_mode() and
-                            AnnexRepo._is_annex_work_tree_message(e.stderr)):
-                        raise
-                    # The git call may fail with
-                    #   fatal: this operation must be run in a work tree
-                    #   fatal: 'git status --porcelain=2' failed in submodule ...
-                    # But that error message doesn't matter for the purpose of
-                    # the "file is tracked" check. It won't be shown if there
-                    # is a pathspec error.
-                    lgr.debug("Ignoring commit --dry-run failure")
-            try:
-                alt_index_file = None
+                # In indirect mode, "git commit files" might fail if some
+                # files "jumped" between git/annex.  Then also preparing a
+                # custom index and calling "commit" without files resolves
+                # the issue
+                changed_files_staged = \
+                    set(self.get_changed_files(staged=True))
+                changed_files_notstaged = \
+                    set(self.get_changed_files(staged=False))
 
-                direct_mode = self.is_direct_mode()
-                # we might need to avoid explicit paths
-                files_to_commit = None if direct_mode else files
-                if files:
-                    # In direct mode, if we commit file(s) they would get
-                    # committed directly into git ignoring possibly being
-                    # staged by annex.  So, if not all files are committed, and
-                    # assuming that what is to be committed is staged (!could be
-                    # wrong assumption), we need to prepare a custom index, and
-                    # commit without specifying any paths.
-                    # In indirect mode, "git commit files" might fail if some
-                    # files "jumped" between git/annex.  Then also preparing a
-                    # custom index and calling "commit" without files resolves
-                    # the issue
-                    changed_files_staged = \
-                        set(self.get_changed_files(staged=True))
-                    changed_files_notstaged = \
-                        set() \
-                        if direct_mode \
-                        else set(self.get_changed_files(staged=False))
+                files_set = {
+                    _normalize_path(self.path, f) if isabs(f) else f
+                    for f in files
+                }
+                # files_notstaged = files_set.difference(changed_files_staged)
+                files_changed_notstaged = files_set.intersection(changed_files_notstaged)
 
-                    files_set = {
-                        _normalize_path(self.path, f) if isabs(f) else f
-                        for f in files
-                    }
-                    # files_notstaged = files_set.difference(changed_files_staged)
-                    files_changed_notstaged = files_set.intersection(changed_files_notstaged)
+                # Files which were staged but not among files
+                staged_not_to_commit = changed_files_staged.difference(files_set)
+                if staged_not_to_commit or files_changed_notstaged:
+                    # Need an alternative index_file
+                    with make_tempfile() as index_file:
+                        # First add those which were changed but not staged yet
+                        if files_changed_notstaged:
+                            self.add(files=list(files_changed_notstaged))
 
-                    # Files which were staged but not among files
-                    staged_not_to_commit = changed_files_staged.difference(files_set)
-                    if staged_not_to_commit or files_changed_notstaged:
-                        # Need an alternative index_file
-                        with make_tempfile() as index_file:
-                            # First add those which were changed but not staged yet
-                            if files_changed_notstaged:
-                                self.add(files=list(files_changed_notstaged))
-
-                            alt_index_file = index_file
-                            index_tree = self.repo.git.write_tree()
-                            self.repo.git.read_tree(index_tree,
-                                                    index_output=index_file)
-                            # Reset the files we are not to be committed
-                            if staged_not_to_commit:
-                                self._git_custom_command(
-                                    list(staged_not_to_commit),
-                                    ['git', 'reset'],
-                                    index_file=alt_index_file)
-
-                            super(AnnexRepo, self).commit(
-                                msg, options,
-                                _datalad_msg=_datalad_msg,
-                                careless=careless,
+                        alt_index_file = index_file
+                        index_tree = self.repo.git.write_tree()
+                        self.repo.git.read_tree(index_tree,
+                                                index_output=index_file)
+                        # Reset the files we are not to be committed
+                        if staged_not_to_commit:
+                            self._git_custom_command(
+                                list(staged_not_to_commit),
+                                ['git', 'reset'],
                                 index_file=alt_index_file)
 
-                            if files_changed_notstaged:
-                                # reset current index to reflect the changes annex might have done
-                                self._git_custom_command(
-                                    list(files_changed_notstaged),
-                                    ['git', 'reset']
-                                )
+                        super(AnnexRepo, self).commit(
+                            msg, options,
+                            _datalad_msg=_datalad_msg,
+                            careless=careless,
+                            index_file=alt_index_file)
 
-                    # in any case we will not specify files explicitly
-                    files_to_commit = None
-                if not alt_index_file:
-                    super(AnnexRepo, self).commit(msg, options,
-                                                  _datalad_msg=_datalad_msg,
-                                                  careless=careless,
-                                                  files=files_to_commit)
-            except CommandError as e:
-                # TODO: just remove this???
-                if self.is_direct_mode() and \
-                    AnnexRepo._is_annex_work_tree_message(e.stderr):
-                    lgr.debug("Commit failed. "
-                              "Trying to commit via git-annex-proxy.")
-                    self.commit(msg, options, _datalad_msg=_datalad_msg,
-                                careless=careless, files=files, proxy=True)
-                else:
-                    raise
-            finally:
-                if alt_index_file and os.path.exists(alt_index_file):
-                    unlink(alt_index_file)
+                        if files_changed_notstaged:
+                            # reset current index to reflect the changes annex might have done
+                            self._git_custom_command(
+                                list(files_changed_notstaged),
+                                ['git', 'reset']
+                            )
+
+                # in any case we will not specify files explicitly
+                files_to_commit = None
+            if not alt_index_file:
+                super(AnnexRepo, self).commit(msg, options,
+                                              _datalad_msg=_datalad_msg,
+                                              careless=careless,
+                                              files=files_to_commit)
+        finally:
+            if alt_index_file and os.path.exists(alt_index_file):
+                unlink(alt_index_file)
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, force=False, **kwargs):
-        """Remove files from git/annex (works in direct mode as well)
+        """Remove files from git/annex
 
         Parameters
         ----------
@@ -3480,6 +3118,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 files=files):
             yield jsn
 
+    # TODO: RM DIRECT?  might remain useful to detect submods left in direct mode
     @staticmethod
     def _is_annex_work_tree_message(out):
         return re.match(

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -200,11 +200,12 @@ class AnnexRepo(GitRepo, RepoInterface):
                 raise e
 
         # Below was initially introduced for setting for direct mode workaround,
-        # where we changed _GIT_COMMON_OPTIONS.
-        # But we should not pass workarounds such as --worktree=.
-        # -c core.bare=False to git annex commands, so for their
-        # invocation we will keep and use pristine version of the
-        # common options
+        # where we changed _GIT_COMMON_OPTIONS and had to avoid passing
+        # --worktree=. -c core.bare=False to git annex commands, so for their
+        # invocation we kept and used pristine version of the
+        # common options.  yoh thought it would be good to keep this as a copy
+        # just in case we do need to pass annex specific options, even if
+        # there is no need ATM
         self._ANNEX_GIT_COMMON_OPTIONS = self._GIT_COMMON_OPTIONS[:]
 
         # check for possible SSH URLs of the remotes in order to set up
@@ -1329,6 +1330,9 @@ class AnnexRepo(GitRepo, RepoInterface):
             lgr.warning("annex_options not yet implemented. Ignored.")
 
         options = options[:] if options else []
+
+        # TODO: RM DIRECT? not clear if this code didn't become "generic" and
+        #       not only "direct mode" specific, so kept for now.
         # Note: As long as we support direct mode, one should not call
         # super().add() directly. Once direct mode is gone, we might remove
         # `git` parameter and call GitRepo's add() instead.
@@ -1353,22 +1357,12 @@ class AnnexRepo(GitRepo, RepoInterface):
                     yield r
                     return
             except CommandError as e:
+                # TODO: RM DIRECT?  left for detection of direct mode submodules
                 if AnnexRepo._is_annex_work_tree_message(e.stderr):
-                    lgr.warning(
-                        "Known bug in direct mode."
-                        "We can't use --dry-run when there are submodules in "
-                        "direct mode, because the internal call to git status "
-                        "fails. To be resolved by using (Dataset's) status "
-                        "instead of a git-add --dry-run altogether.")
-                    # fake the return for now
-                    for r in self._process_git_get_output(
-                            linesep.join(["'{}'".format(f)
-                            for f in files])):
-                        yield r
-                        return
-                else:
-                    # unexpected failure
-                    raise e
+                    raise DirectModeNoLongerSupportedError(
+                        self, exc_str(e)
+                    )
+                raise
 
         # Theoretically we could have done for git as well, if it could have
         # been batched

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -267,6 +267,21 @@ class InvalidAnnexRepositoryError(RuntimeError):
     without init=True"""
 
 
+class DirectModeNoLongerSupportedError(NotImplementedError):
+    """direct mode is no longer supported"""
+
+    def __init__(self, repo, msg=None):
+        super(DirectModeNoLongerSupportedError, self).__init__(
+            ((" " + msg + ", but ") if msg else '')
+            +
+             "direct mode of operation is being deprecated in git-annex and "
+             "no longer supported by DataLad. "
+             "Please use 'git annex upgrade' under %s to upgrade your direct "
+             "mode repository to annex v6 (or later)." % repo.path
+            )
+        self.repo = repo  # might come handy
+
+
 class IncompleteResultsError(RuntimeError):
     """Exception to be raised whenever results are incomplete.
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1824,14 +1824,7 @@ def _test_status(ar):
 
     ar.add('fifth')
     sync_wrapper()
-    # TODO:
-    # Note: For some reason this seems to be the only place, where we actually
-    # need to call commit via annex-proxy. If called via '-c core.bare=False'
-    # and/or '--work-tree=.' the file ends up in git instead of annex.
-    # Note 2: This is only if we explicitly pass a path. Otherwise it works
-    # without annex-proxy.
-    ar.commit(msg="fifth to be unannexed", files='fifth',
-              proxy=ar.is_direct_mode())
+    ar.commit(msg="fifth to be unannexed", files='fifth')
     eq_(stat, ar.get_status())
 
     ar.unannex('fifth')
@@ -2017,9 +2010,6 @@ def _test_status(ar):
     stat['modified'].append('.gitmodules')
     eq_(stat, ar.get_status())
 
-    # Note: Here again we need to use annex-proxy; This contradicts the addition
-    # of the very same submodule, which we needed to commit via
-    # -c core.bare=False instead. Otherwise the very same failure happens.
     # Just vice versa. See above where 'submod' is added.
     ar.commit("submod removed", files=['submod', '.gitmodules'])
     stat['modified'].remove('.gitmodules')

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -54,7 +54,7 @@ from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import create_tree
-from datalad.tests.utils import with_batch_direct
+from datalad.tests.utils import with_parametric_batch
 from datalad.tests.utils import assert_dict_equal as deq_
 from datalad.tests.utils import assert_is_instance
 from datalad.tests.utils import assert_false
@@ -312,11 +312,11 @@ def test_AnnexRepo_get_remote_na(path):
 
 
 # 1 is enough to test file_has_content
-@with_batch_direct
+@with_parametric_batch
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
-def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
-    ar = AnnexRepo.clone(src, annex_path, direct=direct)
+def test_AnnexRepo_file_has_content(batch, src, annex_path):
+    ar = AnnexRepo.clone(src, annex_path)
     testfiles = ["test-annex.dat", "test.dat"]
 
     eq_(ar.file_has_content(testfiles), [False, False])
@@ -331,22 +331,21 @@ def test_AnnexRepo_file_has_content(batch, direct, src, annex_path):
     assert_false(ar.file_has_content("bogus.txt", batch=batch))
     ok_(ar.file_has_content("test-annex.dat", batch=batch))
 
-    if not direct:  # There's no unlock in direct mode.
-        ar.unlock(["test-annex.dat"])
-        eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
-            [ar.supports_unlocked_pointers])
-        with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
-            ofh.write("more")
-        eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
-            [False])
+    ar.unlock(["test-annex.dat"])
+    eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
+        [ar.supports_unlocked_pointers])
+    with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
+        ofh.write("more")
+    eq_(ar.file_has_content(["test-annex.dat"], batch=batch),
+        [False])
 
 
 # 1 is enough to test
-@with_batch_direct
+@with_parametric_batch
 @with_testrepos('.*annex.*', flavors=['local'], count=1)
 @with_tempfile
-def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
-    ar = AnnexRepo.clone(src, annex_path, direct=direct)
+def test_AnnexRepo_is_under_annex(batch, src, annex_path):
+    ar = AnnexRepo.clone(src, annex_path)
 
     with open(opj(annex_path, 'not-committed.txt'), 'w') as f:
         f.write("aaa")
@@ -367,14 +366,13 @@ def test_AnnexRepo_is_under_annex(batch, direct, src, annex_path):
     assert_false(ar.is_under_annex("bogus.txt", batch=batch))
     ok_(ar.is_under_annex("test-annex.dat", batch=batch))
 
-    if not direct:  # There's no unlock in direct mode.
-        ar.unlock(["test-annex.dat"])
-        eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
-            [ar.supports_unlocked_pointers])
-        with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
-            ofh.write("more")
-        eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
-            [False])
+    ar.unlock(["test-annex.dat"])
+    eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
+        [ar.supports_unlocked_pointers])
+    with open(opj(annex_path, "test-annex.dat"), "a") as ofh:
+        ofh.write("more")
+    eq_(ar.is_under_annex(["test-annex.dat"], batch=batch),
+        [False])
 
 
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
@@ -641,11 +639,11 @@ def __test_get_md5s(path):
     print({f: annex.get_file_key(f) for f in files})
 
 
-@with_batch_direct
+@with_parametric_batch
 @with_tree(**tree1args)
-def test_dropkey(batch, direct, path):
+def test_dropkey(batch, path):
     kw = {'batch': batch}
-    annex = AnnexRepo(path, init=True, backend='MD5E', direct=direct)
+    annex = AnnexRepo(path, init=True, backend='MD5E')
     files = list(tree1_md5e_keys)
     annex.add(files)
     annex.commit()
@@ -1479,9 +1477,9 @@ def test_annex_remove(path):
     eq_(out[0], "rm-test.dat")
 
 
-@with_batch_direct
+@with_parametric_batch
 @with_testrepos('basic_annex', flavors=['clone'], count=1)
-def test_is_available(batch, direct, p):
+def test_is_available(batch, p):
     annex = AnnexRepo(p)
 
     # bkw = {'batch': batch}

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -200,50 +200,6 @@ def test_AnnexRepo_is_direct_mode_gitrepo(path):
 
 
 @assert_cwd_unchanged
-@with_testrepos('.*annex.*')
-@with_tempfile
-def test_AnnexRepo_set_direct_mode(src, dst):
-
-    ar = AnnexRepo.clone(src, dst)
-
-    if ar.supports_unlocked_pointers:
-        # there's no direct mode available:
-        assert_raises(CommandError, ar.set_direct_mode, True)
-        raise SkipTest("Test not applicable in repository version >= 6")
-
-    ar.set_direct_mode(True)
-    ok_(ar.is_direct_mode(), "Switching to direct mode failed.")
-    if ar.is_crippled_fs():
-        assert_raises(CommandNotAvailableError, ar.set_direct_mode, False)
-        ok_(
-            ar.is_direct_mode(),
-            "Indirect mode on crippled fs detected. Shouldn't be possible.")
-    else:
-        ar.set_direct_mode(False)
-        assert_false(ar.is_direct_mode(), "Switching to indirect mode failed.")
-
-
-@assert_cwd_unchanged
-@with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
-@with_tempfile
-def test_AnnexRepo_annex_proxy(src, annex_path):
-    ar = AnnexRepo.clone(src, annex_path)
-    if ar.supports_unlocked_pointers:
-        # there's no direct mode available and therefore no 'annex proxy':
-        assert_raises(CommandError, ar.proxy, ['git', 'status'])
-        raise SkipTest("Test not applicable in repository version >= 6")
-    ar.set_direct_mode(True)
-
-    # annex proxy raises in indirect mode:
-    try:
-        ar.set_direct_mode(False)
-        assert_raises(CommandNotAvailableError, ar.proxy, ['git', 'status'])
-    except CommandNotAvailableError:
-        # we can't switch to indirect
-        pass
-
-
-@assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
 def test_AnnexRepo_get_file_key(src, annex_path):
@@ -598,18 +554,13 @@ def test_AnnexRepo_migrating_backends(src, dst):
     # migrating will only do, if file is present
     ok_annex_get(ar, 'test-annex.dat')
 
-    if ar.is_direct_mode():
-        # No migration in direct mode
-        assert_raises(CommandNotAvailableError, ar.migrate_backend,
-                      'test-annex.dat')
-    else:
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
-        ar.migrate_backend('test-annex.dat')
-        eq_(ar.get_file_backend('test-annex.dat'), 'MD5')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
+    ar.migrate_backend('test-annex.dat')
+    eq_(ar.get_file_backend('test-annex.dat'), 'MD5')
 
-        ar.migrate_backend('', backend='SHA1')
-        eq_(ar.get_file_backend(filename), 'SHA1')
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
+    ar.migrate_backend('', backend='SHA1')
+    eq_(ar.get_file_backend(filename), 'SHA1')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
 
 
 tree1args = dict(
@@ -693,14 +644,10 @@ def test_AnnexRepo_get_file_backend(src, dst):
     ar = AnnexRepo.clone(src, dst)
 
     eq_(ar.get_file_backend('test-annex.dat'), 'SHA256E')
-    if not ar.is_direct_mode():
-        # no migration in direct mode
-        ok_annex_get(ar, 'test-annex.dat', network=False)
-        ar.migrate_backend('test-annex.dat', backend='SHA1')
-        eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
-    else:
-        assert_raises(CommandNotAvailableError, ar.migrate_backend,
-                      'test-annex.dat', backend='SHA1')
+    # no migration
+    ok_annex_get(ar, 'test-annex.dat', network=False)
+    ar.migrate_backend('test-annex.dat', backend='SHA1')
+    eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
 
 
 @with_tempfile
@@ -830,12 +777,8 @@ def test_AnnexRepo_add_to_annex(path):
 
     out_json = repo.add(filename)
     # file is known to annex:
-    if not repo.is_direct_mode():
-        assert_true(os.path.islink(filename_abs),
-                    "Annexed file is not a link.")
-    else:
-        assert_false(os.path.islink(filename_abs),
-                     "Annexed file is link in direct mode.")
+    assert_true(os.path.islink(filename_abs),
+                "Annexed file is not a link.")
     assert_in('key', out_json)
     key = repo.get_file_key(filename)
     assert_false(key == '')
@@ -843,11 +786,7 @@ def test_AnnexRepo_add_to_annex(path):
     ok_(repo.file_has_content(filename))
 
     # uncommitted:
-    # but not in direct mode branch
-    if repo.is_direct_mode():
-        ok_(not repo.is_dirty(submodules=False))
-    else:
-        ok_(repo.is_dirty(submodules=False))
+    ok_(repo.is_dirty(submodules=False))
 
     repo.commit("Added file to annex.")
     ok_clean_git(repo, annex=True, ignore_submodules=True)
@@ -902,30 +841,6 @@ def test_AnnexRepo_add_to_git(path):
 
     # and committed:
     ok_clean_git(repo, annex=True, ignore_submodules=True)
-
-
-@with_testrepos('submodule_annex', flavors=['clone'])
-def test_AnnexRepo_add_unexpected_direct_mode(path):
-    # tests a special case where a submodule is in direct mode, while it's
-    # superproject is not.
-    # There is no point in this test, if direct mode was enforced in the
-    # superproject already (either by test run configuration or FS) or if the
-    # repositories are in V6+ by default (where there is no direct mode)
-
-    top = AnnexRepo(path)
-
-    if top.is_direct_mode() or top.supports_unlocked_pointers:
-        raise SkipTest("Nothing to test for")
-
-    top.update_submodule('subm 1', init=True)
-    sub = AnnexRepo(opj(path, 'subm 1'))
-    sub.set_direct_mode(True)
-    with swallow_logs(new_level=logging.WARNING) as cml:
-        top.add('.')
-        cml.assert_logged(msg="Known bug in direct mode.",
-                          level="WARNING",
-                          regex=False)
-
 
 
 @ignore_nose_capturing_stdout
@@ -1049,11 +964,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     eq_(info['size'], 14)
     assert(info['key'])
     # not even added to index yet since we this repo is with default batch_size
-    # but: in direct mode it is added!
-    if ar.is_direct_mode():
-        assert_in(ar.WEB_UUID, ar.whereis(testfile))
-    else:
-        assert_not_in(ar.WEB_UUID, ar.whereis(testfile))
+    assert_not_in(ar.WEB_UUID, ar.whereis(testfile))
 
     # TODO: none of the below should re-initiate the batch process
 
@@ -1099,9 +1010,7 @@ def test_AnnexRepo_addurl_to_file_batched(sitepath, siteurl, dst):
     assert_in(filename, ar2.get_files())
     assert_in(ar.WEB_UUID, ar2.whereis(filename))
 
-    if not ar.is_direct_mode():
-        # in direct mode there's nothing to commit
-        ar.commit("actually committing new files")
+    ar.commit("actually committing new files")
     assert_in(filename, ar.get_files())
     assert_in(ar.WEB_UUID, ar.whereis(filename))
     # this poor bugger still wasn't added since we used default batch_size=0 on him
@@ -1249,37 +1158,36 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ok_(exists(socket_2))
     ssh_manager.close(ctrl_path=[socket_1, socket_2])
 
+
 @with_testrepos('basic_annex', flavors=['clone'])
 @with_tempfile(mkdir=True)
 def test_annex_remove(path1, path2):
-    ar1 = AnnexRepo(path1, create=False)
-    ar2 = AnnexRepo.clone(path1, path2, create=True, direct=True)
+    repo = AnnexRepo(path1, create=False)
 
-    for repo in (ar1, ar2):
-        file_list = repo.get_annexed_files()
-        assert len(file_list) >= 1
-        # remove a single file
-        out = repo.remove(file_list[0])
-        assert_not_in(file_list[0], repo.get_annexed_files())
-        eq_(out[0], file_list[0])
+    file_list = repo.get_annexed_files()
+    assert len(file_list) >= 1
+    # remove a single file
+    out = repo.remove(file_list[0])
+    assert_not_in(file_list[0], repo.get_annexed_files())
+    eq_(out[0], file_list[0])
 
-        with open(opj(repo.path, "rm-test.dat"), "w") as f:
-            f.write("whatever")
+    with open(opj(repo.path, "rm-test.dat"), "w") as f:
+        f.write("whatever")
 
-        # add it
-        repo.add("rm-test.dat")
+    # add it
+    repo.add("rm-test.dat")
 
-        # remove without '--force' should fail, due to staged changes:
-        if repo.is_direct_mode():
-            assert_raises(CommandError, repo.remove, "rm-test.dat")
-        else:
-            assert_raises(GitCommandError, repo.remove, "rm-test.dat")
-        assert_in("rm-test.dat", repo.get_annexed_files())
+    # remove without '--force' should fail, due to staged changes:
+    if repo.is_direct_mode():
+        assert_raises(CommandError, repo.remove, "rm-test.dat")
+    else:
+        assert_raises(GitCommandError, repo.remove, "rm-test.dat")
+    assert_in("rm-test.dat", repo.get_annexed_files())
 
-        # now force:
-        out = repo.remove("rm-test.dat", force=True)
-        assert_not_in("rm-test.dat", repo.get_annexed_files())
-        eq_(out[0], "rm-test.dat")
+    # now force:
+    out = repo.remove("rm-test.dat", force=True)
+    assert_not_in("rm-test.dat", repo.get_annexed_files())
+    eq_(out[0], "rm-test.dat")
 
 
 @with_tempfile
@@ -1827,11 +1735,9 @@ def test_AnnexRepo_dirty(path):
     ok_(repo.dirty)
     # annexed file
     repo.add('file2.txt', git=False)
-    if not repo.is_direct_mode():
-        # in direct mode 'annex add' results in a clean repo
-        ok_(repo.dirty)
-        # commit
-        repo.commit("file2.txt annexed")
+    ok_(repo.dirty)
+    # commit
+    repo.commit("file2.txt annexed")
     ok_(not repo.dirty)
 
     # TODO: unlock/modify
@@ -1901,9 +1807,7 @@ def _test_status(ar):
     ar.add('second')
     sync_wrapper()
     stat['untracked'].remove('second')
-    if not ar.is_direct_mode():
-        # in direct mode annex-status doesn't report an added file 'added'
-        stat['added'].append('second')
+    stat['added'].append('second')
     eq_(stat, ar.get_status())
 
     # commit to be clean again:
@@ -1943,18 +1847,16 @@ def _test_status(ar):
     eq_(stat, ar.get_status())
 
     # modify an annexed file:
-    if not ar.is_direct_mode():
-        # actually: if 'second' isn't locked, which is the case in direct mode
-        ar.unlock('second')
-        if not ar.get_active_branch().endswith('(unlocked)'):
-            stat['type_changed'].append('second')
-        eq_(stat, ar.get_status())
+    ar.unlock('second')
+    if not ar.get_active_branch().endswith('(unlocked)'):
+        stat['type_changed'].append('second')
+    eq_(stat, ar.get_status())
+
     with open(opj(ar.path, 'second'), 'w') as f:
         f.write("Needed to unlock first. Sad!")
-    if not ar.is_direct_mode():
-        ar.add('second')  # => modified
-        if not ar.get_active_branch().endswith('(unlocked)'):
-            stat['type_changed'].remove('second')
+    ar.add('second')  # => modified
+    if not ar.get_active_branch().endswith('(unlocked)'):
+        stat['type_changed'].remove('second')
     stat['modified'].append('second')
     sync_wrapper()
     eq_(stat, ar.get_status())
@@ -2036,15 +1938,6 @@ def _test_status(ar):
     eq_(stat, ar.get_status(submodules=False))
 
     # commit the submodule
-    # in direct mode, commit of a removed submodule fails with:
-    #  error: unable to index file submod
-    #  fatal: updating files failed
-    #
-    # - this happens, when commit is called with -c core.bare=False
-    # - it works when called via annex proxy
-    # - if we add a submodule instead of removing one, it's vice versa with
-    #   the very same error message
-
     ar.commit(msg="submodule added", files=['.gitmodules', 'submod'])
 
     stat['added'].remove('.gitmodules')
@@ -2310,9 +2203,7 @@ def test_AnnexRepo_get_corresponding_branch(path):
 
     ar = AnnexRepo(path)
 
-    # we should be on master or a corresponding branch like annex/direct/master
-    # respectively if ran in direct mode build.
-    # We want to get 'master' in any case
+    # we should be on master.
     eq_('master', ar.get_corresponding_branch())
 
     # special case v6 adjusted branch is not provided by a dedicated build:
@@ -2329,8 +2220,7 @@ def test_AnnexRepo_get_tracking_branch(path):
 
     ar = AnnexRepo(path)
 
-    # we want the relation to original branch, especially in direct mode
-    # or even in v6 adjusted branch
+    # we want the relation to original branch, e.g. in v6+ adjusted branch
     eq_(('origin', 'refs/heads/master'), ar.get_tracking_branch())
 
 
@@ -2339,13 +2229,11 @@ def test_AnnexRepo_is_managed_branch(path):
 
     ar = AnnexRepo(path)
 
-    if ar.is_direct_mode():
-        ok_(ar.is_managed_branch())
-    else:
-        # ATM only direct mode and v6+ adjusted branches should return True.
-        # Adjusted branch requires a call of git-annex-adjust and shouldn't
-        # be the state of a fresh clone
-        ok_(not ar.is_managed_branch())
+    # ATM only v6+ adjusted branches should return True.
+    # Adjusted branch requires a call of git-annex-adjust and shouldn't
+    # be the state of a fresh clone
+    ok_(not ar.is_managed_branch())
+
     if ar.supports_unlocked_pointers:
         ar.adjust()
         ok_(ar.is_managed_branch())
@@ -2489,8 +2377,7 @@ def check_commit_annex_commit_changed(unlock, path):
         , untracked=['untracked']
     )
     ok_file_under_git(path, 'tobechanged-git', annexed=False)
-    # TODO: direct mode gotcha!!!
-    ok_file_under_git(path, 'tobechanged-annex', annexed=not ar.is_direct_mode())
+    ok_file_under_git(path, 'tobechanged-annex', annexed=True)
 
 
 def test_commit_annex_commit_changed():

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -70,7 +70,7 @@ def test_direct_cfg(path1, path2):
     # check if we somehow didn't reset the flag
     assert not ar.is_direct_mode()
 
-    if ar.config.get("datalad.repo.version", 5) >= 6:
+    if ar.config.obtain("datalad.repo.version") >= 6:
         raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
     # and if repo existed before and was in direct mode, we fail too
     # Since direct= option was deprecated entirely, we use protected method now

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -81,6 +81,9 @@ def test_direct_cfg(path1, path2):
         with assert_raises(DirectModeNoLongerSupportedError) as cme:
             AnnexRepo(path1, create=False)
 
+
+    # TODO: RM DIRECT decide what should we here -- should we test/blow?
+    #   ATM both tests below just pass
     ar2 = AnnexRepo(path2, create=True)
     # happily can do it since it doesn't need a worktree to do the clone
     ar2.add_submodule('sub1', url=path1)
@@ -89,7 +92,13 @@ def test_direct_cfg(path1, path2):
     assert not ar2sub1.is_direct_mode()
     ar2sub1._set_direct_mode(True)
     assert ar2sub1.is_direct_mode()
+    del ar2; del ar2sub1; AnnexRepo._unique_instances.clear()  # fight flyweight
+
+    ar2 = AnnexRepo(path2)
     ar2.get_submodules()
 
-    # TODO: RM DIRECT decide what should we here -- should we test/blow?
-    #   ATM just passes
+    # And what if we are trying to add pre-cloned repo in direct mode?
+    ar2sub2 = AnnexRepo.clone(path1, op.join(path2, 'sub2'))
+    ar2sub2._set_direct_mode(True)
+    del ar2sub2; AnnexRepo._unique_instances.clear()  # fight flyweight
+    ar2.add('sub2')

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -26,80 +26,70 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import swallow_logs
 from datalad.distribution.dataset import Dataset
 
+from ..support.exceptions import DirectModeNoLongerSupportedError
+from ..support import path as op
+
 from .utils import with_tempfile
 from .utils import skip_if_no_network
 from .utils import with_testrepos
 from .utils import on_windows
 from .utils import SkipTest
+from .utils import assert_raises
+from .utils import assert_in
+from .utils import eq_
 
 
-if on_windows:
-    raise SkipTest("Can't test direct mode switch, "
-                   "if direct mode is forced by OS anyway.")
-
-repo_version = cfg.get("datalad.repo.version", None)
-if repo_version and int(repo_version) >= 6:
-    raise SkipTest("Can't test direct mode switch, "
-                   "if repository version 6 or later is enforced.")
+# if on_windows:
+#     raise SkipTest("Can't test direct mode switch, "
+#                    "if direct mode is forced by OS anyway.")
+#
+# repo_version = cfg.get("datalad.repo.version", None)
+# if repo_version and int(repo_version) >= 6:
+#     raise SkipTest("Can't test direct mode switch, "
+#                    "if repository version 6 or later is enforced.")
 
 
 @with_tempfile
 @with_tempfile
-@with_tempfile
-@with_tempfile
-def test_direct_cfg(path1, path2, path3, path4):
+def test_direct_cfg(path1, path2):
+    # and if repo already exists and we have env var - we fail too
+    # Adding backend so we get some commit into the repo
+    ar = AnnexRepo(path1, create=True, backend='MD5E')
+    del ar;  AnnexRepo._unique_instances.clear()  # fight flyweight
+    for path in (path1, path2):
+        with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
+            # try to create annex repo in direct mode as see how it fails
+            with assert_raises(DirectModeNoLongerSupportedError) as cme:
+                AnnexRepo(path, create=True)
+            assert_in("no longer supported by DataLad", str(cme.exception)) # we have generic part
+            assert_in("datalad.repo.direct configuration", str(cme.exception)) # situation specific part
+    # assert not op.exists(path2)   # that we didn't create it - we do!
+    #   fixing for that would be too cumbersome since we first call GitRepo.__init__
+    #   with create
+    ar = AnnexRepo(path1)
+    # check if we somehow didn't reset the flag
+    assert not ar.is_direct_mode()
+
+    if ar.config.get("datalad.repo.version", 5) >= 6:
+        raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
+    # and if repo existed before and was in direct mode, we fail too
+    # Since direct= option was deprecated entirely, we use protected method now
+    ar._set_direct_mode(True)
+    assert ar.is_direct_mode()
+    del ar  # but we would need to disable somehow the flywheel
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
-        # create annex repo in direct mode:
-        with swallow_logs(new_level=logging.DEBUG) as cml:
-            ar = AnnexRepo(path1, create=True)
-            cml.assert_logged("Switching to direct mode",
-                              regex=False, level='DEBUG')
-            ok_(ar.is_direct_mode())
+        with assert_raises(DirectModeNoLongerSupportedError) as cme:
+            AnnexRepo(path1, create=False)
 
-        # but don't if repo version is 6 (actually, 6 or above):
-        with swallow_logs(new_level=logging.WARNING) as cml:
-            ar = AnnexRepo(path2, create=True, version=6)
-            ok_(not ar.is_direct_mode())
-            cml.assert_logged("direct mode not available", regex=False,
-                              level='WARNING')
+    ar2 = AnnexRepo(path2, create=True)
+    # happily can do it since it doesn't need a worktree to do the clone
+    ar2.add_submodule('sub1', url=path1)
+    ar2sub1 = AnnexRepo(op.join(path2, 'sub1'))
+    # but now let's convert that sub1 to direct mode
+    assert not ar2sub1.is_direct_mode()
+    ar2sub1._set_direct_mode(True)
+    assert ar2sub1.is_direct_mode()
+    ar2.get_submodules()
 
-        # explicit parameter `direct` has priority:
-        ar = AnnexRepo(path3, create=True, direct=False)
-        if not ar.is_crippled_fs():  # otherwise forced direct mode
-            ok_(not ar.is_direct_mode())
-
-        # don't touch existing repo:
-        ar = AnnexRepo(path2, create=True)
-        if not ar.is_crippled_fs():  # otherwise forced direct mode
-            ok_(not ar.is_direct_mode())
-
-    # make sure, value is relevant:
-    with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': '0'}):
-        # don't use direct mode
-        ar = AnnexRepo(path4, create=True)
-        if not ar.is_crippled_fs():  # otherwise forced direct mode
-            ok_(not ar.is_direct_mode())
-
-
-@with_tempfile
-def test_direct_create(path):
-    with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
-        ds = Dataset(path).create()
-        if not ds.repo.is_crippled_fs():  # otherwise forced direct mode
-            ok_(ds.repo.is_direct_mode())
-
-
-# Note/TODO: Currently flavor 'network' only, since creation of local testrepos
-# fails otherwise ATM. (git submodule add without needed git options to work in
-# direct mode)
-@skip_if_no_network
-@with_testrepos('basic_annex', flavors=['network'])
-@with_tempfile
-def test_direct_install(url, path):
-
-    with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
-        ds = datalad.api.install(
-            path=path, source=url,
-            result_xfm='datasets', return_type='item-or-list')
-        if not ds.repo.is_crippled_fs():  # otherwise forced direct mode
-            ok_(ds.repo.is_direct_mode(), "Not in direct mode: %s" % ds)
+    # TODO: RM DIRECT decide what should we here -- should we test/blow?
+    #   ATM just passes

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -7,7 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_direct_mode
 
 import git
 import os
@@ -56,7 +55,6 @@ def test_clone(src, tempdir):
 
 @usecase
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode  #FIXME
 def test_make_studyforrest_mockup(path):
     # smoke test
     make_studyforrest_mockup(path)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -980,6 +980,22 @@ def test_known_failure_v6():
 from datalad.utils import read_csv_lines
 
 
+def test_known_failure_direct_mode():
+    # Decorator is deprecated now and that is what we check
+    from .utils import known_failure_direct_mode
+
+    x = []
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        @known_failure_direct_mode
+        def failing():
+            x.append('ok')
+            raise AssertionError("Failed")
+
+        assert_raises(AssertionError, failing)  # nothing is swallowed
+        eq_(x, ['ok'])  # everything runs
+        assert_in("Direct mode support is deprecated", cml.out)
+
+
 @with_tempfile(content="h1 h2\nv1 2\nv2 3")
 def test_read_csv_lines_basic(infile):
     # Just a basic test, next one with unicode

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -92,7 +92,7 @@ from .utils import ok_startswith
 from .utils import skip_if_no_module
 from .utils import (
     probe_known_failure, skip_known_failure, known_failure, known_failure_v6,
-    known_failure_direct_mode, skip_if,
+    skip_if,
     ok_file_has_content
 )
 
@@ -962,34 +962,6 @@ def test_known_failure_v6():
     probe = cfg.obtain("datalad.tests.knownfailures.probe")
 
     if v6:
-        if skip:
-            # skipping takes precedence over probing
-            failing()
-        elif probe:
-            # if we probe a known failure it's okay to fail:
-            failing()
-        else:
-            # not skipping and not probing results in the original failure:
-            assert_raises(AssertionError, failing)
-
-    else:
-        # behaves as if it wasn't decorated at all, no matter what
-        assert_raises(AssertionError, failing)
-
-
-def test_known_failure_direct_mode():
-
-    @known_failure_direct_mode
-    def failing():
-        raise AssertionError("Failed")
-
-    from datalad import cfg
-
-    direct = cfg.obtain("datalad.repo.direct")
-    skip = cfg.obtain("datalad.tests.knownfailures.skip")
-    probe = cfg.obtain("datalad.tests.knownfailures.probe")
-
-    if direct:
         if skip:
             # skipping takes precedence over probing
             failing()

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1000,30 +1000,6 @@ def known_failure_v6_or_later(func):
 known_failure_v6 = known_failure_v6_or_later
 
 
-def known_failure_direct_mode(func):
-    """Test decorator marking a test as known to fail in a direct mode test run
-
-    If datalad.repo.direct is set to True behaves like `known_failure`.
-    Otherwise the original (undecorated) function is returned.
-    """
-
-    from datalad import cfg
-
-    direct = cfg.obtain("datalad.repo.direct") or on_windows
-    if direct:
-
-        @known_failure
-        @wraps(func)
-        @attr('known_failure_direct_mode')
-        @attr('direct_mode')
-        def dm_func(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return dm_func
-
-    return func
-
-
 def known_failure_windows(func):
     """Test decorator marking a test as known to fail on windows
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -22,6 +22,7 @@ import multiprocessing
 import logging
 import random
 import socket
+import warnings
 from six import PY2, text_type, iteritems
 from six import binary_type
 from six import string_types
@@ -998,6 +999,26 @@ def known_failure_v6_or_later(func):
 
 # TODO: Remove once the released version of datalad-crawler no longer uses it.
 known_failure_v6 = known_failure_v6_or_later
+
+
+def known_failure_direct_mode(func):
+    """DEPRECATED.  Stop using.  Does nothing
+
+    Test decorator marking a test as known to fail in a direct mode test run
+
+    If datalad.repo.direct is set to True behaves like `known_failure`.
+    Otherwise the original (undecorated) function is returned.
+    """
+    # TODO: consider adopting   nibabel/deprecated.py  nibabel/deprecator.py
+    # mechanism to consistently deprecate functionality and ensure they are
+    # displayed.
+    # Since 2.7 Deprecation warnings aren't displayed by default
+    # and thus kinda pointless to issue a warning here, so we will just log
+    msg = "Direct mode support is deprecated, so no point in using " \
+          "@known_failure_direct_mode for %r since glorious future " \
+          "DataLad 0.12" % func.__name__
+    lgr.warning(msg)
+    return func
 
 
 def known_failure_windows(func):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -185,39 +185,27 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
 
     eq_(sorted(r.untracked_files), sorted(untracked))
 
-    if annex and r.is_direct_mode():
-        if head_modified or index_modified:
-            lgr.warning("head_modified and index_modified are not supported "
-                        "for direct mode repositories!")
+    repo = r.repo
+
+    if repo.index.entries.keys():
+        ok_(repo.head.is_valid())
+
+        if not head_modified and not index_modified:
+            # get string representations of diffs with index to ease
+            # troubleshooting
+            head_diffs = [str(d) for d in repo.index.diff(repo.head.commit)]
+            index_diffs = [str(d) for d in repo.index.diff(None)]
+            eq_(head_diffs, [])
+            eq_(index_diffs, [])
         else:
-            test_untracked = not untracked
-            test_submodules = not ignore_submodules
-            ok_(not r.is_dirty(untracked_files=test_untracked,
-                               submodules=test_submodules),
-                msg="Repo unexpectedly dirty (tested for: untracked({}), submodules({})".format(
-                    test_untracked, test_submodules))
-    else:
-        repo = r.repo
-
-        if repo.index.entries.keys():
-            ok_(repo.head.is_valid())
-
-            if not head_modified and not index_modified:
-                # get string representations of diffs with index to ease
-                # troubleshooting
-                head_diffs = [str(d) for d in repo.index.diff(repo.head.commit)]
-                index_diffs = [str(d) for d in repo.index.diff(None)]
-                eq_(head_diffs, [])
-                eq_(index_diffs, [])
-            else:
-                # TODO: These names are confusing/non-descriptive.  REDO
-                if head_modified:
-                    # we did ask for interrogating changes
-                    head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
-                    eq_(sorted(head_modified_), sorted(head_modified))
-                if index_modified:
-                    index_modified_ = [d.a_path for d in repo.index.diff(None)]
-                    eq_(sorted(index_modified_), sorted(index_modified))
+            # TODO: These names are confusing/non-descriptive.  REDO
+            if head_modified:
+                # we did ask for interrogating changes
+                head_modified_ = [d.a_path for d in repo.index.diff(repo.head.commit)]
+                eq_(sorted(head_modified_), sorted(head_modified))
+            if index_modified:
+                index_modified_ = [d.a_path for d in repo.index.diff(None)]
+                eq_(sorted(index_modified_), sorted(index_modified))
 
 
 def ok_file_under_git(path, filename=None, annexed=False):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1364,14 +1364,13 @@ def skip_httpretty_on_problematic_pythons(func):
 
 
 @optional_args
-def with_batch_direct(t):
+def with_parametric_batch(t):
     """Helper to run parametric test with possible combinations of batch and direct
     """
     @wraps(t)
     def newfunc():
         for batch in (False, True):
-            for direct in (False, True) if not on_windows else (True,):
-                yield t, batch, direct
+                yield t, batch
 
     return newfunc
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1042,25 +1042,6 @@ def skip_v6_or_later(func, method='raise'):
 
 
 @optional_args
-def skip_direct_mode(func, method='raise'):
-    """Skips tests if datalad is configured to use direct mode
-    (set DATALAD_REPO_DIRECT)
-    """
-
-    from datalad import cfg
-
-    @skip_if(cfg.obtain("datalad.repo.direct"),
-             msg="Skip test in direct mode test run",
-             method=method)
-    @wraps(func)
-    @attr('skip_direct_mode')
-    @attr('direct_mode')
-    def newfunc(*args, **kwargs):
-        return func(*args, **kwargs)
-    return newfunc
-
-
-@optional_args
 def assert_cwd_unchanged(func, ok_to_chdir=False):
     """Decorator to test whether the current working directory remains unchanged
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1404,29 +1404,6 @@ def with_testsui(t, responses=None, interactive=True):
 with_testsui.__test__ = False
 
 
-@optional_args
-def with_direct(func):
-    """To test functions under both direct and indirect mode
-
-    Unlike fancy generators would just fail on the first failure
-    """
-    @wraps(func)
-    @attr('direct_mode')
-    def newfunc(*args, **kwargs):
-        if on_windows or on_travis:
-            # since on windows would become indirect anyways
-            # on travis -- we have a dedicated matrix run
-            # which would select one or another based on config
-            # if we specify None
-            directs = [None]
-        else:
-            # otherwise we assume that we have to test both modes
-            directs = [True, False]
-        for direct in directs:
-            func(*(args + (direct,)), **kwargs)
-    return newfunc
-
-
 def assert_no_errors_logged(func, skip_re=None):
     """Decorator around function to assert that no errors logged during its execution"""
     @wraps(func)


### PR DESCRIPTION
These commits are the "remove direct mode" commits from #3076 (all of them @yarikoptic's hard work, not mine).

I'm pushing them here so that we have the option of removing direct mode in master without merging in the "include revolution" commits of #3076.

<details>
<summary>Diff with rf-revolution1</summary>

```
% git rev-parse origin/rf-revolution1
720c9c987edcf0a07620f8e9b2535b5df46dec14
% git rev-parse rf-remove-direct
056c3336fbb4c9e5c3983f9bf1b6744e74946b1b
```

`git diff origin/rf-revolution1 rf-remove-direct -- ':(exclude)datalad/revolution' ':(exclude)3rd/'`

```diff
diff --git a/appveyor.yml b/appveyor.yml
index f3780bd11..1337d91f3 100644
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,8 +81,6 @@ test_script:
   - git annex version
   # first sign of life
   - datalad wtf
-  # revolution -- all must pass
-  - python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.revolution
   # and now this... [keep appending tests that should work!!]
   # one call per datalad component for now -- to better see what is being tested
   - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.cmdline"
diff --git a/datalad/interface/__init__.py b/datalad/interface/__init__.py
index 83a8a8292..65c020915 100644
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -89,5 +89,3 @@
     'datalad-crawler': ('crawl', 'crawl-init'),
     'datalad-neuroimaging': ('bids2scidata',)
 }
-
-from ..revolution import command_suite as _group_revolution_commands
\ No newline at end of file
diff --git a/docs/source/cmdline.rst b/docs/source/cmdline.rst
index 9cc65c765..60c3a6652 100644
--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -23,7 +23,6 @@ Dataset operations
 
    generated/man/datalad-add
    generated/man/datalad-create
-   generated/man/datalad-rev-create
    generated/man/datalad-create-sibling
    generated/man/datalad-create-sibling-github
    generated/man/datalad-drop
@@ -32,7 +31,6 @@ Dataset operations
    generated/man/datalad-publish
    generated/man/datalad-remove
    generated/man/datalad-save
-   generated/man/datalad-rev-save
    generated/man/datalad-update
    generated/man/datalad-uninstall
    generated/man/datalad-unlock
@@ -55,7 +53,6 @@ Reproducible execution
    :maxdepth: 1
 
    generated/man/datalad-run
-   generated/man/datalad-rev-run
    generated/man/datalad-rerun
    generated/man/datalad-run-procedure
 
@@ -96,8 +93,6 @@ Plumbing commands
    generated/man/datalad-clone
    generated/man/datalad-create-test-dataset
    generated/man/datalad-diff
-   generated/man/datalad-rev-diff
    generated/man/datalad-sshrun
-   generated/man/datalad-rev-status
    generated/man/datalad-siblings
    generated/man/datalad-subdatasets
diff --git a/setup.py b/setup.py
index 6762fadb9..b48554956 100755
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ def findsome(subdir, extensions):
         'patool>=1.7',
         'six>=1.8.0',
         'wrapt',
-        'pathlib2; python_version < "3.0"',  # brought to you by revolution1
     ] +
     pbar_requires +
     (['colorama'] if on_windows else []),
diff --git a/tools/injest-revolution b/tools/injest-revolution
deleted file mode 100755
index e870a0448..000000000
--- a/tools/injest-revolution
+++ /dev/null
@@ -1,20 +0,0 @@
-#!/bin/bash
-
-set -eu
-revrepopath=${1:-../datalad-revolution}
-revrepostate=$(git -C "$revrepopath" describe --long)
-revpath=3rd/datalad-revolution
-
-# should be clean
-if git -C "$revrepopath" diff --cached | grep -q . ; then
-    echo "E: DIRTY revolution"
-    git -C "$revrepopath" status
-    exit 1
-fi
-
-echo "I: injesting $revrepopath"
-rm -rf "$revpath" 
-mkdir -p "$revpath"
-git -C $revrepopath archive HEAD | tar -C $revpath -xf-
-echo "$revrepostate" > $revpath/GIT_DESCRIBE
-echo "I: done $revpath"
```

</details>
