### PR TITLE
Make XMP extractor faster (fixes gh-3328)

### DIFF
--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -48,17 +48,17 @@ class MetadataExtractor(BaseMetadataExtractor):
             unit=' Files',
         )
         for f in self.paths:
+            log_progress(
+                lgr.info,
+                'extractorxmp',
+                'Extract XMP metadata from %s', f,
+                update=1,
+                increment=True)
             # run basic file name filter for performance reasons
             # it is OK to let false-positives through
             if fname_match_regex.match(f, re.IGNORECASE) is None:
                 continue
             absfp = opj(self.ds.path, f)
-            log_progress(
-                lgr.info,
-                'extractorxmp',
-                'Extract XMP metadata from %s', absfp,
-                update=1,
-                increment=True)
             info = file_to_dict(absfp)
             if not info:
                 # got nothing, likely nothing there

--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -32,6 +32,13 @@ class MetadataExtractor(BaseMetadataExtractor):
             return {}, []
         context = {}
         contentmeta = []
+
+        # which files to look for
+        fname_match_regex = self.ds.config.get(
+            'datalad.metadata.xmp.fname-match',
+            '.*(jpg|jpeg|pdf|gif|tiff|tif|ps|eps|png|mp3|mp4|avi)$')
+        fname_match_regex = re.compile(fname_match_regex)
+
         log_progress(
             lgr.info,
             'extractorxmp',
@@ -41,6 +48,10 @@ class MetadataExtractor(BaseMetadataExtractor):
             unit=' Files',
         )
         for f in self.paths:
+            # run basic file name filter for performance reasons
+            # it is OK to let false-positives through
+            if fname_match_regex.match(f, re.IGNORECASE) is None:
+                continue
             absfp = opj(self.ds.path, f)
             log_progress(
                 lgr.info,


### PR DESCRIPTION
Massive performance boost by not testing EVERY file in a dataset for XMP metadata, but instead use a file name extension based pre-filter.

This halves(!) the time to aggregate metadata for openfmri (where pretty much all datasets have this extractor enabled.

Timing in https://github.com/datalad/datalad-revolution/pull/84#issuecomment-482807116