### PR TITLE
Add CHANGELOG entries for 0.12rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,103 @@ bet we will fix some bugs and make a world even a better place.
 
 ### Major refactoring and deprecations
 
-- hopefully none
+- The previous `diff` command has been replaced by the diff variant
+  from the [datalad-revolution][] extension.  ([#3366][])
+
+- `rev-create` has been renamed to `create`, and the previous `create`
+  has been removed.  ([#3383][])
+
+- The procedure `setup_yoda_dataset` has been renamed to `cfg_yoda`
+  ([#3353][]).
+
+- The `--nosave` of `addurls` now affects only added content, not
+  newly created subdatasets ([#3259][]).
+
+- `Dataset.get_subdatasets` (deprecated since v0.9.0) has been
+  removed.  ([#3336][])
+
+- The `.is_dirty` method of `GitRepo` and `AnnexRepo` has been
+  replaced by `.status` or, for a subset of cases, the `.dirty`
+  property.  ([#3330][])
+
+- `AnnexRepo.get_status` has been replaced by `AnnexRepo.status`.
+  ([#3330][])
 
 ### Fixes
 
-?
+- `status`
+  - reported on directories that contained only ignored files ([#3238][])
+  - gave a confusing failure when called from a subdataset with an
+    explicitly specified dataset argument and "." as a path ([#3325][])
+  - misleadingly claimed that the locally present content size was
+    zero when `--annex basic` was specified ([#3378][])
+
+- An informative error wasn't given when a download provider was
+  invalid.  ([#3258][])
+
+- Calling `rev-save PATH` saved unspecified untracked subdatasets.
+  ([#3288][])
+
+- The available choices for command-line options that take values are
+  now displayed more consistently in the help output.  ([#3326][])
+
+- The new pathlib-based code had various encoding issues on Python 2.
+  ([#3332][])
 
 ### Enhancements and new features
 
-?
+- [wtf][] now includes information about the Python version.  ([#3255][])
+
+- When operating in an annex repository, checking whether git-annex is
+  available is now delayed until a call to git-annex is actually
+  needed, allowing systems without git-annex to operate on annex
+  repositories in a restricted fashion.  ([#3274][])
+
+- The `load_stream` on helper now supports auto-detection of
+  compressed files.  ([#3289][])
+
+- `create` (formerly `rev-create`)
+  - learned to be speedier by passing a path to `status` ([#3294][])
+  - gained a `--cfg-proc` (or `-c`) convenience option for running
+    configuration procedures (or more accurately any procedure that
+    begins with "cfg_") in the newly created dataset ([#3353][])
+
+- `AnnexRepo.set_metadata` now returns a list while
+  `AnnexRepo.set_metadata_` returns a generator, a behavior which is
+  consistent with the `add` and `add_` method pair.  ([#3298][])
+
+- `AnnexRepo.get_metadata` now supports batch querying of known annex
+   files.  Note, however, that callers should carefully validate the
+   input paths because the batch call will silently hang if given
+   non-annex files.  ([#3364][])
+
+- `status`
+  - now reports a "bytesize" field for files tracked by Git ([#3299][])
+  - gained a new option `eval_subdataset_state` that controls how the
+    subdataset state is evaluated.  Depending on the information you
+    need, you can select a less expensive mode to make `status`
+    faster.  ([#3324][])
+  - colors deleted files "red" ([#3334][])
+
+- Querying repository content is faster due to batching of `git
+  cat-file` calls.  ([#3301][])
+
+- The dataset ID of a subdataset is now recorded in the superdataset.
+  ([#3304][])
+
+- `GitRepo.diffstatus`
+  - now avoids subdataset recursion when the comparison is not with
+    the working tree, which substantially improves performance when
+    diffing large dataset hierarchies  ([#3314][])
+  - got smarter and faster about labeling a subdataset as "modified"
+    ([#3343][])
+
+- `GitRepo.get_content_info` now supports disabling the file type
+  evaluation, which gives a performance boost in cases where this
+  information isn't needed.  ([#3362][])
+
+- The XMP metadata extractor now filters based on file name to improve
+  its performance.  ([#3329][])
 
 ## 0.12.0rc2 (Mar 18, 2019) -- revolution!
 
@@ -1305,6 +1393,7 @@ publishing
 [#3098]: https://github.com/datalad/datalad/issues/3098
 [#3099]: https://github.com/datalad/datalad/issues/3099
 [#3104]: https://github.com/datalad/datalad/issues/3104
+[#3106]: https://github.com/datalad/datalad/issues/3106
 [#3109]: https://github.com/datalad/datalad/issues/3109
 [#3115]: https://github.com/datalad/datalad/issues/3115
 [#3119]: https://github.com/datalad/datalad/issues/3119
@@ -1331,8 +1420,40 @@ publishing
 [#3220]: https://github.com/datalad/datalad/issues/3220
 [#3222]: https://github.com/datalad/datalad/issues/3222
 [#3223]: https://github.com/datalad/datalad/issues/3223
+[#3238]: https://github.com/datalad/datalad/issues/3238
 [#3241]: https://github.com/datalad/datalad/issues/3241
 [#3249]: https://github.com/datalad/datalad/issues/3249
 [#3250]: https://github.com/datalad/datalad/issues/3250
+[#3255]: https://github.com/datalad/datalad/issues/3255
+[#3258]: https://github.com/datalad/datalad/issues/3258
+[#3259]: https://github.com/datalad/datalad/issues/3259
 [#3268]: https://github.com/datalad/datalad/issues/3268
+[#3274]: https://github.com/datalad/datalad/issues/3274
 [#3281]: https://github.com/datalad/datalad/issues/3281
+[#3288]: https://github.com/datalad/datalad/issues/3288
+[#3289]: https://github.com/datalad/datalad/issues/3289
+[#3294]: https://github.com/datalad/datalad/issues/3294
+[#3298]: https://github.com/datalad/datalad/issues/3298
+[#3299]: https://github.com/datalad/datalad/issues/3299
+[#3301]: https://github.com/datalad/datalad/issues/3301
+[#3304]: https://github.com/datalad/datalad/issues/3304
+[#3314]: https://github.com/datalad/datalad/issues/3314
+[#3318]: https://github.com/datalad/datalad/issues/3318
+[#3322]: https://github.com/datalad/datalad/issues/3322
+[#3324]: https://github.com/datalad/datalad/issues/3324
+[#3325]: https://github.com/datalad/datalad/issues/3325
+[#3326]: https://github.com/datalad/datalad/issues/3326
+[#3329]: https://github.com/datalad/datalad/issues/3329
+[#3330]: https://github.com/datalad/datalad/issues/3330
+[#3332]: https://github.com/datalad/datalad/issues/3332
+[#3334]: https://github.com/datalad/datalad/issues/3334
+[#3336]: https://github.com/datalad/datalad/issues/3336
+[#3340]: https://github.com/datalad/datalad/issues/3340
+[#3343]: https://github.com/datalad/datalad/issues/3343
+[#3347]: https://github.com/datalad/datalad/issues/3347
+[#3353]: https://github.com/datalad/datalad/issues/3353
+[#3362]: https://github.com/datalad/datalad/issues/3362
+[#3364]: https://github.com/datalad/datalad/issues/3364
+[#3366]: https://github.com/datalad/datalad/issues/3366
+[#3378]: https://github.com/datalad/datalad/issues/3378
+[#3383]: https://github.com/datalad/datalad/issues/3383


### PR DESCRIPTION
Closes #3386.

<details>
<summary>Changes included</summary>

```
# Generated with
#   git log --format="?  %s%n   %h^-1" --reverse --first-parent 0.12.0rc2..master
#
#
# ?  = unprocessed and undecided
# -  = decided not to include
# +  = included
# +* = included, but might still be bits that should be added

-  Merge pull request #3239 from kyleam/rev-save-doc-typos
   ace1f402d^-1
-  Show must go on AKA Post release changes to changelog
   af7265d60^-1
+  Merge pull request #3238 from kyleam/status-no-empty-dir
   0f0fafc30^-1
-  BM: benchmark master and 0.11.x now, forget elderly 0.[59].x
   b66203983^-1
-  Merge pull request #3251 from kyleam/rev-run-tests
   9f8542e8f^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   6c753c8d7^-1
+  Merge pull request #3255 from driusan/PythonWtf
   4bc1367f2^-1
-  Merge pull request #3257 from mih/tst-coreonwin
   6ba6d53b5^-1
-  Merge pull request #3252 from mih/rf-lessadd
   0bb31b3cd^-1
-  Merge pull request #3260 from yarikoptic/bf-bm-norev
   bde758aa9^-1
+  Merge pull request #3259 from kyleam/addurls-create-save
   828a6c76e^-1
-  Merge pull request #3263 from yarikoptic/bm-forrest
   4b20afe6c^-1
-  Merge pull request #3272 from datalad/driusan-patch-1
   2020bd81a^-1
-  Merge pull request #3271 from datalad/docs
   52719b0e5^-1
-  Merge pull request #3273 from datalad/docs
   f405cff19^-1
+  Merge pull request #3274 from mih/rf-lateannexcheck
   84c36ec92^-1
+  Merge pull request #3258 from driusan/BetterReError
   6d1e534d4^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   c350b96e8^-1
-  Merge pull request #3286 from laurakw/master
   5986b87b6^-1
-  DOC: two minor typo fixes in a docstring
   f9ff64ea8^-1
+  Merge pull request #3289 from mih/enh-loadjsoncompress
   8772fd153^-1
+  Merge pull request #3294 from mih/enh-speed
   54fbc4dfc^-1
+  BF: gitrepo.save_: Don't save unspecified subdatasets (#3288)
   f8752f9cf^-1
-  Merge pull request #3297 from yarikoptic/enh-merge-0.11.x
   c1e765a9e^-1
-  CHANGELOG.md: Remove redundant 0.12.0rc2 entries
   30b0e8e38^-1
+  Merge pull request #3298 from mih/rf-metaset
   7653e0df4^-1
+  Merge pull request #3299 from mih/enh_bytesize
   cc3a9e6dd^-1
+  Merge pull request #3301 from mih/enh-statusperf
   e52de4c51^-1
-  Merge pull request #3307 from kyleam/tst-quiet-run
   a6a1cf471^-1
+  Merge pull request #3304 from mih/enh-subds-id
   2e283e63d^-1
+  Merge pull request #3314 from mih/enh-statusperf
   73145b49d^-1
-  Merge pull request #3310 from yarikoptic/bm-monkey-patch-is-interactive
   1a1a25c98^-1
-  Merge pull request #3317 from yarikoptic/bf-appveyor-coverage
   6f9ac93e4^-1
-  Merge pull request #3319 from yarikoptic/enh-bench
   547282140^-1
-  DOC: Fix "amend" typos
   9ffdca43c^-1
+  Merge pull request #3324 from mih/enh-status
   94aadb226^-1
-  Merge pull request #3331 from kyleam/pr-3324-followup
   6a16b29de^-1
+  Merge pull request #3326 from mih/enh-paramdocs
   7c2c37b20^-1
+  Merge pull request #3325 from kyleam/status-subds-dot
   c44b3d75d^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   50c27505b^-1
+  Merge pull request #3329 from mih/enh-xmp
   bd1e7b670^-1
+  Merge pull request #3330 from mih/rf-repo
   a038f0e51^-1
-  CHANGELOG.md: Drop a duplicate 0.12.0rc1 entry
   d0a477291^-1
-  Merge pull request #3335 from yarikoptic/enh-merge-0.11.x
   f5b995fbf^-1
+  Merge pull request #3334 from kyleam/deleted-color
   e4096cd40^-1
+  Merge pull request #3336 from kyleam/remove-get_subdatasets
   739563996^-1
+  Merge pull request #3332 from kyleam/pathlib-unstr
   e79d4ea81^-1
+  Merge pull request #3343 from mih/enh-status
   8bf737579^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   dd0f860ab^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   d75d58bb0^-1
-  Merge pull request #3349 from kyleam/gitrepo-doc
   dbe9d30d5^-1
+  Merge pull request #3353 from yarikoptic/enh-create-cfg
   7121e8ccd^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   59096c0ea^-1
+  Merge pull request #3362 from mih/opt-ftype
   96826fa22^-1
+  ENH: AnnexRepo.get_metadata(batch=True) (#3364)
   02e344aab^-1
+  Merge remote-tracking branch 'kyleam/absorb-rev-diff'
   ca35877ea^-1
+  Merge pull request #3378 from mih/bf-statusinfo
   df1596c6b^-1
-  Merge pull request #3376 from yarikoptic/bf-3375
   58497de02^-1
-  Merge remote-tracking branch 'origin/0.11.x'
   cae3cbf2e^-1
```

An entry for #3383 is also included.

</details>
