### PR TITLE
RF: Eliminate the use of `add/save/create` outside of then obsolete code

### DIFF
--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -16,8 +16,8 @@ import timeit
 
 from subprocess import call
 
-from datalad.api import rev-save
-from datalad.api import create
+from datalad.api import rev_save
+from datalad.api import rev_create
 from datalad.api import create_test_dataset
 from datalad.api import Dataset
 from datalad.api import install
@@ -102,10 +102,10 @@ class supers(SuprocBenchmarks):
         assert install(self.ds.path + '_', source=self.ds.path, recursive=True)
 
     def time_createadd(self, tarfile_path):
-        assert self.ds.create('newsubds')
+        assert self.ds.rev_create('newsubds')
 
     def time_createadd_to_dataset(self, tarfile_path):
-        subds = create(opj(self.ds.path, 'newsubds'))
+        subds = rev_create(opj(self.ds.path, 'newsubds'))
         self.ds.rev_save(subds.path)
 
     def time_ls(self, tarfile_path):

--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -16,7 +16,7 @@ import timeit
 
 from subprocess import call
 
-from datalad.api import add
+from datalad.api import rev-save
 from datalad.api import create
 from datalad.api import create_test_dataset
 from datalad.api import Dataset
@@ -106,7 +106,7 @@ class supers(SuprocBenchmarks):
 
     def time_createadd_to_dataset(self, tarfile_path):
         subds = create(opj(self.ds.path, 'newsubds'))
-        self.ds.add(subds.path)
+        self.ds.rev_save(subds.path)
 
     def time_ls(self, tarfile_path):
         ls(self.ds.path)

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -352,6 +352,9 @@ class Create(Interface):
         # record an ID for this repo for the afterlife
         # to be able to track siblings and children
         id_var = 'datalad.dataset.id'
+        # Note, that Dataset property `id` will change when we unset the
+        # respective config. Therefore store it before:
+        tbds_id = tbds.id
         if id_var in tbds.config:
             # make sure we reset this variable completely, in case of a
             # re-create
@@ -365,7 +368,7 @@ class Create(Interface):
             uuid_id = str(uuid.UUID(int=random.getrandbits(128)))
         tbds.config.add(
             id_var,
-            tbds.id if tbds.id is not None else uuid_id,
+            tbds_id if tbds_id is not None else uuid_id,
             where='dataset',
             reload=False)
 

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -423,7 +423,7 @@ def test_gh1597(path):
         raise SkipTest(
             'this test causes appveyor to crash, reason unknown')
     ds = Dataset(path).rev_create()
-    sub = ds.create('sub')
+    sub = ds.rev_create('sub')
     res = ds.subdatasets()
     assert_result_count(res, 1, path=sub.path)
     # now modify .gitmodules with another command

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -272,7 +272,7 @@ def check_observe_tqdm(topdir, topurl, outdir):
     for f in '1.tar.gz', '2.tar.gz':
         with chpwd(outdir):
             ds.repo.add_url_to_file(f, topurl + f)
