### PR TITLE
Bring in -revolution's run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -179,24 +179,33 @@ matrix:
     - NOSE_SELECTION_OP=not
     - NOSE_SELECTION=
 
-  - python: 3.5
-    # test with extension datalad-container
-    env:
-    - BUILD_DATALAD_EXTENSION=datalad-container
-    - TESTS_TO_PERFORM=datalad_container
-    # Use a selector that will always be true.
-    - NOSE_SELECTION_OP=not
-    - NOSE_SELECTION=
+  # TODO: The current release of datalad-container (0.3.1) is
+  # incompatible with the current DataLad.  Uncomment this once the
+  # following change makes it into a release:
+  # https://github.com/datalad/datalad-container/pull/73
+  #
+  # - python: 3.5
+  #   # test with extension datalad-container
+  #   env:
+  #   - BUILD_DATALAD_EXTENSION=datalad-container
+  #   - TESTS_TO_PERFORM=datalad_container
+  #   # Use a selector that will always be true.
+  #   - NOSE_SELECTION_OP=not
+  #   - NOSE_SELECTION=
 
-  - python: 3.5
-    # test with extension datalad-revolution
-    env:
-    - BUILD_DATALAD_EXTENSION=datalad-revolution
-    - DATALAD_REPO_VERSION=6
-    - TESTS_TO_PERFORM=datalad_revolution
-    # Use a selector that will always be true.
-    - NOSE_SELECTION_OP=not
-    - NOSE_SELECTION=
+  # TODO: The current release of datalad-revolution (0.9.0) is
+  # incompatible with the current DataLad.  Uncomment this after the
+  # next -revolution release, which will include 1a7c21b.
+  #
+  # - python: 3.5
+  #   # test with extension datalad-revolution
+  #   env:
+  #   - BUILD_DATALAD_EXTENSION=datalad-revolution
+  #   - DATALAD_REPO_VERSION=6
+  #   - TESTS_TO_PERFORM=datalad_revolution
+  #   # Use a selector that will always be true.
+  #   - NOSE_SELECTION_OP=not
+  #   - NOSE_SELECTION=
 
   allow_failures:
   # Test under NFS mount  (full, only in master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,7 +91,7 @@ test_script:
   # remaining fails: test_http
   - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3"
   # remaining fails: test_add_archive_content test_annotate_paths test_diff test_ls_webui test_run test_save test_utils
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.interface.tests.test_base datalad.interface.tests.test_clean datalad.interface.tests.test_docs datalad.interface.tests.test_ls datalad.interface.tests.test_unlock datalad.interface.tests.test_run_procedure"
+  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.interface.tests.test_base datalad.interface.tests.test_clean datalad.interface.tests.test_docs datalad.interface.tests.test_ls datalad.interface.tests.test_unlock datalad.interface.tests.test_run datalad.interface.tests.test_run_procedure"
   # remaining fails: extractors.tests.test_base test_aggregation test_base  datalad.metadata.extractors.tests.test_datacite_xml
   - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822"
   # remaining fails: test_addurls test_export_archive test_plugins"

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -6,38 +6,20 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Thin wrapper around `run` from DataLad core"""
+"""Temporary rev-run -> run alias"""
 
 __docformat__ = 'restructuredtext'
 
-
-import logging
-
-# take everything from run, all we want to be is a thin variant
 from datalad.interface.run import (
     Run as _Run,
     run_command,
     build_doc,
     eval_results,
+    _save_outputs,
 )
 from datalad.distribution.dataset import (
-    Dataset,
     datasetmethod,
 )
-from .save import Save
-
-lgr = logging.getLogger('datalad.core.local.run')
-
-
-def _save_outputs(ds, to_save, msg):
-    """Helper to save results after command execution is completed"""
-    return Save.__call__(
-        to_save,
-        message=msg,
-        # need to convert any incoming dataset into a revolutionary one
-        dataset=Dataset(ds.path),
-        recursive=True,
-        return_type='generator')
 
 
 @build_doc

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -177,13 +177,6 @@ class Run(Interface):
             '.datalad/runinfo' directory (customizable via the
             'datalad.run.record-directory' configuration variable).""",
             constraints=EnsureNone() | EnsureBool()),
-        rerun=Parameter(
-            args=('--rerun',),
-            action='store_true',
-            doc="""re-run the command recorded in the last saved change (if any).
-            Note: This option is deprecated since version 0.9.2 and
-            will be removed in a later release. Use `datalad rerun`
-            instead."""),
     )
 
     @staticmethod
@@ -197,24 +190,14 @@ class Run(Interface):
             expand=None,
             explicit=False,
             message=None,
-            sidecar=None,
-            rerun=False):
-        if rerun:
-            if cmd:
-                lgr.warning("Ignoring provided command in --rerun mode")
-            lgr.warning("The --rerun option is deprecated since version 0.9.2. "
-                        "Use `datalad rerun` instead.")
-            from datalad.interface.rerun import Rerun
-            for r in Rerun.__call__(dataset=dataset, message=message):
-                yield r
-        else:
-            for r in run_command(cmd, dataset=dataset,
-                                 inputs=inputs, outputs=outputs,
-                                 expand=expand,
-                                 explicit=explicit,
-                                 message=message,
-                                 sidecar=sidecar):
-                yield r
+            sidecar=None):
+        for r in run_command(cmd, dataset=dataset,
+                             inputs=inputs, outputs=outputs,
+                             expand=expand,
+                             explicit=explicit,
+                             message=message,
+                             sidecar=sidecar):
+            yield r
 
 
 def _install_and_reglob(dset, gpaths):

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -23,6 +23,8 @@ from os.path import relpath
 from six.moves import map
 from six.moves import shlex_quote
 
