### PR TITLE
ENH: duecredit support for citing datalad itself AND datasets it opens

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -538,6 +538,8 @@ Refer datalad/config.py for information on how to add these environment variable
   Instructs to use `git` as available in current environment, and not the one which possibly comes with git-annex (default behavior).
 - *DATALAD_ASSERT_NO_OPEN_FILES*:
   Instructs test helpers to check for open files at the end of a test. If set, remaining open files are logged at ERROR level. Alternative modes are: "assert" (raise AssertionError if any open file is found), "pdb"/"epdb" (drop into debugger when open files are found, info on files is provided in a "files" dictionary, mapping filenames to psutil process objects).
+- *DATALAD_ALLOW_FAIL*:
+  Instructs `@never_fail` decorator to allow to fail, e.g. to ease debugging.
 
 # Changelog section
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -305,7 +305,7 @@ class Dataset(object):
             # at DEBUG level and if necessary "complaint upstairs"
             lgr.log(5, "Failed to detect a valid repo at %s", self.path)
         elif due.active:
-            # Makes sense only on installed dataset
+            # Makes sense only on installed dataset - @never_fail'ed
             duecredit_dataset(self)
 
         return self._repo

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -28,7 +28,9 @@ from datalad.config import ConfigManager
 from datalad.dochelpers import exc_str
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import Constraint
+from datalad.support.due import due, Doi
 from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.external_versions import external_versions
 from datalad.support.gitrepo import GitRepo
 from datalad.support.gitrepo import InvalidGitRepositoryError
 from datalad.support.gitrepo import NoSuchPathError
@@ -295,11 +297,80 @@ class Dataset(object):
         if not valid:
             self._repo = None
 
+        from datalad.support.due import due, Doi, Url, Text
         if self._repo is None:
             # Often .repo is requested to 'sense' if anything is installed
             # under, and if so -- to proceed forward. Thus log here only
             # at DEBUG level and if necessary "complaint upstairs"
             lgr.log(5, "Failed to detect a valid repo at %s", self.path)
+        elif external_versions['duecredit'] and getattr(due, 'active', None):
+            # TODO: extend duecredit's stub with .active
+            res = self.metadata(
+                reporton='datasets',  # Interested only in the dataset record
+                result_renderer=None,  # No need
+                return_type='item-or-list'  # Expecting a single record
+            )
+            # We have a couple of candidates for looking up references.
+            # In the future (TODO) extractors should provide API to provide
+            # reference(s). Order of extractors from config should be preserved
+            # and define precedence
+            if not isinstance(res, dict):
+                lgr.debug("Got record which is not a dict, no duecredit for now")
+            metadata = res.get('metadata', {})
+
+            # Descend following the dots -- isn't there a helper already? TODO
+            def get_field(struct, field):
+                if not field:
+                    return None
+                value = struct
+                for subfield in field.split('.'):
+                    value = value.get(subfield, None)
+                    if not value:
+                        return None
+                return value
+
+            for cite_field, desc_field, cite_type in [
+                ('bids.DatasetDOI', 'bids.name', Doi), #  our best guess I guess
+                ('bids.HowToAcknowledge', 'bids.name', Text),
+                # ('bids.citation', Text), # non-standard!
+                # ('bids.ReferencesAndLinks', list) #  freeform but we could detect
+                #                                   #  URLs, DOIs, and for the rest use Text
+                # ('datacite.?'  # ?
+                # ('frictionless_datapackage.?'  # ?
+                # ('frictionless_datapackage.homepage'  # ?
+                (None, None, None)  # Catch all so we leave no one behind
+            ]:
+                cite_rec = get_field(metadata, cite_field)
+                if cite_field is not None:
+                    if not cite_rec:
+                        continue
+                    # we found it! ;)
+                else:
+                    # Catch all
+                    cite_rec = "DataLad dataset at %s" % self.path
+
+                desc = None
+                if desc_field:
+                    desc = get_field(metadata, desc_field)
+                desc = desc or "DataLad dataset %s" % self.id
+
+                # DueCredit's path defines groupping of entries, so with
+                # "datalad." we bring them all under datalad's roof!
+                # And as for unique suffix, there is no better one but the ID,
+                # but that one is too long so let's take the first part of UUID
+                path = "datalad:%s" % (self.id.split('-', 1)[0])
+
+                try:
+                    due.cite(
+                        (cite_type or FreeTextEntry)(cite_rec),
+                        path=path,
+                        version=self.repo.describe(),
+                        description=desc
+                    )
+                    break  # we are done. TODO: should we continue? ;)
+                except Exception as exc:
+                    # who knows what could go wrong with DueCredit!?
+                    lgr.debug("DueCredit .cite caused %s", exc_str(exc))
 
         return self._repo
 

