### PR TITLE
Make progress bar "backend" configurable, use the "log" one during tests

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -306,4 +306,11 @@ definitions = {
         'default': 256,
         'type': EnsureInt(),
     },
+    'datalad.ui.progressbar': {
+        'ui': ('question', {
+            'title': 'UI progress bars',
+            'text': 'Which backend for progress reporting to use unless specified otherwise?'}),
+        'default': None,
+        'type': EnsureChoice('tqdm', 'tqdm-ipython', 'log', 'none'),
+    },
 }

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -309,7 +309,7 @@ definitions = {
     'datalad.ui.progressbar': {
         'ui': ('question', {
             'title': 'UI progress bars',
-            'text': 'Which backend for progress reporting to use unless specified otherwise?'}),
+            'text': 'Default backend for progress reporting'}),
         'default': None,
         'type': EnsureChoice('tqdm', 'tqdm-ipython', 'log', 'none'),
     },

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -243,10 +243,10 @@ class OnlyProgressLog(logging.Filter):
 def log_progress(lgrcall, pid, *args, **kwargs):
     """Helper to emit a log message on the progress of some process
 
-    Whenever this helper would report on interim progress and is to be used
-    programmatically, :class:`~datalad.ui.progressbars.LogProgressBar` could be
-    chosen by user (config 'datalad.ui.progressbar' set to 'log') to provide
-    reporting upon completion of the action.
+    Note: Whereas this helper reports on interim progress and is to be used
+    programmatically, :class:`~datalad.ui.progressbars.LogProgressBar` replaces
+    a progress bar with a single log message upon completion and can be chosen
+    by the user (config 'datalad.ui.progressbar' set to 'log').
 
     Parameters
     ----------

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -243,6 +243,11 @@ class OnlyProgressLog(logging.Filter):
 def log_progress(lgrcall, pid, *args, **kwargs):
     """Helper to emit a log message on the progress of some process
 
+    Whenever this helper would report on interim progress and is to be used
+    programmatically, :class:`~datalad.ui.progressbars.LogProgressBar` could be
+    chosen by user (config 'datalad.ui.progressbar' set to 'log') to provide
+    reporting upon completion of the action.
+
     Parameters
     ----------
     lgrcall : callable

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2408,12 +2408,14 @@ class AnnexRepo(GitRepo, RepoInterface):
             # opts might be the '--key' which should go last
             annex_options += opts
 
+        interrupted = True
         try:
             out, err = self._run_annex_command(
                     command,
                     files=files,
                     annex_options=annex_options,
                     **kwargs)
+            interrupted = False
         except CommandError as e:
             # Note: A call might result in several 'failures', that can be or
             # cannot be handled here. Detection of something, we can deal with,
@@ -2511,7 +2513,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 )
         finally:
             if progress_indicators:
-                progress_indicators.finish()
+                progress_indicators.finish(partial=interrupted)
 
         json_objects = (json_loads(line)
                         for line in out.splitlines() if line.startswith('{'))
@@ -3931,15 +3933,15 @@ class ProcessAnnexProgressIndicators(object):
             int(j.get('byte-progress'))
         )
 
-    def finish(self):
-        if self.total_pbar:
-            self.total_pbar.finish()
-            self.total_pbar = None
+    def finish(self, partial=False):
         if self.pbars:
             lgr.warning("Still have %d active progress bars when stopping",
                         len(self.pbars))
+        if self.total_pbar:
+            self.total_pbar.finish(partial=partial)
+            self.total_pbar = None
         for pbar in self.pbars.values():
-            pbar.finish()
+            pbar.finish(partial=partial)
         self.pbars = {}
         self._failed = 0
         self._succeeded = 0

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -517,6 +517,11 @@ class GitPythonProgressBar(RemoteProgress):
                 # spotted used by GitPython tests, so may be at times it is not
                 # known and assumed to be a 100%...? TODO
                 max_count = 100.0
+            if op_code:
+                # Apparently those are composite and we care only about the ones
+                # we know, so to avoid switching the progress bar for no good
+                # reason - first & with the mask
+                op_code = op_code & self.OP_MASK
             if self._op_code is None or self._op_code != op_code:
                 # new type of operation
                 self._close_pbar()

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -528,7 +528,8 @@ class GitPythonProgressBar(RemoteProgress):
 
                 self._pbar = self._ui.get_progressbar(
                     self._get_human_msg(op_code),
-                    total=max_count
+                    total=max_count,
+                    unit=' objects'
                 )
                 self._op_code = op_code
             if not self._pbar:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1673,10 +1673,10 @@ def test_ProcessAnnexProgressIndicators():
         out = cmo.out
 
     from datalad.ui import ui
