### PR TITLE
ENH: prevent users to create a repo in a subdir with files known to git above

### DIFF
--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -35,7 +35,7 @@ from datalad.tests.utils import assert_is
 from datalad.tests.utils import assert_not_equal
 
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import PathOutsideRepositoryError
+from datalad.support.exceptions import PathKnownToRepositoryError
 
 
 def test_EnsureDataset():
@@ -107,7 +107,7 @@ def test_is_installed(src, path):
     # when create/rev-create merge.
     # Unfortunately such protection does not work in direct mode
     if not ds.repo.is_direct_mode():
-        with assert_raises(Exception):
+        with assert_raises(PathKnownToRepositoryError):
             subds.create()
     # get the submodule
     # This would init so there is a .git file with symlink info, which is

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -103,9 +103,12 @@ def test_is_installed(src, path):
     # subdataset path.
     # Note: Unfortunately we would still be able to generate it under
     # subdirectory within submodule, e.g. `subm 1/subdir` but that is
-    # not checked here
-    with assert_raises(Exception):
-        subds.create()
+    # not checked here. `rev-create` will provide that protection
+    # when create/rev-create merge.
+    # Unfortunately such protection does not work in direct mode
+    if not ds.repo.is_direct_mode():
+        with assert_raises(Exception):
+            subds.create()
     # get the submodule
     # This would init so there is a .git file with symlink info, which is
     # as we agreed is more pain than gain, so let's use our install which would

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -87,8 +87,6 @@ def test_resolve_path(somedir):
 # TODO: test remember/recall more extensive?
 
 
-# TODO: There's something wrong with the nested testrepo!
-# Fear mongering detected!
 @with_testrepos('submodule_annex')
 @with_tempfile(mkdir=True)
 def test_is_installed(src, path):
@@ -101,7 +99,13 @@ def test_is_installed(src, path):
     # submodule still not installed:
     subds = Dataset(opj(path, 'subm 1'))
     assert_false(subds.is_installed())
-    subds.create()
+    # We must not be able to create a new repository under a known
+    # subdataset path.
+    # Note: Unfortunately we would still be able to generate it under
+    # subdirectory within submodule, e.g. `subm 1/subdir` but that is
+    # not checked here
+    with assert_raises(Exception):
+        subds.create()
     # get the submodule
     # This would init so there is a .git file with symlink info, which is
     # as we agreed is more pain than gain, so let's use our install which would

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -173,6 +173,12 @@ class PathOutsideRepositoryError(Exception):
         return "path {0} not within repository {1}".format(self.file_, self.repo)
 
 
+class PathKnownToRepositoryError(Exception):
+    """Thrown if file/path is under Git control, and attempted operation
+    must not be ran"""
+    pass
+
+
 class MissingBranchError(Exception):
     """Thrown if accessing a repository's branch, that is not available"""
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -70,6 +70,7 @@ from .exceptions import DeprecatedError
 from .exceptions import FileNotInRepositoryError
 from .exceptions import GitIgnoreError
 from .exceptions import MissingBranchError
+from .exceptions import PathKnownToRepositoryError
 from .network import RI, PathRI
 from .network import is_ssh
 from .repo import Flyweight
@@ -738,7 +739,7 @@ class GitRepo(RepoInterface):
                         op.lexists(op.join(path, f))
                         for f in stdout.split(os.linesep)
                     ):
