### PR TITLE
BF: do not install post-update hook if no UI, allow to reconfigure full hierarchy, no submodule update --init in hook

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -819,9 +819,6 @@ mkdir -p "$dsdir/{WEB_META_LOG}"  # assure logs directory exists
   && ( cd "$dsdir"; GIT_DIR="$PWD/.git" datalad ls -a --json file .; ) \
   || echo "E: no datalad found - skipping generation of indexes for web frontend"; \
 ) &> "$logfile"
-
-# Some submodules might have been added and thus we better init them
-( cd "$dsdir"; git submodule update --init || : ; ) >> "$logfile" 2>&1
 '''.format(WEB_META_LOG=WEB_META_LOG, **locals())
 
         with make_tempfile(content=hook_content) as tempf:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -197,8 +197,8 @@ def _create_dataset_sibling(
         if not path_exists:
             ssh("mkdir -p {}".format(sh_quote(remoteds_path)))
 
-    if inherit:
-        delayed_super = _DelayedSuper(ds)
+    delayed_super = _DelayedSuper(ds)
+    if inherit and delayed_super.super:
         if shared is None:
             # here we must analyze current_ds's super, not the super_ds
             # inherit from the setting on remote end


### PR DESCRIPTION
- Primary issue it resolves -- we have been installing `post-update` hook even when no web UI was asked to be published!  So if your `publish` or `create-sibling` was ... a bit slow while just hanging there without returning any output -- you might know now why. Check if `.git/hooks/post-update` is there on remote and kill it (unless you do use web ui)
  - commit a4d40a607cb54a5cd4b49459496c6c64449ec666 first removes installation of the post-commit hook unless UI is set.  It also avoids running post-update hook unless it is there on remote (and executable)
  - followup commit c680a405b41f0b657e7809ce1908db969cd11a6c fixes regression introduced by the previous one by enabling inheriting having hook or not from super.
  - the last one 22c588227f2c735d8bd0944facb7cdbb3d4ee0d6 just for paranoid me to verify that hierarchy (not just 1 direct subdataset) is inheriting correctly
- I guess it might run into some unpleasant conflicts due to all the `rev_`olutionization when we try to merge to master, so I guess expert revolutionist assistance would be required
- I also later added 78e00dcd23385c29d705590f83a6b421ff349051 which removes running `submodule update --init` from post-update hook.  I do not think it is longer needed, and tests didn't fail for me locally supporting that.  More in the commit msg
- I also later added 01cf595cf3ee41c9b8b22ca4544eb870acb15970 which allows to assure consistent hierarchy of subdatasets on the remote while inheriting settings from their supers.  It would now not blow whenever working on the topmost dataset where there is no super