### PR TITLE
DOC: Auto-set metavar for parameters with value choices

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -380,7 +380,7 @@ class CreateSibling(Interface):
         inherit=inherit_opt,
         shared=Parameter(
             args=("--shared",),
-            metavar='false|true|umask|group|all|world|everybody|0xxx',
+            metavar='{false|true|umask|group|all|world|everybody|0xxx}',
             doc="""if given, configures the access permissions on the server
             for multi-users (this could include access by a webserver!).
             Possible values for this option are identical to those of
@@ -396,7 +396,7 @@ class CreateSibling(Interface):
         ),
         ui=Parameter(
             args=("--ui",),
-            metavar='false|true|html_filename',
+            metavar='{false|true|html_filename}',
             doc="""publish a web interface for the dataset with an
             optional user-specified name for the html at publication
             target. defaults to `index.html` at dataset root""",

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -32,7 +32,10 @@ from ..dochelpers import exc_str
 
 from datalad.interface.common_opts import eval_params
 from datalad.interface.common_opts import eval_defaults
-from datalad.support.constraints import EnsureKeyChoice
+from datalad.support.constraints import (
+    EnsureKeyChoice,
+    EnsureChoice,
+)
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import resolve_path
 from datalad.plugin import _get_plugins
@@ -569,6 +572,20 @@ class Interface(object):
                 if cdoc[0] == '(' and cdoc[-1] == ')':
                     cdoc = cdoc[1:-1]
                 help += '  Constraints: %s' % cdoc
+                if 'metavar' not in parser_kwargs and \
+                        isinstance(param.constraints, EnsureChoice):
+                    parser_kwargs['metavar'] = \
+                        '{%s}' % '|'.join(
+                            # don't use short_description(), because
+                            # it also need to give valid output for
+                            # Python syntax (quotes...), but here we
+                            # can simplify to shell syntax where everything
+                            # is a string
+                            p for p in param.constraints._allowed
+                            # in the cmdline None pretty much means
+                            # don't give the options, so listing it
+                            # doesn't make sense
+                            if p is not None)
             if defaults_idx >= 0:
                 help += " [Default: %r]" % (defaults[defaults_idx],)
             # create the parameter, using the constraint instance for type

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -577,7 +577,7 @@ class Interface(object):
                     parser_kwargs['metavar'] = \
                         '{%s}' % '|'.join(
                             # don't use short_description(), because
-                            # it also need to give valid output for
+                            # it also needs to give valid output for
                             # Python syntax (quotes...), but here we
                             # can simplify to shell syntax where everything
                             # is a string

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -171,7 +171,7 @@ class Run(Interface):
         message=save_message_opt,
         sidecar=Parameter(
             args=('--sidecar',),
-            metavar="yes|no",
+            metavar="{yes|no}",
             doc="""By default, the configuration variable
             'datalad.run.record-sidecar' determines whether a record with
             information on a command's execution is placed into a separate

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -158,10 +158,9 @@ class Run(Interface):
             once. CMD]"""),
         expand=Parameter(
             args=("--expand",),
-            metavar=("WHICH"),
             doc="""Expand globs when storing inputs and/or outputs in the
             commit message.""",
-            constraints=EnsureNone() | EnsureChoice("inputs", "outputs", "both")),
+            constraints=EnsureChoice(None, "inputs", "outputs", "both")),
         explicit=Parameter(
             args=("--explicit",),
             action="store_true",

--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -26,7 +26,11 @@ class AddReadme(Interface):
     from datalad.distribution.dataset import datasetmethod
     from datalad.interface.utils import eval_results
     from datalad.distribution.dataset import EnsureDataset
-    from datalad.support.constraints import EnsureNone, EnsureStr
+    from datalad.support.constraints import (
+        EnsureChoice,
+        EnsureNone,
+        EnsureStr,
+    )
 
     _params_ = dict(
         dataset=Parameter(
@@ -43,11 +47,10 @@ class AddReadme(Interface):
             constraints=EnsureStr()),
         existing=Parameter(
             args=("--existing",),
-            metavar="skip|append|replace",
             doc="""How to react if a file with the target name already exists:
             'skip': do nothing; 'append': append information to the existing
             file; 'replace': replace the existing file with new content.""",
-            constraints=EnsureStr()),
+            constraints=EnsureChoice("skip", "append", "replace")),
     )
 
     @staticmethod

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -658,13 +658,12 @@ class Addurls(Interface):
             Underneath, this passes the --fast flag to `git annex addurl`."""),
         ifexists=Parameter(
             args=("--ifexists",),
-            metavar="ACTION",
             doc="""What to do if a constructed file name already exists.  The
             default behavior is to proceed with the `git annex addurl`, which
             will fail if the file size has changed.  If set to 'overwrite',
             remove the old file before adding the new one.  If set to 'skip',
             do not add the new file.""",
-            constraints=EnsureNone() | EnsureChoice("overwrite", "skip")),
+            constraints=EnsureChoice(None, "overwrite", "skip")),
         missing_value=Parameter(
             args=("--missing-value",),
             metavar="VALUE",

--- a/datalad/plugin/check_dates.py
+++ b/datalad/plugin/check_dates.py
@@ -124,7 +124,6 @@ class CheckDates(Interface):
             CMD]"""),
         annex=Parameter(
             args=("--annex",),
-            metavar="all|tree|none",
             doc="""Mode for "git-annex" branch search. If 'all', all blobs
             within the branch are searched. 'tree' limits the search to blobs
             that are referenced by the tree at the tip of the branch. 'none'

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -22,7 +22,11 @@ class ExportArchive(Interface):
     from datalad.distribution.dataset import datasetmethod
     from datalad.interface.utils import eval_results
     from datalad.distribution.dataset import EnsureDataset
