### PR TITLE
BF: gitrepo.get_content_info: Do not list empty directories

### DIFF
--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -246,11 +246,12 @@ def test_nested_create(path):
     with open(op.join(lvl2path, 'file'), 'w') as f:
         f.write('some')
     ok_(ds.rev_save())
-    assert_repo_status(ds.path, untracked=['lvl1/empty'])
+    # Empty directories are filtered out.
+    assert_repo_status(ds.path, untracked=[])
     # later create subdataset in a fresh dir
     # WINDOWS FAILURE IS NEXT LINE
     subds1 = ds.rev_create(op.join('lvl1', 'subds'))
-    assert_repo_status(ds.path, untracked=['lvl1/empty'])
+    assert_repo_status(ds.path, untracked=[])
     eq_(ds.subdatasets(result_xfm='relpaths'), [op.join('lvl1', 'subds')])
     # later create subdataset in an existing empty dir
     subds2 = ds.rev_create(op.join('lvl1', 'empty'))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2854,7 +2854,7 @@ class GitRepo(RepoInterface):
             if untracked == 'all':
                 cmd.append('-o')
             elif untracked == 'normal':
-                cmd += ['-o', '--directory']
+                cmd += ['-o', '--directory', '--no-empty-directory']
             elif untracked == 'no':
                 pass
             else:

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1555,10 +1555,14 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
     create_tree(
         ds.path,
         {
+            '.gitignore': '*.ignored',
             'subdir': {
                 'file_clean': 'file_clean',
                 'file_deleted': 'file_deleted',
                 'file_modified': 'file_clean',
+            },
+            'subdir-only-ignored': {
+                '1.ignored': '',
             },
             'file_clean': 'file_clean',
             'file_deleted': 'file_deleted',

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1700,6 +1700,7 @@ def get_deeply_nested_structure(path):
     |      │   └── annexed_file.txt -> ../.git/annex/objects/...
     |      └── subds_lvl1_modified
     |          └── directory_untracked
+    |              └── untracked_file
     """
     ds = Dataset(path).rev_create()
     (ds.pathobj / 'subdir').mkdir()
@@ -1710,10 +1711,7 @@ def get_deeply_nested_structure(path):
     # a subtree of datasets
     subds = ds.rev_create('subds_modified')
     # another dataset, plus an additional dir in it
-    (Dataset(
-        ds.create(
-            op.join('subds_modified', 'subds_lvl1_modified')
-        ).path).pathobj / 'directory_untracked').mkdir()
+    ds.create(op.join('subds_modified', 'subds_lvl1_modified'))
     create_tree(
         ds.path,
         {
@@ -1722,6 +1720,10 @@ def get_deeply_nested_structure(path):
             },
             'file_modified': 'file_modified',
         }
+    )
+    create_tree(
+        text_type(ds.pathobj / 'subds_modified' / 'subds_lvl1_modified'),
+        {'directory_untracked' : {"untraced_file": ""}}
     )
     (ut.Path(subds.path) / 'subdir').mkdir()
     (ut.Path(subds.path) / 'subdir' / 'annexed_file.txt').write_text(u'dummy')


### PR DESCRIPTION
When we pass --directory to ls-files, pass --no-empty-directory as
well so that we do not include directories that contain only excluded
files.

Fixes #3235.