+from datalad.core.local.save import Save
+
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
@@ -389,8 +391,9 @@ def _execute_command(command, pwd, expected_exit=None):
 
 def _save_outputs(ds, to_save, msg):
     """Helper to save results after command execution is completed"""
-    return ds.add(
+    return Save.__call__(
         to_save,
+        dataset=ds.path,
         recursive=True,
         message=msg,
         return_type='generator')
@@ -595,7 +598,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 ofh.write(assure_bytes(msg))
             lgr.info("The command had a non-zero exit code. "
                      "If this is expected, you can save the changes with "
-                     "'datalad add -d . -r -F %s .'",
+                     "'datalad rev-save -d . -r -F %s'",
                      msg_path)
         raise exc
     elif outputs_to_save:

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -420,7 +420,6 @@ def test_rerun_just_one_commit(path):
                   report=True, return_type="list")
 
 
-@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_run_failure(path):
     ds = Dataset(path).rev_create()
@@ -448,6 +447,10 @@ def test_run_failure(path):
 
     outfile = op.join(subds.path, "grows")
     eq_('x \n' if on_windows else 'x\n', open(outfile).read())
+
+    if on_windows:
+        # FIXME: Make the remaining code compatible with Windows.
+        return
 
     # There is no CommandError on rerun if the non-zero error matches the
     # original code.

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -365,23 +365,6 @@ def test_rerun_chain(path):
 
 @known_failure_windows
 @with_tempfile(mkdir=True)
-def test_rerun_old_flag_compatibility(path):
-    ds = Dataset(path).create()
-    with swallow_outputs():
-        ds.run("echo x$(cat grows) > grows")
-    # Deprecated `datalad --rerun` still runs the last commit's
-    # command.
-    ds.run(rerun=True)
-    eq_("xx\n", open(opj(path, "grows")).read())
-    # Running with --rerun and a command ignores the command.
-    with swallow_logs(new_level=logging.WARN) as cml:
-        ds.run(rerun=True, cmd="ignored")
-        assert_in("Ignoring provided command in --rerun mode", cml.out)
-        eq_("xxx\n", open(opj(path, "grows")).read())
-
-
-@known_failure_windows
-@with_tempfile(mkdir=True)
 def test_rerun_just_one_commit(path):
     ds = Dataset(path).create()
 

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -949,7 +949,7 @@ def test_run_explicit(path):
 def test_placeholders(path):
     ds = Dataset(path).rev_create(force=True)
     ds.rev_save()
-    assert_repo_status(ds.path, untracked=['subdir'])
+    assert_repo_status(ds.path)
     # ATTN windows is sensitive to spaces before redirect symbol
     ds.run("echo {inputs}>{outputs}", inputs=[".", "*.in"], outputs=["c.out"])
     ok_file_has_content(op.join(path, "c.out"), "a.in b.in\n")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -158,15 +158,17 @@ def test_py2_unicode_command(path):
     assert_repo_status(ds.path)
     ok_exists(op.join(path, u"bβ0.dat"))
 
-    ds.run([sys.executable, "-c", touch_cmd, u"bβ1.dat"])
-    assert_repo_status(ds.path)
-    ok_exists(op.join(path, u"bβ1.dat"))
+    if not on_windows:  # FIXME
+        ds.run([sys.executable, "-c", touch_cmd, u"bβ1.dat"])
+        assert_repo_status(ds.path)
+        ok_exists(op.join(path, u"bβ1.dat"))
 
-    # Send in a list of byte-strings to mimic a py2 command-line invocation.
-    ds.run([s.encode("utf-8")
-            for s in [sys.executable, "-c", touch_cmd, u" β1 "]])
-    assert_repo_status(ds.path)
-    ok_exists(op.join(path, u" β1 "))
+        # Send in a list of byte-strings to mimic a py2 command-line
+        # invocation.
+        ds.run([s.encode("utf-8")
+                for s in [sys.executable, "-c", touch_cmd, u" β1 "]])
+        assert_repo_status(ds.path)
+        ok_exists(op.join(path, u" β1 "))
 
     with assert_raises(CommandError), swallow_outputs():
         ds.run(u"bβ2.dat")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -349,7 +349,6 @@ def test_rerun_chain(path):
     ds = Dataset(path).create()
     commits = []
 
-    grow_file = op.join(path, "grows")
     with swallow_outputs():
         ds.run('echo x$(cat grows) > grows')
     ds.repo.tag("first-run")

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -579,6 +579,7 @@ def test_rerun_ambiguous_revision_file(path):
         len(ds.repo.repo.git.rev_list("ambig", "--").split()))
 
 
+@known_failure_windows
 @with_tree(tree={"subdir": {}})
 def test_rerun_subdir(path):
     # Note: Using with_tree rather than with_tempfile is matters. The latter


### PR DESCRIPTION
This PR is not in its final state and will likely see a lot of churn, especially since I'm relying on appveyor for Windows feedback.  A summary will follow once things are in a state worth summarizing.