### PR TITLE
NF: status(eval_subdataset_state={'no'|'commit'|'full'}

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -229,7 +229,22 @@ class Status(Interface):
         eval_subdataset_state=Parameter(
             args=("-e", "--eval-subdataset-state",),
             constraints=EnsureChoice('no', 'commit', 'full'),
-            doc=""""""),
+            doc="""Evaluation of subdataset state (clean vs.
+            modified) can be expensive for deep dataset hierarchies
+            as subdataset have to be tested recursively for
+            uncommitted modifications. Setting this option to
+            'no' or 'commit' can substantially boost performance
+            by limiting what is being tested. With 'no' no state
+            is evaluated and subdataset result records typically do
+            not contain a 'state' property.
+            With 'commit' only a discrepancy of the HEAD commit
+            shasum of a subdataset and the shasum recorded in the
+            superdataset's record is evaluated,
+            and the 'state' result property only reflects this
+            aspect. With 'full' any other modification is considered
+            too (see the 'untracked' option for further tailoring
+            modification testing).
+            """),
     )
 
     @staticmethod

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -227,7 +227,7 @@ class Status(Interface):
             nargs="*",
             constraints=EnsureStr() | EnsureNone()),
         eval_subdataset_state=Parameter(
-            args=("--eval-subdataset-state",),
+            args=("-e", "--eval-subdataset-state",),
             constraints=EnsureChoice('no', 'commit', 'full'),
             doc=""""""),
     )

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -95,7 +95,7 @@ STATE_COLOR_MAP = {
     'untracked': ac.RED,
     'modified': ac.RED,
     'added': ac.GREEN,
-    'unknown': ac.CYAN,
+    'unknown': ac.YELLOW,
 }
 
 

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -95,10 +95,12 @@ STATE_COLOR_MAP = {
     'untracked': ac.RED,
     'modified': ac.RED,
     'added': ac.GREEN,
+    'unknown': ac.CYAN,
 }
 
 
-def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cache):
+def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried,
+                  eval_submodule_state, cache):
     # take the datase that went in first
     repo_path = ds.repo.pathobj
     lgr.debug('query %s.diffstatus() for paths: %s', ds.repo, paths)
@@ -108,10 +110,7 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cac
         # recode paths with repo reference for low-level API
         paths=[repo_path / p.relative_to(ds.pathobj) for p in paths] if paths else None,
         untracked=untracked,
-        # TODO think about potential optimizations in case of
-        # recursive processing, as this will imply a semi-recursive
-        # look into subdatasets
-        ignore_submodules='other',
+        eval_submodule_state=eval_submodule_state,
         _cache=cache)
     if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
         lgr.debug('query %s.get_content_annexinfo() for paths: %s', ds.repo, paths)
@@ -141,6 +140,7 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried, cac
                         untracked,
                         recursion_limit - 1,
                         queried,
+                        eval_submodule_state,
                         cache):
                     yield r
 
@@ -226,8 +226,11 @@ class Status(Interface):
             doc="""path to be evaluated""",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()),
-        )
-
+        eval_subdataset_state=Parameter(
+            args=("--eval-subdataset-state",),
+            constraints=EnsureChoice('no', 'commit', 'full'),
+            doc=""""""),
+    )
 
     @staticmethod
     @datasetmethod(name='status')
@@ -238,7 +241,8 @@ class Status(Interface):
             annex=None,
             untracked='normal',
             recursive=False,
-            recursion_limit=None):
+            recursion_limit=None,
+            eval_subdataset_state='full'):
         # To the next white knight that comes in to re-implement `status` as a
         # special case of `diff`. There is one fundamental difference between
         # the two commands: `status` can always use the worktree as evident on
@@ -344,6 +348,7 @@ class Status(Interface):
                     if recursion_limit is not None else -1
                     if recursive else 0,
                     queried,
