### PR TITLE
TST: travis: Uncomment widened revolution tests on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,17 +188,15 @@ matrix:
     - NOSE_SELECTION_OP=not
     - NOSE_SELECTION=
 
-# Requires current master (0.12.x) so cannot be tested against 0.11.x
-#
-#  - python: 3.5
-#    # test with extension datalad-revolution
-#    env:
-#    - BUILD_DATALAD_EXTENSION=datalad-revolution
-#    - DATALAD_REPO_VERSION=6
-#    - TESTS_TO_PERFORM=datalad_revolution
-#    # Use a selector that will always be true.
-#    - NOSE_SELECTION_OP=not
-#    - NOSE_SELECTION=
+  - python: 3.5
+    # test with extension datalad-revolution
+    env:
+    - BUILD_DATALAD_EXTENSION=datalad-revolution
+    - DATALAD_REPO_VERSION=6
+    - TESTS_TO_PERFORM=datalad_revolution
+    # Use a selector that will always be true.
+    - NOSE_SELECTION_OP=not
+    - NOSE_SELECTION=
 
   allow_failures:
   # Test under NFS mount  (full, only in master)


### PR DESCRIPTION
a02e6da88 (TST: travis: Widen selector for extension runs, 2019-03-08)
fixed the nose selectors for the extension runs.  This included the
-revolution run, which was running only a small subset of the tests.
62164a3a7 disables the -revolution run entirely on the 0.11.x branch,
though, because -revolution requires 0.12.x.  Re-enable the
-revolution run on master.