-            ds.add(f)
+            ds.rev_save(f)
             add_archive_content(f, delete=True, drop_after=True)
     files = glob.glob(op.join(outdir, '*'))
     ds.drop(files) # will not drop tarballs

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -84,7 +84,7 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
 
     """
     # we apparently can't import api functionality within api
-    from datalad.api import add
+    from datalad.api import rev_save
     # To simplify managing all the file paths etc
     if not isabs(path):
         path = abspath(path)
@@ -119,7 +119,7 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
 
     if ds:
         assert ds.is_installed()
-        out = add(
+        out = rev_save(
             path,
             dataset=ds,
         )

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -42,6 +42,9 @@ from datalad.utils import path_startswith
 from datalad.utils import assure_list
 from datalad.dochelpers import exc_str
 
+# API commands
+import datalad.core.local.save
+
 from .dataset import EnsureDataset
 from .dataset import datasetmethod
 from .dataset import resolve_path
@@ -318,7 +321,7 @@ def _get_submodules(dspath, fulfilled, recursive, recursion_limit,
                     val)
                 # also add to the info we just read above
                 sm['gitmodule_{}'.format(prop)] = val
-            Dataset(dspath).add(
+            Dataset(dspath).rev_save(
                 '.gitmodules', to_git=True,
                 message='[DATALAD] modified subdataset properties')
             # let go of resources, locks, ...

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -167,7 +167,7 @@ def test_add_recursive(path):
     # next one make the parent dirty
     subsub = sub2.create('subsub')
     ok_clean_git(parent.path, index_modified=['sub2'])
-    res = parent.save()
+    res = parent.rev_save()
     ok_clean_git(parent.path)
 
     # now add content deep in the hierarchy

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -226,7 +226,7 @@ def test_create_subdataset_hierarchy_from_top(path):
     ok_(subds.repo.dirty)
     ok_(subsubds.repo.dirty)
     # if we add these three, we should get clean
-    ds.add(['file1', opj(subds.path, 'file2'), opj(subsubds.path, 'file3')])
+    ds.rev_save(['file1', opj(subds.path, 'file2'), opj(subsubds.path, 'file3')])
     ok_clean_git(ds.path)
     ok_(ds.id != subds.id != subsubds.id)
 
@@ -242,7 +242,7 @@ def test_nested_create(path):
     os.makedirs(opj(ds.path, 'lvl1', 'empty'))
     with open(opj(lvl2path, 'file'), 'w') as f:
         f.write('some')
-    ok_(ds.add('.'))
+    ok_(ds.rev_save())
     # later create subdataset in a fresh dir
     subds1 = ds.create(opj('lvl1', 'subds'))
     ok_clean_git(ds.path)
@@ -345,7 +345,7 @@ def test_create_text_no_annex(path):
                      # should we adjust the rule to consider only non empty files?
         }
     )
-    ds.add(['t', 'b'])
+    ds.rev_save(['t', 'b'])
     ok_file_under_git(path, 't', annexed=False)
     ok_file_under_git(path, 'b', annexed=True)
 

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -266,6 +266,8 @@ def test_nested_create(path):
     #    status='error', action='add')
     # only way to make it work is to unannex the content upfront
     ds.repo._run_annex_command('unannex', annex_options=[opj(lvl2relpath, 'file')])
+    # in v7 repos the unannex ends up with a staged deletion
+    ds.repo.commit(careless=True)
     # still nothing without force
     # "err='lvl1/lvl2' already exists in the index"
     assert_in_results(

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -185,7 +185,7 @@ def test_create_sub_nosave(path):
     ok_(ds.repo.dirty)
     ok_(sub_annex.repo.dirty)
     ok_exists(opj(ds.path, ".gitmodules"))
-    ds.save(recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(ds.path)
     ok_clean_git(sub_annex.path)
 
@@ -194,7 +194,7 @@ def test_create_sub_nosave(path):
     ok_(sub_noannex.repo.dirty)
     # Save has no effect because the non-annex subdataset wasn't registered as
     # a submodule.
-    ds.save(recursive=True)
+    ds.rev_save(recursive=True, updated=True)
     ok_(ds.repo.dirty)
     ok_(sub_noannex.repo.dirty)
 
@@ -219,7 +219,7 @@ def test_create_subdataset_hierarchy_from_top(path):
     ok_(subsubds.is_installed())
     ok_(subsubds.repo.dirty)
     ok_(ds.id != subds.id != subsubds.id)
-    ds.save(recursive=True)
+    ds.rev_save(recursive=True, updated=True)
     # 'file*' in each repo was untracked before and should remain as such
     # (we don't want a #1419 resurrection
     ok_(ds.repo.dirty)
@@ -266,10 +266,6 @@ def test_nested_create(path):
     #    status='error', action='add')
     # only way to make it work is to unannex the content upfront
     ds.repo._run_annex_command('unannex', annex_options=[opj(lvl2relpath, 'file')])
-    # nothing to save, git-annex commits the unannex itself
-    assert_status(
-        'ok' if ds.repo.supports_unlocked_pointers else 'notneeded',
-        ds.save())
     # still nothing without force
     # "err='lvl1/lvl2' already exists in the index"
     assert_in_results(

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -31,15 +31,15 @@ except ImportError:
 def test_invalid_call(path):
     # no dataset
     assert_raises(ValueError, create_sibling_github, 'bogus', dataset=path)
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     # no user
     assert_raises(gh.BadCredentialsException, ds.create_sibling_github, 'bogus', github_login='disabledloginfortesting')
 
 
 @with_tempfile
 def test_dont_trip_over_missing_subds(path):
-    ds1 = Dataset(opj(path, 'ds1')).create()
-    ds2 = Dataset(opj(path, 'ds2')).create()
+    ds1 = Dataset(opj(path, 'ds1')).rev_create()
+    ds2 = Dataset(opj(path, 'ds2')).rev_create()
     subds2 = ds1.install(
         source=ds2.path, path='subds2',
         result_xfm='datasets', return_type='item-or-list')

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -461,7 +461,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     url = 'localhost:%s' % dst_relpath
     ds = Dataset(src_path).create()
     create_tree(ds.path, {'sub.dat': 'lots of data'})
-    ds.add('sub.dat')
+    ds.rev_save('sub.dat')
     ds.create_sibling(url)
     published = ds.publish(to='localhost', transfer_data='all')
     assert_result_count(published, 1, path=opj(ds.path, 'sub.dat'))
@@ -485,7 +485,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     # and one more test since in above test it would not puke ATM but just
     # not even try to copy since it assumes that file is already there
     create_tree(ds.path, {'sub2.dat': 'more data'})
-    ds.add('sub2.dat')
+    ds.rev_save('sub2.dat')
     published3 = ds.publish(to='localhost', transfer_data='none')  # we publish just git
     assert_result_count(published3, 0, path=opj(ds.path, 'sub2.dat'))
     # now publish "with" data, which should also trigger the hook!
@@ -518,7 +518,7 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
     # now a month later we created a new subdataset
     subds = ds.create('sub')  # so now we got a hierarchy!
     create_tree(subds.path, {'sub.dat': 'lots of data'})
-    subds.add('sub.dat')
+    subds.rev_save('sub.dat')
     ok_file_under_git(subds.path, 'sub.dat', annexed=True)
 
     target_sub = Dataset(opj(target_path, 'sub'))

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -125,7 +125,7 @@ def test_invalid_call(path):
             ValueError,
             create_sibling, 'localhost:/tmp/somewhere', dataset='/nothere')
     # pre-configure a bogus remote
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ds.repo.add_remote('bogus', 'http://bogus.url.com')
     # fails to reconfigure by default with generated
     # and also when given an existing name
@@ -355,7 +355,7 @@ def test_target_ssh_recursive(origin, src_path, target_path):
         # verify that we can create-sibling which was created later and possibly
         # first published in super-dataset as an empty directory
         sub3_name = 'subm 3-%s' % flat
-        sub3 = source.create(sub3_name)
+        sub3 = source.rev_create(sub3_name)
         # since is an empty value to force it to consider all changes since we published
         # already
         with chpwd(source.path):
@@ -388,7 +388,7 @@ def test_target_ssh_since(origin, src_path, target_path):
     source = install(src_path, source=origin, recursive=True)
     eq_(len(source.subdatasets()), 2)
     # get a new subdataset and make sure it is committed in the super
-    source.create('brandnew')
+    source.rev_create('brandnew')
     eq_(len(source.subdatasets()), 3)
     ok_clean_git(source.path)
 
@@ -407,9 +407,9 @@ def test_target_ssh_since(origin, src_path, target_path):
     eq_(['brandnew'], os.listdir(target_path))
 
     # now test functionality if we add a subdataset with a subdataset
-    brandnew2 = source.create('brandnew2')
-    brandnewsub = brandnew2.create('sub')
-    brandnewsubsub = brandnewsub.create('sub')
+    brandnew2 = source.rev_create('brandnew2')
+    brandnewsub = brandnew2.rev_create('sub')
+    brandnewsubsub = brandnewsub.rev_create('sub')
     # and now we create a sibling for the new subdataset only
     assert_create_sshwebserver(
         name='dominique_carrera',
@@ -427,7 +427,7 @@ def test_target_ssh_since(origin, src_path, target_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_failon_no_permissions(src_path, target_path):
-    ds = Dataset(src_path).create()
+    ds = Dataset(src_path).rev_create()
     # remove user write permissions from target path
     chmod(target_path, stat.S_IREAD | stat.S_IEXEC)
     assert_raises(
@@ -459,7 +459,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     remote_home = remote_home.rstrip('\n')
     dst_relpath = os.path.relpath(dst_path, remote_home)
     url = 'localhost:%s' % dst_relpath
-    ds = Dataset(src_path).create()
+    ds = Dataset(src_path).rev_create()
     create_tree(ds.path, {'sub.dat': 'lots of data'})
     ds.rev_save('sub.dat')
     ds.create_sibling(url)
@@ -504,7 +504,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
 @with_tempfile(mkdir=True)
 @with_tempfile(suffix="target")
 def _test_target_ssh_inherit(standardgroup, src_path, target_path):
-    ds = Dataset(src_path).create()
+    ds = Dataset(src_path).rev_create()
     target_url = 'localhost:%s' % target_path
     remote = "magical"
     # for the test of setting a group, will just smoke test while using current
@@ -516,7 +516,7 @@ def _test_target_ssh_inherit(standardgroup, src_path, target_path):
     ds.publish(to=remote)
 
     # now a month later we created a new subdataset
-    subds = ds.create('sub')  # so now we got a hierarchy!
+    subds = ds.rev_create('sub')  # so now we got a hierarchy!
     create_tree(subds.path, {'sub.dat': 'lots of data'})
     subds.rev_save('sub.dat')
     ok_file_under_git(subds.path, 'sub.dat', annexed=True)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -174,9 +174,8 @@ def test_subdatasets(path):
     eq_(ds.subdatasets(), [])
     # create some file and commit it
     open(os.path.join(ds.path, 'test'), 'w').write('some')
-    ds.rev_save(path='test')
+    ds.rev_save(path='test', message="Hello!", version_tag=1)
     assert_true(ds.is_installed())
-    ds.save("Hello!", version_tag=1)
     # Assuming that tmp location was not under a super-dataset
     eq_(ds.get_superdataset(), None)
     eq_(ds.get_superdataset(topmost=True), ds)
@@ -193,7 +192,7 @@ def test_subdatasets(path):
     eq_(subds.path, ds.subdatasets(result_xfm='paths')[0])
     eq_(subdss, ds.subdatasets(recursive=True))
     eq_(subdss, ds.subdatasets(fulfilled=True))
-    ds.save("with subds", version_tag=2)
+    ds.rev_save(message="with subds", version_tag=2)
     ds.recall_state(1)
     assert_true(ds.is_installed())
     eq_(ds.subdatasets(), [])

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -17,7 +17,7 @@ from os.path import join as opj, abspath, normpath, relpath, exists
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
 from ..dataset import rev_resolve_path
 from datalad import cfg
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.api import get
 import datalad.utils as ut
 from datalad.utils import chpwd, getpwd, rmtree
@@ -36,6 +36,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import assert_is
 from datalad.tests.utils import assert_not_equal
+from datalad.tests.utils import assert_result_count
 
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import PathKnownToRepositoryError
@@ -108,8 +109,16 @@ def test_is_installed(src, path):
     # subdirectory within submodule, e.g. `subm 1/subdir` but that is
     # not checked here. `rev-create` will provide that protection
     # when create/rev-create merge.
-    with assert_raises(PathKnownToRepositoryError):
-        subds.create()
+    res = subds.rev_create(on_failure='ignore',
+                           return_type='list',
+                           result_filter=None,
+                           result_xfm=None)
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, status='error', path=subds.path,
+        message=(
+            'collision with content in parent dataset at %s: %s',
+            ds.path, [subds.path]))
     # get the submodule
     # This would init so there is a .git file with symlink info, which is
     # as we agreed is more pain than gain, so let's use our install which would
@@ -169,7 +178,7 @@ def test_subdatasets(path):
     ds = Dataset(path)
     assert_false(ds.is_installed())
     eq_(ds.subdatasets(), [])
-    ds = ds.create()
+    ds = ds.rev_create()
     assert_true(ds.is_installed())
     eq_(ds.subdatasets(), [])
     # create some file and commit it
@@ -232,7 +241,7 @@ def test_require_dataset(path):
             InsufficientArgumentsError,
             require_dataset,
             None)
-        create('.')
+        rev_create('.')
         # in this folder by default
         assert_equal(
             require_dataset(None).path,
@@ -252,7 +261,7 @@ def test_require_dataset(path):
 def test_dataset_id(path):
     ds = Dataset(path)
     assert_equal(ds.id, None)
-    ds.create()
+    ds.rev_create()
     dsorigid = ds.id
     # ID is always a UUID
     assert_equal(ds.id.count('-'), 4)
@@ -275,7 +284,7 @@ def test_dataset_id(path):
     # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
     # dict isn't a nice approach. May be create needs a fix/RF?
     Dataset._unique_instances.clear()
-    ds.create(no_annex=True, force=True)
+    ds.rev_create(no_annex=True, force=True)
     assert_equal(ds.id, dsorigid)
     # even adding an annex doesn't
     #
@@ -285,7 +294,7 @@ def test_dataset_id(path):
     # dict isn't a nice approach. May be create needs a fix/RF?
     Dataset._unique_instances.clear()
     AnnexRepo._unique_instances.clear()
-    ds.create(force=True)
+    ds.rev_create(force=True)
     assert_equal(ds.id, dsorigid)
     # dataset ID and annex UUID have nothing to do with each other
     # if an ID was already generated
@@ -303,7 +312,7 @@ def test_dataset_id(path):
     assert_equal(ds.id, newds.id)
     # even if we generate a dataset from scratch with an annex UUID right away,
     # this is also not the ID
-    annexds = Dataset(opj(path, 'scratch')).create()
+    annexds = Dataset(opj(path, 'scratch')).rev_create()
     assert_true(annexds.id != annexds.repo.uuid)
 
 
@@ -348,7 +357,7 @@ def test_property_reevaluation(repo1):
     assert_false(ds._cfg_bound)
     assert_is_none(ds.id)
 
-    ds.create()
+    ds.rev_create()
     ok_clean_git(repo1)
     # after creation, we have `repo`, and `config` was reevaluated to point
     # to the repo's config:
@@ -372,7 +381,7 @@ def test_property_reevaluation(repo1):
     assert_is_not(second_config, third_config)
     assert_is_none(ds.id)
 
-    ds.create()
+    ds.rev_create()
     ok_clean_git(repo1)
     # after recreation everything is sane again:
     assert_is_not_none(ds.repo)
@@ -397,7 +406,7 @@ def test_property_reevaluation(repo1):
 @with_tempfile
 def test_symlinked_dataset_properties(repo1, repo2, repo3, non_repo, symlink):
 
-    ds = Dataset(repo1).create()
+    ds = Dataset(repo1).rev_create()
 
     # now, let ds be a symlink and change that symlink to point to different
     # things:
@@ -527,7 +536,7 @@ def test_hashable(path):
     eq_(len(tryme), 2)
     # test whether two different types of repo instances pointing
     # to the same repo on disk are considered different
-    Dataset(path).create()
+    Dataset(path).rev_create()
     tryme.add(GitRepo(path))
     eq_(len(tryme), 3)
     tryme.add(AnnexRepo(path))

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -174,7 +174,7 @@ def test_subdatasets(path):
     eq_(ds.subdatasets(), [])
     # create some file and commit it
     open(os.path.join(ds.path, 'test'), 'w').write('some')
-    ds.add(path='test')
+    ds.rev_save(path='test')
     assert_true(ds.is_installed())
     ds.save("Hello!", version_tag=1)
     # Assuming that tmp location was not under a super-dataset

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -57,7 +57,7 @@ def _make_dataset_hierarchy(path):
     with open(opj(origin_sub3.path, 'file_in_annex.txt'), "w") as f:
         f.write('content3')
     origin_sub4 = origin_sub3.create('sub4')
-    origin.add('.', recursive=True)
+    origin.rev_save(recursive=True)
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
 
@@ -108,7 +108,7 @@ def test_get_invalid_call(path, file_outside):
     ds.create(no_annex=True)
     with open(opj(path, "some.txt"), "w") as f:
         f.write("whatever")
-    ds.add("some.txt", to_git=True)
+    ds.rev_save("some.txt", to_git=True)
     ds.save("Initial commit.")
 
     # make it an annex:
@@ -121,7 +121,7 @@ def test_get_invalid_call(path, file_outside):
     # yoh:  but now we would need to add it to annex since clever code first
     # checks what needs to be fetched at all
     create_tree(path, {'annexed.dat': 'some'})
-    ds.add("annexed.dat")
+    ds.rev_save("annexed.dat")
     ds.repo.drop("annexed.dat", options=['--force'])
     with assert_raises(RemoteNotAvailableError) as ce:
         ds.get("annexed.dat", source='MysteriousRemote')
@@ -168,7 +168,7 @@ def test_get_multiple_files(path, url, ds_dir):
 
     # prepare origin
     origin = Dataset(path).create(force=True)
-    origin.add(file_list)
+    origin.rev_save(file_list)
     origin.save("initial")
 
     ds = install(
@@ -208,7 +208,7 @@ def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
     origin = Dataset(o_path).create(force=True)
-    origin.add('.')
+    origin.rev_save()
 
     ds = install(
         c_path, source=o_path,
@@ -376,8 +376,8 @@ def test_get_mixed_hierarchy(src, path):
         f.write('no idea')
     with open(opj(origin_sub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
-    origin.add('file_in_git.txt', to_git=True)
-    origin_sub.add('file_in_annex.txt')
+    origin.rev_save('file_in_git.txt', to_git=True)
+    origin_sub.rev_save('file_in_annex.txt')
     origin.save()
 
     # now, install that thing:
@@ -422,7 +422,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     origin_subsub = origin_sub.create('subsub')
     with open(opj(origin_subsub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
-    origin.add('.', recursive=True)
+    origin.rev_save(recursive=True)
 
     ds = install(
         path, source=src,

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -108,8 +108,7 @@ def test_get_invalid_call(path, file_outside):
     ds.create(no_annex=True)
     with open(opj(path, "some.txt"), "w") as f:
         f.write("whatever")
-    ds.rev_save("some.txt", to_git=True)
-    ds.save("Initial commit.")
+    ds.rev_save("some.txt", to_git=True, message="Initial commit.")
 
     # make it an annex:
     AnnexRepo(path, init=True, create=True)
@@ -168,8 +167,7 @@ def test_get_multiple_files(path, url, ds_dir):
 
     # prepare origin
     origin = Dataset(path).create(force=True)
-    origin.rev_save(file_list)
-    origin.save("initial")
+    origin.rev_save(file_list, message="initial")
 
     ds = install(
         ds_dir, source=path,
@@ -378,7 +376,7 @@ def test_get_mixed_hierarchy(src, path):
         f.write('content')
     origin.rev_save('file_in_git.txt', to_git=True)
     origin_sub.rev_save('file_in_annex.txt')
-    origin.save()
+    origin.rev_save()
 
     # now, install that thing:
     ds, subds = install(

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -15,7 +15,7 @@ from os import curdir
 from os.path import join as opj, basename
 from glob import glob
 
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.api import get
 from datalad.api import install
 from datalad.interface.results import only_matching_paths
@@ -48,15 +48,15 @@ from ..dataset import Dataset
 
 
 def _make_dataset_hierarchy(path):
-    origin = Dataset(path).create()
-    origin_sub1 = origin.create('sub1')
-    origin_sub2 = origin_sub1.create('sub2')
+    origin = Dataset(path).rev_create()
+    origin_sub1 = origin.rev_create('sub1')
+    origin_sub2 = origin_sub1.rev_create('sub2')
     with open(opj(origin_sub2.path, 'file_in_annex.txt'), "w") as f:
         f.write('content2')
-    origin_sub3 = origin_sub2.create('sub3')
+    origin_sub3 = origin_sub2.rev_create('sub3')
     with open(opj(origin_sub3.path, 'file_in_annex.txt'), "w") as f:
         f.write('content3')
-    origin_sub4 = origin_sub3.create('sub4')
+    origin_sub4 = origin_sub3.rev_create('sub4')
     origin.rev_save(recursive=True)
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
@@ -66,7 +66,7 @@ def _make_dataset_hierarchy(path):
 def test_get_flexible_source_candidates_for_submodule(t, t2):
     f = _get_flexible_source_candidates_for_submodule
     # for now without mocking -- let's just really build a dataset
-    ds = create(t)
+    ds = rev_create(t)
     clone = install(
         t2, source=t,
         result_xfm='datasets', return_type='item-or-list')
@@ -105,12 +105,14 @@ def test_get_invalid_call(path, file_outside):
 
     # have a plain git:
     ds = Dataset(path)
-    ds.create(no_annex=True)
+    ds.rev_create(no_annex=True)
     with open(opj(path, "some.txt"), "w") as f:
         f.write("whatever")
     ds.rev_save("some.txt", to_git=True, message="Initial commit.")
 
-    # make it an annex:
+    # make it an annex (remove indicator file that rev_create has placed
+    # in the dataset to make it possible):
+    (ds.pathobj / '.noannex').unlink()
     AnnexRepo(path, init=True, create=True)
     # call get again on a file in git:
     result = ds.get("some.txt")
@@ -166,7 +168,7 @@ def test_get_multiple_files(path, url, ds_dir):
     [RI(url + f) for f in file_list]
 
     # prepare origin
-    origin = Dataset(path).create(force=True)
+    origin = Dataset(path).rev_create(force=True)
     origin.rev_save(file_list, message="initial")
 
     ds = install(
@@ -205,7 +207,7 @@ def test_get_multiple_files(path, url, ds_dir):
 def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
-    origin = Dataset(o_path).create(force=True)
+    origin = Dataset(o_path).rev_create(force=True)
     origin.rev_save()
 
     ds = install(
@@ -341,7 +343,7 @@ def test_get_install_missing_subdataset(src, path):
     ds = install(
         path=path, source=src,
         result_xfm='datasets', return_type='item-or-list')
-    ds.create(force=True)  # force, to cause dataset initialization
+    ds.rev_create(force=True)  # force, to cause dataset initialization
     subs = ds.subdatasets(result_xfm='datasets')
     ok_(all([not sub.is_installed() for sub in subs]))
 
@@ -368,8 +370,8 @@ def test_get_install_missing_subdataset(src, path):
 @with_tempfile(mkdir=True)
 def test_get_mixed_hierarchy(src, path):
 
-    origin = Dataset(src).create(no_annex=True)
-    origin_sub = origin.create('subds')
+    origin = Dataset(src).rev_create(no_annex=True)
+    origin_sub = origin.rev_create('subds')
     with open(opj(origin.path, 'file_in_git.txt'), "w") as f:
         f.write('no idea')
     with open(opj(origin_sub.path, 'file_in_annex.txt'), "w") as f:
@@ -415,9 +417,9 @@ def test_autoresolve_multiple_datasets(src, path):
 @with_tempfile(mkdir=True)
 def test_get_autoresolve_recurse_subdatasets(src, path):
 
-    origin = Dataset(src).create()
-    origin_sub = origin.create('sub')
-    origin_subsub = origin_sub.create('subsub')
+    origin = Dataset(src).rev_create()
+    origin_sub = origin.rev_create('sub')
+    origin_subsub = origin_sub.rev_create('subsub')
     with open(opj(origin_subsub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
     origin.rev_save(recursive=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -442,7 +442,7 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(subds.path, annex=None)
     # top is too:
     ok_clean_git(ds.path, annex=None)
-    ds.save('addsub')
+    ds.rev_save(message='addsub')
     # now it is:
     ok_clean_git(ds.path, annex=None)
 
@@ -539,7 +539,7 @@ def test_implicit_install(src, dst):
     with open(opj(origin_subsub.path, "file3.txt"), "w") as f:
         f.write("content3")
     origin_subsub.rev_save("file3.txt")
-    origin_top.save(recursive=True)
+    origin_top.rev_save(recursive=True)
 
     # first, install toplevel:
     ds = install(dst, source=src)
@@ -815,7 +815,7 @@ def test_install_consistent_state(src, dest, dest2, dest3):
 
     # and progress subsub2 forward to stay really thorough
     put_file_under_git(subsub2.path, 'file.dat', content="data")
-    subsub2.save("added a file")  # above function does not commit
+    subsub2.rev_save(message="added a file")  # above function does not commit
 
     # just installing a submodule -- apparently different code/logic
     # but also the same story should hold - we should install the version pointed

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -23,7 +23,7 @@ from mock import patch
 
 from datalad.utils import getpwd
 
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.api import install
 from datalad.api import get
 from datalad import consts
@@ -177,7 +177,7 @@ def test_invalid_args(path):
     # install to a remote location
     assert_raises(ValueError, install, 'ssh://mars/Zoidberg', source='Zoidberg')
     # make fake dataset
-    ds = create(path)
+    ds = rev_create(path)
     assert_raises(IncompleteResultsError, install, '/higherup.', 'Zoidberg', dataset=ds)
 
 
@@ -431,7 +431,7 @@ def test_install_recursive_with_data(src, path):
 @with_tempfile
 def test_install_into_dataset(source, top_path):
 
-    ds = create(top_path)
+    ds = rev_create(top_path)
     ok_clean_git(ds.path)
 
     subds = ds.install("sub", source=source, save=False)
@@ -457,7 +457,7 @@ def test_install_into_dataset(source, top_path):
 
     # and we should achieve the same behavior if we create a dataset
     # and then decide to add it
-    create(_path_(top_path, 'sub3'))
+    rev_create(_path_(top_path, 'sub3'))
     ok_clean_git(ds.path, untracked=['dummy.txt', 'sub3/'])
     ds.rev_save('sub3')
     ok_clean_git(ds.path, untracked=['dummy.txt'])
@@ -469,10 +469,10 @@ def test_install_into_dataset(source, top_path):
 @use_cassette('test_install_crcns')
 @with_tempfile
 def test_failed_install_multiple(top_path):
-    ds = create(top_path)
+    ds = rev_create(top_path)
 
-    create(_path_(top_path, 'ds1'))
-    create(_path_(top_path, 'ds3'))
+    rev_create(_path_(top_path, 'ds1'))
+    rev_create(_path_(top_path, 'ds3'))
     ok_clean_git(ds.path, annex=None, untracked=['ds1/', 'ds3/'])
 
     # specify install with multiple paths and one non-existing
@@ -527,9 +527,9 @@ def test_install_known_subdataset(src, path):
 @with_tempfile(mkdir=True)
 def test_implicit_install(src, dst):
 
-    origin_top = create(src)
-    origin_sub = origin_top.create("sub")
-    origin_subsub = origin_sub.create("subsub")
+    origin_top = rev_create(src)
+    origin_sub = origin_top.rev_create("sub")
+    origin_subsub = origin_sub.rev_create("subsub")
     with open(opj(origin_top.path, "file1.txt"), "w") as f:
         f.write("content1")
     origin_top.rev_save("file1.txt")
@@ -588,7 +588,7 @@ def test_implicit_install(src, dst):
 
 @with_tempfile(mkdir=True)
 def test_failed_install(dspath):
-    ds = create(dspath)
+    ds = rev_create(dspath)
     assert_raises(IncompleteResultsError,
                   ds.install,
                   "sub",
@@ -643,10 +643,10 @@ def test_reckless(path, top_path):
 @with_tempfile(mkdir=True)
 @skip_if_on_windows  # Due to "another process error" and buggy ok_clean_git
 def test_install_recursive_repeat(src, path):
-    top_src = Dataset(src).create(force=True)
-    sub1_src = top_src.create('sub 1', force=True)
-    sub2_src = top_src.create('sub 2', force=True)
-    subsub_src = sub1_src.create('subsub', force=True)
+    top_src = Dataset(src).rev_create(force=True)
+    sub1_src = top_src.rev_create('sub 1', force=True)
+    sub2_src = top_src.rev_create('sub 2', force=True)
+    subsub_src = sub1_src.rev_create('subsub', force=True)
     top_src.rev_save(recursive=True)
     ok_clean_git(top_src.path)
 
@@ -757,10 +757,10 @@ def test_install_skip_failed_recursive(src, path):
                  })
 @with_tempfile(mkdir=True)
 def test_install_noautoget_data(src, path):
-    subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
-    sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
-    sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
-    top_src = Dataset(src).create(force=True)
+    subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).rev_create(force=True)
+    sub1_src = Dataset(opj(src, 'sub 1')).rev_create(force=True)
+    sub2_src = Dataset(opj(src, 'sub 2')).rev_create(force=True)
+    top_src = Dataset(src).rev_create(force=True)
     top_src.rev_save(recursive=True)
 
     # install top level:
@@ -775,7 +775,7 @@ def test_install_noautoget_data(src, path):
 @with_tempfile
 @with_tempfile
 def test_install_source_relpath(src, dest):
-    ds1 = create(src)
+    ds1 = rev_create(src)
     src_ = basename(src)
     with chpwd(dirname(src)):
         ds2 = install(dest, source=src_)
@@ -794,8 +794,8 @@ def test_install_consistent_state(src, dest, dest2, dest3):
     # position where previous location was pointing to.
     # It is indeed a mere heuristic which might not hold the assumption in some
     # cases, but it would work for most simple and thus mostly used ones
-    ds1 = create(src)
-    sub1 = ds1.create('sub1')
+    ds1 = rev_create(src)
+    sub1 = ds1.rev_create('sub1')
 
     def check_consistent_installation(ds):
         datasets = [ds] + list(
@@ -811,7 +811,7 @@ def test_install_consistent_state(src, dest, dest2, dest3):
 
     dest_ds = install(dest, source=src)
     # now we progress sub1 by adding sub2
-    subsub2 = sub1.create('sub2')
+    subsub2 = sub1.rev_create('sub2')
 
     # and progress subsub2 forward to stay really thorough
     put_file_under_git(subsub2.path, 'file.dat', content="data")
@@ -849,8 +849,8 @@ from datalad.tests.utils import skip_ssh
 @with_tempfile
 @with_tempfile
 def test_install_subds_with_space(opath, tpath):
-    ds = create(opath)
-    ds.create('sub ds')
+    ds = rev_create(opath)
+    ds.rev_create('sub ds')
     # works even now, boring
     # install(tpath, source=opath, recursive=True)
     if on_windows:
@@ -867,8 +867,8 @@ def test_install_subds_with_space(opath, tpath):
 @with_tempfile
 @with_tempfile
 def test_install_from_tilda(opath, tpath):
-    ds = create(opath)
-    ds.create('sub ds')
+    ds = rev_create(opath)
+    ds.rev_create('sub ds')
     orelpath = os.path.join(
         '~',
         os.path.relpath(opath, os.path.expanduser('~'))
@@ -890,7 +890,7 @@ def test_install_subds_from_another_remote(topdir):
         clone1_ = 'clone1'
         clone2_ = 'clone2'
 
-        origin = create(origin_, no_annex=True)
+        origin = rev_create(origin_, no_annex=True)
         clone1 = install(source=origin, path=clone1_)
         # print("Initial clone")
         clone1.create_sibling('ssh://localhost%s/%s' % (PathRI(getpwd()).posixpath, clone2_), name=clone2_)
@@ -899,7 +899,7 @@ def test_install_subds_from_another_remote(topdir):
         clone1.publish(to=clone2_)
         clone2 = Dataset(clone2_)
         # print("Initiating subdataset")
-        clone2.create('subds1')
+        clone2.rev_create('subds1')
 
         # print("Updating")
         clone1.update(merge=True, sibling=clone2_)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -459,7 +459,7 @@ def test_install_into_dataset(source, top_path):
     # and then decide to add it
     create(_path_(top_path, 'sub3'))
     ok_clean_git(ds.path, untracked=['dummy.txt', 'sub3/'])
-    ds.add('sub3')
+    ds.rev_save('sub3')
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
@@ -482,7 +482,7 @@ def test_failed_install_multiple(top_path):
 
     # install doesn't add existing submodules -- add does that
     ok_clean_git(ds.path, annex=None, untracked=['ds1/', 'ds3/'])
-    ds.add(['ds1', 'ds3'])
+    ds.rev_save(['ds1', 'ds3'])
     ok_clean_git(ds.path, annex=None)
     # those which succeeded should be saved now
     eq_(ds.subdatasets(result_xfm='relpaths'), ['crcns', 'ds1', 'ds3'])
@@ -532,13 +532,13 @@ def test_implicit_install(src, dst):
     origin_subsub = origin_sub.create("subsub")
     with open(opj(origin_top.path, "file1.txt"), "w") as f:
         f.write("content1")
-    origin_top.add("file1.txt")
+    origin_top.rev_save("file1.txt")
     with open(opj(origin_sub.path, "file2.txt"), "w") as f:
         f.write("content2")
-    origin_sub.add("file2.txt")
+    origin_sub.rev_save("file2.txt")
     with open(opj(origin_subsub.path, "file3.txt"), "w") as f:
         f.write("content3")
-    origin_subsub.add("file3.txt")
+    origin_subsub.rev_save("file3.txt")
     origin_top.save(recursive=True)
 
     # first, install toplevel:
@@ -643,11 +643,11 @@ def test_reckless(path, top_path):
 @with_tempfile(mkdir=True)
 @skip_if_on_windows  # Due to "another process error" and buggy ok_clean_git
 def test_install_recursive_repeat(src, path):
-    subsub_src = Dataset(opj(src, 'sub 1', 'subsub')).create(force=True)
-    sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
-    sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.add('.', recursive=True)
+    sub1_src = top_src.create('sub 1', force=True)
+    sub2_src = top_src.create('sub 2', force=True)
+    subsub_src = sub1_src.create('subsub', force=True)
+    top_src.rev_save(recursive=True)
     ok_clean_git(top_src.path)
 
     # install top level:
@@ -761,7 +761,7 @@ def test_install_noautoget_data(src, path):
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
     sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.add('.', recursive=True)
+    top_src.rev_save(recursive=True)
 
     # install top level:
     # don't filter implicitly installed subdataset to check them for content

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -145,7 +145,7 @@ def test_publish_simple(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.add(opj(src_path, 'test_mod_file'), to_git=True,
+    source.rev_save(opj(src_path, 'test_mod_file'), to_git=True,
                message="Modified.")
     ok_clean_git(source.repo, annex=None)
 
@@ -202,7 +202,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.add(opj(src_path, 'test_mod_file'), to_git=True,
+    source.rev_save(opj(src_path, 'test_mod_file'), to_git=True,
                message="Modified.")
     ok_clean_git(source.repo, annex=None)
 
@@ -334,12 +334,12 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # add to subdataset, does not alter super dataset!
     # MIH: use `to_git` because original test author used
     # and explicit `GitRepo.add` -- keeping this for now
-    Dataset(sub2.path).add('file.txt', to_git=True)
+    Dataset(sub2.path).rev_save('file.txt', to_git=True)
 
     # Let's now update one subm
     create_tree(sub2.path, {'file.dat': 'content'})
     # add to subdataset, without reflecting the change in its super(s)
-    Dataset(sub2.path).add('file.dat')
+    Dataset(sub2.path).rev_save('file.dat')
 
     # note: will publish to origin here since that is what it tracks
     res_ = publish(dataset=source, recursive=True, on_failure='ignore')
@@ -538,7 +538,7 @@ def test_publish_depends(
     ok_clean_git(src_path)
     # introduce change in source
     create_tree(src_path, {'probe1': 'probe1'})
-    source.add('probe1')
+    source.rev_save('probe1')
     ok_clean_git(src_path)
     # only the source has the probe
     ok_file_has_content(opj(src_path, 'probe1'), 'probe1')
@@ -606,7 +606,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 
     # some content modification of the superdataset
     create_tree(src_path, {'probe1': 'probe1'})
-    source.add('probe1')
+    source.rev_save('probe1')
     ok_clean_git(src_path)
 
     # create the target(s):
@@ -632,7 +632,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
-    ds.add('1')
+    ds.rev_save('1')
     ds.create_sibling('ssh://localhost:%s/subdir' % desttop,
                       name='target',
                       target_url=desturl + 'subdir/.git')
@@ -659,7 +659,7 @@ def test_gh1763(src, target1, target2):
         publish_depends='target1')
     # a file to annex
     create_tree(src.path, {'probe1': 'probe1'})
-    src.add('probe1', to_git=False)
+    src.rev_save('probe1', to_git=False)
     # make sure the probe is annexed, not straight in Git
     assert_in('probe1', src.repo.get_annexed_files(with_content_only=True))
     # publish to target2, must handle dependency

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -377,7 +377,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 
     # Let's save those present changes and publish while implying "since last
     # merge point"
-    source.save(message="Changes in subm2")
+    source.rev_save(message="Changes in subm2")
     # and test if it could deduce the remote/branch to push to
     source.config.set('branch.master.remote', 'target', where='local')
     with chpwd(source.path):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -19,7 +19,7 @@ from os.path import lexists
 from ..dataset import Dataset
 from datalad.api import publish, install
 from datalad.api import install
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.dochelpers import exc_str
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
@@ -65,8 +65,8 @@ def test_invalid_call(origin, tdir):
     with chpwd(tdir):
         assert_raises(InsufficientArgumentsError, publish, since='HEAD')
     # new dataset, with unavailable subdataset
-    dummy = Dataset(tdir).create()
-    dummy_sub = dummy.create('sub')
+    dummy = Dataset(tdir).rev_create()
+    dummy_sub = dummy.rev_create('sub')
     dummy_sub.uninstall()
     assert_in('sub', dummy.subdatasets(fulfilled=False, result_xfm='relpaths'))
     # now an explicit call to publish the unavailable subdataset
@@ -83,7 +83,7 @@ def test_invalid_call(origin, tdir):
 @with_tempfile
 @with_tempfile
 def test_smth_about_not_supported(p1, p2):
-    source = Dataset(p1).create()
+    source = Dataset(p1).rev_create()
     from datalad.support.network import PathRI
     source.create_sibling(
         'ssh://localhost' + PathRI(p2).posixpath,
@@ -570,7 +570,7 @@ def test_publish_depends(
 @with_tempfile(mkdir=True)
 def test_gh1426(origin_path, target_path):
     # set up a pair of repos, one the published copy of the other
-    origin = create(origin_path)
+    origin = rev_create(origin_path)
     target = AnnexRepo(target_path, create=True)
     target.config.set(
         'receive.denyCurrentBranch', 'updateInstead', where='local')
@@ -582,7 +582,7 @@ def test_gh1426(origin_path, target_path):
 
     # gist of #1426 is that a newly added subdataset does not cause the
     # superdataset to get published
-    origin.create('sub')
+    origin.rev_create('sub')
     ok_clean_git(origin.path)
     assert_not_equal(origin.repo.get_hexsha(), target.get_hexsha())
     # now push
@@ -631,7 +631,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 @serve_path_via_http
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
-    ds = Dataset(src).create(force=True)
+    ds = Dataset(src).rev_create(force=True)
     ds.rev_save('1')
     ds.create_sibling('ssh://localhost:%s/subdir' % desttop,
                       name='target',
@@ -649,7 +649,7 @@ def test_publish_target_url(src, desttop, desturl):
 def test_gh1763(src, target1, target2):
     # this test is very similar to test_publish_depends, but more
     # comprehensible, and directly tests issue 1763
-    src = Dataset(src).create(force=True)
+    src = Dataset(src).rev_create(force=True)
     src.create_sibling(
         'ssh://datalad-test' + target1,
         name='target1')

--- a/datalad/distribution/tests/test_subdataset.py
+++ b/datalad/distribution/tests/test_subdataset.py
@@ -170,8 +170,8 @@ def test_get_subdatasets(path):
 
 @with_tempfile
 def test_state(path):
-    ds = Dataset.create(path)
-    sub = ds.create('sub')
+    ds = Dataset.rev_create(path)
+    sub = ds.rev_create('sub')
     res = ds.subdatasets()
     assert_result_count(res, 1, path=sub.path)
     # by default we are not reporting any state info
@@ -194,9 +194,9 @@ def test_state(path):
 
 @with_tempfile
 def test_get_subdatasets_types(path):
-    from datalad.api import create
-    ds = create(path)
-    ds.create('1')
-    ds.create('true')
+    from datalad.api import rev_create
+    ds = rev_create(path)
+    ds.rev_create('1')
+    ds.rev_create('true')
     # no types casting should happen
     eq_(ds.subdatasets(result_xfm='relpaths'), ['1', 'true'])

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -22,7 +22,7 @@ from datalad.api import uninstall
 from datalad.api import drop
 from datalad.api import remove
 from datalad.api import install
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import ok_
@@ -51,7 +51,7 @@ from ..dataset import Dataset
 
 @with_tempfile()
 def test_safetynet(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     os.makedirs(opj(ds.path, 'deep', 'down'))
     for p in (ds.path, opj(ds.path, 'deep'), opj(ds.path, 'deep', 'down')):
         with chpwd(p):
@@ -74,9 +74,9 @@ def test_uninstall_uninstalled(path):
 
 @with_tempfile()
 def test_clean_subds_removal(path):
-    ds = Dataset(path).create()
-    subds1 = ds.create('one')
-    subds2 = ds.create('two')
+    ds = Dataset(path).rev_create()
+    subds1 = ds.rev_create('one')
+    subds2 = ds.rev_create('two')
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['one', 'two'])
     ok_clean_git(ds.path)
     # now kill one
@@ -92,7 +92,7 @@ def test_clean_subds_removal(path):
     # one is gone
     assert(not exists(subds1.path))
     # and now again, but this time remove something that is not installed
-    ds.create('three')
+    ds.rev_create('three')
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['three', 'two'])
     ds.uninstall('two')
     ok_clean_git(ds.path)
@@ -109,7 +109,7 @@ def test_clean_subds_removal(path):
 
 @with_testrepos('.*basic.*', flavors=['clone'])
 def test_uninstall_invalid(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     for method in (uninstall, remove, drop):
         assert_raises(InsufficientArgumentsError, method)
         # refuse to touch stuff outside the dataset
@@ -222,7 +222,7 @@ def test_uninstall_subdataset(src, dst):
     'keep': 'keep2',
     'kill': 'kill2'})
 def test_uninstall_multiple_paths(path):
-    ds = Dataset(path).create(force=True, save=False)
+    ds = Dataset(path).rev_create(force=True)
     subds = ds.create('deep', force=True)
     subds.rev_save(recursive=True)
     ok_clean_git(subds.path)
@@ -252,7 +252,7 @@ def test_uninstall_multiple_paths(path):
 def test_uninstall_dataset(path):
     ds = Dataset(path)
     ok_(not ds.is_installed())
-    ds.create()
+    ds.rev_create()
     ok_(ds.is_installed())
     ok_clean_git(ds.path)
     # would only drop data
@@ -271,7 +271,7 @@ def test_uninstall_dataset(path):
 
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
 def test_remove_file_handle_only(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.rev_save()
     ok_clean_git(ds.path)
     # make sure there is any key
@@ -300,8 +300,8 @@ def test_remove_file_handle_only(path):
 
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
 def test_uninstall_recursive(path):
-    ds = Dataset(path).create(force=True)
-    subds = ds.create('deep', force=True)
+    ds = Dataset(path).rev_create(force=True)
+    subds = ds.rev_create('deep', force=True)
     # we add one file, but we get a response for the requested
     # directory too
     res = subds.rev_save()
@@ -342,8 +342,8 @@ def test_uninstall_recursive(path):
 
 @with_tempfile()
 def test_remove_dataset_hierarchy(path):
-    ds = Dataset(path).create()
-    ds.create('deep')
+    ds = Dataset(path).rev_create()
+    ds.rev_create('deep')
     ok_clean_git(ds.path)
     # fail on missing --recursive because subdataset is present
     assert_raises(IncompleteResultsError, ds.remove)
@@ -353,8 +353,8 @@ def test_remove_dataset_hierarchy(path):
     ok_(not ds.is_installed())
     ok_(not exists(ds.path))
     # now do it again, but without a reference dataset
-    ds = Dataset(path).create()
-    ds.create('deep')
+    ds = Dataset(path).rev_create()
+    ds.rev_create('deep')
     ok_clean_git(ds.path)
     remove(ds.path, recursive=True)
     # completely gone
@@ -365,9 +365,9 @@ def test_remove_dataset_hierarchy(path):
 @with_tempfile()
 def test_careless_subdataset_uninstall(path):
     # nested datasets
-    ds = Dataset(path).create()
-    subds1 = ds.create('deep1')
-    ds.create('deep2')
+    ds = Dataset(path).rev_create()
+    subds1 = ds.rev_create('deep1')
+    ds.rev_create('deep2')
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1', 'deep2'])
     ok_clean_git(ds.path)
     # now we kill the sub without the parent knowing
@@ -383,12 +383,12 @@ def test_careless_subdataset_uninstall(path):
 @with_tempfile()
 def test_kill(path):
     # nested datasets with load
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     testfile = opj(ds.path, "file.dat")
     with open(testfile, 'w') as f:
         f.write("load")
     ds.rev_save("file.dat")
-    subds = ds.create('deep1')
+    subds = ds.rev_create('deep1')
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1'])
     ok_clean_git(ds.path)
 
@@ -418,9 +418,9 @@ def test_remove_recreation(path):
     # remainings of the old instances
     # see issue #1311
 
-    ds = create(path)
+    ds = rev_create(path)
     ds.remove()
-    ds = create(path)
+    ds = rev_create(path)
     ok_clean_git(ds.path)
     ok_(ds.is_installed())
 
@@ -428,21 +428,21 @@ def test_remove_recreation(path):
 @with_tempfile()
 def test_no_interaction_with_untracked_content(path):
     # extracted from what was a metadata test originally
-    ds = Dataset(opj(path, 'origin')).create(force=True)
+    ds = Dataset(opj(path, 'origin')).rev_create(force=True)
     create_tree(ds.path, {'sub': {'subsub': {'dat': 'lots of data'}}})
-    subds = ds.create('sub', force=True)
+    subds = ds.rev_create('sub', force=True)
     subds.remove(opj('.datalad', 'config'), if_dirty='ignore')
     ok_(not exists(opj(subds.path, '.datalad', 'config')))
     # this will only work, if `remove` didn't do anything stupid and
     # caused all content to be saved
-    subds.create('subsub', force=True)
+    subds.rev_create('subsub', force=True)
 
 
 @with_tempfile()
 def test_remove_nowhining(path):
     # when removing a dataset under a dataset (but not a subdataset)
     # should not provide a meaningless message that something was not right
-    ds = create(path)
+    ds = rev_create(path)
     # just install/clone inside of it
     subds_path = _path_(path, 'subds')
     install(subds_path, source=path)
@@ -465,10 +465,10 @@ def test_remove_recursive_2(tdir):
 def test_failon_nodrop(path):
     # test to make sure that we do not wipe out data when checks are enabled
     # despite the general error behavior mode
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     # we play with a subdataset to bypass the tests that prevent the removal
     # of top-level datasets
-    sub = ds.create('sub')
+    sub = ds.rev_create('sub')
     create_tree(sub.path, {'test': 'content'})
     ds.rev_save(opj('sub', 'test'))
     ok_clean_git(ds.path)
@@ -488,10 +488,10 @@ def test_failon_nodrop(path):
 def test_uninstall_without_super(path):
     # a parent dataset with a proper subdataset, and another dataset that
     # is just placed underneath the parent, but not an actual subdataset
-    parent = Dataset(path).create()
-    sub = parent.create('sub')
+    parent = Dataset(path).rev_create()
+    sub = parent.rev_create('sub')
     ok_clean_git(parent.path)
-    nosub = create(opj(parent.path, 'nosub'))
+    nosub = rev_create(opj(parent.path, 'nosub'))
     ok_clean_git(nosub.path)
     subreport = parent.subdatasets()
     assert_result_count(subreport, 1, path=sub.path)
@@ -515,8 +515,8 @@ def test_uninstall_without_super(path):
 
 @with_tempfile(mkdir=True)
 def test_drop_nocrash_absent_subds(path):
-    parent = Dataset(path).create()
-    sub = parent.create('sub')
+    parent = Dataset(path).rev_create()
+    sub = parent.rev_create('sub')
     parent.uninstall('sub')
     ok_clean_git(parent.path)
     with chpwd(path):
@@ -525,7 +525,7 @@ def test_drop_nocrash_absent_subds(path):
 
 @with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
 def test_remove_more_than_one(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.rev_save()
     ok_clean_git(path)
     # ensure #1912 stays resolved

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -225,11 +225,11 @@ def test_uninstall_subdataset(src, dst):
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True, save=False)
     subds = ds.create('deep', force=True)
-    subds.add('.', recursive=True)
+    subds.rev_save(recursive=True)
     ok_clean_git(subds.path)
     # needs to be able to add a combination of staged files, modified submodule,
     # and untracked files
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(ds.path)
     # drop content of all 'kill' files
     topfile = 'kill'
@@ -273,7 +273,7 @@ def test_uninstall_dataset(path):
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
-    ds.add(os.curdir)
+    ds.rev_save()
     ok_clean_git(ds.path)
     # make sure there is any key
     ok_(len(ds.repo.get_file_key('one')))
@@ -305,7 +305,7 @@ def test_uninstall_recursive(path):
     subds = ds.create('deep', force=True)
     # we add one file, but we get a response for the requested
     # directory too
-    res = subds.add('.')
+    res = subds.rev_save()
     assert_result_count(res, 1, action='add', status='ok', type='file')
     assert_result_count(res, 1, action='save', status='ok', type='dataset')
     # save all -> all clean
@@ -388,7 +388,7 @@ def test_kill(path):
     testfile = opj(ds.path, "file.dat")
     with open(testfile, 'w') as f:
         f.write("load")
-    ds.add("file.dat")
+    ds.rev_save("file.dat")
     subds = ds.create('deep1')
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1'])
     ok_clean_git(ds.path)
@@ -471,7 +471,7 @@ def test_failon_nodrop(path):
     # of top-level datasets
     sub = ds.create('sub')
     create_tree(sub.path, {'test': 'content'})
-    ds.add(opj('sub', 'test'))
+    ds.rev_save(opj('sub', 'test'))
     ok_clean_git(ds.path)
     eq_(['test'], sub.repo.get_annexed_files(with_content_only=True))
     # we put one file into the dataset's annex, no redundant copies
@@ -527,7 +527,7 @@ def test_drop_nocrash_absent_subds(path):
 @with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
 def test_remove_more_than_one(path):
     ds = Dataset(path).create(force=True)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(path)
     # ensure #1912 stays resolved
     ds.remove(['one', 'two'], check=False)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -93,7 +93,6 @@ def test_clean_subds_removal(path):
     assert(not exists(subds1.path))
     # and now again, but this time remove something that is not installed
     ds.create('three')
-    ds.save()
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['three', 'two'])
     ds.uninstall('two')
     ok_clean_git(ds.path)
@@ -309,7 +308,7 @@ def test_uninstall_recursive(path):
     assert_result_count(res, 1, action='add', status='ok', type='file')
     assert_result_count(res, 1, action='save', status='ok', type='dataset')
     # save all -> all clean
-    ds.save(recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(subds.path)
     ok_clean_git(ds.path)
     # now uninstall in subdataset through superdataset

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -133,7 +133,7 @@ def test_update_simple(origin, src_path, dst_path):
 @with_tempfile
 def test_update_git_smoke(src_path, dst_path):
     # Apparently was just failing on git repos for basic lack of coverage, hence this quick test
-    ds = Dataset(src_path).create(no_annex=True)
+    ds = Dataset(src_path).rev_create(no_annex=True)
     target = install(
         dst_path, source=src_path,
         result_xfm='datasets', return_type='item-or-list')
@@ -269,13 +269,13 @@ def test_newthings_coming_down(originpath, destpath):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_update_volatile_subds(originpath, otherpath, destpath):
-    origin = Dataset(originpath).create()
+    origin = Dataset(originpath).rev_create()
     ds = install(
         source=originpath, path=destpath,
         result_xfm='datasets', return_type='item-or-list')
     # as a submodule
     sname = 'subm 1'
-    osm1 = origin.create(sname)
+    osm1 = origin.rev_create(sname)
     assert_result_count(ds.update(), 1, status='ok', type='dataset')
     # nothing without a merge, no inappropriate magic
     assert_not_in(sname, ds.subdatasets(result_xfm='relpaths'))
@@ -294,7 +294,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     assert_false(exists(opj(ds.path, sname)))
 
     # re-introduce at origin
-    osm1 = origin.create(sname)
+    osm1 = origin.rev_create(sname)
     create_tree(osm1.path, {'load.dat': 'heavy'})
     origin.rev_save(opj(osm1.path, 'load.dat'))
     assert_result_count(ds.update(merge=True), 1, status='ok', type='dataset')
@@ -331,7 +331,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     ok_clean_git(ds.path)
 
     # new separate subdataset, not within the origin dataset
-    otherds = Dataset(otherpath).create()
+    otherds = Dataset(otherpath).rev_create()
     # install separate dataset as a submodule
     ds.install(source=otherds.path, path='other')
     create_tree(otherds.path, {'brand': 'new'})
@@ -349,7 +349,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_reobtain_data(originpath, destpath):
-    origin = Dataset(originpath).create()
+    origin = Dataset(originpath).rev_create()
     ds = install(
         source=originpath, path=destpath,
         result_xfm='datasets', return_type='item-or-list')
@@ -391,7 +391,7 @@ def test_reobtain_data(originpath, destpath):
 @with_tempfile(mkdir=True)
 def test_multiway_merge(path):
     # prepare ds with two siblings, but no tracking branch
-    ds = Dataset(op.join(path, 'ds_orig')).create()
+    ds = Dataset(op.join(path, 'ds_orig')).rev_create()
     r1 = AnnexRepo(path=op.join(path, 'ds_r1'), git_opts={'bare': True})
     r2 = GitRepo(path=op.join(path, 'ds_r2'), git_opts={'bare': True})
     ds.siblings(action='add', name='r1', url=r1.path)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -73,8 +73,7 @@ def test_update_simple(origin, src_path, dst_path):
     # modify origin:
     with open(opj(src_path, "update.txt"), "w") as f:
         f.write("Additional content")
-    source.rev_save(path="update.txt")
-    source.save("Added update.txt")
+    source.rev_save(path="update.txt", message="Added update.txt")
     ok_clean_git(src_path)
 
     # fail when asked to update a non-dataset

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -73,7 +73,7 @@ def test_update_simple(origin, src_path, dst_path):
     # modify origin:
     with open(opj(src_path, "update.txt"), "w") as f:
         f.write("Additional content")
-    source.add(path="update.txt")
+    source.rev_save(path="update.txt")
     source.save("Added update.txt")
     ok_clean_git(src_path)
 
@@ -119,7 +119,7 @@ def test_update_simple(origin, src_path, dst_path):
 
     # and now test recursive update with merging in differences
     create_tree(opj(source.path, '2'), {'load.dat': 'heavy'})
-    source.add(opj('2', 'load.dat'),
+    source.rev_save(opj('2', 'load.dat'),
                message="saving changes within subm2",
                recursive=True)
     assert_result_count(
@@ -139,7 +139,7 @@ def test_update_git_smoke(src_path, dst_path):
         dst_path, source=src_path,
         result_xfm='datasets', return_type='item-or-list')
     create_tree(ds.path, {'file.dat': '123'})
-    ds.add('file.dat')
+    ds.rev_save('file.dat')
     assert_result_count(
         target.update(recursive=True, merge=True), 1,
         status='ok', type='dataset')
@@ -214,7 +214,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
-    Dataset(originpath).add('load.dat')
+    Dataset(originpath).rev_save('load.dat')
     ds = install(
         source=originpath, path=destpath,
         result_xfm='datasets', return_type='item-or-list')
@@ -297,7 +297,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     # re-introduce at origin
     osm1 = origin.create(sname)
     create_tree(osm1.path, {'load.dat': 'heavy'})
-    origin.add(opj(osm1.path, 'load.dat'))
+    origin.rev_save(opj(osm1.path, 'load.dat'))
     assert_result_count(ds.update(merge=True), 1, status='ok', type='dataset')
     # grab new content of uninstall subdataset, right away
     ds.get(opj(ds.path, sname, 'load.dat'))
@@ -305,7 +305,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
 
     # modify ds and subds at origin
     create_tree(origin.path, {'mike': 'this', sname: {'probe': 'little'}})
-    origin.add('.', recursive=True)
+    origin.rev_save(recursive=True)
     ok_clean_git(origin.path)
 
     # updates for both datasets should come down the pipe
@@ -336,7 +336,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     # install separate dataset as a submodule
     ds.install(source=otherds.path, path='other')
     create_tree(otherds.path, {'brand': 'new'})
-    otherds.add('.')
+    otherds.rev_save()
     ok_clean_git(otherds.path)
     # pull in changes
     res = ds.update(merge=True, recursive=True)
@@ -358,7 +358,7 @@ def test_reobtain_data(originpath, destpath):
     assert_result_count(ds.update(merge=True, reobtain_data=True), 1)
     # content
     create_tree(origin.path, {'load.dat': 'heavy'})
-    origin.add(opj(origin.path, 'load.dat'))
+    origin.rev_save(opj(origin.path, 'load.dat'))
     # update does not bring data automatically
     assert_result_count(ds.update(merge=True, reobtain_data=True), 1)
     assert_in('load.dat', ds.repo.get_annexed_files())
@@ -368,7 +368,7 @@ def test_reobtain_data(originpath, destpath):
     ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')
     # new content at origin
     create_tree(origin.path, {'novel': 'but boring'})
-    origin.add('.')
+    origin.rev_save()
     # update must not bring in data for new file
     result = ds.update(merge=True, reobtain_data=True)
     assert_in_results(result, action='get', status='notneeded')
@@ -379,7 +379,7 @@ def test_reobtain_data(originpath, destpath):
     # modify content at origin
     os.remove(opj(origin.path, 'load.dat'))
     create_tree(origin.path, {'load.dat': 'light'})
-    origin.add('.')
+    origin.rev_save()
     # update must update file with existing data, but leave empty one alone
     res = ds.update(merge=True, reobtain_data=True)
     assert_result_count(res, 2)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -193,7 +193,7 @@ class Update(Interface):
             lgr.debug(
                 'Subdatasets where updated state may need to be '
                 'saved in the parent dataset: %s', save_paths)
-            for r in Dataset(refds_path).add(
+            for r in Dataset(refds_path).rev_save(
                     path=save_paths,
                     recursive=False,
                     message='[DATALAD] Save updated subdatasets'):

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -156,7 +156,7 @@ class DownloadURL(Interface):
 URLs:
   {}""".format("\n  ".join(urls))
 
