### PR TITLE
RF: versioned depends on sphinx within setup.py itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -275,7 +275,6 @@ install:
   - git config --global user.name "Travis Almighty"
   - cd ..; pip install -q codecov; cd -
   - pip install -r requirements-devel.txt
-  - pip install 'sphinx>=1.7.8'
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
   # TMPDIRs

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ requires.update({
         # used for converting README.md -> .rst for long_description
         'pypandoc',
         # Documentation
-        'sphinx',
+        'sphinx>=1.7.8',
         'sphinx-rtd-theme',
     ],
     'devel-utils': [


### PR DESCRIPTION
Ideally there should be no "manual" installations within CI setups, and such versioned dependencies are due to be specified in setup.py -- similar but a bit more extensive PR is coming to datalad-neuroimaging