### PR TITLE
BF: gitrepo.save_: Don't save unspecified subdatasets

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -627,3 +627,16 @@ def test_surprise_subds(path):
     # with proper subdatasets, all evil is gone
     assert_not_in(ds.repo.pathobj / 'd2' / 'subds' / 'subfile',
                   ds.repo.get_content_info())
+
+
+@with_tree({"foo": ""})
+def test_bf3285(path):
+    ds = Dataset(path).rev_create(force=True)
+    # Note: Using repo.pathobj matters in the "TMPDIR=/var/tmp/sym\ link" case
+    # because assert_repo_status is based off of {Annex,Git}Repo.path, which is
+    # the realpath'd path (from the processing in _flyweight_id_from_args).
+    subds = create(ds.repo.pathobj.joinpath("subds"))
+    # Explicitly saving a path does not save an untracked, unspecified
+    # subdataset.
+    ds.rev_save("foo")
+    assert_repo_status(ds.path, untracked=[subds.path])


### PR DESCRIPTION
Calling save_() with explicit paths that do not include an untracked
directory will result in an empty list being passed as the `paths`
argument to get_content_info().  This causes get_content_info() to
operate on _all_ content and leads to any untracked subdatasets being
saved.

Avoid this behavior by checking that there are untracked directories
before passing them as paths to get_content_info().  Another option
would be to adjust get_content_info() to only fall back to all content
when paths=None, not paths=[], but that deviates from its currently
documented behavior and might affect other callers.

Fixes #3285.