### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,12 @@ Please go through the following checklist before submitting the PR:
 
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
 
+- [ ] Choose a base branch for your PR's topic branch.
+
+  The two branches that are likely candidates are `master` and the maintenance branch `0.11.x`.  Bug fixes that apply to `0.11.x` should usually go there, while everything else can go on top of `master`.
+
+  To choose a base, (1) branch off of that point in your local repository and (2) choose the base branch in the drop-down list when creating the PR on GitHub.
+
 - [ ] **Delete these instructions**. :-)
 
 Thanks for contributing!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,11 @@ Please go through the following checklist before submitting the PR:
 
 - [ ] Include `Fixes #NNN` or `Closes #NNN` somewhere in the description if this PR addresses an existing issue.
 
-- [ ] If this PR is not complete, add the "WiP" label or select "Create Draft Pull Request" in the pull request button's menu.
+- [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
 
   Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
+
+  The Travis tests aren't triggered for draft PRs.  If the PR is in a state where running the tests would be useful, instead submit a regular PR marked with the "WiP" label.
 
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,3 @@ This pull request proposes
 ### Changes
 - [ ] This change is complete
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
-
-Please have a look @datalad/developers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,17 @@
-This pull request fixes #
+### Instructions
 
-This pull request proposes
+Please go through the following checklist before submitting the PR:
 
-### Changes
-- [ ] This change is complete
+- [ ] Provide an overview of the changes you're making and explain why you're proposing them.
+
+- [ ] Include `Fixes #NNN` or `Closes #NNN` somewhere in the description if this PR addresses an existing issue.
+
+- [ ] If this PR is not complete, add the "WiP" label or select "Create Draft Pull Request" in the pull request button's menu.
+
+  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
+
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
+
+- [ ] **Delete these instructions**. :-)
+
+Thanks for contributing!


### PR DESCRIPTION
This is my opinionated update of PULL_REQUEST_TEMPLATE.md.  The main change is to make it into a checklist that is meant to be deleted rather than something in between a to-be-deleted checklist and a to-be-filled-in template, which is its current form.  Since I don't see how we'd get away from using instructions entirely, I find using only instructions clearer.

If others don't want to go in this direction, we should still probably add something about choosing the PR base (last commit) to the current template.
