### PR TITLE
Rename old constant, and define/use a few new ones to avoid hardcoded copies of the paths

### DIFF
--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -30,7 +30,7 @@ from .utils import getpwd
 from .dochelpers import exc_str
 from .support.annexrepo import AnnexRepo
 from .cmdline.helpers import get_repo_instance
-from .consts import HANDLE_META_DIR
+from .consts import DATALAD_DOTDIR
 
 # To be used for a quick detection of path being under .git/
 _DOT_GIT_DIR = pathsep + '.git' + pathsep
@@ -245,7 +245,7 @@ class AutomagicIO(object):
             # level dataset for that
             try:
                 filedir = pathsep.join(
-                    filedir_parts[:filedir_parts.index(HANDLE_META_DIR)]
+                    filedir_parts[:filedir_parts.index(DATALAD_DOTDIR)]
                 )
             except ValueError:
                 # would happen if no .datalad

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -12,7 +12,7 @@
 import datalad
 from datalad.consts import (
     DATASET_CONFIG_FILE,
-    HANDLE_META_DIR,
+    DATALAD_DOTDIR,
 )
 from datalad.cmd import GitRunner
 from datalad.dochelpers import exc_str
@@ -547,7 +547,7 @@ class ConfigManager(object):
                     'none specified')
             # create an empty config file if none exists, `git config` will
             # fail otherwise
