### PR TITLE
ENH: Add low-level switch to prevent file type evaluation

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2816,7 +2816,7 @@ class GitRepo(RepoInterface):
         eval_file_type : bool
           If True, inspect file type of untracked files, and report annex
           symlink pointers as type 'file'. This convenience comes with a
-          cost, disable for to get faster performance if this information
+          cost; disable to get faster performance if this information
           is not needed.
 
         Returns


### PR DESCRIPTION
... in GitRepo.get_content_info()

This can give a significant performance boost in datasets with a large
number of file, and when no homogenized file type semantics are needed
(e.g. "was there any diff?").