### PR TITLE
TST: run: Swallow leaked output

### DIFF
--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -430,13 +430,14 @@ def test_run_failure(path):
     hexsha_initial = ds.repo.get_hexsha()
 
     with assert_raises(CommandError):
-        if on_windows:
-            # this does not do exactly the same as the cmd on other systems
-            # but is close enough to make running the test worthwhile
-            ds.run("echo x>{} & false".format(op.join("sub", "grows")))
-        else:
-            ds.run("echo x$(cat {0}) > {0} && false"
-                   .format(op.join("sub", "grows")))
+        with swallow_outputs():
+            if on_windows:
+                # this does not do exactly the same as the cmd on other systems
+                # but is close enough to make running the test worthwhile
+                ds.run("echo x>{} & false".format(op.join("sub", "grows")))
+            else:
+                ds.run("echo x$(cat {0}) > {0} && false"
+                       .format(op.join("sub", "grows")))
     eq_(hexsha_initial, ds.repo.get_hexsha())
     ok_(ds.repo.dirty)
 


### PR DESCRIPTION
116c21378 (TST: run: Swallow more test output, 2019-03-11) stopped
test_run.py from polluting the test output, but one test has been
leaking output since 3b3818cee (Merge branch 'rev-run-patches' into
rev-run-tests, 2019-03-19).