-            for r in ds.add(downloaded_paths, message=msg):
+            for r in ds.rev_save(downloaded_paths, message=msg):
                 yield r
 
             if isinstance(ds.repo, AnnexRepo):

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -215,10 +215,10 @@ def test_annotate_paths(dspath, nodspath):
 @slow  # 11.0891s
 @with_tree(demo_hierarchy['b'])
 def test_get_modified_subpaths(path):
-    ds = Dataset(path).create(force=True)
-    suba = ds.create('ba', force=True)
-    subb = ds.create('bb', force=True)
-    subsub = ds.create(opj('bb', 'bba', 'bbaa'), force=True)
+    ds = Dataset(path).rev_create(force=True)
+    suba = ds.rev_create('ba', force=True)
+    subb = ds.rev_create('bb', force=True)
+    subsub = ds.rev_create(opj('bb', 'bba', 'bbaa'), force=True)
     ds.rev_save(recursive=True)
     ok_clean_git(path)
 

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -34,6 +34,8 @@ from datalad.api import install
 from datalad.interface.annotate_paths import get_modified_subpaths
 from datalad.utils import chpwd
 
+from datalad.interface.tests.test_utils import make_demo_hierarchy_datasets
+
 
 __docformat__ = 'restructuredtext'
 
@@ -50,17 +52,6 @@ demo_hierarchy = {
                     'file_bbaa': 'file_bbaa'}},
             'file_bb': 'file_bb'}},
 }
