### PR TITLE
Consistently convert pathlib objects with text_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,6 @@ bet we will fix some bugs and make a world even a better place.
 - Discontinued support for git-annex direct-mode (also no longer
   supported upstream).
 
-### Fixes
-
-- Create temporary index files under .git/ to stay on the same filesystem.
-
 ### Enhancements and new features
 
 - Dataset and Repo object instances are now hashable, and can be

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -15,6 +15,7 @@ import logging
 import random
 import uuid
 from six import iteritems
+from six import text_type
 from argparse import REMAINDER
 
 from os import listdir
@@ -187,7 +188,8 @@ class Create(Interface):
         assert(path is not None)
 
         # prep for yield
-        res = dict(action='create', path=str(path), logger=lgr, type='dataset',
+        res = dict(action='create', path=text_type(path),
+                   logger=lgr, type='dataset',
                    refds=refds_path)
 
         refds = None
@@ -204,7 +206,7 @@ class Create(Interface):
                     message=(
                         "dataset containing given paths is not underneath "
                         "the reference dataset %s: %s",
-                        dataset, str(path)),
+                        dataset, text_type(path)),
                 )
                 return
 
@@ -215,7 +217,7 @@ class Create(Interface):
         # in this location
         # it will cost some filesystem traversal though...
         parentds_path = rev_get_dataset_root(
-            op.normpath(op.join(str(path), os.pardir)))
+            op.normpath(op.join(text_type(path), os.pardir)))
         if parentds_path:
             prepo = GitRepo(parentds_path)
             parentds_path = ut.Path(parentds_path)
@@ -239,8 +241,8 @@ class Create(Interface):
                     'status': 'error',
                     'message': (
                         'collision with content in parent dataset at %s: %s',
-                        str(parentds_path),
-                        [str(c) for c in conflict])})
+                        text_type(parentds_path),
+                        [text_type(c) for c in conflict])})
                 yield res
                 return
             # another set of check to see whether the target path is pointing
@@ -257,15 +259,15 @@ class Create(Interface):
                     'status': 'error',
                     'message': (
                         'collision with %s (dataset) in dataset %s',
-                        str(conflict[0]),
-                        str(parentds_path))})
+                        text_type(conflict[0]),
+                        text_type(parentds_path))})
                 yield res
                 return
 
         # important to use the given Dataset object to avoid spurious ID
         # changes with not-yet-materialized Datasets
         tbds = dataset if isinstance(dataset, Dataset) and \
-            dataset.path == path else Dataset(str(path))
+            dataset.path == path else Dataset(text_type(path))
 
         # don't create in non-empty directory without `force`:
         if op.isdir(tbds.path) and listdir(tbds.path) != [] and not force:

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import logging
 from six import iteritems