-            dscfg_dirname = opj(self._dataset_path,  HANDLE_META_DIR)
+            dscfg_dirname = opj(self._dataset_path,  DATALAD_DOTDIR)
             if not exists(dscfg_dirname):
                 os.makedirs(dscfg_dirname)
             if not exists(self._dataset_cfgfname):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -10,6 +10,10 @@
 """
 
 import datalad
+from datalad.consts import (
+    DATASET_CONFIG_FILE,
+    HANDLE_META_DIR,
+)
 from datalad.cmd import GitRunner
 from datalad.dochelpers import exc_str
 from distutils.version import LooseVersion
@@ -180,7 +184,7 @@ class ConfigManager(object):
             self._repo_cfgfname = None
         else:
             self._dataset_path = dataset.path
-            self._dataset_cfgfname = opj(self._dataset_path, '.datalad', 'config')
+            self._dataset_cfgfname = opj(self._dataset_path, DATASET_CONFIG_FILE)
             if not dataset_only:
                 self._repo_cfgfname = opj(self._dataset_path, '.git', 'config')
         self._dataset_only = dataset_only
@@ -543,7 +547,7 @@ class ConfigManager(object):
                     'none specified')
             # create an empty config file if none exists, `git config` will
             # fail otherwise
-            dscfg_dirname = opj(self._dataset_path, '.datalad')
+            dscfg_dirname = opj(self._dataset_path,  HANDLE_META_DIR)
             if not exists(dscfg_dirname):
                 os.makedirs(dscfg_dirname)
             if not exists(self._dataset_cfgfname):

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -14,16 +14,20 @@ from os.path import join
 from os.path import expanduser
 
 # directory containing prepared metadata of a dataset repository:
-# Used at least in the crawler
-HANDLE_META_DIR = ".datalad"
+DATALAD_DOTDIR = ".datalad"
+# Compatibility: Used at least in the crawler
+# TODO: figure out how to make it possible to issue DeprecationWarning
+# upon use.  Possible way: make consts into a class instance, but then they
+# all must be imported as `from datalad import consts` and as `consts.CONSTANT`
+HANDLE_META_DIR = DATALAD_DOTDIR
 
 # Make use of those in datalad.metadata
-OLDMETADATA_DIR = join(HANDLE_META_DIR, 'meta')
+OLDMETADATA_DIR = join(DATALAD_DOTDIR, 'meta')
 OLDMETADATA_FILENAME = 'meta.json'
 
-METADATA_DIR = join(HANDLE_META_DIR, 'metadata')
+METADATA_DIR = join(DATALAD_DOTDIR, 'metadata')
 DATASET_METADATA_FILE = join(METADATA_DIR, 'dataset.json')
-DATASET_CONFIG_FILE = join(HANDLE_META_DIR, 'config')
+DATASET_CONFIG_FILE = join(DATALAD_DOTDIR, 'config')
 
 ARCHIVES_SPECIAL_REMOTE = 'datalad-archives'
 DATALAD_SPECIAL_REMOTE = 'datalad'

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -14,11 +14,12 @@ from os.path import join
 from os.path import expanduser
 
 # directory containing prepared metadata of a dataset repository:
+# Used at least in the crawler
 HANDLE_META_DIR = ".datalad"
 
 # Make use of those in datalad.metadata
-METADATA_DIR = join(HANDLE_META_DIR, 'meta')
-METADATA_FILENAME = 'meta.json'
+OLDMETADATA_DIR = join(HANDLE_META_DIR, 'meta')
+OLDMETADATA_FILENAME = 'meta.json'
 
 ARCHIVES_SPECIAL_REMOTE = 'datalad-archives'
 DATALAD_SPECIAL_REMOTE = 'datalad'

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -21,6 +21,10 @@ HANDLE_META_DIR = ".datalad"
 OLDMETADATA_DIR = join(HANDLE_META_DIR, 'meta')
 OLDMETADATA_FILENAME = 'meta.json'
 
+METADATA_DIR = join(HANDLE_META_DIR, 'metadata')
+DATASET_METADATA_FILE = join(METADATA_DIR, 'dataset.json')
+DATASET_CONFIG_FILE = join(HANDLE_META_DIR, 'config')
+
 ARCHIVES_SPECIAL_REMOTE = 'datalad-archives'
 DATALAD_SPECIAL_REMOTE = 'datalad'
 DATALAD_GIT_DIR = join('.git', 'datalad')

--- a/datalad/interface/ls_webui.py
+++ b/datalad/interface/ls_webui.py
@@ -20,7 +20,7 @@ from os import makedirs, remove, listdir
 from os.path import split, abspath, basename, join as opj, realpath, relpath, \
     isabs, dirname
 
-from datalad.consts import METADATA_DIR, METADATA_FILENAME
+from datalad.consts import OLDMETADATA_DIR, OLDMETADATA_FILENAME
 from datalad.distribution.dataset import Dataset
 from datalad.interface.ls import FsModel, lgr, GitModel
 from datalad.support.network import is_datalad_compat_ri
@@ -137,7 +137,7 @@ def fs_extract(nodepath, repo, basepath='/'):
     }
     # if there is meta-data for the dataset (done by aggregate-metadata)
     # we include it
-    metadata_path = opj(nodepath, METADATA_DIR, METADATA_FILENAME)
+    metadata_path = opj(nodepath, OLDMETADATA_DIR, OLDMETADATA_FILENAME)
     if exists(metadata_path):
         # might need flattening!  TODO: flatten when aggregating?  why wasn't done?
         with open(metadata_path) as t:

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -26,6 +26,10 @@ from hashlib import md5
 import shutil
 
 import datalad
+from datalad.consts import (
+    DATASET_CONFIG_FILE,
+    DATASET_METADATA_FILE,
+)
 from datalad.dochelpers import exc_str
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.base import Interface
@@ -255,8 +259,8 @@ def _dump_extracted_metadata(agginto_ds, aggfrom_ds, db, to_save, force_extracti
     objid = refcommit if refcommit else ''
     # 2, our own dataset-global metadata and the dataset config
     for tfile in (
-            op.join(aggfrom_ds.path, '.datalad', 'metadata', 'dataset.json'),
-            op.join(aggfrom_ds.path, '.datalad', 'config')):
+            op.join(aggfrom_ds.path, DATASET_METADATA_FILE),
+            op.join(aggfrom_ds.path, DATASET_CONFIG_FILE)):
         if op.exists(tfile):
             objid += md5(open(tfile, 'r').read().encode()).hexdigest()
     # 3. potential annex-based metadata

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -19,7 +19,7 @@ from os.path import exists
 
 from datalad.consts import (
     DATASET_METADATA_FILE,
-    HANDLE_META_DIR,
+    DATALAD_DOTDIR,
 )
 from datalad.support.json_py import load as jsonload
 from datalad.support.annexrepo import AnnexRepo
@@ -106,7 +106,7 @@ class MetadataExtractor(BaseMetadataExtractor):
         for file, whereis in self.ds.repo.whereis(
                 self.paths if self.paths and valid_paths is None else '.',
                 output='full').items():
-            if file.startswith(HANDLE_META_DIR) or valid_paths and file not in valid_paths:
+            if file.startswith(DATALAD_DOTDIR) or valid_paths and file not in valid_paths:
                 # do not report on our own internal annexed files (e.g. metadata blobs)
                 continue
             log_progress(

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -17,6 +17,10 @@ from datalad.log import log_progress
 from os.path import join as opj
 from os.path import exists
 
+from datalad.consts import (
+    DATASET_METADATA_FILE,
+    HANDLE_META_DIR,
+)
 from datalad.support.json_py import load as jsonload
 from datalad.support.annexrepo import AnnexRepo
 from datalad.coreapi import subdatasets
@@ -26,7 +30,6 @@ from datalad.metadata.definitions import version as vocabulary_version
 
 
 class MetadataExtractor(BaseMetadataExtractor):
-    _dataset_metadata_filename = opj('.datalad', 'metadata', 'dataset.json')
     _unique_exclude = {"url"}
 
     def _get_dataset_metadata(self):
@@ -36,7 +39,7 @@ class MetadataExtractor(BaseMetadataExtractor):
         dict
           keys are homogenized datalad metadata keys, values are arbitrary
         """
