### PR TITLE
Absorb most  of -revolution's commands

### DIFF
--- a/datalad/core/__init__.py
+++ b/datalad/core/__init__.py
@@ -1,0 +1,22 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Minimal set of commands that serve as the foundation for others.
+
+These receive special scrutiny with regard API composition and changes.
+
+**NOTE**
+
+Actually, the above isn't true at the moment. But that is the plan:
+<https://github.com/datalad/datalad/issues/3192>
+
+Currently new modules that are making their way over from the
+datalad-revolution are following this scheme.
+"""
+
+__docformat__ = 'restructuredtext'

--- a/datalad/core/local/__init__.py
+++ b/datalad/core/local/__init__.py
@@ -1,0 +1,20 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Essential commands for working with a single local dataset(-hierarchy)
+
+**NOTE**
+
+Actually, the above isn't true at the moment. But that is the plan:
+<https://github.com/datalad/datalad/issues/3192>
+
+Currently new modules that are making their way over from the
+datalad-revolution are following this scheme.
+"""
+
+__docformat__ = 'restructuredtext'

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -287,6 +287,7 @@ class Create(Interface):
                 tbds.path,
                 url=None,
                 create=True,
+                create_sanity_checks=False,
                 git_opts=initopts,
                 fake_dates=fake_dates)
             # place a .noannex file to indicate annex to leave this repo alone
@@ -302,6 +303,7 @@ class Create(Interface):
                 tbds.path,
                 url=None,
                 create=True,
