### PR TITLE
On-demand SSHConnection.get/put()

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -824,7 +824,7 @@ mkdir -p "$dsdir/{WEB_META_LOG}"  # assure logs directory exists
         with make_tempfile(content=hook_content) as tempf:
             # create post_update hook script
             # upload hook to dataset
-            ssh.copy(tempf, hook_remote_target)
+            ssh.put(tempf, hook_remote_target)
         # and make it executable
         ssh('chmod +x {}'.format(sh_quote(hook_remote_target)))
 
@@ -840,13 +840,13 @@ mkdir -p "$dsdir/{WEB_META_LOG}"  # assure logs directory exists
         html_target = opj(path, html_targetname)
 
         # upload ui html to target
-        ssh.copy(html_local, html_target)
+        ssh.put(html_local, html_target)
 
         # upload assets to the dataset
         webresources_local = opj(webui_local, 'assets')
         webresources_remote = opj(path, WEB_HTML_DIR)
         ssh('mkdir -p {}'.format(sh_quote(webresources_remote)))
-        ssh.copy(webresources_local, webresources_remote, recursive=True)
+        ssh.put(webresources_local, webresources_remote, recursive=True)
 
         # minimize and upload js assets
         for js_file in glob(opj(webresources_local, 'js', '*.js')):
@@ -861,7 +861,7 @@ mkdir -p "$dsdir/{WEB_META_LOG}"  # assure logs directory exists
                     minified = asset.read()                             # no minify available
                 with make_tempfile(content=minified) as tempf:          # write minified to tempfile
                     js_name = js_file.split('/')[-1]
-                    ssh.copy(tempf, opj(webresources_remote, 'assets', 'js', js_name))  # and upload js
+                    ssh.put(tempf, opj(webresources_remote, 'assets', 'js', js_name))  # and upload js
 
         # explicitly make web+metadata dir of dataset world-readable, if shared set to 'all'
         mode = None

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -33,6 +33,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import (
     auto_repr,
     Path,
+    assure_list,
 )
 from datalad.cmd import Runner
 
@@ -263,7 +264,8 @@ class SSHConnection(object):
                 # not a "normal" SSH error
                 raise e
 
-    def copy(self, source, destination, recursive=False, preserve_attrs=False):
+    def copy_to_remote(self, source, destination,
+                       recursive=False, preserve_attrs=False):
         """Copies source file/folder to destination on the remote.
 
         Parameters
@@ -286,8 +288,7 @@ class SSHConnection(object):
         scp_cmd = ["scp"] + scp_options
 
         # add source filepath(s) to scp command
-        scp_cmd += source if isinstance(source, list) \
-            else [source]
+        scp_cmd += assure_list(source)
 
         # add destination path
         scp_cmd += ['%s:"%s"' % (self.sshri.hostname, destination)]

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -512,7 +512,9 @@ class SSHManager(object):
         if ctrl_path in self._connections:
             return self._connections[ctrl_path]
         else:
-            c = SSHConnection(ctrl_path, sshri, identity_file=identity_file)
+            c = SSHConnection(
+                ctrl_path, sshri, identity_file=identity_file,
+                use_remote_annex_bundle=use_remote_annex_bundle)
             self._connections[ctrl_path] = c
             return c
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -125,7 +125,7 @@ class SSHConnection(object):
         """
 
         # TODO:  do not do all those checks for every invocation!!
-        # TODO: check for annex location once, check for open socket once
+        # TODO: check for open socket once
         #       and provide roll back if fails to run and was not explicitly
         #       checked first
         # make sure we have an open connection, will test if action is needed

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -301,6 +301,35 @@ class SSHConnection(object):
         scp_cmd += ['%s:"%s"' % (self.sshri.hostname, destination)]
         return self.runner.run(scp_cmd)
 
+    def copy_from_remote(self, source, destination,
+                         recursive=False, preserve_attrs=False):
+        """Copies source file/folder from remote to a local destination.
+
+        Parameters
+        ----------
+        source : str or list
+          file/folder path(s) to copy from the remote host
+        destination : str
+          file/folder path to copy to on the local host
+        recursive : bool
+          flag to enable recursive copying of given sources
+        preserve_attrs : bool
+          preserve modification times, access times, and modes from the
+          original file
+
+        Returns
+        -------
+        str
+          stdout, stderr of the copy operation.
+        """
+        scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
+        # add source filepath(s) to scp command, prefixed with the remote host
+        scp_cmd += ['%s:"%s"' % (self.sshri.hostname, s)
+                    for s in assure_list(source)]
+        # add destination path
+        scp_cmd += [destination]
+        return self.runner.run(scp_cmd)
+
     def get_annex_installdir(self):
         key = 'installdir:annex'
         if key in self._remote_props:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -128,11 +128,9 @@ class SSHConnection(object):
         # TODO: check for annex location once, check for open socket once
         #       and provide roll back if fails to run and was not explicitly
         #       checked first
