### PR TITLE
RF: Move the availability check for git-annex all the way to the end

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -178,9 +178,6 @@ class AnnexRepo(GitRepo, RepoInterface):
           Short description that humans can use to identify the
           repository/location, e.g. "Precious data on my laptop"
         """
-        if self.git_annex_version is None:
-            self._check_git_annex_version()
-
         # initialize
         self._uuid = None
         self._annex_common_options = []
@@ -944,6 +941,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         CommandNotAvailableError
             if an annex command call returns "unknown command"
         """
+        if self.git_annex_version is None:
+            self._check_git_annex_version()
+
         debug = ['--debug'] if lgr.getEffectiveLevel() <= 8 else []
         backend = ['--backend=%s' % backend] if backend else []
 


### PR DESCRIPTION
Rational: We otherwise refuse to do anything with repos that could have an annex, but for operations like `status` this is not needed. Doing a late check will enable (more) datalad use on systems that do not have
git-annex.

@effigies wondered if it was possible to get information on a dataset without git-annex. This would be step one. It might be useful in this context to replace `AnnexRepo.get_content_annexinfo()` to not call `git-annex find/findref`, but to inspect the keys in a dataset on its own. This would make `status --annex <mode>` work without git-annex for any query mode where we would want to support this. It would also be straightforward to support a fallback that is only used when git-annex is actually not around.