-
-
-def make_demo_hierarchy_datasets(path, tree, parent=None):
-    if parent is None:
-        parent = Dataset(path).create(force=True)
-    for node, items in tree.items():
-        if isinstance(items, dict):
-            node_path = opj(path, node)
-            nodeds = Dataset(node_path).create(force=True)
-            make_demo_hierarchy_datasets(node_path, items, parent=nodeds)
-    return parent
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -82,6 +82,8 @@ def test_invalid_call(path):
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
+    # TODO RF the helper above to produce a proper hierarchy
+    # and then use rev_save()
     ds.add('.', recursive=True)
     ok_clean_git(ds.path)
 
@@ -228,7 +230,7 @@ def test_get_modified_subpaths(path):
     suba = ds.create('ba', force=True)
     subb = ds.create('bb', force=True)
     subsub = ds.create(opj('bb', 'bba', 'bbaa'), force=True)
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(path)
 
     orig_base_commit = ds.repo.repo.commit().hexsha
@@ -241,7 +243,7 @@ def test_get_modified_subpaths(path):
 
     # modify one subdataset
     create_tree(subsub.path, {'added': 'test'})
-    subsub.add('added')
+    subsub.rev_save('added')
 
     # it will replace the requested path with the path of the closest
     # submodule that is modified
