### PR TITLE
ENH: -d^. to point to the top of the current dataset

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -111,6 +111,9 @@ class Dataset(object, metaclass=Flyweight):
             # might have its ideas on what to do with ^, so better use as -d^
             path_ = Dataset(get_dataset_root(curdir)).get_superdataset(
                 topmost=True).path
+        elif path == '^.':
+            # get the dataset containing current directory
+            path_ = get_dataset_root(curdir)
         elif path == '///':
             # TODO: logic/UI on installing a default dataset could move here
             # from search?

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -203,6 +203,23 @@ def test_subdatasets(path):
 
     # TODO actual submodule checkout is still there
 
+    # Test ^. (the dataset for curdir) shortcut
+    # At the top should point to the top
+    with chpwd(ds.path):
+        dstop = Dataset('^.')
+        eq_(dstop, ds)
+
+    # and still does within subdir
+    os.mkdir(opj(ds.path, 'subdir'))
+    with chpwd(opj(ds.path, 'subdir')):
+        dstop = Dataset('^.')
+        eq_(dstop, ds)
+
+    # within submodule will point to submodule
+    with chpwd(subsubds.path):
+        dstop = Dataset('^.')
+        eq_(dstop, subsubds)
+
 
 @with_tempfile(mkdir=True)
 def test_hat_dataset_more(path):

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -185,6 +185,8 @@ There are also some useful pre-defined "shortcut" values for dataset arguments:
    For example, if you are in ``$HOME/datalad/openfmri/ds000001/sub-01`` and want
    to search metadata of the entire superdataset you are under (in this case
    ``///``), run ``datalad search -d^ [something to search]``.
+``^.``
+   the dataset the current directory is part of.
 
 Commands `install` vs `get`
 ---------------------------


### PR DESCRIPTION
It is often desired to reference current dataset. E.g. to add an existing
dataset as subdataset to the current dataset somewhere not at the top of the
dataset directories tree. Especially in quite nested hierarchies it
becomes a burden to figure out where is the boundary of the dataset to specify
it in -d option.  -d .  would point to the (not installed, and possibly illegit
see #3211) subdataset in current directory, whenever actual need is to specify
smth like -d ../../..  .

With -d^. it becomes possible to say "refer to the current dataset I am in".

The only gotcha I am aware of is that shell might like to use "^" as
a quick substitution for previous command, that is why I specified it
as -d^., i.e. without space - then seems to work as intended -- running
"datalad add -d^. ./subds"  would add subds in current subdirectory to the
dataset without requiring full path in -d.

Depending on the outcome of #3230 discussion, this change might not be really
needed, e.g. if default context for operations (including on subdatasets) would
migrate to be of "current dataset".  Otherwise, if -d would be needed to "bind"
the context to current dataset - at least with this helper it would be easy to
unambigously reference current dataset regardless of the position in the
directories hierarchy.

If you have a better suggestion instead of `^.` - please suggest.  My choice was because we have `^` to point to supermost dataset, thus use it to point to the (very) top. So it kinda made sense to me to point to the top of dataset curdir belongs to with `^.`, and have it on the left because that target path is to the left of curdir (although `.^` probably would have been better for use in shell due to aforementioned gotcha)

### Instructions

- [x] **Delete these instructions**. :-)
