### PR TITLE
Speedier `rev-create`

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -223,7 +223,10 @@ class Create(Interface):
             # GitRepo.get_content_info(), as we need to detect
             # uninstalled/added subdatasets too
             check_path = ut.Path(path)
-            pstatus = prepo.status(untracked='no')
+            pstatus = prepo.status(
+                untracked='no',
+                # limit query to target path for a potentially massive speed-up
+                paths=[check_path.relative_to(parentds_path)])
             if any(
                     check_path == p or check_path in p.parents
                     for p in pstatus):

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -101,7 +101,7 @@ STATE_COLOR_MAP = {
 def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cache):
     # take the datase that went in first
     repo_path = ds.repo.pathobj
-    lgr.debug('query %s.status() for paths: %s', ds.repo, paths)
+    lgr.debug('query %s.diffstatus() for paths: %s', ds.repo, paths)
     status = ds.repo.diffstatus(
         fr='HEAD' if ds.repo.get_hexsha() else None,
         to=None,
@@ -114,6 +114,7 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cac
         ignore_submodules='other',
         _cache=cache)
     if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
+        lgr.debug('query %s.get_content_annexinfo() for paths: %s', ds.repo, paths)
         # this will ammend `status`
         ds.repo.get_content_annexinfo(
             paths=paths if paths else None,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2835,6 +2835,7 @@ class GitRepo(RepoInterface):
           In case of an invalid Git reference (e.g. 'HEAD' in an empty
           repository)
         """
+        lgr.debug('%s.get_content_info(...)', self)
         # TODO limit by file type to replace code in subdatasets command
         info = OrderedDict()
 


### PR DESCRIPTION
Replace unconstrained `status()` call with path-constrained one. In a monster dataset with 700 subdatasets, this brings done the runtime for creating a top-level dataset from 7min to 1.5s.

Worth it...

Fixes #3293 