@@ -283,7 +285,7 @@ def test_get_modified_subpaths(path):
         type='dataset', path=suba.path)
 
     # add/save everything, become clean
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(path)
     # nothing is reported as modified
     assert_result_count(
@@ -331,13 +333,15 @@ def test_get_modified_subpaths(path):
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
+    # TODO RF the helper above to produce a proper hierarchy, and then
+    # use rev_save()
     ds.add('.', recursive=True)
     # label intermediate dataset as 'norecurseinto'
     res = Dataset(opj(ds.path, 'b')).subdatasets(
         contains='bb',
         set_property=[('datalad-recursiveinstall', 'skip')])
     assert_result_count(res, 1, path=opj(ds.path, 'b', 'bb'))
-    ds.add('b/', recursive=True)
+    ds.rev_save('b/', recursive=True)
     ok_clean_git(ds.path)
 
     # recursive install, should skip the entire bb branch

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -266,7 +266,7 @@ def test_get_modified_subpaths(path):
         type='dataset')
 
     # now save uptop, this will the new state of subb, but keep suba dirty
-    ds.save(subb.path, recursive=True)
+    ds.rev_save(subb.path, recursive=True)
     # now if we ask for what was last saved, we only get the new state of subb
     assert_result_count(
         get_modified_subpaths(

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -73,9 +73,7 @@ def test_invalid_call(path):
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
-    # TODO RF the helper above to produce a proper hierarchy
-    # and then use rev_save()
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(ds.path)
 
     with chpwd(dspath):
@@ -324,15 +322,13 @@ def test_get_modified_subpaths(path):
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
-    # TODO RF the helper above to produce a proper hierarchy, and then
-    # use rev_save()
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     # label intermediate dataset as 'norecurseinto'
     res = Dataset(opj(ds.path, 'b')).subdatasets(
         contains='bb',
         set_property=[('datalad-recursiveinstall', 'skip')])
     assert_result_count(res, 1, path=opj(ds.path, 'b', 'bb'))
-    ds.rev_save('b/', recursive=True)
+    ds.rev_save('b', recursive=True)
     ok_clean_git(ds.path)
 
     # recursive install, should skip the entire bb branch

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -69,7 +69,7 @@ def test_diff(path, norepo):
     assert len(ds.diff(revision='HEAD~1')) > 0
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
-    ds.add('.', to_git=True)
+    ds.rev_save(to_git=True)
     ok_clean_git(ds.path)
     res = ds.diff(revision='HEAD~1')
     assert_result_count(res, 1)
@@ -167,11 +167,11 @@ def test_diff_recursive(path):
     assert_result_count(res, 1, action='diff', state='modified', path=sub.path, type='dataset')
     assert_result_count(res, 1, action='diff', state='untracked', path=opj(sub.path, 'twofile'), type='file')
     # save sub
-    sub.add('.')
+    sub.rev_save()
     # save sub in parent
-    ds.save()
+    ds.rev_save(sub.path)
     # save addition in parent
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
     # look at the last change, only one file was added
     res = ds.diff(revision='HEAD~1..HEAD')
@@ -210,10 +210,10 @@ def test_diff_helper(path):
     sub_clean = ds.create('sub_clean', force=True)
     # proper submodule, but commited modifications not commited in parent
     sub_modified = ds.create('sub_modified', force=True)
-    sub_modified.add('modified')
+    sub_modified.rev_save('modified')
     # proper submodule with untracked changes
     sub_dirty = ds.create('sub_dirty', force=True)
-    ds.add(['clean', 'modified'])
+    ds.rev_save(['clean', 'modified'])
     ds.unlock('modified')
     with open(opj(ds.path, 'modified'), 'w') as f:
         f.write('modified_content')

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -50,7 +50,7 @@ def test_magic_number():
 def test_diff(path, norepo):
     with chpwd(norepo):
         assert_status('impossible', diff(on_failure='ignore'))
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ok_clean_git(ds.path)
     # reports stupid revision input
     assert_result_count(
@@ -64,9 +64,6 @@ def test_diff(path, norepo):
     assert_result_count(ds.diff(revision='HEAD'), 0)
     # bogus path makes no difference
     assert_result_count(ds.diff(path='THIS', revision='HEAD'), 0)
-    # comparing to a previous state we should get a diff in most cases
-    # for this test, let's not care what exactly it is -- will do later
-    assert len(ds.diff(revision='HEAD~1')) > 0
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
     ds.rev_save(to_git=True)
@@ -146,8 +143,8 @@ def test_diff(path, norepo):
 
 @with_tempfile(mkdir=True)
 def test_diff_recursive(path):
-    ds = Dataset(path).create()
-    sub = ds.create('sub')
+    ds = Dataset(path).rev_create()
+    sub = ds.rev_create('sub')
     # look at the last change, and confirm a dataset was added
     res = ds.diff(revision='HEAD~1..HEAD')
     assert_result_count(res, 1, action='diff', state='added', path=sub.path, type='dataset')
@@ -203,16 +200,16 @@ def test_diff_recursive(path):
 })
 def test_diff_helper(path):
     # make test dataset components of interesting states
-    ds = Dataset.create(path, force=True)
+    ds = Dataset.rev_create(path, force=True)
     # detached dataset, not a submodule
-    nosub = Dataset.create(opj(path, 'nosub'))
+    nosub = Dataset.rev_create(opj(path, 'nosub'))
     # unmodified, proper submodule
-    sub_clean = ds.create('sub_clean', force=True)
+    sub_clean = ds.rev_create('sub_clean', force=True)
     # proper submodule, but commited modifications not commited in parent
-    sub_modified = ds.create('sub_modified', force=True)
+    sub_modified = ds.rev_create('sub_modified', force=True)
     sub_modified.rev_save('modified')
     # proper submodule with untracked changes
-    sub_dirty = ds.create('sub_dirty', force=True)
+    sub_dirty = ds.rev_create('sub_dirty', force=True)
     ds.rev_save(['clean', 'modified'])
     ds.unlock('modified')
     with open(opj(ds.path, 'modified'), 'w') as f:

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -107,7 +107,7 @@ def test_diff(path, norepo):
     assert_result_count(
         ds.diff(revision='HEAD'), 1,
         action='diff', path=opj(ds.path, 'new'), state='modified')
-    ds.save()
+    ds.rev_save()
     ok_clean_git(ds.path)
 
     # untracked stuff

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -96,7 +96,7 @@ def test_diff(path, norepo):
         ds.diff('new'), 1,
         action='diff', path=opj(ds.path, 'new'), state='modified')
     # stage changes
-    ds.add('.', to_git=True, save=False)
+    ds.repo.add('.', git=True)
     # no diff, because we staged the modification
     assert_result_count(ds.diff(), 0)
     # but we can get at it
@@ -131,7 +131,7 @@ def test_diff(path, norepo):
         ds.diff(path='deep'), 1,
         state='untracked', path=opj(ds.path, 'deep'))
     # now we stage on of the two files in deep
