### PR TITLE
Do not decode fetched content when retrieving status

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -487,7 +487,7 @@ class BaseDownloader(object):
             atexit.register(self._cache.close)
         return self._cache
 
-    def _fetch(self, url, cache=None, size=None, allow_redirects=True):
+    def _fetch(self, url, cache=None, size=None, allow_redirects=True, decode=True):
         """Fetch content from a url into a file.
 
         Very similar to _download but lacks any "file" management and decodes
@@ -541,7 +541,7 @@ class BaseDownloader(object):
             downloaded_size = len(content)
 
             # now that we know size based on encoded content, let's decode into string type
-            if PY3 and isinstance(content, binary_type):
+            if PY3 and isinstance(content, binary_type) and decode:
                 content = content.decode()
             # downloaded_size = os.stat(temp_filepath).st_size
 
@@ -615,7 +615,7 @@ class BaseDownloader(object):
             and self.authenticator.failure_re \
             else 0
 
-        _, headers = self._fetch(url, cache=False, size=download_size)
+        _, headers = self._fetch(url, cache=False, size=download_size, decode=False)
 
         # extract from headers information to depict the status of the url
         status = self.get_status_from_headers(headers)


### PR DESCRIPTION
When annexificator is used in a datalad-crawler pipeline, it attempts
to call get_status on the URL to see if the file has changed. get_status
attempts to use _fetch, which attempts to decode the content under Python3.

This is invalid for content that isn't utf-8, and get_status was only
trying to verify that it wasn't receiving a login or failure page or similar.
_fetch, confusingly, converts the UnicodeFormatError into a generic DownloadError
(despite the fact that the download succeeded, but conversion to a string failed.)

This teaches _fetch a "decode" parameter that toggles whether or not it should
even attempt to decode. In the case of get_status, the content is discarded,
so the decode serves no purpose as far as I can tell.

NB. fetch (without the _)'s documentation claims that it doesn't decode, but
it calls _fetch (which currently always decodes.) This can new parameter can
eventually be used to fix that, but currently trying to fix "fetch" results in
a json.loads error from a mysterious part in the code if fetch is updated to
not decode as documented.