### PR TITLE
BF: gitrepo: Yield 'add' result when saving new submodule

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -22,6 +22,7 @@ from datalad.tests.utils import (
     assert_status,
     assert_result_count,
     assert_in,
+    assert_in_results,
     assert_not_in,
     assert_raises,
     create_tree,
@@ -376,7 +377,8 @@ def test_add_subdataset(path, other):
     assert_not_in('dir', ds.subdatasets(result_xfm='relpaths'))
     # but with a base directory we add the dataset subds as a subdataset
     # to ds
-    ds.rev_save(subds.path)
+    res = ds.rev_save(subds.path)
+    assert_in_results(res, action="add", path=subds.path, refds=ds.path)
     assert_in('dir', ds.subdatasets(result_xfm='relpaths'))
     #  create another one
     other = create(other)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3532,6 +3532,16 @@ class GitRepo(RepoInterface):
                         else ('not a Git repository: %s', exc_str(e)),
                         logger=lgr)
                     continue
+                # This mirrors the result structure yielded for
+                # to_stage_submodules below.
+                yield get_status_dict(
+                    action='add',
+                    refds=self.pathobj,
+                    type='file',
+                    key=None,
+                    path=self.pathobj / ut.PurePosixPath(cand_sm),
+                    status='ok',
+                    logger=lgr)
                 added_submodule = True
         if not need_partial_commit:
             # without a partial commit an AnnexRepo would ignore any submodule


### PR DESCRIPTION
When rev-save saves a fresh subdataset, it doesn't show any
information about adding that subdataset:

    $ datalad create subds
    $ datalad rev-save
    add(ok): .gitmodules (file)  # <- no subdataset mentioned here...
    save(ok): . (dataset)
    action summary:
      add (ok: 1)                # <- ... or here.
      save (ok: 1)

Yield a result so that the output is instead:

    $ datalad rev-save
    add(ok): subds (file)        # <- new entry
    add(ok): .gitmodules (file)
    save(ok): . (dataset)
    action summary:
      add (ok: 2)
      save (ok: 1)

The new result is consistent with the result that is yielded when
saving modified subdatasets.