### PR TITLE
addurls: Don't pass --nosave to create (and use rev-create)

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -750,7 +750,8 @@ class Addurls(Interface):
 
         if not dataset.repo:
             # Populate a new dataset with the URLs.
-            for r in dataset.create(result_xfm=None, return_type='generator'):
+            for r in dataset.rev_create(result_xfm=None,
+                                        return_type='generator'):
                 yield r
 
         annex_options = ["--fast"] if fast else []
@@ -761,8 +762,8 @@ class Addurls(Interface):
                     "Not creating subdataset at existing path: %s",
                     spath)
             else:
-                for r in dataset.create(spath, result_xfm=None,
-                                        return_type='generator'):
+                for r in dataset.rev_create(spath, result_xfm=None,
+                                            return_type='generator'):
                     yield r
 
         for row in rows:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -750,8 +750,7 @@ class Addurls(Interface):
 
         if not dataset.repo:
             # Populate a new dataset with the URLs.
-            for r in dataset.create(result_xfm=None, return_type='generator',
-                                    save=save):
+            for r in dataset.create(result_xfm=None, return_type='generator'):
                 yield r
 
         annex_options = ["--fast"] if fast else []
@@ -763,7 +762,7 @@ class Addurls(Interface):
                     spath)
             else:
                 for r in dataset.create(spath, result_xfm=None,
-                                        return_type='generator', save=save):
+                                        return_type='generator'):
                     yield r
 
         for row in rows:

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -12,6 +12,7 @@
 import json
 import logging
 import os
+import os.path as op
 import tempfile
 
 from mock import patch
@@ -431,8 +432,12 @@ class TestAddurls(object):
                            save=save)
                 hexsha_after = ds.repo.get_hexsha()
 
-                for fname in ["foo-{}/a", "bar-{}/b", "foo-{}/c"]:
-                    ok_exists(fname.format(label))
+                subdirs = ["{}-{}".format(d, label) for d in ["foo", "bar"]]
+                subdir_files = dict(zip(subdirs, [["a", "c"], ["b"]]))
+
+                for subds, fnames in subdir_files.items():
+                    for fname in fnames:
+                        ok_exists(op.join(subds, fname))
 
                 assert_true(save ^ (hexsha_before == hexsha_after))
                 assert_true(save ^ ds.repo.dirty)
@@ -469,16 +474,16 @@ class TestAddurls(object):
         with chpwd(path):
             ds.addurls(self.json_file, "{url}", "{_url0}/{_url_basename}")
 
-            for fname in ["udir/a.dat", "udir/b.dat", "udir/c.dat"]:
-                ok_exists(fname)
+            for fname in ["a.dat", "b.dat", "c.dat"]:
+                ok_exists(op.join("udir", fname))
 
     @with_tempfile(mkdir=True)
     def test_addurls_url_filename(self, path):
         ds = Dataset(path).create(force=True)
         with chpwd(path):
             ds.addurls(self.json_file, "{url}", "{_url0}/{_url_filename}")
-            for fname in ["udir/a.dat", "udir/b.dat", "udir/c.dat"]:
-                ok_exists(fname)
+            for fname in ["a.dat", "b.dat", "c.dat"]:
+                ok_exists(op.join("udir", fname))
 
     @with_tempfile(mkdir=True)
     def test_addurls_url_filename_fail(self, path):

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import chpwd, slow, swallow_logs
 from datalad.tests.utils import assert_false, assert_true, assert_raises
 from datalad.tests.utils import assert_in, assert_re_in, assert_in_results
 from datalad.tests.utils import assert_dict_equal
+from datalad.tests.utils import assert_repo_status
 from datalad.tests.utils import eq_, ok_exists
 from datalad.tests.utils import create_tree, with_tempfile, HTTPPath
 from datalad.utils import get_tempfile_kwargs, rmtemp
@@ -426,11 +427,9 @@ class TestAddurls(object):
         with chpwd(path):
             for save in True, False:
                 label = "save" if save else "nosave"
-                hexsha_before = ds.repo.get_hexsha()
                 ds.addurls(self.json_file, "{url}",
                            "{subdir}-" + label + "//{name}",
                            save=save)
-                hexsha_after = ds.repo.get_hexsha()
 
                 subdirs = ["{}-{}".format(d, label) for d in ["foo", "bar"]]
                 subdir_files = dict(zip(subdirs, [["a", "c"], ["b"]]))
@@ -439,8 +438,14 @@ class TestAddurls(object):
                     for fname in fnames:
                         ok_exists(op.join(subds, fname))
 
-                assert_true(save ^ (hexsha_before == hexsha_after))
-                assert_true(save ^ ds.repo.dirty)
+                if save:
+                    assert_repo_status(path)
+                else:
+                    # The datasets are create and saved ...
+                    assert_repo_status(path, modified=subdirs)
+                    # but the downloaded files aren't.
+                    for subds, fnames in subdir_files.items():
+                        assert_repo_status(subds, added=fnames)
 
             # Now save the "--nosave" changes and check that we have
             # all the subdatasets.

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -358,7 +358,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
 
         def get_annex_commit_counts():
             return int(
@@ -421,7 +421,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_subdataset(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
 
         with chpwd(path):
             for save in True, False:
@@ -456,7 +456,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_repindex(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
 
         with chpwd(path):
             with assert_raises(IncompleteResultsError) as raised:
@@ -470,7 +470,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_url_parts(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
         with chpwd(path):
             ds.addurls(self.json_file, "{url}", "{_url0}/{_url_basename}")
 
@@ -479,7 +479,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_url_filename(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
         with chpwd(path):
             ds.addurls(self.json_file, "{url}", "{_url0}/{_url_filename}")
             for fname in ["a.dat", "b.dat", "c.dat"]:
@@ -487,7 +487,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_url_filename_fail(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
         with chpwd(path):
             assert_raises(IncompleteResultsError,
                           ds.addurls,
@@ -497,7 +497,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_metafail(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
 
         # Force failure by passing a non-existent file name to annex.
         fn = ds.repo.set_metadata
@@ -512,7 +512,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_dropped_urls(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
         with chpwd(path), swallow_logs(new_level=logging.WARNING) as cml:
             ds.addurls(self.json_file, "", "{subdir}//{name}")
             assert_re_in(r".*Dropped [0-9]+ row\(s\) that had an empty URL",
@@ -520,7 +520,7 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_version(self, path):
-        ds = Dataset(path).create(force=True)
+        ds = Dataset(path).rev_create(force=True)
 
         def version_fn(url):
             if url.endswith("b.dat"):


### PR DESCRIPTION
In gh-3252, @mih says

> addurls offer a global save switch that causes any dataset modification to not be saved. This includes the initial dataset content placed in by create as well. I don't see why this would be needed, and it is off by default already.

I don't either.  @yarikoptic, this is from your d3d6610b5 (ENH: --no-save flag for addurls (TODO: tests), 2018-03-14).  Do you recall any reason why you wanted `create` to honor `--nosave`?

This PR stops propagating `--nosave` to create, and updates `addurls` to use `rev-create`.
