### PR TITLE
BF: Repo.dirty will not report on nested empty datasets (fixes gh-3196)

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2276,7 +2276,7 @@ class GitRepo(RepoInterface):
     def dirty(self):
         return len([
             p for p, props in iteritems(self.status(
-                untracked='normal', ignore_submodules='other'))
+                untracked='all', ignore_submodules='other'))
             if props.get('state', None) != 'clean' and
             # -core ignores empty untracked directories, so shall we
             not (p.is_dir() and len(list(p.iterdir())) == 0)]) > 0

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -796,6 +796,13 @@ def test_GitRepo_dirty(path):
     repo.commit("file1.txt modified")
     ok_(not repo.dirty)
 
+    # An empty directory doesn't count as dirty.
+    os.mkdir(op.join(path, "empty"))
+    ok_(not repo.dirty)
+    # Neither does an empty directory with an otherwise empty directory.
+    os.mkdir(op.join(path, "empty", "empty-again"))
+    ok_(not repo.dirty)
+
     # TODO: submodules
 
 


### PR DESCRIPTION
#3196 