### PR TITLE
BF: status: Provide special treatment of "." path

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -276,7 +276,8 @@ class Status(Interface):
                     continue
                 else:
                     if dataset and root == str(p) and \
-                            not orig_path.endswith(op.sep):
+                            not (orig_path.endswith(op.sep) or
+                                 orig_path == "."):
                         # the given path is pointing to a dataset
                         # distinguish rsync-link syntax to identify
                         # the dataset as whole (e.g. 'ds') vs its

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -232,3 +232,12 @@ def test_subds_status(path):
         type='dataset',
         path=subds.path,
         refds=ds.path)
+
+    # path="." gets treated as "this dataset's content" without requiring a
+    # trailing "/".
+    assert_result_count(
+        subds.status(path="."),
+        1,
+        type="dataset",
+        path=op.join(subds.path, "someotherds"),
+        refds=subds.path)

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -482,6 +482,13 @@ def test_run_save_deletion(path):
     assert_repo_status(ds.path)
 
 
+@with_tempfile(mkdir=True)
+def test_run_from_subds(path):
+    subds = Dataset(path).rev_create().rev_create("sub")
+    subds.run("cd .> foo")
+    assert_repo_status(subds.path)
+
+
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_branch(path):

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -484,6 +484,9 @@ def test_run_save_deletion(path):
 
 @with_tempfile(mkdir=True)
 def test_run_from_subds(path):
+    if 'APPVEYOR' in os.environ:
+        raise SkipTest('test causes appveyor (only) to crash, reason unknown')
+
     subds = Dataset(path).rev_create().rev_create("sub")
     subds.run("cd .> foo")
     assert_repo_status(subds.path)


### PR DESCRIPTION
```
When status receives "." as the path, rev_resolve_path() resolves the
path to the dataset (either to the one explicitly provided as an
argument or to the one inferred from the current directory).  So,
using "." means we get the reference dataset as the path.

If a call includes an explicitly specified dataset _and_ "." as a path
argument, whether the call succeeds or fails depends on whether the
specified dataset is a subdataset.  When the reference dataset isn't a
subdataset, status queries within the dataset.  When it is a
subdataset, the call fails with a message saying the subdataset is not
underneath itself:

  $ datalad status -d. .
  [ERROR ] dataset containing given paths is not underneath the
  reference dataset [...]

Even though the desired behavior could be achieved by dropping "." as
a path argument, let's make using "." as the path argument work
because

  * it is consistent with the non-subdataset case, and it won't be
    obvious to a caller why it works in one case but not the other

  * based on the use of "." as a path argument in other places in
    datalad, it's be reasonable for a caller to expect, say,
    subds.status(".") to work

As shown by the added run test, this fixes a regression where calling
'datalad run' failed from within a subdataset, which was introduced by
eba3ccfd6 (BF: run: Save results with rev-save, 2019-03-18) because
the call to rev_save() retained the path="." that is necessary for the
add() call.
```

---

I decided to make this change in `status()` because I couldn't think of a reason why the current behavior is preferable, but we could of course put the kludge in `run()` with something like

```diff
diff --git a/datalad/interface/run.py b/datalad/interface/run.py
index d23247c00..473e734a8 100644
--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -394,7 +394,7 @@ def _execute_command(command, pwd, expected_exit=None):
 def _save_outputs(ds, to_save, msg):
     """Helper to save results after command execution is completed"""
     return Save.__call__(
-        to_save,
+        None if to_save == "." else to_save,
         dataset=ds.path,
         recursive=True,
         message=msg,
```

(We could even drop the custom `saver` parameter in `run.run_command()`, and move to an inline `ds.rev_save()` call because `saver` only existed for -revolution's rev-run.)
