### PR TITLE
ENH: Record a dataset's ID in a superdataset on `add/save` (fixes gh-3303)

### DIFF
--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -164,7 +164,7 @@ def test_create_sub(path):
     ds.rev_create()
 
     # 1. create sub and add to super:
-    subds = ds.rev_create(op.join("some", "what", "deeper")
+    subds = ds.rev_create(op.join("some", "what", "deeper"))
     ok_(isinstance(subds, Dataset))
     ok_(subds.is_installed())
     assert_repo_status(subds.path, annex=True)

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -164,7 +164,7 @@ def test_create_sub(path):
     ds.rev_create()
 
     # 1. create sub and add to super:
-    subds = ds.rev_create("some/what/deeper")
+    subds = ds.rev_create(op.join("some", "what", "deeper")
     ok_(isinstance(subds, Dataset))
     ok_(subds.is_installed())
     assert_repo_status(subds.path, annex=True)

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -168,6 +168,13 @@ def test_create_sub(path):
     ok_(isinstance(subds, Dataset))
     ok_(subds.is_installed())
     assert_repo_status(subds.path, annex=True)
+    assert_in(
+        'submodule.some/what/deeper.datalad-id={}'.format(
+            subds.id),
+        ds.repo._git_custom_command(
+            '',
+            ['git', 'config', '--file', '.gitmodules', '--list'])[0]
+    )
 
     # subdataset is known to superdataset:
     assert_in(op.join("some", "what", "deeper"),

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2440,7 +2440,7 @@ class GitRepo(RepoInterface):
         if subm_id:
             self._git_custom_command(
                 '',
-                ['git', 'config', '--file', '.gitmodules', '--add',
+                ['git', 'config', '--file', '.gitmodules', '--replace-all',
                  'submodule.{}.datalad-id'.format(name), subm_id])
         # ensure supported setup
         _fixup_submodule_dotgit_setup(self, path)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2432,6 +2432,15 @@ class GitRepo(RepoInterface):
                 url = path
         cmd += [url, path]
         self._git_custom_command('', cmd)
+        # record dataset ID if possible for comprehesive metadata on
+        # dataset components within the dataset itself
+        subm_id = GitRepo(op.join(self.path, path)).config.get(
+            'datalad.dataset.id', None)
+        if subm_id:
+            self._git_custom_command(
+                '',
+                ['git', 'config', '--file', '.gitmodules', '--add',
+                 'submodule.{}.datalad-id'.format(name), subm_id])
         # ensure supported setup
         _fixup_submodule_dotgit_setup(self, path)
         # TODO: return value

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3503,7 +3503,7 @@ class GitRepo(RepoInterface):
                 # https://github.com/datalad/datalad/issues/3306
                 for r in GitRepo._save_add(
                         self,
-                        {self.pathobj.joinpath('.gitmodules'): None}):
+                        {op.join(self.path, '.gitmodules'): None}):
                     yield get_status_dict(
                         action='add',
                         refds=self.pathobj,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -60,6 +60,7 @@ from datalad.consts import GIT_SSH_COMMAND
 from datalad.dochelpers import exc_str
 from datalad.config import ConfigManager
 import datalad.utils as ut
+from datalad.utils import Path
 from datalad.utils import assure_list
 from datalad.utils import optional_args
 from datalad.utils import on_windows
@@ -2396,7 +2397,7 @@ class GitRepo(RepoInterface):
           as a tracking branch. If `None`, remote HEAD will be checked out.
         """
         if name is None:
-            name = path
+            name = Path(path).as_posix()
         # XXX the following should do it, but GitPython will refuse to add a submodule
         # unless you specify a URL that is configured as one of its remotes, or you
         # specify no URL, but the repo has at least one remote.


### PR DESCRIPTION
Otherwise we have incomplete identity information on all dataset components (i.e. we only have the state of a subdataset, but not its persistent ID). This is an issue during metadata extraction, where we would require subdatasets to be around in order to be able to give a full report.

We already ensure that create(force=True) does not alter a dataset's ID, so getting out of sync would require manual fiddling with DataLad's internal config. Sure be safe...