### PR TITLE
Absorb rev-diff

### DIFF
--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -12,7 +12,6 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-import os
 import os.path as op
 from six import (
     iteritems,
@@ -40,7 +39,6 @@ from datalad.distribution.dataset import (
 from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
-    EnsureChoice,
 )
 from datalad.support.param import Parameter
 from datalad.consts import PRE_INIT_COMMIT_SHA

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -1,0 +1,337 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Report differences between two states of a dataset (hierarchy)"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import os
+import os.path as op
+from six import (
+    iteritems,
+    text_type,
+)
+from collections import OrderedDict
+from datalad.utils import (
+    assure_list,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+
+from datalad.distribution.dataset import (
+    Dataset,
+    datasetmethod,
+    require_dataset,
+    rev_resolve_path,
+    path_under_rev_dataset,
+    rev_get_dataset_root,
+)
+
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+    EnsureChoice,
+)
+from datalad.support.param import Parameter
+from datalad.consts import PRE_INIT_COMMIT_SHA
+
+from datalad.core.local.status import (
+    Status,
+    _common_diffstatus_params,
+)
+
+lgr = logging.getLogger('datalad.core.local.diff')
+
+
+@build_doc
+class Diff(Interface):
+    """Report differences between two states of a dataset (hierarchy)
+
+    The two to-be-compared states are given via to --from and --to options.
+    These state identifiers are evaluated in the context of the (specified
+    or detected) dataset. In case of a recursive report on a dataset
+    hierarchy corresponding state pairs for any subdataset are determined
+    from the subdataset record in the respective superdataset. Only changes
+    recorded in a subdataset between these two states are reported, and so on.
+
+    Any paths given as additional arguments will be used to constrain the
+    difference report. As with Git's diff, it will not result in an error when
+    a path is specified that does not exist on the filesystem.
+
+    Reports are very similar to those of the `rev-status` command, with the
+    distinguished content types and states being identical.
+    """
+    # make the custom renderer the default one, as the global default renderer
+    # does not yield meaningful output for this command
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        _common_diffstatus_params,
+        path=Parameter(
+            args=("path",),
+            metavar="PATH",
+            doc="""path to contrain the report to""",
+            nargs="*",
+            constraints=EnsureStr() | EnsureNone()),
+        fr=Parameter(
+            args=("-f", "--from",),
+            dest='fr',
+            metavar="REVISION",
+            doc="""original state to compare to, as given by any identifier
+            that Git understands.""",
+            nargs=1,
+            constraints=EnsureStr()),
+        to=Parameter(
+            args=("-t", "--to",),
+            metavar="REVISION",
+            doc="""state to compare against the original state, as given by
+            any identifier that Git understands. If none is specified,
+            the state of the worktree will be used compared.""",
+            nargs=1,
+            constraints=EnsureStr() | EnsureNone()),
+    )
+
+    @staticmethod
+    @datasetmethod(name='diff')
+    @eval_results
+    def __call__(
+            fr='HEAD',
+            to=None,
+            path=None,
+            dataset=None,
+            annex=None,
+            untracked='normal',
+            recursive=False,
+            recursion_limit=None):
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='difference reporting')
+
+        # convert cmdline args into plain labels
+        if isinstance(fr, list):
+            fr = fr[0]
+        if isinstance(to, list):
+            to = to[0]
+
+        for r in _diff_cmd(
+                ds=ds,
+                dataset=dataset,
+                fr=fr,
+                to=to,
+                constant_refs=False,
+                path=path,
+                annex=annex,
+                untracked=untracked,
+                recursive=recursive,
+                recursion_limit=recursion_limit):
+            yield r
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):  # pragma: no cover
+        Status.custom_result_renderer(res, **kwargs)
+
+
+def _diff_cmd(
+        ds,
+        dataset,
+        fr,
+        to,
+        constant_refs,
+        path=None,
+        annex=None,
+        untracked='normal',
+        recursive=False,
+        recursion_limit=None,
+        eval_file_type=True):
+    """Internal helper to actually run the command"""
+    # we cannot really perform any sorting of paths into subdatasets
+    # or rejecting paths based on the state of the filesystem, as
+    # we need to be able to compare with states that are not represented
+    # in the worktree (anymore)
+    if path:
+        ps = []
+        # sort any path argument into the respective subdatasets
+        for p in sorted(assure_list(path)):
+            # it is important to capture the exact form of the
+            # given path argument, before any normalization happens
+            # distinguish rsync-link syntax to identify
+            # a dataset as whole (e.g. 'ds') vs its
+            # content (e.g. 'ds/')
+            # special case is the root dataset, always report its content
+            # changes
+            orig_path = text_type(p)
+            resolved_path = rev_resolve_path(p, dataset)
+            p = \
+                resolved_path, \
+                orig_path.endswith(op.sep) or resolved_path == ds.pathobj
+            str_path = text_type(p[0])
+            root = rev_get_dataset_root(str_path)
+            if root is None:
+                # no root, not possibly underneath the refds
+                yield dict(
+                    action='status',
+                    path=str_path,
+                    refds=ds.path,
+                    status='error',
+                    message='path not underneath this dataset',
+                    logger=lgr)
+                continue
+            if path_under_rev_dataset(ds, str_path) is None:
+                # nothing we support handling any further
+                # there is only a single refds
+                yield dict(
+                    path=str_path,
+                    refds=ds.path,
+                    action='diff',
+                    status='error',
+                    message=(
+                        "dataset containing given paths is not underneath "
+                        "the reference dataset %s: %s",
+                        ds, str_path),
+                    logger=lgr,
+                )
+                continue
+
+            ps.append(p)
+        path = ps
+
+    # TODO we might want to move away from the single-pass+immediate-yield
+    # paradigm for this command. If we gather all information first, we
+    # could do post-processing and detect when a file (same gitsha, or same
+    # key) was copied/moved from another dataset. Another command (e.g.
+    # rev-save) could act on this information and also move/copy
+    # availability information or at least enhance the respective commit
+    # message with cross-dataset provenance info
+
+    # cache to help avoid duplicate status queries
+    content_info_cache = {}
+    for res in _diff_ds(
+            ds,
+            fr,
+            to,
+            constant_refs,
+            recursion_limit
+            if recursion_limit is not None and recursive
+            else -1 if recursive else 0,
+            # TODO recode paths to repo path reference
+            origpaths=None if not path else OrderedDict(path),
+            untracked=untracked,
+            annexinfo=annex,
+            eval_file_type=True,
+            cache=content_info_cache):
+        res.update(
+            refds=ds.path,
+            logger=lgr,
+            action='diff',
+        )
+        yield res
+
+
+def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
+             annexinfo, eval_file_type, cache):
+    if not ds.repo:
+        # asked to query a subdataset that is not available
+        lgr.debug("Skip diff of unavailable subdataset: %s", ds)
+        return
+
+    repo_path = ds.repo.pathobj
+    # filter and normalize paths that match this dataset before passing them
+    # onto the low-level query method
+    paths = None if origpaths is None \
+        else OrderedDict(
+            (repo_path / p.relative_to(ds.pathobj), goinside)
+            for p, goinside in iteritems(origpaths)
+            if ds.pathobj in p.parents or (p == ds.pathobj and goinside)
+        )
+    try:
+        lgr.debug("diff %s from '%s' to '%s'", ds, fr, to)
+        diff_state = ds.repo.diffstatus(
+            fr,
+            to,
+            paths=None if not paths else [p for p in paths],
+            untracked=untracked,
+            eval_file_type=eval_file_type,
+            _cache=cache)
+    except ValueError as e:
+        msg_tmpl = "reference '{}' invalid"
+        # not looking for a debug repr of the exception, just the message
+        estr = text_type(e)
+        if msg_tmpl.format(fr) in estr or msg_tmpl.format(to) in estr:
+            yield dict(
+                path=ds.path,
+                status='impossible',
+                message=estr,
+            )
+            return
+
+    if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
+        # this will ammend `status`
+        ds.repo.get_content_annexinfo(
+            paths=paths if paths else None,
+            init=diff_state,
+            eval_availability=annexinfo in ('availability', 'all'),
+            ref=to)
+        if fr != to:
+            ds.repo.get_content_annexinfo(
+                paths=paths if paths else None,
+                init=diff_state,
+                eval_availability=annexinfo in ('availability', 'all'),
+                ref=fr,
+                key_prefix="prev_")
+
+    for path, props in iteritems(diff_state):
+        pathinds = text_type(ds.pathobj / path.relative_to(repo_path))
+        yield dict(
+            props,
+            path=pathinds,
+            # report the dataset path rather than the repo path to avoid
+            # realpath/symlink issues
+            parentds=ds.path,
+            status='ok',
+        )
+        # if a dataset, and given in rsync-style 'ds/' or with sufficient
+        # recursion level left -> dive in
+        if props.get('type', None) == 'dataset' and (
+                (paths and paths.get(path, False)) or recursion_level != 0):
+            subds_state = props.get('state', None)
+            if subds_state in ('clean', 'deleted'):
+                # no need to look into the subdataset
+                continue
+            elif subds_state in ('added', 'modified'):
+                # dive
+                subds = Dataset(pathinds)
+                for r in _diff_ds(
+                        subds,
+                        # from before time or from the reported state
+                        fr if constant_refs
+                        else PRE_INIT_COMMIT_SHA
+                        if subds_state == 'added'
+                        else props['prev_gitshasum'],
+                        # to the last recorded state, or the worktree
+                        None if to is None
+                        else to if constant_refs
+                        else props['gitshasum'],
+                        constant_refs,
+                        # subtract on level on the way down, unless the path
+                        # args instructed to go inside this subdataset
+                        recursion_level=recursion_level
+                        if paths and paths.get(path, False) else recursion_level - 1,
+                        origpaths=origpaths,
+                        untracked=untracked,
+                        annexinfo=annexinfo,
+                        eval_file_type=eval_file_type,
+                        cache=cache):
+                    yield r
+            else:
+                raise RuntimeError(
+                    "Unexpected subdataset state '{}'. That sucks!".format(
+                        subds_state))

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -87,7 +87,6 @@ class Diff(Interface):
             metavar="REVISION",
             doc="""original state to compare to, as given by any identifier
             that Git understands.""",
