### PR TITLE
ENH: search: Avoid showing an empty log message

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -1261,4 +1261,4 @@ class Search(Interface):
             nhits += 1
             yield r
         if not nhits:
-            lgr.info(searcher.get_nohits_msg() or '')
+            lgr.info(searcher.get_nohits_msg() or 'no hits')


### PR DESCRIPTION
If get_nohits_msg() doesn't return a message, report a generic "no
hits" so that the caller isn't left wondering what the blank message is
about.

Fixes #3195.