### PR TITLE
TST: travis: Widen selector for extension runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,21 +173,27 @@ matrix:
     env:
     - BUILD_DATALAD_EXTENSION=datalad-crawler
     - TESTS_TO_PERFORM=datalad_crawler
-    - NOSE_SELECTION_OP=
+    # Use a selector that will always be true.
+    - NOSE_SELECTION_OP=not
+    - NOSE_SELECTION=
 
   - python: 3.5
     # test with extension datalad-neuroimaging
     env:
     - BUILD_DATALAD_EXTENSION=datalad-neuroimaging
     - TESTS_TO_PERFORM=datalad_neuroimaging
-    - NOSE_SELECTION_OP=
+    # Use a selector that will always be true.
+    - NOSE_SELECTION_OP=not
+    - NOSE_SELECTION=
 
   - python: 3.5
     # test with extension datalad-container
     env:
     - BUILD_DATALAD_EXTENSION=datalad-container
     - TESTS_TO_PERFORM=datalad_container
-    - NOSE_SELECTION_OP=
+    # Use a selector that will always be true.
+    - NOSE_SELECTION_OP=not
+    - NOSE_SELECTION=
 
   - python: 3.5
     # test with extension datalad-revolution
@@ -195,7 +201,9 @@ matrix:
     - BUILD_DATALAD_EXTENSION=datalad-revolution
     - DATALAD_REPO_VERSION=6
     - TESTS_TO_PERFORM=datalad_revolution
-    - NOSE_SELECTION_OP=
+    # Use a selector that will always be true.
+    - NOSE_SELECTION_OP=not
+    - NOSE_SELECTION=
 
   allow_failures:
   # Test under NFS mount  (full, only in master)

--- a/.travis.yml
+++ b/.travis.yml
@@ -263,7 +263,7 @@ before_install:
 
 install:
   # Install standalone build of git-annex for the recent enough version
-  - travis_retry sudo eatmydata apt-get install zip pandoc
+  - travis_retry sudo eatmydata apt-get install zip pandoc p7zip-full
   - travis_retry sudo eatmydata apt-get install shunit2
   # for metadata support
   - travis_retry sudo eatmydata apt-get install exempi

--- a/.travis.yml
+++ b/.travis.yml
@@ -195,15 +195,17 @@ matrix:
     - NOSE_SELECTION_OP=not
     - NOSE_SELECTION=
 
-  - python: 3.5
-    # test with extension datalad-revolution
-    env:
-    - BUILD_DATALAD_EXTENSION=datalad-revolution
-    - DATALAD_REPO_VERSION=6
-    - TESTS_TO_PERFORM=datalad_revolution
-    # Use a selector that will always be true.
-    - NOSE_SELECTION_OP=not
-    - NOSE_SELECTION=
+# Requires current master (0.12.x) so cannot be tested against 0.11.x
+#
+#  - python: 3.5
+#    # test with extension datalad-revolution
+#    env:
+#    - BUILD_DATALAD_EXTENSION=datalad-revolution
+#    - DATALAD_REPO_VERSION=6
+#    - TESTS_TO_PERFORM=datalad_revolution
+#    # Use a selector that will always be true.
+#    - NOSE_SELECTION_OP=not
+#    - NOSE_SELECTION=
 
   allow_failures:
   # Test under NFS mount  (full, only in master)


### PR DESCRIPTION
```
All of the extension runs use 'NOSE_SELECTION_OP=' and
'NOSE_SELECTION="integration or usecase or slow"', restricting the
runs to tests _with_ these attributes.  This presumably wasn't the
intention because it results in very limited runs.  For example, the
crawler run executes only three tests [0].

Adjust NOSE_SELECTION_OP and NOSE_SELECTION for each extension run so
that all tests are executed.

[0]: https://travis-ci.org/datalad/datalad/jobs/503126961
```
