### PR TITLE
BF: check for stdin/out/err to not be closed before checking for .isatty

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -34,6 +34,7 @@ from ..utils import getpwd, chpwd
 from ..utils import get_path_prefix
 from ..utils import auto_repr
 from ..utils import find_files
+from ..utils import is_interactive
 from ..utils import line_profile
 from ..utils import not_supported_on_windows
 from ..utils import file_basename
@@ -1232,3 +1233,37 @@ def test_never_fail():
             raise ValueError
 
         assert_raises(ValueError, ifail2, 1)
+
+
+@with_tempfile
+def test_is_interactive(fout):
+    # must not fail if one of the streams is no longer open:
+    # https://github.com/datalad/datalad/issues/3267
+    from ..cmd import Runner
+
+    bools = ["False", "True"]
+
+    def get_interactive(py_pre="", **run_kwargs):
+        out, err = Runner().run(
+            [sys.executable,
+             "-c",
+             py_pre +
+             'from datalad.utils import is_interactive; '
+             'f = open(%r, "w"); '
+             'f.write(str(is_interactive())); '
+             'f.close()'
+             % fout
+             ],
+            **run_kwargs
+        )
+        with open(fout) as f:
+            out = f.read()
+        assert_in(out, bools)
+        return bool(bools.index(out))
+
+    # we never request for pty in our Runner, so can't be interactive
+    eq_(get_interactive(), False)
+    # and it must not crash if smth is closed
+    for o in ('stderr', 'stdin', 'stdout'):
+        eq_(get_interactive("import sys; sys.%s.close(); " % o), False)
+

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -203,15 +203,22 @@ def auto_repr(cls):
     return cls
 
 
+def _is_stream_tty(stream):
+    try:
+        # TODO: check on windows if hasattr check would work correctly and
+        # add value:
+        return stream.isatty()
+    except ValueError as exc:
+        # Who knows why it is a ValueError, but let's try to be specific
+        # If there is a problem with I/O - non-interactive, otherwise reraise
+        if "I/O" in str(exc):
+            return False
+        raise
+
+
 def is_interactive():
     """Return True if all in/outs are tty"""
-    # TODO: check on windows if hasattr check would work correctly and add value:
-    #
-    return (
-        (not sys.stdin.closed and sys.stdin.isatty()) and
-        (not sys.stdout.closed and sys.stdout.isatty()) and
-        (not sys.stderr.closed and sys.stderr.isatty())
-    )
+    return all(_is_stream_tty(s) for s in (sys.stdin, sys.stdout, sys.stderr))
 
 
 def get_ipython_shell():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -217,7 +217,13 @@ def _is_stream_tty(stream):
 
 
 def is_interactive():
-    """Return True if all in/outs are tty"""
+    """Return True if all in/outs are open and tty.
+
+    Note that in a somewhat abnormal case where e.g. stdin is explicitly
+    closed, and any operation on it would raise a
+    `ValueError("I/O operation on closed file")` exception, this function
+    would just return False, since the session cannot be used interactively.
+    """
     return all(_is_stream_tty(s) for s in (sys.stdin, sys.stdout, sys.stderr))
 
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -207,7 +207,11 @@ def is_interactive():
     """Return True if all in/outs are tty"""
     # TODO: check on windows if hasattr check would work correctly and add value:
     #
-    return sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()
+    return (
+        (not sys.stdin.closed and sys.stdin.isatty()) and
+        (not sys.stdout.closed and sys.stdout.isatty()) and
+        (not sys.stderr.closed and sys.stderr.isatty())
+    )
 
 
 def get_ipython_shell():


### PR DESCRIPTION
Closes #3267 

TODOs:
- [x] test
- [x] try to figure out what change in our behavior lead to the benchmark to start failing after Aug 8 2018. See #3267