### PR TITLE
ENH/BF/RF: GitHub authentication

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -56,4 +56,6 @@ GIT_SSH_COMMAND = "datalad sshrun"
 
 # magic sha is from `git hash-object -t tree /dev/null`, i.e. from nothing
 PRE_INIT_COMMIT_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+
+# git/datalad configuration item to provide a token for github
 CONFIG_HUB_TOKEN_FIELD = 'hub.oauthtoken'

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -56,3 +56,4 @@ GIT_SSH_COMMAND = "datalad sshrun"
 
 # magic sha is from `git hash-object -t tree /dev/null`, i.e. from nothing
 PRE_INIT_COMMIT_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+CONFIG_HUB_TOKEN_FIELD = 'hub.oauthtoken'

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -225,21 +225,24 @@ def _get_2fa_token(user):
     one_time_password = ui.question(
         "2FA one time password", hidden=True, repeat=False
     )
+    token_note = cfg.obtain('datalad.github.token-note')
     try:
         # TODO: can fail if already exists -- handle!?
         # in principle there is .authorization.delete()
-        token_note = 'DataLad'
         auth = user.create_authorization(
             scopes=['user', 'repo'],  # TODO: Configurable??
             note=token_note,  # TODO: Configurable??
             onetime_password=one_time_password)
     except gh.GithubException as exc:
         if (exc.status == 422  # "Unprocessable Entity"
-            and exc.data.get('errors', [{}])[0].get('code') == 'already_exists'
+                and exc.data.get('errors', [{}])[0].get('code') == 'already_exists'
         ):
             raise ValueError(
-                "Token with a note %r already exists. If you specified " 
-                "password -- don't, and specify token in configuration as %s"
+                "Token %r already exists. If you specified "
+                "password -- don't, and specify token in configuration as %s. "
+                "If token already exists and you want to generate a new one "
+                "anyways - specify a new one via 'datalad.github.token-note' "
+                "configuration variable"
                 % (token_note, CONFIG_HUB_TOKEN_FIELD)
             )
         raise

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -8,410 +8,40 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """High-level interface for creating a publication target on GitHub
 """
-
 __docformat__ = 'restructuredtext'
 
 
 import logging
 import re
 
-from os.path import join as opj
 from os.path import relpath
-from datalad import cfg
 