-    ds.add(opj('deep', 'down2'), to_git=True, save=False)
+    ds.repo.add(opj('deep', 'down2'), git=True)
     # without any reference it will ignore the staged stuff and report the remaining
     # untracked file
     assert_result_count(

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -93,7 +93,7 @@ def test_download_url_dataset(toppath, topurl, path):
     files_tosave = ['file1.txt', 'file2.txt']
     urls_tosave = [opj(topurl, f) for f in files_tosave]
 
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
 
     # By default, files are saved when called in a dataset.
     ds.download_url(urls_tosave)
@@ -125,7 +125,7 @@ def test_download_url_dataset(toppath, topurl, path):
 @serve_path_via_http
 @with_tempfile(mkdir=True)
 def test_download_url_archive(toppath, topurl, path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ds.download_url([opj(topurl, "archive.tar.gz")], archive=True)
     ok_(ds.repo.file_has_content(opj("archive", "file1.txt")))
     assert_not_in(opj(ds.path, "archive.tar.gz"),

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -83,8 +83,8 @@ def test_ls_repos(toppath):
 @with_tempfile
 def test_ls_uninstalled(path):
     ds = Dataset(path)
-    ds.create()
-    ds.create('sub')
+    ds.rev_create()
+    ds.rev_create('sub')
     ds.uninstall('sub', check=False)
     with swallow_outputs() as cmo:
         ls([path], recursive=True)

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -151,7 +151,7 @@ def test_ls_json(topdir, topurl):
     # add a subdataset
     ds.install('subds', source=topdir)
 
-    subdirds = ds.create(_path_('dir/subds2'), force=True)
+    subdirds = ds.rev_create(_path_('dir/subds2'), force=True)
     subdirds.rev_save('file')
 
     git = GitRepo(opj(topdir, 'dir', 'subgit'), create=True)                    # create git repo

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -146,14 +146,13 @@ def test_ls_json(topdir, topurl):
     # create some file and commit it
     with open(opj(ds.path, 'subdsfile.txt'), 'w') as f:
         f.write('123')
-    ds.add(path='subdsfile.txt')
-    ds.save("Hello!", version_tag=1)
+    ds.rev_save(path='subdsfile.txt', message="Hello!", version_tag=1)
 
     # add a subdataset
     ds.install('subds', source=topdir)
 
     subdirds = ds.create(_path_('dir/subds2'), force=True)
-    subdirds.add('file')
+    subdirds.rev_save('file')
 
     git = GitRepo(opj(topdir, 'dir', 'subgit'), create=True)                    # create git repo
     git.add(opj(topdir, 'dir', 'subgit', 'fgit.txt'))                           # commit to git to init git repo
@@ -166,8 +165,8 @@ def test_ls_json(topdir, topurl):
     git.add('fgit.txt')              # commit to git to init git repo
     git.commit()
     # annex.add doesn't add submodule, so using ds.add
-    ds.add(opj('dir', 'subgit'))                        # add the non-dataset git repo to annex
-    ds.add('dir')                                  # add to annex (links)
+    ds.rev_save(opj('dir', 'subgit'))                        # add the non-dataset git repo to annex
+    ds.rev_save('dir')                                  # add to annex (links)
     ds.drop(opj('dir', 'subdir', 'file2.txt'), check=False)  # broken-link
 
     # register "external" submodule  by installing and uninstalling it

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -61,7 +61,7 @@ rev_save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 """}})
 @with_tempfile
 def test_basics(path, super_path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     assert_false(ds.repo.is_under_annex("README.md"))
@@ -84,7 +84,7 @@ def test_basics(path, super_path):
     ok_clean_git(ds.path, index_modified=[op.join('.datalad', 'config')])
 
     # make a fresh dataset:
-    super = Dataset(super_path).create()
+    super = Dataset(super_path).rev_create()
     # configure dataset to run the demo procedure prior to the clean command
     super.config.add(
         'datalad.clean.proc-pre',
@@ -129,7 +129,7 @@ def test_procedure_discovery(path, super_path):
             len(ps))
 
     # set up dataset with registered procedure (c&p from test_basics):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder
@@ -160,7 +160,7 @@ def test_procedure_discovery(path, super_path):
     assert_in_results(ps, path=op.join(ds.path, 'code', 'datalad_test_proc.py'))
 
     # make it a subdataset and try again:
-    super = Dataset(super_path).create()
+    super = Dataset(super_path).rev_create()
     super.install('sub', source=ds.path)
 
     ps = super.run_procedure(discover=True)
@@ -213,7 +213,7 @@ rev_save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 def test_configs(path):
 
     # set up dataset with registered procedure (c&p from test_basics):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.run_procedure('setup_yoda_dataset')
     ok_clean_git(ds.path)
     # configure dataset to look for procedures in its code folder

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -53,11 +53,11 @@ def test_invalid_call(path):
     'code': {'datalad_test_proc.py': """\
 import sys
 import os.path as op
-from datalad.api import add, Dataset
+from datalad.api import rev_save, Dataset
 
 with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('hello\\n')
-add(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
+rev_save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 """}})
 @with_tempfile
 def test_basics(path, super_path):
@@ -71,7 +71,7 @@ def test_basics(path, super_path):
         'code',
         where='dataset')
     # commit this procedure config for later use in a clone:
-    ds.add(op.join('.datalad', 'config'))
+    ds.rev_save(op.join('.datalad', 'config'))
     # configure dataset to run the demo procedure prior to the clean command
     ds.config.add(
         'datalad.clean.proc-pre',
@@ -142,7 +142,7 @@ def test_procedure_discovery(path, super_path):
         'datalad.clean.proc-pre',
         'datalad_test_proc',
         where='dataset')
-    ds.add(op.join('.datalad', 'config'))
+    ds.rev_save(op.join('.datalad', 'config'))
 
     # run discovery on the dataset:
     ps = ds.run_procedure(discover=True)
@@ -204,11 +204,11 @@ def test_procedure_discovery(path, super_path):
     'code': {'datalad_test_proc.py': """\
 import sys
 import os.path as op
-from datalad.api import add, Dataset
+from datalad.api import rev_save, Dataset
 
 with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('{}\\n'.format(sys.argv[2]))
-add(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
+rev_save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 """}})
 def test_configs(path):
 

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -29,7 +29,7 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import ok_
 from datalad.api import save
 from datalad.api import create
-from datalad.api import add
+from datalad.api import rev_save
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile
@@ -402,15 +402,14 @@ def test_bf1886(path):
         opj(parent.path, 'subdir', 'subsubdir', 'upup3'))
     # need to use absolute paths
     with chpwd(opj(parent.path, 'subdir', 'subsubdir')):
-        add([opj(parent.path, 'sub3'),
-             opj(parent.path, 'subdir', 'subsubdir', 'upup3')])
-    # here is where we need to disagree with the repo in #1886
-    # we would not expect that `add` registers sub3 as a subdataset
-    # of parent, because no reference dataset was given and the
-    # command cannot decide (with the current semantics) whether
-    # it should "add anything in sub3 to sub3" or "add sub3 to whatever
-    # sub3 is in"
-    ok_clean_git(parent.path, untracked=['sub3/'])
+        rev_save([opj(parent.path, 'sub3'),
+                  opj(parent.path, 'subdir', 'subsubdir', 'upup3')])
+    # in contrast to `add` only operates on a single top-level dataset
+    # although it is not specified, it get's discovered based on the PWD
+    # the logic behind that feels a bit shaky
+    # consult discussion in https://github.com/datalad/datalad/issues/3230
+    # if this comes up as an issue at some point
+    ok_clean_git(parent.path)
 
 
 @with_tree({

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -28,7 +28,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import ok_
 from datalad.api import save
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.api import rev_save
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_testrepos
@@ -93,7 +93,7 @@ def test_save(path):
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # create subdataset
-    subds = ds.create('subds')
+    subds = ds.rev_create('subds')
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
     # modify subds
     with open(opj(subds.path, "some_file.tst"), "w") as f:
@@ -108,7 +108,7 @@ def test_save(path):
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # now introduce a change downstairs
-    subds.create('someotherds')
+    subds.rev_create('someotherds')
     ok_clean_git(subds.path, annex=isinstance(subds.repo, AnnexRepo))
     ok_(ds.repo.dirty)
     # and save via subdataset path
@@ -118,13 +118,13 @@ def test_save(path):
 
 @with_tempfile()
 def test_recursive_save(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     # nothing to save
     assert_status('notneeded', ds.save())
-    subds = ds.create('sub')
+    subds = ds.rev_create('sub')
     # subdataset presence already saved
     ok_clean_git(ds.path)
-    subsubds = subds.create('subsub')
+    subsubds = subds.rev_create('subsub')
     assert_equal(
         ds.subdatasets(recursive=True, fulfilled=True, result_xfm='paths'),
         [subds.path, subsubds.path])
@@ -266,7 +266,7 @@ def test_recursive_save(path):
 
 @with_tempfile()
 def test_save_message_file(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     with assert_raises(ValueError):
         ds.save("blah", message="me", message_file="and me")
 
@@ -281,7 +281,7 @@ def test_save_message_file(path):
 def test_renamed_file():
     @with_tempfile()
     def check_renamed_file(recursive, no_annex, path):
-        ds = Dataset(path).create(no_annex=no_annex)
+        ds = Dataset(path).rev_create(no_annex=no_annex)
         create_tree(path, {'old': ''})
         ds.add('old')
         ds.repo._git_custom_command(['old', 'new'], ['git', 'mv'])
@@ -295,8 +295,8 @@ def test_renamed_file():
 
 @with_tempfile(mkdir=True)
 def test_subdataset_save(path):
-    parent = Dataset(path).create()
-    sub = parent.create('sub')
+    parent = Dataset(path).rev_create()
+    sub = parent.rev_create('sub')
     ok_clean_git(parent.path)
     create_tree(parent.path, {
         "untracked": 'ignore',
@@ -342,7 +342,7 @@ def test_symlinked_relpath(path):
     os.makedirs(opj(path, "origin"))
     dspath = opj(path, "linked")
     os.symlink('origin', dspath)
-    ds = Dataset(dspath).create()
+    ds = Dataset(dspath).rev_create()
     create_tree(dspath, {
         "mike1": 'mike1',  # will be added from topdir
         "later": "later",  # later from within subdir
@@ -370,8 +370,8 @@ def test_symlinked_relpath(path):
 
 @with_tempfile(mkdir=True)
 def test_bf1886(path):
-    parent = Dataset(path).create()
-    sub = parent.create('sub')
+    parent = Dataset(path).rev_create()
+    sub = parent.rev_create('sub')
     ok_clean_git(parent.path)
     # create a symlink pointing down to the subdataset, and add it
     os.symlink('sub', opj(parent.path, 'down'))
@@ -388,7 +388,7 @@ def test_bf1886(path):
     ok_clean_git(parent.path)
     # simulatenously add a subds and a symlink pointing to it
     # create subds, but don't register it
-    sub2 = create(opj(parent.path, 'sub2'))
+    sub2 = rev_create(opj(parent.path, 'sub2'))
     os.symlink(
         opj(pardir, pardir, 'sub2'),
         opj(parent.path, 'subdir', 'subsubdir', 'upup2'))
@@ -396,7 +396,7 @@ def test_bf1886(path):
     ok_clean_git(parent.path)
     # full replication of #1886: the above but be in subdir of symlink
     # with no reference dataset
-    sub3 = create(opj(parent.path, 'sub3'))
+    sub3 = rev_create(opj(parent.path, 'sub3'))
     os.symlink(
         opj(pardir, pardir, 'sub3'),
         opj(parent.path, 'subdir', 'subsubdir', 'upup3'))
@@ -419,7 +419,7 @@ def test_bf1886(path):
 def test_gh2043p1(path):
     # this tests documents the interim agreement on what should happen
     # in the case documented in gh-2043
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.add('1')
     ok_clean_git(ds.path, untracked=['2', '3'])
     ds.unlock('1')
@@ -445,7 +445,7 @@ def test_gh2043p1(path):
     'staged': 'staged',
     'untracked': 'untracked'})
 def test_bf2043p2(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.add('staged', save=False)
     ok_clean_git(ds.path, head_modified=['staged'], untracked=['untracked'])
     # plain save does not commit untracked content

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -78,7 +78,7 @@ def test_dirty(path):
     handle_dirty_dataset(ds, 'ignore')
     assert_raises(RuntimeError, handle_dirty_dataset, ds, 'save-before')
     # should yield a clean repo
-    ds.create()
+    ds.rev_create()
     orig_state = ds.repo.get_hexsha()
     _check_all_clean(ds, orig_state)
     # tainted: untracked
@@ -91,7 +91,7 @@ def test_dirty(path):
     orig_state = _check_auto_save(ds, orig_state)
     # tainted: submodule
     # not added to super on purpose!
-    subds = ds.create('subds')
+    subds = ds.rev_create('subds')
     _check_all_clean(subds, subds.repo.get_hexsha())
     ok_clean_git(ds.path)
     # subdataset must be added as a submodule!
@@ -125,7 +125,7 @@ demo_hierarchy = {
 
 def make_demo_hierarchy_datasets(path, tree, parent=None):
     if parent is None:
-        parent = Dataset(path).create(force=True)
+        parent = Dataset(path).rev_create(force=True)
     for node, items in tree.items():
         if isinstance(items, dict):
             node_path = opj(path, node)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -152,7 +152,7 @@ def test_save_hierarchy(path):
         ok_(d.repo.dirty)
     # need to give file specifically, otherwise it will simply just preserve
     # staged changes
-    ds_bb.save(path=opj(ds_bbaa.path, 'file_bbaa'))
+    ds_bb.rev_save(path=opj(ds_bbaa.path, 'file_bbaa'))
     # it has saved all changes in the subtrees spanned
     # by the given datasets, but nothing else
     for d in (ds_bb, ds_bba, ds_bbaa):
@@ -165,7 +165,7 @@ def test_save_hierarchy(path):
     db = Dataset(opj(d.path, 'db'))
     db.repo.remove('file_db')
     # generator
-    d.save(recursive=True)
+    d.rev_save(recursive=True)
     for d in (d, da, db):
         ok_clean_git(d.path)
     ok_(ds.repo.dirty)
@@ -183,17 +183,12 @@ def test_save_hierarchy(path):
     ca.repo.remove('file_ca')
     d = Dataset(opj(ds.path, 'd'))
     d.repo.remove('file_d')
-    ds.save(
+    ds.rev_save(
         # append trailing slashes to the path to indicate that we want to
         # have the staged content in the dataset saved, rather than only the
         # subdataset state in the respective superds.
-        # an alternative would have been to pass `save` annotated paths of
-        # type {'path': dspath, 'process_content': True} for each dataset
-        # in question, but here we want to test how this would most likely
-        # by used from cmdline
         path=[opj(p, '')
-               for p in (aa.path, ba.path, bb.path, c.path, ca.path, d.path)],
-        super_datasets=True)
+               for p in (aa.path, ba.path, bb.path, c.path, ca.path, d.path)])
 
 
 # Note: class name needs to match module's name

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -139,6 +139,8 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)
+    # TODO RF the helper above to produce a proper hierarchy
+    # and then use rev_save()
     ds.add('.', recursive=True)
     ok_clean_git(ds.path)
     ds_bb = Dataset(opj(ds.path, 'b', 'bb'))
@@ -317,6 +319,8 @@ def test_discover_ds_trace(path, otherdir):
     # we have to check whether we get the correct hierarchy, as the test
     # subject is also involved in this
     assert_true(exists(opj(db, 'file_db')))
+    # TODO RF the helper above to produce a proper hierarchy
+    # and then use rev_save()
     ds.add('.', recursive=True)
     ok_clean_git(ds.path)
     # now two datasets which are not available locally, but we

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -129,7 +129,7 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
     for node, items in tree.items():
         if isinstance(items, dict):
             node_path = opj(path, node)
-            nodeds = Dataset(node_path).create(force=True)
+            nodeds = parent.rev_create(node_path, force=True)
             make_demo_hierarchy_datasets(node_path, items, parent=nodeds)
     return parent
 
@@ -139,9 +139,7 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)
-    # TODO RF the helper above to produce a proper hierarchy
-    # and then use rev_save()
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(ds.path)
     ds_bb = Dataset(opj(ds.path, 'b', 'bb'))
     ds_bba = Dataset(opj(ds_bb.path, 'bba'))
@@ -314,9 +312,7 @@ def test_discover_ds_trace(path, otherdir):
     # we have to check whether we get the correct hierarchy, as the test
     # subject is also involved in this
     assert_true(exists(opj(db, 'file_db')))
-    # TODO RF the helper above to produce a proper hierarchy
-    # and then use rev_save()
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(ds.path)
     # now two datasets which are not available locally, but we
     # know about them (e.g. from metadata)

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -33,7 +33,7 @@ from datalad.interface.utils import (
     eval_results,
     discover_dataset_trace_to_targets,
 )
-from datalad.interface.save import Save
+from datalad.core.local.save import Save
 from datalad.interface.base import build_doc
 from datalad.interface.common_opts import (
     recursion_limit,
@@ -1072,7 +1072,8 @@ class AggregateMetaData(Interface):
             return
         lgr.info('Attempting to save %i files/datasets', len(to_save))
         for res in Save.__call__(
-                path=to_save,
+                # rev-save does not need any pre-annotated path hints
+                path=[r['path'] for r in to_save],
                 dataset=refds_path,
                 message='[DATALAD] Dataset aggregate metadata update',
                 return_type='generator',

--- a/datalad/metadata/extractors/tests/test_audio.py
+++ b/datalad/metadata/extractors/tests/test_audio.py
@@ -48,7 +48,7 @@ def test_audio(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'audio.mp3'),
         path)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_audio.py
+++ b/datalad/metadata/extractors/tests/test_audio.py
@@ -43,7 +43,7 @@ target = {
 
 @with_tempfile(mkdir=True)
 def test_audio(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ds.config.add('datalad.metadata.nativetype', 'audio', where='dataset')
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'audio.mp3'),

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -21,7 +21,7 @@ from nose.tools import assert_equal
 
 @with_tree(tree={'file.dat': ''})
 def check_api(no_annex, path):
-    ds = Dataset(path).create(force=True, no_annex=no_annex)
+    ds = Dataset(path).rev_create(force=True, no_annex=no_annex)
     ds.rev_save()
     ok_clean_git(ds.path)
 

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -22,7 +22,7 @@ from nose.tools import assert_equal
 @with_tree(tree={'file.dat': ''})
 def check_api(no_annex, path):
     ds = Dataset(path).create(force=True, no_annex=no_annex)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
 
     processed_extractors, skipped_extractors = [], []

--- a/datalad/metadata/extractors/tests/test_datacite_xml.py
+++ b/datalad/metadata/extractors/tests/test_datacite_xml.py
@@ -68,7 +68,7 @@ def test_get_metadata(path1, path2):
     for p in (path1, path2):
         print('PATH')
         ds = create(p, force=True)
-        ds.add('.')
+        ds.rev_save()
         meta = MetadataExtractor(
                 ds,
                 _get_metadatarelevant_paths(ds, []))._get_dataset_metadata()

--- a/datalad/metadata/extractors/tests/test_exif.py
+++ b/datalad/metadata/extractors/tests/test_exif.py
@@ -76,7 +76,7 @@ target = {
 
 @with_tempfile(mkdir=True)
 def test_exif(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ds.config.add('datalad.metadata.nativetype', 'exif', where='dataset')
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'exif.jpg'),

--- a/datalad/metadata/extractors/tests/test_exif.py
+++ b/datalad/metadata/extractors/tests/test_exif.py
@@ -81,7 +81,7 @@ def test_exif(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'exif.jpg'),
         path)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_frictionless_datapackage.py
+++ b/datalad/metadata/extractors/tests/test_frictionless_datapackage.py
@@ -40,7 +40,7 @@ from datalad.tests.utils import with_tree, with_tempfile
 """})
 def test_get_metadata(path):
 
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     p = MetadataExtractor(ds, [])
     meta = p._get_dataset_metadata()
     assert_equal(

--- a/datalad/metadata/extractors/tests/test_image.py
+++ b/datalad/metadata/extractors/tests/test_image.py
@@ -44,7 +44,7 @@ def test_image(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'exif.jpg'),
         path)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_image.py
+++ b/datalad/metadata/extractors/tests/test_image.py
@@ -39,7 +39,7 @@ target = {
 
 @with_tempfile(mkdir=True)
 def test_image(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ds.config.add('datalad.metadata.nativetype', 'image', where='dataset')
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'exif.jpg'),

--- a/datalad/metadata/extractors/tests/test_rfc822.py
+++ b/datalad/metadata/extractors/tests/test_rfc822.py
@@ -41,7 +41,7 @@ DOI: 10.5281/zenodo.48421
 """}})
 def test_get_metadata(path):
 
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.rev_save()
     meta = MetadataExtractor(ds, [])._get_dataset_metadata()
     assert_equal(

--- a/datalad/metadata/extractors/tests/test_rfc822.py
+++ b/datalad/metadata/extractors/tests/test_rfc822.py
@@ -42,7 +42,7 @@ DOI: 10.5281/zenodo.48421
 def test_get_metadata(path):
 
     ds = Dataset(path).create(force=True)
-    ds.add('.')
+    ds.rev_save()
     meta = MetadataExtractor(ds, [])._get_dataset_metadata()
     assert_equal(
         dumps(meta, sort_keys=True, indent=2),

--- a/datalad/metadata/extractors/tests/test_xmp.py
+++ b/datalad/metadata/extractors/tests/test_xmp.py
@@ -49,7 +49,7 @@ def test_xmp(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'xmp.pdf'),
         path)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_xmp.py
+++ b/datalad/metadata/extractors/tests/test_xmp.py
@@ -44,7 +44,7 @@ target = {
 
 @with_tempfile(mkdir=True)
 def test_xmp(path):
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     ds.config.add('datalad.metadata.nativetype', 'xmp', where='dataset')
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'xmp.pdf'),

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -57,10 +57,10 @@ _dataset_hierarchy_template = {
 @with_tree(tree=_dataset_hierarchy_template)
 def test_basic_aggregate(path):
     # TODO give datasets some more metadata to actually aggregate stuff
-    base = Dataset(opj(path, 'origin')).create(force=True)
-    sub = base.create('sub', force=True)
+    base = Dataset(opj(path, 'origin')).rev_create(force=True)
+    sub = base.rev_create('sub', force=True)
     #base.metadata(sub.path, init=dict(homepage='this'), apply2global=True)
-    subsub = base.create(opj('sub', 'subsub'), force=True)
+    subsub = base.rev_create(opj('sub', 'subsub'), force=True)
     base.rev_save(recursive=True)
     ok_clean_git(base.path)
     # we will first aggregate the middle dataset on its own, this will
@@ -118,7 +118,7 @@ def test_basic_aggregate(path):
 """}}},
 })
 def test_aggregate_query(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     # no magic change to actual dataset metadata due to presence of
     # aggregated metadata
     res = ds.metadata(reporton='datasets', on_failure='ignore')
@@ -131,7 +131,7 @@ def test_aggregate_query(path):
     # when no reference dataset is given the command will report the
     # aggregated metadata as it is recorded in the dataset that is the
     # closest parent on disk
-    ds.create('sub', force=True)
+    ds.rev_create('sub', force=True)
     res = metadata(opj(path, 'sub', 'deep', 'some'), reporton='datasets')
     assert_result_count(res, 1)
     eq_({'homepage': 'http://sub.example.com'}, res[0]['metadata'])
@@ -145,13 +145,13 @@ def test_aggregate_query(path):
 # this is for gh-1971
 @with_tree(tree=_dataset_hierarchy_template)
 def test_reaggregate_with_unavailable_objects(path):
-    base = Dataset(opj(path, 'origin')).create(force=True)
+    base = Dataset(opj(path, 'origin')).rev_create(force=True)
     # force all metadata objects into the annex
     with open(opj(base.path, '.datalad', '.gitattributes'), 'w') as f:
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
-    sub = base.create('sub', force=True)
-    subsub = base.create(opj('sub', 'subsub'), force=True)
+    sub = base.rev_create('sub', force=True)
+    subsub = base.rev_create(opj('sub', 'subsub'), force=True)
     base.rev_save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
@@ -179,13 +179,13 @@ def test_reaggregate_with_unavailable_objects(path):
 @with_tree(tree=_dataset_hierarchy_template)
 @with_tempfile(mkdir=True)
 def test_aggregate_with_unavailable_objects_from_subds(path, target):
-    base = Dataset(opj(path, 'origin')).create(force=True)
+    base = Dataset(opj(path, 'origin')).rev_create(force=True)
     # force all metadata objects into the annex
     with open(opj(base.path, '.datalad', '.gitattributes'), 'w') as f:
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
-    sub = base.create('sub', force=True)
-    subsub = base.create(opj('sub', 'subsub'), force=True)
+    sub = base.rev_create('sub', force=True)
+    subsub = base.rev_create(opj('sub', 'subsub'), force=True)
     base.rev_save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
@@ -193,7 +193,7 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
 
     # now make that a subdataset of a new one, so aggregation needs to get the
     # metadata objects first:
-    super = Dataset(target).create()
+    super = Dataset(target).rev_create()
     super.install("base", source=base.path)
     ok_clean_git(super.path)
     clone = Dataset(opj(super.path, "base"))
@@ -214,12 +214,12 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
 @skip_ssh
 @with_tree(tree=_dataset_hierarchy_template)
 def test_publish_aggregated(path):
-    base = Dataset(opj(path, 'origin')).create(force=True)
+    base = Dataset(opj(path, 'origin')).rev_create(force=True)
     # force all metadata objects into the annex
     with open(opj(base.path, '.datalad', '.gitattributes'), 'w') as f:
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
-    base.create('sub', force=True)
+    base.rev_create('sub', force=True)
     base.rev_save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
@@ -260,13 +260,13 @@ def _get_referenced_objs(ds):
 
 @with_tree(tree=_dataset_hierarchy_template)
 def test_aggregate_removal(path):
-    base = Dataset(opj(path, 'origin')).create(force=True)
+    base = Dataset(opj(path, 'origin')).rev_create(force=True)
     # force all metadata objects into the annex
     with open(opj(base.path, '.datalad', '.gitattributes'), 'w') as f:
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
-    sub = base.create('sub', force=True)
-    subsub = sub.create(opj('subsub'), force=True)
+    sub = base.rev_create('sub', force=True)
+    subsub = sub.rev_create(opj('subsub'), force=True)
     base.rev_save(recursive=True)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -295,13 +295,13 @@ def test_aggregate_removal(path):
 
 @with_tree(tree=_dataset_hierarchy_template)
 def test_update_strategy(path):
-    base = Dataset(opj(path, 'origin')).create(force=True)
+    base = Dataset(opj(path, 'origin')).rev_create(force=True)
     # force all metadata objects into the annex
     with open(opj(base.path, '.datalad', '.gitattributes'), 'w') as f:
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
-    sub = base.create('sub', force=True)
-    subsub = sub.create(opj('subsub'), force=True)
+    sub = base.rev_create('sub', force=True)
+    subsub = sub.rev_create(opj('subsub'), force=True)
     base.rev_save(recursive=True)
     ok_clean_git(base.path)
     # we start clean
@@ -353,9 +353,9 @@ def test_update_strategy(path):
     'sub1': {'here': 'there'},
     'sub2': {'down': 'under'}})
 def test_partial_aggregation(path):