-            nargs=1,
             constraints=EnsureStr()),
         to=Parameter(
             args=("-t", "--to",),
@@ -95,7 +94,6 @@ class Diff(Interface):
             doc="""state to compare against the original state, as given by
             any identifier that Git understands. If none is specified,
             the state of the worktree will be used compared.""",
-            nargs=1,
             constraints=EnsureStr() | EnsureNone()),
     )
 
@@ -113,12 +111,6 @@ class Diff(Interface):
             recursion_limit=None):
         ds = require_dataset(
             dataset, check_installed=True, purpose='difference reporting')
-
-        # convert cmdline args into plain labels
-        if isinstance(fr, list):
-            fr = fr[0]
-        if isinstance(to, list):
-            to = to[0]
 
         for r in _diff_cmd(
                 ds=ds,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -262,6 +262,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                 message=estr,
             )
             return
+        raise
 
     if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
         # this will ammend `status`

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -103,9 +103,9 @@ class Diff(Interface):
     @datasetmethod(name='diff')
     @eval_results
     def __call__(
+            path=None,
             fr='HEAD',
             to=None,
-            path=None,
             dataset=None,
             annex=None,
             untracked='normal',

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -267,13 +267,13 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
     if annexinfo and hasattr(ds.repo, 'get_content_annexinfo'):
         # this will ammend `status`
         ds.repo.get_content_annexinfo(
-            paths=paths if paths else None,
+            paths=paths.keys() if paths is not None else paths,
             init=diff_state,
             eval_availability=annexinfo in ('availability', 'all'),
             ref=to)
         if fr != to:
             ds.repo.get_content_annexinfo(
-                paths=paths if paths else None,
+                paths=paths.keys() if paths is not None else paths,
                 init=diff_state,
                 eval_availability=annexinfo in ('availability', 'all'),
                 ref=fr,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -228,7 +228,7 @@ def _diff_cmd(
 
 def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
              annexinfo, eval_file_type, cache):
-    if not ds.repo:
+    if not ds.is_installed():
         # asked to query a subdataset that is not available
         lgr.debug("Skip diff of unavailable subdataset: %s", ds)
         return

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -1,0 +1,441 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""test dataset diff
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+from six import text_type
+import os
+import os.path as op
+from datalad.support.exceptions import (
+    NoDatasetArgumentFound,
+)
+
+from datalad.consts import PRE_INIT_COMMIT_SHA
+from datalad.cmd import GitRunner
+from datalad.utils import (
+    on_windows,
+)
+from datalad.tests.utils import (
+    with_tempfile,
+    create_tree,
+    eq_,
+    ok_,
+    assert_raises,
+    assert_status,
+    assert_in,
+    chpwd,
+    assert_result_count,
+    OBSCURE_FILENAME,
+)
+
+import datalad.utils as ut
+from datalad.distribution.dataset import Dataset
+from datalad.api import (
+    rev_save as save,
+    rev_create as create,
+    diff,
+)
+from datalad.tests.utils import (
+    get_deeply_nested_structure,
+    has_symlink_capability,
+    assert_repo_status,
+)
+
+
+def test_magic_number():
+    # we hard code the magic SHA1 that represents the state of a Git repo
+    # prior to the first commit -- used to diff from scratch to a specific
+    # commit
+    # given the level of dark magic, we better test whether this stays
+    # constant across Git versions (it should!)
+    out, err = GitRunner().run('cd ./ | git hash-object --stdin -t tree')
+    eq_(out.strip(), PRE_INIT_COMMIT_SHA)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_repo_diff(path, norepo):
+    ds = Dataset(path).rev_create()
+    assert_repo_status(ds.path)
+    assert_raises(ValueError, ds.repo.diff, fr='WTF', to='MIKE')
+    # no diff
+    eq_(ds.repo.diff('HEAD', None), {})
+    # bogus path makes no difference
+    eq_(ds.repo.diff('HEAD', None, paths=['THIS']), {})
+    # let's introduce a known change
+    create_tree(ds.path, {'new': 'empty'})
+    ds.rev_save(to_git=True)
+    assert_repo_status(ds.path)
+    eq_(ds.repo.diff(fr='HEAD~1', to='HEAD'),
+        {ut.Path(ds.repo.pathobj / 'new'): {
+            'state': 'added',
+            'type': 'file',
+            'bytesize': 5,
+            'gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6'}})
+    # modify known file
+    create_tree(ds.path, {'new': 'notempty'})
+    eq_(ds.repo.diff(fr='HEAD', to=None),
+        {ut.Path(ds.repo.pathobj / 'new'): {
+            'state': 'modified',
+            'type': 'file',
+            # the beast is modified, but no change in shasum -> not staged
+            'gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6',
+            'prev_gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6'}})
+    # per path query gives the same result
+    eq_(ds.repo.diff(fr='HEAD', to=None),
+        ds.repo.diff(fr='HEAD', to=None, paths=['new']))
+    # also given a directory as a constraint does the same
+    eq_(ds.repo.diff(fr='HEAD', to=None),
+        ds.repo.diff(fr='HEAD', to=None, paths=['.']))
+    # but if we give another path, it doesn't show up
+    eq_(ds.repo.diff(fr='HEAD', to=None, paths=['other']), {})
+
+    # make clean
+    ds.rev_save()
+    assert_repo_status(ds.path)
+
+    # untracked stuff
+    create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
+    # default is to report all files
+    eq_(ds.repo.diff(fr='HEAD', to=None),
+        {
+            ut.Path(ds.repo.pathobj / 'deep' / 'down'): {
+                'state': 'untracked',
+                'type': 'file'},
+            ut.Path(ds.repo.pathobj / 'deep' / 'down2'): {
+                'state': 'untracked',
+                'type': 'file'}})
+    # but can be made more compact
+    eq_(ds.repo.diff(fr='HEAD', to=None, untracked='normal'),
+        {
+            ut.Path(ds.repo.pathobj / 'deep'): {
+                'state': 'untracked',
+                'type': 'directory'}})
+
+    # again a unmatching path constrainted will give an empty report
+    eq_(ds.repo.diff(fr='HEAD', to=None, paths=['other']), {})
+    # perfect match and anything underneath will do
+    eq_(ds.repo.diff(fr='HEAD', to=None, paths=['deep']),
+        {
+            ut.Path(ds.repo.pathobj / 'deep' / 'down'): {
+                'state': 'untracked',
+                'type': 'file'},
+            ut.Path(ds.repo.pathobj / 'deep' / 'down2'): {
+                'state': 'untracked',
+                'type': 'file'}})
+
+
+def _dirty_results(res):
+    return [r for r in res if r.get('state', None) != 'clean']
+
+
+# this is an extended variant of `test_repo_diff()` above
+# that focuses on the high-level command API
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_diff(path, norepo):
+    with chpwd(norepo):
+        assert_raises(NoDatasetArgumentFound, diff)
+    ds = Dataset(path).rev_create()
+    assert_repo_status(ds.path)
+    # reports stupid revision input
+    assert_result_count(
+        ds.diff(fr='WTF', on_failure='ignore'),
+        1,
+        status='impossible',
+        message="Git reference 'WTF' invalid")
+    # no diff
+    assert_result_count(_dirty_results(ds.diff()), 0)
+    assert_result_count(_dirty_results(ds.diff(fr='HEAD')), 0)
+    # bogus path makes no difference
+    assert_result_count(_dirty_results(ds.diff(path='THIS', fr='HEAD')), 0)
+    # let's introduce a known change
+    create_tree(ds.path, {'new': 'empty'})
+    ds.rev_save(to_git=True)
+    assert_repo_status(ds.path)
+    res = _dirty_results(ds.diff(fr='HEAD~1'))
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, action='diff', path=op.join(ds.path, 'new'), state='added')
+    # we can also find the diff without going through the dataset explicitly
+    with chpwd(ds.path):
+        assert_result_count(
+            _dirty_results(diff(fr='HEAD~1')), 1,
+            action='diff', path=op.join(ds.path, 'new'), state='added')
+    # no diff against HEAD
+    assert_result_count(_dirty_results(ds.diff()), 0)
+    # modify known file
+    create_tree(ds.path, {'new': 'notempty'})
+    res = _dirty_results(ds.diff())
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, action='diff', path=op.join(ds.path, 'new'),
+        state='modified')
+    # but if we give another path, it doesn't show up
+    assert_result_count(ds.diff(path='otherpath'), 0)
+    # giving the right path must work though
+    assert_result_count(
+        ds.diff(path='new'), 1,
+        action='diff', path=op.join(ds.path, 'new'), state='modified')
+    # stage changes
+    ds.repo.add('.', git=True)
+    # no change in diff, staged is not commited
+    assert_result_count(_dirty_results(ds.diff()), 1)
+    ds.rev_save()
+    assert_repo_status(ds.path)
+    assert_result_count(_dirty_results(ds.diff()), 0)
+
+    # untracked stuff
+    create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
+    # a plain diff should report the untracked file
+    # but not directly, because the parent dir is already unknown
+    res = _dirty_results(ds.diff())
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, state='untracked', type='directory',
+        path=op.join(ds.path, 'deep'))
+    # report of individual files is also possible
+    assert_result_count(
+        ds.diff(untracked='all'), 2, state='untracked', type='file')
+    # an unmatching path will hide this result
+    assert_result_count(ds.diff(path='somewhere'), 0)
+    # perfect match and anything underneath will do
+    assert_result_count(
+        ds.diff(path='deep'), 1, state='untracked',
+        path=op.join(ds.path, 'deep'),
+        type='directory')
+    assert_result_count(
+        ds.diff(path='deep'), 1,
+        state='untracked', path=op.join(ds.path, 'deep'))
+    ds.repo.add(op.join('deep', 'down2'), git=True)
+    # now the remaining file is the only untracked one
+    assert_result_count(
+        ds.diff(), 1, state='untracked',
+        path=op.join(ds.path, 'deep', 'down'),
+        type='file')
+
+
+@with_tempfile(mkdir=True)
+def test_diff_recursive(path):
+    ds = Dataset(path).rev_create()
+    sub = ds.rev_create('sub')
+    # look at the last change, and confirm a dataset was added
+    res = ds.diff(fr='HEAD~1', to='HEAD')
+    assert_result_count(
+        res, 1, action='diff', state='added', path=sub.path, type='dataset')
+    # now recursive
+    res = ds.diff(recursive=True, fr='HEAD~1', to='HEAD')
+    # we also get the entire diff of the subdataset from scratch
+    assert_status('ok', res)
+    ok_(len(res) > 3)
+    # one specific test
+    assert_result_count(
+        res, 1, action='diff', state='added',
+        path=op.join(sub.path, '.datalad', 'config'))
+
+    # now we add a file to just the parent
+    create_tree(
+        ds.path,
+        {'onefile': 'tobeadded', 'sub': {'twofile': 'tobeadded'}})
+    res = ds.diff(recursive=True, untracked='all')
+    assert_result_count(_dirty_results(res), 3)
+    assert_result_count(
+        res, 1,
+        action='diff', state='untracked', path=op.join(ds.path, 'onefile'),
+        type='file')
+    assert_result_count(
+        res, 1,
+        action='diff', state='modified', path=sub.path, type='dataset')
+    assert_result_count(
+        res, 1,
+        action='diff', state='untracked', path=op.join(sub.path, 'twofile'),
+        type='file')
+    # intentional save in two steps to make check below easier
+    ds.rev_save('sub', recursive=True)
+    ds.rev_save()
+    assert_repo_status(ds.path)
+    # look at the last change, only one file was added
+    res = ds.diff(fr='HEAD~1', to='HEAD')
+    assert_result_count(_dirty_results(res), 1)
+    assert_result_count(
+        res, 1,
+        action='diff', state='added', path=op.join(ds.path, 'onefile'),
+        type='file')
+
+    # now the exact same thing with recursion, must not be different from the
+    # call above
+    res = ds.diff(recursive=True, fr='HEAD~1', to='HEAD')
+    assert_result_count(_dirty_results(res), 1)
+    # last change in parent
+    assert_result_count(
+        res, 1, action='diff', state='added', path=op.join(ds.path, 'onefile'),
+        type='file')
+
+    # one further back brings in the modified subdataset, and the added file
+    # within it
+    res = ds.diff(recursive=True, fr='HEAD~2', to='HEAD')
+    assert_result_count(_dirty_results(res), 3)
+    assert_result_count(
+        res, 1,
+        action='diff', state='added', path=op.join(ds.path, 'onefile'),
+        type='file')
+    assert_result_count(
+        res, 1,
+        action='diff', state='added', path=op.join(sub.path, 'twofile'),
+        type='file')
+    assert_result_count(
+        res, 1,
+        action='diff', state='modified', path=sub.path, type='dataset')
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_path_diff(_path, linkpath):
+    # do the setup on the real path, not the symlink, to have its
+    # bugs not affect this test of status()
+    ds = get_deeply_nested_structure(str(_path))
+    if has_symlink_capability():
+        # make it more complicated by default
+        ut.Path(linkpath).symlink_to(_path, target_is_directory=True)
+        path = linkpath
+    else:
+        path = _path
+
+    ds = Dataset(path)
+    if not on_windows:
+        # TODO test should also be has_symlink_capability(), but
+        # something in the repo base class is not behaving yet
+        # check the premise of this test
+        assert ds.pathobj != ds.repo.pathobj
+
+    plain_recursive = ds.diff(recursive=True, annex='all')
+    # check integrity of individual reports with a focus on how symlinks
+    # are reported
+    for res in plain_recursive:
+        # anything that is an "intended" symlink should be reported
+        # as such. In contrast, anything that is a symlink for mere
+        # technical reasons (annex using it for something in some mode)
+        # should be reported as the thing it is representing (i.e.
+        # a file)
+        if 'link2' in text_type(res['path']):
+            assert res['type'] == 'symlink', res
+        else:
+            assert res['type'] != 'symlink', res
+        # every item must report its parent dataset
+        assert_in('parentds', res)
+
+    # bunch of smoke tests
+    # query of '.' is same as no path
+    eq_(plain_recursive, ds.diff(path='.', recursive=True, annex='all'))
+    # duplicate paths do not change things
+    eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all'))
+    # neither do nested paths
+    eq_(plain_recursive,
+        ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all'))
+    # when invoked in a subdir of a dataset it still reports on the full thing
+    # just like `git status`, as long as there are no paths specified
+    with chpwd(op.join(path, 'directory_untracked')):
+        plain_recursive = diff(recursive=True, annex='all')
+    # should be able to take absolute paths and yield the same
+    # output
+    eq_(plain_recursive, ds.diff(path=ds.path, recursive=True, annex='all'))
+
+    # query for a deeply nested path from the top, should just work with a
+    # variety of approaches
+    rpath = op.join('subds_modified', 'subds_lvl1_modified',
+                    u'{}_directory_untracked'.format(OBSCURE_FILENAME))
+    apathobj = ds.pathobj / rpath
+    apath = text_type(apathobj)
+    for p in (rpath, apath, None):
+        if p is None:
+            # change into the realpath of the dataset and
+            # query with an explicit path
+            with chpwd(ds.path):
+                res = ds.diff(
+                    path=op.join('.', rpath),
+                    recursive=True,
+                    annex='all')
+        else:
+            res = ds.diff(
+                path=p,
+                recursive=True,
+                annex='all')
+        assert_result_count(
+            res,
+            1,
+            state='untracked',
+            type='directory',
+            refds=ds.path,
+            # path always comes out a full path inside the queried dataset
+            path=apath,
+        )
+
+    assert_result_count(
+        ds.diff(
+            recursive=True),
+        1,
+        path=apath)
+    # limiting recursion will exclude this particular path
+    assert_result_count(
+        ds.diff(
+            recursive=True,
+            recursion_limit=1),
+        0,
+        path=apath)
+    # negative limit is unlimited limit
+    eq_(
+        ds.diff(recursive=True, recursion_limit=-1),
+        ds.diff(recursive=True)
+    )
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_diff_nods(path, otherpath):
+    ds = Dataset(path).rev_create()
+    assert_result_count(
+        ds.diff(path=otherpath, on_failure='ignore'),
+        1,
+        status='error',
+        message='path not underneath this dataset')
+    otherds = Dataset(otherpath).rev_create()
+    assert_result_count(
+        ds.diff(path=otherpath, on_failure='ignore'),
+        1,
+        path=otherds.path,
+        status='error',
+        message=(
+            'dataset containing given paths is not underneath the '
+            'reference dataset %s: %s', ds, otherds.path)
+    )
+
+
+@with_tempfile(mkdir=True)
+def test_diff_rsync_syntax(path):
+    # three nested datasets
+    ds = Dataset(path).rev_create()
+    subds = ds.rev_create('sub')
+    subsubds = subds.rev_create('deep')
+    justtop = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub')
+    # we only get a single result, the subdataset in question
+    assert_result_count(justtop, 1)
+    assert_result_count(justtop, 1, type='dataset', path=subds.path)
+    # now with "peak inside the dataset" syntax
+    inside = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub' + os.sep)
+    # we get both subdatasets, but nothing else inside the nested one
+    assert_result_count(inside, 2, type='dataset')
+    assert_result_count(inside, 1, type='dataset', path=subds.path)
+    assert_result_count(inside, 1, type='dataset', path=subsubds.path)
+    assert_result_count(inside, 0, type='file', parentds=subsubds.path)
+    # just for completeness, we get more when going full recursive
+    rec = ds.diff(fr=PRE_INIT_COMMIT_SHA, recursive=True, path='sub' + os.sep)
+    assert(len(inside) < len(rec))

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -96,7 +96,7 @@ def has_diff(ds, refspec, remote, paths):
     lgr.debug("Testing for changes with respect to '%s' of remote '%s'",
               remote_branch_name, remote)
     current_commit = ds.repo.get_hexsha()
-    within_ds_paths = [p for p in paths if p['path'] != ds.path]
+    within_ds_paths = [p['path'] for p in paths if p['path'] != ds.path]
     commit_differ = current_commit != ds.repo.get_hexsha(remote_ref)
     # yoh: not sure what "logic" was intended here for comparing only
     # some files.  By now we get a list of files, if any were changed,
@@ -110,13 +110,11 @@ def has_diff(ds, refspec, remote, paths):
         # in which case we can do the same muuuch cheaper (see below)
         # if there were custom paths, we will look at the diff
         lgr.debug("Since paths provided, looking at diff")
-        return any(ds.diff(
-            path=within_ds_paths,
-            revision=remote_ref,
-            # only commited changes in this dataset
-            staged=False,
-            # consider only commited changes in subdataset
-            ignore_subdatasets='dirty')) > 0
+        return any(r["state"] != "clean"
+                   for r in ds.diff(path=within_ds_paths,
+                                    fr="HEAD",
+                                    to=remote_ref,
+                                    untracked="no"))
     else:
         # if commits differ at all
         lgr.debug("Since no paths provided, comparing commits")

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -78,7 +78,7 @@ _group_plumbing = (
         ('datalad.distribution.clone', 'Clone'),
         ('datalad.distribution.create_test_dataset', 'CreateTestDataset',
          'create-test-dataset'),
-        ('datalad.interface.diff', 'Diff', 'diff'),
+        ('datalad.core.local.diff', 'Diff', 'diff'),
         ('datalad.distribution.siblings', 'Siblings', 'siblings'),
         ('datalad.support.sshrun', 'SSHRun', 'sshrun'),
         ('datalad.distribution.subdatasets', 'Subdatasets', 'subdatasets'),

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -177,7 +177,9 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None,
 
     # life is simple: we diff the base dataset
     modified = []
-    for r in refds.diff(
+    from datalad.interface.diff import Diff
+    for r in Diff.__call__(
+            dataset=refds,
             # we cannot really limit the diff paths easily because we might get
             # or miss content (e.g. subdatasets) if we don't figure out which
             # ones are known -- and we don't want that

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -177,6 +177,9 @@ def get_modified_subpaths(aps, refds, revision, recursion_limit=None,
 
     # life is simple: we diff the base dataset
     modified = []
+    # Diff.__call__ is used to get access to the now obsolete interface.diff
+    # that exists merely for annotate_paths. (refds.diff corresponds to
+    # core.local.diff.)
     from datalad.interface.diff import Diff
     for r in Diff.__call__(
             dataset=refds,

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -6,7 +6,11 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Plumbing command for reporting changes in datasets"""
+"""Plumbing command for reporting changes in datasets
+
+Note: This module is obsolete and will be removed once annotate_paths.py no
+longer needs it. Use core.local.diff instead.
+"""
 
 __docformat__ = 'restructuredtext'
 
@@ -203,6 +207,10 @@ def _parse_git_diff(dspath, diff_thingie=None, paths=None,
 class Diff(Interface):
     """Report changes of dataset components.
 
+    *Note*: This is an obsolete interface and will be removed once
+    annotate_paths.py no longer needs it. Use datalad.api.diff or Dataset.diff
+    instead.
+
     Reports can be generated for changes between recorded revisions, or
     between a revision and the state of a dataset's work tree.
 
@@ -291,7 +299,7 @@ class Diff(Interface):
         recursion_limit=recursion_limit)
 
     @staticmethod
-    @datasetmethod(name='diff')
+    @datasetmethod(name='_diff')
     @eval_results
     def __call__(
             path=None,

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -532,13 +532,13 @@ def diff_revision(dataset, revision="HEAD"):
     Generator that yields AnnotatePaths instances
     """
     if dataset.repo.commit_exists(revision + "^"):
-        revrange = "{rev}^..{rev}".format(rev=revision)
+        fr = revision + "^"
     else:
         # No other commits are reachable from this revision.  Diff
         # with an empty tree instead.
-        revrange = "{}..{}".format(PRE_INIT_COMMIT_SHA, revision)
+        fr = PRE_INIT_COMMIT_SHA
     diff = dataset.diff(recursive=True,
-                        revision=revrange,
+                        fr=fr, to=revision,
                         return_type='generator', result_renderer=None)
     for r in diff:
         yield r

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -48,61 +48,54 @@ def test_magic_number():
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_diff(path, norepo):
-    with chpwd(norepo):
-        assert_status('impossible', diff(on_failure='ignore'))
     ds = Dataset(path).rev_create()
     ok_clean_git(ds.path)
     # reports stupid revision input
     assert_result_count(
-        ds.diff(revision='WTF', on_failure='ignore'),
+        ds._diff(revision='WTF', on_failure='ignore'),
         1,
         status='impossible',
         message="fatal: bad revision 'WTF'")
-    assert_result_count(ds.diff(), 0)
+    assert_result_count(ds._diff(), 0)
     # no diff
-    assert_result_count(ds.diff(), 0)
-    assert_result_count(ds.diff(revision='HEAD'), 0)
+    assert_result_count(ds._diff(), 0)
+    assert_result_count(ds._diff(revision='HEAD'), 0)
     # bogus path makes no difference
-    assert_result_count(ds.diff(path='THIS', revision='HEAD'), 0)
+    assert_result_count(ds._diff(path='THIS', revision='HEAD'), 0)
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
     ds.rev_save(to_git=True)
     ok_clean_git(ds.path)
-    res = ds.diff(revision='HEAD~1')
+    res = ds._diff(revision='HEAD~1')
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, action='diff', path=opj(ds.path, 'new'), state='added')
-    # we can also find the diff without going through the dataset explicitly
-    with chpwd(ds.path):
-        assert_result_count(
-            diff(revision='HEAD~1'), 1,
-            action='diff', path=opj(ds.path, 'new'), state='added')
     # no diff against HEAD
-    assert_result_count(ds.diff(), 0)
+    assert_result_count(ds._diff(), 0)
     # modify known file
     create_tree(ds.path, {'new': 'notempty'})
     for diffy in (None, 'HEAD'):
-        res = ds.diff(revision=diffy)
+        res = ds._diff(revision=diffy)
         assert_result_count(res, 1)
         assert_result_count(
             res, 1, action='diff', path=opj(ds.path, 'new'), state='modified')
     # but if we give another path, it doesn't show up
-    assert_result_count(ds.diff('otherpath'), 0)
+    assert_result_count(ds._diff('otherpath'), 0)
     # giving the right path must work though
     assert_result_count(
-        ds.diff('new'), 1,
+        ds._diff('new'), 1,
         action='diff', path=opj(ds.path, 'new'), state='modified')
     # stage changes
     ds.repo.add('.', git=True)
     # no diff, because we staged the modification
-    assert_result_count(ds.diff(), 0)
+    assert_result_count(ds._diff(), 0)
     # but we can get at it
     assert_result_count(
-        ds.diff(staged=True), 1,
+        ds._diff(staged=True), 1,
         action='diff', path=opj(ds.path, 'new'), state='modified')
     # OR
     assert_result_count(
-        ds.diff(revision='HEAD'), 1,
+        ds._diff(revision='HEAD'), 1,
         action='diff', path=opj(ds.path, 'new'), state='modified')
     ds.rev_save()
     ok_clean_git(ds.path)
@@ -111,30 +104,30 @@ def test_diff(path, norepo):
     create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
     # a plain diff should report the untracked file
     # but not directly, because the parent dir is already unknown
-    res = ds.diff()
+    res = ds._diff()
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, state='untracked', type='directory', path=opj(ds.path, 'deep'))
     # report of individual files is also possible
     assert_result_count(
-        ds.diff(report_untracked='all'), 2, state='untracked', type='file')
+        ds._diff(report_untracked='all'), 2, state='untracked', type='file')
     # an unmatching path will hide this result
-    assert_result_count(ds.diff(path='somewhere'), 0)
+    assert_result_count(ds._diff(path='somewhere'), 0)
     # perfect match and anything underneath will do
     assert_result_count(
-        ds.diff(path='deep'), 1, state='untracked', path=opj(ds.path, 'deep'),
+        ds._diff(path='deep'), 1, state='untracked', path=opj(ds.path, 'deep'),
         type='directory')
     assert_result_count(
-        ds.diff(path='deep'), 1,
+        ds._diff(path='deep'), 1,
         state='untracked', path=opj(ds.path, 'deep'))
     # now we stage on of the two files in deep
     ds.repo.add(opj('deep', 'down2'), git=True)
     # without any reference it will ignore the staged stuff and report the remaining
     # untracked file
     assert_result_count(
-        ds.diff(), 1, state='untracked', path=opj(ds.path, 'deep', 'down'),
+        ds._diff(), 1, state='untracked', path=opj(ds.path, 'deep', 'down'),
         type='file')
-    res = ds.diff(staged=True)
+    res = ds._diff(staged=True)
     assert_result_count(
         res, 1, state='untracked', path=opj(ds.path, 'deep', 'down'), type='file')
     assert_result_count(
@@ -146,10 +139,10 @@ def test_diff_recursive(path):
     ds = Dataset(path).rev_create()
     sub = ds.rev_create('sub')
     # look at the last change, and confirm a dataset was added
-    res = ds.diff(revision='HEAD~1..HEAD')
+    res = ds._diff(revision='HEAD~1..HEAD')
     assert_result_count(res, 1, action='diff', state='added', path=sub.path, type='dataset')
     # now recursive
-    res = ds.diff(recursive=True, revision='HEAD~1..HEAD')
+    res = ds._diff(recursive=True, revision='HEAD~1..HEAD')
     # we also get the entire diff of the subdataset from scratch
     assert_status('ok', res)
     ok_(len(res) > 3)
@@ -158,7 +151,7 @@ def test_diff_recursive(path):
 
     # now we add a file to just the parent
     create_tree(ds.path, {'onefile': 'tobeadded', 'sub': {'twofile': 'tobeadded'}})
-    res = ds.diff(recursive=True, report_untracked='all')
+    res = ds._diff(recursive=True, report_untracked='all')
     assert_result_count(res, 3)
     assert_result_count(res, 1, action='diff', state='untracked', path=opj(ds.path, 'onefile'), type='file')
     assert_result_count(res, 1, action='diff', state='modified', path=sub.path, type='dataset')
@@ -171,19 +164,19 @@ def test_diff_recursive(path):
     ds.rev_save()
     ok_clean_git(ds.path)
     # look at the last change, only one file was added
-    res = ds.diff(revision='HEAD~1..HEAD')
+    res = ds._diff(revision='HEAD~1..HEAD')
     assert_result_count(res, 1)
     assert_result_count(res, 1, action='diff', state='added', path=opj(ds.path, 'onefile'), type='file')
 
     # now the exact same thing with recursion, must not be different from the call
     # above
-    res = ds.diff(recursive=True, revision='HEAD~1..HEAD')
+    res = ds._diff(recursive=True, revision='HEAD~1..HEAD')
     assert_result_count(res, 1)
     # last change in parent
     assert_result_count(res, 1, action='diff', state='added', path=opj(ds.path, 'onefile'), type='file')
 
     # one further back brings in the modified subdataset, and the added file within it
-    res = ds.diff(recursive=True, revision='HEAD~2..HEAD')
+    res = ds._diff(recursive=True, revision='HEAD~2..HEAD')
     assert_result_count(res, 3)
     assert_result_count(res, 1, action='diff', state='added', path=opj(ds.path, 'onefile'), type='file')
     assert_result_count(res, 1, action='diff', state='added', path=opj(sub.path, 'twofile'), type='file')

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -325,7 +325,7 @@ def test_rerun_onto(path):
     ok_(ds.repo.get_active_branch() is None)
     neq_(ds.repo.get_hexsha(),
          ds.repo.get_hexsha("static"))
-    assert_result_count(ds.diff(revision="HEAD..static"), 0)
+    ok_(all(r["state"] == "clean" for r in ds.diff(fr="HEAD", to="static")))
     for revrange in ["..static", "static.."]:
         assert_result_count(
             ds.repo.repo.git.rev_list(revrange).split(), 1)
@@ -353,7 +353,8 @@ def test_rerun_onto(path):
     with swallow_outputs():
         ds.rerun(since="", onto="", branch="from-base")
     eq_(ds.repo.get_active_branch(), "from-base")
-    assert_result_count(ds.diff(revision="master..from-base"), 0)
+    ok_(all(r["state"] == "clean"
+            for r in ds.diff(fr="master", to="from-base")))
     eq_(ds.repo.get_merge_base(["static", "from-base"]),
         ds.repo.get_hexsha("static^"))
 


### PR DESCRIPTION
```
Replace core's diff with -revolution's.  Update the few diff callers
to use the new variant, with the exception of annotate_paths.  Keep
the older diff around but hidden (not listed in an interface group and
named with an underscore) for annotate_paths.  We could update it to
use the new diff, but it's not worth the effort because it is only
used by add, create, and the save, which are on their way out.

This is copied from revolution's 38df2ddd2858fa8786b6fcca6c472ef9be8a53e8.
You can verify that there are no substantial changes by checking
datalad-revolution out at that commit, pointing $DL_REV_DIR to the
repository, and then running

  % git diff --no-index -- \
    $DL_REV_DIR/datalad_revolution/revdiff.py \
    datalad/core/local/diff.py

  % git diff --no-index -- \
    $DL_REV_DIR/datalad_revolution/tests/test_diff.py \
    datalad/core/local/tests/test_diff.py
```

Closes #3190.
