### PR TITLE
travis: Drop some runs from regular build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
     # We cannot have empty -A selector, so the one which always will be fulfilled
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+    - _DL_CRON=1
   - python: 3.6
     # Single run for Python 3.6
     env:
@@ -48,6 +49,7 @@ matrix:
     # We cannot have empty -A selector, so the one which always will be fulfilled
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+    - _DL_CRON=1
   - python: 3.5
     # Split runs for v6 since a single one is too long now
     env:
@@ -68,6 +70,7 @@ matrix:
     # And the leading - in filenames for the most challenge
     - DATALAD_TESTS_OBSCURE_PREFIX=-
     - DATALAD_LOG_TRACEBACK=collide  # just a smoke test for now
+    - _DL_CRON=1
   - python: 3.5
     # A run loaded with various customizations to smoke test those functionalities
     # apparently moving symlink outside has different effects on abspath
@@ -101,6 +104,7 @@ matrix:
     - GIT_COMMITTER_DATE="Thu, 07 Apr 2005 22:13:13 +0200"
     - GIT_COMMITTER_NAME=blah
     - GIT_COMMITTER_EMAIL=committer@example.com
+    - _DL_CRON=1
   - python: 3.5
     # Test some under NFS mount  (only selected sub-set)
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_DIRECT=yes
 ##1    - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5
 
@@ -58,6 +57,9 @@ matrix:
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=""
+  - python: 3.5
+    env:
+    - DATALAD_REPO_DIRECT=yes
   - python: 3.5
     # Run slow etc tests under a single tricky scenario
     env:


### PR DESCRIPTION
Mark more runs as cron runs and remove py2 direct mode test.

---

These are things that I think we don't need to test every PR.  The benefit is of course faster test runs, but the downside is that an issue will go unnoticed because it is failing in the cron run.  If we go forward with this though, I'll set myself a weekly reminder to check those :]

Note: This is against 0.11.x.  It will require a manual merge into master so that the direct mode run isn't introduced into master's .travis.yml.
