### PR TITLE
RF: Make AnnexRepo.set_metadata() work without iteration

### DIFF
--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -201,8 +201,8 @@ def test_within_ds_file_search(path):
     ok_file_under_git(path, opj('stim', 'stim1.mp3'), annexed=True)
     # If it is not under annex, below addition of metadata silently does
     # not do anything
-    list(ds.repo.set_metadata(
-        opj('stim', 'stim1.mp3'), init={'importance': 'very'}))
+    ds.repo.set_metadata(
+        opj('stim', 'stim1.mp3'), init={'importance': 'very'})
     ds.aggregate_metadata()
     ok_clean_git(ds.path)
     # basic sanity check on the metadata structure of the dataset

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -496,7 +496,7 @@ def add_meta(rows):
 
         with patch.object(ds.repo, "always_commit", False):
             lgr.debug("Adding metadata to %s in %s", filename, ds.path)
-            for a in ds.repo.set_metadata(filename, add=row["meta_args"]):
+            for a in ds.repo.set_metadata_(filename, add=row["meta_args"]):
                 res = annexjson2result(a, ds, type="file", logger=lgr)
                 # Don't show all added metadata for the file because that
                 # could quickly flood the output.

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -511,7 +511,7 @@ class TestAddurls(object):
             for i in fn("wreaking-havoc-and-such", **kwargs):
                 yield i
 
-        with chpwd(path), patch.object(ds.repo, 'set_metadata', set_meta):
+        with chpwd(path), patch.object(ds.repo, 'set_metadata_', set_meta):
             with assert_raises(IncompleteResultsError):
                 ds.addurls(self.json_file, "{url}", "{name}")
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -505,7 +505,7 @@ class TestAddurls(object):
         ds = Dataset(path).rev_create(force=True)
 
         # Force failure by passing a non-existent file name to annex.
-        fn = ds.repo.set_metadata
+        fn = ds.repo.set_metadata_
 
         def set_meta(_, **kwargs):
             for i in fn("wreaking-havoc-and-such", **kwargs):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3084,9 +3084,17 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         Returns
         -------
-        generator
+        list
           JSON obj per modified file
         """
+        return list(self.set_metadata_(
+            files, reset=reset, add=add, init=init,
+            remove=remove, purge=purge, recursive=recursive))
+
+    def set_metadata_(
+            self, files, reset=None, add=None, init=None,
+            remove=None, purge=None, recursive=False):
+        """Like set_metadata() but returns a generator"""
 
         def _genspec(expr, d):
             return [expr.format(k, v) for k, vs in d.items() for v in assure_list(vs)]

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2106,13 +2106,13 @@ def test_AnnexRepo_metadata(path):
     eq_([], list(ar.get_metadata([])))
     eq_({'up.dat': {}}, dict(ar.get_metadata('up.dat')))
     # basic invocation
-    eq_(1, len(list(ar.set_metadata(
+    eq_(1, len(ar.set_metadata(
         'up.dat',
         reset={'mike': 'awesome'},
         add={'tag': 'awesome'},
         remove={'tag': 'awesome'},  # cancels prev, just to use it
         init={'virgin': 'true'},
-        purge=['nothere']))))
+        purge=['nothere'])))
     # no timestamps by default
     md = dict(ar.get_metadata('up.dat'))
     deq_({'up.dat': {
@@ -2125,13 +2125,13 @@ def test_AnnexRepo_metadata(path):
         assert_in('{}-lastchanged'.format(k), md_ts['up.dat'])
     assert_in('lastchanged', md_ts['up.dat'])
     # recursive needs a flag
-    assert_raises(CommandError, list, ar.set_metadata('.', purge=['virgin']))
-    list(ar.set_metadata('.', purge=['virgin'], recursive=True))
+    assert_raises(CommandError, ar.set_metadata, '.', purge=['virgin'])
+    ar.set_metadata('.', purge=['virgin'], recursive=True)
     deq_({'up.dat': {
         'mike': ['awesome']}},
         dict(ar.get_metadata('up.dat')))
     # Use trickier tags (spaces, =)
-    list(ar.set_metadata('.', reset={'tag': 'one and= '}, purge=['mike'], recursive=True))
+    ar.set_metadata('.', reset={'tag': 'one and= '}, purge=['mike'], recursive=True)
     playfile = opj('d o"w n', 'd o w n.dat')
     target = {
         'up.dat': {
@@ -2140,21 +2140,21 @@ def test_AnnexRepo_metadata(path):
             'tag': ['one and= ']}}
     deq_(target, dict(ar.get_metadata('.')))
     # incremental work like a set
-    list(ar.set_metadata(playfile, add={'tag': 'one and= '}))
+    ar.set_metadata(playfile, add={'tag': 'one and= '})
     deq_(target, dict(ar.get_metadata('.')))
-    list(ar.set_metadata(playfile, add={'tag': ' two'}))
+    ar.set_metadata(playfile, add={'tag': ' two'})
     # returned values are sorted
     eq_([' two', 'one and= '], dict(ar.get_metadata(playfile))[playfile]['tag'])
     # init honor prior values
-    list(ar.set_metadata(playfile, init={'tag': 'three'}))
+    ar.set_metadata(playfile, init={'tag': 'three'})
     eq_([' two', 'one and= '], dict(ar.get_metadata(playfile))[playfile]['tag'])
-    list(ar.set_metadata(playfile, remove={'tag': ' two'}))
+    ar.set_metadata(playfile, remove={'tag': ' two'})
     deq_(target, dict(ar.get_metadata('.')))
     # remove non-existing doesn't error and doesn't change anything
-    list(ar.set_metadata(playfile, remove={'ether': 'best'}))
+    ar.set_metadata(playfile, remove={'ether': 'best'})
     deq_(target, dict(ar.get_metadata('.')))
     # add works without prior existence
-    list(ar.set_metadata(playfile, add={'novel': 'best'}))
+    ar.set_metadata(playfile, add={'novel': 'best'})
     eq_(['best'], dict(ar.get_metadata(playfile))[playfile]['novel'])
 
 
@@ -2165,7 +2165,7 @@ def test_AnnexRepo_addurl_batched_and_set_metadata(path, url, dest):
     ar = AnnexRepo(dest, create=True)
     fname = "file.txt"
     ar.add_url_to_file(fname, urljoin(url, fname), batch=True)
-    list(ar.set_metadata(fname, init={"number": "one"}))
+    ar.set_metadata(fname, init={"number": "one"})
     eq_(["one"], dict(ar.get_metadata(fname))[fname]["number"])
 
 


### PR DESCRIPTION
Analog to function like add/add_ the normal version now just does things, whereas the _ version returns a generator that needs to be iterator over to actually perform anything. The prior behavior was
a constant source of surprise and anger.

Related to #2755 