### PR TITLE
BF/ENH: create-sibling with --ui true for publish_on_github cast

### DIFF
--- a/docs/casts/publish_on_github.sh
+++ b/docs/casts/publish_on_github.sh
@@ -18,8 +18,8 @@ say "1. Host the data file at some publicly accessible location"
 say "2. Configure DataLad to make sure that getting data from GitHub transparently requests from this other location instead"
 
 say "Here we use a personal webserver with SSH access, but, in principle, any hosting solution supported by git-annex is equally suitable"
-say "We create a remote sibling of our dataset under the name 'myserver' via SSH, and tell datalad to track it as a common data source that is available for any future installation of this dataset. Access to this location will happen via the given http:// URL"
-run "datalad create-sibling -s myserver demo.datalad.org:public_html/publish-demo --as-common-datasrc demo-server --target-url http://demo.datalad.org/publish-demo/.git"
+say "We create a remote sibling of our dataset under the name 'myserver' via SSH, and tell datalad to track it as a common data source that is available for any future installation of this dataset. Access to this location will happen via the given http:// URL, and --ui true tells to install DataLad web UI as on http://datasets.datalad.org. Note that /.git in the URL most likely to be necessary in your case."
+run "datalad create-sibling -s myserver demo.datalad.org:public_html/publish-demo --ui true --as-common-datasrc demo-server --target-url http://demo.datalad.org/publish-demo/.git"
 
 say "With this configuration in place, we can now create a repository on GitHub, and configure the remote sibling on the SSH server as a publication dependency"
 run "datalad create-sibling-github --github-organization datalad --publish-depends myserver --access-protocol ssh publish-demo"


### PR DESCRIPTION
In #3318 (a4d40a607cb54a5cd4b49459496c6c64449ec666 in particular) I changed behavior
that no post-update hook  is installed by default.  And that is indeed desired since
unless it is a publicly facing via http git repository there is no need in such a hook.
BUT ATM the hook is unconfigurably melds two effects together:

  - making this repo accessible via dummy git http backend (by running git update-server-info)
  - and generating web listing metadata

There is no configuration to enable one but not another action in the hook.

So for this cast to still work with current functionality, we would need to enable web UI
which will establish the hook (and also install web UI index.html and all the needed JS
libraries).  In the long run I guess we should disentangle two aspects somehow and
grow the hook with needed feature depending on the configuration.
