### PR TITLE
Monkey patch nose to avoid need for -s, deprecate ignore_nose_capturing_stdout, make travis output more concise (no -s -v)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -281,7 +281,7 @@ install:
 
 script:
   # Test installation system-wide
-  - sudo pip install .
+  - pip install .
   - if [ ! -z "${BUILD_DATALAD_EXTENSION:-}" ]; then pip install "$BUILD_DATALAD_EXTENSION"; fi
   - mkdir -p __testhome__
   - cd __testhome__

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - DATALAD_TESTS_SSH=1
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=datalad
-    - NOSE_OPTS=-s
+    - NOSE_OPTS=
     - NOSE_SELECTION="integration or usecase or slow"
     - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
     # Special settings/helper for combined coverage from special remotes execution
@@ -289,7 +289,7 @@ script:
   - WRAPT_DISABLE_EXTENSIONS=1 http_proxy=
     PATH=$PWD/../tools/coverage-bin:$PATH
     $NOSE_WRAPPER `which nosetests` $NOSE_OPTS
-      -v -A "$NOSE_SELECTION_OP($NOSE_SELECTION)"
+      -A "$NOSE_SELECTION_OP($NOSE_SELECTION)"
       --with-doctest
       --with-cov --cover-package datalad
       --logging-level=INFO

--- a/.travis.yml
+++ b/.travis.yml
@@ -281,7 +281,7 @@ install:
 
 script:
   # Test installation system-wide
-  - pip install .
+  - sudo pip install .
   - if [ ! -z "${BUILD_DATALAD_EXTENSION:-}" ]; then pip install "$BUILD_DATALAD_EXTENSION"; fi
   - mkdir -p __testhome__
   - cd __testhome__

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -171,6 +171,7 @@ def setup_package():
 
     class StringIO(OrigStringIO):
         fileno = lambda self: 1
+        encoding = None
 
     from nose.ext import dtcompat
     from nose.plugins import capture, multiprocess, plugintest

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -165,6 +165,20 @@ def setup_package():
     # obtain() since that one consults for the default value
     ui.set_backend(cfg.obtain('datalad.tests.ui.backend'))
 
+    # Monkey patch nose so it does not ERROR out whenever code asks for fileno
+    # of the output. See https://github.com/nose-devs/nose/issues/6
+    from six.moves import StringIO as OrigStringIO
+
+    class StringIO(OrigStringIO):
+        fileno = lambda self: 1
+
+    from nose.ext import dtcompat
+    from nose.plugins import capture, multiprocess, plugintest
+    dtcompat.StringIO = StringIO
+    capture.StringIO = StringIO
+    multiprocess.StringIO = StringIO
+    plugintest.StringIO = StringIO
+
 
 def teardown_package():
     import os

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -100,7 +100,8 @@ def _get_output_stream(log_std, false_value):
 
 
 def _cleanup_output(stream, std):
-    if isinstance(stream, file_class) and _MAGICAL_OUTPUT_MARKER in stream.name:
+    if isinstance(stream, file_class) and \
+        _MAGICAL_OUTPUT_MARKER in getattr(stream, 'name', ''):
         if not stream.closed:
             stream.close()
         if op.exists(stream.name):
@@ -332,8 +333,8 @@ class Runner(object):
         """Helper to process output which might have been obtained from popen or
         should be loaded from file"""
         out = binary_type()
-        if isinstance(stream,
-                      file_class) and _MAGICAL_OUTPUT_MARKER in stream.name:
+        if isinstance(stream, file_class) and \
+                _MAGICAL_OUTPUT_MARKER in getattr(stream, 'name', ''):
             assert out_ is None, "should have gone into a file"
             if not stream.closed:
                 stream.close()

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -60,7 +60,6 @@ from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import known_failure_windows
-from datalad.tests.utils import ignore_nose_capturing_stdout
 from datalad.tests.utils import slow
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import OBSCURE_FILENAME
@@ -77,7 +76,6 @@ def test_invalid_call(path):
         assert_status('impossible', run('doesntmatter', on_failure='ignore'))
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -186,7 +184,6 @@ def test_sidecar(path):
 
 
 @slow  # 17.1880s
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -275,7 +272,6 @@ def test_rerun_empty_branch(path):
     assert_status("impossible", ds.rerun(on_failure="ignore"))
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
@@ -348,7 +344,6 @@ def test_rerun_onto(path):
         1, status="error", action="run")
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_chain(path):
@@ -370,7 +365,6 @@ def test_rerun_chain(path):
     assert info["chain"] == commits[:1]
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_old_flag_compatibility(path):
@@ -387,7 +381,6 @@ def test_rerun_old_flag_compatibility(path):
         eq_("xxx\n", open(opj(path, "grows")).read())
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_just_one_commit(path):
@@ -424,7 +417,6 @@ def test_rerun_just_one_commit(path):
                   report=True, return_type="list")
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @known_failure_direct_mode
 @with_tempfile(mkdir=True)