--- a/datalad/support/due.py
+++ b/datalad/support/due.py
@@ -1,0 +1,73 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/datalad/support/due.py
+++ b/datalad/support/due.py
@@ -57,7 +57,7 @@ try:
         raise RuntimeError(
             "Imported due lacks .cite. DueCredit is now disabled")
 except Exception as e:
-    if type(e).__name__ != 'ImportError':
+    if type(e).__name__ not in ('ImportError', 'ModuleNotFoundError'):
         import logging
         logging.getLogger("datalad.duecredit").error(
             "Failed to import duecredit due to %s" % str(e))

--- a/datalad/support/due.py
+++ b/datalad/support/due.py
@@ -15,16 +15,16 @@ installed duecredit.
 
 Then use in your code as
 
-    from .due import due, Doi, BibTeX
+    from .due import due, Doi, BibTeX, Text
 
 See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
 
 Origin:     Originally a part of the duecredit
-Copyright:  2015-2016  DueCredit developers
+Copyright:  2015-2019  DueCredit developers
 License:    BSD-2
 """
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
 
 class InactiveDueCreditCollector(object):
@@ -51,18 +51,18 @@ def _donothing_func(*args, **kwargs):
 
 
 try:
-    from duecredit import due, BibTeX, Doi, Url
+    from duecredit import due, BibTeX, Doi, Url, Text
     if 'due' in locals() and not hasattr(due, 'cite'):
         raise RuntimeError(
             "Imported due lacks .cite. DueCredit is now disabled")
 except Exception as e:
     if type(e).__name__ != 'ImportError':
         import logging
-        logging.getLogger("duecredit").error(
+        logging.getLogger("datalad.support.due").error(
             "Failed to import duecredit due to %s" % str(e))
     # Initiate due stub
     due = InactiveDueCreditCollector()
-    BibTeX = Doi = Url = _donothing_func
+    BibTeX = Doi = Url = Text = _donothing_func
 
 # Emacs mode definitions
 # Local Variables:

--- a/datalad/support/due.py
+++ b/datalad/support/due.py
@@ -39,7 +39,8 @@ class InactiveDueCreditCollector(object):
             return func
         return nondecorating_decorator
 
-    cite = load = add = _donothing
+    active = False
+    activate = add = cite = dump = load = _donothing
 
     def __repr__(self):
         return self.__class__.__name__ + '()'
@@ -58,7 +59,7 @@ try:
 except Exception as e:
     if type(e).__name__ != 'ImportError':
         import logging
-        logging.getLogger("datalad.support.due").error(
+        logging.getLogger("datalad.duecredit").error(
             "Failed to import duecredit due to %s" % str(e))
     # Initiate due stub
     due = InactiveDueCreditCollector()

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -73,8 +73,12 @@ def duecredit_dataset(dataset):
             return next(first(get_field(struct, f) for f in field), None)
         if not field:
             return None
+        # I think it is better to be case insensitive
+        field = field.lower()
         value = struct
         for subfield in field.split('.'):
+            # lower case all the keys
+            value = {k.lower(): v for k, v in value.items()}
             value = value.get(subfield, None)
             if not value:
                 return None

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -1,0 +1,98 @@
+#emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*- 
+#ex: set sts=4 ts=4 sw=4 noet:
+"""
+Support functionality for using DueCredit
+"""
+
+# Note Text was added/exposed only since DueCredit 0.6.5
+from .due import due, Doi, Url, Text
+
+import logging
+lgr = logging.getLogger('datalad.duecredit')
+
+
+# Ad-hoc list of candidate metadata fields and corresponding
+# DueCredit entries. First hit will win it all.
+# In the future (TODO) extractors should provide API to provide
+# reference(s). Order of extractors from config should be preserved
+# and define precedence.
+# Field for citation, Field for Description, DueCredit Entry.
+CITATION_CANDIDATES = [
+    ('bids.DatasetDOI', 'bids.name', Doi),  # our best guess I guess
+    ('bids.HowToAcknowledge', 'bids.name', Text),
+    # ('bids.citation', Text), # non-standard!
+    # ('bids.ReferencesAndLinks', list) #  freeform but we could detect
+    #                                   #  URLs, DOIs, and for the rest use Text
+    # ('datacite.?'  # ?
+    # ('frictionless_datapackage.?'  # ?
+    # ('frictionless_datapackage.homepage'  # ?
+    (None, None, None)  # Catch all so we leave no one behind
+]
+
+
+# Not worth being a @datasetmethod at least in this shape.
+# Could in principle provide rendering of the citation(s) etc
+# using duecredit
+def duecredit_dataset(dataset):
+    """Duecredit cite a dataset if Duecredit is active
+
+    ATM it is an ad-hoc implementation which largely just supports
+    extraction of citation information from BIDS extractor
+    (datalad-neuroimaging extension) only ATM.
+    Generic implementation would require minor harmonization and/or
+    support of extraction of relevant information by each extractor.
+    """
+
+    res = dataset.metadata(
+        reporton='datasets',  # Interested only in the dataset record
+        result_renderer=None,  # No need
+        return_type='item-or-list'  # Expecting a single record
+    )
+
+    if not isinstance(res, dict):
+        lgr.debug("Got record which is not a dict, no duecredit for now")
+    metadata = res.get('metadata', {})
+
+    # Descend following the dots -- isn't there a helper already - TODO?
+    def get_field(struct, field):
+        if not field:
+            return None
+        value = struct
+        for subfield in field.split('.'):
+            value = value.get(subfield, None)
+            if not value:
+                return None
+        return value
+
+    for cite_field, desc_field, cite_type in CITATION_CANDIDATES:
+        cite_rec = get_field(metadata, cite_field)
+        if cite_field is not None:
+            if not cite_rec:
+                continue
+            # we found it! ;)
+        else:
+            # Catch all
+            cite_rec = "DataLad dataset at %s" % dataset.path
+
+        desc = None
+        if desc_field:
+            desc = get_field(metadata, desc_field)
+        desc = desc or "DataLad dataset %s" % dataset.id
+
+        # DueCredit's path defines groupping of entries, so with
+        # "datalad." we bring them all under datalad's roof!
+        # And as for unique suffix, there is no better one but the ID,
+        # but that one is too long so let's take the first part of UUID
+        path = "datalad:%s" % (dataset.id.split('-', 1)[0])
+
+        try:
+            due.cite(
+                (cite_type or Text)(cite_rec),
+                path=path,
+                version=dataset.repo.describe(),
+                description=desc
+            )
+            break  # we are done. TODO: should we continue? ;)
+        except Exception as exc:
+            # who knows what could go wrong with DueCredit!?
+            lgr.debug("DueCredit .cite caused %s", exc_str(exc))

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -60,6 +60,8 @@ def duecredit_dataset(dataset):
 
     if not isinstance(res, dict):
         lgr.debug("Got record which is not a dict, no duecredit for now")
+        return
+    
     metadata = res.get('metadata', {})
 
     # Descend following the dots -- isn't there a helper already - TODO?

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -6,6 +6,7 @@ Support functionality for using DueCredit
 
 # Note Text was added/exposed only since DueCredit 0.6.5
 from .due import due, Doi, Url, Text
+from ..utils import never_fail
 
 import logging
 lgr = logging.getLogger('datalad.duecredit')
@@ -35,6 +36,7 @@ CITATION_CANDIDATES = [
 # Not worth being a @datasetmethod at least in this shape.
 # Could in principle provide rendering of the citation(s) etc
 # using duecredit
+@never_fail  # For paranoid Yarik
 def duecredit_dataset(dataset):
     """Duecredit cite a dataset if Duecredit is active
 