-        if not self.is_open():
-            if not self.open():
-                raise RuntimeError(
-                    'Cannot open SSH connection to {}'.format(
-                        self.sshri))
+        # make sure we have an open connection, will test if action is needed
+        # by itself
+        self.open()
 
         # locate annex and set the bundled vs. system Git machinery in motion
         remote_annex_installdir = self.get_annex_installdir()
@@ -293,6 +291,9 @@ class SSHConnection(object):
         str
           stdout, stderr of the copy operation.
         """
+        # make sure we have an open connection, will test if action is needed
+        # by itself
+        self.open()
         scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
         # add source filepath(s) to scp command
         scp_cmd += assure_list(source)
@@ -320,6 +321,9 @@ class SSHConnection(object):
         str
           stdout, stderr of the copy operation.
         """
+        # make sure we have an open connection, will test if action is needed
+        # by itself
+        self.open()
         scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
         # add source filepath(s) to scp command, prefixed with the remote host
         scp_cmd += ['%s:"%s"' % (self.sshri.hostname, s)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -224,7 +224,13 @@ class SSHConnection(object):
         bool
           Whether SSH reports success opening the connection
         """
-        if self.is_open():
+        # the socket should vanish almost instantly when the connection closes
+        # sending explicit 'check' commands to the control master is expensive
+        # (needs tempfile to shield stdin, Runner overhead, etc...)
+        # as we do not use any advanced features (forwarding, stop[ing the
+        # master without exiting) it should be relatively safe to just perform
+        # the much cheaper check of an existing control path
+        if self.ctrl_path.exists():
             return
 
         # set control options

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -273,8 +273,7 @@ class SSHConnection(object):
         scp_options += ["-p"] if preserve_attrs else []
         return ["scp"] + scp_options
 
-    def copy_to_remote(self, source, destination,
-                       recursive=False, preserve_attrs=False):
+    def put(self, source, destination, recursive=False, preserve_attrs=False):
         """Copies source file/folder to destination on the remote.
 
         Parameters
@@ -301,8 +300,7 @@ class SSHConnection(object):
         scp_cmd += ['%s:"%s"' % (self.sshri.hostname, destination)]
         return self.runner.run(scp_cmd)
 
-    def copy_from_remote(self, source, destination,
-                         recursive=False, preserve_attrs=False):
+    def get(self, source, destination, recursive=False, preserve_attrs=False):
         """Copies source file/folder from remote to a local destination.
 
         Parameters

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -124,10 +124,14 @@ class SSHConnection(object):
           stdout, stderr of the command run.
         """
 
-        # TODO:  do not do all those checks for every invocation!!
-        # TODO: check for open socket once
-        #       and provide roll back if fails to run and was not explicitly
-        #       checked first
+        # XXX: check for open socket once
+        #      and provide roll back if fails to run and was not explicitly
+        #      checked first
+        # MIH: this would mean that we would have to distinguish failure
+        #      of a payload command from failure of SSH itself. SSH however,
+        #      only distinguishes success and failure of the entire operation
+        #      Increase in fragility from introspection makes a potential
+        #      performance benefit a questionable improvement.
         # make sure we have an open connection, will test if action is needed
         # by itself
         self.open()

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1077,9 +1077,9 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
 
     # check whether we are the first to use these sockets:
     socket_1 = opj(text_type(ssh_manager.socket_dir),
-                   get_connection_hash('datalad-test'))
+                   get_connection_hash('datalad-test', bundled=True))
     socket_2 = opj(text_type(ssh_manager.socket_dir),
-                   get_connection_hash('localhost'))
+                   get_connection_hash('localhost', bundled=True))
     datalad_test_was_open = exists(socket_1)
     localhost_was_open = exists(socket_2)
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -527,7 +527,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     remote_repo = GitRepo(remote_path, create=False)
     url = "ssh://localhost" + op.abspath(remote_path)
     socket_path = op.join(text_type(ssh_manager.socket_dir),
-                          get_connection_hash('localhost'))
+                          get_connection_hash('localhost', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -556,7 +556,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + op.abspath(remote_path)
     socket_path = op.join(text_type(ssh_manager.socket_dir),
-                          get_connection_hash('localhost'))
+                          get_connection_hash('localhost', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -592,7 +592,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + op.abspath(remote_path)
     socket_path = op.join(text_type(ssh_manager.socket_dir),
-                          get_connection_hash('localhost'))
+                          get_connection_hash('localhost', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -243,7 +243,8 @@ def test_ssh_custom_identity_file():
                 cmd_out, _ = ssh("echo blah")
                 expected_socket = op.join(
                     text_type(manager.socket_dir),
-                    get_connection_hash("localhost", identity_file=ifile))
+                    get_connection_hash("localhost", identity_file=ifile,
+                                        bundled=True))
                 ok_(exists(expected_socket))
                 manager.close()
                 assert_in("-i", cml.out)

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -71,7 +71,7 @@ def test_ssh_get_connection():
     manager.close()
 
 
-@skip_if_on_windows  # our test setup has no SSH server running
+@skip_if_on_windows
 @skip_ssh
 @with_tempfile(suffix=' "`suffix:;& ',  # get_most_obscure_supported_name(),
                content="1")
@@ -109,7 +109,7 @@ def test_ssh_open_close(tfile1):
     ok_(exists(path) == existed_before)
 
 
-@skip_if_on_windows  # our test setup has no SSH server running
+@skip_if_on_windows
 @skip_ssh
 def test_ssh_manager_close():
 
@@ -172,7 +172,7 @@ def test_ssh_manager_close_no_throw(bogus_socket):
         assert_in('Failed to close a connection: oh I am so bad', cml.out)
 
 
-@skip_if_on_windows  # our test setup has no `scp` command
+@skip_if_on_windows
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile(content="one")
@@ -216,7 +216,7 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
     ssh.close()
 
 
-@skip_if_on_windows  # our test setup has no SSH server running
+@skip_if_on_windows
 @skip_ssh
 def test_ssh_compound_cmds():
     ssh = SSHManager().get_connection('ssh://localhost')
@@ -253,7 +253,7 @@ def test_ssh_custom_identity_file():
         cfg.reload(force=True)
 
 
-@skip_if_on_windows  # our test setup has no SSH server running
+@skip_if_on_windows
 @skip_ssh
 def test_ssh_git_props():
     remote_url = 'ssh://localhost'

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -22,17 +22,19 @@ from six import text_type
 from datalad.support.external_versions import external_versions
 from datalad.utils import Path
 
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import eq_
-from datalad.tests.utils import skip_ssh
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import get_most_obscure_supported_name
-from datalad.tests.utils import swallow_logs
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import ok_
-from datalad.tests.utils import assert_is_instance
-from datalad.tests.utils import skip_if_on_windows
-
+from datalad.tests.utils import (
+    assert_raises,
+    eq_,
+    skip_ssh,
+    with_tempfile,
+    get_most_obscure_supported_name,
+    swallow_logs,
+    assert_in,
+    assert_false,
+    ok_,
+    assert_is_instance,
+    skip_if_on_windows,
+)
 from ..sshconnector import SSHConnection, SSHManager, sh_quote
 from ..sshconnector import get_connection_hash
 
@@ -192,7 +194,7 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
     sourcefiles = [sourcefile1, sourcefile2, obscure_file]
     ssh.put(sourcefiles, opj(remote_url, sourcedir))
     # docs promise that connection is auto-opened
-    assert(ssh.is_open())
+    ok_(ssh.is_open())
 
     # recursive copy tempdir to remote_url:targetdir
     targetdir = sourcedir + '.c opy'
@@ -216,8 +218,8 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
     # and now a quick smoke test for get
     togetfile = Path(targetdir) / '2get.txt'
     togetfile.write_text(text_type('something'))
-    ssh.get(opj(remote_url, togetfile), sourcedir)
-    (Path(sourcedir) / '2get.txt').exists()
+    ssh.get(opj(remote_url, text_type(togetfile)), sourcedir)
+    ok_((Path(sourcedir) / '2get.txt').exists())
 
     ssh.close()
 
@@ -285,8 +287,8 @@ def test_bundle_invariance(path):
     manager = SSHManager()
     testfile = Path(path) / 'dummy'
     for flag in (True, False):
-        assert(not testfile.exists())
+        assert_false(testfile.exists())
         ssh = manager.get_connection(remote_url, use_remote_annex_bundle=flag)
         ssh('cd .>{}'.format(text_type(testfile)))
-        assert(testfile.exists())
+        ok_(testfile.exists())
         testfile.unlink()

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -216,10 +216,10 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
             eq_(content, fp.read())
 
     # and now a quick smoke test for get
-    togetfile = Path(targetdir) / '2get.txt'
+    togetfile = Path(targetdir) / '2|g>e"t.t&x;t'
     togetfile.write_text(text_type('something'))
     ssh.get(opj(remote_url, text_type(togetfile)), sourcedir)
-    ok_((Path(sourcedir) / '2get.txt').exists())
+    ok_((Path(sourcedir) / '2|g>e"t.t&x;t').exists())
 
     ssh.close()
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -80,7 +80,7 @@ def test_ssh_open_close(tfile1):
     manager = SSHManager()
 
     path = opj(text_type(manager.socket_dir),
-               get_connection_hash('localhost'))
+               get_connection_hash('localhost', bundled=True))
     # TODO: facilitate the test when it didn't exist
     existed_before = exists(path)
     print("%s existed: %s" % (path, existed_before))
@@ -131,9 +131,9 @@ def test_ssh_manager_close():
         manager.get_connection('ssh://localhost').open()
 
     ok_(exists(opj(text_type(manager.socket_dir),
-                   get_connection_hash('localhost'))))
+                   get_connection_hash('localhost', bundled=True))))
     ok_(exists(opj(text_type(manager.socket_dir),
-                   get_connection_hash('datalad-test'))))
+                   get_connection_hash('datalad-test', bundled=True))))
 
     manager.close()
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -182,7 +182,6 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
     remote_url = 'ssh://localhost:22'
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
-    ssh.open()
 
     # write to obscurely named file in sourcedir
     obscure_file = opj(sourcedir, get_most_obscure_supported_name())
