### PR TITLE
BF: specify correctly dependency on pylibzma as prior python 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,14 +57,6 @@ on_windows = platform_system == 'windows'
 if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
     keyring_requires = ['keyring<8.0']
 
-# lzma is included in python since 3.3
-# We now support backports.lzma as well (besides AutomagicIO), but since
-# there is not way to define an alternative here (AFAIK, yoh), we will
-# use pyliblzma as the default for now.  Patch were you would prefer
-# backports.lzma instead
-req_lzma = ['pyliblzma'] if sys.version_info < (3, 3) else []
-
-
 requires = {
     'core': [
         'appdirs',
@@ -104,12 +96,18 @@ requires = {
         'vcrpy',
     ],
     'metadata': [
+        # lzma is included in python since 3.3
+        # We now support backports.lzma as well (besides AutomagicIO), but since
+        # there is not way to define an alternative here (AFAIK, yoh), we will
+        # use pyliblzma as the default for now.  Patch were you would prefer
+        # backports.lzma instead
+        'pyliblzma; python_version < "3.3"',
         # was added in https://github.com/datalad/datalad/pull/1995 without
         # due investigation, should not be needed until we add duecredit support
         # 'duecredit',
         'simplejson',
         'whoosh',
-    ] + req_lzma,
+    ],
     'metadata-extra': [
         'PyYAML',  # very optional
         'mutagen>=1.36',  # audio metadata


### PR DESCRIPTION
0.12.0rc1 was sdist uploaded while building package using python3. That
caused pyliblzma not being listed altogether as dependency, and thus no
longer autoinstalled.  The reason was this ad-hoc specification.  It might
have been done by me this way because of elderly Debians but it is just not
right in the Python world, so we need to have it fixed.