### PR TITLE
BF: annexrepo: Create temporary index under .git/

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2937,7 +2937,10 @@ class AnnexRepo(GitRepo, RepoInterface):
                     staged_not_to_commit = changed_files_staged.difference(files_set)
                     if staged_not_to_commit or files_changed_notstaged:
                         # Need an alternative index_file
-                        with make_tempfile() as index_file:
+                        with make_tempfile(dir=opj(self.path,
+                                                   GitRepo.get_git_dir(self)),
+                                           prefix="datalad-",
+                                           suffix=".index") as index_file:
                             # First add those which were changed but not staged yet
                             if files_changed_notstaged:
                                 self.add(files=list(files_changed_notstaged))


### PR DESCRIPTION
Write the temporary index file under the git directory to ensure that
the it resides on the same file system as the main index file.  See
the description of `--index-output` in `git-read-tree`s manpage.

Fixes #3181.

---

I've tested on smaug and confirmed that this patch fixes the following sequence:


```
$ echo one >one
$ git add one
$ echo two >two
$ datalad add two
```
