### PR TITLE
ENH: short -R for --recursion-limit

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -391,7 +391,7 @@ class Get(Interface):
             constraints=EnsureStr() | EnsureNone()),
         recursive=recursion_flag,
         recursion_limit=Parameter(
-            args=("--recursion-limit",),
+            args=("-R", "--recursion-limit",),
             metavar="LEVELS",
             constraints=EnsureInt() | EnsureChoice('existing') | EnsureNone(),
             doc="""limit recursion into subdataset to the given number of levels.

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -33,7 +33,7 @@ recursion_flag = Parameter(
     doc="""if set, recurse into potential subdataset""")
 
 recursion_limit = Parameter(
-    args=("--recursion-limit",),
+    args=("-R", "--recursion-limit",),
     metavar="LEVELS",
     constraints=EnsureInt() | EnsureNone(),
     doc="""limit recursion into subdataset to the given number of levels""")


### PR DESCRIPTION
Because of otherwise too long of a run time I often need to use --recursion-limit
for operations such as diff while working with deep hierarchies. So I felt that it
would be nice to have a short cmdline option for it.  Another to  -R was -L (tree
uses it), but we do use -L already in elderly  datalad ls   so decided to go for -R

But if you feel that not desired/needed or different option than -R to use -- I am all ears ;)