@@ -100,14 +102,10 @@ def duecredit_dataset(dataset):
         version = get_field(metadata, version_field) if version_field else None
         version = version or dataset.repo.describe()
 
-        try:
-            due.cite(
-                (cite_type or Text)(cite_rec),
-                path=path,
-                version=version,
-                description=desc
-            )
-            break  # we are done. TODO: should we continue? ;)
-        except Exception as exc:
-            # who knows what could go wrong with DueCredit!?
-            lgr.debug("DueCredit .cite caused %s", exc_str(exc))
+        due.cite(
+            (cite_type or Text)(cite_rec),
+            path=path,
+            version=version,
+            description=desc
+        )
+        return  # we are done. TODO: should we continue? ;)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -47,6 +47,8 @@ from git.exc import NoSuchPathError
 from git.exc import InvalidGitRepositoryError
 from git.objects.blob import Blob
 
+from datalad.support.due import due, Doi
+
 from datalad import ssh_manager
 from datalad.cmd import GitRunner
 from datalad.consts import GIT_SSH_COMMAND
@@ -604,6 +606,13 @@ class GitRepo(RepoInterface):
 
     # End Flyweight
 
+    # This is the least common denominator to claim that a user
+    # used DataLad.
+    # For now citing Zenodo's all (i.e., latest) version
+    @due.dcite(Doi("10.5281/zenodo.808846"),
+               # override path since there is no need ATM for such details
+               path="datalad",
+               description="Data management and distribution platform")
     def __init__(self, path, url=None, runner=None, create=True,
                  git_opts=None, repo=None, fake_dates=False, **kwargs):
         """Creates representation of git repository at `path`.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -612,7 +612,7 @@ class GitRepo(RepoInterface):
     @due.dcite(Doi("10.5281/zenodo.808846"),
                # override path since there is no need ATM for such details
                path="datalad",
-               description="Data management and distribution platform")
+               description="DataLad - Data management and distribution platform")
     def __init__(self, path, url=None, runner=None, create=True,
                  git_opts=None, repo=None, fake_dates=False, **kwargs):
         """Creates representation of git repository at `path`.