-    from datalad.ui.dialog import SilentConsoleLog
+    from datalad.ui.dialog import QuietConsoleLog
 
     assert out \
-        if not isinstance(ui.ui, SilentConsoleLog) else not out
+        if not isinstance(ui.ui, QuietConsoleLog) else not out
     assert proc.total_pbar is not None
     # and no side-effect of any kind in finish
     with swallow_outputs() as cmo:

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -23,8 +23,9 @@ from .dialog import (
     IPythonUI,
     UnderAnnexUI,
     UnderTestsUI,
+    SilentConsoleLog,
+    QuietConsoleLog,
 )
-from .dialog import SilentConsoleLog
 from ..utils import (
     is_interactive,
     get_ipython_shell,
@@ -36,7 +37,7 @@ KNOWN_BACKENDS = {
     'ipython': IPythonUI,
     'annex': UnderAnnexUI,
     'tests': UnderTestsUI,
-    'tests-noninteractive': SilentConsoleLog,
+    'tests-noninteractive': QuietConsoleLog,
     'no-progress': SilentConsoleLog,
 }
 

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -117,7 +117,16 @@ class SilentConsoleLog(ConsoleLog):
 
     def get_progressbar(self, *args, **kwargs):
         from .progressbars import SilentProgressBar
-        return SilentProgressBar(*args, out=self.out, **kwargs)
+        return SilentProgressBar(*args, **kwargs)
+
+
+@auto_repr
+class QuietConsoleLog(ConsoleLog):
+    """A ConsoleLog with a LogProgressbar"""
+
+    def get_progressbar(self, *args, **kwargs):
+        from .progressbars import LogProgressBar
+        return LogProgressBar(*args, **kwargs)
 
 
 def getpass_echo(prompt='Password', stream=None):

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -93,6 +93,11 @@ class ConsoleLog(object):
             progressbars = ConsoleLog.progressbars
 
         if backend is None:
+            # Resort to the configuration
+            from .. import cfg
+            backend = cfg.get('datalad.ui.progressbar', None)
+
+        if backend is None:
             try:
                 pbar = progressbars['tqdm']
             except KeyError:

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -26,10 +26,12 @@ from .. import lgr
 class ProgressBarBase(object):
     """Base class for any progress bar"""
 
-    def __init__(self, label=None, total=None, fill_text=None, out=None, unit='B', initial=0):
+    def __init__(self, label=None, fill_text=None, total=None, out=None, unit='B', initial=0):
         self.label = label
+        self.fill_test = fill_text
         self.total = total
         self.unit = unit
+        self.out = out
         self._current = initial
 
     def refresh(self):

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -149,10 +149,10 @@ class LogProgressBar(ProgressBarBase):
             msg += ' in %s'
             args += [self._naturaldelta(dt)]
 
-        if amount:
-            speed = amount / dt
-            msg += ' at %s/sec'
-            args += [self._naturalsize(speed)]
+            if amount:
+                speed = amount / dt
+                msg += ' at %s/sec'
+                args += [self._naturalsize(speed)]
 
         lgr.info(msg, *args)
 

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -96,8 +96,9 @@ class LogProgressBar(ProgressBarBase):
 
     def __init__(self, *args, **kwargs):
         super(LogProgressBar, self).__init__(*args, **kwargs)
-        # I think we never generate progress bars unless we are the beginning
-        # of reporting something lengthy.  .start is not always invoked
+        # I think we never generate progress bars unless we are at the beginning
+        # of reporting something lengthy.  .start is not always invoked so
+        # we cannot reliably set it there instead of the constructor (here)
         self._start_time = time.time()
 
     @staticmethod
@@ -140,7 +141,8 @@ class LogProgressBar(ProgressBarBase):
                     else:
                         # well well -- we still probably have some issue with
                         # over-reporting when getting data from datalad-archives
-                        # Instead of providing non-sense % here, j
+                        # Instead of providing non-sense % here, just report
+                        # our best guess
                         msg += "possibly partially "
                 else:
                     # well -- that means that we did manage to get all of it

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -100,19 +100,27 @@ class LogProgressBar(ProgressBarBase):
         # of reporting something lengthy.  .start is not always invoked
         self._start_time = time.time()
 
+    @staticmethod
+    def _naturalfloat(x):
+        """Return string representation of a number for human consumption
+
+        For abs(x) <= 1000 would use 'scientific' (%g) notation, and for the
+        larger a regular int (after rounding)
+        """
+        return ('%g' % x) if abs(x) <= 1000 else '%i' % int(round(x))
+
     def _naturalsize(self, x):
         if self.unit == 'B':
             return humanize.naturalsize(x)
         else:
-            # No need for precision in case of large numbers
-            return '%s%s' % (int(x) if x >= 100 else x, self.unit or '')
+            return '%s%s' % (self._naturalfloat(x), self.unit or '')
 
     @staticmethod
     def _naturaldelta(x):
         # humanize is too human for little things
         return humanize.naturaldelta(x) \
             if x > 2 \
-            else ('%.3f' % x).rstrip('0').rstrip('.') + ' sec'
+            else LogProgressBar._naturalfloat(x) + ' sec'
 
     def finish(self, partial=False):
         msg, args = ' %s ', [self.label]

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -87,7 +87,13 @@ class SilentProgressBar(ProgressBarBase):
 
 class LogProgressBar(ProgressBarBase):
     """A progress bar which logs upon completion of the item
+
+    Note that there is also :func:`~datalad.log.log_progress` which can be used
+    to get progress bars when attached to a tty but incremental log messages
+    otherwise (as opposed to just the final log message provided by
+    `LogProgressBar`).
     """
+
     def __init__(self, *args, **kwargs):
         super(LogProgressBar, self).__init__(*args, **kwargs)
         # I think we never generate progress bars unless we are the beginning

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -117,6 +117,8 @@ def _test_progress_bar(backend, len, increment):
         'label', fill_str, total=10, backend=backend)
     pb.start()
     # we can't increment 11 times
