### PR TITLE
Prepare for first preview release of 0.12 series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,24 @@ We would recommend to consult log of the
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
 
-## 0.11.4 (??? ??, 2019) -- will be better than ever
-
-bet we will fix some bugs and make a world even a better place.
+## 0.12.0rc1 (Mar 03, 2019) -- to boldly go ...
 
 ### Major refactoring and deprecations
 
-- hopefully none
+- Discontinued support for git-annex direct-mode (also no longer
+  supported upstream).
 
 ### Fixes
 
-?
+- Create temporary index files under .git/ to stay on the same filesystem.
 
 ### Enhancements and new features
 
-?
+- Dataset and Repo object instances are now hashable, and can be
+  created based on pathlib Path object instances
+
+- Imported various additional methods for the Repo classes to query
+  information and save changes.
 
 
 ## 0.11.3 (Feb 19, 2019) -- read-me-gently

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -15,7 +15,7 @@ from os.path import lexists, dirname, join as opj, curdir
 # Hard coded version, to be done by release process,
 # it is also "parsed" (not imported) by setup.py, that is why assigned as
 # __hardcoded_version__ later and not vise versa
-__version__ = '0.11.3'
+__version__ = '0.12.0rc1'
 __hardcoded_version__ = __version__
 __full_version__ = __version__
 


### PR DESCRIPTION
I see no point of adding tons of changelog entries for individual
pre-releases (not even a real RC yet). Instead, I started an 0.12.0 entry
so we can fill it up with what is to come.

I would have preferred to call this 0.12.0pre1, but setuptools insists
on "normalizing" the version to 0.12.0rc1 -- so we better use that right
away.

Once this gets a GO, I will merge it, push a tag (I don't see the need to pollute github releases, so I'll skip that), upload to pypi, point -revolution to use it as a dependency, and be done.