### PR TITLE
DOC: common_cfg: Add entry for datalad.repo.backend

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -333,7 +333,7 @@ class Create(Interface):
             )
             # set the annex backend in .gitattributes as a staged change
             tbrepo.set_default_backend(
-                cfg.obtain('datalad.repo.backend', default='MD5E'),
+                cfg.obtain('datalad.repo.backend'),
                 persistent=True, commit=False)
             add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
                 'type': 'file',

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -226,6 +226,12 @@ definitions = {
         'destination': 'global',
         'default': None,
     },
+    'datalad.repo.backend': {
+        'ui': ('question', {
+               'title': 'git-annex backend',
+               'text': 'Backend to use when creating git-annex repositories'}),
+        'default': 'MD5E',
+    },
     'datalad.repo.direct': {
         'ui': ('yesno', {
                'title': 'Direct Mode for git-annex repositories',


### PR DESCRIPTION
The new create() configures the annex backend based on the
datalad.repo.backend.  Document it in interface/common_cfg.py.
