### PR TITLE
ENH: run: Add 'tmpdir' placeholder

### DIFF
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -526,11 +526,12 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         exc = None
 
     try:
-        cmd_expanded = format_command(ds, cmd,
-                                      pwd=pwd,
-                                      dspath=ds.path,
-                                      inputs=inputs,
-                                      outputs=outputs)
+        cmd_expanded = format_command(
+            ds, cmd,
+            pwd=pwd,
+            dspath=ds.path,
+            inputs=inputs,
+            outputs=outputs)
     except KeyError as exc:
         yield get_status_dict(
             'run',

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -19,6 +19,7 @@ import os.path as op
 from os.path import join as opj
 from os.path import normpath
 from os.path import relpath
+from tempfile import mkdtemp
 
 from six.moves import map
 from six.moves import shlex_quote
@@ -82,7 +83,8 @@ class Run(Interface):
     A few placeholders are supported in the command via Python format
     specification. "{pwd}" will be replaced with the full path of the current
     working directory. "{dspath}" will be replaced with the full path of the
-    dataset that run is invoked on. "{inputs}" and "{outputs}" represent the
+    dataset that run is invoked on. "{tmpdir}" will be replaced with the full
+    path of a temporary directory. "{inputs}" and "{outputs}" represent the
     values specified by [CMD: --input and --output CMD][PY: `inputs` and
     `outputs` PY]. If multiple values are specified, the values will be joined
     by a space. The order of the values will match that order from the command
@@ -530,6 +532,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             ds, cmd,
             pwd=pwd,
             dspath=ds.path,
+            # Check if the command contains "{tmpdir}" to avoid creating an
+            # unnecessary temporary directory in most but not all cases.
+            tmpdir=mkdtemp(prefix="datalad-run-") if "{tmpdir}" in cmd else "",
             inputs=inputs,
             outputs=outputs)
     except KeyError as exc:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -979,6 +979,9 @@ def test_placeholders(path):
         ds.rerun(script="-")
         assert_in("gpl3", cmout.getvalue())
 
+    ds.run("echo {tmpdir} >tout")
+    ok_file_has_content(op.join(path, "tout"), ".*datalad-run.*", re_=True)
+
 
 @known_failure_windows
 @with_tree(tree={OBSCURE_FILENAME + u".t": "obscure",


### PR DESCRIPTION
For some commands, it is useful to have a temporary directory.  For
example, one can be used as the source component of a Singularity or
Docker mount point.  Expose a temporary directory with the '{tmpdir}'
placeholder so that users do not need to embed $(mktemp -d) within the
command or write a command wrapper.

Re: datalad/datalad-container#50

---

As I was writing the commit message, I thought "actually, using $(mktemp -d) isn't that bad" (ignoring portability issues).  I could take or leave this PR at this point.
