### PR TITLE
Fix up index logic from gh-3009

### DIFF
--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -482,3 +482,17 @@ def test_save_directory(path):
     with chpwd(opj(path, 'sdir3')):
         save(path='sdir')
     ok_clean_git(ds.path)
+
+
+@with_tree({'.gitattributes': "* annex.largefiles=(largerthan=4b)",
+            "foo": "in annex"})
+def test_save_partial_index(path):
+    ds = Dataset(path).create(force=True)
+    ds.add("foo")
+    ok_clean_git(ds.path)
+    ds.unlock(path="foo")
+    create_tree(ds.path, tree={"foo": "a", "staged": ""},
+                remove_existing=True)
+    ds.repo.add("staged", git=True)
+    ds.save(path="foo")
+    ok_clean_git(ds.path, head_modified=["staged"])

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2937,15 +2937,15 @@ class AnnexRepo(GitRepo, RepoInterface):
                     # Files which were staged but not among files
                     staged_not_to_commit = all_changed_staged.difference(files_changed_staged)
 
-                    if staged_not_to_commit or files_changed_notstaged:
+                    if files_changed_notstaged:
+                        self.add(files=list(files_changed_notstaged))
+
+                    if staged_not_to_commit:
                         # Need an alternative index_file
                         with make_tempfile(dir=opj(self.path,
                                                    GitRepo.get_git_dir(self)),
                                            prefix="datalad-",
                                            suffix=".index") as index_file:
-                            # First add those which were changed but not staged yet
-                            if files_changed_notstaged:
-                                self.add(files=list(files_changed_notstaged))
 
                             alt_index_file = index_file
                             index_tree = self.repo.git.write_tree()

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2964,12 +2964,12 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 careless=careless,
                                 index_file=alt_index_file)
 
-                            if files_changed_notstaged:
-                                # reset current index to reflect the changes annex might have done
-                                self._git_custom_command(
-                                    list(files_changed_notstaged),
-                                    ['git', 'reset']
-                                )
+                            # reset current index to reflect the changes annex might have done
+                            self._git_custom_command(
+                                list(files_changed_notstaged |
+                                     files_changed_staged),
+                                ['git', 'reset']
+                            )
 
                     # in any case we will not specify files explicitly
                     files_to_commit = None


### PR DESCRIPTION

This PR

  * fixes an issue with the partial commit workaround in AnnexRepo.commit() introduced by gh-3009.
  * avoids using the temporary index in a case where it is unnecessary

<details>
<summary>Demo of the issue</summary>

```sh
#!/bin/sh

set -ex

cd $(mktemp -dt dl-XXXXXXX)
datalad create
printf '\n* annex.largefiles=(largerthan=4b)\n' >>.gitattributes
datalad add .gitattributes

printf "so big; to annex i go" >ishrink
datalad save ishrink

datalad unlock ishrink
: >ishrink

# A staged change that won't be specified as a path to save,
# triggering the partial commit.
: >staged && git add staged

datalad save ishrink

git status -s
```

Without this PR, the status output is

```
TT ishrink
A  staged
```

even though ishrink was just committed and should be clean.

</details>