+from six import text_type
 
 from datalad.interface.base import (
     Interface,
@@ -268,7 +269,7 @@ class Save(Interface):
                     # version
                     for k in ('path', 'refds'):
                         if k in res:
-                            res[k] = str(
+                            res[k] = text_type(
                                 # recode path back to dataset path anchor
                                 pds.pathobj / res[k].relative_to(
                                     pds.repo.pathobj)

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 
 from datalad.utils import (
     assure_list,
+    assure_unicode,
 )
 from datalad.interface.base import (
     Interface,
@@ -124,14 +125,14 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried,
         cpath = ds.pathobj / path.relative_to(repo_path)
         yield dict(
             props,
-            path=str(cpath),
+            path=text_type(cpath),
             # report the dataset path rather than the repo path to avoid
             # realpath/symlink issues
             parentds=ds.path,
         )
         queried.add(ds.pathobj)
         if recursion_limit and props.get('type', None) == 'dataset':
-            subds = Dataset(str(cpath))
+            subds = Dataset(text_type(cpath))
             if subds.is_installed():
                 for r in _yield_status(
                         subds,
@@ -280,9 +281,9 @@ class Status(Interface):
                 # it is important to capture the exact form of the
                 # given path argument, before any normalization happens
                 # for further decision logic below
-                orig_path = str(p)
+                orig_path = text_type(p)
                 p = rev_resolve_path(p, dataset)
-                root = rev_get_dataset_root(str(p))
+                root = rev_get_dataset_root(text_type(p))
                 if root is None:
                     # no root, not possibly underneath the refds
                     yield dict(
@@ -294,7 +295,7 @@ class Status(Interface):
                         logger=lgr)
                     continue
                 else:
-                    if dataset and root == str(p) and \
+                    if dataset and root == text_type(p) and \
                             not (orig_path.endswith(op.sep) or
                                  orig_path == "."):
                         # the given path is pointing to a dataset
@@ -354,7 +355,7 @@ class Status(Interface):
             if qdspath in queried:
                 # do not report on a single dataset twice
                 continue
-            qds = Dataset(str(qdspath))
+            qds = Dataset(text_type(qdspath))
             for r in _yield_status(
                     qds,
                     qpaths,
@@ -387,12 +388,15 @@ class Status(Interface):
         refds = res.get('refds', None)
         refds = refds if kwargs.get('dataset', None) is not None \
             or refds == os.getcwd() else None
-        path = res['path'] if refds is None \
-            else str(ut.Path(res['path']).relative_to(refds))
+        # Note: We have to force unicode for res['path'] because
+        # interface.utils encodes it on py2 before passing it to
+        # custom_result_renderer().
+        path = assure_unicode(res['path']) if refds is None \
+            else text_type(ut.Path(res['path']).relative_to(refds))
         type_ = res.get('type', res.get('type_src', ''))
         max_len = len('untracked')
         state = res.get('state', 'unknown')
-        ui.message('{fill}{state}: {path}{type_}'.format(
+        ui.message(u'{fill}{state}: {path}{type_}'.format(
             fill=' ' * max(0, max_len - len(state)),
             state=ac.color_word(
                 state,

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -14,6 +15,8 @@ from datalad.tests.utils import known_failure_windows
 
 import os
 import os.path as op
+
+from six import text_type
 
 from datalad.distribution.dataset import (
     Dataset
@@ -35,6 +38,7 @@ from datalad.tests.utils import (
     assert_status,
     assert_in_results,
     with_tree,
+    OBSCURE_FILENAME,
 )
 
 from datalad.tests.utils import assert_repo_status
@@ -43,7 +47,7 @@ from datalad.tests.utils import assert_repo_status
 _dataset_hierarchy_template = {
     'origin': {
         'file1': '',
-        'sub': {
+        OBSCURE_FILENAME: {
             'file2': 'file2',
             'subsub': {
                 'file3': 'file3'}}}}
@@ -75,33 +79,33 @@ def test_create_raises(path, outside_path):
             'dataset containing given paths is not underneath the reference '
             'dataset %s: %s', ds, outside_path))
     # create a sub:
-    ds.rev_create('sub')
+    ds.rev_create(OBSCURE_FILENAME)
     # fail when doing it again
     assert_in_results(
-        ds.rev_create('sub', **raw),
+        ds.rev_create(OBSCURE_FILENAME, **raw),
         status='error',
         message=('collision with content in parent dataset at %s: %s',
                  ds.path,
-                 [str(ds.pathobj / 'sub')]),
+                 [text_type(ds.pathobj / OBSCURE_FILENAME)]),
     )
 
     # now deinstall the sub and fail trying to create a new one at the
     # same location
-    ds.uninstall('sub', check=False)
-    assert_in('sub', ds.subdatasets(fulfilled=False, result_xfm='relpaths'))
+    ds.uninstall(OBSCURE_FILENAME, check=False)
+    assert_in(OBSCURE_FILENAME, ds.subdatasets(fulfilled=False, result_xfm='relpaths'))
     # and now should fail to also create inplace or under
     assert_in_results(
-        ds.rev_create('sub', **raw),
+        ds.rev_create(OBSCURE_FILENAME, **raw),
         status='error',
         message=('collision with content in parent dataset at %s: %s',
                  ds.path,
-                 [str(ds.pathobj / 'sub')]),
+                 [text_type(ds.pathobj / OBSCURE_FILENAME)]),
     )
     assert_in_results(
-        ds.rev_create(_path_('sub/subsub'), **raw),
+        ds.rev_create(op.join(OBSCURE_FILENAME, 'subsub'), **raw),
         status='error',
         message=('collision with %s (dataset) in dataset %s',
-                 str(ds.pathobj / 'sub'),
+                 text_type(ds.pathobj / OBSCURE_FILENAME),
                  ds.path)
     )
     os.makedirs(op.join(ds.path, 'down'))
@@ -113,7 +117,7 @@ def test_create_raises(path, outside_path):
         status='error',
         message=('collision with content in parent dataset at %s: %s',
                  ds.path,
-                 [str(ds.pathobj / 'down' / 'someotherfile.tst')]),
+                 [text_type(ds.pathobj / 'down' / 'someotherfile.tst')]),
     )
 
 
@@ -216,7 +220,7 @@ def test_create_subdataset_hierarchy_from_top(path):
     ok_(ds.is_installed())
     # ... but it has untracked content
     ok_(ds.repo.dirty)
-    subds = ds.rev_create('sub', force=True)
+    subds = ds.rev_create(OBSCURE_FILENAME, force=True)
     ok_(subds.is_installed())
     ok_(subds.repo.dirty)
     subsubds = subds.rev_create('subsub', force=True)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -10,6 +11,7 @@
 import os
 import os.path as op
 from six import iteritems
+from six import text_type
 
 from datalad.utils import (
     on_windows,
@@ -315,6 +317,19 @@ def test_bf2043p2(path):
     assert_repo_status(ds.path, untracked=['untracked'])
 
 
+@with_tree({
+    OBSCURE_FILENAME + u'_staged': 'staged',
+    OBSCURE_FILENAME + u'_untracked': 'untracked'})
+def test_encoding(path):
+    staged = OBSCURE_FILENAME + u'_staged'
+    untracked = OBSCURE_FILENAME + u'_untracked'
+    ds = Dataset(path).rev_create(force=True)
+    ds.repo.add(staged)
+    assert_repo_status(ds.path, added=[staged], untracked=[untracked])
+    ds.rev_save(updated=True)
+    assert_repo_status(ds.path, untracked=[untracked])
+
+
 @with_tree(**tree_arg)
 def test_add_files(path):
     ds = Dataset(path).rev_create(force=True)
@@ -336,7 +351,7 @@ def test_add_files(path):
         else:
             result = ds.rev_save(arg[0], to_git=arg[1])
             for a in assure_list(arg[0]):
-                assert_result_count(result, 1, path=str(ds.pathobj / a))
+                assert_result_count(result, 1, path=text_type(ds.pathobj / a))
             status = ds.repo.get_content_annexinfo(
                 ut.Path(p) for p in assure_list(arg[0]))
         for f, p in iteritems(status):
@@ -465,7 +480,7 @@ def test_gh1597_simpler(path):
 def test_update_known_submodule(path):
     def get_baseline(p):
         ds = Dataset(p).rev_create()
-        sub = create(str(ds.pathobj / 'sub'))
+        sub = create(text_type(ds.pathobj / 'sub'))
         assert_repo_status(ds.path, untracked=['sub'])
         return ds
     # attempt one

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -33,6 +34,7 @@ from datalad.tests.utils import (
     get_deeply_nested_structure,
     has_symlink_capability,
     assert_repo_status,
+    OBSCURE_FILENAME,
 )
 from datalad.api import (
     status,
@@ -106,7 +108,7 @@ def test_status_nods(path, otherpath):
 def test_status(_path, linkpath):
     # do the setup on the real path, not the symlink, to have its
     # bugs not affect this test of status()
-    ds = get_deeply_nested_structure(str(_path))
+    ds = get_deeply_nested_structure(text_type(_path))
     if has_symlink_capability():
         # make it more complicated by default
         ut.Path(linkpath).symlink_to(_path, target_is_directory=True)
@@ -126,10 +128,10 @@ def test_status(_path, linkpath):
     assert_result_count(
         ds.status(annex='all'),
         1,
-        path=str(ds.pathobj / 'subdir' / 'annexed_file.txt'),
+        path=text_type(ds.pathobj / 'subdir' / 'annexed_file.txt'),
         key='MD5E-s5--275876e34cf609db118f3d84b799a790.txt',
         has_content=True,
-        objloc=str(ds.repo.pathobj / '.git' / 'annex' / 'objects' /
+        objloc=text_type(ds.repo.pathobj / '.git' / 'annex' / 'objects' /
         # hashdir is different on windows
         ('f33' if on_windows else '7p') /
         ('94b' if on_windows else 'gp') /
@@ -171,9 +173,9 @@ def test_status(_path, linkpath):
     # query for a deeply nested path from the top, should just work with a
     # variety of approaches
     rpath = op.join('subds_modified', 'subds_lvl1_modified',
-                    'directory_untracked')
+                    OBSCURE_FILENAME + u'_directory_untracked')
     apathobj = ds.pathobj / rpath
-    apath = str(apathobj)
+    apath = text_type(apathobj)
     # ds.repo.pathobj will have the symlink resolved
     arealpath = ds.repo.pathobj / rpath
     # TODO include explicit relative path in test

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -610,7 +610,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dataset = Dataset(dspath)
 
     assert(dataset is not None)
-    lgr.debug("Resolved dataset{0}: {1}".format(
+    lgr.debug(u"Resolved dataset{0}: {1}".format(
         ' for {}'.format(purpose) if purpose else '',
         dataset))
 
@@ -660,9 +660,9 @@ def rev_resolve_path(path, ds=None):
         path = ut.Path(path)
     # we have a dataset
     # stringify in case a pathobj came in
-    elif not op.isabs(str(path)) and \
-            not (str(path).startswith(os.curdir + os.sep) or
-                 str(path).startswith(os.pardir + os.sep)):
+    elif not op.isabs(text_type(path)) and \
+            not (text_type(path).startswith(os.curdir + os.sep) or
+                 text_type(path).startswith(os.pardir + os.sep)):
         # we have a dataset and no abspath nor an explicit relative path ->
         # resolve it against the dataset
         path = ds.pathobj / path

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -14,6 +14,8 @@ import shutil
 import os.path as op
 from os.path import join as opj, abspath, normpath, relpath, exists
 
+from six import text_type
+
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
 from ..dataset import rev_resolve_path
 from datalad import cfg
@@ -470,10 +472,10 @@ def test_rev_resolve_path(path):
     for d in (opath,) if on_windows else (opath, lpath):
         ds_local = Dataset(d)
         # no symlink resolution
-        eq_(str(rev_resolve_path(d)), d)
+        eq_(text_type(rev_resolve_path(d)), d)
         with chpwd(d):
             # be aware: knows about cwd, but this CWD has symlinks resolved
-            eq_(str(rev_resolve_path(d).cwd()), opath)
+            eq_(text_type(rev_resolve_path(d).cwd()), opath)
             # using pathlib's `resolve()` will resolve any
             # symlinks
             # also resolve `opath`, as on old windows systems the path might
@@ -482,20 +484,20 @@ def test_rev_resolve_path(path):
             eq_(rev_resolve_path('.').resolve(), ut.Path(opath).resolve())
             # no norming, but absolute paths, without resolving links
             eq_(rev_resolve_path('.'), ut.Path(d))
-            eq_(str(rev_resolve_path('.')), d)
+            eq_(text_type(rev_resolve_path('.')), d)
 
-            eq_(str(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
+            eq_(text_type(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
                 op.join(d, 'bu'))
-            eq_(str(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
+            eq_(text_type(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
                 op.join(ds_global.path, 'bu'))
 
         # resolve against a dataset
-        eq_(str(rev_resolve_path('bu', ds=ds_local)), op.join(d, 'bu'))
-        eq_(str(rev_resolve_path('bu', ds=ds_global)), op.join(path, 'bu'))
+        eq_(text_type(rev_resolve_path('bu', ds=ds_local)), op.join(d, 'bu'))
+        eq_(text_type(rev_resolve_path('bu', ds=ds_global)), op.join(path, 'bu'))
         # but paths outside the dataset are left untouched
-        eq_(str(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
+        eq_(text_type(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
             op.join(getpwd(), 'bu'))
-        eq_(str(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
+        eq_(text_type(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
             op.normpath(op.join(getpwd(), os.pardir, 'bu')))
 
 
@@ -504,7 +506,7 @@ def test_rev_resolve_path(path):
 @with_tempfile(mkdir=True)
 def test_rev_resolve_path_symlink_edition(path):
     deepest = ut.Path(path) / 'one' / 'two' / 'three'
-    deepest_str = str(deepest)
+    deepest_str = text_type(deepest)
     os.makedirs(deepest_str)
     with chpwd(deepest_str):
         # direct absolute

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -41,6 +41,7 @@ from weakref import WeakValueDictionary
 
 from six import string_types, PY2
 from six import iteritems
+from six import text_type
 from six.moves import filter
 from git import InvalidGitRepositoryError
 
@@ -3049,7 +3050,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 if testpath.exists():
                     r.pop('hashdirlower', None)
                     r.pop('hashdirmixed', None)
-                    r['objloc'] = str(testpath)
+                    r['objloc'] = text_type(testpath)
                     r['has_content'] = True
                     break
 
@@ -3117,7 +3118,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             cmd = 'find'
             # stringify any pathobjs
-            opts.extend([str(p) for p in paths]
+            opts.extend([text_type(p) for p in paths]
                         if paths else ['--include', '*'])
         for j in self._run_annex_command_json(cmd, opts=opts):
             path = self.pathobj.joinpath(ut.PurePosixPath(j['file']))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -61,6 +61,7 @@ from datalad.dochelpers import exc_str
 from datalad.config import ConfigManager
 import datalad.utils as ut
 from datalad.utils import Path
+from datalad.utils import assure_bytes
 from datalad.utils import assure_list
 from datalad.utils import optional_args
 from datalad.utils import on_windows
@@ -816,7 +817,11 @@ class GitRepo(RepoInterface):
         if self._repo is None:
             # Note, that this may raise GitCommandError, NoSuchPathError,
             # InvalidGitRepositoryError:
-            self._repo = self.cmd_call_wrapper(Repo, self.path)
+            self._repo = self.cmd_call_wrapper(
+                Repo,
+                # Encode path on Python 2 because, as of v2.1.11, GitPython's
+                # Repo will pass the path to str() otherwise.
+                assure_bytes(self.path) if PY2 else self.path)
             lgr.log(8, "Using existing Git repository at %s", self.path)
 
         # inject git options into GitPython's git call wrapper:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1378,14 +1378,14 @@ class GitRepo(RepoInterface):
         except CommandError as e:
             if 'nothing to commit' in e.stdout:
                 if careless:
-                    lgr.debug("nothing to commit in {}. "
+                    lgr.debug(u"nothing to commit in {}. "
                               "Ignored.".format(self))
                 else:
                     raise
             elif 'no changes added to commit' in e.stdout or \
                     'nothing added to commit' in e.stdout:
                 if careless:
-                    lgr.debug("no changes added to commit in {}. "
+                    lgr.debug(u"no changes added to commit in {}. "
                               "Ignored.".format(self))
                 else:
                     raise
@@ -3146,7 +3146,7 @@ class GitRepo(RepoInterface):
                     self.pathobj.joinpath(ut.PurePosixPath(p))
                     for p in self._git_custom_command(
                         # low-level code cannot handle pathobjs
-                        [str(p) for p in paths] if paths else None,
+                        [text_type(p) for p in paths] if paths else None,
                         ['git', 'ls-files', '-z', '-m'])[0].split('\0')
                     if p)
                 _cache[key] = modified
@@ -3346,7 +3346,7 @@ class GitRepo(RepoInterface):
 
         # TODO remove pathobj stringification when commit() can
         # handle it
-        to_commit = [str(f.relative_to(self.pathobj))
+        to_commit = [text_type(f.relative_to(self.pathobj))
                      for f, props in iteritems(status)] \
                     if partial_commit else None
         if not partial_commit or to_commit:
@@ -3426,7 +3426,7 @@ class GitRepo(RepoInterface):
         to_remove = [
             # TODO remove pathobj stringification when delete() can
             # handle it
-            str(f.relative_to(self.pathobj))
+            text_type(f.relative_to(self.pathobj))
             for f, props in iteritems(status)
             if props.get('state', None) == 'deleted' and
             # staged deletions have a gitshasum reported for them
@@ -3477,7 +3477,7 @@ class GitRepo(RepoInterface):
             for cand_sm in to_add_submodules:
                 try:
                     self.add_submodule(
-                        str(cand_sm.relative_to(self.pathobj)),
+                        text_type(cand_sm.relative_to(self.pathobj)),
                         url=None, name=None)
                 except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(
@@ -3494,7 +3494,7 @@ class GitRepo(RepoInterface):
             # without a partial commit an AnnexRepo would ignore any submodule
             # path in its add helper, hence `git add` them explicitly
             to_stage_submodules = {
-                str(f.relative_to(self.pathobj)): props
+                text_type(f.relative_to(self.pathobj)): props
                 for f, props in iteritems(status)
                 if props.get('state', None) in ('modified', 'untracked')
                 and props.get('type', None) == 'dataset'}
@@ -3543,12 +3543,12 @@ class GitRepo(RepoInterface):
         to_add = {
             # TODO remove pathobj stringification when add() can
             # handle it
-            str(f.relative_to(self.pathobj)): props
+            text_type(f.relative_to(self.pathobj)): props
             for f, props in iteritems(status)
             if props.get('state', None) in ('modified', 'untracked')}
         if to_add:
             lgr.debug(
-                '%i path(s) to add to %r %s',
+                '%i path(s) to add to %s %s',
                 len(to_add), self, to_add if len(to_add) < 10 else '')
             for r in self._save_add(
                     to_add,

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1689,7 +1689,7 @@ def get_deeply_nested_structure(path):
     |  .
     |  ├── directory_untracked
     |  │   └── link2dir -> ../subdir
-    |  ├── file_modified
+    |  ├── OBSCURE_FILENAME_file_modified
     |  ├── link2dir -> subdir
     |  ├── link2subdsdir -> subds_modified/subdir
     |  ├── link2subdsroot -> subds_modified
@@ -1703,7 +1703,7 @@ def get_deeply_nested_structure(path):
     |      ├── subdir
     |      │   └── annexed_file.txt -> ../.git/annex/objects/...
     |      └── subds_lvl1_modified
-    |          └── directory_untracked
+    |          └── OBSCURE_FILENAME_directory_untracked
     |              └── untracked_file
     """
     ds = Dataset(path).rev_create()
@@ -1722,12 +1722,12 @@ def get_deeply_nested_structure(path):
             'subdir': {
                 'file_modified': 'file_modified',
             },
-            'file_modified': 'file_modified',
+            OBSCURE_FILENAME + u'file_modified_': 'file_modified',
         }
     )
     create_tree(
         text_type(ds.pathobj / 'subds_modified' / 'subds_lvl1_modified'),
-        {'directory_untracked' : {"untraced_file": ""}}
+        {OBSCURE_FILENAME + u'_directory_untracked': {"untraced_file": ""}}
     )
     (ut.Path(subds.path) / 'subdir').mkdir()
     (ut.Path(subds.path) / 'subdir' / 'annexed_file.txt').write_text(u'dummy')


### PR DESCRIPTION
* Avoid `str(pathobj)` to prevent py2-encoding issues.
* Make `runner.(..., env={...})` work when env has unicode values (py2).

---

A couple of notes:

  * This will very likely conflict with ongoing topics.  I'm fine leaving this until those land and then dealing with the conflicts.

  * I've avoided OBSCURE_FILENAME for compatibility with older Windows, but I'm not sure that is something worth doing.  I'm happy to rewrite the tests using OBSCURE_FILENAME.

  * This PR carries a change dealing with the runner.  That commit is branched off of 0.11.x so that it can be merged into that line separately, but it is needed here too.