-    from datalad.support.constraints import EnsureNone, EnsureStr
+    from datalad.support.constraints import (
+        EnsureChoice,
+        EnsureNone,
+        EnsureStr,
+    )
 
     _params_ = dict(
         dataset=Parameter(
@@ -43,19 +47,16 @@ class ExportArchive(Interface):
             constraints=EnsureStr() | EnsureNone()),
         archivetype=Parameter(
             args=("-t", "--archivetype"),
-            metavar="tar|zip",
             doc="""Type of archive to generate.""",
-            constraints=EnsureStr()),
+            constraints=EnsureChoice("tar", "zip")),
         compression=Parameter(
             args=("-c", "--compression"),
-            metavar="gz|bz2|",
             doc="""Compression method to use.  'bz2' is not supported for ZIP
             archives.  No compression is used when an empty string is
             given.""",
-            constraints=EnsureStr()),
+            constraints=EnsureChoice("gz", "bz2", "")),
         missing_content=Parameter(
             args=("--missing-content",),
-            metavar="error|continue|ignore",
             doc="""By default, any discovered file with missing content will
             result in an error and the export is aborted. Setting this to
             'continue' will issue warnings instead of failing on error. The
@@ -63,7 +64,7 @@ class ExportArchive(Interface):
             level. The latter two can be helpful when generating a TAR archive
             from a dataset where some file content is not available
             locally.""",
-            constraints=EnsureStr()),
+            constraints=EnsureChoice("error", "continue", "ignore")),
     )
 
     @staticmethod

--- a/datalad/plugin/export_to_figshare.py
+++ b/datalad/plugin/export_to_figshare.py
@@ -152,7 +152,12 @@ class ExportToFigshare(Interface):
     from datalad.distribution.dataset import datasetmethod
     from datalad.interface.utils import eval_results
     from datalad.distribution.dataset import EnsureDataset
-    from datalad.support.constraints import EnsureNone, EnsureInt, EnsureStr
+    from datalad.support.constraints import (
+        EnsureChoice,
+        EnsureInt,
+        EnsureNone,
+        EnsureStr,
+    )
 
     _params_ = dict(
         dataset=Parameter(
@@ -179,7 +184,6 @@ class ExportToFigshare(Interface):
             disables this behavior."""),
         missing_content=Parameter(
             args=("--missing-content",),
-            metavar="error|continue|ignore",
             doc="""By default, any discovered file with missing content will
             result in an error and the plugin is aborted. Setting this to
             'continue' will issue warnings instead of failing on error. The
@@ -187,7 +191,7 @@ class ExportToFigshare(Interface):
             level. The latter two can be helpful when generating a TAR archive
             from a dataset where some file content is not available
             locally.""",
-            constraints=EnsureStr()),
+            constraints=EnsureChoice("error", "continue", "ignore")),
         # article_id=Parameter(
         #     args=("--project-id",),
         #     metavar="ID",

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -263,7 +263,7 @@ class WTF(Interface):
             constraints=EnsureDataset() | EnsureNone()),
         sensitive=Parameter(
             args=("-s", "--sensitive",),
-            constraints=EnsureChoice('some', 'all') | EnsureNone(),
+            constraints=EnsureChoice(None, 'some', 'all'),
             doc="""if set to 'some' or 'all', it will display sections such as 
             config and metadata which could potentially contain sensitive 
             information (credentials, names, etc.).  If 'some', the fields


### PR DESCRIPTION
Old output:

`--eval-subdataset-state EVAL_SUBDATASET_STATE`

New output:

`--eval-subdataset-state {no|commit|full}`

This improves the docs of a range of commands, and addresses a comment by @kyleam in https://github.com/datalad/datalad/pull/3324