-                    raise RuntimeError(
+                    raise PathKnownToRepositoryError(
                         "Failing to initialize new repository under %s where "
                         "following files are known to a repository above: %s"
                         % (path, stdout)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -727,7 +727,17 @@ class GitRepo(RepoInterface):
                 stdout, _ = self._git_custom_command(
                     None, ['git', 'ls-files'], cwd=path, expect_fail=True
                 )
-                if stdout:
+                # The 2nd check to verify that the files exctually exist is for
+                # the cases of direct-mode:  there ls-files just lists files
+                # in the top tree of the repository instead of the current
+                # directory.  all() check should be removed whenever this
+                # is to be merged into master, where there is no direct mode
+                # support
+                if stdout and \
+                    all(
+                        op.lexists(op.join(path, f))
+                        for f in stdout.split(os.linesep)
+                    ):
                     raise RuntimeError(
                         "Failing to initialize new repository under %s where "
                         "following files are known to a repository above: %s"

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -65,6 +65,7 @@ from datalad.support.gitrepo import guard_BadName
 from datalad.support.exceptions import DeprecatedError
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import FileNotInRepositoryError
+from datalad.support.exceptions import PathKnownToRepositoryError
 from datalad.support.protocol import ExecutionTimeProtocol
 from .utils import check_repo_deals_with_inode_change
 
@@ -154,12 +155,12 @@ def test_init_fail_under_known_subdir(path):
     repo = GitRepo(path, create=True)
     repo.add(op.join('subds', 'file_name'))
     # Should fail even if we do not commit but only add to index:
-    with assert_raises(RuntimeError) as cme:
+    with assert_raises(PathKnownToRepositoryError) as cme:
         GitRepo(op.join(path, 'subds'), create=True)
     assert_in("file_name", str(cme.exception))  # we provide a list of offenders
     # and after we commit - the same story
     repo.commit("added file")
-    with assert_raises(RuntimeError) as cme:
+    with assert_raises(PathKnownToRepositoryError) as cme:
         GitRepo(op.join(path, 'subds'), create=True)
 
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1399,11 +1399,14 @@ def test_custom_runner_protocol(path):
     # Check that a runner with a non-default protocol gets wired up correctly.
     prot = ExecutionTimeProtocol()
     gr = GitRepo(path, runner=Runner(cwd=path, protocol=prot), create=True)
-    eq_(len(prot), 1)
-    ok_(prot[0]['duration'] >= 0)
-    gr.add("foo")
+    # now we run two commands
+    #  1. to check if no known to possible git upstairs files in current path
+    #  2. actually call git init
     eq_(len(prot), 2)
-    assert_in("add", prot[1]["command"])
-    gr.commit("commit foo")
+    gr.add("foo")
     eq_(len(prot), 3)
-    assert_in("commit", prot[2]["command"])
+    assert_in("add", prot[2]["command"])
+    gr.commit("commit foo")
+    eq_(len(prot), 4)
+    assert_in("commit", prot[3]["command"])
+    ok_(all(p['duration'] >= 0 for p in prot))

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -143,6 +143,26 @@ def test_GitRepo_init_options(path):
     ok_(cfg.get_value(section="core", option="bare"))
 
 
+@with_tree(
+    tree={
+        'subds': {
+            'file_name': ''
+        }
+    }
+)
+def test_init_fail_under_known_subdir(path):
+    repo = GitRepo(path, create=True)
+    repo.add(op.join('subds', 'file_name'))
+    # Should fail even if we do not commit but only add to index:
+    with assert_raises(RuntimeError) as cme:
+        GitRepo(op.join(path, 'subds'), create=True)
+    assert_in("file_name", str(cme.exception))  # we provide a list of offenders
+    # and after we commit - the same story
+    repo.commit("added file")
+    with assert_raises(RuntimeError) as cme:
+        GitRepo(op.join(path, 'subds'), create=True)
+
+
 @with_tempfile
 @with_tempfile
 def test_GitRepo_equals(path1, path2):


### PR DESCRIPTION
This pull request should prevent such problematic situations as it was revealed in https://github.com/datalad/datalad/issues/3068#issuecomment-470549719 from occurring. 

This situation was probably also the origin for the situation which inspired https://github.com/datalad/datalad/issues/3139, although in that report I have come up with a minimal use case (empty git subrepo) which might have actually be a different problem.

Merge into master would conflict, and it might (or not) be wiser to just use `get_content_info` which is provided in there instead of a custom call to `ls-files`