+                create_sanity_checks=False,
                 # do not set backend here, to avoid a dedicated commit
                 backend=None,
                 # None causes version to be taken from config

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -1,0 +1,421 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""High-level interface for dataset creation
+
+"""
+
+import os
+import logging
+import random
+import uuid
+from six import iteritems
+from argparse import REMAINDER
+
+from os import listdir
+import os.path as op
+
+from datalad import cfg
+from datalad import _seed
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.interface.common_opts import (
+    location_description,
+)
+from datalad.interface.results import ResultXFM
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureNone,
+    EnsureKeyChoice,
+)
+from datalad.support.param import Parameter
+from datalad.utils import getpwd
+
+from datalad.distribution.dataset import (
+    Dataset,
+    datasetmethod,
+    EnsureDataset,
+    rev_get_dataset_root,
+    rev_resolve_path,
+    path_under_rev_dataset,
+    require_dataset,
+)
+
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
+import datalad.utils as ut
+
+
+__docformat__ = 'restructuredtext'
+
+lgr = logging.getLogger('datalad.core.local.create')
+
+
+@build_doc
+class Create(Interface):
+    """Create a new dataset from scratch.
+
+    This command initializes a new dataset at a given location, or the
+    current directory. The new dataset can optionally be registered in an
+    existing superdataset (the new dataset's path needs to be located
+    within the superdataset for that, and the superdataset needs to be given
+    explicitly via [PY: `dataset` PY][CMD: --dataset CMD]). It is recommended
+    to provide a brief description to label the dataset's nature *and*
+    location, e.g. "Michael's music on black laptop". This helps humans to
+    identify data locations in distributed scenarios.  By default an identifier
+    comprised of user and machine name, plus path will be generated.
+
+    This command only creates a new dataset, it does not add existing content
+    to it, even if the target directory already contains additional files or
+    directories.
+
+    Plain Git repositories can be created via the [PY: `no_annex` PY][CMD: --no-annex CMD] flag.
+    However, the result will not be a full dataset, and, consequently,
+    not all features are supported (e.g. a description).
+
+    || REFLOW >>
+    To create a local version of a remote dataset use the
+    :func:`~datalad.api.install` command instead.
+    << REFLOW ||
+
+    .. note::
+      Power-user info: This command uses :command:`git init` and
+      :command:`git annex init` to prepare the new dataset. Registering to a
+      superdataset is performed via a :command:`git submodule add` operation
+      in the discovered superdataset.
+    """
+
+    # in general this command will yield exactly one result
+    return_type = 'item-or-list'
+    # in general users expect to get an instance of the created dataset
+    result_xfm = 'datasets'
+    # result filter
+    result_filter = \
+        EnsureKeyChoice('action', ('create',)) & \
+        EnsureKeyChoice('status', ('ok', 'notneeded'))
+
+    _params_ = dict(
+        path=Parameter(
+            args=("path",),
+            nargs='?',
+            metavar='PATH',
+            doc="""path where the dataset shall be created, directories
+            will be created as necessary. If no location is provided, a dataset
+            will be created in the current working directory. Either way the
+            command will error if the target directory is not empty.
+            Use `force` to create a dataset in a non-empty directory.""",
+            # put dataset 2nd to avoid useless conversion
+            constraints=EnsureStr() | EnsureDataset() | EnsureNone()),
+        initopts=Parameter(
+            args=("initopts",),
+            metavar='INIT OPTIONS',
+            nargs=REMAINDER,
+            doc="""options to pass to :command:`git init`. [PY: Options can be
+            given as a list of command line arguments or as a GitPython-style
+            option dictionary PY][CMD: Any argument specified after the
+            destination path of the repository will be passed to git-init
+            as-is CMD]. Note that not all options will lead to viable results.
+            For example '--bare' will not yield a repository where DataLad
+            can adjust files in its worktree."""),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            metavar='DATASET',
+            doc="""specify the dataset to perform the create operation on. If
+            a dataset is given, a new subdataset will be created in it.""",
+            constraints=EnsureDataset() | EnsureNone()),
+        force=Parameter(
+            args=("-f", "--force",),
+            doc="""enforce creation of a dataset in a non-empty directory""",
+            action='store_true'),
+        description=location_description,
+        no_annex=Parameter(
+            args=("--no-annex",),
+            doc="""if set, a plain Git repository will be created without any
+            annex""",
+            action='store_true'),
+        # TODO seems to only cause a config flag to be set, this could be done
+        # in a procedure
+        fake_dates=Parameter(
+            args=('--fake-dates',),
+            action='store_true',
+            doc="""Configure the repository to use fake dates. The date for a
+            new commit will be set to one second later than the latest commit
+            in the repository. This can be used to anonymize dates."""),
+    )
+
+    @staticmethod
+    @datasetmethod(name='rev_create')
+    @eval_results
+    def __call__(
+            path=None,
+            initopts=None,
+            force=False,
+            description=None,
+            dataset=None,
+            no_annex=False,
+            fake_dates=False
+    ):
+        refds_path = dataset.path if hasattr(dataset, 'path') else dataset
+
+        # two major cases
+        # 1. we got a `dataset` -> we either want to create it (path is None),
+        #    or another dataset in it (path is not None)
+        # 2. we got no dataset -> we want to create a fresh dataset at the
+        #    desired location, either at `path` or PWD
+
+        # sanity check first
+        if no_annex:
+            if description:
+                raise ValueError("Incompatible arguments: cannot specify "
+                                 "description for annex repo and declaring "
+                                 "no annex repo.")
+
+        if path:
+            path = rev_resolve_path(path, dataset)
+
+        path = path if path \
+            else getpwd() if dataset is None \
+            else refds_path
+
+        # we know that we need to create a dataset at `path`
+        assert(path is not None)
+
+        # prep for yield
+        res = dict(action='create', path=str(path), logger=lgr, type='dataset',
+                   refds=refds_path)
+
+        refds = None
+        if refds_path and refds_path != path:
+            refds = require_dataset(
+                refds_path, check_installed=True,
+                purpose='creating a subdataset')
+
+            path_inrefds = path_under_rev_dataset(refds, path)
+            if path_inrefds is None:
+                yield dict(
+                    res,
+                    status='error',
+                    message=(
+                        "dataset containing given paths is not underneath "
+                        "the reference dataset %s: %s",
+                        dataset, str(path)),
+                )
+                return
+
+        # try to locate an immediate parent dataset
+        # we want to know this (irrespective of whether we plan on adding
+        # this new dataset to a parent) in order to avoid conflicts with
+        # a potentially absent/uninstalled subdataset of the parent
+        # in this location
+        # it will cost some filesystem traversal though...
+        parentds_path = rev_get_dataset_root(
+            op.normpath(op.join(str(path), os.pardir)))
+        if parentds_path:
+            prepo = GitRepo(parentds_path)
+            parentds_path = ut.Path(parentds_path)
+            # we cannot get away with a simple
+            # GitRepo.get_content_info(), as we need to detect
+            # uninstalled/added subdatasets too
+            check_path = ut.Path(path)
+            pstatus = prepo.status(untracked='no')
+            if any(
+                    check_path == p or check_path in p.parents
+                    for p in pstatus):
+                # redo the check in a slower fashion, it is already broken
+                # let's take our time for a proper error message
+                conflict = [
+                    p for p in pstatus
+                    if check_path == p or check_path in p.parents]
+                res.update({
+                    'status': 'error',
+                    'message': (
+                        'collision with content in parent dataset at %s: %s',
+                        str(parentds_path),
+                        [str(c) for c in conflict])})
+                yield res
+                return
+            # another set of check to see whether the target path is pointing
+            # into a known subdataset that is not around ATM
+            subds_status = {
+                parentds_path / k.relative_to(prepo.path)
+                for k, v in iteritems(pstatus)
+                if v.get('type', None) == 'dataset'}
+            check_paths = [check_path]
+            check_paths.extend(check_path.parents)
+            if any(p in subds_status for p in check_paths):
+                conflict = [p for p in check_paths if p in subds_status]
+                res.update({
+                    'status': 'error',
+                    'message': (
+                        'collision with %s (dataset) in dataset %s',
+                        str(conflict[0]),
+                        str(parentds_path))})
+                yield res
+                return
+
+        # important to use the given Dataset object to avoid spurious ID
+        # changes with not-yet-materialized Datasets
+        tbds = dataset if isinstance(dataset, Dataset) and \
+            dataset.path == path else Dataset(str(path))
+
+        # don't create in non-empty directory without `force`:
+        if op.isdir(tbds.path) and listdir(tbds.path) != [] and not force:
+            res.update({
+                'status': 'error',
+                'message':
+                    'will not create a dataset in a non-empty directory, use '
+                    '`force` option to ignore'})
+            yield res
+            return
+
+        # stuff that we create and want to have tracked with git (not annex)
+        add_to_git = {}
+
+        if initopts is not None and isinstance(initopts, list):
+            initopts = {'_from_cmdline_': initopts}
+
+        # create and configure desired repository
+        if no_annex:
+            lgr.info("Creating a new git repo at %s", tbds.path)
+            tbrepo = GitRepo(
+                tbds.path,
+                url=None,
+                create=True,
+                git_opts=initopts,
+                fake_dates=fake_dates)
+            # place a .noannex file to indicate annex to leave this repo alone
+            stamp_path = ut.Path(tbrepo.path) / '.noannex'
+            stamp_path.touch()
+            add_to_git[stamp_path] = {
+                'type': 'file',
+                'state': 'untracked'}
+        else:
+            # always come with annex when created from scratch
+            lgr.info("Creating a new annex repo at %s", tbds.path)
+            tbrepo = AnnexRepo(
+                tbds.path,
+                url=None,
+                create=True,
+                # do not set backend here, to avoid a dedicated commit
+                backend=None,
+                # None causes version to be taken from config
+                version=None,
+                description=description,
+                git_opts=initopts,
+                fake_dates=fake_dates
+            )
+            # set the annex backend in .gitattributes as a staged change
+            tbrepo.set_default_backend(
+                cfg.obtain('datalad.repo.backend', default='MD5E'),
+                persistent=True, commit=False)
+            add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
+                'type': 'file',
+                'state': 'added'}
+            # make sure that v6 annex repos never commit content under .datalad
+            attrs_cfg = (
+                ('config', 'annex.largefiles', 'nothing'),
+                ('metadata/aggregate*', 'annex.largefiles', 'nothing'),
+                ('metadata/objects/**', 'annex.largefiles',
+                 '({})'.format(cfg.obtain(
+                     'datalad.metadata.create-aggregate-annex-limit'))))
+            attrs = tbds.repo.get_gitattributes(
+                [op.join('.datalad', i[0]) for i in attrs_cfg])
+            set_attrs = []
+            for p, k, v in attrs_cfg:
+                if not attrs.get(
+                        op.join('.datalad', p), {}).get(k, None) == v:
+                    set_attrs.append((p, {k: v}))
+            if set_attrs:
+                tbds.repo.set_gitattributes(
+                    set_attrs,
+                    attrfile=op.join('.datalad', '.gitattributes'))
+
+            # prevent git annex from ever annexing .git* stuff (gh-1597)
+            attrs = tbds.repo.get_gitattributes('.git')
+            if not attrs.get('.git', {}).get(
+                    'annex.largefiles', None) == 'nothing':
+                tbds.repo.set_gitattributes([
+                    ('**/.git*', {'annex.largefiles': 'nothing'})])
+                # must use the repo.pathobj as this will have resolved symlinks
+                add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
+                    'type': 'file',
+                    'state': 'untracked'}
+
+        # record an ID for this repo for the afterlife
+        # to be able to track siblings and children
+        id_var = 'datalad.dataset.id'
+        if id_var in tbds.config:
+            # make sure we reset this variable completely, in case of a
+            # re-create
+            tbds.config.unset(id_var, where='dataset')
+
+        if _seed is None:
+            # just the standard way
+            uuid_id = uuid.uuid1().urn.split(':')[-1]
+        else:
+            # Let's generate preseeded ones
+            uuid_id = str(uuid.UUID(int=random.getrandbits(128)))
+        tbds.config.add(
+            id_var,
+            tbds.id if tbds.id is not None else uuid_id,
+            where='dataset',
+            reload=False)
+
+        # make config overrides permanent in the repo config
+        # this is similar to what `annex init` does
+        # we are only doing this for config overrides and do not expose
+        # a dedicated argument, because it is sufficient for the cmdline
+        # and unnecessary for the Python API (there could simply be a
+        # subsequence ds.config.add() call)
+        for k, v in iteritems(tbds.config.overrides):
+            tbds.config.add(k, v, where='local', reload=False)
+
+        # all config manipulation is done -> fll reload
+        tbds.config.reload()
+
+        # must use the repo.pathobj as this will have resolved symlinks
+        add_to_git[tbds.repo.pathobj / '.datalad'] = {
+            'type': 'directory',
+            'state': 'untracked'}
+
+        # save everything, we need to do this now and cannot merge with the
+        # call below, because we may need to add this subdataset to a parent
+        # but cannot until we have a first commit
+        tbds.repo.save(
+            message='[DATALAD] new dataset',
+            git=True,
+            # we have to supply our own custom status, as the repo does
+            # not have a single commit yet and the is no HEAD reference
+            # TODO make `GitRepo.status()` robust to this state.
+            _status=add_to_git,
+        )
+
+        # the next only makes sense if we saved the created dataset,
+        # otherwise we have no committed state to be registered
+        # in the parent
+        if isinstance(dataset, Dataset) and dataset.path != tbds.path:
+            # we created a dataset in another dataset
+            # -> make submodule
+            for r in dataset.rev_save(
+                    path=tbds.path,
+            ):
+                yield r
+
+        res.update({'status': 'ok'})
+        yield res
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):  # pragma: no cover
+        from datalad.ui import ui
+        if res.get('action', None) == 'create' and \
+                res.get('status', None) == 'ok' and \
+                res.get('type', None) == 'dataset':
+            ui.message("Created dataset at {}.".format(res['path']))
+        else:
+            ui.message("Nothing was created")

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -1,0 +1,66 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Thin wrapper around `run` from DataLad core"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+
+# take everything from run, all we want to be is a thin variant
+from datalad.interface.run import (
+    Run as _Run,
+    run_command,
+    build_doc,
+    eval_results,
+)
+from datalad.distribution.dataset import (
+    Dataset,
+    datasetmethod,
+)
+from .save import Save
+
+lgr = logging.getLogger('datalad.core.local.run')
+
+
+def _save_outputs(ds, to_save, msg):
+    """Helper to save results after command execution is completed"""
+    return Save.__call__(
+        to_save,
+        message=msg,
+        # need to convert any incoming dataset into a revolutionary one
+        dataset=Dataset(ds.path),
+        recursive=True,
+        return_type='generator')
+
+
+@build_doc
+class Run(_Run):
+    __doc__ = _Run.__doc__
+
+    @staticmethod
+    @datasetmethod(name='rev_run')
+    @eval_results
+    def __call__(
+            cmd=None,
+            dataset=None,
+            inputs=None,
+            outputs=None,
+            expand=None,
+            explicit=False,
+            message=None,
+            sidecar=None):
+        for r in run_command(cmd, dataset=dataset,
+                             inputs=inputs, outputs=outputs,
+                             expand=expand,
+                             explicit=explicit,
+                             message=message,
+                             sidecar=sidecar,
+                             saver=_save_outputs):
+            yield r

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -1,0 +1,305 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Interface to add content, and save modifications to a dataset
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from six import iteritems
+
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.common_opts import (
+    recursion_limit,
+    recursion_flag,
+    save_message_opt,
+)
+from datalad.interface.utils import (
+    eval_results,
+    get_tree_roots,
+    discover_dataset_trace_to_targets,
+)
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureNone,
+)
+from datalad.support.exceptions import CommandError
+from datalad.utils import (
+    assure_list,
+)
+import datalad.utils as ut
+
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from .status import (
+    Status,
+)
+
+lgr = logging.getLogger('datalad.core.local.save')
+
+
+@build_doc
+class Save(Interface):
+    """Save the current state of a dataset
+
+    Saving the state of a dataset records changes that have been made to it.
+    This change record is annotated with a user-provided description.
+    Optionally, an additional tag, such as a version, can be assigned to the
+    saved state. Such tag enables straightforward retrieval of past versions at
+    a later point in time.
+
+    Examples:
+
+      Save any content underneath the current directory, without altering
+      any potential subdataset (use --recursive for that)::
+
+        % datalad save .
+
+      Save any modification of known dataset content, but leave untracked
+      files (e.g. temporary files) untouched::
+
+        % dataset save -d <path_to_dataset>
+
+      Tag the most recent saved state of a dataset::
+
+        % dataset save -d <path_to_dataset> --version-tag bestyet
+
+    .. note::
+      For performance reasons, any Git repository without an initial commit
+      located inside a Dataset is ignored, and content underneath it will be
+      saved to the respective superdataset. DataLad datasets always have an
+      initial commit, hence are not affected by this behavior.
+    """
+    # note above documents that out behavior is like that of `git add`, but
+    # does not explicitly mention the connection to keep it simple.
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc=""""specify the dataset to save""",
+            constraints=EnsureDataset() | EnsureNone()),
+        path=Parameter(
+            args=("path",),
+            metavar='PATH',
+            doc="""path/name of the dataset component to save. If given, only
+            changes made to those components are recorded in the new state.""",
+            nargs='*',
+            constraints=EnsureStr() | EnsureNone()),
+        message=save_message_opt,
+        message_file=Parameter(
+            args=("-F", "--message-file"),
+            doc="""take the commit message from this file. This flag is
+            mutually exclusive with -m.""",
+            constraints=EnsureStr() | EnsureNone()),
+        version_tag=Parameter(
+            args=("-t", "--version-tag",),
+            metavar='ID',
+            doc="""an additional marker for that state. Every dataset that
+            is touched will receive the tag.""",
+            constraints=EnsureStr() | EnsureNone()),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+        updated=Parameter(
+            args=('-u', '--updated',),
+            action='store_true',
+            doc="""if given, only saves previously tracked paths."""),
+        to_git=Parameter(
+            args=("--to-git",),
+            action='store_true',
+            doc="""flag whether to add data directly to Git, instead of
+            tracking data identity only.  Usually this is not desired,
+            as it inflates dataset sizes and impacts flexibility of data
+            transport. If not specified - it will be up to git-annex to
+            decide, possibly on .gitattributes options. Use this flag
+            with a simultaneous selection of paths to save. In general,
+            it is better to pre-configure a dataset to track particular paths,
+            file types, or file sizes with either Git or git-annex.
+            See https://git-annex.branchable.com/tips/largefiles/"""),
+    )
+
+    @staticmethod
+    @datasetmethod(name='rev_save')
+    @eval_results
+    def __call__(path=None, message=None, dataset=None,
+                 version_tag=None,
+                 recursive=False, recursion_limit=None,
+                 updated=False,
+                 message_file=None,
+                 to_git=None,
+                 ):
+        if message and message_file:
+            raise ValueError(
+                "Both a message and message file were specified for save()")
+
+        path = assure_list(path)
+
+        if message_file:
+            with open(message_file) as mfh:
+                message = mfh.read()
+
+        # we want 'normal' to achieve the most compact argument list
+        # for git calls
+        # untracked_mode = 'no' if updated else 'normal'
+        # TODO however, Repo.add() would refuse to add any dotfiles
+        # in a directory that is itself untracked, hence the only
+        # choice is to go with potentially crazy long lists
+        # until https://github.com/datalad/datalad/issues/1454
+        # has a resolution
+        untracked_mode = 'no' if updated else 'all'
+
+        # there are three basic scenarios:
+        # 1. save modifications to any already tracked content
+        # 2. save any content (including removal of deleted content)
+        #    to bring things to a clean state
+        # 3. like (2), but only operate on a given subset of content
+        #    identified by paths
+        # - all three have to work in conjunction with --recursive
+        # - the difference between (1) and (2) should be no more
+        #   that a switch from --untracked=no to --untracked=all
+        #   in Repo.save()
+
+        # we do not support
+        # - simultaneous operations on multiple datasets from disjoint
+        #   dataset hierarchies, hence a single reference dataset must be
+        #   identifiable from the either
+        #   - curdir or
+        #   - the `dataset` argument.
+        #   This avoids complex annotation loops and hierarchy tracking.
+        # - any modification upwards from the root dataset
+
+        ds = require_dataset(dataset, check_installed=True, purpose='saving')
+
+        # use status() to do all discovery and annotation of paths
+        paths_by_ds = {}
+        for s in Status()(
+                # ATTN: it is vital to pass the `dataset` argument as it,
+                # and not a dataset instance in order to maintain the path
+                # semantics between here and the status() call
+                dataset=dataset,
+                path=path,
+                untracked=untracked_mode,
+                recursive=recursive,
+                recursion_limit=recursion_limit,
+                result_renderer='disabled'):
+            # fish out status dict for this parent dataset
+            ds_status = paths_by_ds.get(s['parentds'], {})
+            # reassemble path status info as repo.status() would have made it
+            ds_status[ut.Path(s['path'])] = \
+                {k: v for k, v in iteritems(s)
+                 if k not in (
+                     'path', 'parentds', 'refds', 'status', 'action',
+                     'logger')}
+            paths_by_ds[s['parentds']] = ds_status
+
+        lgr.debug('Determined %i datasets for saving from input arguments',
+                  len(paths_by_ds))
+        # figure out what datasets to process, start with the ones containing
+        # the paths that were given as arguments
+        discovered_datasets = list(paths_by_ds.keys())
+        if dataset:
+            # if a reference dataset was given we want to save all the way up
+            # to it, so let's throw it into the mix
+            discovered_datasets.append(ds.path)
+        # sort the datasets into (potentially) disjoint hierarchies,
+        # or a single one, if a reference dataset was given
+        dataset_hierarchies = get_tree_roots(discovered_datasets)
+        for rootds, children in iteritems(dataset_hierarchies):
+            edges = {}
+            discover_dataset_trace_to_targets(
+                rootds, children, [], edges, includeds=children)
+            for superds, subdss in iteritems(edges):
+                superds_status = paths_by_ds.get(superds, {})
+                for subds in subdss:
+                    # TODO actually start from an entry that may already
+                    # exist in the status record
+                    superds_status[ut.Path(subds)] = dict(
+                        # shot from the hip, some status config
+                        # to trigger this specific super/sub
+                        # relation to be saved
+                        state='untracked',
+                        type='dataset')
+                paths_by_ds[superds] = superds_status
+
+        # TODO parallelize, whenever we have multiple subdataset of a single
+        # dataset they can all be processed simultaneously
+        # sort list of dataset to handle, starting with the ones deep down
+        for pdspath in sorted(paths_by_ds, reverse=True):
+            pds = Dataset(pdspath)
+            # pop status for this dataset, we are not coming back to it
+            pds_status = {
+                # for handing over to the low-level code, we recode any
+                # path relative to the real repo location, this avoid
+                # cumbersome symlink handling without context in the
+                # lower levels
+                pds.repo.pathobj / p.relative_to(pdspath): props
+                for p, props in iteritems(paths_by_ds.pop(pdspath))}
+            start_commit = pds.repo.get_hexsha()
+            if not all(p['state'] == 'clean' for p in pds_status.values()):
+                for res in pds.repo.save_(
+                        message=message,
+                        # make sure to have the `path` arg be None, as we want
+                        # to prevent and bypass any additional repo.status()
+                        # calls
+                        paths=None,
+                        # prevent whining of GitRepo
+                        git=True if not hasattr(ds.repo, 'annexstatus')
+                        else to_git,
+                        # we are supplying the full status already, do not
+                        # detect anything else
+                        untracked='no',
+                        _status=pds_status):
+                    # TODO remove stringification when datalad-core can handle
+                    # path objects, or when PY3.6 is the lowest supported
+                    # version
+                    for k in ('path', 'refds'):
+                        if k in res:
+                            res[k] = str(
+                                # recode path back to dataset path anchor
+                                pds.pathobj / res[k].relative_to(
+                                    pds.repo.pathobj)
+                            )
+                    yield res
+            # report on the dataset itself
+            dsres = dict(
+                action='save',
+                type='dataset',
+                path=pds.path,
+                refds=ds.path,
+                status='ok'
+                if start_commit != pds.repo.get_hexsha()
+                else 'notneeded',
+                logger=lgr,
+            )
+            if not version_tag:
+                yield dsres
+                continue
+            try:
+                pds.repo.tag(version_tag)
+                dsres.update(
+                    status='ok',
+                    version_tag=version_tag)
+                yield dsres
+            except CommandError as e:
+                if dsres['status'] == 'ok':
+                    # first we yield the result for the actual save
+                    yield dsres.copy()
+                # and now complain that tagging didn't work
+                dsres.update(
+                    status='error',
+                    message=('cannot tag this version: %s', e.stderr.strip()))
+                yield dsres

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -1,0 +1,439 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Report status of a dataset (hierarchy)'s work tree"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import os
+import os.path as op
+from six import (
+    iteritems,
+    text_type,
+)
+from collections import OrderedDict
+
+from datalad.utils import (
+    assure_list,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.common_opts import (
+    recursion_limit,
+    recursion_flag,
+)
+from datalad.interface.utils import eval_results
+import datalad.support.ansi_colors as ac
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+    rev_resolve_path,
+    path_under_rev_dataset,
+    rev_get_dataset_root,
+)
+
+import datalad.utils as ut
+
+from datalad.dochelpers import single_or_plural
+
+lgr = logging.getLogger('datalad.core.local.status')
+
+_common_diffstatus_params = dict(
+    dataset=Parameter(
+        args=("-d", "--dataset"),
+        doc="""specify the dataset to query.  If
+        no dataset is given, an attempt is made to identify the dataset
+        based on the current working directory""",
+        constraints=EnsureDataset() | EnsureNone()),
+    annex=Parameter(
+        args=('--annex',),
+        metavar='MODE',
+        constraints=EnsureChoice(None, 'basic', 'availability', 'all'),
+        doc="""Switch whether to include information on the annex
+        content of individual files in the status report, such as
+        recorded file size. By default no annex information is reported
+        (faster). Three report modes are available: basic information
+        like file size and key name ('basic'); additionally test whether
+        file content is present in the local annex ('availability';
+        requires one or two additional file system stat calls, but does
+        not call git-annex), this will add the result properties
+        'has_content' (boolean flag) and 'objloc' (absolute path to an
+        existing annex object file); or 'all' which will report all
+        available information (presently identical to 'availability').
+        """),
+    untracked=Parameter(
+        args=('--untracked',),
+        metavar='MODE',
+        constraints=EnsureChoice('no', 'normal', 'all'),
+        doc="""If and how untracked content is reported when comparing
+        a revision to the state of the work tree. 'no': no untracked
+        content is reported; 'normal': untracked files and entire
+        untracked directories are reported as such; 'all': report
+        individual files even in fully untracked directories."""),
+    recursive=recursion_flag,
+    recursion_limit=recursion_limit)
+
+
+STATE_COLOR_MAP = {
+    'untracked': ac.RED,
+    'modified': ac.RED,
+    'added': ac.GREEN,
+}
+
+
+def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cache):
+    # take the datase that went in first
+    repo_path = ds.repo.pathobj
+    lgr.debug('query %s.status() for paths: %s', ds.repo, paths)
+    status = ds.repo.diffstatus(
+        fr='HEAD' if ds.repo.get_hexsha() else None,
+        to=None,
+        # recode paths with repo reference for low-level API
+        paths=[repo_path / p.relative_to(ds.pathobj) for p in paths] if paths else None,
+        untracked=untracked,
+        # TODO think about potential optimizations in case of
+        # recursive processing, as this will imply a semi-recursive
+        # look into subdatasets
+        ignore_submodules='other',
+        _cache=cache)
+    if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
+        # this will ammend `status`
+        ds.repo.get_content_annexinfo(
+            paths=paths if paths else None,
+            init=status,
+            eval_availability=annexinfo in ('availability', 'all'),
+            ref=None)
+    for path, props in iteritems(status):
+        cpath = ds.pathobj / path.relative_to(repo_path)
+        yield dict(
+            props,
+            path=str(cpath),
+            # report the dataset path rather than the repo path to avoid
+            # realpath/symlink issues
+            parentds=ds.path,
+        )
+        queried.add(ds.pathobj)
+        if recursion_limit and props.get('type', None) == 'dataset':
+            subds = Dataset(str(cpath))
+            if subds.is_installed():
+                for r in _yield_status(
+                        subds,
+                        None,
+                        annexinfo,
+                        untracked,
+                        recursion_limit - 1,
+                        queried,
+                        cache):
+                    yield r
+
+
+@build_doc
+class Status(Interface):
+    """Report on the state of dataset content.
+
+    This is an analog to `git status` that is simultaneously crippled and more
+    powerful. It is crippled, because it only supports a fraction of the
+    functionality of its counter part and only distinguishes a subset of the
+    states that Git knows about. But it is also more powerful as it can handle
+    status reports for a whole hierarchy of datasets, with the ability to
+    report on a subset of the content (selection of paths) across any number
+    of datasets in the hierarchy.
+
+    *Path conventions*
+
+    All reports are guaranteed to use absolute paths that are underneath the
+    given or detected reference dataset, regardless of whether query paths are
+    given as absolute or relative paths (with respect to the working directory,
+    or to the reference dataset, when such a dataset is given explicitly).
+    Moreover, so-called "explicit relative paths" (i.e. paths that start with
+    '.' or '..') are also supported, and are interpreted as relative paths with
+    respect to the current working directory regardless of whether a reference
+    dataset with specified.
+
+    When it is necessary to address a subdataset record in a superdataset
+    without causing a status query for the state _within_ the subdataset
+    itself, this can be achieved by explicitly providing a reference dataset
+    and the path to the root of the subdataset like so::
+
+      datalad status --dataset . subdspath
+
+    In contrast, when the state of the subdataset within the superdataset is
+    not relevant, a status query for the content of the subdataset can be
+    obtained by adding a trailing path separator to the query path (rsync-like
+    syntax)::
+
+      datalad status --dataset . subdspath/
+
+    When both aspects are relevant (the state of the subdataset content
+    and the state of the subdataset within the superdataset), both queries
+    can be combined::
+
+      datalad status --dataset . subdspath subdspath/
+
+    When performing a recursive status query, both status aspects of subdataset
+    are always included in the report.
+
+
+    *Content types*
+
+    The following content types are distinguished:
+
+    - 'dataset' -- any top-level dataset, or any subdataset that is properly
+      registered in superdataset
+    - 'directory' -- any directory that does not qualify for type 'dataset'
+    - 'file' -- any file, or any symlink that is placeholder to an annexed
+      file
+    - 'symlink' -- any symlink that is not used as a placeholder for an annexed
+      file
+
+    *Content states*
+
+    The following content states are distinguished:
+
+    - 'clean'
+    - 'added'
+    - 'modified'
+    - 'deleted'
+    - 'untracked'
+    """
+    # make the custom renderer the default one, as the global default renderer
+    # does not yield meaningful output for this command
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        _common_diffstatus_params,
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="""path to be evaluated""",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
+        )
+
+
+    @staticmethod
+    @datasetmethod(name='status')
+    @eval_results
+    def __call__(
+            path=None,
+            dataset=None,
+            annex=None,
+            untracked='normal',
+            recursive=False,
+            recursion_limit=None):
+        # To the next white knight that comes in to re-implement `status` as a
+        # special case of `diff`. There is one fundamental difference between
+        # the two commands: `status` can always use the worktree as evident on
+        # disk as a contraint (e.g. to figure out which subdataset a path is in)
+        # `diff` cannot do that (everything need to be handled based on a
+        # "virtual" representation of a dataset hierarchy).
+        # MIH concludes that while `status` can be implemented as a special case
+        # of `diff` doing so would complicate and slow down both `diff` and
+        # `status`. So while the apparent almost code-duplication between the
+        # two commands feels wrong, the benefit is speed. Any future RF should
+        # come with evidence that speed does not suffer, and complexity stays
+        # on a manageable level
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='status reporting')
+
+        paths_by_ds = OrderedDict()
+        if path:
+            # sort any path argument into the respective subdatasets
+            for p in sorted(assure_list(path)):
+                # it is important to capture the exact form of the
+                # given path argument, before any normalization happens
+                # for further decision logic below
+                orig_path = str(p)
+                p = rev_resolve_path(p, dataset)
+                root = rev_get_dataset_root(str(p))
+                if root is None:
+                    # no root, not possibly underneath the refds
+                    yield dict(
+                        action='status',
+                        path=p,
+                        refds=ds.path,
+                        status='error',
+                        message='path not underneath this dataset',
+                        logger=lgr)
+                    continue
+                else:
+                    if dataset and root == str(p) and \
+                            not orig_path.endswith(op.sep):
+                        # the given path is pointing to a dataset
+                        # distinguish rsync-link syntax to identify
+                        # the dataset as whole (e.g. 'ds') vs its
+                        # content (e.g. 'ds/')
+                        super_root = rev_get_dataset_root(op.dirname(root))
+                        if super_root:
+                            # the dataset identified by the path argument
+                            # is contained in a superdataset, and no
+                            # trailing path separator was found in the
+                            # argument -> user wants to address the dataset
+                            # as a whole (in the superdataset)
+                            root = super_root
+
+                root = ut.Path(root)
+                ps = paths_by_ds.get(root, [])
+                ps.append(p)
+                paths_by_ds[root] = ps
+        else:
+            paths_by_ds[ds.pathobj] = None
+
+        queried = set()
+        content_info_cache = {}
+        while paths_by_ds:
+            qdspath, qpaths = paths_by_ds.popitem(last=False)
+            if qpaths and qdspath in qpaths:
+                # this is supposed to be a full query, save some
+                # cycles sifting through the actual path arguments
+                qpaths = []
+            # try to recode the dataset path wrt to the reference
+            # dataset
+            # the path that it might have been located by could
+            # have been a resolved path or another funky thing
+            qds_inrefds = path_under_rev_dataset(ds, qdspath)
+            if qds_inrefds is None:
+                # nothing we support handling any further
+                # there is only a single refds
+                yield dict(
+                    path=text_type(qdspath),
+                    refds=ds.path,
+                    action='status',
+                    status='error',
+                    message=(
+                        "dataset containing given paths is not underneath "
+                        "the reference dataset %s: %s",
+                        ds, qpaths),
+                    logger=lgr,
+                )
+                continue
+            elif qds_inrefds != qdspath:
+                # the path this dataset was located by is not how it would
+                # be referenced underneath the refds (possibly resolved
+                # realpath) -> recode all paths to be underneath the refds
+                qpaths = [qds_inrefds / p.relative_to(qdspath) for p in qpaths]
+                qdspath = qds_inrefds
+            if qdspath in queried:
+                # do not report on a single dataset twice
+                continue
+            qds = Dataset(str(qdspath))
+            for r in _yield_status(
+                    qds,
+                    qpaths,
+                    annex,
+                    untracked,
+                    recursion_limit
+                    if recursion_limit is not None else -1
+                    if recursive else 0,
+                    queried,
+                    content_info_cache):
+                yield dict(
+                    r,
+                    refds=ds.path,
+                    action='status',
+                    status='ok',
+                )
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):  # pragma: no cover
+        if not (res['status'] == 'ok' \
+                and res['action'] in ('status', 'diff') \
+                and res.get('state', None) != 'clean'):
+            # logging reported already
+            return
+        from datalad.ui import ui
+        # when to render relative paths:
+        #  1) if a dataset arg was given
+        #  2) if CWD is the refds
+        refds = res.get('refds', None)
+        refds = refds if kwargs.get('dataset', None) is not None \
+            or refds == os.getcwd() else None
+        path = res['path'] if refds is None \
+            else str(ut.Path(res['path']).relative_to(refds))
+        type_ = res.get('type', res.get('type_src', ''))
+        max_len = len('untracked')
+        state = res['state']
+        ui.message('{fill}{state}: {path}{type_}'.format(
+            fill=' ' * max(0, max_len - len(state)),
+            state=ac.color_word(
+                state,
+                STATE_COLOR_MAP.get(res['state'], ac.WHITE)),
+            path=path,
+            type_=' ({})'.format(
+                ac.color_word(type_, ac.MAGENTA) if type_ else '')))
+
+    @staticmethod
+    def custom_result_summary_renderer(results):  # pragma: no cover
+        # fish out sizes of annexed files. those will only be present
+        # with --annex ...
+        annexed = [
+            (int(r['bytesize']), r.get('has_content', False))
+            for r in results
+            if r.get('action', None) == 'status' \
+            and 'key' in r and 'bytesize' in r]
+        if annexed:
+            from datalad.ui import ui
+            ui.message(
+                "{} annex'd {} ({}/{} present/total size)".format(
+                    len(annexed),
+                    single_or_plural('file', 'files', len(annexed)),
+                    bytes2human(sum(a[0] for a in annexed if a[1])),
+                    bytes2human(sum(a[0] for a in annexed))))
+
+
+# TODO move to datalad.utils eventually
+def bytes2human(n, format='%(value).1f %(symbol)sB'):
+    """
+    Convert n bytes into a human readable string based on format.
+    symbols can be either "customary", "customary_ext", "iec" or "iec_ext",
+    see: http://goo.gl/kTQMs
+
+      >>> bytes2human(1)
+      '1.0 B'
+      >>> bytes2human(1024)
+      '1.0 KB'
+      >>> bytes2human(1048576)
+      '1.0 MB'
+      >>> bytes2human(1099511627776127398123789121)
+      '909.5 YB'
+
+      >>> bytes2human(10000, "%(value).1f %(symbol)s/sec")
+      '9.8 K/sec'
+
+      >>> # precision can be adjusted by playing with %f operator
+      >>> bytes2human(10000, format="%(value).5f %(symbol)s")
+      '9.76562 K'
+
+    Taken from: http://goo.gl/kTQMs and subsequently simplified
+    Original Author: Giampaolo Rodola' <g.rodola [AT] gmail [DOT] com>
+    License: MIT
+    """
+    n = int(n)
+    if n < 0:
+        raise ValueError("n < 0")
+    symbols = ('', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+    prefix = {}
+    for i, s in enumerate(symbols[1:]):
+        prefix[s] = 1 << (i + 1) * 10
+    for symbol in reversed(symbols[1:]):
+        if n >= prefix[symbol]:
+            value = float(n) / prefix[symbol]
+            return format % locals()
+    return format % dict(symbol=symbols[0], value=n)

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -1,0 +1,355 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test create action
+
+"""
+
+from datalad.tests.utils import known_failure_windows
+
+
+import os
+import os.path as op
+
+from datalad.distribution.dataset import (
+    Dataset
+)
+from datalad.api import rev_create as create
+from datalad.utils import (
+    chpwd,
+    _path_,
+)
+from datalad.cmd import Runner
+
+from datalad.tests.utils import (
+    with_tempfile,
+    eq_,
+    ok_,
+    assert_not_in,
+    assert_in,
+    assert_raises,
+    assert_status,
+    assert_in_results,
+    with_tree,
+)
+
+from datalad.tests.utils import assert_repo_status
+
+
+_dataset_hierarchy_template = {
+    'origin': {
+        'file1': '',
+        'sub': {
+            'file2': 'file2',
+            'subsub': {
+                'file3': 'file3'}}}}
+
+raw = dict(return_type='list', result_filter=None, result_xfm=None, on_failure='ignore')
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_create_raises(path, outside_path):
+    ds = Dataset(path)
+    # incompatible arguments (annex only):
+    assert_raises(ValueError, ds.create, no_annex=True, description='some')
+
+    with open(op.join(path, "somefile.tst"), 'w') as f:
+        f.write("some")
+    # non-empty without `force`:
+    assert_in_results(
+        ds.rev_create(force=False, **raw),
+        status='error',
+        message='will not create a dataset in a non-empty directory, use `force` option to ignore')
+    # non-empty with `force`:
+    ds.rev_create(force=True)
+    # create sub outside of super:
+    assert_in_results(
+        ds.rev_create(outside_path, **raw),
+        status='error',
+        message=(
+            'dataset containing given paths is not underneath the reference '
+            'dataset %s: %s', ds, outside_path))
+    # create a sub:
+    ds.rev_create('sub')
+    # fail when doing it again
+    assert_in_results(
+        ds.rev_create('sub', **raw),
+        status='error',
+        message=('collision with content in parent dataset at %s: %s',
+                 ds.path,
+                 [str(ds.pathobj / 'sub')]),
+    )
+
+    # now deinstall the sub and fail trying to create a new one at the
+    # same location
+    ds.uninstall('sub', check=False)
+    assert_in('sub', ds.subdatasets(fulfilled=False, result_xfm='relpaths'))
+    # and now should fail to also create inplace or under
+    assert_in_results(
+        ds.rev_create('sub', **raw),
+        status='error',
+        message=('collision with content in parent dataset at %s: %s',
+                 ds.path,
+                 [str(ds.pathobj / 'sub')]),
+    )
+    assert_in_results(
+        ds.rev_create(_path_('sub/subsub'), **raw),
+        status='error',
+        message=('collision with %s (dataset) in dataset %s',
+                 str(ds.pathobj / 'sub'),
+                 ds.path)
+    )
+    os.makedirs(op.join(ds.path, 'down'))
+    with open(op.join(ds.path, 'down', "someotherfile.tst"), 'w') as f:
+        f.write("someother")
+    ds.rev_save()
+    assert_in_results(
+        ds.rev_create('down', **raw),
+        status='error',
+        message=('collision with content in parent dataset at %s: %s',
+                 ds.path,
+                 [str(ds.pathobj / 'down' / 'someotherfile.tst')]),
+    )
+
+
+@with_tempfile
+@with_tempfile
+def test_create_curdir(path, path2):
+    with chpwd(path, mkdir=True):
+        create()
+    ds = Dataset(path)
+    ok_(ds.is_installed())
+    assert_repo_status(ds.path, annex=True)
+
+    with chpwd(path2, mkdir=True):
+        create(no_annex=True)
+    ds = Dataset(path2)
+    ok_(ds.is_installed())
+    assert_repo_status(ds.path, annex=False)
+    ok_(op.exists(op.join(ds.path, '.noannex')))
+
+
+@with_tempfile
+def test_create(path):
+    ds = Dataset(path)
+    ds.rev_create(
+        description="funny",
+        # custom git init option
+        initopts=dict(shared='world'))
+    ok_(ds.is_installed())
+    assert_repo_status(ds.path, annex=True)
+
+    # check default backend
+    eq_(ds.config.get("annex.backends"), 'MD5E')
+    eq_(ds.config.get("core.sharedrepository"), '2')
+    runner = Runner()
+    # check description in `info`
+    cmd = ['git', 'annex', 'info']
+    cmlout = runner.run(cmd, cwd=path)
+    assert_in('funny [here]', cmlout[0])
+    # check datset ID
+    eq_(ds.config.get_value('datalad.dataset', 'id'),
+        ds.id)
+
+
+@with_tempfile
+def test_create_sub(path):
+
+    ds = Dataset(path)
+    ds.rev_create()
+
+    # 1. create sub and add to super:
+    subds = ds.rev_create("some/what/deeper")
+    ok_(isinstance(subds, Dataset))
+    ok_(subds.is_installed())
+    assert_repo_status(subds.path, annex=True)
+
+    # subdataset is known to superdataset:
+    assert_in(op.join("some", "what", "deeper"),
+              ds.subdatasets(result_xfm='relpaths'))
+    # and was committed:
+    assert_repo_status(ds.path)
+
+    # subds finds superdataset
+    ok_(subds.get_superdataset() == ds)
+
+    # 2. create sub without adding to super:
+    subds2 = Dataset(op.join(path, "someother")).rev_create()
+    ok_(isinstance(subds2, Dataset))
+    ok_(subds2.is_installed())
+    assert_repo_status(subds2.path, annex=True)
+
+    # unknown to superdataset:
+    assert_not_in("someother", ds.subdatasets(result_xfm='relpaths'))
+
+    # 3. create sub via super:
+    subds3 = ds.rev_create("third", no_annex=True)
+    ok_(isinstance(subds3, Dataset))
+    ok_(subds3.is_installed())
+    assert_repo_status(subds3.path, annex=False)
+    assert_in("third", ds.subdatasets(result_xfm='relpaths'))
+
+
+# windows failure triggered by
+# File "C:\Miniconda35\envs\test-environment\lib\site-packages\datalad\tests\utils.py", line 421, in newfunc
+#    rmtemp(d)
+# PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_tree_h43urkyc\\origin'
+@known_failure_windows
+@with_tree(tree=_dataset_hierarchy_template)
+def test_create_subdataset_hierarchy_from_top(path):
+    # how it would look like to overlay a subdataset hierarchy onto
+    # an existing directory tree
+    ds = Dataset(op.join(path, 'origin')).rev_create(force=True)
+    # we got a dataset ....
+    ok_(ds.is_installed())
+    # ... but it has untracked content
+    ok_(ds.repo.dirty)
+    subds = ds.rev_create('sub', force=True)
+    ok_(subds.is_installed())
+    ok_(subds.repo.dirty)
+    subsubds = subds.rev_create('subsub', force=True)
+    ok_(subsubds.is_installed())
+    ok_(subsubds.repo.dirty)
+    ok_(ds.id != subds.id != subsubds.id)
+    ds.rev_save(updated=True, recursive=True)
+    # 'file*' in each repo was untracked before and should remain as such
+    # (we don't want a #1419 resurrection
+    ok_(ds.repo.dirty)
+    ok_(subds.repo.dirty)
+    ok_(subsubds.repo.dirty)
+    # if we add these three, we should get clean
+    ds.rev_save([
+        'file1',
+        op.join(subds.path, 'file2'),
+        op.join(subsubds.path, 'file3')])
+    assert_repo_status(ds.path)
+    ok_(ds.id != subds.id != subsubds.id)
+
+
+# CommandError: command '['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'annex', 'init', '--version', '6']' failed with exitcode 1
+# Failed to run ['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'annex', 'init', '--version', '6'] under 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_okvmx7gq\\lvl1\\subds'. Exit code=1.
+@known_failure_windows
+@with_tempfile
+def test_nested_create(path):
+    # to document some more organic usage pattern
+    ds = Dataset(path).rev_create()
+    assert_repo_status(ds.path)
+    lvl2relpath = op.join('lvl1', 'lvl2')
+    lvl2path = op.join(ds.path, lvl2relpath)
+    os.makedirs(lvl2path)
+    os.makedirs(op.join(ds.path, 'lvl1', 'empty'))
+    with open(op.join(lvl2path, 'file'), 'w') as f:
+        f.write('some')
+    ok_(ds.rev_save())
+    assert_repo_status(ds.path, untracked=['lvl1/empty'])
+    # later create subdataset in a fresh dir
+    # WINDOWS FAILURE IS NEXT LINE
+    subds1 = ds.rev_create(op.join('lvl1', 'subds'))
+    assert_repo_status(ds.path, untracked=['lvl1/empty'])
+    eq_(ds.subdatasets(result_xfm='relpaths'), [op.join('lvl1', 'subds')])
+    # later create subdataset in an existing empty dir
+    subds2 = ds.rev_create(op.join('lvl1', 'empty'))
+    assert_repo_status(ds.path)
+    # later try to wrap existing content into a new subdataset
+    # but that won't work
+    assert_in_results(
+        ds.rev_create(lvl2relpath, **raw),
+        status='error',
+        message=(
+            'collision with content in parent dataset at %s: %s',
+            ds.path, [op.join(lvl2path, 'file')]))
+    # even with force, as to do this properly complicated surgery would need to
+    # take place
+    # MIH disable shaky test till proper dedicated upfront check is in-place in `create`
+    # gh-1725
+    #assert_in_results(
+    #    ds.rev_create(lvl2relpath, force=True,
+    #              on_failure='ignore', result_xfm=None, result_filter=None),
+    #    status='error', action='add')
+    # only way to make it work is to unannex the content upfront
+    ds.repo._run_annex_command('unannex', annex_options=[op.join(lvl2relpath, 'file')])
+    # nothing to save, git-annex commits the unannex itself, but only on v5
+    ds.repo.commit()
+    # still nothing without force
+    # "err='lvl1/lvl2' already exists in the index"
+    assert_in_results(
+        ds.rev_create(lvl2relpath, **raw),
+        status='error',
+        message='will not create a dataset in a non-empty directory, use `force` option to ignore')
+    # XXX even force doesn't help, because (I assume) GitPython doesn't update
+    # its representation of the Git index properly
+    ds.rev_create(lvl2relpath, force=True)
+    assert_in(lvl2relpath, ds.subdatasets(result_xfm='relpaths'))
+
+
+# Imported from #1016
+@with_tree({'ds2': {'file1.txt': 'some'}})
+def test_saving_prior(topdir):
+    # the problem is that we might be saving what is actually needed to be
+    # "created"
+
+    # we would like to place this structure into a hierarchy of two datasets
+    # so we create first top one
+    ds1 = create(topdir, force=True)
+    # and everything is ok, stuff is not added BUT ds1 will be considered dirty
+    assert_repo_status(ds1.path, untracked=['ds2'])
+    # And then we would like to initiate a sub1 subdataset
+    ds2 = create('ds2', dataset=ds1, force=True)
+    # But what will happen is file1.txt under ds2 would get committed first into
+    # ds1, and then the whole procedure actually crashes since because ds2/file1.txt
+    # is committed -- ds2 is already known to git and it just pukes with a bit
+    # confusing    'ds2' already exists in the index
+    assert_in('ds2', ds1.subdatasets(result_xfm='relpaths'))
+
+
+@with_tempfile(mkdir=True)
+def test_create_withprocedure(path):
+    # first without
+    ds = create(path)
+    assert(not op.lexists(op.join(ds.path, 'README.rst')))
+    ds.remove()
+    assert(not op.lexists(ds.path))
+    # now for reals...
+    ds = create(
+        # needs to identify the dataset, otherwise post-proc
+        # procedure doesn't know what to run on
+        dataset=path,
+        proc_post=[['cfg_metadatatypes', 'xmp', 'datacite']])
+    assert_repo_status(path)
+    ds.config.reload()
+    eq_(ds.config['datalad.metadata.nativetype'], ('xmp', 'datacite'))
+
+
+@with_tempfile(mkdir=True)
+def test_create_fake_dates(path):
+    ds = create(path, fake_dates=True)
+
+    ok_(ds.config.getbool("datalad", "fake-dates"))
+    ok_(ds.repo.fake_dates_enabled)
+
+    # Another instance detects the fake date configuration.
+    ok_(Dataset(path).repo.fake_dates_enabled)
+
+    first_commit = ds.repo.repo.commit(
+        ds.repo.repo.git.rev_list("--reverse", "--all").split()[0])
+
+    eq_(ds.config.obtain("datalad.fake-dates-start") + 1,
+        first_commit.committed_date)
+
+
+@with_tempfile(mkdir=True)
+def test_cfg_passthrough(path):
+    runner = Runner()
+    _ = runner.run(
+        ['datalad',
+         '-c', 'annex.tune.objecthash1=true',
+         '-c', 'annex.tune.objecthashlower=true',
+         'rev-create', path])
+    ds = Dataset(path)
+    eq_(ds.config.get('annex.tune.objecthash1', None), 'true')
+    eq_(ds.config.get('annex.tune.objecthashlower', None), 'true')

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -1,0 +1,629 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test save command"""
+
+import os
+import os.path as op
+from six import iteritems
+
+from datalad.utils import (
+    on_windows,
+    assure_list,
+    rmtree,
+)
+from datalad.tests.utils import (
+    assert_status,
+    assert_result_count,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    create_tree,
+    with_tempfile,
+    with_tree,
+    with_testrepos,
+    eq_,
+    ok_,
+    chpwd,
+    known_failure_windows,
+    OBSCURE_FILENAME,
+    SkipTest,
+)
+from datalad.distribution.tests.test_add import tree_arg
+
+import datalad.utils as ut
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.api import (
+    rev_save as save,
+    rev_create as create,
+    install,
+)
+
+from datalad.tests.utils import (
+    assert_repo_status,
+    skip_wo_symlink_capability,
+)
+
+
+@with_testrepos('.*git.*', flavors=['clone'])
+def test_save(path):
+
+    ds = Dataset(path)
+
+    with open(op.join(path, "new_file.tst"), "w") as f:
+        f.write("something")
+
+    ds.repo.add("new_file.tst", git=True)
+    ok_(ds.repo.dirty)
+
+    ds.rev_save(message="add a new file")
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    with open(op.join(path, "new_file.tst"), "w") as f:
+        f.write("modify")
+
+    ok_(ds.repo.dirty)
+    ds.rev_save(message="modified new_file.tst")
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    # save works without ds and files given in the PWD
+    with open(op.join(path, "new_file.tst"), "w") as f:
+        f.write("rapunzel")
+    with chpwd(path):
+        save(message="love rapunzel")
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    # and also without `-a` when things are staged
+    with open(op.join(path, "new_file.tst"), "w") as f:
+        f.write("exotic")
+    ds.repo.add("new_file.tst", git=True)
+    with chpwd(path):
+        save(message="love marsians")
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    files = ['one.txt', 'two.txt']
+    for fn in files:
+        with open(op.join(path, fn), "w") as f:
+            f.write(fn)
+
+    ds.rev_save([op.join(path, f) for f in files])
+    # superfluous call to save (alll saved it already), should not fail
+    # but report that nothing was saved
+    assert_status('notneeded', ds.rev_save(message="set of new files"))
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    # create subdataset
+    subds = ds.rev_create('subds')
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+    # modify subds
+    with open(op.join(subds.path, "some_file.tst"), "w") as f:
+        f.write("something")
+    subds.rev_save()
+    assert_repo_status(subds.path, annex=isinstance(subds.repo, AnnexRepo))
+    # ensure modified subds is committed
+    ds.rev_save()
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+
+    # now introduce a change downstairs
+    subds.rev_create('someotherds')
+    assert_repo_status(subds.path, annex=isinstance(subds.repo, AnnexRepo))
+    ok_(ds.repo.dirty)
+    # and save via subdataset path
+    ds.rev_save('subds', version_tag='new_sub')
+    assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
+    tags = ds.repo.get_tags()
+    ok_(len(tags) == 1)
+    eq_(tags[0], dict(hexsha=ds.repo.get_hexsha(), name='new_sub'))
+    # fails when retagged, like git does
+    res = ds.rev_save(version_tag='new_sub', on_failure='ignore')
+    assert_status('error', res)
+    assert_result_count(
+        res, 1,
+        action='save', type='dataset', path=ds.path,
+        message=('cannot tag this version: %s',
+                 "fatal: tag 'new_sub' already exists"))
+
+
+@with_tempfile()
+def test_save_message_file(path):
+    ds = Dataset(path).rev_create()
+    with assert_raises(ValueError):
+        ds.rev_save("blah", message="me", message_file="and me")
+
+    create_tree(path, {"foo": "x",
+                       "msg": "add foo"})
+    ds.repo.add("foo")
+    ds.rev_save(message_file=op.join(ds.path, "msg"))
+    eq_(ds.repo.repo.git.show("--format=%s", "--no-patch"),
+        "add foo")
+
+
+def test_renamed_file():
+    @with_tempfile()
+    def check_renamed_file(recursive, no_annex, path):
+        ds = Dataset(path).rev_create(no_annex=no_annex)
+        create_tree(path, {'old': ''})
+        ds.repo.add('old')
+        ds.repo._git_custom_command(['old', 'new'], ['git', 'mv'])
+        ds.rev_save(recursive=recursive)
+        assert_repo_status(path)
+
+    for recursive in False,:  #, True TODO when implemented
+        for no_annex in True, False:
+            yield check_renamed_file, recursive, no_annex
+
+
+@with_tempfile(mkdir=True)
+def test_subdataset_save(path):
+    parent = Dataset(path).rev_create()
+    sub = parent.rev_create('sub')
+    assert_repo_status(parent.path)
+    create_tree(parent.path, {
+        "untracked": 'ignore',
+        'sub': {
+            "new": "wanted"}})
+    sub.rev_save('new')
+    # defined state: one untracked, modified (but clean in itself) subdataset
+    assert_repo_status(sub.path)
+    assert_repo_status(parent.path, untracked=['untracked'], modified=['sub'])
+
+    # `save sub` does not save the parent!!
+    with chpwd(parent.path):
+        assert_status('notneeded', save(dataset=sub.path))
+    assert_repo_status(parent.path, untracked=['untracked'], modified=['sub'])
+    # `save -u .` saves the state change in the subdataset,
+    # but leaves any untracked content alone
+    with chpwd(parent.path):
+        assert_status('ok', parent.rev_save(updated=True))
+    assert_repo_status(parent.path, untracked=['untracked'])
+
+    # get back to the original modified state and check that -S behaves in
+    # exactly the same way
+    create_tree(parent.path, {
+        'sub': {
+            "new2": "wanted2"}})
+    sub.rev_save('new2')
+    assert_repo_status(parent.path, untracked=['untracked'], modified=['sub'])
+
+
+@skip_wo_symlink_capability
+@with_tempfile(mkdir=True)
+def test_symlinked_relpath(path):
+    # initially ran into on OSX https://github.com/datalad/datalad/issues/2406
+    os.makedirs(op.join(path, "origin"))
+    dspath = op.join(path, "linked")
+    os.symlink('origin', dspath)
+    ds = Dataset(dspath).rev_create()
+    create_tree(dspath, {
+        "mike1": 'mike1',  # will be added from topdir
+        "later": "later",  # later from within subdir
+        "d": {
+            "mike2": 'mike2', # to be added within subdir
+        }
+    })
+
+    # in the root of ds
+    with chpwd(dspath):
+        ds.repo.add("mike1", git=True)
+        ds.rev_save(message="committing", path="./mike1")
+
+    # Let's also do in subdirectory
+    with chpwd(op.join(dspath, 'd')):
+        ds.rev_save(
+            message="committing", path=op.join(op.curdir, "mike2"))
+
+        later = op.join(op.pardir, "later")
+        ds.repo.add(later, git=True)
+        ds.rev_save(message="committing", path=later)
+
+    assert_repo_status(dspath)
+
+
+@skip_wo_symlink_capability
+@with_tempfile(mkdir=True)
+def test_bf1886(path):
+    parent = Dataset(path).rev_create()
+    parent.rev_create('sub')
+    assert_repo_status(parent.path)
+    # create a symlink pointing down to the subdataset, and add it
+    os.symlink('sub', op.join(parent.path, 'down'))
+    parent.rev_save('down')
+    assert_repo_status(parent.path)
+    # now symlink pointing up
+    os.makedirs(op.join(parent.path, 'subdir', 'subsubdir'))
+    os.symlink(op.join(op.pardir, 'sub'), op.join(parent.path, 'subdir', 'up'))
+    parent.rev_save(op.join('subdir', 'up'))
+    # 'all' to avoid the empty dir being listed
+    assert_repo_status(parent.path, untracked_mode='all')
+    # now symlink pointing 2xup, as in #1886
+    os.symlink(
+        op.join(op.pardir, op.pardir, 'sub'),
+        op.join(parent.path, 'subdir', 'subsubdir', 'upup'))
+    parent.rev_save(op.join('subdir', 'subsubdir', 'upup'))
+    assert_repo_status(parent.path)
+    # simulatenously add a subds and a symlink pointing to it
+    # create subds, but don't register it
+    create(op.join(parent.path, 'sub2'))
+    os.symlink(
+        op.join(op.pardir, op.pardir, 'sub2'),
+        op.join(parent.path, 'subdir', 'subsubdir', 'upup2'))
+    parent.rev_save(['sub2', op.join('subdir', 'subsubdir', 'upup2')])
+    assert_repo_status(parent.path)
+    # full replication of #1886: the above but be in subdir of symlink
+    # with no reference dataset
+    create(op.join(parent.path, 'sub3'))
+    os.symlink(
+        op.join(op.pardir, op.pardir, 'sub3'),
+        op.join(parent.path, 'subdir', 'subsubdir', 'upup3'))
+    # need to use absolute paths
+    with chpwd(op.join(parent.path, 'subdir', 'subsubdir')):
+        save([op.join(parent.path, 'sub3'),
+              op.join(parent.path, 'subdir', 'subsubdir', 'upup3')])
+    assert_repo_status(parent.path)
+
+
+@with_tree({
+    '1': '',
+    '2': '',
+    '3': ''})
+def test_gh2043p1(path):
+    # this tests documents the interim agreement on what should happen
+    # in the case documented in gh-2043
+    ds = Dataset(path).rev_create(force=True)
+    ds.rev_save('1')
+    assert_repo_status(ds.path, untracked=['2', '3'])
+    ds.unlock('1')
+    assert_repo_status(
+        ds.path,
+        # on windows we are in an unlocked branch by default, hence
+        # we would see no change
+        modified=[] if on_windows else ['1'],
+        untracked=['2', '3'])
+    # save(.) should recommit unlocked file, and not touch anything else
+    # this tests the second issue in #2043
+    with chpwd(path):
+        # only save modified bits
+        save(path='.', updated=True)
+    # state of the file (unlocked/locked) is committed as well, and the
+    # test doesn't lock the file again
+    assert_repo_status(ds.path, untracked=['2', '3'])
+    with chpwd(path):
+        # but when a path is given, anything that matches this path
+        # untracked or not is added/saved
+        save(path='.')
+    # state of the file (unlocked/locked) is committed as well, and the
+    # test doesn't lock the file again
+    assert_repo_status(ds.path)
+
+
+@with_tree({
+    'staged': 'staged',
+    'untracked': 'untracked'})
+def test_bf2043p2(path):
+    ds = Dataset(path).rev_create(force=True)
+    ds.repo.add('staged')
+    assert_repo_status(ds.path, added=['staged'], untracked=['untracked'])
+    # save -u does not commit untracked content
+    # this tests the second issue in #2043
+    with chpwd(path):
+        save(updated=True)
+    assert_repo_status(ds.path, untracked=['untracked'])
+
+
+@with_tree(**tree_arg)
+def test_add_files(path):
+    ds = Dataset(path).rev_create(force=True)
+
+    test_list_1 = ['test_annex.txt']
+    test_list_2 = ['test.txt']
+    test_list_3 = ['test1.dat', 'test2.dat']
+    test_list_4 = [op.join('dir', 'testindir'),
+                   op.join('dir', OBSCURE_FILENAME)]
+
+    for arg in [(test_list_1[0], False),
+                (test_list_2[0], True),
+                (test_list_3, False),
+                (test_list_4, False)]:
+        # special case 4: give the dir:
+        if arg[0] == test_list_4:
+            result = ds.rev_save('dir', to_git=arg[1])
+            status = ds.repo.annexstatus(['dir'])
+        else:
+            result = ds.rev_save(arg[0], to_git=arg[1])
+            for a in assure_list(arg[0]):
+                assert_result_count(result, 1, path=str(ds.pathobj / a))
+            status = ds.repo.get_content_annexinfo(
+                ut.Path(p) for p in assure_list(arg[0]))
+        for f, p in iteritems(status):
+            if arg[1]:
+                assert p.get('key', None) is None, f
+            else:
+                assert p.get('key', None) is not None, f
+
+
+@with_tree(**tree_arg)
+@with_tempfile(mkdir=True)
+def test_add_subdataset(path, other):
+    subds = create(op.join(path, 'dir'), force=True)
+    ds = create(path, force=True)
+    ok_(subds.repo.dirty)
+    ok_(ds.repo.dirty)
+    assert_not_in('dir', ds.subdatasets(result_xfm='relpaths'))
+    # "add everything in subds to subds"
+    save(dataset=subds.path)
+    assert_repo_status(subds.path)
+    assert_not_in('dir', ds.subdatasets(result_xfm='relpaths'))
+    # but with a base directory we add the dataset subds as a subdataset
+    # to ds
+    ds.rev_save(subds.path)
+    assert_in('dir', ds.subdatasets(result_xfm='relpaths'))
+    #  create another one
+    other = create(other)
+    # install into superdataset, but don't add
+    other_clone = install(source=other.path, path=op.join(ds.path, 'other'))
+    # little dance to get the revolution-type dataset
+    other_clone = Dataset(other_clone.path)
+    ok_(other_clone.is_installed)
+    assert_not_in('other', ds.subdatasets(result_xfm='relpaths'))
+    # now add, it should pick up the source URL
+    ds.rev_save('other')
+    # and that is why, we can reobtain it from origin
+    ds.uninstall('other')
+    ok_(not other_clone.is_installed())
+    ds.get('other')
+    ok_(other_clone.is_installed())
+
+
+# CommandError: command '['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'annex', 'add', '--json', '--', 'empty', 'file.txt']' failed with exitcode 1
+# Failed to run ['git', '-c', 'receive.autogc=0', '-c', 'gc.auto=0', 'annex', 'add', '--json', '--', 'empty', 'file.txt'] under 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_tree_j2mk92y3'. Exit code=1.
+@known_failure_windows
+@with_tree(tree={
+    'file.txt': 'some text',
+    'empty': '',
+    'file2.txt': 'some text to go to annex',
+    '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
+)
+def test_add_mimetypes(path):
+    ds = Dataset(path).rev_create(force=True)
+    ds.repo.add('.gitattributes')
+    ds.repo.commit('added attributes to git explicitly')
+    # now test that those files will go into git/annex correspondingly
+    # WINDOWS FAILURE NEXT
+    __not_tested__ = ds.rev_save(['file.txt', 'empty'])
+    assert_repo_status(path, untracked=['file2.txt'])
+    # But we should be able to force adding file to annex when desired
+    ds.rev_save('file2.txt', to_git=False)
+    # check annex file status
+    annexinfo = ds.repo.get_content_annexinfo()
+    for path, in_annex in (
+           # Empty one considered to be  application/octet-stream
+           # i.e. non-text
+           ('empty', True),
+           ('file.txt', False),
+           ('file2.txt', True)):
+        # low-level API report -> repo path reference, no ds path
+        p = ds.repo.pathobj / path
+        assert_in(p, annexinfo)
+        if in_annex:
+            assert_in('key', annexinfo[p], p)
+        else:
+            assert_not_in('key', annexinfo[p], p)
+
+
+@with_tempfile(mkdir=True)
+def test_gh1597(path):
+    if 'APPVEYOR' in os.environ:
+        # issue only happens on appveyor, Python itself implodes
+        # cannot be reproduced on a real windows box
+        raise SkipTest(
+            'this test causes appveyor to crash, reason unknown')
+    ds = Dataset(path).rev_create()
+    sub = ds.create('sub')
+    res = ds.subdatasets()
+    assert_result_count(res, 1, path=sub.path)
+    # now modify .gitmodules with another command
+    ds.subdatasets(contains=sub.path, set_property=[('this', 'that')])
+    # now modify low-level
+    with open(op.join(ds.path, '.gitmodules'), 'a') as f:
+        f.write('\n')
+    assert_repo_status(ds.path, modified=['.gitmodules'])
+    ds.rev_save('.gitmodules')
+    # must not come under annex mangement
+    assert_not_in(
+        'key',
+        ds.repo.annexstatus(paths=['.gitmodules']).popitem()[1])
+
+
+@with_tempfile(mkdir=True)
+def test_gh1597_simpler(path):
+    ds = Dataset(path).rev_create()
+    # same goes for .gitattributes
+    with open(op.join(ds.path, '.gitignore'), 'a') as f:
+        f.write('*.swp\n')
+    ds.rev_save('.gitignore')
+    assert_repo_status(ds.path)
+    # put .gitattributes in some subdir and add all, should also go into Git
+    attrfile = op.join ('subdir', '.gitattributes')
+    ds.repo.set_gitattributes(
+        [('*', dict(mycustomthing='this'))],
+        attrfile)
+    assert_repo_status(ds.path, untracked=[attrfile], untracked_mode='all')
+    ds.rev_save()
+    assert_repo_status(ds.path)
+    # no annex key, not in annex
+    assert_not_in(
+        'key',
+        ds.repo.get_content_annexinfo([ut.Path(attrfile)]).popitem()[1])
+
+
+@with_tempfile(mkdir=True)
+def test_update_known_submodule(path):
+    def get_baseline(p):
+        ds = Dataset(p).rev_create()
+        sub = create(str(ds.pathobj / 'sub'))
+        assert_repo_status(ds.path, untracked=['sub'])
+        return ds
+    # attempt one
+    ds = get_baseline(op.join(path, 'wo_ref'))
+    with chpwd(ds.path):
+        save(recursive=True)
+    assert_repo_status(ds.path)
+
+    # attempt two, same as above but call add via reference dataset
+    ds = get_baseline(op.join(path, 'w_ref'))
+    ds.rev_save(recursive=True)
+    assert_repo_status(ds.path)
+
+
+@with_tempfile(mkdir=True)
+def test_add_recursive(path):
+    # make simple hierarchy
+    parent = Dataset(path).rev_create()
+    assert_repo_status(parent.path)
+    sub1 = parent.rev_create(op.join('down', 'sub1'))
+    assert_repo_status(parent.path)
+    sub2 = parent.rev_create('sub2')
+    # next one make the parent dirty
+    subsub = sub2.rev_create('subsub')
+    assert_repo_status(parent.path, modified=['sub2'])
+    res = parent.rev_save()
+    assert_repo_status(parent.path)
+
+    # now add content deep in the hierarchy
+    create_tree(subsub.path, {'new': 'empty'})
+    assert_repo_status(parent.path, modified=['sub2'])
+
+    # recursive add should not even touch sub1, because
+    # it knows that it is clean
+    res = parent.rev_save(recursive=True)
+    # the key action is done
+    assert_result_count(
+        res, 1, path=op.join(subsub.path, 'new'), action='add', status='ok')
+    # saved all the way up
+    assert_result_count(res, 3, action='save', status='ok')
+    assert_repo_status(parent.path)
+
+
+@with_tree(**tree_arg)
+def test_relpath_add(path):
+    ds = Dataset(path).rev_create(force=True)
+    with chpwd(op.join(path, 'dir')):
+        eq_(save('testindir')[0]['path'],
+            op.join(ds.path, 'dir', 'testindir'))
+        # and now add all
+        save('..')
+    # auto-save enabled
+    assert_repo_status(ds.path)
+
+
+@skip_wo_symlink_capability
+@with_tempfile()
+def test_bf2541(path):
+    ds = create(path)
+    subds = ds.rev_create('sub')
+    assert_repo_status(ds.path)
+    os.symlink('sub', op.join(ds.path, 'symlink'))
+    with chpwd(ds.path):
+        res = save(recursive=True)
+    assert_repo_status(ds.path)
+
+
+@with_tempfile()
+def test_remove_subds(path):
+    ds = create(path)
+    ds.rev_create('sub')
+    ds.rev_create(op.join('sub', 'subsub'))
+    assert_repo_status(ds.path)
+    assert_result_count(
+        ds.subdatasets(), 1,
+        path=op.join(ds.path, 'sub'))
+    # all good at this point, subdataset known, dataset clean
+    # now have some external force wipe out the subdatasets
+    rmtree(op.join(ds.path, 'sub'))
+    assert_result_count(
+        ds.status(), 1,
+        path=op.join(ds.path, 'sub'),
+        state='deleted')
+    # a single call to save() must fix up the mess
+    assert_status('ok', ds.rev_save())
+    assert_repo_status(ds.path)
+
+
+@with_tempfile()
+def test_partial_unlocked(path):
+    # https://github.com/datalad/datalad/issues/1651
+    ds = create(path)
+    (ds.pathobj / 'normal.txt').write_text(u'123')
+    ds.rev_save()
+    assert_repo_status(ds.path)
+    ds.unlock('normal.txt')
+    ds.rev_save()
+    # mixed git and git-annex'ed files
+    (ds.pathobj / 'ingit.txt').write_text(u'234')
+    ds.rev_save(to_git=True)
+    (ds.pathobj / 'culprit.txt').write_text(u'345')
+    (ds.pathobj / 'ingit.txt').write_text(u'modified')
+    ds.rev_save()
+    assert_repo_status(ds.path)
+    # but now a change in the attributes
+    ds.unlock('culprit.txt')
+    ds.repo.set_gitattributes([
+        ('*', {'annex.largefiles': 'nothing'})])
+    ds.rev_save()
+    assert_repo_status(ds.path)
+
+
+@with_tempfile()
+def test_path_arg_call(path):
+    ds = create(path)
+    for testfile in (
+            ds.pathobj / 'abs.txt',
+            ds.pathobj / 'rel.txt'):
+        testfile.write_text(u'123')
+        save(dataset=ds.path, path=[testfile.name], to_git=True)
+
+
+@with_tree(tree={
+    'file.txt': 'some text',
+    'd1': {
+        'subrepo': {
+            'subfile': 'more repo text',
+        },
+    },
+    'd2': {
+        'subds': {
+            'subfile': 'more ds text',
+        },
+    },
+})
+def test_surprise_subds(path):
+    # https://github.com/datalad/datalad/issues/3139
+    ds = create(path, force=True)
+    # a lonely repo without any commit
+    somerepo = AnnexRepo(path=op.join(path, 'd1', 'subrepo'), create=True)
+    # a proper subdataset
+    subds = create(op.join(path, 'd2', 'subds'), force=True)
+    # save non-recursive
+    ds.rev_save(recursive=False)
+    # the content of both subds and subrepo are not added to their
+    # respective parent as no --recursive was given
+    assert_repo_status(subds.path, untracked=['subfile'])
+    assert_repo_status(somerepo.path, untracked=['subfile'])
+    # however, while the subdataset is added (and reported as modified
+    # because it content is still untracked) the subrepo
+    # cannot be added (it has no commit)
+    # worse: its untracked file add been added to the superdataset
+    # XXX the next conditional really says: if the subrepo is not in an
+    # adjusted branch: #datalad/3178 (that would have a commit)
+    if not on_windows:
+        assert_repo_status(ds.path, modified=['d2/subds'])
+        assert_in(ds.repo.pathobj / 'd1' / 'subrepo' / 'subfile',
+                  ds.repo.get_content_info())
+    # with proper subdatasets, all evil is gone
+    assert_not_in(ds.repo.pathobj / 'd2' / 'subds' / 'subfile',
+                  ds.repo.get_content_info())

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -1,0 +1,233 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test status command"""
+
+import os.path as op
+from six import text_type
+import datalad.utils as ut
+
+from datalad.utils import (
+    chpwd,
+    on_windows,
+)
+from datalad.tests.utils import (
+    eq_,
+    assert_in,
+    assert_raises,
+    assert_status,
+    assert_result_count,
+    with_tempfile,
+)
+from datalad.support.exceptions import (
+    NoDatasetArgumentFound,
+    IncompleteResultsError,
+)
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.tests.utils import (
+    get_deeply_nested_structure,
+    has_symlink_capability,
+    assert_repo_status,
+)
+from datalad.api import (
+    status,
+)
+
+
+@with_tempfile(mkdir=True)
+def test_runnin_on_empty(path):
+    # empty repo
+    repo = AnnexRepo(path, create=True)
+    # just wrap with a dataset
+    ds = Dataset(path)
+    # and run status ... should be good and do nothing
+    eq_([], ds.status())
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile(mkdir=True)
+def test_status_basics(path, linkpath, otherdir):
+    if not on_windows:
+        # make it more complicated by default
+        ut.Path(linkpath).symlink_to(path, target_is_directory=True)
+        path = linkpath
+
+    with chpwd(path):
+        assert_raises(NoDatasetArgumentFound, status)
+    ds = Dataset(path).rev_create()
+    # outcome identical between ds= and auto-discovery
+    with chpwd(path):
+        assert_raises(IncompleteResultsError, status, path=otherdir)
+        stat = status()
+    eq_(stat, ds.status())
+    assert_status('ok', stat)
+    # we have a bunch of reports (be vague to be robust to future changes
+    assert len(stat) > 2
+    # check the composition
+    for s in stat:
+        eq_(s['status'], 'ok')
+        eq_(s['action'], 'status')
+        eq_(s['state'], 'clean')
+        eq_(s['type'], 'file')
+        assert_in('gitshasum', s)
+        eq_(s['refds'], ds.path)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_status_nods(path, otherpath):
+    ds = Dataset(path).rev_create()
+    assert_result_count(
+        ds.status(path=otherpath, on_failure='ignore'),
+        1,
+        status='error',
+        message='path not underneath this dataset')
+    otherds = Dataset(otherpath).rev_create()
+    assert_result_count(
+        ds.status(path=otherpath, on_failure='ignore'),
+        1,
+        path=otherds.path,
+        status='error',
+        message=(
+            'dataset containing given paths is not underneath the reference dataset %s: %s',
+            ds, [])
+        )
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_status(_path, linkpath):
+    # do the setup on the real path, not the symlink, to have its
+    # bugs not affect this test of status()
+    ds = get_deeply_nested_structure(str(_path))
+    if has_symlink_capability():
+        # make it more complicated by default
+        ut.Path(linkpath).symlink_to(_path, target_is_directory=True)
+        path = linkpath
+    else:
+        path = _path
+
+    ds = Dataset(path)
+    if not on_windows:
+        # TODO test should also be has_symlink_capability(), but
+        # something in the repo base class is not behaving yet
+        # check the premise of this test
+        assert ds.pathobj != ds.repo.pathobj
+
+    # spotcheck that annex status reporting and availability evaluation
+    # works
+    assert_result_count(
+        ds.status(annex='all'),
+        1,
+        path=str(ds.pathobj / 'subdir' / 'annexed_file.txt'),
+        key='MD5E-s5--275876e34cf609db118f3d84b799a790.txt',
+        has_content=True,
+        objloc=str(ds.repo.pathobj / '.git' / 'annex' / 'objects' /
+        # hashdir is different on windows
+        ('f33' if on_windows else '7p') /
+        ('94b' if on_windows else 'gp') /
+        'MD5E-s5--275876e34cf609db118f3d84b799a790.txt' /
+        'MD5E-s5--275876e34cf609db118f3d84b799a790.txt'))
+
+    plain_recursive = ds.status(recursive=True)
+    # check integrity of individual reports with a focus on how symlinks
+    # are reported
+    for res in plain_recursive:
+        # anything that is an "intended" symlink should be reported
+        # as such. In contrast, anything that is a symlink for mere
+        # technical reasons (annex using it for something in some mode)
+        # should be reported as the thing it is representing (i.e.
+        # a file)
+        if 'link2' in text_type(res['path']):
+            assert res['type'] == 'symlink', res
+        else:
+            assert res['type'] != 'symlink', res
+        # every item must report its parent dataset
+        assert_in('parentds', res)
+
+    # bunch of smoke tests
+    # query of '.' is same as no path
+    eq_(plain_recursive, ds.status(path='.', recursive=True))
+    # duplicate paths do not change things
+    eq_(plain_recursive, ds.status(path=['.', '.'], recursive=True))
+    # neither do nested paths
+    eq_(plain_recursive,
+        ds.status(path=['.', 'subds_modified'], recursive=True))
+    # when invoked in a subdir of a dataset it still reports on the full thing
+    # just like `git status`, as long as there are no paths specified
+    with chpwd(op.join(path, 'directory_untracked')):
+        plain_recursive = status(recursive=True)
+    # should be able to take absolute paths and yield the same
+    # output
+    eq_(plain_recursive, ds.status(path=ds.path, recursive=True))
+
+    # query for a deeply nested path from the top, should just work with a
+    # variety of approaches
+    rpath = op.join('subds_modified', 'subds_lvl1_modified',
+                    'directory_untracked')
+    apathobj = ds.pathobj / rpath
+    apath = str(apathobj)
+    # ds.repo.pathobj will have the symlink resolved
+    arealpath = ds.repo.pathobj / rpath
+    # TODO include explicit relative path in test
+    for p in (rpath, apath, arealpath, None):
+        if p is None:
+            # change into the realpath of the dataset and
+            # query with an explicit path
+            with chpwd(ds.repo.path):
+                res = ds.status(path=op.join('.', rpath))
+        else:
+            res = ds.status(path=p)
+        assert_result_count(
+            res,
+            1,
+            state='untracked',
+            type='directory',
+            refds=ds.path,
+            # path always comes out a full path inside the queried dataset
+            path=apath,
+        )
+
+    assert_result_count(
+        ds.status(
+            recursive=True),
+        1,
+        path=apath)
+    # limiting recursion will exclude this particular path
+    assert_result_count(
+        ds.status(
+            recursive=True,
+            recursion_limit=1),
+        0,
+        path=apath)
+    # negative limit is unlimited limit
+    eq_(
+        ds.status(recursive=True, recursion_limit=-1),
+        ds.status(recursive=True)
+    )
+
+
+# https://github.com/datalad/datalad-revolution/issues/64
+# breaks when the tempdir is a symlink
+@with_tempfile(mkdir=True)
+def test_subds_status(path):
+    ds = Dataset(path).rev_create()
+    subds = ds.rev_create('subds')
+    assert_repo_status(ds.path)
+    subds.rev_create('someotherds')
+    assert_repo_status(subds.path)
+    assert_repo_status(ds.path, modified=['subds'])
+    assert_result_count(
+        ds.status(path='subds'),
+        1,
+        # must be modified, not added (ds was clean after it was added)
+        state='modified',
+        type='dataset',
+        path=subds.path,
+        refds=ds.path)

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -84,6 +84,16 @@ _group_plumbing = (
         ('datalad.distribution.subdatasets', 'Subdatasets', 'subdatasets'),
     ])
 
+# Avoid _group_revolution to prevent confusing interface commands.
+_group_future = (
+    'Commands of the future',
+    [
+        ('datalad.core.local.create', 'Create', 'rev-create', 'rev_create'),
+        ('datalad.core.local.run', 'Run', 'rev-run', 'rev_run'),
+        ('datalad.core.local.save', 'Save', 'rev-save', 'rev_save'),
+        ('datalad.core.local.status', 'Status', 'status'),
+    ])
+
 # Some known extensions and their commands to suggest whenever lookup fails
 _known_extension_commands = {
     'datalad-crawler': ('crawl', 'crawl-init'),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -131,7 +131,8 @@ class AnnexRepo(GitRepo, RepoInterface):
     _ALLOW_LOCAL_URLS = False
 
     def __init__(self, path, url=None, runner=None,
-                 backend=None, always_commit=True, create=True,
+                 backend=None, always_commit=True,
+                 create=True, create_sanity_checks=True,
                  init=False, batch_size=None, version=None, description=None,
                  git_opts=None, annex_opts=None, annex_init_opts=None,
                  repo=None, fake_dates=False):
@@ -161,6 +162,8 @@ class AnnexRepo(GitRepo, RepoInterface):
           Create and initialize an annex repository at path, in case
           there is none. If set to False, and this repository is not an annex
           repository (initialized or not), an exception is raised.
+        create_sanity_checks: bool, optional
+          Passed to GitRepo.
         init: bool, optional
           Initialize git-annex repository (run "git annex init") if path is an
           annex repository which just was not yet initialized by annex (e.g. a
@@ -191,10 +194,10 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         fix_it = False
         try:
-            super(AnnexRepo, self).__init__(path, url, runner=runner,
-                                            create=create, repo=repo,
-                                            git_opts=git_opts,
-                                            fake_dates=fake_dates)
+            super(AnnexRepo, self).__init__(
+                path, url, runner=runner,
+                create=create, create_sanity_checks=create_sanity_checks,
+                repo=repo, git_opts=git_opts, fake_dates=fake_dates)
         except GitCommandError as e:
             if create and "Clone succeeded, but checkout failed." in str(e):
                 lgr.warning("Experienced issues while cloning. "

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -1,0 +1,202 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test file info getters"""
+
+import os.path as op
+import datalad.utils as ut
+
+from datalad.tests.utils import (
+    with_tempfile,
+    assert_equal,
+    assert_dict_equal,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+)
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.gitrepo import GitRepo
+from datalad.tests.utils import (
+    assert_repo_status,
+    get_convoluted_situation,
+)
+
+
+@with_tempfile
+def test_get_content_info(path):
+    repo = GitRepo(path)
+    assert_equal(repo.get_content_info(), {})
+    # an invalid reference causes an exception
+    assert_raises(ValueError, repo.get_content_info, ref='HEAD')
+
+    ds = get_convoluted_situation(path)
+    repopath = ds.repo.pathobj
+
+    assert_equal(ds.repo.pathobj, repopath)
+    assert_equal(ds.pathobj, ut.Path(path))
+
+    # verify general rules on fused info records that are incrementally
+    # assembled: for git content info, amended with annex info on 'HEAD'
+    # (to get the last commited stage and with it possibly vanished
+    # content), and lastly annex info wrt to the present worktree, to
+    # also get info on added/staged content
+    # this fuses the info reported from
+    # - git ls-files
+    # - git annex findref HEAD
+    # - git annex find --include '*'
+    for f, r in ds.repo.annexstatus().items():
+        if f.match('*_untracked'):
+            assert(r.get('gitshasum', None) is None)
+        if f.match('*_deleted'):
+            assert(not f.exists() and not f.is_symlink() is None)
+        if f.match('subds_*'):
+            assert(r['type'] == 'dataset' if r.get('gitshasum', None) else 'directory')
+        if f.match('file_*'):
+            # which one exactly depends on many things
+            assert_in(r['type'], ('file', 'symlink'))
+        if f.match('file_ingit*'):
+            assert(r['type'] == 'file')
+        elif '.datalad' not in f.parts and not f.match('.git*') and \
+                r.get('gitshasum', None) and not f.match('subds*'):
+            # this should be known to annex, one way or another
+            # regardless of whether things add deleted or staged
+            # or anything inbetween
+            assert_in('key', r, f)
+            assert_in('keyname', r, f)
+            assert_in('backend', r, f)
+            assert_in('bytesize', r, f)
+            # no duplication with path
+            assert_not_in('file', r, f)
+
+    # query full untracked report
+    res = ds.repo.get_content_info()
+    assert_in(repopath.joinpath('dir_untracked', 'file_untracked'), res)
+    assert_not_in(repopath.joinpath('dir_untracked'), res)
+    # query for compact untracked report
+    res = ds.repo.get_content_info(untracked='normal')
+    assert_not_in(repopath.joinpath('dir_untracked', 'file_untracked'), res)
+    assert_in(repopath.joinpath('dir_untracked'), res)
+    # query no untracked report
+    res = ds.repo.get_content_info(untracked='no')
+    assert_not_in(repopath.joinpath('dir_untracked', 'file_untracked'), res)
+    assert_not_in(repopath.joinpath('dir_untracked'), res)
+
+    # git status integrity
+    status = ds.repo.status()
+    for t in ('subds', 'file'):
+        for s in ('untracked', 'added', 'deleted', 'clean',
+                  'ingit_clean', 'dropped_clean', 'modified',
+                  'ingit_modified'):
+            for l in ('', ut.PurePosixPath('subdir', '')):
+                if t == 'subds' and 'ingit' in s or 'dropped' in s:
+                    # invalid combination
+                    continue
+                if t == 'subds' and s == 'deleted':
+                    # same as subds_unavailable -> clean
+                    continue
+                p = repopath.joinpath(l, '{}_{}'.format(t, s))
+                assert p.match('*_{}'.format(status[p]['state'])), p
+                if t == 'subds':
+                    assert_in(status[p]['type'], ('dataset', 'directory'), p)
+                else:
+                    assert_in(status[p]['type'], ('file', 'symlink'), p)
+
+    # git annex status integrity
+    annexstatus = ds.repo.annexstatus()
+    for t in ('file',):
+        for s in ('untracked', 'added', 'deleted', 'clean',
+                  'ingit_clean', 'dropped_clean', 'modified',
+                  'ingit_modified'):
+            for l in ('', ut.PurePosixPath('subdir', '')):
+                p = repopath.joinpath(l, '{}_{}'.format(t, s))
+                if s in ('untracked', 'ingit_clean', 'ingit_modified'):
+                    # annex knows nothing about these things
+                    assert_not_in('key', annexstatus[p])
+                    continue
+                assert_in('key', annexstatus[p])
+                # dear future,
+                # if the next one fails, git-annex might have changed the
+                # nature of the path that are being reported by
+                # `annex find --json`
+                # when this was written `hashir*` was a native path, but
+                # `file` was a POSIX path
+                assert_equal(annexstatus[p]['has_content'], 'dropped' not in s)
+
+
+@with_tempfile
+def test_compare_content_info(path):
+    # TODO remove when `create` is RF to return the new Dataset
+    ds = Dataset(path).rev_create()
+    assert_repo_status(path)
+
+    # for a clean repo HEAD and worktree query should yield identical results
+    wt = ds.repo.get_content_info(ref=None)
+    assert_dict_equal(wt, ds.repo.get_content_info(ref='HEAD'))
+
+
+@with_tempfile
+def test_subds_path(path):
+    # a dataset with a subdataset with a file, all neatly tracked
+    ds = Dataset(path).rev_create()
+    subds = ds.rev_create('sub')
+    assert_repo_status(path)
+    with (subds.pathobj / 'some.txt').open('w') as f:
+        f.write(u'test')
+    ds.rev_save(recursive=True)
+    assert_repo_status(path)
+
+    # querying the toplevel dataset repo for a subdspath should
+    # report the subdataset record in the dataset
+    # (unlike `git status`, which is silent for subdataset paths),
+    # but definitely not report the subdataset as deleted
+    # https://github.com/datalad/datalad-revolution/issues/17
+    stat = ds.repo.status(paths=[op.join('sub', 'some.txt')])
+    assert_equal(list(stat.keys()), [subds.repo.pathobj])
+    assert_equal(stat[subds.repo.pathobj]['state'], 'clean')
+
+
+@with_tempfile
+def test_report_absent_keys(path):
+    ds = Dataset(path).rev_create()
+    # create an annexed file
+    testfile = ds.pathobj / 'dummy'
+    testfile.write_text(u'nothing')
+    ds.rev_save()
+    # present in a full report and in a partial report
+    # based on worktree of HEAD ref
+    for ai in (
+            ds.repo.get_content_annexinfo(eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                paths=['dummy'],
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                paths=['dummy'],
+                eval_availability=True)):
+        assert_in(testfile, ai)
+        assert_equal(ai[testfile]['has_content'], True)
+    # drop the key, not available anywhere else
+    ds.drop('dummy', check=False)
+    # does not change a thing, except the key is gone
+    for ai in (
+            ds.repo.get_content_annexinfo(eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                paths=['dummy'],
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                eval_availability=True),
+            ds.repo.get_content_annexinfo(
+                ref='HEAD',
+                paths=['dummy'],
+                eval_availability=True)):
+        assert_in(testfile, ai)
+        assert_equal(ai[testfile]['has_content'], False)

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -42,7 +42,12 @@ def _test_save_all(path, repocls):
     ds = get_convoluted_situation(path, GitRepo)
     orig_status = ds.repo.status(untracked='all', ignore_submodules='no')
     # TODO test the results when the are crafted
-    ds.repo.save()
+    res = ds.repo.save()
+    # make sure we get a 'delete' result for each deleted file
+    eq_(
+        set(r['path'] for r in res if r['action'] == 'delete'),
+        {k for k, v in iteritems(orig_status) if k.name == 'file_deleted'}
+    )
     saved_status = ds.repo.status(untracked='all', ignore_submodules='no')
     # we still have an entry for everything that did not get deleted
     # intentionally

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -1,0 +1,90 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test saveds fuction"""
+
+from six import iteritems
+
+from datalad.tests.utils import (
+    assert_in,
+    assert_not_in,
+    create_tree,
+    with_tempfile,
+    eq_,
+)
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
+from datalad.tests.utils import (
+    assert_repo_status,
+    get_convoluted_situation,
+)
+
+
+@with_tempfile
+def test_save_basics(path):
+    ds = Dataset(path).rev_create()
+    # nothing happens
+    eq_(list(ds.repo.save(paths=[], _status={})),
+        [])
+
+    # dataset is clean, so nothing happens with all on default
+    eq_(list(ds.repo.save()),
+        [])
+
+
+def _test_save_all(path, repocls):
+    ds = get_convoluted_situation(path, GitRepo)
+    orig_status = ds.repo.status(untracked='all', ignore_submodules='no')
+    # TODO test the results when the are crafted
+    ds.repo.save()
+    saved_status = ds.repo.status(untracked='all', ignore_submodules='no')
+    # we still have an entry for everything that did not get deleted
+    # intentionally
+    eq_(
+        len([f for f, p in iteritems(orig_status)
+             if not f.match('*_deleted')]),
+        len(saved_status))
+    # everything but subdataset entries that contain untracked content,
+    # or modified subsubdatasets is now clean, a repo simply doesn touch
+    # other repos' private parts
+    for f, p in iteritems(saved_status):
+        if p.get('state', None) != 'clean':
+            assert f.match('subds_modified'), f
+    return ds
+
+
+@with_tempfile
+def test_gitrepo_save_all(path):
+    _test_save_all(path, GitRepo)
+
+
+@with_tempfile
+def test_annexrepo_save_all(path):
+    _test_save_all(path, AnnexRepo)
+
+
+@with_tempfile
+def test_save_to_git(path):
+    ds = Dataset(path).rev_create()
+    create_tree(
+        ds.path,
+        {
+            'file_ingit': 'file_ingit',
+            'file_inannex': 'file_inannex',
+        }
+    )
+    ds.repo.save(paths=['file_ingit'], git=True)
+    ds.repo.save(paths=['file_inannex'])
+    assert_repo_status(ds.repo)
+    for f, p in iteritems(ds.repo.annexstatus()):
+        eq_(p['state'], 'clean')
+        if f.match('*ingit'):
+            assert_not_in('key', p, f)
+        elif f.match('*inannex'):
+            assert_in('key', p, f)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -51,6 +51,8 @@ from nose.tools import assert_set_equal
 from nose.tools import assert_is_instance
 from nose import SkipTest
 
+import datalad.utils as ut
+
 from ..cmd import Runner
 from .. import utils
 from ..utils import *
@@ -121,6 +123,7 @@ import os
 from os.path import exists, join
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo, FileNotInAnnexError
+from datalad.distribution.dataset import Dataset
 from ..utils import chpwd, getpwd
 
 
@@ -1460,6 +1463,316 @@ def get_datasets_topdir():
     """Delayed parsing so it could be monkey patched etc"""
     from datalad.consts import DATASETS_TOPURL
     return RI(DATASETS_TOPURL).hostname
+
+
+def assert_repo_status(path, annex=None, untracked_mode='normal', **kwargs):
+    """Compare a repo status against (optional) exceptions.
+
+    Anything file/directory that is not explicitly indicated must have
+    state 'clean', i.e. no modifications and recorded in Git.
+
+    This is an alternative to the traditional `ok_clean_git` helper.
+
+    Parameters
+    ----------
+    path: str or Repo
+      in case of a str: path to the repository's base dir;
+      Note, that passing a Repo instance prevents detecting annex. This might
+      be useful in case of a non-initialized annex, a GitRepo is pointing to.
+    annex: bool or None
+      explicitly set to True or False to indicate, that an annex is (not)
+      expected; set to None to autodetect, whether there is an annex.
+      Default: None.
+    untracked_mode: {'no', 'normal', 'all'}
+      If and how untracked content is reported. The specification of untracked
+      files that are OK to be found must match this mode. See `Repo.status()`
+    **kwargs
+      Files/directories that are OK to not be in 'clean' state. Each argument
+      must be one of 'added', 'untracked', 'deleted', 'modified' and each
+      value must be a list of filenames (relative to the root of the
+      repository, in POSIX convention).
+    """
+    r = None
+    if isinstance(path, AnnexRepo):
+        if annex is None:
+            annex = True
+        # if `annex` was set to False, but we find an annex => fail
+        assert_is(annex, True)
+        r = path
+    elif isinstance(path, GitRepo):
+        if annex is None:
+            annex = False
+        # explicitly given GitRepo instance doesn't make sense with
+        # 'annex' True
+        assert_is(annex, False)
+        r = path
+    else:
+        # 'path' is an actual path
+        try:
+            r = AnnexRepo(path, init=False, create=False)
+            if annex is None:
+                annex = True
+            # if `annex` was set to False, but we find an annex => fail
+            assert_is(annex, True)
+        except Exception:
+            # Instantiation failed => no annex
+            try:
+                r = GitRepo(path, init=False, create=False)
+            except Exception:
+                raise AssertionError("Couldn't find an annex or a git "
+                                     "repository at {}.".format(path))
+            if annex is None:
+                annex = False
+            # explicitly given GitRepo instance doesn't make sense with
+            # 'annex' True
+            assert_is(annex, False)
+
+    status = r.status(untracked=untracked_mode)
+    # for any file state that indicates some kind of change (all but 'clean)
+    for state in ('added', 'untracked', 'deleted', 'modified'):
+        oktobefound = sorted(r.pathobj.joinpath(ut.PurePosixPath(p))
+                             for p in kwargs.get(state, []))
+        state_files = sorted(k for k, v in iteritems(status)
+                             if v.get('state', None) == state)
+        eq_(state_files, oktobefound,
+            'unexpected content of state "%s": %r != %r'
+            % (state, state_files, oktobefound))
+
+
+def get_convoluted_situation(path, repocls=AnnexRepo):
+    from datalad.api import rev_create as create
+
+    if 'APPVEYOR' in os.environ:
+        # issue only happens on appveyor, Python itself implodes
+        # cannot be reproduced on a real windows box
+        raise SkipTest(
+            'get_convoluted_situation() causes appveyor to crash, '
+            'reason unknown')
+    repo = repocls(path, create=True)
+    # use create(force) to get an ID and config into the empty repo
+    ds = Dataset(path).rev_create(force=True)
+    # base content
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_clean': 'file_clean',
+                'file_deleted': 'file_deleted',
+                'file_modified': 'file_clean',
+            },
+            'file_clean': 'file_clean',
+            'file_deleted': 'file_deleted',
+            'file_staged_deleted': 'file_staged_deleted',
+            'file_modified': 'file_clean',
+        }
+    )
+    if isinstance(ds.repo, AnnexRepo):
+        create_tree(
+            ds.path,
+            {
+                'subdir': {
+                    'file_dropped_clean': 'file_dropped_clean',
+                },
+                'file_dropped_clean': 'file_dropped_clean',
+            }
+        )
+    ds.rev_save()
+    if isinstance(ds.repo, AnnexRepo):
+        # some files straight in git
+        create_tree(
+            ds.path,
+            {
+                'subdir': {
+                    'file_ingit_clean': 'file_ingit_clean',
+                    'file_ingit_modified': 'file_ingit_clean',
+                },
+                'file_ingit_clean': 'file_ingit_clean',
+                'file_ingit_modified': 'file_ingit_clean',
+            }
+        )
+        ds.rev_save(to_git=True)
+        ds.drop([
+            'file_dropped_clean',
+            op.join('subdir', 'file_dropped_clean')],
+            check=False)
+    # clean and proper subdatasets
+    ds.rev_create('subds_clean')
+    ds.rev_create(op.join('subdir', 'subds_clean'))
+    ds.rev_create('subds_unavailable_clean')
+    ds.rev_create(op.join('subdir', 'subds_unavailable_clean'))
+    # uninstall some subdatasets (still clean)
+    ds.uninstall([
+        'subds_unavailable_clean',
+        op.join('subdir', 'subds_unavailable_clean')],
+        check=False)
+    assert_repo_status(ds.path)
+    # make a dirty subdataset
+    ds.rev_create('subds_modified')
+    ds.rev_create(op.join('subds_modified', 'someds'))
+    ds.rev_create(op.join('subds_modified', 'someds', 'dirtyds'))
+    # make a subdataset with additional commits
+    ds.rev_create(op.join('subdir', 'subds_modified'))
+    pdspath = op.join(ds.path, 'subdir', 'subds_modified', 'progressedds')
+    ds.rev_create(pdspath)
+    create_tree(
+        pdspath,
+        {'file_clean': 'file_ingit_clean'}
+    )
+    Dataset(pdspath).rev_save()
+    assert_repo_status(pdspath)
+    # staged subds, and files
+    create(op.join(ds.path, 'subds_added'))
+    ds.repo.add_submodule('subds_added')
+    create(op.join(ds.path, 'subdir', 'subds_added'))
+    ds.repo.add_submodule(op.join('subdir', 'subds_added'))
+    # some more untracked files
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_untracked': 'file_untracked',
+                'file_added': 'file_added',
+            },
+            'file_untracked': 'file_untracked',
+            'file_added': 'file_added',
+            'dir_untracked': {
+                'file_untracked': 'file_untracked',
+            },
+            'subds_modified': {
+                'someds': {
+                    "dirtyds": {
+                        'file_untracked': 'file_untracked',
+                    },
+                },
+            },
+        }
+    )
+    ds.repo.add(['file_added', op.join('subdir', 'file_added')])
+    # untracked subdatasets
+    create(op.join(ds.path, 'subds_untracked'))
+    create(op.join(ds.path, 'subdir', 'subds_untracked'))
+    # deleted files
+    os.remove(op.join(ds.path, 'file_deleted'))
+    os.remove(op.join(ds.path, 'subdir', 'file_deleted'))
+    # staged deletion
+    ds.repo.remove('file_staged_deleted')
+    # modified files
+    if isinstance(ds.repo, AnnexRepo):
+        ds.repo.unlock(['file_modified', op.join('subdir', 'file_modified')])
+        create_tree(
+            ds.path,
+            {
+                'subdir': {
+                    'file_ingit_modified': 'file_ingit_modified',
+                },
+                'file_ingit_modified': 'file_ingit_modified',
+            }
+        )
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_modified': 'file_modified',
+            },
+            'file_modified': 'file_modified',
+        }
+    )
+    return ds
+
+
+def get_deeply_nested_structure(path):
+    """ Here is what this does (assuming UNIX, locked):
+    .
+    ├── directory_untracked
+    │   └── link2dir -> ../subdir
+    ├── file_modified
+    ├── link2dir -> subdir
+    ├── link2subdsdir -> subds_modified/subdir
+    ├── link2subdsroot -> subds_modified
+    ├── subdir
+    │   ├── annexed_file.txt -> ../.git/annex/objects/...
+    │   ├── file_modified
+    │   ├── git_file.txt
+    │   └── link2annex_files.txt -> annexed_file.txt
+    └── subds_modified
+        ├── link2superdsdir -> ../subdir
+        ├── subdir
+        │   └── annexed_file.txt -> ../.git/annex/objects/...
+        └── subds_lvl1_modified
+            └── directory_untracked
+    """
+    ds = Dataset(path).rev_create()
+    (ds.pathobj / 'subdir').mkdir()
+    (ds.pathobj / 'subdir' / 'annexed_file.txt').write_text(u'dummy')
+    ds.rev_save()
+    (ds.pathobj / 'subdir' / 'git_file.txt').write_text(u'dummy')
+    ds.rev_save(to_git=True)
+    # a subtree of datasets
+    subds = ds.rev_create('subds_modified')
+    # another dataset, plus an additional dir in it
+    (Dataset(
+        ds.create(
+            op.join('subds_modified', 'subds_lvl1_modified')
+        ).path).pathobj / 'directory_untracked').mkdir()
+    create_tree(
+        ds.path,
+        {
+            'subdir': {
+                'file_modified': 'file_modified',
+            },
+            'file_modified': 'file_modified',
+        }
+    )
+    (ut.Path(subds.path) / 'subdir').mkdir()
+    (ut.Path(subds.path) / 'subdir' / 'annexed_file.txt').write_text(u'dummy')
+    subds.rev_save()
+    (ds.pathobj / 'directory_untracked').mkdir()
+    # symlink farm #1
+    # symlink to annexed file
+    (ds.pathobj / 'subdir' / 'link2annex_files.txt').symlink_to(
+        'annexed_file.txt')
+    # symlink to directory within the dataset
+    (ds.pathobj / 'link2dir').symlink_to('subdir')
+    # upwards pointing symlink to directory within the same dataset
+    (ds.pathobj / 'directory_untracked' / 'link2dir').symlink_to(
+        op.join('..', 'subdir'))
+    # symlink pointing to a subdataset mount in the same dataset
+    (ds.pathobj / 'link2subdsroot').symlink_to('subds_modified')
+    # symlink to a dir in a subdataset (across dataset boundaries)
+    (ds.pathobj / 'link2subdsdir').symlink_to(
+        op.join('subds_modified', 'subdir'))
+    # symlink to a dir in a superdataset (across dataset boundaries)
+    (ut.Path(subds.path) / 'link2superdsdir').symlink_to(
+        op.join('..', 'subdir'))
+    return ds
+
+
+def has_symlink_capability():
+    try:
+        wdir = ut.Path(tempfile.mkdtemp())
+        (wdir / 'target').touch()
+        (wdir / 'link').symlink_to(wdir / 'target')
+        return True
+    except Exception:
+        return False
+    finally:
+        shutil.rmtree(str(wdir))
+
+
+def skip_wo_symlink_capability(func):
+    """Skip test when environment does not support symlinks
+
+    Perform a behavioral test instead of top-down logic, as on
+    windows this could be on or off on a case-by-case basis.
+    """
+    @wraps(func)
+    @attr('skip_wo_symlink_capability')
+    def newfunc(*args, **kwargs):
+        if not has_symlink_capability():
+            raise SkipTest("no symlink capabilities")
+        return func(*args, **kwargs)
+    return newfunc
+
 
 #
 # Context Managers

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1682,24 +1682,24 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
 
 def get_deeply_nested_structure(path):
     """ Here is what this does (assuming UNIX, locked):
-    .
-    ├── directory_untracked
-    │   └── link2dir -> ../subdir
-    ├── file_modified
-    ├── link2dir -> subdir
-    ├── link2subdsdir -> subds_modified/subdir
-    ├── link2subdsroot -> subds_modified
-    ├── subdir
-    │   ├── annexed_file.txt -> ../.git/annex/objects/...
-    │   ├── file_modified
-    │   ├── git_file.txt
-    │   └── link2annex_files.txt -> annexed_file.txt
-    └── subds_modified
-        ├── link2superdsdir -> ../subdir
-        ├── subdir
-        │   └── annexed_file.txt -> ../.git/annex/objects/...
-        └── subds_lvl1_modified
-            └── directory_untracked
+    |  .
+    |  ├── directory_untracked
+    |  │   └── link2dir -> ../subdir
+    |  ├── file_modified
+    |  ├── link2dir -> subdir
+    |  ├── link2subdsdir -> subds_modified/subdir
+    |  ├── link2subdsroot -> subds_modified
+    |  ├── subdir
+    |  │   ├── annexed_file.txt -> ../.git/annex/objects/...
+    |  │   ├── file_modified
+    |  │   ├── git_file.txt
+    |  │   └── link2annex_files.txt -> annexed_file.txt
+    |  └── subds_modified
+    |      ├── link2superdsdir -> ../subdir
+    |      ├── subdir
+    |      │   └── annexed_file.txt -> ../.git/annex/objects/...
+    |      └── subds_lvl1_modified
+    |          └── directory_untracked
     """
     ds = Dataset(path).rev_create()
     (ds.pathobj / 'subdir').mkdir()

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -96,3 +96,14 @@ Plumbing commands
    generated/man/datalad-sshrun
    generated/man/datalad-siblings
    generated/man/datalad-subdatasets
+
+Commands of the future
+======================
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-rev-create
+   generated/man/datalad-rev-run
+   generated/man/datalad-rev-save
+   generated/man/datalad-status


### PR DESCRIPTION
This series follows #3183 and brings in the second wave of datalad-revolution bits.  It

  * places the commands in the directory proposed by #3192 (I expect this will get some pushback)

  * brings in the following commands:
    - `rev-diff` (keeping `rev-`, for now at least) (#3190)
    - `rev-status -> status` (with wrapper remaining in revolution) (#3187)
    - `rev-save` (#3188)
    - `rev-create` (#3189)
    - `rev-run` (core's `run` still uses the `add`-based saver function for now)

  * brings in the tests that were orphaned by the first wave (https://github.com/datalad/datalad/pull/3183#issuecomment-468755440)

  * brings in the tests for the above commands aside from those for `rev-run` (leaving that to be done separately)

  * applies @mih's patch for #3221: https://github.com/datalad/datalad-revolution/tree/tst-save

  * makes `rev_create` use the new `create_sanity_checks` switch (datalad/datalad-revolution#95)

---

I'm opening this aware that there is at least one failure. (Oh, and the doc generation will probably fail too.)

<details>
<summary>failure details</summary>

```
======================================================================
FAIL: datalad.tests.test_api.test_consistent_order_of_args(<class 'datalad.core.local.revdiff.RevDiff'>, {'path'})
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kyle/src/python/venvs/dl-rev-merge/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/kyle/src/python/datalad-revmerge/datalad/tests/test_api.py", line 59, in _test_consistent_order_of_args
    eq_(set(args[:len(spec_posargs)]), spec_posargs)
AssertionError: {'fr'} != {'path'}

----------------------------------------------------------------------
```

That test could be appeased with

```diff
diff --git a/datalad/core/local/revdiff.py b/datalad/core/local/revdiff.py
index eca3937ee..6dd31a5d4 100644
--- a/datalad/core/local/revdiff.py
+++ b/datalad/core/local/revdiff.py
@@ -150,9 +150,9 @@ class RevDiff(Interface):
     @datasetmethod(name='rev_diff')
     @eval_results
     def __call__(
+            path=None,
             fr='HEAD',
             to=None,
-            path=None,
             dataset=None,
             annex=None,
             untracked='normal',
```

and quickly grepping for python callers, they all seem to use keyword arguments, so that change is probably the way to go.

</details>