@@ -468,7 +460,6 @@ def test_run_failure(path):
     assert_false(op.exists(msgfile))
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
@@ -521,7 +512,6 @@ def test_rerun_branch(path):
                   ds.rerun, since="prerun", branch="rerun2")
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 @known_failure_direct_mode  #FIXME
@@ -539,7 +529,6 @@ def test_rerun_cherry_pick(path):
         assert_in_results(results, status='ok', rerun_action=action)
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_outofdate_tree(path):
@@ -558,7 +547,6 @@ def test_rerun_outofdate_tree(path):
     assert_raises(CommandError, ds.rerun, revision="HEAD~")
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_ambiguous_revision_file(path):
@@ -571,7 +559,6 @@ def test_rerun_ambiguous_revision_file(path):
         len(ds.repo.repo.git.rev_list("ambig", "--").split()))
 
 
-@ignore_nose_capturing_stdout
 @with_tree(tree={"subdir": {}})
 def test_rerun_subdir(path):
     # Note: Using with_tree rather than with_tempfile is matters. The latter
@@ -661,7 +648,6 @@ def test_new_or_modified(path):
         {"to_modify", "d/to_modify"})
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_script(path):
@@ -701,7 +687,6 @@ def test_rerun_script(path):
 
 
 @slow  # ~10s
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tree(tree={"input.dat": "input",
                  "extra-input.dat": "extra input",
@@ -858,7 +843,6 @@ def test_run_inputs_outputs(src, path):
                         strip=True)
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_run_inputs_no_annex_repo(path):
@@ -870,7 +854,6 @@ def test_run_inputs_no_annex_repo(path):
 
 
 @slow  # ~10s
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_run_explicit(path):
@@ -923,7 +906,6 @@ def test_run_explicit(path):
     ok_(ds.repo.file_has_content(opj("subdir", "foo")))
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c",
                  "subdir": {}})
