### PR TITLE
Small improvements re Dataset/*Repo handling

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -126,6 +126,10 @@ class Dataset(object):
         if path is None:
             raise AttributeError
 
+        # mirror what is happening in __init__
+        if isinstance(path, ut.PurePath):
+            path = text_type(path)
+
         # Custom handling for few special abbreviations
         path_ = path
         if path == '^':
@@ -163,10 +167,12 @@ class Dataset(object):
         """
         Parameters
         ----------
-        path : str
+        path : str or Path
           Path to the dataset location. This location may or may not exist
           yet.
         """
+        if isinstance(path, ut.PurePath):
+            path = text_type(path)
         self._path = path
         self._repo = None
         self._id = None

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -154,6 +154,11 @@ class Dataset(object):
         return path_, args, kwargs
     # End Flyweight
 
+    def __hash__(self):
+        # the flyweight key is already determining unique instances
+        # add the class name to distinguish from strings of a path
+        return hash((self.__class__.__name__, self.__weakref__.key))
+
     def __init__(self, path):
         """
         Parameters

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -516,15 +516,15 @@ def test_hashable(path):
     path = ut.Path(path)
     tryme = set()
     # is it considered hashable at all
-    tryme.add(Dataset(str(path / 'one')))
+    tryme.add(Dataset(path / 'one'))
     eq_(len(tryme), 1)
     # do another one, same class different path
-    tryme.add(Dataset(str(path / 'two')))
+    tryme.add(Dataset(path / 'two'))
     eq_(len(tryme), 2)
     # test whether two different types of repo instances pointing
     # to the same repo on disk are considered different
-    Dataset(str(path)).create()
-    tryme.add(GitRepo(str(path)))
+    Dataset(path).create()
+    tryme.add(GitRepo(path))
     eq_(len(tryme), 3)
-    tryme.add(AnnexRepo(str(path)))
+    tryme.add(AnnexRepo(path))
     eq_(len(tryme), 4)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -509,3 +509,22 @@ def test_rev_resolve_path_symlink_edition(path):
         eq_(deepest, rev_resolve_path(op.join('..', 'three', '.')))
         eq_(deepest, rev_resolve_path(op.join('..', 'three', '.')))
         eq_(deepest, rev_resolve_path(op.join('.', '..', 'three')))
+
+
+@with_tempfile(mkdir=True)
+def test_hashable(path):
+    path = ut.Path(path)
+    tryme = set()
+    # is it considered hashable at all
+    tryme.add(Dataset(str(path / 'one')))
+    eq_(len(tryme), 1)
+    # do another one, same class different path
+    tryme.add(Dataset(str(path / 'two')))
+    eq_(len(tryme), 2)
+    # test whether two different types of repo instances pointing
+    # to the same repo on disk are considered different
+    Dataset(str(path)).create()
+    tryme.add(GitRepo(str(path)))
+    eq_(len(tryme), 3)
+    tryme.add(AnnexRepo(str(path)))
+    eq_(len(tryme), 4)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -38,6 +38,7 @@ from weakref import WeakValueDictionary
 
 
 from six import string_types
+from six import text_type
 from six import add_metaclass
 from six import iteritems
 from six import PY2
@@ -576,6 +577,10 @@ class GitRepo(RepoInterface):
 
         if path is None:
             raise AttributeError
+
+        # mirror what is happening in __init__
+        if isinstance(path, ut.PurePath):
+            path = text_type(path)
 
         # Sanity check for argument `path`:
         # raise if we cannot deal with `path` at all or

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -608,6 +608,11 @@ class GitRepo(RepoInterface):
 
     # End Flyweight
 
+    def __hash__(self):
+        # the flyweight key is already determining unique instances
+        # add the class name to distinguish from strings of a path
+        return hash((self.__class__.__name__, self.__weakref__.key))
+
     def __init__(self, path, url=None, runner=None, create=True,
                  git_opts=None, repo=None, fake_dates=False, **kwargs):
         """Creates representation of git repository at `path`.

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -313,11 +313,13 @@ def is_explicit_path(path):
 if PY2:
     from pathlib2 import (
         Path,
+        PurePath,
         PurePosixPath,
     )
 else:
     from pathlib import (
         Path,
+        PurePath,
         PurePosixPath,
     )
 


### PR DESCRIPTION
- [x] both instances are hashable now
- [x]  both can be created from pathlib's Path objects