+                    eval_subdataset_state,
                     content_info_cache):
                 yield dict(
                     r,
@@ -370,12 +375,12 @@ class Status(Interface):
             else str(ut.Path(res['path']).relative_to(refds))
         type_ = res.get('type', res.get('type_src', ''))
         max_len = len('untracked')
-        state = res['state']
+        state = res.get('state', 'unknown')
         ui.message('{fill}{state}: {path}{type_}'.format(
             fill=' ' * max(0, max_len - len(state)),
             state=ac.color_word(
                 state,
-                STATE_COLOR_MAP.get(res['state'], ac.WHITE)),
+                STATE_COLOR_MAP.get(res.get('state', 'unknown'), ac.WHITE)),
             path=path,
             type_=' ({})'.format(
                 ac.color_word(type_, ac.MAGENTA) if type_ else '')))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3267,7 +3267,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 eval_availability=False,
                 init=self.status(
                     paths=paths,
-                    ignore_submodules='other')
+                    eval_submodule_state='full')
             )
         )
         self._mark_content_availability(info)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3287,7 +3287,7 @@ class GitRepo(RepoInterface):
                     else 'clean'
             else:
                 raise ValueError(
-                    'unknown `eval_submodule_state` parameter value: %s',
+                    'unknown `eval_submodule_state` parameter value: %s' %
                     eval_submodule_state)
 
         return status

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -129,6 +129,23 @@ def test_get_content_info(path):
                 # `file` was a POSIX path
                 assert_equal(annexstatus[p]['has_content'], 'dropped' not in s)
 
+    # check the different subds evaluation modes
+    someds = Dataset(ds.pathobj / 'subds_modified' / 'someds')
+    dirtyds_path = someds.pathobj / 'dirtyds'
+    assert_not_in(
+        'state',
+        someds.repo.status(eval_submodule_state='no')[dirtyds_path]
+    )
+    assert_equal(
+        'clean',
+        someds.repo.status(eval_submodule_state='commit')[dirtyds_path]['state']
+    )
+    assert_equal(
+        'modified',
+        someds.repo.status(eval_submodule_state='full')[dirtyds_path]['state']
+    )
+
+
 
 @with_tempfile
 def test_compare_content_info(path):

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -40,7 +40,7 @@ def test_save_basics(path):
 
 def _test_save_all(path, repocls):
     ds = get_convoluted_situation(path, GitRepo)
-    orig_status = ds.repo.status(untracked='all', ignore_submodules='no')
+    orig_status = ds.repo.status(untracked='all')
     # TODO test the results when the are crafted
     res = ds.repo.save()
     # make sure we get a 'delete' result for each deleted file
@@ -48,7 +48,7 @@ def _test_save_all(path, repocls):
         set(r['path'] for r in res if r['action'] == 'delete'),
         {k for k, v in iteritems(orig_status) if k.name == 'file_deleted'}
     )
-    saved_status = ds.repo.status(untracked='all', ignore_submodules='no')
+    saved_status = ds.repo.status(untracked='all')
     # we still have an entry for everything that did not get deleted
     # intentionally
     eq_(


### PR DESCRIPTION
New mode to fully or partially disable subdataset state evaluation (which involves recursion into all present subdatasets to find potential uncommited changes), without disabling subdataset discovery and
reporting.

This addition allows for using status() unconditionally for (fast(er)) discovery operation.

This also replaces the (undocumented) argument and behavior switch 'ignore_submodules' that wasn't used in any sensible way, because it didn't actually provide sensible switching. It could only distinguish
"clever" operation and "needlessly wasteful" operation.

- [x] final docs

Performance info on the `///` dataset:

`datalad status --eval-subdataset-state commit -r  744.29s user 601.62s system 102% cpu 21:47.48 total`

Looks ridiculous, but a plain `git status` at the top-level already takes 7min. In contrast this is a recursion across all datasets, with reporting on all datasets. Interestingly, the difference to "full" on the present state of that dataset's working tree (mixture of all kinds of things) is only 2min (~24min total runtime).

So here is an artificial "worst case" example with a deep and clean hierarchy that show maximum performance difference between the modes "commit" and "full":

```
import datalad.api as dl
ds = dl.rev_create('deep')
path = ds.pathobj  
for i in range(20):       
     path = path / 'down'
     ds.rev_create(path)
```
```
%timeit ds.status(eval_subdataset_state='no', result_renderer='disabled')
10 loops, best of 3: 51.8 ms per loop                                                    

%timeit ds.status(eval_subdataset_state='commit', result_renderer='disabled')
10 loops, best of 3: 66.6 ms per loop

%timeit ds.status(eval_subdataset_state='full', result_renderer='disabled')
1 loop, best of 3: 1.07 s per loop
```