### PR TITLE
RF: Absorb revolution's gitrepo, annexrepo, and dataset

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -10,6 +10,8 @@
 """
 
 import logging
+import os
+import os.path as op
 from os.path import curdir
 from os.path import exists
 from os.path import join as opj
@@ -20,6 +22,7 @@ from os.path import relpath
 from weakref import WeakValueDictionary
 from six import PY2
 from six import string_types
+from six import text_type
 from six import add_metaclass
 import wrapt
 
@@ -36,6 +39,7 @@ from datalad.support.repo import Flyweight
 from datalad.support.network import RI
 from datalad.support.exceptions import InvalidAnnexRepositoryError
 
+import datalad.utils as ut
 from datalad.utils import getpwd
 from datalad.utils import optional_args, expandpath, is_explicit_path
 from datalad.utils import get_dataset_root
@@ -163,6 +167,13 @@ class Dataset(object):
         self._id = None
         self._cfg = None
         self._cfg_bound = None
+
+    @property
+    def pathobj(self):
+        """pathobj for the dataset"""
+        # XXX this relies on the assumption that self._path as managed
+        # by the base class is always a native path
+        return ut.Path(self._path)
 
     def __repr__(self):
         return "<Dataset path=%s>" % self.path
@@ -590,6 +601,156 @@ def require_dataset(dataset, check_installed=True, purpose=None):
                          "{0}.".format(dataset.path))
 
     return dataset
+
+
+# New helpers, courtesy of datalad-revolution.
+
+
+def rev_resolve_path(path, ds=None):
+    """Resolve a path specification (against a Dataset location)
+
+    Any explicit path (absolute or relative) is returned as an absolute path.
+    In case of an explicit relative path (e.g. "./some", or ".\\some" on
+    windows), the current working directory is used as reference. Any
+    non-explicit relative path is resolved against as dataset location, i.e.
+    considered relative to the location of the dataset. If no dataset is
+    provided, the current working directory is used.
+
+    Note however, that this function is not able to resolve arbitrarily
+    obfuscated path specifications. All operations are purely lexical, and no
+    actual path resolution against the filesystem content is performed.
+    Consequently, common relative path arguments like '../something' (relative
+    to PWD) can be handled properly, but things like 'down/../under' cannot, as
+    resolving this path properly depends on the actual target of any
+    (potential) symlink leading up to '..'.
+
+    Parameters
+    ----------
+    path : str or PathLike
+      Platform-specific path specific path specification.
+    ds : Dataset or None
+      Dataset instance to resolve non-explicit relative paths against.
+
+    Returns
+    -------
+    `pathlib.Path` object
+    """
+    if ds is not None and not isinstance(ds, Dataset):
+        ds = require_dataset(ds, check_installed=False, purpose='path resolution')
+    if ds is None:
+        # CWD is the reference
+        path = ut.Path(path)
+    # we have a dataset
+    # stringify in case a pathobj came in
+    elif not op.isabs(str(path)) and \
+            not (str(path).startswith(os.curdir + os.sep) or
+                 str(path).startswith(os.pardir + os.sep)):
+        # we have a dataset and no abspath nor an explicit relative path ->
+        # resolve it against the dataset
+        path = ds.pathobj / path
+    else:
+        # CWD is the reference
+        path = ut.Path(path)
+
+    # make sure we return an absolute path, but without actually
+    # resolving anything
+    if not path.is_absolute():
+        # in general it is almost impossible to use resolve() when
+        # we can have symlinks in the root path of a dataset
+        # (that we don't want to resolve here), symlinks to annex'ed
+        # files (that we never want to resolve), and other within-repo
+        # symlinks that we (sometimes) want to resolve (i.e. symlinked
+        # paths for addressing content vs adding content)
+        # CONCEPT: do the minimal thing to catch most real-world inputs
+        # ASSUMPTION: the only sane relative path input that needs
+        # handling and can be handled are upward references like
+        # '../../some/that', wherease stuff like 'down/../someotherdown'
+        # are intellectual excercises
+        # ALGORITHM: match any number of leading '..' path components
+        # and shorten the PWD by that number
+        # NOT using ut.Path.cwd(), because it has symlinks resolved!!
+        pwd_parts = ut.Path(getpwd()).parts
+        path_parts = path.parts
+        leading_parents = 0
+        for p in path.parts:
+            if p == op.pardir:
+                leading_parents += 1
+                path_parts = path_parts[1:]
+            elif p == op.curdir:
+                # we want to discard that, but without stripping
+                # a corresponding parent
+                path_parts = path_parts[1:]
+            else:
+                break
+        path = ut.Path(
+            op.join(
+                *(pwd_parts[:-leading_parents if leading_parents else None]
+                  + path_parts)))
+    # note that we will not "normpath()" the result, check the
+    # pathlib docs for why this is the only sane choice in the
+    # face of the possibility of symlinks in the path
+    return path
+
+
+def path_under_rev_dataset(ds, path):
+    ds_path = ds.pathobj
+    try:
+        rpath = text_type(ut.Path(path).relative_to(ds_path))
+        if not rpath.startswith(op.pardir):
+            # path is already underneath the dataset
+            return path
+    except Exception:
+        # whatever went wrong, we gotta play save
+        pass
+
+    root = rev_get_dataset_root(text_type(path))
+    while root is not None and not ds_path.samefile(root):
+        # path and therefore root could be relative paths,
+        # hence in the next round we cannot use dirname()
+        # to jump in the the next directory up, but we have
+        # to use ./.. and get_dataset_root() will handle
+        # the rest just fine
+        root = rev_get_dataset_root(op.join(root, op.pardir))
+    if root is None:
+        return None
+    return ds_path / op.relpath(text_type(path), root)
+
+
+# XXX this is a copy of the change proposed in
+# https://github.com/datalad/datalad/pull/2944
+def rev_get_dataset_root(path):
+    """Return the root of an existent dataset containing a given path
+
+    The root path is returned in the same absolute or relative form
+    as the input argument. If no associated dataset exists, or the
+    input path doesn't exist, None is returned.
+
+    If `path` is a symlink or something other than a directory, its
+    the root dataset containing its parent directory will be reported.
+    If none can be found, at a symlink at `path` is pointing to a
+    dataset, `path` itself will be reported as the root.
+    """
+    suffix = '.git'
+    altered = None
+    if op.islink(path) or not op.isdir(path):
+        altered = path
+        path = op.dirname(path)
+    apath = op.abspath(path)
+    # while we can still go up
+    while op.split(apath)[1]:
+        if op.exists(op.join(path, suffix)):
+            return path
+        # new test path in the format we got it
+        path = op.normpath(op.join(path, os.pardir))
+        # no luck, next round
+        apath = op.abspath(path)
+    # if we applied dirname() at the top, we give it another go with
+    # the actual path, if it was itself a symlink, it could be the
+    # top-level dataset itself
+    if altered and op.exists(op.join(altered, suffix)):
+        return altered
+
+    return None
 
 
 lgr.log(5, "Done importing dataset")

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -11,12 +11,15 @@
 
 import os
 import shutil
+import os.path as op
 from os.path import join as opj, abspath, normpath, relpath, exists
 
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
+from ..dataset import rev_resolve_path
 from datalad import cfg
 from datalad.api import create
 from datalad.api import get
+import datalad.utils as ut
 from datalad.utils import chpwd, getpwd, rmtree
 from datalad.utils import _path_
 from datalad.utils import get_dataset_root
@@ -435,3 +438,74 @@ def test_symlinked_dataset_properties(repo1, repo2, repo3, non_repo, symlink):
     assert_is_not(ds_link.config, ar3.config)
     assert_false(ds_link._cfg_bound)
     assert_is_none(ds_link.id)
+
+
+@with_tempfile(mkdir=True)
+def test_rev_resolve_path(path):
+    if op.realpath(path) != path:
+        raise SkipTest("Test assumptions require non-symlinked parent paths")
+    # initially ran into on OSX https://github.com/datalad/datalad/issues/2406
+    opath = op.join(path, "origin")
+    os.makedirs(opath)
+    if not on_windows:
+        lpath = op.join(path, "linked")
+        os.symlink('origin', lpath)
+
+    ds_global = Dataset(path)
+    # path resolution of absolute paths is not influenced by symlinks
+    # ignore the linked path on windows, it is not a symlink in the POSIX sense
+    for d in (opath,) if on_windows else (opath, lpath):
+        ds_local = Dataset(d)
+        # no symlink resolution
+        eq_(str(rev_resolve_path(d)), d)
+        with chpwd(d):
+            # be aware: knows about cwd, but this CWD has symlinks resolved
+            eq_(str(rev_resolve_path(d).cwd()), opath)
+            # using pathlib's `resolve()` will resolve any
+            # symlinks
+            # also resolve `opath`, as on old windows systems the path might
+            # come in crippled (e.g. C:\Users\MIKE~1/...)
+            # and comparison would fails unjustified
+            eq_(rev_resolve_path('.').resolve(), ut.Path(opath).resolve())
+            # no norming, but absolute paths, without resolving links
+            eq_(rev_resolve_path('.'), ut.Path(d))
+            eq_(str(rev_resolve_path('.')), d)
+
+            eq_(str(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
+                op.join(d, 'bu'))
+            eq_(str(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
+                op.join(ds_global.path, 'bu'))
+
+        # resolve against a dataset
+        eq_(str(rev_resolve_path('bu', ds=ds_local)), op.join(d, 'bu'))
+        eq_(str(rev_resolve_path('bu', ds=ds_global)), op.join(path, 'bu'))
+        # but paths outside the dataset are left untouched
+        eq_(str(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
+            op.join(getpwd(), 'bu'))
+        eq_(str(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
+            op.normpath(op.join(getpwd(), os.pardir, 'bu')))
+
+
+# little brother of the test above, but actually (must) run
+# under any circumstances
+@with_tempfile(mkdir=True)
+def test_rev_resolve_path_symlink_edition(path):
+    deepest = ut.Path(path) / 'one' / 'two' / 'three'
+    deepest_str = str(deepest)
+    os.makedirs(deepest_str)
+    with chpwd(deepest_str):
+        # direct absolute
+        eq_(deepest, rev_resolve_path(deepest))
+        eq_(deepest, rev_resolve_path(deepest_str))
+        # explicit direct relative
+        eq_(deepest, rev_resolve_path('.'))
+        eq_(deepest, rev_resolve_path(op.join('.', '.')))
+        eq_(deepest, rev_resolve_path(op.join('..', 'three')))
+        eq_(deepest, rev_resolve_path(op.join('..', '..', 'two', 'three')))
+        eq_(deepest, rev_resolve_path(op.join('..', '..', '..',
+                                              'one', 'two', 'three')))
+        # weird ones
+        eq_(deepest, rev_resolve_path(op.join('..', '.', 'three')))
+        eq_(deepest, rev_resolve_path(op.join('..', 'three', '.')))
+        eq_(deepest, rev_resolve_path(op.join('..', 'three', '.')))
+        eq_(deepest, rev_resolve_path(op.join('.', '..', 'three')))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -12,10 +12,12 @@ For further information on git-annex see https://git-annex.branchable.com/.
 
 """
 