-        fpath = opj(self.ds.path, self._dataset_metadata_filename)
+        fpath = opj(self.ds.path, DATASET_METADATA_FILE)
         obj = {}
         if exists(fpath):
             obj = jsonload(fpath, fixup=True)
@@ -103,7 +106,7 @@ class MetadataExtractor(BaseMetadataExtractor):
         for file, whereis in self.ds.repo.whereis(
                 self.paths if self.paths and valid_paths is None else '.',
                 output='full').items():
-            if file.startswith('.datalad') or valid_paths and file not in valid_paths:
+            if file.startswith(HANDLE_META_DIR) or valid_paths and file not in valid_paths:
                 # do not report on our own internal annexed files (e.g. metadata blobs)
                 continue
             log_progress(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -64,8 +64,8 @@ from datalad.utils import (
 from datalad.ui import ui
 from datalad.dochelpers import exc_str
 from datalad.consts import (
-    METADATA_DIR,
-    METADATA_FILENAME,
+    OLDMETADATA_DIR,
+    OLDMETADATA_FILENAME,
 )
 from datalad.log import log_progress
 
@@ -802,7 +802,7 @@ def get_ds_aggregate_db_locations(ds, version='default', warn_absent=True):
             info_files = glob.glob(info_glob)
             msg = "Found no aggregated metadata info file %s." \
                   % info_fpath
-            old_metadata_file = op.join(ds.path, METADATA_DIR, METADATA_FILENAME)
+            old_metadata_file = op.join(ds.path, OLDMETADATA_DIR, OLDMETADATA_FILENAME)
             if op.exists(old_metadata_file):
                 msg += " Found metadata generated with pre-0.10 version of " \
                        "DataLad, but it will not be used."

--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -6,6 +6,9 @@ Additional arguments: <metadata type label> [...]
 import sys
 import os.path as op
 
+from datalad.consts import (
+    DATASET_CONFIG_FILE
+)
 from datalad.distribution.dataset import require_dataset
 
 ds = require_dataset(
@@ -25,7 +28,7 @@ for nt in sys.argv[2:]:
 
 ds.save(
     path=[dict(
-        path=op.join(ds.path, '.datalad', 'config'),
+        path=op.join(ds.path, DATASET_CONFIG_FILE),
         type='file',
         parentds=ds.path)],
     message="Configure metadata type(s)",


### PR DESCRIPTION
Rationale is to make them defined in a single place and be able to quickly (git grep) identify code which relies on them.  Otherwise it is quite hard since string quotes and spacing (separate lines) could vary etc.  Moreover e.g. DATASET_METADATA_FILE I believe was defined separately in multiple points.
    
I have not touched the tests somewhat on purpose, e.g. to make consts somewhat more constant ;)
