### PR TITLE
BF: Fix PWD to match provided cwd in Runner

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -450,7 +450,7 @@ class Runner(object):
         popen_env = env or self.env
         popen_cwd = cwd or self.cwd
 
-        if popen_cwd and popen_env and 'PWD' in popen_env and not shell:
+        if popen_cwd and popen_env and 'PWD' in popen_env:
             # we must have inherited PWD, but cwd was provided, so we must
             # adjust it
             popen_env = popen_env.copy()  # to avoid side-effects

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -448,6 +448,13 @@ class Runner(object):
         errstream = _get_output_stream(log_stderr, sys.stderr)
 
         popen_env = env or self.env
+        popen_cwd = cwd or self.cwd
+
+        if popen_cwd and popen_env and 'PWD' in popen_env:
+            # we must have inherited PWD, but cwd was provided, so we must
+            # adjust it
+            popen_env = popen_env.copy()  # to avoid side-effects
+            popen_env['PWD'] = popen_cwd
 
         # TODO: if outputstream is sys.stdout and that one is set to StringIO
         #       we have to "shim" it with something providing fileno().
@@ -461,7 +468,7 @@ class Runner(object):
         log_args = [cmd]
         if self.log_cwd:
             log_msgs += ['cwd=%r']
-            log_args += [cwd or self.cwd]
+            log_args += [popen_cwd]
         if self.log_stdin:
             log_msgs += ['stdin=%r']
             log_args += [stdin]
@@ -491,7 +498,7 @@ class Runner(object):
                                         stdout=outputstream,
                                         stderr=errstream,
                                         shell=shell,
-                                        cwd=cwd or self.cwd,
+                                        cwd=popen_cwd,
                                         env=popen_env,
                                         stdin=stdin)
 
@@ -535,7 +542,7 @@ class Runner(object):
 
                 if status not in [0, None]:
                     msg = "Failed to run %r%s. Exit code=%d.%s%s" \
-                        % (cmd, " under %r" % (cwd or self.cwd), status,
+                        % (cmd, " under %r" % (popen_cwd), status,
                            "" if log_online else " out=%s" % out[0],
                            "" if log_online else " err=%s" % out[1])
                     lgr.log(9 if expect_fail else 11, msg)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -450,7 +450,7 @@ class Runner(object):
         popen_env = env or self.env
         popen_cwd = cwd or self.cwd
 
-        if popen_cwd and popen_env and 'PWD' in popen_env:
+        if popen_cwd and popen_env and 'PWD' in popen_env and not shell:
             # we must have inherited PWD, but cwd was provided, so we must
             # adjust it
             popen_env = popen_env.copy()  # to avoid side-effects

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -291,7 +291,11 @@ def test_runner_fix_PWD(path):
     env = os.environ.copy()
     env['PWD'] = orig_cwd = os.getcwd()
     runner = Runner(cwd=path, env=env)
-    out, err = runner.run(u"echo $PWD", cwd=path)
+    out, err = runner.run(
+        [sys.executable, '-c', 'import os; print(os.environ["PWD"])'],
+        cwd=path,
+        shell=False
+    )
     eq_(err, '')
     eq_(out.rstrip(os.linesep), path)  # was fixed up to point to point to cwd's path
     eq_(env['PWD'], orig_cwd)  # no side-effect

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -285,6 +285,18 @@ def test_runner_failure_unicode(path):
         runner.run(u"β-command-doesnt-exist", cwd=path)
 
 
+@skip_if_on_windows  # likely would fail
+@with_tempfile(mkdir=True)
+def test_runner_fix_PWD(path):
+    env = os.environ.copy()
+    env['PWD'] = orig_cwd = os.getcwd()
+    runner = Runner(cwd=path, env=env)
+    out, err = runner.run(u"echo $PWD", cwd=path)
+    eq_(err, '')
+    eq_(out.rstrip(os.linesep), path)  # was fixed up to point to point to cwd's path
+    eq_(env['PWD'], orig_cwd)  # no side-effect
+
+
 @with_tempfile(mkdir=True)
 def test_git_path(dir_):
     from ..support.gitrepo import GitRepo


### PR DESCRIPTION
We do take care about tuning up PWD while chdir etc.  But when we run
external process and set its cwd, we left PWD unchanged if was provided
in (likely) inherited and tuned environment.  This fix would change
PWD to match provided cwd, if it is known to the environment and cwd
is set.

I was not bold enough to always get an env (if not provided) and change it
there, but may be that is what we will need to end up doing at some
point.

This should resolve the failing test in
https://github.com/datalad/datalad/pull/3184
caused by underlying datalad process, which is started from a temp directory
while we provide it with a now non-matching PWD:
https://travis-ci.org/datalad/datalad/jobs/501525590#L4325
