### PR TITLE
ENH: AnnexRepo.get_metadata(batch=True) 

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -778,8 +778,10 @@ class BatchedCommand(object):
         if not input_multiple:
             cmds = [cmds]
 
-        output = []
+        output = [o for o in self.yield_(cmds)]
+        return output if input_multiple else output[0]
 
+    def yield_(self, cmds):
         for entry in cmds:
             if not isinstance(entry, string_types):
                 entry = ' '.join(entry)
@@ -805,9 +807,7 @@ class BatchedCommand(object):
             if stderr:
                 lgr.warning("Received output in stderr: %r", stderr)
             lgr.log(5, "Received output: %r" % stdout)
-            output.append(stdout)
-
-        return output if input_multiple else output[0]
+            yield stdout
 
     def __del__(self):
         self.close()

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1851,6 +1851,9 @@ def test_AnnexRepo_metadata(path):
         playfile: {
             'tag': ['one and= ']}}
     deq_(target, dict(ar.get_metadata('.')))
+    for batch in (True, False):
+        # no difference in reporting between modes
+        deq_(target, dict(ar.get_metadata(['up.dat', playfile], batch=batch)))
     # incremental work like a set
     ar.set_metadata(playfile, add={'tag': 'one and= '})
     deq_(target, dict(ar.get_metadata('.')))


### PR DESCRIPTION
This is a fragile enterprise due to the limitations of `BatchedCommand()`. When queried for a non-annexed file, git annex will error not via JSON response, but through stderr

```
{"file": "."}
git-annex: not an annexed file: .
```

which ATM is not monitored at all. I assume due to the general sadness of subprocess under PY2.

Docstrings warn about this, and there is no `batch=None` automagic because of this.

Other than that, it works.

This is needed to achieve a sensible performance of the `annex` extractor in -revolution (the behavior of the one in -core is pointless anyways), where all these limitation do not matter.

Waiting here: https://github.com/datalad/datalad-revolution/compare/enh-annex