+    SILENT_BACKENDS = ('annex-remote', 'silent', 'none')
+    ONLY_THE_END_BACKENDS = ('log',)
     for x in range(11):
         if not (increment and x == 0):
             # do not increment on 0
@@ -128,15 +130,17 @@ def _test_progress_bar(backend, len, increment):
         # or just force the refresh
         pb.refresh()
         pstr = out.getvalue()
-        if backend not in ('annex-remote', 'silent'):  # no str repr
+        if backend not in SILENT_BACKENDS + ONLY_THE_END_BACKENDS:  # no str repr
             ok_startswith(pstr.lstrip('\r'), 'label:')
             assert_re_in(r'.*\b%d%%.*' % (10*x), pstr)
         if backend == 'progressbar':
             assert_in('ETA', pstr)
     pb.finish()
-    if backend not in ('annex-remote', 'silent'):
+    output = out.getvalue()
+    if backend not in SILENT_BACKENDS:
         # returns back and there is no spurious newline
-        ok_endswith(out.getvalue(), '\r')
+        if output:
+            ok_endswith(output, '\r')
 
 
 def test_progress_bar():


### PR DESCRIPTION
Closes #3393

Adds `LogProgressBar` which logs completion (possibly partial) for the item.

<details>
<summary>Here are examples on how reporting looks like with `log` with some being interrupted or completed fully</summary>

