### PR TITLE
BF: Fix LORIS token authenticator type with Python3

### DIFF
--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -39,6 +39,7 @@ class LORISTokenGenerator(object):
         except HTTPError:
             raise AccessDeniedError("Could not authenticate into LORIS")
 
-        data = json.load(response)
+        str_response = response.read().decode('utf-8')
+        data = json.loads(str_response)
         return data["token"]
 

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -13,6 +13,7 @@ from six.moves.urllib.request import Request, urlopen
 from six.moves.urllib.error import HTTPError
 
 from datalad.downloaders.base import AccessDeniedError, AccessFailedError
+from datalad.utils import assure_unicode
 
 
 class LORISTokenGenerator(object):
@@ -39,7 +40,7 @@ class LORISTokenGenerator(object):
         except HTTPError:
             raise AccessDeniedError("Could not authenticate into LORIS")
 
-        str_response = response.read().decode('utf-8')
+        str_response = assure_unicode(response.read())
         data = json.loads(str_response)
         return data["token"]
 


### PR DESCRIPTION
The HTTPResponse object returned by urlopen under Python3 is not
compatible with json.load(!) because read() returns bytes, while json.load
is a thin wrapper around json.loads (which expects a str). This stores
the response as a str in a temporary variable and converts it to a string,
before calling json.loads directly to prevent a type error when used under
Python3 while trying to authenticate against a LORIS instance.