### PR TITLE
OPT: do not bother sleeping when not output was received in the Runner processing of output

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -317,8 +317,8 @@ class Runner(object):
             if log_stderr_:
                 stderr_ = self._process_one_line(*stderr_args)
                 stderr += stderr_
-            if not (stdout_ or stderr_):
-                # no output was generated, so sleep a tiny bit
+            if stdout_ is None and stderr_ is None:
+                # no output was really produced, so sleep a tiny bit
                 time.sleep(0.001)
 
         # Handle possible remaining output


### PR DESCRIPTION
As "discussed" in #3319 
It could help quite a bit for any runs of `git-annex CMD --json` (not batched)