-from ..ui import ui
-
-from datalad.interface.common_opts import recursion_flag, recursion_limit
-from datalad.interface.common_opts import publish_depends
-from datalad.downloaders.credentials import UserPassword
-from datalad.dochelpers import exc_str
-from datalad.utils import (
+from ..interface.base import (
+    build_doc,
+    Interface,
+)
+from ..interface.common_opts import (
+    recursion_flag,
+    recursion_limit,
+    publish_depends,
+)
+from ..support.param import Parameter
+from ..support.constraints import (
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+from ..utils import (
     assure_list,
-    assure_tuple_or_list,
-    unique,
 )
-from datalad.support.param import Parameter
-from datalad.support.network import URL
-from datalad.support.constraints import EnsureStr, EnsureNone
-from datalad.support.constraints import EnsureChoice
-from datalad.support.exceptions import (
-    MissingExternalDependency,
-    AccessDeniedError,
+from .dataset import (
+    datasetmethod,
+    EnsureDataset,
+    require_dataset,
 )
-from ..interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.distribution.dataset import EnsureDataset, datasetmethod, \
-    require_dataset, Dataset
-from datalad.distribution.siblings import Siblings
+from .siblings import Siblings
 
 lgr = logging.getLogger('datalad.distribution.create_sibling_github')
-
-CONFIG_HUB_TOKEN_FIELD = 'hub.oauthtoken'
-
-
-def get_repo_url(repo, access_protocol, github_login):
-    """Report the repository access URL for Git matching the protocol"""
-    prop = {
-        'https': repo.clone_url,
-        'ssh': repo.ssh_url
-    }[access_protocol]
-    if access_protocol == 'https' and github_login:
-        # we were provided explicit github login.  For ssh access it is
-        # impossible to specify different login within ssh RI, but it is
-        # possible to do so for https logins
-        url = URL(prop)
-        assert url.scheme in ('http', 'https')
-        url.username = github_login
-        prop = url.as_str()
-    return prop
-
-
-def _token_str(token):
-    """Shorten token so we do not leak sensitive info into the logs"""
-    return token[:3] + '...' + token[-3:]
-
-
-def _get_tokens_for_login(login, tokens):
-    import github as gh
-    selected_tokens = []
-    for t in tokens:
-        try:
-            g = gh.Github(t)
-            gu = g.get_user()
-            if gu.login == login:
-                selected_tokens.append(t)
-        except gh.BadCredentialsException as exc:
-            lgr.debug(
-                "Token %s caused %s while trying to check token's use"
-                " login name. Skipping", _token_str(t), exc_str(exc))
-    lgr.debug(
-        "Selected %d tokens out of %d for the login %s",
-        len(selected_tokens), len(tokens), login
-    )
-    return selected_tokens
-
-
-def _gen_github_ses(github_login, github_passwd):
-    """Generate viable Github sessions
-
-    The idea is that we keep trying "new" ways to authenticate until we either
-    exhaust or external loop stops asking for more
-
-    Parameters
-    ----------
-    github_login:
-    github_passwd:
-
-    Yields
-    -------
-    Github, credential
-      credential might be None if there is no credential associated as when
-      we consider tokens from the config (instead of credentials store)
-
-    """
-    import github as gh
-    if github_login == 'disabledloginfortesting':
-        raise gh.BadCredentialsException(403, 'no login specified')
-
-    # see if we have tokens - might be many. Doesn't cost us much so get at once
-    all_tokens = tokens = unique(
-        assure_list(cfg.get(CONFIG_HUB_TOKEN_FIELD, None)),
-        reverse=True
-    )
-
-    if not (github_login and github_passwd):
-        # we don't have both
-        # Check the tokens.  If login is provided, only the token(s) for the
-        # login are considered. We consider oauth tokens as stored/used by
-        # https://github.com/sociomantic/git-hub
-
-        if github_login and tokens:
-            # Take only the tokens which are Ok and correspond to that login
-            tokens = _get_tokens_for_login(github_login, tokens)
-
-        for token in tokens:
-            try:
-                yield(gh.Github(token), None)
-            except gh.BadCredentialsException as exc:
-                lgr.debug("Failed to obtain Github session for token %s",
-                          _token_str(token))
-
-    # We got here so time to try credentials
-
-    # make it per user if github_login was provided. People might want to use
-    # different credentials etc
-    cred_identity = "%s@github" % github_login if github_login else "github"
-
-    # if login and passwd were provided - try that one first
-    try_creds = github_login and github_passwd
-
-    while True:
-        if try_creds:
-            # So we do not store them into cred store and thus do not need to
-            # remove
-            cred = None
-            ses = gh.Github(github_login, password=github_passwd)
-            user_name = github_login
-            try_creds = None
-        else:
-            cred = UserPassword(cred_identity, 'https://github.com/login')
-            if not cred.is_known:
-                cred.enter_new()
-            creds = cred()
-            user_name = creds['user']
-            ses = gh.Github(user_name, password=creds['password'])
-        # Get user and list its authorizations to verify that we do
-        # not need 2FA
-        user = ses.get_user()
-        try:
-            user_name_ = user.name  # should trigger need for 2FA
-            # authorizations = list(user.get_authorizations())
-            yield ses, cred
-        except gh.BadCredentialsException as exc:
-            lgr.error("Bad Github credentials")
-        except (gh.TwoFactorException, gh.GithubException) as exc:
-            # With github 1.43.5, in comparison to 1.40 we get a "regular"
-            # GithubException for some reason, yet to check/report upstream
-            # so we will just check for the expected in such cases messages
-            if not (
-                isinstance(exc, gh.GithubException) and
-                getattr(exc, 'data', {}).get('message', '').startswith(
-                    'Must specify two-factor authentication OTP code')
-            ):
-                raise
-
-            # 2FA - we need to interact!
-            if not ui.is_interactive:
-                # Or should we just allow to pass
-                raise RuntimeError(
-                    "Cannot proceed with 2FA for Github - UI is not interactive. "
-                    "Please 'manually' establish token based authentication "
-                    "with Github and specify it in  %s  config"
-                    % CONFIG_HUB_TOKEN_FIELD
-                )
-            if not ui.yesno(
-                title="GitHub credentials - %s uses 2FA" % user_name,
-                text="Generate a GitHub token to proceed? "
-                     "If you already have a token for the account, "
-                     "just say 'no' now and specify it in config (%s), "
-                     "otherwise say 'yes' "
-                    % (CONFIG_HUB_TOKEN_FIELD,)
-                ):
-                return
-
-            token = _get_2fa_token(user)
-            yield gh.Github(token), None  # None for cred so does not get killed
-
-        # if we are getting here, it means we are asked for more and thus
-        # aforementioned one didn't work out :-/
-        if ui.is_interactive:
-            if cred is not None:
-                if ui.yesno(
-                    title="GitHub credentials",
-                    text="Do you want to try (re)entering GitHub credentials?"
-                ):
-                    cred.enter_new()
-                else:
-                    break
-        else:
-            # Nothing we could do
-            lgr.debug(
-                "UI is not interactive - we cannot query for more credentials"
-            )
-            break
-
-
-def _get_2fa_token(user):
-    import github as gh
-    one_time_password = ui.question(
-        "2FA one time password", hidden=True, repeat=False
-    )
-    token_note = cfg.obtain('datalad.github.token-note')
-    try:
-        # TODO: can fail if already exists -- handle!?
-        # in principle there is .authorization.delete()
-        auth = user.create_authorization(
-            scopes=['user', 'repo'],  # TODO: Configurable??
-            note=token_note,  # TODO: Configurable??
-            onetime_password=one_time_password)
-    except gh.GithubException as exc:
-        if (exc.status == 422  # "Unprocessable Entity"
-                and exc.data.get('errors', [{}])[0].get('code') == 'already_exists'
-        ):
-            raise ValueError(
-                "Token %r already exists. If you specified "
-                "password -- don't, and specify token in configuration as %s. "
-                "If token already exists and you want to generate a new one "
-                "anyways - specify a new one via 'datalad.github.token-note' "
-                "configuration variable"
-                % (token_note, CONFIG_HUB_TOKEN_FIELD)
-            )
-        raise
-    token = auth.token
-    where_to_store = ui.question(
-        title="Where to store token %s?" % _token_str(token),
-        text="Empty string would result in the token not being "
-             "stored for future reuse, so you will have to adjust "
-             "configuration manually",
-        choices=["global", "local", ""]
-    )
-    if where_to_store:
-        try:
-            # Using .add so other (possibly still legit tokens) are not lost
-            if cfg.get(CONFIG_HUB_TOKEN_FIELD, None):
-                lgr.info("Found that there is some other known tokens already, "
-                         "adding one more")
-            cfg.add(CONFIG_HUB_TOKEN_FIELD, auth.token,
-                    where=where_to_store)
-            lgr.info("Stored %s=%s in %s config.",
-                     CONFIG_HUB_TOKEN_FIELD, _token_str(token),
-                     where_to_store)
-        except Exception as exc:
-            lgr.error("Failed to store token: %s",
-                      # sanitize away the token
-                      exc_str(exc).replace(token, _token_str(token)))
-            # assuming that it is ok to display the token to the user, since
-            # otherwise it would be just lost.  ui  shouldn't log it (at least
-            # ATM)
-            ui.error(
-                "Failed to store the token (%s), please store manually as %s"
-                % (token, CONFIG_HUB_TOKEN_FIELD)
-            )
-    return token
-
-
-def _gen_github_entity(
-    github_login, github_passwd,
-    github_organization
-):
-    import github as gh
-    for ses, cred in _gen_github_ses(github_login, github_passwd):
-        if github_organization:
-            try:
-                yield ses.get_organization(github_organization), cred
-            except gh.UnknownObjectException as e:
-                # yoh thinks it might be due to insufficient credentials?
-                raise ValueError('unknown organization "{}" [{}]'.format(
-                                 github_organization,
-                                 exc_str(e)))
-        else:
-            yield ses.get_user(), cred
-
-
-def _make_github_repos(
-        github_login, github_passwd, github_organization, rinfo, existing,
-        access_protocol, dryrun):
-    import github as gh
-    res = []
-    if not rinfo:
-        return res  # no need to even try!
-
-    ncredattempts = 0
-    # determine the entity under which to create the repos.  It might be that
-    # we would need to check a few credentials
-    for entity, cred in _gen_github_entity(
-            github_login,
-            github_passwd,
-            github_organization):
-        lgr.debug("Using entity %s with credential %s", entity, cred)
-        ncredattempts += 1
-        for ds, reponame in rinfo:
-            lgr.debug("Trying to create %s for %s", reponame, ds)
-            try:
-                res_ = _make_github_repo(
-                    github_login,
-                    entity,
-                    reponame,
-                    existing,
-                    access_protocol,
-                    dryrun)
-                # output will contain whatever is returned by _make_github_repo
-                # but with a dataset prepended to the record
-                res.append((ds,) + assure_tuple_or_list(res_))
-            except gh.BadCredentialsException as e:
-                if res:
-                    # so we have succeeded with at least one repo already -
-                    # we should not try any other credential.
-                    # TODO: may be it would make sense to have/use different
-                    # credentials for different datasets e.g. if somehow spread
-                    # across different organizations? but it is not the case here
-                    # IMHO (-- yoh)
-                    raise e
-                # things blew up, wipe out cred store, if anything is in it
-                if cred:
-                    lgr.warning("Authentication failed using %s.", cred.name)
-                else:
-                    lgr.warning("Authentication failed using a token.")
-                break  # go to the next attempt to authenticate
-        if res:
-            return res
-
-    # External loop should stop querying for the next possible way when it succeeds,
-    # so we should never get here if everything worked out
-    if ncredattempts:
-        raise AccessDeniedError(
-            "Tried %d times to get authenticated access to GitHub but kept failing"
-            % ncredattempts
-        )
-    else:
-        raise RuntimeError("Did not even try to create a repo on github")
-
-
-def _make_github_repo(github_login, entity, reponame, existing, access_protocol, dryrun):
-    import github as gh
-    repo = None
-    try:
-        repo = entity.get_repo(reponame)
-    except gh.GithubException as e:
-        if e.status != 404:
-            # this is not a not found message, raise
-            raise e
-        lgr.debug(
-            'To be created repository "%s" does not yet exist on Github',
-            reponame)
-
-    if repo is not None:
-        if existing in ('skip', 'reconfigure'):
-            access_url = get_repo_url(repo, access_protocol, github_login)
-            return access_url, existing == 'skip'
-        elif existing == 'error':
-            msg = 'repository "{}" already exists on Github'.format(reponame)
-            if dryrun:
-                lgr.error(msg)
-            else:
-                raise ValueError(msg)
-        else:
-            RuntimeError('to must not happen')
-
-    if repo is None and not dryrun:
-        try:
-            repo = entity.create_repo(
-                reponame,
-                # TODO description='',
-                # TODO homepage='',
-                # TODO private=False,
-                has_issues=False,
-                has_wiki=False,
-                has_downloads=False,
-                auto_init=False)
-        except gh.GithubException as e:
-            msg = "Github {}: {}".format(
-                e.data.get('message', str(e) or 'unknown'),
-                ', '.join([err.get('message')
-                           for err in e.data.get('errors', [])
-                           if 'message' in err]))
-            raise RuntimeError(msg)
-
-    if repo is None and not dryrun:
-        raise RuntimeError(
-            'something went wrong, we got no Github repository')
-
-    if dryrun:
-        return '{}:github/.../{}'.format(access_protocol, reponame), False
-    else:
-        # report URL for given access protocol
-        return get_repo_url(repo, access_protocol, github_login), False
-
 
 # presently only implemented method to turn subdataset paths into Github
 # compliant repository name suffixes
@@ -519,14 +149,9 @@ class CreateSiblingGithub(Interface):
             access_protocol='https',
             publish_depends=None,
             dryrun=False):
-        try:
-            # this is an absolute leaf package, import locally to avoid
-            # unnecessary dependencies
-            import github as gh
-        except ImportError:
-            raise MissingExternalDependency(
-                'PyGitHub',
-                msg='GitHub-related functionality is unavailable without this package')
+        # this is an absolute leaf package, import locally to avoid
+        # unnecessary dependencies
+        from datalad.support.github_ import _make_github_repos
 
         # what to operate on
         ds = require_dataset(

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -538,7 +538,7 @@ class CreateSiblingGithub(Interface):
         for d, mp in toprocess:
             if name in d.repo.get_remotes():
                 if existing == 'error':
-                    msg = '{} already had a configured sibling "{}"'.format(
+                    msg = '{} already has a configured sibling "{}"'.format(
                         d, name)
                     if dryrun:
                         lgr.error(msg)

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """High-level interface for creating a publication target on GitHub
 """
+
 __docformat__ = 'restructuredtext'
 
 

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -201,12 +201,19 @@ def _gen_github_ses(gh,
                     choices=["global", "local", ""]
                 )
                 if where_to_store:
-                    cfg.set(CONFIG_HUB_TOKEN_FIELD, auth.token,
-                            where=where_to_store)
-                    lgr.info("Stored %s=%s in %s config.",
-                             CONFIG_HUB_TOKEN_FIELD, _token_str(token),
-                             where_to_store)
-                yield gh.Github("token"), cred
+                    try:
+                        cfg.set(CONFIG_HUB_TOKEN_FIELD, auth.token,
+                                where=where_to_store)
+                        lgr.info("Stored %s=%s in %s config.",
+                                 CONFIG_HUB_TOKEN_FIELD, _token_str(token),
+                                 where_to_store)
+                    except Exception as exc:
+                        lgr.debug("Failed to store token: %s", exc_str(exc))
+                        ui.error(
+                            "Failed to store the token (%s), please store manually as %s"
+                            % (token, CONFIG_HUB_TOKEN_FIELD)
+                        )
+                yield gh.Github(token), None  # None for cred so does not get killed
 
         # if we are getting here, it means we are asked for more and thus
         # aforementioned one didn't work out :-/

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -7,7 +7,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test create publication target github"""
 
-import mock
 from os.path import join as opj
 
 from datalad import cfg
@@ -15,7 +14,6 @@ from datalad import cfg
 from datalad.api import create_sibling_github
 from datalad.api import Dataset
 from datalad.support.exceptions import (
-    AccessDeniedError,
     MissingExternalDependency,
 )
 from datalad.utils import (
@@ -24,7 +22,6 @@ from datalad.utils import (
 )
 from datalad.tests.utils import (
     eq_,
-    swallow_logs,
     with_memory_keyring,
     with_tempfile,
     with_testsui,
@@ -33,10 +30,6 @@ from datalad.tests.utils import (
 from nose.tools import assert_raises, assert_in, assert_true, assert_false, \
     assert_not_in, assert_equal
 from nose import SkipTest
-
-from ..create_sibling_github import get_repo_url
-
-import logging
 
 try:
     import github as gh
@@ -50,6 +43,7 @@ except ImportError:
 from datalad.support import path as op
 
 FIXTURES_PATH = op.join(op.dirname(__file__), 'vcr_cassettes')
+
 
 def use_cassette(name, *args, **kwargs):
     """Adapter to store fixtures locally
@@ -65,7 +59,10 @@ def test_invalid_call(path):
     assert_raises(ValueError, create_sibling_github, 'bogus', dataset=path)
     ds = Dataset(path).create()
     # no user
-    assert_raises(gh.BadCredentialsException, ds.create_sibling_github, 'bogus', github_login='disabledloginfortesting')
+    assert_raises(gh.BadCredentialsException,
+                  ds.create_sibling_github,
+                  'bogus',
+                  github_login='disabledloginfortesting')
 
 
 @with_tempfile
@@ -102,97 +99,6 @@ def test_dont_trip_over_missing_subds(path):
             'bogus', recursive=True,
             github_login='disabledloginfortesting', existing='skip'),
         [])
-
-
-def test_get_repo_url():
-    from collections import namedtuple
-    FakeRepo = namedtuple('FakeRepo', ('clone_url', 'ssh_url'))
-    https_url1 = 'https://github.com/user1/repo'
-    ssh_ri1 = 'git@github.com/user1/repo1'
-    repo1 = FakeRepo(https_url1, ssh_ri1)
-
-    assert_equal(get_repo_url(repo1, 'ssh', None), ssh_ri1)
-    assert_equal(get_repo_url(repo1, 'ssh', 'user2'), ssh_ri1)  # no support for changing
-    assert_equal(get_repo_url(repo1, 'https', None), https_url1)
-    assert_equal(get_repo_url(repo1, 'https', 'user2'), 'https://user2@github.com/user1/repo')
-
-
-def test__make_github_repos():
-    github_login = 'test'
-    github_passwd = 'fake'
-    github_organization = 'fakeorg'
-    rinfo = [
-        # (ds, reponame) pairs
-        ("/fakeds1", "fakeds1"),
-        ("/fakeds2", "fakeds2"),
-    ]
-    existing = '???'
-    access_protocol = '???'
-    dryrun = False
-    from .. import create_sibling_github as csgh
-    args = (
-            github_login,
-            github_passwd,
-            github_organization,
-            rinfo,
-            existing,
-            access_protocol,
-            dryrun,
-    )
-
-    # with default mock, no attempts would be made and an exception will be raised
-    with mock.patch.object(csgh, '_gen_github_entity'):
-        assert_raises(RuntimeError, csgh._make_github_repos, *args)
-
-    def _gen_github_entity(*args):
-        return [("entity1", "cred1")]
-
-    with mock.patch.object(csgh, '_gen_github_entity', _gen_github_entity), \
-            mock.patch.object(csgh, '_make_github_repo'):
-        res = csgh._make_github_repos(*args)
-    eq_(len(res), 2)
-    # first entries are our datasets
-    eq_(res[0][0], "/fakeds1")
-    eq_(res[1][0], "/fakeds2")
-    assert(all(len(x) > 1 for x in res))  # there is more than just a dataset
-
-    #
-    # Now test the logic whenever first credential fails and we need to get
-    # to the next one
-    #
-    class FakeCred:
-        def __init__(self, name):
-            self.name = name
-
-    # Let's test not blowing up whenever first credential is not good enough
-    def _gen_github_entity(*args):
-        return [
-            ("entity1", FakeCred("cred1")),
-            ("entity2", FakeCred("cred2")),
-            ("entity3", FakeCred("cred3"))
-        ]
-
-    def _make_github_repo(github_login, entity, reponame, *args):
-        if entity == 'entity1':
-            raise gh.BadCredentialsException("very bad status", "some data")
-        return reponame
-
-    with mock.patch.object(csgh, '_gen_github_entity', _gen_github_entity), \
-            mock.patch.object(csgh, '_make_github_repo', _make_github_repo), \
-            swallow_logs(new_level=logging.INFO) as cml:
-        res = csgh._make_github_repos(*args)
-        assert_in('Authentication failed using cred1', cml.out)
-        eq_(res, [('/fakeds1', 'fakeds1'), ('/fakeds2', 'fakeds2')])
-
-    def _make_github_repo(github_login, entity, reponame, *args):
-        # Always throw an exception
-        raise gh.BadCredentialsException("very bad status", "some data")
-
-    with mock.patch.object(csgh, '_gen_github_entity', _gen_github_entity), \
-            mock.patch.object(csgh, '_make_github_repo', _make_github_repo):
-        with assert_raises(AccessDeniedError) as cme:
-            csgh._make_github_repos(*args)
-        assert_in("Tried 3 times", str(cme.exception))
 
 
 # Ran on Yarik's laptop, so would use his available token

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -192,7 +192,7 @@ def check_integration1(login, keyring,
         # exists already
         with assert_raises(ValueError) as cme:
             ds.create_sibling_github(repo_name, name="github2", **kwargs)
-            assert_in("already exists on", str(cme.exception))
+        assert_in("already exists on", str(cme.exception))
         # we should not leave the broken sibling behind
         assert_not_in('github2', ds.repo.get_remotes())
 

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -7,17 +7,28 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test create publication target github"""
 
+import mock
+
 from os.path import join as opj
 # this must with with and without pygithub
 from datalad.api import create_sibling_github
 from datalad.api import Dataset
-from datalad.support.exceptions import MissingExternalDependency
-from datalad.tests.utils import with_tempfile
+from datalad.support.exceptions import (
+    AccessDeniedError,
+    MissingExternalDependency,
+)
+from datalad.tests.utils import (
+    eq_,
+    swallow_logs,
+    with_tempfile,
+)
 from nose.tools import assert_raises, assert_in, assert_true, assert_false, \
     assert_not_in, assert_equal
 from nose import SkipTest
 
 from ..create_sibling_github import get_repo_url
+
+import logging
 
 try:
     import github as gh
@@ -83,3 +94,81 @@ def test_get_repo_url():
     assert_equal(get_repo_url(repo1, 'ssh', 'user2'), ssh_ri1)  # no support for changing
     assert_equal(get_repo_url(repo1, 'https', None), https_url1)
     assert_equal(get_repo_url(repo1, 'https', 'user2'), 'https://user2@github.com/user1/repo')
+
+
+def test__make_github_repos():
+    github_login = 'test'
+    github_passwd = 'fake'
+    github_organization = 'fakeorg'
+    rinfo = [
+        # (ds, reponame) pairs
+        ("/fakeds1", "fakeds1"),
+        ("/fakeds2", "fakeds2"),
+    ]
+    existing = '???'
+    access_protocol = '???'
+    dryrun = False
+    from .. import create_sibling_github as csgh
+    args = (
+            github_login,
+            github_passwd,
+            github_organization,
+            rinfo,
+            existing,
+            access_protocol,
+            dryrun,
+    )
+
+    # with default mock, no attempts would be made and an exception will be raised
+    with mock.patch.object(csgh, '_gen_github_entity'):
+        assert_raises(RuntimeError, csgh._make_github_repos, *args)
+
+    def _gen_github_entity(*args):
+        return [("entity1", "cred1")]
+
+    with mock.patch.object(csgh, '_gen_github_entity', _gen_github_entity), \
+            mock.patch.object(csgh, '_make_github_repo'):
+        res = csgh._make_github_repos(*args)
+    eq_(len(res), 2)
+    # first entries are our datasets
+    eq_(res[0][0], "/fakeds1")
+    eq_(res[1][0], "/fakeds2")
+    assert(all(len(x) > 1 for x in res))  # there is more than just a dataset
+
+    #
+    # Now test the logic whenever first credential fails and we need to get
+    # to the next one
+    #
+    class FakeCred:
+        def __init__(self, name):
+            self.name = name
+
+    # Let's test not blowing up whenever first credential is not good enough
+    def _gen_github_entity(*args):
+        return [
+            ("entity1", FakeCred("cred1")),
+            ("entity2", FakeCred("cred2")),
+            ("entity3", FakeCred("cred3"))
+        ]
+
+    def _make_github_repo(github_login, entity, reponame, *args):
+        if entity == 'entity1':
+            raise gh.BadCredentialsException("very bad status", "some data")
+        return reponame
+
+    with mock.patch.object(csgh, '_gen_github_entity', _gen_github_entity), \
+            mock.patch.object(csgh, '_make_github_repo', _make_github_repo), \
+            swallow_logs(new_level=logging.INFO) as cml:
+        res = csgh._make_github_repos(*args)
+        assert_in('Authentication failed using cred1', cml.out)
+        eq_(res, [('/fakeds1', 'fakeds1'), ('/fakeds2', 'fakeds2')])
+
+    def _make_github_repo(github_login, entity, reponame, *args):
+        # Always throw an exception
+        raise gh.BadCredentialsException("very bad status", "some data")
+
+    with mock.patch.object(csgh, '_gen_github_entity', _gen_github_entity), \
+            mock.patch.object(csgh, '_make_github_repo', _make_github_repo):
+        with assert_raises(AccessDeniedError) as cme:
+            csgh._make_github_repos(*args)
+        assert_in("Tried 3 times", str(cme.exception))

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -50,16 +50,26 @@ def test_dont_trip_over_missing_subds(path):
     assert_false(subds2.is_installed())
     # see if it wants to talk to github (and fail), or if it trips over something
     # before
-    assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting')
+    assert_raises(gh.BadCredentialsException,
+        ds1.create_sibling_github, 'bogus', recursive=True,
+        github_login='disabledloginfortesting')
     # inject remote config prior run
     assert_not_in('github', ds1.repo.get_remotes())
     # fail on existing
     ds1.repo.add_remote('github', 'http://nothere')
-    assert_raises(ValueError, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting')
+    assert_raises(ValueError,
+        ds1.create_sibling_github, 'bogus', recursive=True,
+        github_login='disabledloginfortesting')
     # talk to github when existing is OK
-    assert_raises(gh.BadCredentialsException, ds1.create_sibling_github, 'bogus', recursive=True, github_login='disabledloginfortesting', existing='reconfigure')
+    assert_raises(gh.BadCredentialsException,
+        ds1.create_sibling_github, 'bogus', recursive=True,
+        github_login='disabledloginfortesting', existing='reconfigure')
     # return happy emptiness when all is skipped
-    assert_equal(ds1.create_sibling_github('bogus', recursive=True, github_login='disabledloginfortesting', existing='skip'), [])
+    assert_equal(
+        ds1.create_sibling_github(
+            'bogus', recursive=True,
+            github_login='disabledloginfortesting', existing='skip'),
+        [])
 
 
 def test_get_repo_url():

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -10,27 +10,33 @@
 from os.path import join as opj
 
 from datalad import cfg
-# this must with with and without pygithub
-from datalad.api import create_sibling_github
-from datalad.api import Dataset
-from datalad.support.exceptions import (
-    MissingExternalDependency,
+
+# this must import ok with and without pygithub
+from datalad.api import (
+    create_sibling_github,
+    Dataset,
 )
 from datalad.utils import (
     assure_list,
     chpwd,
 )
 from datalad.tests.utils import (
+    assert_equal,
+    assert_false,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    assert_true,
     eq_,
+    SkipTest,
+    use_cassette as use_cassette_,
     with_memory_keyring,
     with_tempfile,
     with_testsui,
-    use_cassette as use_cassette_,
 )
-from nose.tools import assert_raises, assert_in, assert_true, assert_false, \
-    assert_not_in, assert_equal
-from nose import SkipTest
-
+from datalad.support.exceptions import (
+    MissingExternalDependency,
+)
 try:
     import github as gh
 except ImportError:

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -126,7 +126,6 @@ def test_integration1_datalad_tester():
 
 @use_cassette('github_datalad_tester_org')
 @with_testsui(responses=[
-     'datalad-tester',  # bug -- shouldn't ask probably
      'secret-password',
      'yes',      # Generate a GitHub token?
      '2FA code', # VCR tape has a real one

--- a/datalad/distribution/tests/vcr_cassettes/github_datalad_tester.yaml
+++ b/datalad/distribution/tests/vcr_cassettes/github_datalad_tester.yaml
@@ -1,0 +1,446 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic XXX==]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: !!python/unicode '{"message":"Must specify two-factor authentication
+        OTP code.","documentation_url":"https://developer.github.com/v3/auth#working-with-two-factor-authentication"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      content-length: ['160']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:43:45 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [401 Unauthorized]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-otp: [required; app]
+      x-github-request-id: ['B470:108F:352213:68BDA2:5CBE7BE1']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['58']
+      x-ratelimit-reset: ['1555991025']
+      x-xss-protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: !!python/unicode '{"note": "DataLad", "scopes": ["user", "repo"]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic XXX==]
+      Connection: [keep-alive]
+      Content-Length: ['47']
+      Content-Type: [application/json]
+      User-Agent: [PyGithub/Python]
+      X-GitHub-OTP: ['686273']
+    method: POST
+    uri: https://api.github.com/authorizations
+  response:
+    body: {string: !!python/unicode '{"id":282583716,"url":"https://api.github.com/authorizations/282583716","app":{"name":"DataLad","url":"https://developer.github.com/v3/oauth_authorizations/","client_id":"00000000000000000000"},"token":"token","hashed_token":"7d2d850f4d5ae6fb8bfd9bf8f28c979de60ae08284583342f3ccff8fee0c16a4","token_last_eight":"3e6cde8a","note":"DataLad","note_url":null,"created_at":"2019-04-23T02:43:58Z","updated_at":"2019-04-23T02:43:58Z","scopes":["user","repo"],"fingerprint":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['506']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:43:58 GMT']
+      etag: ['"48764ef7692db900147b1e18699d7507"']
+      location: ['https://api.github.com/authorizations/282583716']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['B470:108F:3525DB:68BDAA:5CBE7BE1']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4999']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51UTY/aMBD9Lz4D+SBlm0jVHraXHtrVSrSqeokcxwS3jm3ZDpSN+O99TsLSsitV
+        ChfweObN85t59ETqRihSkJp6Kmm99Nx5bsmCiJoUaZpn6/x9siBK17wMIfL549Pm2/cvkv38dHrc
+        Pj0/bpvfSKcHANiysxI5e++NK6JoDLpk1Qi/76rOccu08lz5FdNt1EWXBveHDxlAGjvBDJ0QuIEz
+        YkIaywHnolfE976VNzzG9kPRq/SdllIfgXTL/f/NopdaUB1/C9XMxkFtH2m/55ARTzsHQYTzc4gN
+        dX0UvjC1gOQwHcvrGeSmSlA7KrDqI8uNHiC7yjErjBdazSH5Tz3wtG2oEs90Lh7qHWACvTl0hjrU
+        8wP2cw7AWNhHxooDZacgkeWMiwNknw16gwBMfzIc7viKFQlDEJ6XtG6DiXdUOg6v0hYJqpNyQbDy
+        hqrT5VjB7pM/Yc/JCysIBySp2SA97h9OFQxhKONBj5YKmHrE2wvLaSVf8CuhL1emq6Rg5ShjkcQL
+        MkWGZSQFAle/XE/Y+uGOAdhDKepBII2TzTKJl0m+TfJiHRfr9Q9Q6Qwo/5WTL+P1Ms62cVakSLsL
+        OYP60OTa1Wv8tZWX+MQPHcM+12/Ea+F+wYG0wSuTNGgoJa20pV7b8R3+qMsdZTiXtINhlRcX7bzt
+        MAIjKXTsp1GQneVByVHRIr/bvNukWZ6/BX1DM4nxOZ//AM0PTWioBQAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:05 GMT']
+      etag: [W/"27d5cdd87627495e3c3f2702d8cf37ef"]
+      last-modified: ['Mon, 04 Mar 2019 04:29:37 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['CB28:7199:B3E7B:1F236C:5CBE7BF5']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4998']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/datalad-tester/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:05 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [404 Not Found]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      x-accepted-oauth-scopes: [repo]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['CB28:7199:B3E81:1F2374:5CBE7BF5']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4997']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 404, message: Not Found}
+- request:
+    body: !!python/unicode '{"has_issues": false, "auto_init": false, "has_wiki":
+      false, "name": "test_integration1", "has_downloads": false}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      Content-Length: ['113']
+      Content-Type: [application/json]
+      User-Agent: [PyGithub/Python]
+    method: POST
+    uri: https://api.github.com/user/repos
+  response:
+    body: {string: !!python/unicode '{"id":182912407,"node_id":"MDEwOlJlcG9zaXRvcnkxODI5MTI0MDc=","name":"test_integration1","full_name":"datalad-tester/test_integration1","private":false,"owner":{"login":"datalad-tester","id":22943981,"node_id":"MDQ6VXNlcjIyOTQzOTgx","avatar_url":"https://avatars1.githubusercontent.com/u/22943981?v=4","gravatar_id":"","url":"https://api.github.com/users/datalad-tester","html_url":"https://github.com/datalad-tester","followers_url":"https://api.github.com/users/datalad-tester/followers","following_url":"https://api.github.com/users/datalad-tester/following{/other_user}","gists_url":"https://api.github.com/users/datalad-tester/gists{/gist_id}","starred_url":"https://api.github.com/users/datalad-tester/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/datalad-tester/subscriptions","organizations_url":"https://api.github.com/users/datalad-tester/orgs","repos_url":"https://api.github.com/users/datalad-tester/repos","events_url":"https://api.github.com/users/datalad-tester/events{/privacy}","received_events_url":"https://api.github.com/users/datalad-tester/received_events","type":"User","site_admin":false},"html_url":"https://github.com/datalad-tester/test_integration1","description":null,"fork":false,"url":"https://api.github.com/repos/datalad-tester/test_integration1","forks_url":"https://api.github.com/repos/datalad-tester/test_integration1/forks","keys_url":"https://api.github.com/repos/datalad-tester/test_integration1/keys{/key_id}","collaborators_url":"https://api.github.com/repos/datalad-tester/test_integration1/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/datalad-tester/test_integration1/teams","hooks_url":"https://api.github.com/repos/datalad-tester/test_integration1/hooks","issue_events_url":"https://api.github.com/repos/datalad-tester/test_integration1/issues/events{/number}","events_url":"https://api.github.com/repos/datalad-tester/test_integration1/events","assignees_url":"https://api.github.com/repos/datalad-tester/test_integration1/assignees{/user}","branches_url":"https://api.github.com/repos/datalad-tester/test_integration1/branches{/branch}","tags_url":"https://api.github.com/repos/datalad-tester/test_integration1/tags","blobs_url":"https://api.github.com/repos/datalad-tester/test_integration1/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/datalad-tester/test_integration1/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/datalad-tester/test_integration1/git/refs{/sha}","trees_url":"https://api.github.com/repos/datalad-tester/test_integration1/git/trees{/sha}","statuses_url":"https://api.github.com/repos/datalad-tester/test_integration1/statuses/{sha}","languages_url":"https://api.github.com/repos/datalad-tester/test_integration1/languages","stargazers_url":"https://api.github.com/repos/datalad-tester/test_integration1/stargazers","contributors_url":"https://api.github.com/repos/datalad-tester/test_integration1/contributors","subscribers_url":"https://api.github.com/repos/datalad-tester/test_integration1/subscribers","subscription_url":"https://api.github.com/repos/datalad-tester/test_integration1/subscription","commits_url":"https://api.github.com/repos/datalad-tester/test_integration1/commits{/sha}","git_commits_url":"https://api.github.com/repos/datalad-tester/test_integration1/git/commits{/sha}","comments_url":"https://api.github.com/repos/datalad-tester/test_integration1/comments{/number}","issue_comment_url":"https://api.github.com/repos/datalad-tester/test_integration1/issues/comments{/number}","contents_url":"https://api.github.com/repos/datalad-tester/test_integration1/contents/{+path}","compare_url":"https://api.github.com/repos/datalad-tester/test_integration1/compare/{base}...{head}","merges_url":"https://api.github.com/repos/datalad-tester/test_integration1/merges","archive_url":"https://api.github.com/repos/datalad-tester/test_integration1/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/datalad-tester/test_integration1/downloads","issues_url":"https://api.github.com/repos/datalad-tester/test_integration1/issues{/number}","pulls_url":"https://api.github.com/repos/datalad-tester/test_integration1/pulls{/number}","milestones_url":"https://api.github.com/repos/datalad-tester/test_integration1/milestones{/number}","notifications_url":"https://api.github.com/repos/datalad-tester/test_integration1/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/datalad-tester/test_integration1/labels{/name}","releases_url":"https://api.github.com/repos/datalad-tester/test_integration1/releases{/id}","deployments_url":"https://api.github.com/repos/datalad-tester/test_integration1/deployments","created_at":"2019-04-23T02:44:05Z","updated_at":"2019-04-23T02:44:05Z","pushed_at":"2019-04-23T02:44:06Z","git_url":"git://github.com/datalad-tester/test_integration1.git","ssh_url":"git@github.com:datalad-tester/test_integration1.git","clone_url":"https://github.com/datalad-tester/test_integration1.git","svn_url":"https://github.com/datalad-tester/test_integration1","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_projects":true,"has_downloads":false,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"network_count":0,"subscribers_count":0}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['5600']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:06 GMT']
+      etag: ['"3fd6b0aed40288407d4a2faee0442b28"']
+      location: ['https://api.github.com/repos/datalad-tester/test_integration1']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['public_repo, repo']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['CB28:7199:B3E84:1F237B:5CBE7BF5']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4996']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51UTY/TMBT8Lz63zUdDl0RCHODCAVYrFYS4RI7jpgbXtmynpRv1vzPOx7JkV0JK
+        L61f38ybjN+kI1I3QpGC1NRTSeu1585zS1ZE1KRI0zzb5m+TFVG65mUokc8fH3bfvn+R7Oen6/3+
+        4fF+3/xGOz2DwJatleg5em9cEUVD0SWbRvhjW7WOW6aV58pvmD5FbTQNeH9+l4GksSNNPwmFGZ0R
+        I9MAB52LXgg/+pOc6RjG96AX7Qctpb6Aaa79/8OiJyykDr+FahbzANtF2h85bMSj3YIhwvklwnpc
+        F4Uv3Fpgcrgdy+sF4kYkpF0UVHWR5Ub3lG3lmBXGC62WiPwHDz5tG6rEI13KB7wDTZC3RE6PA56f
+        sZ9LCAZgFxkrzpRdg0WWMy7OsH0x6YwBnP5qONLxFSsSLkF4XtL6FEJ8oNJxZJWe0KBaKVcEK2+o
+        uk7HCnEf84l4jlnYwDgwSc166/H/h2uFQBjKePDjRAVCPfAdheW0kk/8ldDTX6atpGDlYGOR4KUx
+        VvplJEU8ZQTUz07Y+v7EQOzhFPUQkMbJbp3E6yTfJ3mxjYvt9gektAaSn/Xk63i7jrN9nBUp2u5C
+        T+8+PPk71Wu82sqpPurDxLDP9Sv1WrhfSCBt8JRJGjyUklbaUq9H5f6iywNlOJe0RWCVF5N33ra4
+        AiMpfOzGqyAHy4OTg6NFfrd7s0uzPH+NeiYzifG53f4A1Qbwz6gFAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:06 GMT']
+      etag: [W/"0f52a22cfaf01ad706ad86ee9b4a4b89"]
+      last-modified: ['Mon, 04 Mar 2019 04:29:37 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['B474:69D5:2C6B51:60599F:5CBE7BF6']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4995']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/datalad-tester/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Y32/bNhDH/xe/Lglt1+1qA0X3kGHIgCzokA3FXgxaoi02kqiRlN1EyP/e75H6
+        6aS1avAlsWnyw+Px7nh31UTGk9Xs/Xw5my+mv15MchWLNY1Nbq9/P9ylf6bRH8sn/vnvfZQ/fL27
+        vnl7e38zvb2OPkwwmWcCM60wdi1zK3aaW6nyGX7almm6rn+PueUpjy9pntDstemFlntuAdvy1IiL
+        iTrkQk9W1SRVO5ljjyEDG5CM8/ly8Wb5fjYU+9O7fz//lUZfbh7v7j893d3vvmI6B57rdalTwBJr
+        C7NizA+a2dVO2qTclEboSOEcub2KVMZK1mzwcf9hAQjO5zFOQRg4whWyJvnlwBn2QvDEZumRHH57
+        t+jF9K1KU3UA6Vj205uxdi1diOPIfHc2B2srpmwioEYc7ZkUIo09RzC3rmL0D8ZGJIPb0SI+Q7h6
+        JUQjm3mumBaFcshyYyItCzLJc4QcrAdP6R3P5ZMz8XN4WG+AIfHOWe7WYb3Ywz7PAfiFFXO+Fj2S
+        irSIhNxD7WdDjwhg2seCgsI/MBG6BGnFmscZObHz7ecLuN94D3g1WsSivdjJKkekIfPWD230+KFb
+        Oj0e+dmruxDyhJ7HseCHIEEZD+IxDJBAFcPf2nsiODffKIRfdSpQjBR5QKxY/ysZjhU8C3MURwIx
+        USqQth0JRGlMKUZZ9kidOKBhjR/lZbbxYXCM94zcw6MgPTdG7nIhwmi5pVWsid0bzfMoCcRvYBXz
+        n5yN8F0Y4QkE3iZVmzBAvLfM0SpmEu4fMrsOJi/hCTaga7ENJzzBWrrVoazECU60lo3H1cJgwkje
+        wFhVaz3l+a7ku0D4lkbPDtKJHX86mTaN9MoOBzaliFpuyoCxtgOS7D5vQWwJpPaO19FdVvTjbGus
+        bnppltNOlslT+clIdM0a+FFIPtn78R70/XSC9RMHIFjFusfCP0v1NkFuoH6XGsn7m9XlTBhDamCs
+        +qXgNqG4iT0LrkWQY9QsVm040sSrq6sqEdwVB5nQoYKER4HJdZQg9Q0iedXAkOhl3LoaZEuCx6hJ
+        UsXjMPpvaSD7Ow8ivUf1raZASh1GZEfqozOZogug8kAxv8P1N8mVlVsZjanURjrygFh9NDKPxAVH
+        4QHrtzKS8AeUx3TlyMNFIOV5FA6GNouv1lIB1whzM1p4WMV8AR6LIlWP4UJfj0dxQgu0d+I1tygN
+        59PZ8nK6uJy/uZ/OV4vFavr2P8wpCzQ/TswpSpN8f8o7wiCo126BT2jyfLe58rLoo+4NCMYkHeG3
+        bv3qVCOrXh+lsO8j1zxDiv3x+/wTDJwiUZkokFw1FbKRT/g8HeRGkSpz3AgGD9yiGEDG0Q01+VQD
+        SLhZ+1jRFto0VGj1RUTWTFZWl2jd0VgXqZqGHo0e5IMcLqXcrx3x9Xa3fya1VnXLzhf5dZhF861u
+        E8bS8E0qugFViLwWsn8SGYnctJrw5Tidujd9oAX3JRZbXqZ27Ssa2G3GqX8J1RZCZ9AE9YGoR1m3
+        N/zxyUIbVVD085/R9UC0UIe1+b/kMC/3DDXT/C9uCEJT+jT8RQt6EYdrcmEP6Cr0DtlPGxslPn8D
+        mCRPDuAVAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:06 GMT']
+      etag: [W/"3fd6b0aed40288407d4a2faee0442b28"]
+      last-modified: ['Tue, 23 Apr 2019 02:44:05 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: [repo]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['B474:69D5:2C6B58:6059AC:5CBE7BF6']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4994']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51UTY/TMBT8Lz63zUdDl0RCHODCAVYrFYS4RI7jpgbXtmynpRv1vzPOx7JkV0JK
+        L61f38ybjN+kI1I3QpGC1NRTSeu1585zS1ZE1KRI0zzb5m+TFVG65mUokc8fH3bfvn+R7Oen6/3+
+        4fF+3/xGOz2DwJatleg5em9cEUVD0SWbRvhjW7WOW6aV58pvmD5FbTQNeH9+l4GksSNNPwmFGZ0R
+        I9MAB52LXgg/+pOc6RjG96AX7Qctpb6Aaa79/8OiJyykDr+FahbzANtF2h85bMSj3YIhwvklwnpc
+        F4Uv3Fpgcrgdy+sF4kYkpF0UVHWR5Ub3lG3lmBXGC62WiPwHDz5tG6rEI13KB7wDTZC3RE6PA56f
+        sZ9LCAZgFxkrzpRdg0WWMy7OsH0x6YwBnP5qONLxFSsSLkF4XtL6FEJ8oNJxZJWe0KBaKVcEK2+o
+        uk7HCnEf84l4jlnYwDgwSc166/H/h2uFQBjKePDjRAVCPfAdheW0kk/8ldDTX6atpGDlYGOR4KUx
+        VvplJEU8ZQTUz07Y+v7EQOzhFPUQkMbJbp3E6yTfJ3mxjYvt9gektAaSn/Xk63i7jrN9nBUp2u5C
+        T+8+PPk71Wu82sqpPurDxLDP9Sv1WrhfSCBt8JRJGjyUklbaUq9H5f6iywNlOJe0RWCVF5N33ra4
+        AiMpfOzGqyAHy4OTg6NFfrd7s0uzPH+NeiYzifG53f4A1Qbwz6gFAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:07 GMT']
+      etag: [W/"0f52a22cfaf01ad706ad86ee9b4a4b89"]
+      last-modified: ['Mon, 04 Mar 2019 04:29:37 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['CB2C:69D2:3A9C4B:75291C:5CBE7BF7']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4993']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token token]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/datalad-tester/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Y32/bNhDH/xe/Lglt1+1qA0X3kGHIgCzokA3FXgxaoi02kqiRlN1EyP/e75H6
+        6aS1avAlsWnyw+Px7nh31UTGk9Xs/Xw5my+mv15MchWLNY1Nbq9/P9ylf6bRH8sn/vnvfZQ/fL27
+        vnl7e38zvb2OPkwwmWcCM60wdi1zK3aaW6nyGX7almm6rn+PueUpjy9pntDstemFlntuAdvy1IiL
+        iTrkQk9W1SRVO5ljjyEDG5CM8/ly8Wb5fjYU+9O7fz//lUZfbh7v7j893d3vvmI6B57rdalTwBJr
+        C7NizA+a2dVO2qTclEboSOEcub2KVMZK1mzwcf9hAQjO5zFOQRg4whWyJvnlwBn2QvDEZumRHH57
+        t+jF9K1KU3UA6Vj205uxdi1diOPIfHc2B2srpmwioEYc7ZkUIo09RzC3rmL0D8ZGJIPb0SI+Q7h6
+        JUQjm3mumBaFcshyYyItCzLJc4QcrAdP6R3P5ZMz8XN4WG+AIfHOWe7WYb3Ywz7PAfiFFXO+Fj2S
+        irSIhNxD7WdDjwhg2seCgsI/MBG6BGnFmscZObHz7ecLuN94D3g1WsSivdjJKkekIfPWD230+KFb
+        Oj0e+dmruxDyhJ7HseCHIEEZD+IxDJBAFcPf2nsiODffKIRfdSpQjBR5QKxY/ysZjhU8C3MURwIx
+        USqQth0JRGlMKUZZ9kidOKBhjR/lZbbxYXCM94zcw6MgPTdG7nIhwmi5pVWsid0bzfMoCcRvYBXz
+        n5yN8F0Y4QkE3iZVmzBAvLfM0SpmEu4fMrsOJi/hCTaga7ENJzzBWrrVoazECU60lo3H1cJgwkje
+        wFhVaz3l+a7ku0D4lkbPDtKJHX86mTaN9MoOBzaliFpuyoCxtgOS7D5vQWwJpPaO19FdVvTjbGus
+        bnppltNOlslT+clIdM0a+FFIPtn78R70/XSC9RMHIFjFusfCP0v1NkFuoH6XGsn7m9XlTBhDamCs
+        +qXgNqG4iT0LrkWQY9QsVm040sSrq6sqEdwVB5nQoYKER4HJdZQg9Q0iedXAkOhl3LoaZEuCx6hJ
+        UsXjMPpvaSD7Ow8ivUf1raZASh1GZEfqozOZogug8kAxv8P1N8mVlVsZjanURjrygFh9NDKPxAVH
+        4QHrtzKS8AeUx3TlyMNFIOV5FA6GNouv1lIB1whzM1p4WMV8AR6LIlWP4UJfj0dxQgu0d+I1tygN
+        59PZ8nK6uJy/uZ/OV4vFavr2P8wpCzQ/TswpSpN8f8o7wiCo126BT2jyfLe58rLoo+4NCMYkHeG3
+        bv3qVCOrXh+lsO8j1zxDiv3x+/wTDJwiUZkokFw1FbKRT/g8HeRGkSpz3AgGD9yiGEDG0Q01+VQD
+        SLhZ+1jRFto0VGj1RUTWTFZWl2jd0VgXqZqGHo0e5IMcLqXcrx3x9Xa3fya1VnXLzhf5dZhF861u
+        E8bS8E0qugFViLwWsn8SGYnctJrw5Tidujd9oAX3JRZbXqZ27Ssa2G3GqX8J1RZCZ9AE9YGoR1m3
+        N/zxyUIbVVD085/R9UC0UIe1+b/kMC/3DDXT/C9uCEJT+jT8RQt6EYdrcmEP6Cr0DtlPGxslPn8D
+        mCRPDuAVAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 23 Apr 2019 02:44:07 GMT']
+      etag: [W/"3fd6b0aed40288407d4a2faee0442b28"]
+      last-modified: ['Tue, 23 Apr 2019 02:44:05 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: [repo]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['CB2C:69D2:3A9C56:75292C:5CBE7BF7']
+      x-oauth-scopes: ['user, repo']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4992']
+      x-ratelimit-reset: ['1555991038']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/datalad/distribution/tests/vcr_cassettes/github_datalad_tester.yaml
+++ b/datalad/distribution/tests/vcr_cassettes/github_datalad_tester.yaml
@@ -49,7 +49,7 @@ interactions:
     method: POST
     uri: https://api.github.com/authorizations
   response:
-    body: {string: !!python/unicode '{"id":282583716,"url":"https://api.github.com/authorizations/282583716","app":{"name":"DataLad","url":"https://developer.github.com/v3/oauth_authorizations/","client_id":"00000000000000000000"},"token":"token","hashed_token":"7d2d850f4d5ae6fb8bfd9bf8f28c979de60ae08284583342f3ccff8fee0c16a4","token_last_eight":"3e6cde8a","note":"DataLad","note_url":null,"created_at":"2019-04-23T02:43:58Z","updated_at":"2019-04-23T02:43:58Z","scopes":["user","repo"],"fingerprint":null}'}
+    body: {string: !!python/unicode '{"id":282583716,"url":"https://api.github.com/authorizations/282583716","app":{"name":"DataLad","url":"https://developer.github.com/v3/oauth_authorizations/","client_id":"00000000000000000000"},"token":"token","hashed_token":"XXX","token_last_eight":"3e6cde8a","note":"DataLad","note_url":null,"created_at":"2019-04-23T02:43:58Z","updated_at":"2019-04-23T02:43:58Z","scopes":["user","repo"],"fingerprint":null}'}
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,

--- a/datalad/distribution/tests/vcr_cassettes/github_datalad_tester_org.yaml
+++ b/datalad/distribution/tests/vcr_cassettes/github_datalad_tester_org.yaml
@@ -1,0 +1,753 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token fake1]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['83']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:49:59 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['24F9:1C7C:659E99:DE075A:5CBF4237']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['59']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token fake2]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['83']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:49:59 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['8950:52CF:7CD285:FA3F09:5CBF4237']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['58']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic XXX==]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Must specify two-factor authentication OTP code.","documentation_url":"https://developer.github.com/v3/auth#working-with-two-factor-authentication"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['160']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:08 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-OTP: [required; app]
+      X-GitHub-Request-Id: ['BE0C:0789:80002D:105A231:5CBF4240']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['57']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: '{"scopes": ["user", "repo"], "note": "DataLad"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic XXX==]
+      Connection: [keep-alive]
+      Content-Length: ['47']
+      Content-Type: [application/json]
+      User-Agent: [PyGithub/Python]
+      X-GitHub-OTP: ['796221']
+    method: POST
+    uri: https://api.github.com/authorizations
+  response:
+    body: {string: '{"id":282841148,"url":"https://api.github.com/authorizations/282841148","app":{"name":"DataLad","url":"https://developer.github.com/v3/oauth_authorizations/","client_id":"00000000000000000000"},"token":"sometoken","hashed_token":"XXX","token_last_eight":"329ec22f","note":"DataLad","note_url":null,"created_at":"2019-04-23T16:50:16Z","updated_at":"2019-04-23T16:50:16Z","scopes":["user","repo"],"fingerprint":null}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Length: ['506']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:16 GMT']
+      ETag: ['"3e37dd4c88d09e1fdcbb66dd15d5701c"']
+      Location: ['https://api.github.com/authorizations/282841148']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [201 Created]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['BE0C:0789:800380:105A255:5CBF4240']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4999']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/orgs/datalad-tester-org
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTyW7bMBT8F52jyFEdtxZQtIekRQ+FUSCHIhfiSXqSGVOkysWGa/jfO1pSK3GA
+        Au5NfOIMOQsPkTK11FEWleRJURl7dp5tbGwdXUWyjLL5cnmz+JDOriJtShbdKPp+d79fbZb7x/RL
+        oJ/tuvyqtvnTj9vVw326uvu2AzRYhY1r71uXJQm18rqWfh3y68I0Cdhd8uaJllvjxCXgpIfiZN6y
+        9hdyDFiQrI3ZXMjRQzvznAt8IceABUnDTc72QpYRfEiGjyP42pArWYj/on3JMWWnLVpkX8fXD91s
+        LEBwbAujPULquxCS54Z92n6c44olu8LK1kuDXuqgVGel2LKVlWS0ryLlGAmRE+gRafmbur2iteaJ
+        C++izNswbug7Ib2x+7Pfo4qhNRnqPQ5q6ToODCqjlNnB/clK6rpfrX2jXumc9PvNaheWyXMpyONh
+        pLObZTybx+m7h5tFNkvxzB67V9MC+o89ft8yGFYT7UB6g/cLkRJuszipMjsNvvP58+Qkt5RuI4Kj
+        GuxQWEA95cYS3BscyKVS0C+4Idk9bhjL8aA6fqn4s9Fsg3OSdJdxH2pFQfnhYmMgbBv0vI85gjfl
+        pO4FaTH4dUJI/hut3xlRUYGb4fevIC03qJNgTbmaVKRVBO5DpKnpHKssM85wLRVYLt8vbhcpuofk
+        z1yrIBW2OSSGQ+cADV+z4/EPvJnsXjMFAAA=
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:18 GMT']
+      ETag: [W/"c611133c5e69817584e50fd8ea60b9cb"]
+      Last-Modified: ['Tue, 23 Apr 2019 16:02:49 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: ['admin:org, read:org, repo, user, write:org']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['7349:4752:1D0A22:4D8E83:5CBF424A']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4998']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/datalad-tester-org/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:18 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [404 Not Found]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      X-Accepted-OAuth-Scopes: [repo]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['7349:4752:1D0A2B:4D8EA1:5CBF424A']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4997']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"name": "test_integration1", "has_issues": false, "has_wiki": false, "has_downloads":
+      false, "auto_init": false}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      Content-Length: ['113']
+      Content-Type: [application/json]
+      User-Agent: [PyGithub/Python]
+    method: POST
+    uri: https://api.github.com/orgs/datalad-tester-org/repos
+  response:
+    body: {string: '{"id":183058162,"node_id":"MDEwOlJlcG9zaXRvcnkxODMwNTgxNjI=","name":"test_integration1","full_name":"datalad-tester-org/test_integration1","private":false,"owner":{"login":"datalad-tester-org","id":49916820,"node_id":"MDEyOk9yZ2FuaXphdGlvbjQ5OTE2ODIw","avatar_url":"https://avatars0.githubusercontent.com/u/49916820?v=4","gravatar_id":"","url":"https://api.github.com/users/datalad-tester-org","html_url":"https://github.com/datalad-tester-org","followers_url":"https://api.github.com/users/datalad-tester-org/followers","following_url":"https://api.github.com/users/datalad-tester-org/following{/other_user}","gists_url":"https://api.github.com/users/datalad-tester-org/gists{/gist_id}","starred_url":"https://api.github.com/users/datalad-tester-org/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/datalad-tester-org/subscriptions","organizations_url":"https://api.github.com/users/datalad-tester-org/orgs","repos_url":"https://api.github.com/users/datalad-tester-org/repos","events_url":"https://api.github.com/users/datalad-tester-org/events{/privacy}","received_events_url":"https://api.github.com/users/datalad-tester-org/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/datalad-tester-org/test_integration1","description":null,"fork":false,"url":"https://api.github.com/repos/datalad-tester-org/test_integration1","forks_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/forks","keys_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/keys{/key_id}","collaborators_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/teams","hooks_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/hooks","issue_events_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/issues/events{/number}","events_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/events","assignees_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/assignees{/user}","branches_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/branches{/branch}","tags_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/tags","blobs_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/git/refs{/sha}","trees_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/git/trees{/sha}","statuses_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/statuses/{sha}","languages_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/languages","stargazers_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/stargazers","contributors_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/contributors","subscribers_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/subscribers","subscription_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/subscription","commits_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/commits{/sha}","git_commits_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/git/commits{/sha}","comments_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/comments{/number}","issue_comment_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/issues/comments{/number}","contents_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/contents/{+path}","compare_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/compare/{base}...{head}","merges_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/merges","archive_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/downloads","issues_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/issues{/number}","pulls_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/pulls{/number}","milestones_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/milestones{/number}","notifications_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/labels{/name}","releases_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/releases{/id}","deployments_url":"https://api.github.com/repos/datalad-tester-org/test_integration1/deployments","created_at":"2019-04-23T16:50:18Z","updated_at":"2019-04-23T16:50:18Z","pushed_at":"2019-04-23T16:50:19Z","git_url":"git://github.com/datalad-tester-org/test_integration1.git","ssh_url":"git@github.com:datalad-tester-org/test_integration1.git","clone_url":"https://github.com/datalad-tester-org/test_integration1.git","svn_url":"https://github.com/datalad-tester-org/test_integration1","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_projects":true,"has_downloads":false,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"organization":{"login":"datalad-tester-org","id":49916820,"node_id":"MDEyOk9yZ2FuaXphdGlvbjQ5OTE2ODIw","avatar_url":"https://avatars0.githubusercontent.com/u/49916820?v=4","gravatar_id":"","url":"https://api.github.com/users/datalad-tester-org","html_url":"https://github.com/datalad-tester-org","followers_url":"https://api.github.com/users/datalad-tester-org/followers","following_url":"https://api.github.com/users/datalad-tester-org/following{/other_user}","gists_url":"https://api.github.com/users/datalad-tester-org/gists{/gist_id}","starred_url":"https://api.github.com/users/datalad-tester-org/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/datalad-tester-org/subscriptions","organizations_url":"https://api.github.com/users/datalad-tester-org/orgs","repos_url":"https://api.github.com/users/datalad-tester-org/repos","events_url":"https://api.github.com/users/datalad-tester-org/events{/privacy}","received_events_url":"https://api.github.com/users/datalad-tester-org/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Length: ['6904']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:19 GMT']
+      ETag: ['"9a6bd71d4d28485de0be79b73fdf9478"']
+      Location: ['https://api.github.com/repos/datalad-tester-org/test_integration1']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [201 Created]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: ['public_repo, repo']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['7349:4752:1D0A2E:4D8EA7:5CBF424A']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4996']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token fake1]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['83']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:21 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['419A:447E:8669DE:10F40C4:5CBF424C']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['56']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token fake2]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['83']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:21 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['38A2:0788:681D7B:DE1571:5CBF424D']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['55']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51UTY/aMBD9Lz4D+SBlm0jVHraXHtrVSrSqeokcxwS3jm3ZDpSN+O99TsLSsitV
+        ChfweObN85t59ETqRihSkJp6Kmm99Nx5bsmCiJoUaZpn6/x9siBK17wMIfL549Pm2/cvkv38dHrc
+        Pj0/bpvfSKcHANiysxI5e++NK6JoDLpk1Qi/76rOccu08lz5FdNt1EWXBveHDxlAGjvBDJ0QuIEz
+        YkIaywHnolfE976VNzzG9kPRq/SdllIfgXTL/f/NopdaUB1/C9XMxkFtH2m/55ARTzsHQYTzc4gN
+        dX0UvjC1gOQwHcvrGeSmSlA7KrDqI8uNHiC7yjErjBdazSH5Tz3wtG2oEs90Lh7qHWACvTl0hjrU
+        8wP2cw7AWNhHxooDZacgkeWMiwNknw16gwBMfzIc7viKFQlDEJ6XtG6DiXdUOg6v0hYJqpNyQbDy
+        hqrT5VjB7pM/Yc/JCysIBySp2SA97h9OFQxhKONBj5YKmHrE2wvLaSVf8CuhL1emq6Rg5ShjkcQL
+        MkWGZSQFAle/XE/Y+uGOAdhDKepBII2TzTKJl0m+TfJiHRfr9Q9Q6Qwo/5WTL+P1Ms62cVakSLsL
+        OYP60OTa1Wv8tZWX+MQPHcM+12/Ea+F+wYG0wSuTNGgoJa20pV7b8R3+qMsdZTiXtINhlRcX7bzt
+        MAIjKXTsp1GQneVByVHRIr/bvNukWZ6/BX1DM4nxOZ//AM0PTWioBQAA
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:22 GMT']
+      ETag: [W/"090ee3357e52cf73b31161d67a27b965"]
+      Last-Modified: ['Mon, 04 Mar 2019 04:29:37 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: ['']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['C697:4C28:39C272:90E63C:5CBF424E']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4995']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/orgs/datalad-tester-org
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTyW7bMBT8F52jSFYdtzYQtIekRQ+FUSCHIhfiSXqSGVOkysWGa+TfO1qSKHGA
+        Au5NpDhDzvKOkTK11NEqKsmTojL27Dzb2Ng6uohkGa3my+Vs8SlLLyJtShbdVvTj5vaw3i4P99nX
+        QL/aTflN7fKHn1fru9tsffN9D2iwCgc33rdulSTUysta+k3ILwvTJGB3ybs3Wm6NE+eAkx6Km3nH
+        2p/JMWBBsjFmeyZHD+3Mcy7wmRwDFiQNNznbM1lG8DEZPh7B14ZcyUL8F+1rjik77dAi+za+ftOl
+        YwGCY1sY7RFS34WQPDXs8+56jieW7AorWy8NeqmDUp2VYsdWVpLRvoqUYyRETqBHpOUf6s6K1poH
+        LryLVt6G8UDfCemNPZz8HlUMrVnNnq2ppes40PfKKGX2cH+ykrruVxvfqDc6J/1+t9qFZfJcCvIY
+        jCydLeN0Hmcf7maLVZphzO67qWkB/ccZf2gZDOuJdiC9wfxCpITbLEZVeKjZa/Cd7j/tvMgtpduK
+        4KgGO4AF1FNuLMG9wYFcKgX9ghuS3XDDWI4H1fFrxV+MZhuck6S7jPtQKwrKDw8bA2HboOd9zBG8
+        KSd1L0iLwa8XhOTnaP3eiIoKvAy/fwdpuUGdBGvK1aQirSJwHyNNTedYZZlxh2upwHL5cXG1yNA9
+        JH/iWgWpsM0hMVw6B2j4Sh8f/wKjzBz6MwUAAA==
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:22 GMT']
+      ETag: [W/"7e5228ad7342e648fc760e47f588e90c"]
+      Last-Modified: ['Tue, 23 Apr 2019 16:02:49 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: ['admin:org, read:org, repo, user, write:org']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['1A88:14D0:64AC5D:DA7276:5CBF424E']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4994']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/datalad-tester-org/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXTULbTYLEQNE9pFt0gdbYRQ9FLwYl0RYTSdSSlF1HyLvvP6Rk
+        yY4bxy6PuSQyJX7DGc4Mh1MPZDKYjG7eDa9uRtfjs0GhEjGjscGXu4+rafZ3Fn+6feTf/13GxcPP
+        6d2X1ddvi59f7z+/H+Bjngt8aYWxM1lYsdDcSlWM8GpeZdmseZ9wyzOenNN3Qp8rvWD7ppRaLrkF
+        cM4zI84GalUIPZjUg0wtZAE5zzkQRGu9vL0dXd+MhzvLX08fbtc/xn9V/HuZJp+yZXT/z9X028fx
+        9O7zClM5xHE9q3QGeGptaSaM+UEzvFhIm1ZRZYSOFXQr7EWsclaxVtiH5ftLQKCzxzijYWAHV8qG
+        5KcDZ9heRVKbZztr8UtwE/dOmassUysQd3V4nVC2mU8b5liyWPwWC/NrpmwqYFao+kQGksaeukA3
+        t2b0D05JNIMd0yI5cZHNbCyRfOupZlqUymGryMRaluS+py52iwEm/JwX8tGFxKlMMAxQtMxTEW4u
+        GGIJHz4V4ifXzMVovCaTaRELucRW/BZ4hwKuXZeUVKY969EGSStmPMkpEbj88HSGkD0uYvZmnURs
+        Nn4wKZC1KBT0wyYLvRjOzrZ7YnOvJMIesP/reYhd0GCYB7EOByVYzfC3ibYYSYFHCmldHUoyRyx9
+        i1qz/k9yLCt4Hk4lRwM1VSqg9R0NVGlMJV4VAUfYx0ENa2OuqPLIp9LXRNoRcjwOWnBj5KIQIpzV
+        N8SatedApHkRpwFltMCa+SfnO3wRTgmCgRllKgoHxZnOHLFmJuX+gLSzoOsmEQTckqDFPKwSBNxI
+        sDqk9zgFiLjh4+C2cKRwGrRAVje7kPFiUfFFQBEbIh1fKFsW/PFgqXZE9HZI8KlE1TKqAufpDko6
+        +BoJuSjgNnTMToKrwl6u8I6xU6+0c5bKc3moDjoC3/C2Yi20DIqHXTn0+3BBd6QiBKxZd+D4460R
+        FWxHmvOt1aAvsLlqhXOwFsjqP0puU8q3kFtyLYKp0/BYHXGUpRcXF3UquLus5EKHTCgeBy7XcYrS
+        O5gGdQtEUZlz6+5Fc1IgwT0pUzwJtx8bIujeD4Jp4XF9bypRzodbuqP18bnM0NFQRcAzo0P2BRXK
+        yrmMX3OTPCLgt6j1ByOLWJxxXIAQHVbGEvGC6zy5Ae4AIqAhPQ4Kon3kb5KZQOiE2yktPLBmvmmQ
+        iDJT67DpsseknKIFWlfJjFtcXcfD0e358PJ8/O7b6HpyNUR/7Qe+qUo0cQ58U1Ym/fUnt4TBYdCE
+        DJ7QsHqxSfT8IkrdKFCMSTvKnx1j8rzR9EtGnMH3d8L3xNUsd8/7IznQKFW5KFHAtbd4Ix/xjJ5g
+        r/aKVVVghzC44haXEVQy3VBbr7WAlJuZzymbZgANlVrdi9iawcTqCm1KGuuyWtu8pNGVfJDbU6m+
+        3Iz4fkAnP5daq6Yd6RsRTVpGY7FpiSbS8CgT3YAqRdEssq+JjEVhNpbwrQLSuvf5lhXcj0TMeZXZ
+        mb9NwY9zTv1amLYUOoclqI9F/dimDePVJ49tTUEZ0j+jO4NMolYz81/F4Wru6Go/82/cEBZN5dj2
+        Gy3oJN2e02+mvfWEo7ee8FtP+K0nvKcnXAi7Qme0lwz719Y22T79D6vbxcj4GgAA
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:23 GMT']
+      ETag: [W/"9a6bd71d4d28485de0be79b73fdf9478"]
+      Last-Modified: ['Tue, 23 Apr 2019 16:50:18 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: [repo]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['1A88:14D0:64AC6D:DA728E:5CBF424E']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4993']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token fake1]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['83']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:23 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['1FF8:4247:7FFB2C:101220C:5CBF424F']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['54']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token fake2]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body: {string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Content-Length: ['83']
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:23 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [401 Unauthorized]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['BCAC:52E1:63A2F5:DEE5BB:5CBF424F']
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['53']
+      X-RateLimit-Reset: ['1556041799']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51UTY/aMBD9Lz4D+SBlm0jVHraXHtrVSrSqeokcxwS3jm3ZDpSN+O99TsLSsitV
+        ChfweObN85t59ETqRihSkJp6Kmm99Nx5bsmCiJoUaZpn6/x9siBK17wMIfL549Pm2/cvkv38dHrc
+        Pj0/bpvfSKcHANiysxI5e++NK6JoDLpk1Qi/76rOccu08lz5FdNt1EWXBveHDxlAGjvBDJ0QuIEz
+        YkIaywHnolfE976VNzzG9kPRq/SdllIfgXTL/f/NopdaUB1/C9XMxkFtH2m/55ARTzsHQYTzc4gN
+        dX0UvjC1gOQwHcvrGeSmSlA7KrDqI8uNHiC7yjErjBdazSH5Tz3wtG2oEs90Lh7qHWACvTl0hjrU
+        8wP2cw7AWNhHxooDZacgkeWMiwNknw16gwBMfzIc7viKFQlDEJ6XtG6DiXdUOg6v0hYJqpNyQbDy
+        hqrT5VjB7pM/Yc/JCysIBySp2SA97h9OFQxhKONBj5YKmHrE2wvLaSVf8CuhL1emq6Rg5ShjkcQL
+        MkWGZSQFAle/XE/Y+uGOAdhDKepBII2TzTKJl0m+TfJiHRfr9Q9Q6Qwo/5WTL+P1Ms62cVakSLsL
+        OYP60OTa1Wv8tZWX+MQPHcM+12/Ea+F+wYG0wSuTNGgoJa20pV7b8R3+qMsdZTiXtINhlRcX7bzt
+        MAIjKXTsp1GQneVByVHRIr/bvNukWZ6/BX1DM4nxOZ//AM0PTWioBQAA
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:23 GMT']
+      ETag: [W/"090ee3357e52cf73b31161d67a27b965"]
+      Last-Modified: ['Mon, 04 Mar 2019 04:29:37 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: ['']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['1EEF:0789:800628:105ADF4:5CBF424F']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4992']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/orgs/datalad-tester-org
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTyW7bMBT8F52jSFYdtzYQtIekRQ+FUSCHIhfiSXqSGVOkysWGa+TfO1qSKHGA
+        Au5NpDhDzvKOkTK11NEqKsmTojL27Dzb2Ng6uohkGa3my+Vs8SlLLyJtShbdVvTj5vaw3i4P99nX
+        QL/aTflN7fKHn1fru9tsffN9D2iwCgc33rdulSTUysta+k3ILwvTJGB3ybs3Wm6NE+eAkx6Km3nH
+        2p/JMWBBsjFmeyZHD+3Mcy7wmRwDFiQNNznbM1lG8DEZPh7B14ZcyUL8F+1rjik77dAi+za+ftOl
+        YwGCY1sY7RFS34WQPDXs8+56jieW7AorWy8NeqmDUp2VYsdWVpLRvoqUYyRETqBHpOUf6s6K1poH
+        LryLVt6G8UDfCemNPZz8HlUMrVnNnq2ppes40PfKKGX2cH+ykrruVxvfqDc6J/1+t9qFZfJcCvIY
+        jCydLeN0Hmcf7maLVZphzO67qWkB/ccZf2gZDOuJdiC9wfxCpITbLEZVeKjZa/Cd7j/tvMgtpduK
+        4KgGO4AF1FNuLMG9wYFcKgX9ghuS3XDDWI4H1fFrxV+MZhuck6S7jPtQKwrKDw8bA2HboOd9zBG8
+        KSd1L0iLwa8XhOTnaP3eiIoKvAy/fwdpuUGdBGvK1aQirSJwHyNNTedYZZlxh2upwHL5cXG1yNA9
+        JH/iWgWpsM0hMVw6B2j4Sh8f/wKjzBz6MwUAAA==
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:23 GMT']
+      ETag: [W/"7e5228ad7342e648fc760e47f588e90c"]
+      Last-Modified: ['Tue, 23 Apr 2019 16:02:49 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: ['admin:org, read:org, repo, user, write:org']
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['C0CC:108E:5BEB4B:CCFFF9:5CBF424F']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4991']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [token sometoken]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/datalad-tester-org/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXTULbTYLEQNE9pFt0gdbYRQ9FLwYl0RYTSdSSlF1HyLvvP6Rk
+        yY4bxy6PuSQyJX7DGc4Mh1MPZDKYjG7eDa9uRtfjs0GhEjGjscGXu4+rafZ3Fn+6feTf/13GxcPP
+        6d2X1ddvi59f7z+/H+Bjngt8aYWxM1lYsdDcSlWM8GpeZdmseZ9wyzOenNN3Qp8rvWD7ppRaLrkF
+        cM4zI84GalUIPZjUg0wtZAE5zzkQRGu9vL0dXd+MhzvLX08fbtc/xn9V/HuZJp+yZXT/z9X028fx
+        9O7zClM5xHE9q3QGeGptaSaM+UEzvFhIm1ZRZYSOFXQr7EWsclaxVtiH5ftLQKCzxzijYWAHV8qG
+        5KcDZ9heRVKbZztr8UtwE/dOmassUysQd3V4nVC2mU8b5liyWPwWC/NrpmwqYFao+kQGksaeukA3
+        t2b0D05JNIMd0yI5cZHNbCyRfOupZlqUymGryMRaluS+py52iwEm/JwX8tGFxKlMMAxQtMxTEW4u
+        GGIJHz4V4ifXzMVovCaTaRELucRW/BZ4hwKuXZeUVKY969EGSStmPMkpEbj88HSGkD0uYvZmnURs
+        Nn4wKZC1KBT0wyYLvRjOzrZ7YnOvJMIesP/reYhd0GCYB7EOByVYzfC3ibYYSYFHCmldHUoyRyx9
+        i1qz/k9yLCt4Hk4lRwM1VSqg9R0NVGlMJV4VAUfYx0ENa2OuqPLIp9LXRNoRcjwOWnBj5KIQIpzV
+        N8SatedApHkRpwFltMCa+SfnO3wRTgmCgRllKgoHxZnOHLFmJuX+gLSzoOsmEQTckqDFPKwSBNxI
+        sDqk9zgFiLjh4+C2cKRwGrRAVje7kPFiUfFFQBEbIh1fKFsW/PFgqXZE9HZI8KlE1TKqAufpDko6
+        +BoJuSjgNnTMToKrwl6u8I6xU6+0c5bKc3moDjoC3/C2Yi20DIqHXTn0+3BBd6QiBKxZd+D4460R
+        FWxHmvOt1aAvsLlqhXOwFsjqP0puU8q3kFtyLYKp0/BYHXGUpRcXF3UquLus5EKHTCgeBy7XcYrS
+        O5gGdQtEUZlz6+5Fc1IgwT0pUzwJtx8bIujeD4Jp4XF9bypRzodbuqP18bnM0NFQRcAzo0P2BRXK
+        yrmMX3OTPCLgt6j1ByOLWJxxXIAQHVbGEvGC6zy5Ae4AIqAhPQ4Kon3kb5KZQOiE2yktPLBmvmmQ
+        iDJT67DpsseknKIFWlfJjFtcXcfD0e358PJ8/O7b6HpyNUR/7Qe+qUo0cQ58U1Ym/fUnt4TBYdCE
+        DJ7QsHqxSfT8IkrdKFCMSTvKnx1j8rzR9EtGnMH3d8L3xNUsd8/7IznQKFW5KFHAtbd4Ix/xjJ5g
+        r/aKVVVghzC44haXEVQy3VBbr7WAlJuZzymbZgANlVrdi9iawcTqCm1KGuuyWtu8pNGVfJDbU6m+
+        3Iz4fkAnP5daq6Yd6RsRTVpGY7FpiSbS8CgT3YAqRdEssq+JjEVhNpbwrQLSuvf5lhXcj0TMeZXZ
+        mb9NwY9zTv1amLYUOoclqI9F/dimDePVJ49tTUEZ0j+jO4NMolYz81/F4Wru6Go/82/cEBZN5dj2
+        Gy3oJN2e02+mvfWEo7ee8FtP+K0nvKcnXAi7Qme0lwz719Y22T79D6vbxcj4GgAA
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      Cache-Control: ['private, max-age=60, s-maxage=60']
+      Content-Encoding: [gzip]
+      Content-Security-Policy: [default-src 'none']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 23 Apr 2019 16:50:24 GMT']
+      ETag: [W/"9a6bd71d4d28485de0be79b73fdf9478"]
+      Last-Modified: ['Tue, 23 Apr 2019 16:50:18 GMT']
+      Referrer-Policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      Server: [GitHub.com]
+      Status: [200 OK]
+      Strict-Transport-Security: [max-age=31536000; includeSubdomains; preload]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      X-Accepted-OAuth-Scopes: [repo]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-GitHub-Media-Type: [github.v3; format=json]
+      X-GitHub-Request-Id: ['C0CC:108E:5BEB5D:CD0016:5CBF424F']
+      X-OAuth-Scopes: ['user, repo']
+      X-RateLimit-Limit: ['5000']
+      X-RateLimit-Remaining: ['4990']
+      X-RateLimit-Reset: ['1556041816']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/datalad/distribution/tests/vcr_cassettes/github_yarikoptic.yaml
+++ b/datalad/distribution/tests/vcr_cassettes/github_yarikoptic.yaml
@@ -1,0 +1,367 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA52TX2/aMBTFvwrLMxASoAqRpnUqk/YwNiZ11dYXdOOYxKtjR7YTxFC/e48TVhUm
+        TYInHPue3z3cP4dA6kKoIA32ZMSTrp1gwTAQeZBOF0myGAZK53zjv4PV8vvNw8+vkv1ezb8tizni
+        qCVHZtMYiffSudqmYdhf2um4EK5sssZyw7RyXLkx01XYhB35Q/t+BkJhjowuBS7OWLU4YnotWDY8
+        sVq6Sp4Z6PN2gpPQrZZS70A4N/z/JOGrDvb6s1DFVQzoDqF2JUfN8FeefQGEdZca6jSH0P+gNZ5i
+        0QbD8wtNHVWwtFNwcwgNr3WHazLLjMA0aHWpuRMtWNoUpMQfuoYFrQXC27rURqeBlrcYvEvFvegQ
+        1ka0xPa+JIYzLlqU+CrgmRo8t685Jv4HxsAXXDi+obzyq7glaTkWjyof8IuMtpLawWeSrOTqSSMc
+        o12T2uN5ScZVunHl4A7TzQs+HNwueSZI+QO28wvlOK33q4f1Rxy2JGSckQIkw+qDsNvtxhrtb6yF
+        ym8N3qRmXcPwvpakuBt8QqLS17MCAdd5l+T2H2UpDKdMwrpqpEQWoRF9V3Ls3Tvo6yaTgm369qTx
+        Yv561U11kMbJ3y2DAp9R/GbrghSvDBkcOkEO5HgySUZRPIqi+yhJ51E6TR6RpqnztzHRYjSZjSbJ
+        fTRL45s0mjwGzy/u9Bc1/AQAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:20 GMT']
+      etag: [W/"124a82f895a9c516ff34c113ec540eae"]
+      last-modified: ['Mon, 08 Apr 2019 14:26:10 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['AA5E:50A4:19BE69:37C74B:5CBE3E9C']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4969']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/yarikoptic/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:20 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [404 Not Found]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      x-accepted-oauth-scopes: [repo]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['AA5E:50A4:19BE6D:37C755:5CBE3E9C']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4968']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 404, message: Not Found}
+- request:
+    body: !!python/unicode '{"has_issues": false, "auto_init": false, "has_wiki":
+      false, "name": "test_integration1", "has_downloads": false}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      Content-Length: ['113']
+      Content-Type: [application/json]
+      User-Agent: [PyGithub/Python]
+    method: POST
+    uri: https://api.github.com/user/repos
+  response:
+    body: {string: !!python/unicode '{"id":182876873,"node_id":"MDEwOlJlcG9zaXRvcnkxODI4NzY4NzM=","name":"test_integration1","full_name":"yarikoptic/test_integration1","private":false,"owner":{"login":"yarikoptic","id":39889,"node_id":"MDQ6VXNlcjM5ODg5","avatar_url":"https://avatars3.githubusercontent.com/u/39889?v=4","gravatar_id":"","url":"https://api.github.com/users/yarikoptic","html_url":"https://github.com/yarikoptic","followers_url":"https://api.github.com/users/yarikoptic/followers","following_url":"https://api.github.com/users/yarikoptic/following{/other_user}","gists_url":"https://api.github.com/users/yarikoptic/gists{/gist_id}","starred_url":"https://api.github.com/users/yarikoptic/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/yarikoptic/subscriptions","organizations_url":"https://api.github.com/users/yarikoptic/orgs","repos_url":"https://api.github.com/users/yarikoptic/repos","events_url":"https://api.github.com/users/yarikoptic/events{/privacy}","received_events_url":"https://api.github.com/users/yarikoptic/received_events","type":"User","site_admin":false},"html_url":"https://github.com/yarikoptic/test_integration1","description":null,"fork":false,"url":"https://api.github.com/repos/yarikoptic/test_integration1","forks_url":"https://api.github.com/repos/yarikoptic/test_integration1/forks","keys_url":"https://api.github.com/repos/yarikoptic/test_integration1/keys{/key_id}","collaborators_url":"https://api.github.com/repos/yarikoptic/test_integration1/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/yarikoptic/test_integration1/teams","hooks_url":"https://api.github.com/repos/yarikoptic/test_integration1/hooks","issue_events_url":"https://api.github.com/repos/yarikoptic/test_integration1/issues/events{/number}","events_url":"https://api.github.com/repos/yarikoptic/test_integration1/events","assignees_url":"https://api.github.com/repos/yarikoptic/test_integration1/assignees{/user}","branches_url":"https://api.github.com/repos/yarikoptic/test_integration1/branches{/branch}","tags_url":"https://api.github.com/repos/yarikoptic/test_integration1/tags","blobs_url":"https://api.github.com/repos/yarikoptic/test_integration1/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/yarikoptic/test_integration1/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/yarikoptic/test_integration1/git/refs{/sha}","trees_url":"https://api.github.com/repos/yarikoptic/test_integration1/git/trees{/sha}","statuses_url":"https://api.github.com/repos/yarikoptic/test_integration1/statuses/{sha}","languages_url":"https://api.github.com/repos/yarikoptic/test_integration1/languages","stargazers_url":"https://api.github.com/repos/yarikoptic/test_integration1/stargazers","contributors_url":"https://api.github.com/repos/yarikoptic/test_integration1/contributors","subscribers_url":"https://api.github.com/repos/yarikoptic/test_integration1/subscribers","subscription_url":"https://api.github.com/repos/yarikoptic/test_integration1/subscription","commits_url":"https://api.github.com/repos/yarikoptic/test_integration1/commits{/sha}","git_commits_url":"https://api.github.com/repos/yarikoptic/test_integration1/git/commits{/sha}","comments_url":"https://api.github.com/repos/yarikoptic/test_integration1/comments{/number}","issue_comment_url":"https://api.github.com/repos/yarikoptic/test_integration1/issues/comments{/number}","contents_url":"https://api.github.com/repos/yarikoptic/test_integration1/contents/{+path}","compare_url":"https://api.github.com/repos/yarikoptic/test_integration1/compare/{base}...{head}","merges_url":"https://api.github.com/repos/yarikoptic/test_integration1/merges","archive_url":"https://api.github.com/repos/yarikoptic/test_integration1/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/yarikoptic/test_integration1/downloads","issues_url":"https://api.github.com/repos/yarikoptic/test_integration1/issues{/number}","pulls_url":"https://api.github.com/repos/yarikoptic/test_integration1/pulls{/number}","milestones_url":"https://api.github.com/repos/yarikoptic/test_integration1/milestones{/number}","notifications_url":"https://api.github.com/repos/yarikoptic/test_integration1/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/yarikoptic/test_integration1/labels{/name}","releases_url":"https://api.github.com/repos/yarikoptic/test_integration1/releases{/id}","deployments_url":"https://api.github.com/repos/yarikoptic/test_integration1/deployments","created_at":"2019-04-22T22:22:20Z","updated_at":"2019-04-22T22:22:20Z","pushed_at":"2019-04-22T22:22:21Z","git_url":"git://github.com/yarikoptic/test_integration1.git","ssh_url":"git@github.com:yarikoptic/test_integration1.git","clone_url":"https://github.com/yarikoptic/test_integration1.git","svn_url":"https://github.com/yarikoptic/test_integration1","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_projects":true,"has_downloads":false,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"network_count":0,"subscribers_count":1}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['5370']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:21 GMT']
+      etag: ['"b9488ea91df827cbd915d22f146216b6"']
+      location: ['https://api.github.com/repos/yarikoptic/test_integration1']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['public_repo, repo']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['AA5E:50A4:19BE72:37C760:5CBE3E9C']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4967']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA52TXW/aMBSG/wrLNRASPhQiTetUJu1ibJ3UVVtv0IljEq+OHdlOEEP9732dsKow
+        aRJc4djnfc7L+TgEUhdCBWmwJyOedO0EC4aByIN0ukyS5TBQOucb/x2sV98XDz+/SvZ7Pf+2KuaI
+        o5YcmU1jJN5L52qbhmF/aafjQriyyRrLDdPKceXGTFdhE3bkD+37GQiFOTK6FLg4Y9XiiOm1YNnw
+        xGrpKnlmoM/bCU5Ct1pKvQPh3PD/k4SvOtjrz0IVVzGgO4TalRw1w1959gUQ1l1qqNMcQv+D1niK
+        RRsMzy80dVTB0k7BzSE0vNYdrsksMwLToNWl5k60YGlTkBJ/6BoWtBYIb+tSG50GWt5i8C4V96JD
+        WBvREtv7khjOuGhR4quAZ2rw3L7mmPgfGANfcOH4hvLKr+KWpOVYPKp8wC8y2kpqB59JspKrJ41w
+        jHZNao/nFRlX6caVg1tMNy/4cHCz4pkg5Q/Yzi+U43S3Xz/cfcRhS0LGGSlAMqw+CLvdbqzR/sZa
+        qPzW4E1q1jUM73eSFHeDT0hU+npWIOA675Lc/KMsheGUSVhXjZTIIjSib0uOvXsHfd1kUrBN3540
+        Xi5er7qpDtI4+btlUOAzit9sXZDilSGDQyfIgRxPJskoikdRdB8l6TxKp8kj0jR1/jYmWo4ms9Ek
+        uY9mabxIo8lj8PwCLTqSUfwEAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:22 GMT']
+      etag: [W/"a8fa37524fee015da76c68778eb7f335"]
+      last-modified: ['Mon, 08 Apr 2019 14:26:10 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['C116:0A12:FEB71:279699:5CBE3E9E']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4966']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/yarikoptic/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62YbW/bNhDHv4vfLg0TJ20TA0X3IsOwAWmxYRu6vTFoiZbYSKRGUvYSId99/yP1
+        6GWxXAnIg03xfjye7si7qxYyXqwub5Y379/dvL86WygdizWNLe7vfth/zn7Ooh9vn/iXX3eRevjn
+        891P15+e/sTv/YcFJvNcYKYT1q2lciIx3EmtLvFoW2bZun7+yI180IWTEXtpamHkjjuAtjyz4myh
+        90qYxapaZDqRCvxOHmDS7er25uZ2qOsv7/748imLvt6//XyXvMU8DiY369JkIKTOFXbFWBi0V+eJ
+        dGm5Ka0wkYbiyp1HOmcl8+SPuw/XIGA3geHNgYEDViFrTJAFy7KBqqnLswMFwrpeYDB1q7NM70E4
+        VPj1RVgrRyb3DKmSb2JArmLapQI2w1aeyQDSulMV8jIVo39wI6JYvAYj4hOVqqWgEnnDc8WMKLTH
+        lRsbGQlv0upU5QayYGmTcCWfvNOeyoKsBYLUOlXUy0BW7OB4pwoHoYr5qIkeySRGRELuYOJvAh5I
+        g+ceCwrr3+EGZHDpxJrHOYWij9DnM8TTOM9+Md5j0b7AxUrhnCDXNQ9t/L8aZt52vdh5cQXCHbHr
+        cQ5iCxQY4EE8TocRpGL4W0dFhGDlG40DUx8L+hGqDmgV638lB3GC59O34CmgpVrPYF1PAU1aW4pR
+        njvCDh5mWRMjqsw34SgbExkj+AEDrbm1MlFCTLdqS6pYc+5uDFdROgO7AVUsfPK+wJPpShMErE2m
+        N9NhuBOZJ1XMpjxcPG49i56EJtCAbMR2HqUJ1JKdmcMbvMJEarm4CB0cY7rGDYhVtZUzrpKSJzOg
+        WxJdF7juE/50NJUZEW0dClzK04zclDOdlx2MdA45Bc6KGczcsTqyz1Zez4DG2KOX+niL5Lk8lj+M
+        wNacQYzMxSZ/PuTT9+OJz0jFCVSx7qAP10m9xGSL1/dJo3F/obpumO4wDYhV3xXcpXT+Yb2CGzFZ
+        /ZrDqg1H2nZ+fl6lgvukPBdmjsAPGPC4iVKkoJM1rhoQkq+cO5/3b0nhGHVApnk83d4tCdTwfidr
+        HTB97yiQ1k5X1VP62FxmqLW1muHM7lD9BZR2ciujMRXRiAAd0KqPVqpInHEk/PBudAMk/B1lJ71e
+        5MJiBoMFDDaExkSojDIB15/+JowIoIqFojYWRaYf5znGeiyKfSPQDInX3KEEW15c3r65uH6zXP62
+        XK7o5+IvzCmL+OicorTp/2MuCYPDuXZ9fEJ35MXmxH8LLOp6QNratJP+vpNdvdbuqWWjDD58EHYn
+        rr47vE9HykPzVOeiQOLTVJ9WPuHzxSB3iXSp8AYwuOcOyTgyg26oyXcaQMrtOpwBbRFLQ4XRX0Xk
+        7GLlTInGFo11p0/T7qLRvXyQQ1HKy9qRUM926+fSGF33tkIBXR+baFTVTbRYWr7JRDegC6FqJfs7
+        kZFQtrVEKHlp173pAyv4L7HY8jJz61BVwE9zbp1vFhTC5LAE9VOog1e3DcL2ySMbU9DJFj6jm4AT
+        Qe/X9u+Sw6X8ldJMC0/8EJSmdGf4xAi62YYySrg9KvfeJvvpXW3Ey+d/AcPXEmL6FAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:22 GMT']
+      etag: [W/"b9488ea91df827cbd915d22f146216b6"]
+      last-modified: ['Mon, 22 Apr 2019 22:22:20 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: [repo]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['C116:0A12:FEB75:2796A4:5CBE3E9E']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4965']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA52TXW/aMBSG/wrLNRASPhQiTetUJu1ibJ3UVVtv0IljEq+OHdlOEEP9732dsKow
+        aRJc4djnfc7L+TgEUhdCBWmwJyOedO0EC4aByIN0ukyS5TBQOucb/x2sV98XDz+/SvZ7Pf+2KuaI
+        o5YcmU1jJN5L52qbhmF/aafjQriyyRrLDdPKceXGTFdhE3bkD+37GQiFOTK6FLg4Y9XiiOm1YNnw
+        xGrpKnlmoM/bCU5Ct1pKvQPh3PD/k4SvOtjrz0IVVzGgO4TalRw1w1959gUQ1l1qqNMcQv+D1niK
+        RRsMzy80dVTB0k7BzSE0vNYdrsksMwLToNWl5k60YGlTkBJ/6BoWtBYIb+tSG50GWt5i8C4V96JD
+        WBvREtv7khjOuGhR4quAZ2rw3L7mmPgfGANfcOH4hvLKr+KWpOVYPKp8wC8y2kpqB59JspKrJ41w
+        jHZNao/nFRlX6caVg1tMNy/4cHCz4pkg5Q/Yzi+U43S3Xz/cfcRhS0LGGSlAMqw+CLvdbqzR/sZa
+        qPzW4E1q1jUM73eSFHeDT0hU+npWIOA675Lc/KMsheGUSVhXjZTIIjSib0uOvXsHfd1kUrBN3540
+        Xi5er7qpDtI4+btlUOAzit9sXZDilSGDQyfIgRxPJskoikdRdB8l6TxKp8kj0jR1/jYmWo4ms9Ek
+        uY9mabxIo8lj8PwCLTqSUfwEAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:22 GMT']
+      etag: [W/"a8fa37524fee015da76c68778eb7f335"]
+      last-modified: ['Mon, 08 Apr 2019 14:26:10 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: ['']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['AA62:108E:17B94B:34ADC9:5CBE3E9E']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4964']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode token TOKEN]
+      Connection: [keep-alive]
+      User-Agent: [PyGithub/Python]
+    method: GET
+    uri: https://api.github.com/repos/yarikoptic/test_integration1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62YbW/bNhDHv4vfLg0TJ20TA0X3IsOwAWmxYRu6vTFoiZbYSKRGUvYSId99/yP1
+        6GWxXAnIg03xfjye7si7qxYyXqwub5Y379/dvL86WygdizWNLe7vfth/zn7Ooh9vn/iXX3eRevjn
+        891P15+e/sTv/YcFJvNcYKYT1q2lciIx3EmtLvFoW2bZun7+yI180IWTEXtpamHkjjuAtjyz4myh
+        90qYxapaZDqRCvxOHmDS7er25uZ2qOsv7/748imLvt6//XyXvMU8DiY369JkIKTOFXbFWBi0V+eJ
+        dGm5Ka0wkYbiyp1HOmcl8+SPuw/XIGA3geHNgYEDViFrTJAFy7KBqqnLswMFwrpeYDB1q7NM70E4
+        VPj1RVgrRyb3DKmSb2JArmLapQI2w1aeyQDSulMV8jIVo39wI6JYvAYj4hOVqqWgEnnDc8WMKLTH
+        lRsbGQlv0upU5QayYGmTcCWfvNOeyoKsBYLUOlXUy0BW7OB4pwoHoYr5qIkeySRGRELuYOJvAh5I
+        g+ceCwrr3+EGZHDpxJrHOYWij9DnM8TTOM9+Md5j0b7AxUrhnCDXNQ9t/L8aZt52vdh5cQXCHbHr
+        cQ5iCxQY4EE8TocRpGL4W0dFhGDlG40DUx8L+hGqDmgV638lB3GC59O34CmgpVrPYF1PAU1aW4pR
+        njvCDh5mWRMjqsw34SgbExkj+AEDrbm1MlFCTLdqS6pYc+5uDFdROgO7AVUsfPK+wJPpShMErE2m
+        N9NhuBOZJ1XMpjxcPG49i56EJtCAbMR2HqUJ1JKdmcMbvMJEarm4CB0cY7rGDYhVtZUzrpKSJzOg
+        WxJdF7juE/50NJUZEW0dClzK04zclDOdlx2MdA45Bc6KGczcsTqyz1Zez4DG2KOX+niL5Lk8lj+M
+        wNacQYzMxSZ/PuTT9+OJz0jFCVSx7qAP10m9xGSL1/dJo3F/obpumO4wDYhV3xXcpXT+Yb2CGzFZ
+        /ZrDqg1H2nZ+fl6lgvukPBdmjsAPGPC4iVKkoJM1rhoQkq+cO5/3b0nhGHVApnk83d4tCdTwfidr
+        HTB97yiQ1k5X1VP62FxmqLW1muHM7lD9BZR2ciujMRXRiAAd0KqPVqpInHEk/PBudAMk/B1lJ71e
+        5MJiBoMFDDaExkSojDIB15/+JowIoIqFojYWRaYf5znGeiyKfSPQDInX3KEEW15c3r65uH6zXP62
+        XK7o5+IvzCmL+OicorTp/2MuCYPDuXZ9fEJ35MXmxH8LLOp6QNratJP+vpNdvdbuqWWjDD58EHYn
+        rr47vE9HykPzVOeiQOLTVJ9WPuHzxSB3iXSp8AYwuOcOyTgyg26oyXcaQMrtOpwBbRFLQ4XRX0Xk
+        7GLlTInGFo11p0/T7qLRvXyQQ1HKy9qRUM926+fSGF33tkIBXR+baFTVTbRYWr7JRDegC6FqJfs7
+        kZFQtrVEKHlp173pAyv4L7HY8jJz61BVwE9zbp1vFhTC5LAE9VOog1e3DcL2ySMbU9DJFj6jm4AT
+        Qe/X9u+Sw6X8ldJMC0/8EJSmdGf4xAi62YYySrg9KvfeJvvpXW3Ey+d/AcPXEmL6FAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Location, Retry-After, X-GitHub-OTP,
+          X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes,
+          X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 22 Apr 2019 22:22:22 GMT']
+      etag: [W/"b9488ea91df827cbd915d22f146216b6"]
+      last-modified: ['Mon, 22 Apr 2019 22:22:20 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-accepted-oauth-scopes: [repo]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; format=json]
+      x-github-request-id: ['AA62:108E:17B950:34ADD4:5CBE3E9E']
+      x-oauth-scopes: [repo]
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4963']
+      x-ratelimit-reset: ['1555973199']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -123,6 +123,16 @@ class Credential(object):
           Any given key value pairs with non-None values are used to set the
           field `key` to the given value, without asking for user input
         """
+        if kwargs:
+            unknown_fields = set(kwargs).difference(self._FIELDS)
+            known_fields = set(self._FIELDS).difference(kwargs)
+            if unknown_fields:
+                raise ValueError(
+                    "Unknown to %s field(s): %s.  Known but not specified: %s"
+                    % (self,
+                       ', '.join(sorted(unknown_fields)),
+                       ', '.join(sorted(known_fields))
+                       ))
         # Use ui., request credential fields corresponding to the type
         for f in self._FIELDS:
             if kwargs.get(f, None):

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -106,6 +106,12 @@ definitions = {
         'type': EnsureInt(),
         'default': 1112911993,
     },
+    'datalad.github.token-note': {
+        'ui': ('question', {
+            'title': 'Github token note',
+            'text': 'Description for a Personal access token to generate.'}),
+        'default': 'DataLad',
+    },
     'datalad.tests.nonetwork': {
         'ui': ('yesno', {
                'title': 'Skips network tests completely if this flag is set Examples include test for s3, git_repositories, openfmri etc'}),

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -1,0 +1,390 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Helpers for interaction with GitHub
+"""
+from .. import cfg
+from ..consts import CONFIG_HUB_TOKEN_FIELD
+from ..dochelpers import exc_str
+from ..downloaders.credentials import UserPassword
+from ..ui import ui
+from ..utils import unique, assure_list, assure_tuple_or_list
+
+from .exceptions import (
+    AccessDeniedError,
+    MissingExternalDependency,
+)
+from .network import URL
+
+import logging
+lgr = logging.getLogger('datalad.support.github_')
+
+try:
+    import github as gh
+except ImportError:
+    raise MissingExternalDependency(
+        'PyGitHub',
+        msg='GitHub-related functionality is unavailable without this package')
+
+
+def get_repo_url(repo, access_protocol, github_login):
+    """Report the repository access URL for Git matching the protocol"""
+    prop = {
+        'https': repo.clone_url,
+        'ssh': repo.ssh_url
+    }[access_protocol]
+    if access_protocol == 'https' and github_login:
+        # we were provided explicit github login.  For ssh access it is
+        # impossible to specify different login within ssh RI, but it is
+        # possible to do so for https logins
+        url = URL(prop)
+        assert url.scheme in ('http', 'https')
+        url.username = github_login
+        prop = url.as_str()
+    return prop
+
+
+def _token_str(token):
+    """Shorten token so we do not leak sensitive info into the logs"""
+    return token[:3] + '...' + token[-3:]
+
+
+def _get_tokens_for_login(login, tokens):
+    selected_tokens = []
+    for t in tokens:
+        try:
+            g = gh.Github(t)
+            gu = g.get_user()
+            if gu.login == login:
+                selected_tokens.append(t)
+        except gh.BadCredentialsException as exc:
+            lgr.debug(
+                "Token %s caused %s while trying to check token's use"
+                " login name. Skipping", _token_str(t), exc_str(exc))
+    lgr.debug(
+        "Selected %d tokens out of %d for the login %s",
+        len(selected_tokens), len(tokens), login
+    )
+    return selected_tokens
+
+
+def _gen_github_ses(github_login, github_passwd):
+    """Generate viable Github sessions
+
+    The idea is that we keep trying "new" ways to authenticate until we either
+    exhaust or external loop stops asking for more
+
+    Parameters
+    ----------
+    github_login:
+    github_passwd:
+
+    Yields
+    -------
+    Github, credential
+      credential might be None if there is no credential associated as when
+      we consider tokens from the config (instead of credentials store)
+
+    """
+    if github_login == 'disabledloginfortesting':
+        raise gh.BadCredentialsException(403, 'no login specified')
+
+    # see if we have tokens - might be many. Doesn't cost us much so get at once
+    all_tokens = tokens = unique(
+        assure_list(cfg.get(CONFIG_HUB_TOKEN_FIELD, None)),
+        reverse=True
+    )
+
+    if not (github_login and github_passwd):
+        # we don't have both
+        # Check the tokens.  If login is provided, only the token(s) for the
+        # login are considered. We consider oauth tokens as stored/used by
+        # https://github.com/sociomantic/git-hub
+
+        if github_login and tokens:
+            # Take only the tokens which are Ok and correspond to that login
+            tokens = _get_tokens_for_login(github_login, tokens)
+
+        for token in tokens:
+            try:
+                yield(gh.Github(token), None)
+            except gh.BadCredentialsException as exc:
+                lgr.debug("Failed to obtain Github session for token %s",
+                          _token_str(token))
+
+    # We got here so time to try credentials
+
+    # make it per user if github_login was provided. People might want to use
+    # different credentials etc
+    cred_identity = "%s@github" % github_login if github_login else "github"
+
+    # if login and passwd were provided - try that one first
+    try_creds = github_login and github_passwd
+
+    while True:
+        if try_creds:
+            # So we do not store them into cred store and thus do not need to
+            # remove
+            cred = None
+            ses = gh.Github(github_login, password=github_passwd)
+            user_name = github_login
+            try_creds = None
+        else:
+            cred = UserPassword(cred_identity, 'https://github.com/login')
+            if not cred.is_known:
+                cred.enter_new()
+            creds = cred()
+            user_name = creds['user']
+            ses = gh.Github(user_name, password=creds['password'])
+        # Get user and list its authorizations to verify that we do
+        # not need 2FA
+        user = ses.get_user()
+        try:
+            user_name_ = user.name  # should trigger need for 2FA
+            # authorizations = list(user.get_authorizations())
+            yield ses, cred
+        except gh.BadCredentialsException as exc:
+            lgr.error("Bad Github credentials")
+        except (gh.TwoFactorException, gh.GithubException) as exc:
+            # With github 1.43.5, in comparison to 1.40 we get a "regular"
+            # GithubException for some reason, yet to check/report upstream
+            # so we will just check for the expected in such cases messages
+            if not (
+                isinstance(exc, gh.GithubException) and
+                getattr(exc, 'data', {}).get('message', '').startswith(
+                    'Must specify two-factor authentication OTP code')
+            ):
+                raise
+
+            # 2FA - we need to interact!
+            if not ui.is_interactive:
+                # Or should we just allow to pass
+                raise RuntimeError(
+                    "Cannot proceed with 2FA for Github - UI is not interactive. "
+                    "Please 'manually' establish token based authentication "
+                    "with Github and specify it in  %s  config"
+                    % CONFIG_HUB_TOKEN_FIELD
+                )
+            if not ui.yesno(
+                title="GitHub credentials - %s uses 2FA" % user_name,
+                text="Generate a GitHub token to proceed? "
+                     "If you already have a token for the account, "
+                     "just say 'no' now and specify it in config (%s), "
+                     "otherwise say 'yes' "
+                    % (CONFIG_HUB_TOKEN_FIELD,)
+                ):
+                return
+
+            token = _get_2fa_token(user)
+            yield gh.Github(token), None  # None for cred so does not get killed
+
+        # if we are getting here, it means we are asked for more and thus
+        # aforementioned one didn't work out :-/
+        if ui.is_interactive:
+            if cred is not None:
+                if ui.yesno(
+                    title="GitHub credentials",
+                    text="Do you want to try (re)entering GitHub credentials?"
+                ):
+                    cred.enter_new()
+                else:
+                    break
+        else:
+            # Nothing we could do
+            lgr.debug(
+                "UI is not interactive - we cannot query for more credentials"
+            )
+            break
+
+
+def _get_2fa_token(user):
+    one_time_password = ui.question(
+        "2FA one time password", hidden=True, repeat=False
+    )
+    token_note = cfg.obtain('datalad.github.token-note')
+    try:
+        # TODO: can fail if already exists -- handle!?
+        # in principle there is .authorization.delete()
+        auth = user.create_authorization(
+            scopes=['user', 'repo'],  # TODO: Configurable??
+            note=token_note,  # TODO: Configurable??
+            onetime_password=one_time_password)
+    except gh.GithubException as exc:
+        if (exc.status == 422  # "Unprocessable Entity"
+                and exc.data.get('errors', [{}])[0].get('code') == 'already_exists'
+        ):
+            raise ValueError(
+                "Token %r already exists. If you specified "
+                "password -- don't, and specify token in configuration as %s. "
+                "If token already exists and you want to generate a new one "
+                "anyways - specify a new one via 'datalad.github.token-note' "
+                "configuration variable"
+                % (token_note, CONFIG_HUB_TOKEN_FIELD)
+            )
+        raise
+    token = auth.token
+    where_to_store = ui.question(
+        title="Where to store token %s?" % _token_str(token),
+        text="Empty string would result in the token not being "
+             "stored for future reuse, so you will have to adjust "
+             "configuration manually",
+        choices=["global", "local", ""]
+    )
+    if where_to_store:
+        try:
+            # Using .add so other (possibly still legit tokens) are not lost
+            if cfg.get(CONFIG_HUB_TOKEN_FIELD, None):
+                lgr.info("Found that there is some other known tokens already, "
+                         "adding one more")
+            cfg.add(CONFIG_HUB_TOKEN_FIELD, auth.token,
+                    where=where_to_store)
+            lgr.info("Stored %s=%s in %s config.",
+                     CONFIG_HUB_TOKEN_FIELD, _token_str(token),
+                     where_to_store)
+        except Exception as exc:
+            lgr.error("Failed to store token: %s",
+                      # sanitize away the token
+                      exc_str(exc).replace(token, _token_str(token)))
+            # assuming that it is ok to display the token to the user, since
+            # otherwise it would be just lost.  ui  shouldn't log it (at least
+            # ATM)
+            ui.error(
+                "Failed to store the token (%s), please store manually as %s"
+                % (token, CONFIG_HUB_TOKEN_FIELD)
+            )
+    return token
+
+
+def _gen_github_entity(
+    github_login, github_passwd,
+    github_organization
+):
+    for ses, cred in _gen_github_ses(github_login, github_passwd):
+        if github_organization:
+            try:
+                yield ses.get_organization(github_organization), cred
+            except gh.UnknownObjectException as e:
+                # yoh thinks it might be due to insufficient credentials?
+                raise ValueError('unknown organization "{}" [{}]'.format(
+                                 github_organization,
+                                 exc_str(e)))
+        else:
+            yield ses.get_user(), cred
+
+
+def _make_github_repos(
+        github_login, github_passwd, github_organization, rinfo, existing,
+        access_protocol, dryrun):
+    res = []
+    if not rinfo:
+        return res  # no need to even try!
+
+    ncredattempts = 0
+    # determine the entity under which to create the repos.  It might be that
+    # we would need to check a few credentials
+    for entity, cred in _gen_github_entity(
+            github_login,
+            github_passwd,
+            github_organization):
+        lgr.debug("Using entity %s with credential %s", entity, cred)
+        ncredattempts += 1
+        for ds, reponame in rinfo:
+            lgr.debug("Trying to create %s for %s", reponame, ds)
+            try:
+                res_ = _make_github_repo(
+                    github_login,
+                    entity,
+                    reponame,
+                    existing,
+                    access_protocol,
+                    dryrun)
+                # output will contain whatever is returned by _make_github_repo
+                # but with a dataset prepended to the record
+                res.append((ds,) + assure_tuple_or_list(res_))
+            except gh.BadCredentialsException as e:
+                if res:
+                    # so we have succeeded with at least one repo already -
+                    # we should not try any other credential.
+                    # TODO: may be it would make sense to have/use different
+                    # credentials for different datasets e.g. if somehow spread
+                    # across different organizations? but it is not the case here
+                    # IMHO (-- yoh)
+                    raise e
+                # things blew up, wipe out cred store, if anything is in it
+                if cred:
+                    lgr.warning("Authentication failed using %s.", cred.name)
+                else:
+                    lgr.warning("Authentication failed using a token.")
+                break  # go to the next attempt to authenticate
+        if res:
+            return res
+
+    # External loop should stop querying for the next possible way when it succeeds,
+    # so we should never get here if everything worked out
+    if ncredattempts:
+        raise AccessDeniedError(
+            "Tried %d times to get authenticated access to GitHub but kept failing"
+            % ncredattempts
+        )
+    else:
+        raise RuntimeError("Did not even try to create a repo on github")
+
+
+def _make_github_repo(github_login, entity, reponame, existing, access_protocol, dryrun):
+    repo = None
+    try:
+        repo = entity.get_repo(reponame)
+    except gh.GithubException as e:
+        if e.status != 404:
+            # this is not a not found message, raise
+            raise e
+        lgr.debug(
+            'To be created repository "%s" does not yet exist on Github',
+            reponame)
+
+    if repo is not None:
+        if existing in ('skip', 'reconfigure'):
+            access_url = get_repo_url(repo, access_protocol, github_login)
+            return access_url, existing == 'skip'
+        elif existing == 'error':
+            msg = 'repository "{}" already exists on Github'.format(reponame)
+            if dryrun:
+                lgr.error(msg)
+            else:
+                raise ValueError(msg)
+        else:
+            RuntimeError('to must not happen')
+
+    if repo is None and not dryrun:
+        try:
+            repo = entity.create_repo(
+                reponame,
+                # TODO description='',
+                # TODO homepage='',
+                # TODO private=False,
+                has_issues=False,
+                has_wiki=False,
+                has_downloads=False,
+                auto_init=False)
+        except gh.GithubException as e:
+            msg = "Github {}: {}".format(
+                e.data.get('message', str(e) or 'unknown'),
+                ', '.join([err.get('message')
+                           for err in e.data.get('errors', [])
+                           if 'message' in err]))
+            raise RuntimeError(msg)
+
+    if repo is None and not dryrun:
+        raise RuntimeError(
+            'something went wrong, we got no Github repository')
+
+    if dryrun:
+        return '{}:github/.../{}'.format(access_protocol, reponame), False
+    else:
+        # report URL for given access protocol
+        return get_repo_url(repo, access_protocol, github_login), False

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -125,6 +125,7 @@ def _gen_github_ses(github_login, github_passwd):
 
     # if login and passwd were provided - try that one first
     try_creds = github_login and github_passwd
+    try_login = bool(github_login)
 
     while True:
         if try_creds:
@@ -136,8 +137,12 @@ def _gen_github_ses(github_login, github_passwd):
             try_creds = None
         else:
             cred = UserPassword(cred_identity, 'https://github.com/login')
+            # if github_login was provided, we should first try it as is,
+            # and only ask for password
             if not cred.is_known:
-                cred.enter_new()
+                creds = {'user': github_login} if try_login else {}
+                cred.enter_new(**creds)
+            try_login = None
             creds = cred()
             user_name = creds['user']
             ses = gh.Github(user_name, password=creds['password'])

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -1,0 +1,112 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for github helpers"""
+
+import logging
+import mock
+
+import github as gh
+
+from ..exceptions import AccessDeniedError
+from ...tests.utils import assert_raises, assert_equal, eq_, assert_in
+
+from ...utils import swallow_logs
+
+from .. import github_
+from ..github_ import get_repo_url
+
+
+def test_get_repo_url():
+    from collections import namedtuple
+    FakeRepo = namedtuple('FakeRepo', ('clone_url', 'ssh_url'))
+    https_url1 = 'https://github.com/user1/repo'
+    ssh_ri1 = 'git@github.com/user1/repo1'
+    repo1 = FakeRepo(https_url1, ssh_ri1)
+
+    assert_equal(get_repo_url(repo1, 'ssh', None), ssh_ri1)
+    assert_equal(get_repo_url(repo1, 'ssh', 'user2'), ssh_ri1)  # no support for changing
+    assert_equal(get_repo_url(repo1, 'https', None), https_url1)
+    assert_equal(get_repo_url(repo1, 'https', 'user2'), 'https://user2@github.com/user1/repo')
+
+
+def test__make_github_repos():
+    github_login = 'test'
+    github_passwd = 'fake'
+    github_organization = 'fakeorg'
+    rinfo = [
+        # (ds, reponame) pairs
+        ("/fakeds1", "fakeds1"),
+        ("/fakeds2", "fakeds2"),
+    ]
+    existing = '???'
+    access_protocol = '???'
+    dryrun = False
+    args = (
+            github_login,
+            github_passwd,
+            github_organization,
+            rinfo,
+            existing,
+            access_protocol,
+            dryrun,
+    )
+
+    # with default mock, no attempts would be made and an exception will be raised
+    with mock.patch.object(github_, '_gen_github_entity'):
+        assert_raises(RuntimeError, github_._make_github_repos, *args)
+
+    def _gen_github_entity(*args):
+        return [("entity1", "cred1")]
+
+    with mock.patch.object(github_, '_gen_github_entity', _gen_github_entity), \
+            mock.patch.object(github_, '_make_github_repo'):
+        res = github_._make_github_repos(*args)
+    eq_(len(res), 2)
+    # first entries are our datasets
+    eq_(res[0][0], "/fakeds1")
+    eq_(res[1][0], "/fakeds2")
+    assert(all(len(x) > 1 for x in res))  # there is more than just a dataset
+
+    #
+    # Now test the logic whenever first credential fails and we need to get
+    # to the next one
+    #
+    class FakeCred:
+        def __init__(self, name):
+            self.name = name
+
+    # Let's test not blowing up whenever first credential is not good enough
+    def _gen_github_entity(*args):
+        return [
+            ("entity1", FakeCred("cred1")),
+            ("entity2", FakeCred("cred2")),
+            ("entity3", FakeCred("cred3"))
+        ]
+
+    def _make_github_repo(github_login, entity, reponame, *args):
+        if entity == 'entity1':
+            raise gh.BadCredentialsException("very bad status", "some data")
+        return reponame
+
+    with mock.patch.object(github_, '_gen_github_entity', _gen_github_entity), \
+            mock.patch.object(github_, '_make_github_repo', _make_github_repo), \
+            swallow_logs(new_level=logging.INFO) as cml:
+        res = github_._make_github_repos(*args)
+        assert_in('Authentication failed using cred1', cml.out)
+        eq_(res, [('/fakeds1', 'fakeds1'), ('/fakeds2', 'fakeds2')])
+
+    def _make_github_repo(github_login, entity, reponame, *args):
+        # Always throw an exception
+        raise gh.BadCredentialsException("very bad status", "some data")
+
+    with mock.patch.object(github_, '_gen_github_entity', _gen_github_entity), \
+            mock.patch.object(github_, '_make_github_repo', _make_github_repo):
+        with assert_raises(AccessDeniedError) as cme:
+            github_._make_github_repos(*args)
+        assert_in("Tried 3 times", str(cme.exception))

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -599,15 +599,25 @@ def test_make_tempfile():
 
 def test_unique():
     eq_(unique(range(3)), [0, 1, 2])
+    eq_(unique(range(3), reverse=True), [0, 1, 2])
     eq_(unique((1, 0, 1, 3, 2, 0, 1)), [1, 0, 3, 2])
+    eq_(unique((1, 0, 1, 3, 2, 0, 1), reverse=True), [3, 2, 0, 1])
     eq_(unique([]), [])
+    eq_(unique([], reverse=True), [])
     eq_(unique([(1, 2), (1,), (1, 2), (0, 3)]), [(1, 2), (1,), (0, 3)])
+    eq_(unique([(1, 2), (1,), (1, 2), (0, 3)], reverse=True),
+        [(1,), (1, 2), (0, 3)])
 
     # with a key now
     eq_(unique([(1, 2), (1,), (1, 2), (0, 3)],
                key=itemgetter(0)), [(1, 2), (0, 3)])
+    eq_(unique([(1, 2), (1,), (1, 2), (0, 3)],
+               key=itemgetter(0), reverse=True), [(1, 2), (0, 3)])
+
     eq_(unique([(1, 2), (1, 3), (1, 2), (0, 3)],
                key=itemgetter(1)), [(1, 2), (1, 3)])
+    eq_(unique([(1, 2), (1, 3), (1, 2), (0, 3)],
+               key=itemgetter(1), reverse=True), [(1, 2), (0, 3)])
 
 
 def test_all_same():

--- a/datalad/ui/base.py
+++ b/datalad/ui/base.py
@@ -27,7 +27,8 @@ class InteractiveUI(object):
     def question(self, text,
                  title=None, choices=None,
                  default=None,
-                 hidden=False):
+                 hidden=False,
+                 repeat=None):
         pass
 
     def yesno(self, *args, **kwargs):

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -175,7 +175,8 @@ class DialogUI(ConsoleLog, InteractiveUI):
     def question(self, text,
                  title=None, choices=None,
                  default=None,
-                 hidden=False):
+                 hidden=False,
+                 repeat=None):
         # Do initial checks first
         if default and choices and default not in choices:
             raise ValueError("default value %r is not among choices: %s"
@@ -214,7 +215,9 @@ class DialogUI(ConsoleLog, InteractiveUI):
             # TODO: dedicated option?  got annoyed by this one
             # multiple times already, typically we are not defining
             # new credentials where repetition would be needed.
-            repeat = hidden and choices is None
+            if hidden and repeat is None:
+                repeat = hidden and choices is None
+
             if repeat:
                 response_r = self.input('{} (repeat): '.format(msg), hidden=hidden)
                 if response != response_r:

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -102,6 +102,13 @@ def test_hidden_doubleentry():
         eq_(response, 'ab')
         gpcm.assert_has_calls([call('?: '), call('? (repeat): ')])
 
+    # explicitly request no repeats
+    with patch_getpass(return_value='ab') as gpcm:
+        response = ui.question(
+            "?", hidden=True, repeat=False)
+        eq_(response, 'ab')
+        gpcm.assert_has_calls([call('?: ')])
+
 
 def _test_progress_bar(backend, len, increment):
     out = StringIO()

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -740,7 +740,7 @@ def as_unicode(val, cast_types=object):
             % (val, cast_types))
 
 
-def unique(seq, key=None):
+def unique(seq, key=None, reverse=False):
     """Given a sequence return a list only with unique elements while maintaining order
 
     This is the fastest solution.  See
@@ -757,15 +757,23 @@ def unique(seq, key=None):
     key: callable, optional
       Function to call on each element so we could decide not on a full
       element, but on its member etc
+    reverse: bool, optional
+      If True, uniqueness checked in the reverse order, so that the later ones
+      will take the order
     """
     seen = set()
     seen_add = seen.add
+
+    trans = reversed if reverse else lambda x: x
+
     if not key:
-        return [x for x in seq if not (x in seen or seen_add(x))]
+        out = [x for x in trans(seq) if not (x in seen or seen_add(x))]
     else:
         # OPT: could be optimized, since key is called twice, but for our cases
         # should be just as fine
-        return [x for x in seq if not (key(x) in seen or seen_add(key(x)))]
+        out = [x for x in trans(seq) if not (key(x) in seen or seen_add(key(x)))]
+
+    return out[::-1] if reverse else out
 
 
 def all_same(items):

--- a/setup.py
+++ b/setup.py
@@ -223,6 +223,7 @@ setup(
         'datalad':
             findsome('resources', {'sh', 'html', 'js', 'css', 'png', 'svg', 'txt', 'py'}) +
             findsome(opj('downloaders', 'configs'), {'cfg'}) +
+            findsome(opj('distribution', 'tests'), {'yaml'}) +
             findsome(opj('metadata', 'tests', 'data'), {'mp3', 'jpg', 'pdf'})
     },
     **setup_kwargs


### PR DESCRIPTION
This pull request fixes #2004 , fixes #2005, and I also think it might fix #3126 if @effigies says so ;-)

This pull request proposes to do a more thorough pass over possibly available github authentication mechanisms to achieve the goal.  I have tried to maintain currently present "non standard" handling of authentication for github:

- token - we do not store those in the credentials store, but rely on it/them being present in the (git) config.  But since multiple tokens could be defined (globally, and then within a dataset), we might need to consider multiple (I somehow get 3 values with 2 unique ones)
- user/password could be provided in the command line (we don't do that for any other remote etc)

change in behavior
- provided in cmdline user/password are not stored in the credential store (and thus also not deleted - so no dances with removing some credential if smth doesn't work)

additional changes
- `.ui.question` has now `repeat` option (defaults to `None` to maintain previous behavior) to be able to force or disable repeated entry for a hidden value.  In my case I wanted to get rid of it -- entering 2FA token twice is really not called for
- `.utils.unique` got option `reverse=False` which, if set to `True`, would return unique values while maintaining the order from the back (not from the front as originally)

overall now for `create-sibling-github`:

- multiple ways to authenticate are considered - we pretty much loop until we succeed by offering user to enter new user/password or until we really fail
- unless both user and password are provided in command line, tokens are considered first (if user/password are provided -- no stored tokens are considered)
- if user (no password) is provided, only the token(s) associated with that user will be considered
- regular user/password credential is considered next, if fails, asked to re-enter
- if it is detected that user/password authentication leads to 2FA error, we offer to generate token (with "user" and "repo" permissions) and store it in config ("global", "local", no "dataset) (or not store at all - empty value)
   - we only alert/error out if a token with our note (DataLad) already exists
- if session is non-interactive, we don't do much really, and I guess with 2FA even if user/password are provided - we would simply fail. So token must be set via config first then

In addition to authentication related changes

### TODOs
- [x] Move all the `_` helper functions which now also `import github as gh` into `datalad.support.github_`. I kept that in-place for now with hope to still have some meaningful `diff`
- [x] make it possible to avoid reentering the login name if it was specified (see U1 below)
- [ ] consider reverting aforementioned change in behavior that credentials aren't stored if provided in the cmdline.  May be there should be `ui.question` to either do it or not and if not interactive - an INFO msg.
- [x] Try to come up with at least some rudimentary test for all the authentication logic

I would really appreciate any attempts to use it - once again, I have tried it only in a few scenarios and there were no and remain no tests for all the logic there.

**U1

```shell
$> datalad create-sibling-github --github-login yarikoptic-test --name gh-yarikoptic-test shablona
You need to authenticate with 'yarikoptic-test@github' credentials. https://github.com/login provides information on how to gain access
user: 
```