-    ds = Dataset(path).create(force=True)
-    sub1 = ds.create('sub1', force=True)
-    sub2 = ds.create('sub2', force=True)
+    ds = Dataset(path).rev_create(force=True)
+    sub1 = ds.rev_create('sub1', force=True)
+    sub2 = ds.rev_create('sub2', force=True)
     ds.rev_save(recursive=True)
 
     # if we aggregate a path(s) and say to recurse, we must not recurse into

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -61,7 +61,7 @@ def test_basic_aggregate(path):
     sub = base.create('sub', force=True)
     #base.metadata(sub.path, init=dict(homepage='this'), apply2global=True)
     subsub = base.create(opj('sub', 'subsub'), force=True)
-    base.add('.', recursive=True)
+    base.rev_save(recursive=True)
     ok_clean_git(base.path)
     # we will first aggregate the middle dataset on its own, this will
     # serve as a smoke test for the reuse of metadata objects later on
@@ -152,7 +152,7 @@ def test_reaggregate_with_unavailable_objects(path):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = base.create(opj('sub', 'subsub'), force=True)
-    base.add('.', recursive=True)
+    base.rev_save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -186,7 +186,7 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = base.create(opj('sub', 'subsub'), force=True)
-    base.add('.', recursive=True)
+    base.rev_save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -220,7 +220,7 @@ def test_publish_aggregated(path):
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     base.create('sub', force=True)
-    base.add('.', recursive=True)
+    base.rev_save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -267,7 +267,7 @@ def test_aggregate_removal(path):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = sub.create(opj('subsub'), force=True)
-    base.add('.', recursive=True)
+    base.rev_save(recursive=True)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
     res = base.metadata(get_aggregates=True)
@@ -302,7 +302,7 @@ def test_update_strategy(path):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = sub.create(opj('subsub'), force=True)
-    base.add('.', recursive=True)
+    base.rev_save(recursive=True)
     ok_clean_git(base.path)
     # we start clean
     for ds in base, sub, subsub:
@@ -356,7 +356,7 @@ def test_partial_aggregation(path):
     ds = Dataset(path).create(force=True)
     sub1 = ds.create('sub1', force=True)
     sub2 = ds.create('sub2', force=True)
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
 
     # if we aggregate a path(s) and say to recurse, we must not recurse into
     # the dataset itself and aggregate others

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -66,7 +66,7 @@ def test_basic_aggregate(path):
     # we will first aggregate the middle dataset on its own, this will
     # serve as a smoke test for the reuse of metadata objects later on
     sub.aggregate_metadata()
-    base.save()
+    base.rev_save()
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -390,7 +390,7 @@ def test_partial_aggregation(path):
     sub1.unlock('here')
     with open(opj(sub1.path, 'here'), 'w') as f:
         f.write('fresh')
-    ds.save(recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(path)
     # TODO for later
     # test --since with non-incremental

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -67,7 +67,7 @@ _dataset_hierarchy_template = {
 
 @with_tempfile(mkdir=True)
 def test_get_metadata_type(path):
-    Dataset(path).create()
+    Dataset(path).rev_create()
     # nothing set, nothing found
     assert_equal(get_metadata_type(Dataset(path)), [])
     # got section, but no setting
@@ -101,17 +101,17 @@ def test_aggregation(path):
     with chpwd(path):
         assert_raises(InsufficientArgumentsError, aggregate_metadata, None)
     # a hierarchy of three (super/sub)datasets, each with some native metadata
-    ds = Dataset(opj(path, 'origin')).create(force=True)
+    ds = Dataset(opj(path, 'origin')).rev_create(force=True)
     # before anything aggregated we would get nothing and only a log warning
     with swallow_logs(new_level=logging.WARNING) as cml:
         assert_equal(list(query_aggregated_metadata('all', ds, [])), [])
     assert_re_in('.*Found no aggregated metadata.*update', cml.out)
     ds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                   where='dataset')
-    subds = ds.create('sub', force=True)
+    subds = ds.rev_create('sub', force=True)
     subds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                      where='dataset')
-    subsubds = subds.create('subsub', force=True)
+    subsubds = subds.rev_create('subsub', force=True)
     subsubds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                         where='dataset')
     ds.rev_save(recursive=True)
@@ -204,7 +204,7 @@ def test_ignore_nondatasets(path):
                     del m[k]
         return meta
 
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     meta = _kill_time(ds.metadata(reporton='datasets', on_failure='ignore'))
     n_subm = 0
     # placing another repo in the dataset has no effect on metadata
@@ -228,7 +228,7 @@ def test_ignore_nondatasets(path):
 def test_get_aggregates_fails(path):
     with chpwd(path), assert_raises(NoDatasetArgumentFound):
         metadata(get_aggregates=True)
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     res = ds.metadata(get_aggregates=True, on_failure='ignore')
     assert_result_count(res, 1, path=ds.path, status='impossible')
 
@@ -236,7 +236,7 @@ def test_get_aggregates_fails(path):
 @with_tree({'dummy': 'content'})
 @with_tempfile(mkdir=True)
 def test_bf2458(src, dst):
-    ds = Dataset(src).create(force=True)
+    ds = Dataset(src).rev_create(force=True)
     ds.rev_save(to_git=False)
 
     # no clone (empty) into new dst

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -114,7 +114,7 @@ def test_aggregation(path):
     subsubds = subds.create('subsub', force=True)
     subsubds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                         where='dataset')
-    ds.add('.', recursive=True)
+    ds.rev_save(recursive=True)
     ok_clean_git(ds.path)
     # aggregate metadata from all subdatasets into any superdataset, including
     # intermediate ones
@@ -218,7 +218,7 @@ def test_ignore_nondatasets(path):
         assert_true(Dataset(subm_path).is_installed())
         assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         # making it a submodule has no effect either
-        ds.add(subpath)
+        ds.rev_save(subpath)
         assert_equal(len(ds.subdatasets()), n_subm + 1)
         assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         n_subm += 1
@@ -237,7 +237,7 @@ def test_get_aggregates_fails(path):
 @with_tempfile(mkdir=True)
 def test_bf2458(src, dst):
     ds = Dataset(src).create(force=True)
-    ds.add('.', to_git=False)
+    ds.rev_save(to_git=False)
 
     # no clone (empty) into new dst
     clone = install(source=ds.path, path=dst)