+from collections import OrderedDict
 import json
 import logging
 import math
 import os
+import os.path as op
 import re
 import shlex
 import tempfile
@@ -46,6 +48,8 @@ from datalad import ssh_manager
 from datalad.dochelpers import exc_str
 from datalad.dochelpers import borrowdoc
 from datalad.dochelpers import borrowkwargs
+from datalad.ui import ui
+import datalad.utils as ut
 from datalad.utils import linux_distribution_name
 from datalad.utils import nothing_cm
 from datalad.utils import auto_repr
@@ -3119,6 +3123,198 @@ class AnnexRepo(GitRepo, RepoInterface):
             r'git status.*failed in submodule',
             out,
             re.MULTILINE | re.DOTALL | re.IGNORECASE)
+
+
+    def _mark_content_availability(self, info):
+        objectstore = self.pathobj.joinpath(
+            self.path, GitRepo.get_git_dir(self), 'annex', 'objects')
+        for f, r in iteritems(info):
+            if 'key' not in r or 'has_content' in r:
+                # not annexed or already processed
+                continue
+            # test hashdirmixed first, as it is used in non-bare repos
+            # which be a more frequent target
+            # TODO optimize order based on some check that reveals
+            # what scheme is used in a given annex
+            r['has_content'] = False
+            key = r['key']
+            for testpath in (
+                    # ATM git-annex reports hashdir in native path
+                    # conventions and the actual file path `f` in
+                    # POSIX, weired...
+                    # we need to test for the actual key file, not
+                    # just the containing dir, as on windows the latter
+                    # may not always get cleaned up on `drop`
+                    objectstore.joinpath(
+                        ut.Path(r['hashdirmixed']), key, key),
+                    objectstore.joinpath(
+                        ut.Path(r['hashdirlower']), key, key)):
+                if testpath.exists():
+                    r.pop('hashdirlower', None)
+                    r.pop('hashdirmixed', None)
+                    r['objloc'] = str(testpath)
+                    r['has_content'] = True
+                    break
+
+    def get_content_annexinfo(
+            self, paths=None, init='git', ref=None, eval_availability=False,
+            key_prefix='', **kwargs):
+        """
+        Parameters
+        ----------
+        paths : list
+          Specific paths to query info for. In none are given, info is
+          reported for all content.
+        init : 'git' or dict-like or None
+          If set to 'git' annex content info will ammend the output of
+          GitRepo.get_content_info(), otherwise the dict-like object
+          supplied will receive this information and the present keys will
+          limit the report of annex properties. Alternatively, if `None`
+          is given, no initialization is done, and no limit is in effect.
+        ref : gitref or None
+          If not None, annex content info for this Git reference will be
+          produced, otherwise for the content of the present worktree.
+        eval_availability : bool
+          If this flag is given, evaluate whether the content of any annex'ed
+          file is present in the local annex.
+        **kwargs :
+          Additional arguments for GitRepo.get_content_info(), if `init` is
+          set to 'git'.
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under its relative path within
+          the repository. Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+          `revision`
+            SHASUM is last commit affecting the item, or None, if not
+            tracked.
+          `key`
+            Annex key of a file (if an annex'ed file)
+          `bytesize`
+            Size of an annexed file in bytes.
+          `has_content`
+            Bool whether a content object for this key exists in the local
+            annex (with `eval_availability`)
+          `objloc`
+            pathlib.Path of the content object in the local annex, if one
+            is available (with `eval_availability`)
+        """
+        if init is None:
+            info = OrderedDict()
+        elif init == 'git':
+            info = super(AnnexRepo, self).get_content_info(
+                paths=paths, ref=ref, **kwargs)
+        else:
+            info = init
+        # use this funny-looking option with both find and findref
+        # it takes care of git-annex reporting on any known key, regardless
+        # of whether or not it actually (did) exist in the local annex
+        opts = ['--copies', '0']
+        if ref:
+            cmd = 'findref'
+            opts.append(ref)
+        else:
+            cmd = 'find'
+            # stringify any pathobjs
+            opts.extend([str(p) for p in paths]
+                        if paths else ['--include', '*'])
+        for j in self._run_annex_command_json(cmd, opts=opts):
+            path = self.pathobj.joinpath(ut.PurePosixPath(j['file']))
+            rec = info.get(path, None)
+            if init is not None and rec is None:
+                # init constraint knows nothing about this path -> skip
+                continue
+            rec.update({'{}{}'.format(key_prefix, k): j[k]
+                       for k in j if k != 'file'})
+            if 'bytesize' in rec:
+                # it makes sense to make this an int that one can calculate with
+                # with
+                rec['bytesize'] = int(rec['bytesize'])
+            info[path] = rec
+            # TODO make annex availability checks optional and move in here
+            if not eval_availability:
+                # not desired, or not annexed
+                continue
+            self._mark_content_availability(info)
+        return info
+
+    def annexstatus(self, paths=None, untracked='all'):
+        info = self.get_content_annexinfo(
+            paths=paths,
+            eval_availability=False,
+            init=self.get_content_annexinfo(
+                paths=paths,
+                ref='HEAD',
+                eval_availability=False,
+                init=self.status(
+                    paths=paths,
+                    ignore_submodules='other')
+            )
+        )
+        self._mark_content_availability(info)
+        return info
+
+    def _save_add(self, files, git=None, git_opts=None):
+        """Simple helper to add files in save()"""
+        # alter default behavior of git-annex by considering dotfiles
+        # too
+        # however, this helper is controlled by save() which itself
+        # operates on status() which itself honors .gitignore, so
+        # there is a standard mechanism that is uniform between Git
+        # Annex repos to decide on the behavior on a case-by-case
+        # basis
+        # TODO have a dedicated test for this
+        options = ['--include-dotfiles']
+        # if None -- leave it to annex to decide
+        if git is not None:
+            options += [
+                '-c',
+                'annex.largefiles=%s' % (('anything', 'nothing')[int(git)])
+            ]
+        if on_windows:
+            # git-annex ignores symlinks on windows
+            # https://github.com/datalad/datalad/issues/2955
+            # check if there are any and pass them to git-add
+            symlinks_toadd = {
+                p: props for p, props in iteritems(files)
+                if props.get('type', None) == 'symlink'}
+            if symlinks_toadd:
+                for r in GitRepo._save_add(
+                        self,
+                        symlinks_toadd,
+                        git_opts=git_opts):
+                    yield r
+            # trim `files` of symlinks
+            files = {
+                p: props for p, props in iteritems(files)
+                if props.get('type', None) != 'symlink'}
+
+        expected_additions = None
+        if ui.is_interactive:
+            # without an interactive UI there is little benefit from
+            # progressbar info, hence save the stat calls
+            def _get_file_size(relpath):
+                path = op.join(self.path, relpath)
+                return 0 if not op.exists(path) else os.stat(path).st_size
+
+            expected_additions = {p: _get_file_size(p) for p in files}
+
+        for r in self._run_annex_command_json(
+                'add',
+                opts=options,
+                files=list(files.keys()),
+                backend=None,
+                expect_fail=True,
+                # TODO
+                jobs=None,
+                expected_entries=expected_additions,
+                expect_stderr=True):
+            yield r
+
 
 # TODO: Why was this commented out?
 # @auto_repr

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -722,10 +722,6 @@ class GitRepo(RepoInterface):
         # Set by fake_dates_enabled to cache config value across this instance.
         self._fake_dates_enabled = None
 
