### PR TITLE
ENH: Use 3.7 (not -dev) and add a single run for 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - 2.7
   - 3.5
 ##1  - 3.6
+##1  - 3.7
+##1  - 3.8-dev
 
 cache:
   - apt
@@ -35,7 +37,14 @@ env:
 matrix:
   include:
   # Additional custom ones
-  - python: 3.7-dev
+  - python: 3.8-dev
+    # Single run for Python 3.8
+    env:
+    # Run all tests in a single whoop here
+    # We cannot have empty -A selector, so the one which always will be fulfilled
+    - NOSE_SELECTION=
+    - NOSE_SELECTION_OP=not
+  - python: 3.7
     # Single run for Python 3.7
     env:
     # Run all tests in a single whoop here

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,14 @@ matrix:
   # Additional custom ones
   - python: 3.8-dev
     # Single run for Python 3.8
+    dist: xenial
     env:
     # Run all tests in a single whoop here
     # We cannot have empty -A selector, so the one which always will be fulfilled
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
   - python: 3.7
+    dist: xenial
     # Single run for Python 3.7
     env:
     # Run all tests in a single whoop here

--- a/setup.py
+++ b/setup.py
@@ -48,14 +48,14 @@ datalad_pkgs = [pkg for pkg in find_packages('.') if pkg.startswith('datalad')]
 keyring_requires = ['keyring>=8.0', 'keyrings.alt']
 pbar_requires = ['tqdm']
 
-dist = platform.dist()
+# dist = platform.dist()
 # Identical to definition in datalad.utils
 platform_system = platform.system().lower()
 on_windows = platform_system == 'windows'
 
-# on oldstable Debian let's ask for lower versions of keyring
-if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
-    keyring_requires = ['keyring<8.0']
+# # on oldstable Debian let's ask for lower versions of keyring
+# if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
+#     keyring_requires = ['keyring<8.0']
 
 requires = {
     'core': [


### PR DESCRIPTION
If passes, up to discussion either we care enough to test for it already