### PR TITLE
BF: fix execution of patool commands

### DIFF
--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -81,7 +81,19 @@ def _patool_run(cmd, verbosity=0, **kwargs):
     # use our runner
     try:
         # kwargs_ = kwargs[:];         kwargs_['shell'] = True
-        _runner.run(cmd, **kwargs)
+        # Any debug/progress output could be spit out to stderr so let's
+        # "expect" it.
+        #
+        if isinstance(cmd, (list, tuple)) and kwargs.get('shell'):
+            # patool (as far as I see it) takes care about quoting args
+            cmd = ' '.join(cmd)
+        out, err = _runner.run(cmd,
+                    #log_stdout='offline',
+                    #log_stderr='offline',
+                    #expect_stderr=True,
+                    #stdin=open('/dev/null'),
+                    **kwargs)
+        lgr.debug("Finished running for patool. stdout=%s, stderr=%s", out, err)
         return 0
     except CommandError as e:
         return e.code

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -18,13 +18,24 @@ from .utils import (
 )
 from .utils import assert_equal
 
-from ..support.archives import decompress_file, compress_files, unixify_path
-from ..support.archives import ExtractedArchive, ArchivesCache
+from ..dochelpers import exc_str
+from ..support.archives import (
+    ArchivesCache,
+    compress_files,
+    decompress_file,
+    ExtractedArchive,
+    unixify_path,
+)
+from ..support.exceptions import MissingExternalDependency
 from ..support import path as op
 
-from .utils import OBSCURE_FILENAME, assert_raises
-from .utils import assert_in
-from .utils import ok_generator
+from .utils import (
+    assert_in,
+    assert_raises,
+    OBSCURE_FILENAME,
+    ok_generator,
+    SkipTest,
+)
 
 fn_in_archive_obscure = OBSCURE_FILENAME
 fn_archive_obscure = fn_in_archive_obscure.replace('a', 'b')
@@ -124,7 +135,10 @@ def check_compress_file(ext, annex, path, name):
         repo.commit(files=[_filename], msg="commit")
 
     dir_extracted = name + "_extracted"
-    decompress_file(archive, dir_extracted)
+    try:
+        decompress_file(archive, dir_extracted)
+    except MissingExternalDependency as exc:
+        raise SkipTest(exc_str(exc))
     _filepath = op.join(dir_extracted, _filename)
 
     import glob

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -98,6 +98,7 @@ def test_compress_file():
     yield check_compress_file, '.tar.gz'
     yield check_compress_file, '.tar'
     yield check_compress_file, '.zip'
+    yield check_compress_file, '.gz'
 
 
 @with_tree(**tree_simplearchive)


### PR DESCRIPTION
It is an incomplete fix, which would still cause test failure in the crawler if no p7zip is installed in crawler due to  https://github.com/datalad/datalad/issues/3175 , but wanted to see if anything breaks here before proceeding further