### PR TITLE
BF: Fixing for the needed post-release dance with Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ We would recommend to consult log of the
 [DataLad git repository](http://github.com/datalad/datalad) for more details.
 
 
+## 0.12.0rc2 (??? ??, 2019) -- will be better than ever
+
+bet we will fix some bugs and make a world even a better place.
+
+### Major refactoring and deprecations
+
+- hopefully none
+
+### Fixes
+
+?
+
+### Enhancements and new features
+
+?
+
+
 ## 0.12.0rc1 (Mar 03, 2019) -- to boldly go ...
 
 ### Major refactoring and deprecations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -543,7 +543,7 @@ Refer datalad/config.py for information on how to add these environment variable
 
 For the upcoming release use this template
 
-## 0.11.5 (??? ??, 2019) -- will be better than ever
+## 0.12.0rc3 (??? ??, 2019) -- will be better than ever
 
 bet we will fix some bugs and make a world even a better place.
 

--- a/datalad/tests/test_version.py
+++ b/datalad/tests/test_version.py
@@ -65,7 +65,8 @@ def test__version__():
                 assert_not_in('will be better than ever', regd['codename'])
                 assert_equal(__hardcoded_version__, changelog_version)
                 if __hardcoded_version__ != san__version__:
-                    # It was not tagged yet!
+                    # It was not tagged yet and Changelog should have its
+                    # template record for the next release
                     assert_greater(lv_changelog_version, lv__version__)
                     assert_in('.dev', san__version__)
                 else:


### PR DESCRIPTION
Post release commit must introduce a placeholder for the next Changelog entry
and adjust CONTRIBUTING.md to match the after next one so it could be simply
copy pasted next time

This pull should fix currently failing in master `test_version.py`