### PR TITLE
ENH: provide a "switch" to disable custom checks at GitRepo level while creating a new one

### DIFF
--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -108,10 +108,8 @@ def test_is_installed(src, path):
     # subdirectory within submodule, e.g. `subm 1/subdir` but that is
     # not checked here. `rev-create` will provide that protection
     # when create/rev-create merge.
-    # Unfortunately such protection does not work in direct mode
-    if not ds.repo.is_direct_mode():
-        with assert_raises(PathKnownToRepositoryError):
-            subds.create()
+    with assert_raises(PathKnownToRepositoryError):
+        subds.create()
     # get the submodule
     # This would init so there is a .git file with symlink info, which is
     # as we agreed is more pain than gain, so let's use our install which would

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -736,7 +736,9 @@ class GitRepo(RepoInterface):
         self.pathobj = ut.Path(self.path)
 
     def _create_empty_repo(self, path, **kwargs):
-        if op.lexists(path):
+        if not op.lexists(path):
+            os.makedirs(path)
+        else:
             # Verify that we are not trying to initialize a new git repository
             # under a directory some files of which are already tracked by git
             # use case: https://github.com/datalad/datalad/issues/3068
@@ -753,8 +755,6 @@ class GitRepo(RepoInterface):
             except CommandError:
                 # assume that all is good -- we are not under any repo
                 pass
-        else:
-            os.makedirs(path)
 
         cmd = ['git', 'init']
         cmd.extend(kwargs.pop('_from_cmdline_', []))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -744,17 +744,7 @@ class GitRepo(RepoInterface):
                 stdout, _ = self._git_custom_command(
                     None, ['git', 'ls-files'], cwd=path, expect_fail=True
                 )
-                # The 2nd check to verify that the files exctually exist is for
-                # the cases of direct-mode:  there ls-files just lists files
-                # in the top tree of the repository instead of the current
-                # directory.  all() check should be removed whenever this
-                # is to be merged into master, where there is no direct mode
-                # support
-                if stdout and \
-                    all(
-                        op.lexists(op.join(path, f))
-                        for f in stdout.split(os.linesep)
-                    ):
+                if stdout:
                     raise PathKnownToRepositoryError(
                         "Failing to initialize new repository under %s where "
                         "following files are known to a repository above: %s"

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -163,6 +163,9 @@ def test_init_fail_under_known_subdir(path):
     with assert_raises(PathKnownToRepositoryError) as cme:
         GitRepo(op.join(path, 'subds'), create=True)
 
+    # But it would succeed if we disable the checks
+    GitRepo(op.join(path, 'subds'), create=True, create_sanity_checks=False)
+
 
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
- By popular demand of our revolutionists. 
- Of no use ATM in the master itself
- Sits on top of #3218 

Feel welcome to tune naming of the "switch" to your liking. 