### PR TITLE
Don't pollute non-interactive output with progress bars

### DIFF
--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -80,7 +80,7 @@ class _UI_Switcher(object):
                 else:
                     backend = 'dialog'
             else:
-                backend = 'console' if not is_interactive() else 'dialog'
+                backend = 'dialog' if is_interactive() else 'no-progress'
         self._ui = KNOWN_BACKENDS[backend]()
         lgr.debug("UI set to %s" % self._ui)
         self._backend = backend

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -37,6 +37,7 @@ KNOWN_BACKENDS = {
     'annex': UnderAnnexUI,
     'tests': UnderTestsUI,
     'tests-noninteractive': SilentConsoleLog,
+    'no-progress': SilentConsoleLog,
 }
 
 


### PR DESCRIPTION
As a concrete example:

```sh
tdir=$(mktemp -d)
datalad install -s ///openneuro/ds000001 $tdir/ds >$tdir/out 2>&1
```

Before this PR, that produces the following output:

```
[INFO] Cloning http://datasets.datalad.org/openneuro/ds000001 [1 other candidates] into '/tmp/tmp.KdwAWch08N/ds'

Cloning (counting objects):   0%|          | 0.00/100 [00:00<?, ?B/s]
Cloning (counting objects): 2.39kB [00:00, 36.4MB/s]                 
                                                    

Cloning (compressing objects):   0%|          | 0.00/600 [00:00<?, ?B/s]
Cloning (compressing objects):   0%|          | 1.00/600 [00:00<00:00, 25.4kB/s]
[... lots more ....]
```

After this PR:

```
[INFO] Cloning http://datasets.datalad.org/openneuro/ds000001 [1 other candidates] into '/tmp/tmp.FcS5wWd4qi/ds'
[INFO] warning: Not setting branch master as its own upstream.
[INFO] access to dataset sibling "s3-PUBLIC" not auto-enabled, enable with:
| 		datalad siblings -d "/tmp/tmp.FcS5wWd4qi/ds" enable -s s3-PUBLIC
[INFO] access to dataset sibling "s3-PRIVATE" not auto-enabled, enable with:
| 		datalad siblings -d "/tmp/tmp.FcS5wWd4qi/ds" enable -s s3-PRIVATE
install(ok): /tmp/tmp.FcS5wWd4qi/ds (dataset)
```

If callers want things even quieter, they could now achieve that by configuring the log level and `report_status`.

---

Closes #3092.
