### PR TITLE
BF: join with ds.path when trying to see if any other metadata file is available

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -798,7 +798,7 @@ def get_ds_aggregate_db_locations(ds, version='default', warn_absent=True):
             # caller had no specific idea what metadata version is needed/available
             # This dataset does not have aggregated metadata.  Does it have any
             # other version?
-            info_glob = agginfo_relpath_template.format('*')
+            info_glob = op.join(ds.path, agginfo_relpath_template).format('*')
             info_files = glob.glob(info_glob)
             msg = "Found no aggregated metadata info file %s." \
                   % info_fpath


### PR DESCRIPTION
Otherwise it would complain about "wrong version" when files not present at
all for the dataset being queried, but present in curdir dataset (e.g. when
querying from a super dataset).  See e.g.
 https://github.com/datalad/datalad/issues/3055#issue-387483697
which shows such a message when it should not