-        # the sole purpose of this init is to add a pathlib
-        # native path object to the instance
-        # XXX this relies on the assumption that self.path as managed
-        # by the base class is always a native path
         self.pathobj = ut.Path(self.path)
 
     def _create_empty_repo(self, path, **kwargs):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -13,6 +13,7 @@ For further information on GitPython see http://gitpython.readthedocs.org/
 """
 
 import logging
+from collections import OrderedDict
 import re
 import shlex
 import time
@@ -38,6 +39,8 @@ from weakref import WeakValueDictionary
 
 from six import string_types
 from six import add_metaclass
+from six import iteritems
+from six import PY2
 from functools import wraps
 import git as gitpy
 from git import RemoteProgress
@@ -52,6 +55,7 @@ from datalad.cmd import GitRunner
 from datalad.consts import GIT_SSH_COMMAND
 from datalad.dochelpers import exc_str
 from datalad.config import ConfigManager
+import datalad.utils as ut
 from datalad.utils import assure_list
 from datalad.utils import optional_args
 from datalad.utils import on_windows
@@ -718,20 +722,40 @@ class GitRepo(RepoInterface):
         # Set by fake_dates_enabled to cache config value across this instance.
         self._fake_dates_enabled = None
 
+        # the sole purpose of this init is to add a pathlib
+        # native path object to the instance
+        # XXX this relies on the assumption that self.path as managed
+        # by the base class is always a native path
+        self.pathobj = ut.Path(self.path)
+
     def _create_empty_repo(self, path, **kwargs):
+        cmd = ['git', 'init']
+        cmd.extend(kwargs.pop('_from_cmdline_', []))
+        cmd.extend(to_options(**kwargs))
+        lgr.debug(
+            "Initialize empty Git repository at '%s'%s",
+            path,
+            ' %s' % cmd[2:] if cmd[2:] else '')
+        if not op.exists(path):
+            os.makedirs(path)
         try:
-            lgr.debug(
-                "Initialize empty Git repository at '%s'%s",
-                path,
-                ' %s' % kwargs if kwargs else '')
-            repo = self.cmd_call_wrapper(gitpy.Repo.init, path,
-                                         mkdir=True,
-                                         odbt=default_git_odbt,
-                                         **kwargs)
-        except GitCommandError as e:
-            lgr.error(exc_str(e))
+            stdout, stderr = self._git_custom_command(
+                None,
+                cmd,
+                cwd=path,
+                log_stderr=True,
+                log_stdout=True,
+                log_online=False,
+                expect_stderr=False,
+                shell=False,
+                # we don't want it to scream on stdout
+                expect_fail=True)
+        except CommandError as exc:
+            lgr.error(exc_str(exc))
             raise
-        return repo
+        # we want to return None and have lazy eval take care of
+        # the rest
+        return
 
     @property
     def repo(self):
@@ -2240,9 +2264,16 @@ class GitRepo(RepoInterface):
                                   untracked_files=untracked_files,
                                   submodules=submodules, path=path)
 
+    # run() needs this ATM, but should eventually be RF'ed to a
+    # status(recursive=True) call
     @property
     def dirty(self):
-        return self.is_dirty()
+        return len([
+            p for p, props in iteritems(self.status(
+                untracked='normal', ignore_submodules='other'))
+            if props.get('state', None) != 'clean' and
+            # -core ignores empty untracked directories, so shall we
+            not (p.is_dir() and len(list(p.iterdir())) == 0)]) > 0
 
     @property
     def untracked_files(self):
@@ -2704,6 +2735,689 @@ class GitRepo(RepoInterface):
                     else:
                         attrline += ' {}={}'.format(a, val)
                 f.write('\n{}'.format(attrline))
+
+
+    def get_content_info(self, paths=None, ref=None, untracked='all'):
+        """Get identifier and type information from repository content.
+
+        This is simplified front-end for `git ls-files/tree`.
+
+        Both commands differ in their behavior when queried about subdataset
+        paths. ls-files will not report anything, ls-tree will report on the
+        subdataset record. This function uniformly follows the behavior of
+        ls-tree (report on the respective subdataset mount).
+
+        Parameters
+        ----------
+        paths : list(patlib.PurePath)
+          Specific paths, relative to the (resolved repository root, to query
+          info for. Paths must be normed to match the reporting done by Git,
+          i.e. no parent dir components (ala "some/../this").
+          If none are given, info is reported for all content.
+        ref : gitref or None
+          If given, content information is retrieved for this Git reference
+          (via ls-tree), otherwise content information is produced for the
+          present work tree (via ls-files).
+        untracked : {'no', 'normal', 'all'}
+          If and how untracked content is reported when no `ref` was given:
+          'no': no untracked files are reported; 'normal': untracked files
+          and entire untracked directories are reported as such; 'all': report
+          individual files even in fully untracked directories.
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under a pathlib `Path` object instance
+          pointing to its absolute path inside the repository (this path is
+          guaranteed to be underneath `Repo.path`).
+          Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+
+            Note that the reported type will not always match the type of
+            content commited to Git, rather it will reflect the nature
+            of the content minus platform/mode-specifics. For example,
+            a symlink to a locked annexed file on Unix will have a type
+            'file', reported, while a symlink to a file in Git or directory
+            will be of type 'symlink'.
+
+          `gitshasum`
+            SHASUM of the item as tracked by Git, or None, if not
+            tracked. This could be different from the SHASUM of the file
+            in the worktree, if it was modified.
+
+        Raises
+        ------
+        ValueError
+          In case of an invalid Git reference (e.g. 'HEAD' in an empty
+          repository)
+        """
+        # TODO limit by file type to replace code in subdatasets command
+        info = OrderedDict()
+
+        mode_type_map = {
+            '100644': 'file',
+            '100755': 'file',
+            '120000': 'symlink',
+            '160000': 'dataset',
+        }
+        if paths:
+            # path matching will happen against what Git reports
+            # and Git always reports POSIX paths
+            # any incoming path has to be relative already, so we can simply
+            # convert unconditionally
+            paths = [ut.PurePosixPath(p) for p in paths]
+
+        # this will not work in direct mode, but everything else should be
+        # just fine
+        if not ref:
+            # --exclude-standard will make sure to honor and standard way
+            # git can be instructed to ignore content, and will prevent
+            # crap from contaminating untracked file reports
+            cmd = ['git', 'ls-files',
+                   '--stage', '-z', '-d', '-m', '--exclude-standard']
+            # untracked report mode, using labels from `git diff` option style
+            if untracked == 'all':
+                cmd.append('-o')
+            elif untracked == 'normal':
+                cmd += ['-o', '--directory']
+            elif untracked == 'no':
+                pass
+            else:
+                raise ValueError(
+                    'unknown value for `untracked`: %s', untracked)
+        else:
+            cmd = ['git', 'ls-tree', ref, '-z', '-r', '--full-tree']
+        # works for both modes
+        props_re = re.compile(r'([0-9]+) (.*) (.*)\t(.*)$')
+
+        try:
+            stdout, stderr = self._git_custom_command(
+                # specifically always ask for a full report and
+                # filter out matching path later on to
+                # homogenize wrt subdataset content paths across
+                # ls-files and ls-tree
+                None,
+                cmd,
+                log_stderr=True,
+                log_stdout=True,
+                # not sure why exactly, but log_online has to be false!
+                log_online=False,
+                expect_stderr=False,
+                shell=False,
+                # we don't want it to scream on stdout
+                expect_fail=True)
+        except CommandError as exc:
+            if "fatal: Not a valid object name" in str(exc):
+                raise ValueError("Git reference '{}' invalid".format(ref))
+            raise
+
+        for line in stdout.split('\0'):
+            if not line:
+                continue
+            inf = {}
+            props = props_re.match(line)
+            if not props:
+                # not known to Git, but Git always reports POSIX
+                path = ut.PurePosixPath(line)
+                inf['gitshasum'] = None
+            else:
+                # again Git reports always in POSIX
+                path = ut.PurePosixPath(props.group(4))
+                inf['gitshasum'] = props.group(2 if not ref else 3)
+                inf['type'] = mode_type_map.get(
+                    props.group(1), props.group(1))
+                if inf['type'] == 'symlink' and \
+                        '.git/annex/objects' in \
+                        ut.Path(
+                            op.realpath(op.join(
+                                # this is unicode
+                                self.path,
+                                # this has to become unicode on older Pythons
+                                # it doesn't only look ugly, it is ugly
+                                # and probably wrong
+                                unicode(str(path), 'utf-8')
+                                if PY2 else str(path)))).as_posix():
+                    # ugly thing above could be just
+                    #  (self.pathobj / path).resolve().as_posix()
+                    # but PY3.5 does not support resolve(strict=False)
+
+                    # report locked annexed files as file, their
+                    # symlink-nature is a technicality that is dependent
+                    # on the particular mode annex is in
+                    inf['type'] = 'file'
+
+            # the function assumes that any `path` is a relative path lib
+            # instance if there were path constraints given, we need to reject
+            # paths now
+            # reject anything that is:
+            # - not a direct match with a constraint
+            # - has no constraint as a parent
+            #   (relevant to find matches of regular files in a repository)
+            # - is not a parent of a constraint
+            #   (relevant for finding the matching subds entry for
+            #    subds-content paths)
+            if paths \
+                and not any(
+                    path == c or path in c.parents or c in path.parents
+                    for c in paths):
+                continue
+
+            # join item path with repo path to get a universally useful
+            # path representation with auto-conversion and tons of other
+            # stuff
+            path = self.pathobj.joinpath(path)
+            if 'type' not in inf:
+                # be nice and assign types for untracked content
+                inf['type'] = 'symlink' if path.is_symlink() \
+                    else 'directory' if path.is_dir() else 'file'
+            info[path] = inf
+
+        return info
+
+    def status(self, paths=None, untracked='all', ignore_submodules='no'):
+        """Simplified `git status` equivalent.
+
+        Parameters
+        ----------
+        paths : list or None
+          If given, limits the query to the specified paths. To query all
+          paths specify `None`, not an empty list. If a query path points
+          into a subdataset, a report is made on the subdataset record
+          within the queried dataset only (no recursion).
+        untracked : {'no', 'normal', 'all'}
+          If and how untracked content is reported when no `ref` was given:
+          'no': no untracked files are reported; 'normal': untracked files
+          and entire untracked directories are reported as such; 'all': report
+          individual files even in fully untracked directories.
+        ignore_submodules : {'no', 'other', 'all'}
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under a pathlib `Path` object instance
+          pointing to its absolute path inside the repository (this path is
+          guaranteed to be underneath `Repo.path`).
+          Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+          `state`
+            Can be 'added', 'untracked', 'clean', 'deleted', 'modified'.
+        """
+        lgr.debug('Query status of %r for %s paths',
+                  self, len(paths) if paths else 'all')
+        return self.diffstatus(
+            fr='HEAD' if self.get_hexsha() else None,
+            to=None,
+            paths=paths,
+            untracked=untracked,
+            ignore_submodules=ignore_submodules)
+
+    def diff(self, fr, to, paths=None, untracked='all',
+             ignore_submodules='no'):
+        """Like status(), but reports changes between to arbitrary revisions
+
+        Parameters
+        ----------
+        fr : str
+          Revision specification (anything that Git understands). Passing
+          `None` considers anything in the target state as new.
+        to : str or None
+          Revision specification (anything that Git understands), or None
+          to compare to the state of the work tree.
+        paths : list or None
+          If given, limits the query to the specified paths. To query all
+          paths specify `None`, not an empty list.
+        untracked : {'no', 'normal', 'all'}
+          If and how untracked content is reported when no `ref` was given:
+          'no': no untracked files are reported; 'normal': untracked files
+          and entire untracked directories are reported as such; 'all': report
+          individual files even in fully untracked directories.
+        ignore_submodules : {'no', 'other', 'all'}
+
+        Returns
+        -------
+        dict
+          Each content item has an entry under a pathlib `Path` object instance
+          pointing to its absolute path inside the repository (this path is
+          guaranteed to be underneath `Repo.path`).
+          Each value is a dictionary with properties:
+
+          `type`
+            Can be 'file', 'symlink', 'dataset', 'directory'
+          `state`
+            Can be 'added', 'untracked', 'clean', 'deleted', 'modified'.
+        """
+        return {k: v for k, v in iteritems(self.diffstatus(
+            fr=fr, to=to, paths=paths,
+            untracked=untracked,
+            ignore_submodules=ignore_submodules))
+            if v.get('state', None) != 'clean'}
+
+    def diffstatus(self, fr, to, paths=None, untracked='all',
+                   ignore_submodules='no', _cache=None):
+        """Like diff(), but reports the status of 'clean' content too"""
+        def _get_cache_key(label, paths, ref, untracked=None):
+            return self.path, label, tuple(paths) if paths else None, \
+                ref, untracked
+
+        if _cache is None:
+            _cache = {}
+
+        if paths:
+            # at this point we must normalize paths to the form that
+            # Git would report them, to easy matching later on
+            paths = [ut.Path(p) for p in paths]
+            paths = [
+                p.relative_to(self.pathobj) if p.is_absolute() else p
+                for p in paths
+            ]
+
+        # TODO report more info from get_content_info() calls in return
+        # value, those are cheap and possibly useful to a consumer
+        status = OrderedDict()
+        # we need (at most) three calls to git
+        if to is None:
+            # everything we know about the worktree, including os.stat
+            # for each file
+            key = _get_cache_key('ci', paths, None, untracked)
+            if key in _cache:
+                to_state = _cache[key]
+            else:
+                to_state = self.get_content_info(
+                    paths=paths, ref=None, untracked=untracked)
+                _cache[key] = to_state
+            # we want Git to tell us what it considers modified and avoid
+            # reimplementing logic ourselves
+            key = _get_cache_key('mod', paths, None)
+            if key in _cache:
+                modified = _cache[key]
+            else:
+                modified = set(
+                    self.pathobj.joinpath(ut.PurePosixPath(p))
+                    for p in self._git_custom_command(
+                        # low-level code cannot handle pathobjs
+                        [str(p) for p in paths] if paths else None,
+                        ['git', 'ls-files', '-z', '-m'])[0].split('\0')
+                    if p)
+                _cache[key] = modified
+        else:
+            key = _get_cache_key('ci', paths, to)
+            if key in _cache:
+                to_state = _cache[key]
+            else:
+                to_state = self.get_content_info(paths=paths, ref=to)
+                _cache[key] = to_state
+            # we do not need worktree modification detection in this case
+            modified = None
+        # origin state
+        key = _get_cache_key('ci', paths, fr)
+        if key in _cache:
+            from_state = _cache[key]
+        else:
+            if fr:
+                from_state = self.get_content_info(paths=paths, ref=fr)
+            else:
+                # no ref means from nothing
+                from_state = {}
+            _cache[key] = from_state
+
+        for f, to_state_r in iteritems(to_state):
+            props = None
+            if f not in from_state:
+                # this is new, or rather not known to the previous state
+                props = dict(
+                    state='added' if to_state_r['gitshasum'] else 'untracked',
+                    type=to_state_r['type'],
+                )
+            elif to_state_r['gitshasum'] == from_state[f]['gitshasum'] and \
+                    (modified is None or f not in modified):
+                if ignore_submodules != 'all' or to_state_r['type'] != 'dataset':
+                    # no change in git record, and no change on disk
+                    props = dict(
+                        state='clean' if f.exists() or
+                              f.is_symlink() else 'deleted',
+                        type=to_state_r['type'],
+                    )
+            else:
+                # change in git record, or on disk
+                props = dict(
+                    # TODO we could have a new file that is already staged
+                    # but had subsequent modifications done to it that are
+                    # unstaged. Such file would presently show up as 'added'
+                    # ATM I think this is OK, but worth stating...
+                    state='modified' if f.exists() or
+                    f.is_symlink() else 'deleted',
+                    # TODO record before and after state for diff-like use
+                    # cases
+                    type=to_state_r['type'],
+                )
+            if props['state'] in ('clean', 'added', 'modified'):
+                props['gitshasum'] = to_state_r['gitshasum']
+            if props['state'] in ('clean', 'modified', 'deleted'):
+                props['prev_gitshasum'] = from_state[f]['gitshasum']
+            status[f] = props
+
+        for f, from_state_r in iteritems(from_state):
+            if f not in to_state:
+                # we new this, but now it is gone and Git is not complaining
+                # about it being missing -> properly deleted and deletion
+                # stages
+                status[f] = dict(
+                    state='deleted',
+                    type=from_state_r['type'],
+                    # report the shasum to distinguish from a plainly vanished
+                    # file
+                    gitshasum=from_state_r['gitshasum'],
+                )
+
+        if ignore_submodules == 'all':
+            return status
+
+        # loop over all subdatasets and look for additional modifications
+        for f, st in iteritems(status):
+            if not (st['type'] == 'dataset' and st['state'] == 'clean' and
+                    GitRepo.is_valid_repo(str(f))):
+                # no business here
+                continue
+            # we have to recurse into the dataset and get its status
+            subrepo = GitRepo(str(f))
+            # subdataset records must be labeled clean up to this point
+            if st['gitshasum'] != subrepo.get_hexsha():
+                # current commit in subdataset deviates from what is
+                # recorded in the dataset, cheap test
+                st['state'] = 'modified'
+            else:
+                # the recorded commit did not change, so we need to make
+                # a more expensive traversal
+                rstatus = subrepo.diffstatus(
+                    # we can use 'HEAD' because we know that the commit
+                    # did not change. using 'HEAD' will facilitate
+                    # caching the result
+                    fr='HEAD',
+                    to=None,
+                    paths=None,
+                    untracked=untracked,
+                    ignore_submodules='other',
+                    _cache=_cache)
+                if any(v['state'] != 'clean'
+                       for k, v in iteritems(rstatus)):
+                    st['state'] = 'modified'
+            if ignore_submodules == 'other' and st['state'] == 'modified':
+                # we know for sure that at least one subdataset is modified
+                # go home quick
+                break
+        return status
+
+    def _save_pre(self, paths, _status, **kwargs):
+        # helper to get an actionable status report
+        if paths is not None and not paths and not _status:
+            return
+        if _status is None:
+            if 'untracked' not in kwargs:
+                kwargs['untracked'] = 'normal'
+            status = self.status(
+                paths=paths,
+                **{k: kwargs[k] for k in kwargs
+                   if k in ('untracked', 'ignore_submodules')})
+        else:
+            # we want to be able to add items down the line
+            # make sure to detach from prev. owner
+            status = _status.copy()
+        status = OrderedDict(
+            (k, v) for k, v in iteritems(status)
+            if v.get('state', None) != 'clean'
+        )
+        return status
+
+    def get_staged_paths(self):
+        """Returns a list of any stage repository path(s)
+
+        This is a rather fast call, as it will not depend on what is going on
+        in the worktree.
+        """
+        try:
+            stdout, stderr = self._git_custom_command(
+                None,
+                ['git', 'diff', '--name-only', '--staged'],
+                cwd=self.path,
+                log_stderr=True,
+                log_stdout=True,
+                log_online=False,
+                expect_stderr=False,
+                expect_fail=True)
+        except CommandError as e:
+            lgr.debug(exc_str(e))
+            stdout = ''
+        return [f for f in stdout.split('\n') if f]
+
+    def _save_post(self, message, status, partial_commit):
+        # helper to commit changes reported in status
+        _datalad_msg = False
+        if not message:
+            message = 'Recorded changes'
+            _datalad_msg = True
+
+        # TODO remove pathobj stringification when commit() can
+        # handle it
+        to_commit = [str(f.relative_to(self.pathobj))
+                     for f, props in iteritems(status)] \
+                    if partial_commit else None
+        if not partial_commit or to_commit:
+            # we directly call GitRepo.commit() to avoid a whole slew
+            # if direct-mode safeguards and workarounds in the AnnexRepo
+            # implementation (which also run an additional dry-run commit
+            GitRepo.commit(
+                self,
+                files=to_commit,
+                msg=message,
+                _datalad_msg=_datalad_msg,
+                options=None,
+                # do not raise on empty commit
+                # it could be that the `add` in this save-cycle has already
+                # brought back a 'modified' file into a clean state
+                careless=True,
+            )
+
+    def save(self, message=None, paths=None, _status=None, **kwargs):
+        """Save dataset content.
+
+        Parameters
+        ----------
+        message : str or None
+          A message to accompany the changeset in the log. If None,
+          a default message is used.
+        paths : list or None
+          Any content with path matching any of the paths given in this
+          list will be saved. Matching will be performed against the
+          dataset status (GitRepo.status()), or a custom status provided
+          via `_status`. If no paths are provided, ALL non-clean paths
+          present in the repo status or `_status` will be saved.
+        ignore_submodules : {'no', 'all'}
+          If `_status` is not given, will be passed as an argument to
+          Repo.status(). With 'all' no submodule state will be saved in
+          the dataset. Note that submodule content will never be saved
+          in their respective datasets, as this function's scope is
+          limited to a single dataset.
+        _status : dict or None
+          If None, Repo.status() will be queried for the given `ds`. If
+          a dict is given, its content will be used as a constraint.
+          For example, to save only modified content, but no untracked
+          content, set `paths` to None and provide a `_status` that has
+          no entries for untracked content.
+        **kwargs :
+          Additional arguments that are passed to underlying Repo methods.
+          Supported:
+
+          - git : bool (passed to Repo.add()
+          - ignore_submodules : {'no', 'other', 'all'} passed to Repo.status()
+          - untracked : {'no', 'normal', 'all'} - passed to Repo.satus()
+        """
+        return list(
+            self.save_(
+                message=message,
+                paths=paths,
+                _status=_status,
+                **kwargs
+            )
+        )
+
+    def save_(self, message=None, paths=None, _status=None, **kwargs):
+        """Like `save()` but working as a generator."""
+        from datalad.interface.results import get_status_dict
+
+        status = self._save_pre(paths, _status, **kwargs)
+        if not status:
+            # all clean, nothing todo
+            lgr.debug('Nothing to save in %r, exiting early', self)
+            return
+
+        # three things are to be done:
+        # - remove (deleted if not already staged)
+        # - add (modified/untracked)
+        # - commit (with all paths that have been touched, to bypass
+        #   potential pre-staged bits)
+
+        need_partial_commit = True if self.get_staged_paths() else False
+
+        # remove first, because removal of a subds would cause a
+        # modification of .gitmodules to be added to the todo list
+        to_remove = [
+            # TODO remove pathobj stringification when delete() can
+            # handle it
+            str(f.relative_to(self.pathobj))
+            for f, props in iteritems(status)
+            if props.get('state', None) == 'deleted' and
+            # staged deletions have a gitshasum reported for them
+            # those should not be processed as git rm will error
+            # due to them being properly gone already
+            not props.get('gitshasum', None)]
+        vanished_subds = any(
+            props.get('type', None) == 'dataset' and
+            props.get('state', None) == 'deleted'
+            for f, props in iteritems(status))
+        if to_remove:
+            for r in self.remove(
+                    to_remove,
+                    # we would always see individual files
+                    recursive=False):
+                # TODO normalize result
+                yield r
+
+        # TODO this additonal query should not be, base on status as given
+        # if anyhow possible, however, when paths are given, status may
+        # not contain all required information. In case of path=None AND
+        # _status=None, we should be able to avoid this, because
+        # status should have the full info already
+        # looks for contained repositories
+        to_add_submodules = [sm for sm, sm_props in iteritems(
+            self.get_content_info(
+                # get content info for any untracked directory
+                [f.relative_to(self.pathobj) for f, props in iteritems(status)
+                 if props.get('state', None) == 'untracked' and
+                 props.get('type', None) == 'directory'],
+                ref=None,
+                # request exhaustive list, so that everything that is
+                # still reported as a directory must be its own repository
+                untracked='all'))
+            if sm_props.get('type', None) == 'directory']
+        added_submodule = False
+        for cand_sm in to_add_submodules:
+            try:
+                self.add_submodule(
+                    str(cand_sm.relative_to(self.pathobj)),
+                    url=None, name=None)
+            except (CommandError, InvalidGitRepositoryError) as e:
+                yield get_status_dict(
+                    action='add_submodule',
+                    ds=self,
+                    path=self.pathobj / ut.PurePosixPath(cand_sm),
+                    status='error',
+                    message=e.stderr if hasattr(e, 'stderr')
+                    else ('not a Git repository: %s', exc_str(e)),
+                    logger=lgr)
+                continue
+            added_submodule = True
+        if not need_partial_commit:
+            # without a partial commit an AnnexRepo would ignore any submodule
+            # path in its add helper, hence `git add` them explicitly
+            to_stage_submodules = {
+                str(f.relative_to(self.pathobj)): props
+                for f, props in iteritems(status)
+                if props.get('state', None) in ('modified', 'untracked')
+                and props.get('type', None) == 'dataset'}
+            if to_stage_submodules:
+                lgr.debug(
+                    '%i submodule path(s) to stage in %r %s',
+                    len(to_stage_submodules), self,
+                    to_stage_submodules
+                    if len(to_stage_submodules) < 10 else '')
+                for r in GitRepo._save_add(
+                        self,
+                        to_stage_submodules,
+                        git_opts=None):
+                    # TODO the helper can yield proper dicts right away
+                    yield get_status_dict(
+                        action=r.get('command', 'add'),
+                        refds=self.pathobj,
+                        type='file',
+                        path=(self.pathobj / ut.PurePosixPath(r['file']))
+                        if 'file' in r else None,
+                        status='ok' if r.get('success', None) else 'error',
+                        key=r.get('key', None),
+                        logger=lgr)
+
+        if added_submodule or vanished_subds:
+            # need to include .gitmodules in what needs saving
+            status[self.pathobj.joinpath('.gitmodules')] = dict(
+                type='file', state='modified')
+        to_add = {
+            # TODO remove pathobj stringification when add() can
+            # handle it
+            str(f.relative_to(self.pathobj)): props
+            for f, props in iteritems(status)
+            if props.get('state', None) in ('modified', 'untracked')}
+        if to_add:
+            lgr.debug(
+                '%i path(s) to add to %r %s',
+                len(to_add), self, to_add if len(to_add) < 10 else '')
+            for r in self._save_add(
+                    to_add,
+                    git_opts=None,
+                    **{k: kwargs[k] for k in kwargs
+                       if k in (('git',) if hasattr(self, 'annexstatus')
+                                else tuple())}):
+                # TODO the helper can yield proper dicts right away
+                yield get_status_dict(
+                    action=r.get('command', 'add'),
+                    refds=self.pathobj,
+                    type='file',
+                    path=(self.pathobj / ut.PurePosixPath(r['file']))
+                    if 'file' in r else None,
+                    status='ok' if r.get('success', None) else 'error',
+                    key=r.get('key', None),
+                    logger=lgr)
+
+        self._save_post(message, status, need_partial_commit)
+        # TODO yield result for commit, prev helper checked hexsha pre
+        # and post...
+
+    def _save_add(self, files, git_opts=None):
+        """Simple helper to add files in save()"""
+        try:
+            # without --verbose git 2.9.3  add does not return anything
+            add_out = self._git_custom_command(
+                list(files.keys()),
+                ['git', 'add'] + assure_list(git_opts) + ['--verbose']
+            )
+            # get all the entries
+            for o in self._process_git_get_output(*add_out):
+                yield o
+        except OSError as e:
+            lgr.error("add: %s" % e)
+            raise
 
 
 # TODO

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1379,11 +1379,21 @@ def test_custom_runner_protocol(path):
     # Check that a runner with a non-default protocol gets wired up correctly.
     prot = ExecutionTimeProtocol()
     gr = GitRepo(path, runner=Runner(cwd=path, protocol=prot), create=True)
-    eq_(len(prot), 1)
+
+    ok_(len(prot) > 0)
     ok_(prot[0]['duration'] >= 0)
+
+    def check(prev_len, prot, command):
+        # Check that the list grew and has the expected command without
+        # assuming that it gained _only_ a one command.
+        ok_(len(prot) > prev_len)
+        assert_in(command,
+                  sum([p["command"] for p in prot[prev_len:]], []))
+
+    prev_len = len(prot)
     gr.add("foo")
-    eq_(len(prot), 2)
-    assert_in("add", prot[1]["command"])
+    check(prev_len, prot, "add")
+
+    prev_len = len(prot)
     gr.commit("commit foo")
-    eq_(len(prot), 3)
-    assert_in("commit", prot[2]["command"])
+    check(prev_len, prot, "commit")

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -308,6 +308,20 @@ def is_explicit_path(path):
         or path.startswith(os.pardir + os.sep)
 
 
+# handle this dance once, and import pathlib from here
+# in all other places
+if PY2:
+    from pathlib2 import (
+        Path,
+        PurePosixPath,
+    )
+else:
+    from pathlib import (
+        Path,
+        PurePosixPath,
+    )
+
+
 def rotree(path, ro=True, chmod_files=True):
     """To make tree read-only or writable
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ requires = {
         'patool>=1.7',
         'six>=1.8.0',
         'wrapt',
+        'pathlib2; python_version < "3.0"',  # brought to you by revolution1
     ] +
     pbar_requires +
     (['colorama'] if on_windows else []),


### PR DESCRIPTION
I'm proposing this as the initial phase of bringing in changes from datalad-revolution.  While it's still not clear how (or even if) each -revolution interface module will be integrated or adopted in core, we're at a point where we can drop in -revolution's GitRepo, AnnexRepo, and Dataset without an issue.  And on -revolution's side, these classes should be in a stable state, so moving them to core shouldn't be problematic or slow development.

Note that this PR doesn't prevent or make it harder for us to follow the vision from #2926 and #3076 of incorporating all or at least nearly all of -revolution in the core codebase.

To bring in the changes, I took the approach of simply copying over the -revolution methods into the parent classes.  Doing it this way---rather than copying over the -revolution modules and wiring them up to use and live beside "hidden" core modules---avoids a lot of the hassle of file renaming, of needing to adjust at least some imports, and of dealing with leakage from the "hidden" modules.  But it does assume that these classes will be frozen in -revolution.  It also makes verifying that no unintended changes were dropped from -revolution less straightforward.  Here's the method suggested in 5f156911f:

```
This cross-repository movement isn't easy to review, but with
datalad-revolution checked out to af7f4f05f and located at
$DL_REV_DIR, you can use the following commands to convince yourself
that nothing important from the revolution is being dropped or
modified by examining the "-" lines in:

  % git diff --color-moved --no-index -- \
    $DL_REV_DIR/datalad_revolution/gitrepo.py datalad/support/gitrepo.py

  % git diff --color-moved --no-index -- \
    $DL_REV_DIR/datalad_revolution/annexrepo.py datalad/support/annexrepo.py

  % git diff --color-moved --no-index -- \
    $DL_REV_DIR/datalad_revolution/dataset.py datalad/distribution/dataset.py
```

This PR will be paired with one in datalad-revolution that removes the -revolution classes in favor of the ones added here.