@@ -192,6 +191,8 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
     # copy tempfile list to remote_url:sourcedir
     sourcefiles = [sourcefile1, sourcefile2, obscure_file]
     ssh.put(sourcefiles, opj(remote_url, sourcedir))
+    # docs promise that connection is auto-opened
+    assert(ssh.is_open())
 
     # recursive copy tempdir to remote_url:targetdir
     targetdir = sourcedir + '.c opy'

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -213,6 +213,12 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
         with open(targetpath, 'r') as fp:
             eq_(content, fp.read())
 
+    # and now a quick smoke test for get
+    togetfile = Path(targetdir) / '2get.txt'
+    togetfile.write_text(text_type('something'))
+    ssh.get(opj(remote_url, togetfile), sourcedir)
+    (Path(sourcedir) / '2get.txt').exists()
+
     ssh.close()
 
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -191,12 +191,12 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
 
     # copy tempfile list to remote_url:sourcedir
     sourcefiles = [sourcefile1, sourcefile2, obscure_file]
-    ssh.copy(sourcefiles, opj(remote_url, sourcedir))
+    ssh.put(sourcefiles, opj(remote_url, sourcedir))
 
     # recursive copy tempdir to remote_url:targetdir
     targetdir = sourcedir + '.c opy'
-    ssh.copy(sourcedir, opj(remote_url, targetdir),
-             recursive=True, preserve_attrs=True)
+    ssh.put(sourcedir, opj(remote_url, targetdir),
+            recursive=True, preserve_attrs=True)
 
     # check if sourcedir copied to remote_url:targetdir
     ok_(isdir(targetdir))

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -266,3 +266,21 @@ def test_ssh_git_props():
     # how annex was installed
     ok_(ssh.get_git_version())
     manager.close()  # close possibly still present connections
+
+
+# situation on our test windows boxes is complicated
+# login shell is a POSIX one, path handling and equivalence between
+# local and "remote" needs more research
+@skip_if_on_windows
+@skip_ssh
+@with_tempfile(mkdir=True)
+def test_bundle_invariance(path):
+    remote_url = 'ssh://localhost'
+    manager = SSHManager()
+    testfile = Path(path) / 'dummy'
+    for flag in (True, False):
+        assert(not testfile.exists())
+        ssh = manager.get_connection(remote_url, use_remote_annex_bundle=flag)
+        ssh('cd .>{}'.format(text_type(testfile)))
+        assert(testfile.exists())
+        testfile.unlink()


### PR DESCRIPTION
- [x] methods for file transfer from AND to a remote host (fixes #3401)
- [x] add test once API has gotten positive feedback
- [x] fixes #3403 (on demand connection)
- [x] allows for disabling remote annex bundle detection -- e.g. useful when it is known that a connection is not used to run Git commands. Include switch in connection hash so that there can be two connections to the same system/user, one with and one without a modified PATH
- [x] add a tiny test that should also run on windows, but doesn't, hence disabled for now (comment inside)
- [x] add a test for `get()`