### PR TITLE
RF: Various little annoyances in SSH support code

### DIFF
--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -13,12 +13,10 @@ Allows for connecting via ssh and keeping the connection open
 git calls to a ssh remote without the need to reauthenticate.
 """
 
+import os
 import logging
 from socket import gethostname
 from hashlib import md5
-from os import remove
-from os.path import exists
-from os.path import join as opj
 from subprocess import Popen
 # importing the quote function here so it can always be imported from this
 # module
@@ -33,6 +31,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import assure_dir
 from datalad.utils import auto_repr
 from datalad.cmd import Runner
+from datalad.utils import Path
 
 lgr = logging.getLogger('datalad.support.sshconnector')
 
@@ -92,8 +91,8 @@ class SSHConnection(object):
                 "connections: {}".format(sshri))
         self.sshri = SSHRI(**{k: v for k, v in sshri.fields.items()
                               if k in ('username', 'hostname', 'port')})
-        self.ctrl_path = ctrl_path
-        self._ctrl_options = ["-o", "ControlPath=\"%s\"" % self.ctrl_path]
+        self._ctrl_options = ["-o", "ControlPath=\"%s\"" % ctrl_path]
+        self.ctrl_path = Path(ctrl_path)
         if self.sshri.port:
             self._ctrl_options += ['-p', '{}'.format(self.sshri.port)]
 
@@ -168,7 +167,7 @@ class SSHConnection(object):
         return self._runner
 
     def is_open(self):
-        if not exists(self.ctrl_path):
+        if not self.ctrl_path.exists():
             lgr.log(
                 5,
                 "Not opening %s for checking since %s does not exist",
@@ -178,6 +177,7 @@ class SSHConnection(object):
         # check whether controlmaster is still running:
         cmd = ["ssh", "-O", "check"] + self._ctrl_options + [self.sshri.as_str()]
         lgr.debug("Checking %s by calling %s" % (self, cmd))
+        # TODO does not work on windows!
         null = open('/dev/null')
         try:
             # expect_stderr since ssh would announce to stderr
@@ -194,7 +194,10 @@ class SSHConnection(object):
             res = False
         finally:
             null.close()
-        lgr.debug("Check of %s has %s", self, {True: 'succeeded', False: 'failed'}[res])
+        lgr.debug(
+            "Check of %s has %s",
+            self,
+            {True: 'succeeded', False: 'failed'}[res])
         return res
 
     def open(self):
@@ -252,10 +255,10 @@ class SSHConnection(object):
             self.runner.run(cmd, expect_stderr=True, expect_fail=True)
         except CommandError as e:
             lgr.debug("Failed to run close command")
-            if exists(self.ctrl_path):
+            if self.ctrl_path.exists():
                 lgr.debug("Removing existing control path %s", self.ctrl_path)
                 # socket need to go in any case
-                remove(self.ctrl_path)
+                self.ctrl_path.unlink()
             if e.code != 255:
                 # not a "normal" SSH error
                 raise e
@@ -299,6 +302,7 @@ class SSHConnection(object):
         # more
         self._remote_props[key] = annex_install_dir
         try:
+            # TODO does not work on windows
             with open('/dev/null') as null:
                 annex_install_dir = self(
                     # use sh -e to be able to fail at each stage of the process
@@ -379,13 +383,12 @@ class SSHManager(object):
         if self._socket_dir is not None:
             return
         from ..config import ConfigManager
-        from os import chmod
         cfg = ConfigManager()
-        self._socket_dir = opj(cfg.obtain('datalad.locations.cache'),
-                               'sockets')
-        assure_dir(self._socket_dir)
+        self._socket_dir = \
+            Path(cfg.obtain('datalad.locations.cache')) / 'sockets'
+        self._socket_dir.mkdir(exist_ok=True, parents=True)
         try:
-            chmod(self._socket_dir, 0o700)
+            os.chmod(self._socket_dir, 0o700)
         except OSError as exc:
             lgr.warning(
                 "Failed to (re)set permissions on the %s. "
@@ -394,12 +397,10 @@ class SSHManager(object):
                 self._socket_dir, exc_str(exc)
             )
 
-        from os import listdir
-        from os.path import isdir
         try:
-            self._prev_connections = [opj(self.socket_dir, p)
-                                      for p in listdir(self.socket_dir)
-                                      if not isdir(opj(self.socket_dir, p))]
+            self._prev_connections = [p
+                                      for p in self.socket_dir.iterdir()
+                                      if not p.is_dir()]
         except OSError as exc:
             self._prev_connections = []
             lgr.warning(
@@ -450,7 +451,7 @@ class SSHManager(object):
             identity_file=identity_file or "",
             username=sshri.username)
         # determine control master:
-        ctrl_path = "%s/%s" % (self.socket_dir, conhash)
+        ctrl_path = self.socket_dir / conhash
 
         # do we know it already?
         if ctrl_path in self._connections:
@@ -478,7 +479,7 @@ class SSHManager(object):
                         # don't close if connection wasn't opened by SSHManager
                         if self._connections[c].ctrl_path
                         not in self._prev_connections and
-                        exists(self._connections[c].ctrl_path)
+                        self._connections[c].ctrl_path.exists()
                         and (not ctrl_paths
                              or self._connections[c].ctrl_path in ctrl_paths)]
             if to_close:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -21,6 +21,7 @@ from subprocess import Popen
 import tempfile
 # importing the quote function here so it can always be imported from this
 # module
+from six.moves import shlex_quote as sh_quote
 from six import text_type
 
 # !!! Do not import network here -- delay import, allows to shave off 50ms or so

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -21,7 +21,7 @@ from subprocess import Popen
 import tempfile
 # importing the quote function here so it can always be imported from this
 # module
-from six.moves import shlex_quote as sh_quote
+from six import text_type
 
 # !!! Do not import network here -- delay import, allows to shave off 50ms or so
 # on initial import datalad time
@@ -30,7 +30,6 @@ from six.moves import shlex_quote as sh_quote
 from datalad.support.exceptions import CommandError
 from datalad.dochelpers import exc_str
 from datalad.utils import (
-    assure_dir,
     auto_repr,
     Path,
 )
@@ -388,7 +387,7 @@ class SSHManager(object):
             Path(cfg.obtain('datalad.locations.cache')) / 'sockets'
         self._socket_dir.mkdir(exist_ok=True, parents=True)
         try:
-            os.chmod(self._socket_dir, 0o700)
+            os.chmod(text_type(self._socket_dir), 0o700)
         except OSError as exc:
             lgr.warning(
                 "Failed to (re)set permissions on the %s. "

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -180,7 +180,6 @@ class SSHConnection(object):
         # check whether controlmaster is still running:
         cmd = ["ssh", "-O", "check"] + self._ctrl_options + [self.sshri.as_str()]
         lgr.debug("Checking %s by calling %s" % (self, cmd))
-        # TODO does not work on windows!
         try:
             # expect_stderr since ssh would announce to stderr
             # "Master is running" and that is normal, not worthy warning about
@@ -303,8 +302,8 @@ class SSHConnection(object):
         # more
         self._remote_props[key] = annex_install_dir
         try:
-            # TODO does not work on windows
             with tempfile.TemporaryFile() as tempf:
+                # TODO does not work on windows
                 annex_install_dir = self(
                     # use sh -e to be able to fail at each stage of the process
                     "sh -e -c 'dirname $(readlink -f $(which git-annex-shell))'"

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -18,6 +18,7 @@ __docformat__ = 'restructuredtext'
 import logging
 import os
 import sys
+import tempfile
 
 from datalad.support.param import Parameter
 from datalad.interface.base import Interface
@@ -56,7 +57,7 @@ class SSHRun(Interface):
             args=("-n",),
             action="store_true",
             dest="no_stdin",
-            doc="Redirect stdin from /dev/null"),
+            doc="Do not connect stdin to the process"),
     )
 
     @staticmethod
@@ -83,8 +84,8 @@ class SSHRun(Interface):
             login,
             ':{}'.format(port) if port else '')
         ssh = ssh_manager.get_connection(sshurl)
-        # TODO: /dev/null on windows ;)  or may be could be just None?
-        stdin_ = open('/dev/null', 'r') if no_stdin else sys.stdin
+        # use an empty temp file as stdin if none shall be connected
+        stdin_ = tempfile.TemporaryFile() if no_stdin else sys.stdin
         try:
             out, err = ssh(cmd, stdin=stdin_, log_output=False)
         finally:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -27,6 +27,8 @@ from os.path import exists
 from shutil import copyfile
 from nose.tools import assert_not_is_instance
 
+from six import text_type
+
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlsplit
 
@@ -1074,8 +1076,10 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     rm2 = AnnexRepo(remote_2_path, create=False)
 
     # check whether we are the first to use these sockets:
-    socket_1 = opj(ssh_manager.socket_dir, get_connection_hash('datalad-test'))
-    socket_2 = opj(ssh_manager.socket_dir, get_connection_hash('localhost'))
+    socket_1 = opj(text_type(ssh_manager.socket_dir),
+                   get_connection_hash('datalad-test'))
+    socket_2 = opj(text_type(ssh_manager.socket_dir),
+                   get_connection_hash('localhost'))
     datalad_test_was_open = exists(socket_1)
     localhost_was_open = exists(socket_2)
 
@@ -1090,7 +1094,7 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ar = AnnexRepo(repo_path, create=False)
 
     # connection to 'datalad-test' should be known to ssh manager:
-    assert_in(socket_1, ssh_manager._connections)
+    assert_in(socket_1, list(map(text_type, ssh_manager._connections)))
     # but socket was not touched:
     if datalad_test_was_open:
         ok_(exists(socket_1))
@@ -1127,7 +1131,7 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ar.add_remote('ssh-remote-2', "ssh://localhost" + remote_2_path)
 
     # now, this connection to localhost was requested:
-    assert_in(socket_2, ssh_manager._connections)
+    assert_in(socket_2, list(map(text_type, ssh_manager._connections)))
     # but socket was not touched:
     if localhost_was_open:
         # FIXME: occasionally(?) fails in V6:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -20,6 +20,7 @@ import os.path as op
 
 import sys
 
+from six import text_type
 
 from datalad import get_encoding_info
 from datalad.cmd import Runner
@@ -525,7 +526,8 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 
     remote_repo = GitRepo(remote_path, create=False)
     url = "ssh://localhost" + op.abspath(remote_path)
-    socket_path = op.join(ssh_manager.socket_dir, get_connection_hash('localhost'))
+    socket_path = op.join(text_type(ssh_manager.socket_dir),
+                          get_connection_hash('localhost'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -537,7 +539,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     ok_clean_git(repo)
 
     # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, ssh_manager._connections)
+    assert_in(socket_path, list(map(text_type, ssh_manager._connections)))
     # and socket was created:
     ok_(op.exists(socket_path))
 
@@ -553,7 +555,8 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
 
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + op.abspath(remote_path)
-    socket_path = op.join(ssh_manager.socket_dir, get_connection_hash('localhost'))
+    socket_path = op.join(text_type(ssh_manager.socket_dir),
+                          get_connection_hash('localhost'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -572,7 +575,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     ok_clean_git(repo.path, annex=False)
 
     # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, ssh_manager._connections)
+    assert_in(socket_path, list(map(text_type, ssh_manager._connections)))
     # and socket was created:
     ok_(op.exists(socket_path))
 
@@ -588,7 +591,8 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
 
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + op.abspath(remote_path)
-    socket_path = op.join(ssh_manager.socket_dir, get_connection_hash('localhost'))
+    socket_path = op.join(text_type(ssh_manager.socket_dir),
+                          get_connection_hash('localhost'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -608,7 +612,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     assert_in("ssh-remote/ssh-test", [commit.remote_ref.name for commit in pushed])
 
     # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, ssh_manager._connections)
+    assert_in(socket_path, list(map(text_type, ssh_manager._connections)))
     # and socket was created:
     ok_(op.exists(socket_path))
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -17,6 +17,8 @@ from mock import patch
 
 from nose import SkipTest
 
+from six import text_type
+
 from datalad.support.external_versions import external_versions
 from datalad.utils import Path
 
@@ -77,7 +79,8 @@ def test_ssh_open_close(tfile1):
 
     manager = SSHManager()
 
-    path = opj(manager.socket_dir, get_connection_hash('localhost'))
+    path = opj(text_type(manager.socket_dir),
+               get_connection_hash('localhost'))
     # TODO: facilitate the test when it didn't exist
     existed_before = exists(path)
     print("%s existed: %s" % (path, existed_before))
@@ -113,9 +116,9 @@ def test_ssh_manager_close():
     manager = SSHManager()
 
     # check for previously existing sockets:
-    existed_before_1 = exists(opj(manager.socket_dir,
+    existed_before_1 = exists(opj(text_type(manager.socket_dir),
                                   get_connection_hash('localhost')))
-    existed_before_2 = exists(opj(manager.socket_dir,
+    existed_before_2 = exists(opj(text_type(manager.socket_dir),
                                   get_connection_hash('datalad-test')))
 
     manager.get_connection('ssh://localhost').open()
@@ -127,14 +130,16 @@ def test_ssh_manager_close():
         manager.get_connection('ssh://localhost').close()
         manager.get_connection('ssh://localhost').open()
 
-    ok_(exists(opj(manager.socket_dir, get_connection_hash('localhost'))))
-    ok_(exists(opj(manager.socket_dir, get_connection_hash('datalad-test'))))
+    ok_(exists(opj(text_type(manager.socket_dir),
+                   get_connection_hash('localhost'))))
+    ok_(exists(opj(text_type(manager.socket_dir),
+                   get_connection_hash('datalad-test'))))
 
     manager.close()
 
-    still_exists_1 = exists(opj(manager.socket_dir,
+    still_exists_1 = exists(opj(text_type(manager.socket_dir),
                                 get_connection_hash('localhost')))
-    still_exists_2 = exists(opj(manager.socket_dir,
+    still_exists_2 = exists(opj(text_type(manager.socket_dir),
                                 get_connection_hash('datalad-test')))
 
     eq_(existed_before_1, still_exists_1)
@@ -236,7 +241,7 @@ def test_ssh_custom_identity_file():
                 ssh = manager.get_connection('ssh://localhost')
                 cmd_out, _ = ssh("echo blah")
                 expected_socket = op.join(
-                    manager.socket_dir,
+                    text_type(manager.socket_dir),
                     get_connection_hash("localhost", identity_file=ifile))
                 ok_(exists(expected_socket))
                 manager.close()

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -18,6 +18,7 @@ from mock import patch
 from nose import SkipTest
 
 from datalad.support.external_versions import external_versions
+from datalad.utils import Path
 
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import eq_
@@ -152,7 +153,7 @@ def test_ssh_manager_close_no_throw(bogus_socket):
         def ctrl_path(self):
             with open(bogus_socket, "w") as f:
                 f.write("whatever")
-            return bogus_socket
+            return Path(bogus_socket)
 
     # since we are digging into protected area - should also set _prev_connections
     manager._prev_connections = {}


### PR DESCRIPTION
- [x] stop use of `/dev/null`
- [x] stop unconditional use of POSIX path conventions