### PR TITLE
More useful AnnexRepo.whereis()

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -778,8 +778,12 @@ class BatchedCommand(object):
         if not input_multiple:
             cmds = [cmds]
 
-        output = [o for o in self.yield_(cmds)]
-        return output if input_multiple else output[0]
+        output = list(self.yield_(cmds))
+        if input_multiple:
+            return output
+        else:
+            assert len(output) == 1, "There should be a single output item"
+            return output[0]
 
     def yield_(self, cmds):
         for entry in cmds:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -778,8 +778,10 @@ class BatchedCommand(object):
         if not input_multiple:
             cmds = [cmds]
 
-        output = []
+        output = [o for o in self.yield_(cmds)]
+        return output if input_multiple else output[0]
 
+    def yield_(self, cmds):
         for entry in cmds:
             if not isinstance(entry, string_types):
                 entry = ' '.join(entry)
@@ -805,9 +807,7 @@ class BatchedCommand(object):
             if stderr:
                 lgr.warning("Received output in stderr: %r", stderr)
             lgr.log(5, "Received output: %r" % stdout)
-            output.append(stdout)
-
-        return output if input_multiple else output[0]
+            yield stdout
 
     def __del__(self):
         self.close()

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2234,7 +2234,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         ------
         dict
             A response dictionary to each query path with the following keys:
-            'path' with the queried path in the same form t was provided;
+            'path' with the queried path in the same form it was provided;
             'status' {ok|error} indicating whether git annex was queried
             successfully for a path; 'key' with the annex key for the file;
             'remotes' with a dictionary of remotes that have a copy of the
@@ -2244,7 +2244,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         if isinstance(paths, string_types):
             raise ValueError('AnnexRepo.whereis_file(paths): paths must be '
-                             'iterable, not a string type')
+                             'a non-string type iterable')
 
         cmd = self._batched.get('whereis', json=True, path=self.path)
         for path in paths:


### PR DESCRIPTION
https://github.com/datalad/datalad-revolution/pull/84 needs efficient batched whereis queries. The current `AnnexRepo.whereis()` is not suitable for this. It aims to be universal and fails at it. Given that `annex whereis` does not support all queries in batched mode, I decided that it would be best to have a dedicated implementation for path queries.

In contrast to the previous whereis() this one has:

- a simpler API (no options at all)
- cannot query for a key (not possible in batched mode)
- cannot do recursive queries (not possible in batched mode)
- states what file a response belongs too

I comes in two flavors: single-path queries, and generator for multi-path queries.

I also include an RF for `BatchedCommand` that adds a `yield_()` method which bypasses the collect-everything-into-a-list-first approach, which torpedos generator-style usage.

I will adjust the tests, once it is clear to me that this solution is optimal for the metadata use case.