### PR TITLE
BF: do not cause a side-effect on kwargs in @eval_results

### DIFF
--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -263,6 +263,11 @@ def test_eval_results_plus_build_doc():
     result = Dataset('/does/not/matter').fake_command(3)
     assert_equal(len(list(result)), 3)
 
+    # test absent side-effect of popping eval_defaults
+    kwargs = dict(return_type='list')
+    TestUtils().__call__(2, **kwargs)
+    assert_equal(list(kwargs), ['return_type'])
+
     # test signature:
     from inspect import getargspec
     assert_equal(getargspec(Dataset.fake_command)[0], ['number', 'dataset'])

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -331,6 +331,7 @@ def eval_results(func):
 
         # retrieve common options from kwargs, and fall back on the command
         # class attributes, or general defaults if needed
+        kwargs = kwargs.copy()  # we will pop, which might cause side-effect
         common_params = {
             p_name: kwargs.pop(
                 p_name,


### PR DESCRIPTION
Ran into it while creating a test where multiple kwargs should have been
consistently passed to subsequent invocations of metadata (as a function or
a method).  But pre-created kwargs dictionary was augmented by calling
metadata, which (as any side-effect) was quite confusing.