### PR TITLE
BF: appveyor - prepare coverage.xml in a separate invocation.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,30 +84,32 @@ test_script:
   # and now this... [keep appending tests that should work!!]
   # one call per datalad component for now -- to better see what is being tested
   # everything in core/ must work
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.core"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.core"
   # cmdline
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.cmdline"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.cmdline"
   # remaining fails: test_archives.test_basic_scenario test_datalad.test_basic_scenario_local_url
   #- python -m nose -s -v datalad.customremotes
   # remaining fails: test_add test_create_test_dataset test_get test_uninstall test_utils
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.distribution.tests.test_create datalad.distribution.tests.test_create_github datalad.distribution.tests.test_dataset_binding datalad.distribution.tests.test_siblings datalad.distribution.tests.test_update datalad.distribution.tests.test_dataset datalad.distribution.tests.test_publish datalad.distribution.tests.test_subdataset datalad.distribution.tests.test_clone datalad.distribution.tests.test_create_sibling"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.distribution.tests.test_create datalad.distribution.tests.test_create_github datalad.distribution.tests.test_dataset_binding datalad.distribution.tests.test_siblings datalad.distribution.tests.test_update datalad.distribution.tests.test_dataset datalad.distribution.tests.test_publish datalad.distribution.tests.test_subdataset datalad.distribution.tests.test_clone datalad.distribution.tests.test_create_sibling"
   # remaining fails: test_http
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3"
   # remaining fails: test_add_archive_content test_annotate_paths test_diff test_ls_webui test_run test_save test_utils
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.interface.tests.test_base datalad.interface.tests.test_clean datalad.interface.tests.test_docs datalad.interface.tests.test_ls datalad.interface.tests.test_unlock datalad.interface.tests.test_run datalad.interface.tests.test_run_procedure"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.interface.tests.test_base datalad.interface.tests.test_clean datalad.interface.tests.test_docs datalad.interface.tests.test_ls datalad.interface.tests.test_unlock datalad.interface.tests.test_run datalad.interface.tests.test_run_procedure"
   # remaining fails: extractors.tests.test_base test_aggregation test_base  datalad.metadata.extractors.tests.test_datacite_xml
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822"
   # remaining fails: test_addurls test_export_archive test_plugins"
   # additional tests need module `dateutil`!!
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.plugin.tests.test_check_dates"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates"
   # remaining fails: test_annexrepo test_digests test_gitrepo test_locking test_repodates test_sshrun 
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_"
   # remaining fails: test__main__ test_archives test_cmd test_log  test_protocols test_test_utils test_utils test_auto
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos"
 
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.ui"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.ui"
   
-  - "python -m nose -s -v --with-cov --cover-package datalad --cover-xml --cover-xml-file=coverage.xml datalad.distribution.tests.test_install"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.distribution.tests.test_install"
+  # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
+  - "python -m coverage xml"
 
 after_test:
   - ps: |


### PR DESCRIPTION
 If invoked directly with nose - do not include test_ files themselves in the .xml report

```
$> rm -f .coverage .coverage.xml ; python -m nose -s -v --with-cov --cover-package=datalad --cover-xml --cover-xml-file=coverage.xml datalad/tests/test_cmd.py >/dev/null 2>&1              
python -m nose -s -v --with-cov --cover-package=datalad --cover-xml   >  2>&1  4.15s user 3.01s system 113% cpu 6.328 total
(dev) 1 17826.....................................:Wed 10 Apr 2019 04:13:21 PM EDT:.
(git)hopa:~datalad/datalad-master[bf-appveyor-coverage]git
$> grep test_ coverage.xml                                                                                                                                                    
(dev) 1 17827 ->1.....................................:Wed 10 Apr 2019 04:13:24 PM EDT:.
(git)hopa:~datalad/datalad-master[bf-appveyor-coverage]git
$> python -m coverage xml                                                                                                                                                     
(dev) 1 17828.....................................:Wed 10 Apr 2019 04:13:33 PM EDT:.
(git)hopa:~datalad/datalad-master[bf-appveyor-coverage]git
$> grep test_cmd coverage.xml 
				<class branch-rate="0" complexity="0" filename="datalad/tests/test_cmd.py" line-rate="0.9691" name="test_cmd.py">
```

[skip travis]

