### PR TITLE
ENH: Uniformize API and capabilities of JSON dump and dump2stream

### DIFF
--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -50,21 +50,28 @@ from ..log import lgr
 from ..dochelpers import exc_str
 
 
-def dump(obj, fname):
+def dump(obj, fname, compressed=False):
+
+    _open = LZMAFile if compressed else io.open
+
     indir = dirname(fname)
     if not exists(indir):
         makedirs(indir)
     if lexists(fname):
         os.unlink(fname)
-    with io.open(fname, 'wb') as f:
-        return dump2fileobj(obj, f)
+    with _open(fname, 'wb') as f:
+        return dump2fileobj(
+            obj,
+            f,
+            **(compressed_json_dump_kwargs if compressed else json_dump_kwargs)
+        )
 
 
-def dump2fileobj(obj, fileobj):
+def dump2fileobj(obj, fileobj, **kwargs):
     return jsondump(
         obj,
         codecs.getwriter('utf-8')(fileobj),
-        **json_dump_kwargs)
+        **kwargs)
 
 
 def LZMAFile(*args, **kwargs):

--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -51,6 +51,17 @@ from ..dochelpers import exc_str
 
 
 def dump(obj, fname, compressed=False):
+    """Dump a JSON-serializable objects into a file
+
+    Parameters
+    ----------
+    obj : object
+      Structure to serialize.
+    fname : str
+      Name of the file to dump into.
+    compressed : bool
+      Flag whether to use LZMA compression for file content.
+    """
 
     _open = LZMAFile if compressed else io.open
 
@@ -68,6 +79,17 @@ def dump(obj, fname, compressed=False):
 
 
 def dump2fileobj(obj, fileobj, **kwargs):
+    """Dump a JSON-serializable objects into a file-like
+
+    Parameters
+    ----------
+    obj : object
+      Structure to serialize.
+    fileobj : file
+      Writeable file-like object to dump into.
+    **kwargs
+      Keyword arguments to be passed on to simplejson.dump()
+    """
     return jsondump(
         obj,
         codecs.getwriter('utf-8')(fileobj),

--- a/datalad/support/tests/test_json_py.py
+++ b/datalad/support/tests/test_json_py.py
@@ -8,16 +8,26 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
+import os.path as op
 
-from datalad.support.json_py import load
-from datalad.support.json_py import loads
-from datalad.support.json_py import JSONDecodeError
+from datalad.support.json_py import (
+    dump,
+    dump2stream,
+    dump2xzstream,
+    load_stream,
+    load_xzstream,
+    load,
+    loads,
+    JSONDecodeError,
+)
 
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import eq_
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import (
+    with_tempfile,
+    eq_,
+    assert_raises,
+    assert_in,
+    swallow_logs,
+)
 
 
 @with_tempfile(content=b'{"Authors": ["A1"\xc2\xa0, "A2"]}')
@@ -35,3 +45,37 @@ def test_loads():
             swallow_logs(new_level=logging.WARNING) as cml:
         loads('{"a": 2}x')
     assert_in('Failed to load content from', cml.out)
+
+
+@with_tempfile(mkdir=True)
+def test_compression(path):
+    fname = op.join(path, 'test.json.xz')
+    content = 'dummy'
+    # dump compressed
+    dump(content, fname, compressed=True)
+    # filename extension match auto-enabled compression "detection"
+    eq_(load(fname), content)
+    # but was it actually compressed?
+    # we don't care how exactly it blows up (UnicodeDecodeError, etc),
+    # but it has to blow
+    assert_raises(Exception, load, fname, compressed=False)
+
+
+@with_tempfile
+def test_dump(path):
+    assert(not op.exists(path))
+    # dump is nice and create the target directory
+    dump('some', op.join(path, 'file.json'))
+    assert(op.exists(path))
+
+
+# at least a smoke test
+@with_tempfile
+def test_dump2stream(path):
+    stream = [dict(a=5), dict(b=4)]
+    dump2stream([dict(a=5), dict(b=4)], path)
+    eq_(list(load_stream(path)), stream)
+
+    # the same for compression
+    dump2xzstream([dict(a=5), dict(b=4)], path)
+    eq_(list(load_xzstream(path)), stream)


### PR DESCRIPTION
This PR makes it a bit easier to read/write compressed JSON dumps, by softening the association stream==compressed, dump==uncompressed. Nothing amazing though.

Also a few more "tests".

Required for https://github.com/datalad/datalad-revolution/pull/84