@@ -984,7 +966,6 @@ def test_placeholders(path):
         assert_in("gpl3", cmout.getvalue())
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tree(tree={OBSCURE_FILENAME + u".t": "obscure",
                  "bar.txt": "b",
@@ -1011,7 +992,6 @@ def test_inputs_quotes_needed(path):
     ok_file_has_content(opj(path, "out0"), "bar.txt foo!blah.txt!out0")
 
 
-@ignore_nose_capturing_stdout
 @known_failure_windows
 @with_tree(tree={"foo": "f", "bar": "b"})
 def test_inject(path):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -48,7 +48,6 @@ from datalad.utils import rmtree
 from datalad.utils import linux_distribution_name
 from datalad.utils import unlink
 
-from datalad.tests.utils import ignore_nose_capturing_stdout
 from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
@@ -109,7 +108,6 @@ from datalad.support.annexrepo import (
 from .utils import check_repo_deals_with_inode_change
 
 
-@ignore_nose_capturing_stdout
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*')
 @with_tempfile
@@ -127,7 +125,6 @@ def test_AnnexRepo_instance_from_clone(src, dst):
             assert("already exists" in cm.out)
 
 
-@ignore_nose_capturing_stdout
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 def test_AnnexRepo_instance_from_existing(path):
@@ -137,7 +134,6 @@ def test_AnnexRepo_instance_from_existing(path):
     ok_(os.path.exists(os.path.join(path, '.git')))
 
 
-@ignore_nose_capturing_stdout
 @assert_cwd_unchanged
 @with_tempfile
 def test_AnnexRepo_instance_brand_new(path):
@@ -930,7 +926,6 @@ def test_AnnexRepo_add_unexpected_direct_mode(path):
 
 
 
-@ignore_nose_capturing_stdout
 @with_testrepos('.*annex.*', flavors=['local'])
 # TODO: flavor 'network' has wrong content for test-annex.dat!
 @with_tempfile

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -29,7 +29,6 @@ from .utils import (
     skip_if_on_windows,
     with_tempfile,
     assert_cwd_unchanged,
-    ignore_nose_capturing_stdout,
     swallow_outputs,
     swallow_logs,
     ok_file_has_content,
@@ -45,7 +44,6 @@ from ..support.exceptions import CommandError
 from ..support.protocol import DryRunProtocol
 
 
-@ignore_nose_capturing_stdout
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner_dry(tempfile):
@@ -71,7 +69,6 @@ def test_runner_dry(tempfile):
     assert_equal("args=('foo', 'bar')", dry[1]['command'][1])
 
 
-@ignore_nose_capturing_stdout
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner(tempfile):
@@ -113,7 +110,6 @@ def test_runner(tempfile):
                  "Call of: os.path.join, 'foo', 'bar' returned %s" % output)
 
 
-@ignore_nose_capturing_stdout
 def test_runner_instance_callable_dry():
 
     cmd_ = ['echo', 'Testing', '__call__', 'with', 'string']
@@ -138,7 +134,6 @@ def test_runner_instance_callable_dry():
                  "Buffer: %s" % dry)
 
 
-@ignore_nose_capturing_stdout
 def test_runner_instance_callable_wet():
 
     runner = Runner()
@@ -152,7 +147,6 @@ def test_runner_instance_callable_wet():
     eq_(ret, os.path.join('foo', 'bar'))
 
 
-@ignore_nose_capturing_stdout
 def test_runner_log_stderr():
 
     runner = Runner(log_outputs=True)
@@ -178,7 +172,6 @@ def test_runner_log_stderr():
                           "stderr| stderr-Message should not be logged")
 
 
-@ignore_nose_capturing_stdout
 def test_runner_log_stdout():
     # TODO: no idea of how to check correct logging via any kind of
     # assertion yet.
@@ -210,7 +203,6 @@ def test_runner_log_stdout():
             eq_(cml.out, "")
 
 
-@ignore_nose_capturing_stdout
 def check_runner_heavy_output(log_online):
     # TODO: again, no automatic detection of this resulting in being
     # stucked yet.

--- a/datalad/tests/test_installed.py
+++ b/datalad/tests/test_installed.py
@@ -10,8 +10,7 @@
 """
 
 from mock import patch
-from .utils import ok_startswith, eq_, \
-    ignore_nose_capturing_stdout, assert_cwd_unchanged
+from .utils import ok_startswith, eq_, assert_cwd_unchanged
 
 from datalad.cmd import Runner
 from datalad.support.exceptions import CommandError
@@ -27,7 +26,6 @@ def check_run_and_get_output(cmd):
                              "Exited with %d and output %s" % (e.code, (e.stdout, e.stderr)))
     return output
 
-@ignore_nose_capturing_stdout
 @assert_cwd_unchanged
 def test_run_datalad_help():
     out, err = check_run_and_get_output("datalad --help")

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -640,7 +640,7 @@ def test_ignore_nose_capturing_stdout():
     def raise_exc():
         raise AttributeError('nose causes a message which includes words '
                              'StringIO and fileno')
-    with assert_raises(SkipTest):
+    with assert_raises(AttributeError):
         ignore_nose_capturing_stdout(raise_exc)()
 
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1322,27 +1322,22 @@ def assert_result_values_cond(results, prop, cond):
 
 
 def ignore_nose_capturing_stdout(func):
-    """Decorator workaround for nose's behaviour with redirecting sys.stdout
+    """DEPRECATED and will be removed soon.  Does nothing!
 
-    Needed for tests involving the runner and nose redirecting stdout.
-    Counter-intuitively, that means it needed for nosetests without '-s'.
+    Originally was intended as a decorator workaround for nose's behaviour
+    with redirecting sys.stdout, but now we monkey patch nose now so no test
+    should no longer be skipped.
+
     See issue reported here:
     https://code.google.com/p/python-nose/issues/detail?id=243&can=1&sort=-id&colspec=ID%20Type%20Status%20Priority%20Stars%20Milestone%20Owner%20Summary
-    """
 
-    @make_decorator(func)
-    def newfunc(*args, **kwargs):
-        import io
-        try:
-            func(*args, **kwargs)
-        except (AttributeError, io.UnsupportedOperation) as e:
-            # Use args instead of .message which is PY2 specific
-            message = e.args[0] if e.args else ""
-            if re.search('^(.*StringIO.*)?fileno', message):
-                raise SkipTest("Triggered nose defect in masking out real stdout")
-            else:
-                raise
-    return newfunc
+    """
+    lgr.warning(
+        "@ignore_nose_capturing_stdout no longer does anything - nose should "
+        "just be monkey patched in setup_package. {} still has it"
+        .format(func.__name__)
+    )
+    return func
 
 
 def skip_httpretty_on_problematic_pythons(func):


### PR DESCRIPTION
Closes #3213 