### PR TITLE
Provide a warning when a regex in a provider isn't valid

### DIFF
--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -331,10 +331,10 @@ class Providers(object):
                     if re.match(url_re, url):
                         lgr.debug("Returning provider %s for url %s", provider, url)
                         matching_providers.append(provider)
-                except re.error as ex:
+                except re.error:
                     lgr.warning(
-                        "Invalid regex %s in provider %s: %s"
-                        % (url_re, provider.name, ex.msg)
+                        "Invalid regex %s in provider %s"
+                        % (url_re, provider.name)
                     )
 
         if matching_providers:

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -327,9 +327,15 @@ class Providers(object):
         matching_providers = []
         for provider in self._providers[::-1]:
             for url_re in provider.url_res:
-                if re.match(url_re, url):
-                    lgr.debug("Returning provider %s for url %s", provider, url)
-                    matching_providers.append(provider)
+                try:
+                    if re.match(url_re, url):
+                        lgr.debug("Returning provider %s for url %s", provider, url)
+                        matching_providers.append(provider)
+                except Exception:
+                    lgr.warning(
+                        "Invalid regex %s in provider %s"
+                        % (url_re, provider.name)
+                    )
 
         if matching_providers:
             if return_all:

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -331,10 +331,10 @@ class Providers(object):
                     if re.match(url_re, url):
                         lgr.debug("Returning provider %s for url %s", provider, url)
                         matching_providers.append(provider)
-                except Exception:
+                except re.error as ex:
                     lgr.warning(
-                        "Invalid regex %s in provider %s"
-                        % (url_re, provider.name)
+                        "Invalid regex %s in provider %s: %s"
+                        % (url_re, provider.name, ex.msg)
                     )
 
         if matching_providers:

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -249,8 +249,9 @@ def test_providers_badre(path):
     providers = Providers.from_config_files(
         files=[op.join(path, "providers.cfg")], reload=True)
 
-
-    # When selecting a single one, the later one is given priority.
+    # Regexes are evaluated when get_provider is called,
+    # so we need to get a random provider, even though it
+    # doesn't match.
     with swallow_logs(logging.WARNING) as msg:
         the_chosen_one = providers.get_provider('https://foo.org/data')
         assert_in("Invalid regex", msg.out)


### PR DESCRIPTION
When a provider has an invalid regular expression, datalad
currently provides obtuse error messages like
"bad character range [re.py_compile:251] (error)".

This catches any exceptions while compiling the re to explicitly
warn the user that there is an invalid regular expression in the
provider.

Unfortunately, there doesn't seem to be any way to provide the
path to the provider config file at this point in the code, so we
simply give the provider name.