--- a/datalad/metadata/tests/test_extract_metadata.py
+++ b/datalad/metadata/tests/test_extract_metadata.py
@@ -45,7 +45,7 @@ def test_ds_extraction(path):
     except ImportError:
         raise SkipTest
 
-    ds = Dataset(path).create()
+    ds = Dataset(path).rev_create()
     copy(testpath, path)
     ds.rev_save()
     ok_clean_git(ds.path)

--- a/datalad/metadata/tests/test_extract_metadata.py
+++ b/datalad/metadata/tests/test_extract_metadata.py
@@ -47,7 +47,7 @@ def test_ds_extraction(path):
 
     ds = Dataset(path).create()
     copy(testpath, path)
-    ds.add('.')
+    ds.rev_save()
     ok_clean_git(ds.path)
 
     res = extract_metadata(

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -197,7 +197,7 @@ def test_within_ds_file_search(path):
         copy(
             opj(dirname(dirname(__file__)), 'tests', 'data', src),
             opj(path, dst))
-    ds.add('.')
+    ds.rev_save()
     ok_file_under_git(path, opj('stim', 'stim1.mp3'), annexed=True)
     # If it is not under annex, below addition of metadata silently does
     # not do anything

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -97,7 +97,7 @@ def test_search_outside1_install_default_ds(tdir, default_dspath):
                 list(search("."))
 
             # and if path exists and is a valid dataset and we say "no"
-            Dataset(default_dspath).create()
+            Dataset(default_dspath).rev_create()
             ui.add_responses('no')
             mock_install.reset_mock()
             with assert_raises(NoDatasetArgumentFound):
@@ -184,7 +184,7 @@ def test_within_ds_file_search(path):
         import mutagen
     except ImportError:
         raise SkipTest
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     # override default and search for datasets and files for this test
     for m in ('egrep', 'textblob', 'autofield'):
         ds.config.add(

--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -141,7 +141,7 @@ see the DataLad documentation at: http://docs.datalad.org
                 type='file',
                 action='add_readme')
 
-        for r in dataset.add(
+        for r in dataset.rev_save(
                 filename,
                 message='[DATALAD] added README',
                 result_filter=None,

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -137,7 +137,7 @@ class NoAnnex(Interface):
             attrfile=gitattr_file)
         yield dict(res_kwargs, status='ok')
 
-        for r in dataset.add(
+        for r in dataset.rev_save(
                 gitattr_file,
                 to_git=True,
                 message="[DATALAD] exclude paths from annex'ing",

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -288,7 +288,7 @@ def test_extract_wrong_input_type():
 
 @with_tempfile(mkdir=True)
 def test_addurls_nonannex_repo(path):
-    ds = Dataset(path).create(force=True, no_annex=True)
+    ds = Dataset(path).rev_create(force=True, no_annex=True)
     with assert_raises(IncompleteResultsError) as raised:
         ds.addurls("dummy_arg0", "dummy_arg1", "dummy_arg2")
     assert_in("not an annex repo", str(raised.exception))
@@ -296,7 +296,7 @@ def test_addurls_nonannex_repo(path):
 
 @with_tempfile(mkdir=True)
 def test_addurls_dry_run(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
 
     with chpwd(path):
         json_file = "links.json"

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -306,7 +306,7 @@ def test_addurls_dry_run(path):
                        {"url": "URL/c.dat", "name": "c", "subdir": "foo"}],
                       jfh)
 
-        ds.add(".", message="setup")
+        ds.rev_save(message="setup")
 
         with swallow_logs(new_level=logging.INFO) as cml:
             ds.addurls(json_file,
@@ -405,7 +405,7 @@ class TestAddurls(object):
             ds.unlock("a")
             with open("a", "w") as ofh:
                 ofh.write("changed")
-            ds.add("a")
+            ds.rev_save("a")
 
             assert_raises(IncompleteResultsError,
                           ds.addurls,
@@ -439,7 +439,7 @@ class TestAddurls(object):
 
             # Now save the "--nosave" changes and check that we have
             # all the subdatasets.
-            ds.add(".")
+            ds.rev_save()
             eq_(set(subdatasets(ds, recursive=True,
                                 result_xfm="relpaths")),
                 {"foo-save", "bar-save", "foo-nosave", "bar-nosave"})

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -45,7 +45,7 @@ def test_failure(path):
 @with_tree(_dataset_template)
 def test_archive(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
-    ds.add('.')
+    ds.rev_save()
     committed_date = ds.repo.get_commit_date()
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
     with chpwd(path):
@@ -96,7 +96,7 @@ def test_archive(path):
 @with_tree(_dataset_template)
 def test_zip_archive(path):
     ds = Dataset(opj(path, 'ds')).create(force=True, no_annex=True)
-    ds.add('.')
+    ds.rev_save()
     with chpwd(path):
         ds.export_archive(filename='my', archivetype='zip')
         assert_true(os.path.exists('my.zip'))

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -44,7 +44,7 @@ def test_failure(path):
 
 @with_tree(_dataset_template)
 def test_archive(path):
-    ds = Dataset(opj(path, 'ds')).create(force=True)
+    ds = Dataset(opj(path, 'ds')).rev_create(force=True)
     ds.rev_save()
     committed_date = ds.repo.get_commit_date()
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
@@ -95,7 +95,7 @@ def test_archive(path):
 
 @with_tree(_dataset_template)
 def test_zip_archive(path):
-    ds = Dataset(opj(path, 'ds')).create(force=True, no_annex=True)
+    ds = Dataset(opj(path, 'ds')).rev_create(force=True, no_annex=True)
     ds.rev_save()
     with chpwd(path):
         ds.export_archive(filename='my', archivetype='zip')

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -126,10 +126,10 @@ def test_no_annex(path):
             'notinannex': 'othercontent'},
          'README': 'please'})
     # add inannex pre configuration
-    ds.add(opj('code', 'inannex'))
+    ds.rev_save(opj('code', 'inannex'))
     no_annex(pattern=['code/**', 'README'], dataset=ds)
     # add inannex and README post configuration
-    ds.add([opj('code', 'notinannex'), 'README'])
+    ds.rev_save([opj('code', 'notinannex'), 'README'])
     ok_clean_git(ds.path)
     # one is annex'ed, the other is not, despite no change in add call
     # importantly, also .gitattribute is not annexed
@@ -159,7 +159,7 @@ _ds_template = {
 @with_tree(_ds_template)
 def test_add_readme(path):
     ds = Dataset(path).create(force=True)
-    ds.add('.')
+    ds.rev_save()
     ds.aggregate_metadata()
     ok_clean_git(ds.path)
     assert_status('ok', ds.add_readme())

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -13,7 +13,7 @@
 
 from os.path import join as opj
 
-from datalad.coreapi import create
+from datalad.api import rev_create
 from datalad.coreapi import Dataset
 from datalad.dochelpers import exc_str
 from datalad.api import wtf
@@ -72,7 +72,7 @@ def test_wtf(path):
             assert_not_in('## dataset', cmo.out)
             assert_in('## configuration', cmo.out)
     # now with a dataset
-    ds = create(path)
+    ds = rev_create(path)
     with swallow_outputs() as cmo:
         wtf(dataset=ds.path)
         assert_in('## configuration', cmo.out)
@@ -117,7 +117,7 @@ def test_wtf(path):
 
 @with_tempfile(mkdir=True)
 def test_no_annex(path):
-    ds = create(path)
+    ds = rev_create(path)
     ok_clean_git(ds.path)
     create_tree(
         ds.path,
@@ -158,7 +158,7 @@ _ds_template = {
 
 @with_tree(_ds_template)
 def test_add_readme(path):
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).rev_create(force=True)
     ds.rev_save()
     ds.aggregate_metadata()
     ok_clean_git(ds.path)

--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -23,10 +23,7 @@ for nt in sys.argv[2:]:
         where='dataset',
         reload=False)
 
-ds.save(
-    path=[dict(
-        path=op.join(ds.path, '.datalad', 'config'),
-        type='file',
-        parentds=ds.path)],
+ds.rev_save(
+    path=op.join(ds.path, '.datalad', 'config'),
     message="Configure metadata type(s)",
 )

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -18,9 +18,7 @@ if not attrs.get('*', {}).get(
         ('*', {'annex.largefiles': annex_largefiles})])
 
 git_attributes_file = op.join(ds.path, '.gitattributes')
-ds.add([dict(
-    path=git_attributes_file,
-    type='file',
-    parentds=ds.path)],
+ds.rev_save(
+    git_attributes_file,
     message="Instruct annex to add text files to Git",
 )

--- a/datalad/resources/procedures/setup_yoda_dataset.py
+++ b/datalad/resources/procedures/setup_yoda_dataset.py
@@ -61,10 +61,6 @@ ds.repo.set_gitattributes(
 
 # leave clean
 # TODO only commit actually changed/added files
-ds.add(
-    path=[dict(
-        path=ds.path,
-        type='dataset',
-        parentds=ds.path)],
+ds.rev_save(
     message="Apply YODA dataset setup",
 )

--- a/datalad/tests/utils_testdatasets.py
+++ b/datalad/tests/utils_testdatasets.py
@@ -68,7 +68,7 @@ def make_studyforrest_mockup(path):
         create_tree(
             aligned.path,
             {'modification{}.txt'.format(i): 'unique{}'.format(i)})
-        aligned.add('.')
+        aligned.rev_save()
     # finally aggregate data
     aggregate = public.create('aggregate', description='aggregate data')
     aggregate.clone(source=aligned.path, path=opj('src', 'aligned'), reckless=True)

--- a/datalad/tests/utils_testdatasets.py
+++ b/datalad/tests/utils_testdatasets.py
@@ -9,7 +9,7 @@
 
 
 from os.path import join as opj
-from datalad.api import create
+from datalad.api import rev_create
 from datalad.tests.utils import create_tree
 
 
@@ -24,21 +24,21 @@ def make_studyforrest_mockup(path):
     The 'public' directory itself is a superdataset, the 'private' directory
     is just a directory that contains standalone datasets in subdirectories.
     """
-    public = create(opj(path, 'public'), description="umbrella dataset")
+    public = rev_create(opj(path, 'public'), description="umbrella dataset")
     # the following tries to capture the evolution of the project
-    phase1 = public.create('phase1',
+    phase1 = public.rev_create('phase1',
                            description='old-style, no connection to RAW')
-    structural = public.create('structural', description='anatomy')
-    tnt = public.create('tnt', description='image templates')
+    structural = public.rev_create('structural', description='anatomy')
+    tnt = public.rev_create('tnt', description='image templates')
     tnt.clone(source=phase1.path, path=opj('src', 'phase1'), reckless=True)
     tnt.clone(source=structural.path, path=opj('src', 'structural'), reckless=True)
-    aligned = public.create('aligned', description='aligned image data')
+    aligned = public.rev_create('aligned', description='aligned image data')
     aligned.clone(source=phase1.path, path=opj('src', 'phase1'), reckless=True)
     aligned.clone(source=tnt.path, path=opj('src', 'tnt'), reckless=True)
     # new acquisition
-    labet = create(opj(path, 'private', 'labet'), description="raw data ET")
-    phase2_dicoms = create(opj(path, 'private', 'p2dicoms'), description="raw data P2MRI")
-    phase2 = public.create('phase2',
+    labet = rev_create(opj(path, 'private', 'labet'), description="raw data ET")
+    phase2_dicoms = rev_create(opj(path, 'private', 'p2dicoms'), description="raw data P2MRI")
+    phase2 = public.rev_create('phase2',
                            description='new-style, RAW connection')
     phase2.clone(source=labet.path, path=opj('src', 'labet'), reckless=True)
     phase2.clone(source=phase2_dicoms.path, path=opj('src', 'dicoms'), reckless=True)
@@ -46,17 +46,17 @@ def make_studyforrest_mockup(path):
     tnt.clone(source=phase2.path, path=opj('src', 'phase2'), reckless=True)
     aligned.clone(source=phase2.path, path=opj('src', 'phase2'), reckless=True)
     # never to be published media files
-    media = create(opj(path, 'private', 'media'), description="raw data ET")
+    media = rev_create(opj(path, 'private', 'media'), description="raw data ET")
     # assuming all annotations are in one dataset (in reality this is also
     # a superdatasets with about 10 subdatasets
-    annot = public.create('annotations', description='stimulus annotation')
+    annot = public.rev_create('annotations', description='stimulus annotation')
     annot.clone(source=media.path, path=opj('src', 'media'), reckless=True)
     # a few typical analysis datasets
     # (just doing 3, actual status quo is just shy of 10)
     # and also the real goal -> meta analysis
-    metaanalysis = public.create('metaanalysis', description="analysis of analyses")
+    metaanalysis = public.rev_create('metaanalysis', description="analysis of analyses")
     for i in range(1, 3):
-        ana = public.create('analysis{}'.format(i),
+        ana = public.rev_create('analysis{}'.format(i),
                             description='analysis{}'.format(i))
         ana.clone(source=annot.path, path=opj('src', 'annot'), reckless=True)
         ana.clone(source=aligned.path, path=opj('src', 'aligned'), reckless=True)
@@ -70,7 +70,7 @@ def make_studyforrest_mockup(path):
             {'modification{}.txt'.format(i): 'unique{}'.format(i)})
         aligned.rev_save()
     # finally aggregate data
-    aggregate = public.create('aggregate', description='aggregate data')
+    aggregate = public.rev_create('aggregate', description='aggregate data')
     aggregate.clone(source=aligned.path, path=opj('src', 'aligned'), reckless=True)
     # the toplevel dataset is intentionally left dirty, to reflect the
     # most likely condition for the joint dataset to be in at any given


### PR DESCRIPTION
This is aiming toward not having DataLad itself depend on `add()`, `save()`, and `create()` anymore. It will keep use of those commands in their own tests, of course.

Let's see where we stand.

- [x] replace standard `add` calls with `rev_save()`
- [x] deal with the tests that do `add(save=False)` -- must use repo method now.
- [x] replace (now often pointless) calls to `save()` with either nothing or `rev_save()` too
- [x] RF `make_demo_hierarchy_datasets()` helper to make a properly linked dataset hierarchy, not a pile of datasets
- [x] RF tests that assumed a `create()` can simply turn a git repo into an annex repo
- [x] RF tests that relied on the fact that a single `create()` yields more than one commit in a dataset, whereas `rev_create()` just yield one.
- [x] BF `rev_create` to prevent spurious dataset ID change on force-recreate
- check which additional tests can be exercised on appveyor after the RF -- this is left for a dedicated exploration of the big picture at a later date

#### Protocol of functionality that relies on features of `create()` that are not supported by `rev_create()`:
- `addurls` offer a global `save` switch that causes any dataset modification to not be saved. This includes the initial dataset content placed in by `create` as well. I don't see why this would be needed, and it is off by default already.

#### Performance anecdote:

Picking what I believe is our most organic test scenario, although it is mostly cloning...

on current master
```
% timeit make_studyforrest_mockup('/tmp/mockup_'+str(uuid.uuid1()))
1 loop, best of 3: 35.7 s per loop
```

this PR
```
% timeit make_studyforrest_mockup('/tmp/mockup_'+str(uuid.uuid1()))
1 loop, best of 3: 30.4 s per loop
```



