### PR TITLE
TEMP ENH(Q&D): @collect_call_sigs_stats to determine signatures of most frequent calls

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -390,7 +390,7 @@ class Runner(object):
         elif hasattr(x, '__call__'):
             if getattr(x, '__name__', None) == '<lambda>':
                 try:
-                    return "lambda %s" % getsource(x)
+                    return getsource(x).strip()
                 except IOError:
                     return "<unknown-lambda>"
             return x.__class__.__name__

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2229,5 +2229,62 @@ def get_suggestions_msg(values, known, sep="\n        "):
     return ''
 
 
+@optional_args
+def collect_call_sigs_stats(f,
+                            name=None,
+                            ignore_args=set(),
+                            kwargs_handlers={},
+                            ):
+    """Collect function call statistics.
+
+    """
+    if not name:
+        name = f.__name__
+
+    CALL_SIGS_STATS = {}
+
+    def display_call_sigs_stats():
+        print("===== Call signature statistics for %s" % name)
+        # sort by count
+        items = sorted(CALL_SIGS_STATS.items(), key=lambda x: x[1], reverse=True)
+        for (args, kwargs), count in items:
+            kwargs = tuple("%s=%r" % x for x in kwargs)
+            print("%d of %s" % (count, ', '.join(map(str, tuple(args) + kwargs))))
+
+    import atexit
+    atexit.register(display_call_sigs_stats)
+
+    def immutable(x):
+        if isinstance(x, (list, tuple, set)):
+            return tuple(map(immutable, x))
+        elif isinstance(x, dict):
+            return tuple(map(immutable, x.items()))
+        else:
+            return x
+
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        # dummy one, assumes that args aren't mentioned as kwargs
+        sig_args = tuple(immutable(a) for i, a in enumerate(args)
+                        if i not in ignore_args)
+        # import inspect
+        # if inspect.isgenerator(sig_args[0]):
+        #     import pdb; pdb.set_trace()
+        sig_kwargs = {}
+        for kwarg, value in kwargs.items():
+            if kwarg in kwargs_handlers:
+                value = kwargs_handlers[kwarg](value)
+            sig_kwargs[kwarg] = value
+
+        sig_kwargs = immutable(sig_kwargs)
+        SIG = (sig_args, sig_kwargs)
+        if SIG not in CALL_SIGS_STATS:
+            CALL_SIGS_STATS[SIG] = 0
+        CALL_SIGS_STATS[SIG] += 1
+        return f(*args, **kwargs)
+
+    return wrapped
+
+
 
 lgr.log(5, "Done importing datalad.utils")


### PR DESCRIPTION
Initial use case is the Runner, which is currently "slow", see https://github.com/datalad/datalad/issues/3262 .

With this Quick&Dirty @collect_call_sigs_stats it is possible to see what are the
most frequent calls, and here we check it on Runner.run.  If running across support/tests/*repo*.py
the summary is

    ===== Call signature statistics for run
    2335 of log_stderr=True, env="<some-True>"
    678 of shell=None, expect_fail=False, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd=None, expect_stderr=True
    555 of env="<some-True>"
    549 of shell=None, expect_fail=True, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd=None, expect_stderr=True
    431 of shell=False, expect_fail=True, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd=None, expect_stderr=False
    167 of log_online=True, log_stderr="lambda             log_stderr=lambda s: lgr.info(s.rstrip()), log_online=True,\n", env="<some-True>"
    130 of shell=False, expect_fail=True, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd="<some-True>", expect_stderr=False
    122 of expect_fail=True, env="<some-True>"
    109 of log_stdout="ProcessAnnexProgressIndicators", env="<some-True>", log_online=True, log_stderr="offline", expect_fail=True, expect_stderr=True
    69 of expect_fail=True, env="<some-True>", expect_stderr=True
    66 of shell=None, expect_fail=True, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd="<some-True>", expect_stderr=False
    53 of shell=None, expect_fail=True, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd="<some-True>", expect_stderr=True
    34 of log_online=True, log_stderr="offline", log_stdout="ProcessAnnexProgressIndicators", env="<some-True>"
    30 of cwd="<some-True>", log_stdout=True, env="<some-True>", log_stderr=True, expect_fail=True, expect_stderr=True
    26 of expect_stderr=True
    15 of shell=None, expect_fail=False, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, cwd="<some-True>", expect_stderr=True
    14 of log_stdout="ProcessAnnexProgressIndicators", log_stderr="offline", log_online=True, env="<some-True>"
    8 of
    8 of shell=False, log_stdout=True, env="<some-True>", log_online=False, log_stderr=True, expect_fail=True, expect_stderr=False
    7 of env="<some-True>", expect_stderr=True
    5 of cwd="<some-True>"
    3 of log_online=True, log_stderr=False, cwd=None, env="<some-True>"
    1 of shell=False, expect_fail=True, log_stdout=True, env=None, log_online=False, log_stderr=True, cwd="<some-True>", expect_stderr=False
    1 of shell=None, expect_fail=False, log_stdout=True, env=None, log_online=False, log_stderr=True, cwd=None, expect_stderr=True
    1 of expect_fail=True, expect_stderr=True
    1 of shell=None, expect_fail=True, log_stdout=True, env=None, log_online=False, log_stderr=True, cwd="<some-True>", expect_stderr=True
    1 of shell=None, expect_fail=True, log_stdout=True, env=None, log_online=False, log_stderr=True, cwd=None, expect_stderr=True

With the next commit I will include timing information.  This PR is not intended to be merged, although if others see value, I could tune it up for merging so we could reuse this elsewhere when/if needed.

[ci skip]