### PR TITLE
ENH: clean - remove annex transfer directories

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -43,6 +43,7 @@ DATALAD_SPECIAL_REMOTES_UUIDS = {
 
 ARCHIVES_TEMP_DIR = join(DATALAD_GIT_DIR, 'tmp', 'archives')
 ANNEX_TEMP_DIR = join('.git', 'annex', 'tmp')
+ANNEX_TRANSFER_DIR = join('.git', 'annex', 'transfer')
 
 SEARCH_INDEX_DOTGITDIR = join('datalad', 'search_index')
 

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -61,7 +61,7 @@ class Clean(Interface):
         what=Parameter(
             args=("--what",),
             dest='what',
-            choices=('cached-archives', 'annex-tmp', 'search-index'),
+            choices=('cached-archives', 'annex-tmp', 'annex-transfer', 'search-index'),
             nargs="*",
             doc="""What to clean.  If none specified -- all known targets are
             cleaned"""),

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -15,9 +15,12 @@ from glob import glob
 from .base import Interface
 from ..utils import rmtree
 from ..support.param import Parameter
-from ..consts import ARCHIVES_TEMP_DIR
-from ..consts import ANNEX_TEMP_DIR
-from ..consts import SEARCH_INDEX_DOTGITDIR
+from ..consts import (
+    ARCHIVES_TEMP_DIR,
+    ANNEX_TEMP_DIR,
+    ANNEX_TRANSFER_DIR,
+    SEARCH_INDEX_DOTGITDIR,
+)
 
 from datalad.support.gitrepo import GitRepo
 from datalad.support.constraints import EnsureNone
@@ -91,13 +94,17 @@ class Clean(Interface):
                 continue
             d = ap['path']
             gitdir = GitRepo.get_git_dir(d)
+            DIRS_PLURAL = ("directory", "directories")
+            FILES_PLURAL = ("file", "files")
             for dirpath, flag, msg, sing_pl in [
                 (ARCHIVES_TEMP_DIR, "cached-archives",
-                 "temporary archive", ("directory", "directories")),
+                 "temporary archive", DIRS_PLURAL),
                 (ANNEX_TEMP_DIR, "annex-tmp",
-                 "temporary annex", ("file", "files")),
+                 "temporary annex", FILES_PLURAL),
+                (ANNEX_TRANSFER_DIR, "annex-transfer",
+                 "annex temporary transfer", DIRS_PLURAL),
                 (opj(gitdir, SEARCH_INDEX_DOTGITDIR), 'search-index',
-                 "metadata search index", ("file", "files")),
+                 "metadata search index", FILES_PLURAL),
             ]:
                 topdir = opj(d, dirpath)
                 lgr.debug("Considering to clean %s:%s", d, dirpath)


### PR DESCRIPTION
Found a repository which a bunch of logs on what files failed to download:

```
(git)smaug:/mnt/btrfs/datasets/datalad/crawl/openneuro/ds000201[master]git
$> cat ./.git/annex/transfer/failed/download/d46236ce-1f9e-4216-9676-35f10fd6c553/MD5E-s131899529--67071615cc9e1041d0700547dd676ced.nii.gz
1543974478.691019986s
sub-9100/ses-1/func/sub-9100_ses-1_task-sleepiness_bold.nii.gz
```

I think it should be safe to remove them.  Cons of the approach, that removing
top level directories so not providing list of specific files, which could be
taken as pros since there could be many ;)
