### PR TITLE
ENH: Report 'bytesize' from plain Git, whenever ls-tree runs anyways

### DIFF
--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -76,6 +76,7 @@ def test_status_basics(path, linkpath, otherdir):
         eq_(s['state'], 'clean')
         eq_(s['type'], 'file')
         assert_in('gitshasum', s)
+        assert_in('bytesize', s)
         eq_(s['refds'], ds.path)
 
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2799,7 +2799,9 @@ class GitRepo(RepoInterface):
         ref : gitref or None
           If given, content information is retrieved for this Git reference
           (via ls-tree), otherwise content information is produced for the
-          present work tree (via ls-files).
+          present work tree (via ls-files). With a given reference, the
+          reported content properties also contain a 'bytesize' record,
+          stating the size of a file in bytes.
         untracked : {'no', 'normal', 'all'}
           If and how untracked content is reported when no `ref` was given:
           'no': no untracked files are reported; 'normal': untracked files

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2870,10 +2870,10 @@ class GitRepo(RepoInterface):
             else:
                 raise ValueError(
                     'unknown value for `untracked`: %s', untracked)
+            props_re = re.compile(r'([0-9]+) (.*) (.*)\t(.*)$')
         else:
-            cmd = ['git', 'ls-tree', ref, '-z', '-r', '--full-tree']
-        # works for both modes
-        props_re = re.compile(r'([0-9]+) (.*) (.*)\t(.*)$')
+            cmd = ['git', 'ls-tree', ref, '-z', '-r', '--full-tree', '-l']
+            props_re = re.compile(r'([0-9]+) ([a-z]*) ([^ ]*) [\s]*([0-9-]+)\t(.*)$')
 
         try:
             stdout, stderr = self._git_custom_command(
@@ -2907,7 +2907,7 @@ class GitRepo(RepoInterface):
                 inf['gitshasum'] = None
             else:
                 # again Git reports always in POSIX
-                path = ut.PurePosixPath(props.group(4))
+                path = ut.PurePosixPath(props.group(4 if not ref else 5))
                 inf['gitshasum'] = props.group(2 if not ref else 3)
                 inf['type'] = mode_type_map.get(
                     props.group(1), props.group(1))
@@ -2930,6 +2930,8 @@ class GitRepo(RepoInterface):
                     # symlink-nature is a technicality that is dependent
                     # on the particular mode annex is in
                     inf['type'] = 'file'
+                if ref and inf['type'] == 'file':
+                    inf['bytesize'] = int(props.group(4))
 
             # the function assumes that any `path` is a relative path lib
             # instance if there were path constraints given, we need to reject
@@ -3139,6 +3141,12 @@ class GitRepo(RepoInterface):
                 )
             if props['state'] in ('clean', 'added', 'modified'):
                 props['gitshasum'] = to_state_r['gitshasum']
+                if 'bytesize' in to_state_r:
+                    # if we got this cheap, report it
+                    props['bytesize'] = to_state_r['bytesize']
+                elif props['state'] == 'clean' and 'bytesize' in from_state[f]:
+                    # no change, we can take this old size info
+                    props['bytesize'] = from_state[f]['bytesize']
             if props['state'] in ('clean', 'modified', 'deleted'):
                 props['prev_gitshasum'] = from_state[f]['gitshasum']
             status[f] = props

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -7,6 +7,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test file info getters"""
 
+
+from six import iteritems
 import os.path as op
 import datalad.utils as ut
 
@@ -135,8 +137,14 @@ def test_compare_content_info(path):
     assert_repo_status(path)
 
     # for a clean repo HEAD and worktree query should yield identical results
+    # minus a 'bytesize' report that is readily available for HEAD, but would
+    # not a stat call per file for the worktree, and is not done ATM
     wt = ds.repo.get_content_info(ref=None)
-    assert_dict_equal(wt, ds.repo.get_content_info(ref='HEAD'))
+    assert_dict_equal(
+        wt,
+        {f: {k: v for k, v in iteritems(p) if k != 'bytesize'}
+         for f, p in iteritems(ds.repo.get_content_info(ref='HEAD'))}
+    )
 
 
 @with_tempfile


### PR DESCRIPTION
It is cheap and useful.