--- a/datalad/support/tests/test_due_utils.py
+++ b/datalad/support/tests/test_due_utils.py
@@ -1,0 +1,92 @@
+from ...distribution import dataset as dataset_mod
+from ...distribution.dataset import Dataset
+from .. import due_utils
+from ..due_utils import duecredit_dataset
+
+from ..due import due
+
+from ...tests.utils import (
+    assert_raises,
+    eq_,
+    integration,
+    ok_,
+    SkipTest,
+    skip_if_no_module,
+    swallow_logs,
+    with_tempfile,
+)
+import logging
+from mock import patch
+
+
+@with_tempfile(mkdir=True)
+@patch.object(due_utils, 'Doi')
+@patch.object(due_utils, 'Text')
+def test_duecredit_dataset(path, Text, Doi):
+    dataset = Dataset(path)
+
+    # Verify that we do not call duecredit_dataset if due is not enabled
+    # Seems cant patch.object.enabled so we will just test differently
+    # depending on either enabled or not
+    if not due.active:
+        with patch.object(dataset_mod, 'duecredit_dataset') as cmdc:
+            dataset.create()
+            cmdc.assert_not_called()
+    else:
+        with patch.object(dataset_mod, 'duecredit_dataset') as cmdc:
+            dataset.create()
+            cmdc.assert_called_once_with(dataset)
+
+
+    # note: doesn't crash even if we call it incorrectly (needs dataset)
+    duecredit_dataset()
+
+    # No metadata -- no citation ATM.
+    # TODO: possibly reconsider - may be our catch-all should be used there
+    # as well
+    with patch.object(due, 'cite') as mcite:
+        with swallow_logs(new_level=logging.WARNING) as cml:
+            duecredit_dataset(dataset)  # should not crash or anything
+            # since no metadata - we issue warning and return without citing
+            # anything
+            cml.assert_logged(
+                regex='.*Failed to obtain metadata.*Will not provide duecredit.*'
+            )
+        mcite.assert_not_called()
+
+    # Let's provide some, but no relevant, metadata
+    with patch.object(due, 'cite') as mcite, \
+        patch.object(dataset, 'metadata') as mmetadata:
+        mmetadata.return_value = {'metadata': {'mumbo': {'jumbo': True}}}
+        duecredit_dataset(dataset)
+        # We resort to catch all
+        mcite.assert_called_once_with(
+            # TODO: make a proper class for Text/Doi not just magical mock
+            Text("CONTENT ISN'T CHECKED"), # ""DataLad dataset at %s" % dataset.path),
+            description='DataLad dataset %s' % dataset.id,
+            path='datalad:%s' % dataset.id[:8],
+            version=None
+        )
+
+    # A sample call with BIDS dataset metadata
+    with patch.object(due, 'cite') as mcite, \
+        patch.object(dataset, 'metadata') as mmetadata:
+        doi = 'xxx.12/12.345'
+        mmetadata.return_value = {
+            'metadata': {
+                'bids': {
+                    # here we would test also to be case insensitive
+                    'DatasetDoi': doi,
+                    'name': "ds name",
+            }}}
+        duecredit_dataset(dataset)
+        # TODO: somehow if worked for Text() - doesn't work for Doi
+        #       Claims that we didn't specify doi for Doi() in expected
+        # mcite.assert_called_once_with(
+        #     # TODO: make a proper class for Text/Doi not just magical mock
+        #     Doi(doi), # ""DataLad dataset at %s" % dataset.path),
+        #     description='ds name',
+        #     path='datalad:%s' % dataset.id[:8],
+        #     version=None
+        # )
+

