### PR TITLE
Add Python information to "datalad wtf" command

### DIFF
--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -128,7 +128,7 @@ def _describe_environment():
 def _describe_python():
     import platform
     return {
-        'python': platform.python_version(),
+        'version': platform.python_version(),
         'implementation': platform.python_implementation(),
     }
 

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -125,6 +125,12 @@ def _describe_environment():
     from datalad import get_envvars_info
     return get_envvars_info()
 
+def _describe_python():
+    import platform
+    return {
+        'python': platform.python_version(),
+        'implementation': platform.python_implementation(),
+    }
 
 def _describe_configuration(cfg, sensitive):
     if not cfg:
@@ -307,6 +313,7 @@ class WTF(Interface):
             infos=infos,
         )
         infos['datalad'] = _describe_datalad()
+        infos['python'] = _describe_python()
         infos['git-annex'] = _describe_annex()
         infos['system'] = _describe_system()
         infos['environment'] = _describe_environment()


### PR DESCRIPTION
datalad wtf did not include any information about which
version of Python is being used. This adds a section to
include the python version number and python implementation
being used to run datalad to aid in debugging.