### PR TITLE
ENH: issue a warning (using warnings.warn) if git is too old for us to check

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -351,3 +351,19 @@ class CrawlerError(Exception):
 
 class PipelineNotSpecifiedError(CrawlerError):
     pass
+
+
+#
+# Warnings
+#
+
+class DataLadWarning(Warning):
+    pass
+
+
+# We have an exception OutdatedExternalDependency, but it is intended for
+# an instance being raised.  `warnings` module requires a class to be provided
+# as a category, so here is a dedicated Warning class
+class OutdatedExternalDependencyWarning(DataLadWarning):
+    """Warning "category" to use to report about outdated"""
+    pass

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import local_testrepo_flavors
 from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import SkipTest
+from datalad.tests.utils import skip_if
 from datalad.utils import rmtree
 from datalad.tests.utils_testrepos import BasicAnnexTestRepo
 from datalad.utils import getpwd, chpwd
@@ -147,6 +148,7 @@ def test_GitRepo_init_options(path):
     ok_(cfg.get_value(section="core", option="bare"))
 
 
+@skip_if(external_versions['cmd:git'] < '2.14.0')
 @with_tree(
     tree={
         'subds': {


### PR DESCRIPTION
for known paths from parent directory.

Decided to (start) using warnings.warn (instead of logging.warn) because

- we need to have it issued only once, not upon every init (why to flood?)

- we are expecting action on "client" side -- upgrade, so that is the recommended way
  to do it according to https://docs.python.org/2/howto/logging.html#when-to-use-logging

Closes #3295
Replaces #3296