--- a/datalad/support/tests/test_due_utils.py
+++ b/datalad/support/tests/test_due_utils.py
@@ -9,6 +9,7 @@ from ..due import (
     Text,
 )
 
+from ..external_versions import external_versions
 
 from ...tests.utils import (
     assert_raises,
@@ -60,10 +61,12 @@ def test_duecredit_dataset(path):
     # Below we will rely on duecredit Entries being comparable, so if
     # duecredit is available and does not provide __cmp__ we make it for now
     # Whenever https://github.com/duecredit/duecredit/pull/148 is merged, and
-    # probably 0.7.1 released - we will eventually remove this monkey patching
+    # probably 0.7.1 released - we will eventually remove this monkey patching.
+    # Checking if __eq__ was actually provided seems tricky on py2, so decided
+    # to just do version comparison
     try:
-        from duecredit.entries import DueCreditEntry
-        if not hasattr(DueCreditEntry, '__eq__'):
+        if external_versions['duecredit'] < '0.7.1':
+            from duecredit.entries import DueCreditEntry
             def _entry_eq(self, other):
                 return (
                         (self._rawentry == other._rawentry) and

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -18,6 +18,8 @@ import os
 from os import linesep
 import os.path as op
 
+import sys
+
 
 from datalad import get_encoding_info
 from datalad.cmd import Runner
@@ -65,6 +67,7 @@ from datalad.support.gitrepo import guard_BadName
 from datalad.support.exceptions import DeprecatedError
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import FileNotInRepositoryError
+from datalad.support.external_versions import external_versions
 from datalad.support.protocol import ExecutionTimeProtocol
 from .utils import check_repo_deals_with_inode_change
 
@@ -1387,3 +1390,33 @@ def test_custom_runner_protocol(path):
     gr.commit("commit foo")
     eq_(len(prot), 3)
     assert_in("commit", prot[2]["command"])
+
+
+@with_tempfile(mkdir=True)
+def test_duecredit(path):
+    # Just to check that no obvious side-effects
+    run = Runner(cwd=path).run
+    cmd = [
+        sys.executable, "-c",
+        "from datalad.support.gitrepo import GitRepo; GitRepo(%r, create=True)" % path
+    ]
+
+    env = os.environ.copy()
+
+    # Test with duecredit not enabled for sure
+    env.pop('DUECREDIT_ENABLE', None)
+
+    out, err = run(cmd, env=env, expect_stderr=True)
+    outs = out + err  # Let's not depend on where duecredit decides to spit out
+    # All quiet
+    eq_(outs, '')
+
+    # and now enable DUECREDIT - output could come to stderr
+    env['DUECREDIT_ENABLE'] = '1'
+    out, err = run(cmd, env=env, expect_stderr=True)
+    outs = out + err
+
+    if external_versions['duecredit']:
+        assert_in('Data management and distribution platform', outs)
+    else:
+        eq_(outs, '')

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1405,6 +1405,11 @@ def test_duecredit(path):
 
     # Test with duecredit not enabled for sure
     env.pop('DUECREDIT_ENABLE', None)
+    # Alternative workaround for what to be fixed by
+    # https://github.com/datalad/datalad/pull/3215
+    # where underlying datalad process might issue a warning since our temp
+    # cwd is not matching possibly present PWD env variable
+    env.pop('PWD', None)
 
     out, err = run(cmd, env=env, expect_stderr=True)
     outs = out + err  # Let's not depend on where duecredit decides to spit out

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -64,6 +64,8 @@ from ..utils import map_items
 from ..utils import unlink
 from ..utils import CMD_MAX_ARG
 from ..utils import create_tree
+from ..utils import never_fail
+
 from ..support.annexrepo import AnnexRepo
 
 from nose.tools import (
@@ -1208,3 +1210,25 @@ def test_create_tree(path):
     ok_file_has_content(op.join(path, '1'), content)
     ok_file_has_content(op.join(path, 'sd', '1'), content*2)
     ok_file_has_content(op.join(path, 'sd', '1.gz'), content*3, decompress=True)
+
+
+def test_never_fail():
+
+    @never_fail
+    def iamok(arg):
+        return arg
+    eq_(iamok(1), 1)
+
+    @never_fail
+    def ifail(arg):
+        raise ValueError
+    eq_(ifail(1), None)
+
+    with patch.dict('os.environ', {'DATALAD_ALLOW_FAIL': '1'}):
+        # decision to create failing or not failing function
+        # is done at the time of decoration
+        @never_fail
+        def ifail2(arg):
+            raise ValueError
+
+        assert_raises(ValueError, ifail2, 1)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -952,6 +952,30 @@ def line_profile(func):
             prof.print_stats()
     return newfunc
 
+
+# Borrowed from duecredit to wrap duecredit-handling to guarantee failsafe
+def never_fail(f):
+    """Assure that function never fails -- all exceptions are caught
+
+    Returns `None` if function fails internally.
+    """
+    @wraps(f)
+    def wrapped_func(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            lgr.warning(
+                "DataLad internal failure while running %s: %r. "
+                "Please report at https://github.com/datalad/datalad/issues"
+                % (f, e)
+            )
+
+    if os.environ.get('DATALAD_ALLOW_FAIL', False):
+        return f
+    else:
+        return wrapped_func
+
+
 #
 # Context Managers
 #

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ requires = {
         'vcrpy',
     ],
     'metadata': [
-        'duecredit',  # needs >= 0.6.6 to be usable, but should be "safe" with prior ones
         # lzma is included in python since 3.3
         # We now support backports.lzma as well (besides AutomagicIO), but since
         # there is not way to define an alternative here (AFAIK, yoh), we will
@@ -115,7 +114,10 @@ requires = {
         'exifread',  # EXIF metadata
         'python-xmp-toolkit',  # XMP metadata, also requires 'exempi' to be available locally
         'Pillow',  # generic image metadata
-    ]
+    ],
+    'duecredit': [
+        'duecredit',  # needs >= 0.6.6 to be usable, but should be "safe" with prior ones
+    ],
 }
 
 requires['full'] = sum(list(requires.values()), [])

--- a/setup.py
+++ b/setup.py
@@ -104,9 +104,7 @@ requires = {
         'vcrpy',
     ],
     'metadata': [
-        # was added in https://github.com/datalad/datalad/pull/1995 without
-        # due investigation, should not be needed until we add duecredit support
-        # 'duecredit',
+        'duecredit',  # needs >= 0.6.6 to be usable, but should be "safe" with prior ones
         'simplejson',
         'whoosh',
     ] + req_lzma,


### PR DESCRIPTION
This pull request fixes #2065 - those eyes didn't let me sleep! I will blame @tyarkoni for anything to come.
- includes support for actually DueCrediting any dataset we "instantiate"
- ATM just ad-hoc extraction of metadata fields from `bids` and `datacite` (for CRCNS) records. Proper solution will need integration with extractors or some other harmonization which we do not have ATM
- Relies on changes yet to be merged/released in DueCredit: https://github.com/duecredit/duecredit/pull/144
   - basic support for free text citations (so we could at least point to those datasets etc)
   - access to `due.active`

With those changes and this PR, we are getting smth like:
```shell
> rm .duecredit.p; DUECREDIT_ENABLE=1 datalad ls ~/datalad/openfmri/ds000241 /home/yoh/datalad/crcns/aa-1                                                                        
/home/yoh/datalad/openfmri/ds000241   [annex]  master  1.0.0+1-2-g6bb6937 2018-06-08/07:44:21  ✓
/home/yoh/datalad/crcns/aa-1   [annex]  master  ✗ 2018-06-08/10:23:47  ✓

DueCredit Report:
- DataLad - Data management and distribution platform / datalad (v 0.11.3.dev22) [1]
  - Single-unit recordings from two auditory areas in male zebra finches / datalad:77271f9e (v 1.0) [2]
  - AK6: Animal Kingdom; 6 Species / datalad:f7ccf78c (v 1.0.0+1-2-g6bb6937) [3]

1 package cited
0 modules cited
2 functions cited

References
----------

[1] Visconti di Oleggio Castello, M. et al., 2019. datalad/datalad 0.11.3.
[2] Theunissen, F.E. et al., 2009. Single-unit recordings from two auditory areas in male zebra finches.
[3] Please cite: 'Connolly, A. C., J. S. Guntupalli, J. Gors, M. Hanke, Y. O. Halchenko, Y.-C. Wu, H. Abdi, and J. V. Haxby. The Representation of Biological Classes in the Human Brain. Journal of Neuroscience 32.8 (2012): 2608-618.' and include the following message: 'This data was obtained from the OpenfMRI database. Its accession number is ds000241'
```

```shell
$> duecredit summary --format bibtex              
@misc{https://doi.org/10.5281/zenodo.808846,
  doi = {10.5281/zenodo.808846},
  url = {https://zenodo.org/record/808846},
  author = {Visconti di Oleggio Castello, Matteo and Halchenko, Yaroslav O. and Hanke, Michael and Poldrack, Benjamin and Meyer, Kyle and Solanky, Debanjum Singh and Alteva, Gergana and Gors, Jason and MacFarlane, Dave and Olaf Häusler, Christian and Olson, Taylor and Waite, Alex and De La Vega, Alejandro and Sochat, Vanessa and Keshavan, Anisha and Ma, Feilong and Christian, Horea and Poelen, Jorrit and Skytén, Kusti and Visconti di Oleggio Castello, Matteo and Hardcastle, Nell and Stoeter, Torsten and C Lau, Vicky},
  keywords = {data version control, data distribution, execution provenance tracking},
  title = {datalad/datalad 0.11.3},
  publisher = {Zenodo},
  year = {2019}
}
@misc{https://doi.org/10.6080/k0f769gp,
  doi = {10.6080/k0f769gp},
  url = {http://crcns.org/data-sets/aa/aa-1},
  author = {Theunissen, Frederic E. and Hauber, ME and Woolley, Sarah M. N. and Gill, Patrick and Shaevitz, SS and Amin, Noopur and Hsu, A and Singh, NC and Grace, GA and Fremouw, Thane and Zhang, Junli and Cassey, P and Doupe, AJ and David, SV and Vinje, WE},
  keywords = {Neuroscience, Electrophysiology, auditory area, avian (zebra finch)},
  language = {eng},
  title = {Single-unit recordings from two auditory areas in male zebra finches},
  publisher = {CRCNS.org},
  year = {2009}
}
2019-02-28 23:40:55,436 [WARNING] Failed to generate bibtex for Text(u"Please cite: 'Connolly, A. C., J. S. Guntupalli, J. Gors, M. Hanke, Y. O. Halchenko, Y.-C. Wu, H. Abdi, and J. V. Haxby. The Representation of Biological Classes in the Human Brain. Journal of Neuroscience 32.8 (2012): 2608-618.' and include the following message: 'This data was obtained from the OpenfMRI database. Its accession number is ds000241'", key=u"please cite: 'connolly, a. c., j. s. guntupalli, j. gors, m. hanke, y. o. halchenko, y.-c. wu, h. abdi, and j. v. haxby. the representation of biological classes in the human brain. journal of neuroscience 32.8 (2012): 2608-618.' and include the following message: 'this data was obtained from the openfmri database. its accession number is ds000241'") (io.py:383)
```

Would be fun to see it output for a real use case with Python analysis script which uses DataLad to get the data -- have any in mind? ;)

### TODOs
- [x] Basic unit- or integration/smoke test

Please have a look @datalad/developers