```shell
$> sudo rm -rf QA simon ds00* face_place dartmouth-phantoms; DATALAD_UI_PROGRESSBAR=log datalad install -g ///openfmri/ds000105
[INFO   ] Cloning http://datasets.datalad.org/openfmri/ds000105 [1 other candidates] into '/tmp/ds000105' 
[INFO   ]  Cloning (counting objects) 100 objects done in 0 sec at 1880853 objects/sec 
[INFO   ]  Cloning (compressing objects) 68466 objects done in 0.001 sec at 52508176 objects/sec 
[INFO   ]  Cloning (receiving objects) 152614 objects done in 6 seconds at 25248 objects/sec 
[INFO   ]  Cloning (resolving stuff) 80063 objects done in 0.003 sec at 23785845 objects/sec 
[INFO   ] access to dataset sibling "datalad" not auto-enabled, enable with:
| 		datalad siblings -d "/tmp/ds000105" enable -s datalad 
install(ok): /tmp/ds000105 (dataset)
[INFO   ]  derivatives/mriqc/anatomical_sub-3.pdf 63.2 kB done in 0.172 sec at 366.9 kB/sec 
[INFO   ]  derivatives/mriqc/anatomical_sub-4.pdf 63.5 kB done in 0.13 sec at 490.0 kB/sec 
[INFO   ]  derivatives/mriqc/functional_group.pdf 182.8 kB done in 0.045 sec at 4.1 MB/sec 
[INFO   ]  derivatives/mriqc/funcMRIQC.csv 29.0 kB done in 0.198 sec at 146.6 kB/sec 
^C[WARNING] Still have 4 active progress bars when stopping 
[INFO   ]  Total partially (1.38% of 1.9 GB) done in 17 seconds at 1.5 MB/sec 
[INFO   ]  sub-1/anat/sub-1_T1w.nii.gz partially (84.71% of 6.0 MB) done in 15 seconds at 319.8 kB/sec 
[INFO   ]  sub-1/func/sub-1_task-objectviewing_run-02_bold.nii.gz partially (22.58% of 25.8 MB) done in 15 seconds at 373.5 kB/sec 
[INFO   ]  sub-1/func/sub-1_task-objectviewing_run-01_bold.nii.gz partially (28.36% of 25.7 MB) done in 15 seconds at 478.3 kB/sec 
[INFO   ]  sub-1/func/sub-1_task-objectviewing_run-03_bold.nii.gz partially (24.89% of 25.8 MB) done in 14 seconds at 428.5 kB/sec 
ERROR: 
Interrupted by user while doing magic: KeyboardInterrupt() [cmd.py:_process_one_line:358]
DATALAD_UI_PROGRESSBAR=log datalad install -g ///openfmri/ds000105  6.27s user 2.08s system 24% cpu 34.728 total

$> sudo rm -rf QA simon dartmouth-phantoms velasco; DATALAD_UI_PROGRESSBAR=log datalad install -g ///labs/tarr/face_place      
[INFO   ] Cloning http://datasets.datalad.org/labs/tarr/face_place [1 other candidates] into '/tmp/face_place' 
[INFO   ]  Cloning (counting objects) 100 objects done in 0 sec at 2853268 objects/sec 
[INFO   ]  Cloning (compressing objects) 28649 objects done in 0.001 sec at 38002092 objects/sec 
[INFO   ]  Cloning (receiving objects) 31593 objects done in 1.418 sec at 22275 objects/sec 
[INFO   ]  Cloning (resolving stuff) 387 objects done in 0.003 sec at 137477 objects/sec 
install(ok): /tmp/face_place (dataset)
[INFO   ] To obtain some keys we need to fetch an archive of size 42.5 MB 
[INFO   ]  MD5E-s42453590--70418661c05ac77945454b58f7a02789.zip 42.5 MB done in 32 seconds at 1.3 MB/sec 
[INFO   ] To obtain some keys we need to fetch an archive of size 28.8 MB 
^C[WARNING] Still have 1 active progress bars when stopping 
[INFO   ]  Total possibly partially done in 46 seconds at 1.3 MB/sec 
[INFO   ]  MD5E-s28831000--2d7e46964c86637e36c26745b8455aea.zip partially (28.79% of 28.8 MB) done in 6 seconds at 1.2 MB/sec 
ERROR: 
Interrupted by user while doing magic: KeyboardInterrupt() [cmd.py:_process_one_line:358]
DATALAD_UI_PROGRESSBAR=log datalad install -g ///labs/tarr/face_place  10.14s user 2.26s system 20% cpu 1:00.97 total

$> sudo rm -rf QA simon dartmouth-phantoms velasco; DATALAD_UI_PROGRESSBAR=log datalad install -g ///labs/tarr/face_place
[INFO   ] To obtain some keys we need to fetch an archive of size 28.8 MB 
[INFO   ]  MD5E-s28831000--2d7e46964c86637e36c26745b8455aea.zip 28.8 MB done in 14 seconds at 2.0 MB/sec 
[INFO   ] To obtain some keys we need to fetch an archive of size 118.2 MB 
[INFO   ]  MD5E-s118229974--970c5c314ec41a2950e98aeefb2faf44.zip 118.2 MB done in a minute at 1.1 MB/sec 
[INFO   ] To obtain some keys we need to fetch an archive of size 16.7 MB 
[INFO   ]  MD5E-s16663731--4735c5882fd6736c1b0829c428a40503.zip 16.7 MB done in 11 seconds at 1.4 MB/sec 
[INFO   ] To obtain some keys we need to fetch an archive of size 16.3 MB 
[INFO   ]  MD5E-s16251761--d049c7c7316b38e847833f574a1ba2ad.zip 16.3 MB done in 13 seconds at 1.2 MB/sec 
[INFO   ]  Total 40.8 MB done in 2 minutes at 233.6 kB/sec 
action summary:
  get (ok: 5290)
  install (notneeded: 1)
DATALAD_UI_PROGRESSBAR=log datalad install -g ///labs/tarr/face_place  69.89s user 21.58s system 50% cpu 3:02.77 total
```
</details>

Ideally should have dedicated test(s) but not sure if I would have juice for that ATM, but let's see if some bugs get revealed by just using it through the tests