### PR TITLE
NF: Add check for whether color is enabled

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -75,6 +75,11 @@
     },
     { 
       "name": "C Lau, Vicky"
+    },
+    {
+      "name": "Markiewicz, Christopher J.",
+      "affiliation": "Department of Psychology, Stanford University",
+      "orcid": "0000-0002-6533-164X"
     }
   ],
   "grants": [

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -313,4 +313,11 @@ definitions = {
         'default': None,
         'type': EnsureChoice('tqdm', 'tqdm-ipython', 'log', 'none'),
     },
+    'datalad.ui.color': {
+        'ui': ('question', {
+            'title': 'Colored terminal output',
+            'text': 'Enable or disable ANSI color codes in outputs; "on" overrides NO_COLOR environment variable'}),
+        'default': 'auto',
+        'type': EnsureChoice('on', 'off', 'auto'),
+    },
 }

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -366,16 +366,6 @@ class FsModel(AnnexModel):
 
 
 class LsFormatter(string.Formatter):
-    # condition by interactive
-    if is_interactive():
-        BLUE = ansi_colors.COLOR_SEQ % ansi_colors.BLUE
-        RED = ansi_colors.COLOR_SEQ % ansi_colors.RED
-        GREEN = ansi_colors.COLOR_SEQ % ansi_colors.GREEN
-        RESET = ansi_colors.RESET_SEQ
-        DATASET = ansi_colors.COLOR_SEQ % ansi_colors.UNDERLINE
-    else:
-        BLUE = RED = GREEN = RESET = DATASET = u""
-
     # TODO: we might want to just ignore and force utf8 while explicitly .encode()'ing output!
     # unicode versions which look better but which blow during tests etc
     # Those might be reset by the constructor
@@ -415,15 +405,22 @@ class LsFormatter(string.Formatter):
             else:
                 return u'-'
         elif conversion == 'X':  # colored bool
-            chr, col = (self.OK, self.GREEN) if value else (self.NOK, self.RED)
-            return u"%s%s%s" % (col, chr, self.RESET)
+            if value:
+                mark, col = self.OK, ansi_colors.GREEN
+            else:
+                mark, col = self.NOK, ansi_colors.RED
+            return ansi_colors.color_word(mark, col)
         elif conversion == 'N':  # colored Red - if None
             if value is None:
                 # return "%s✖%s" % (self.RED, self.RESET)
-                return u"%s%s%s" % (self.RED, self.NONE, self.RESET)
+                return ansi_colors.color_word(self.NONE, ansi_colors.RED)
             return value
         elif conversion in {'B', 'R', 'U'}:
-            return u"%s%s%s" % ({'B': self.BLUE, 'R': self.RED, 'U': self.DATASET}[conversion], value, self.RESET)
+            return ansi_colors.color_word(
+                value,
+                {'B': ansi_colors.BLUE,
+                 'R': ansi_colors.RED,
+                 'U': ansi_colors.DATASET}[conversion])
 
         return super(LsFormatter, self).convert_field(value, conversion)
 

--- a/datalad/support/ansi_colors.py
+++ b/datalad/support/ansi_colors.py
@@ -44,24 +44,19 @@ FIELD = BOLD
 def color_enabled():
     """Check for whether color output is enabled
 
-    Color is only enabled if the terminal is interactive.
-    If the datalad.ui.color configuration setting is 'on' or 'off', then
-    respect that.
-    If the datalad.ui.color setting is 'auto' (default), then color is
-    enabled unless the environment variable NO_COLOR is defined.
+    If the configuration value ``datalad.ui.color`` is ``'on'`` or ``'off'``,
+    that takes precedence.
+    If ``datalad.ui.color`` is ``'auto'``, and the environment variable
+    ``NO_COLOR`` is defined (see https://no-color.org), then color is disabled.
+    Otherwise, enable colors if a TTY is detected by ``datalad.ui.ui.is_interactive``.
 
     Returns
     -------
     bool
     """
-    if not ui.is_interactive:
-        return False
-
     ui_color = cfg.obtain('datalad.ui.color')
-    if ui_color == 'off':
-        return False
-
-    return ui_color == 'on' or os.getenv('NO_COLOR') is None
+    return (ui_color == 'on' or
+            ui_color == 'auto' and os.getenv('NO_COLOR') is None and ui.is_interactive)
 
 
 def format_msg(fmt, use_color=False):

--- a/datalad/support/ansi_colors.py
+++ b/datalad/support/ansi_colors.py
@@ -49,21 +49,19 @@ def color_enabled():
     respect that.
     If the datalad.ui.color setting is 'auto' (default), then color is
     enabled unless the environment variable NO_COLOR is defined.
+
+    Returns
+    -------
+    bool
     """
     if not ui.is_interactive:
         return False
 
-    UIC = cfg.get_value('datalad', 'ui.color', 'auto')
-    if UIC == 'off':
-        return False
-    elif UIC not in ('auto', 'on'):
-        raise ValueError("Unknown value for datalad.ui.color: '%s'; "
-                         "Must be one of 'on', 'off', 'auto'" % UIC)
-
-    if UIC == 'auto' and os.getenv('NO_COLOR') is not None:
+    ui_color = cfg.obtain('datalad.ui.color')
+    if ui_color == 'off':
         return False
 
-    return True
+    return ui_color == 'on' or os.getenv('NO_COLOR') is None
 
 
 def format_msg(fmt, use_color=False):

--- a/datalad/support/tests/test_ansi_colors.py
+++ b/datalad/support/tests/test_ansi_colors.py
@@ -1,0 +1,105 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test ANSI color tools """
+
+import os
+from mock import patch
+from datalad.tests.utils import assert_equal
+from datalad.tests.utils import patch_config
+
+from datalad.support import ansi_colors as colors
+
+
+def test_color_enabled():
+    # In the absence of NO_COLOR, default to enable, failing if non-interactive terminal
+    # or ui.color is off
+    with patch.dict(os.environ):
+        os.environ.pop('NO_COLOR', None)
+        with patch('datalad.support.ansi_colors.ui'):
+            colors.ui.is_interactive = False
+            for ui_color in ('on', 'off', 'auto'):
+                with patch_config({'datalad.ui.color': ui_color}):
+                    assert_equal(colors.color_enabled(), False)
+        with patch('datalad.support.ansi_colors.ui'):
+            colors.ui.is_interactive = True
+            with patch_config({'datalad.ui.color': 'off'}):
+                assert_equal(colors.color_enabled(), False)
+            for ui_color in ('on', 'auto'):
+                with patch_config({'datalad.ui.color': ui_color}):
+                    assert_equal(colors.color_enabled(), True)
+
+    # In the presence of NO_COLOR, default to disable, unless terminal is interactive
+    # and ui.color is on
+    # The value of NO_COLOR should have no effect
+    for NO_COLOR in ("", "1", "0"):
+        with patch.dict(os.environ, {'NO_COLOR': NO_COLOR}):
+            with patch('datalad.support.ansi_colors.ui'):
+                colors.ui.is_interactive = False
+                for ui_color in ('on', 'off', 'auto'):
+                    with patch_config({'datalad.ui.color': ui_color}):
+                        assert_equal(colors.color_enabled(), False)
+            with patch('datalad.support.ansi_colors.ui'):
+                colors.ui.is_interactive = True
+                with patch_config({'datalad.ui.color': 'on'}):
+                    assert_equal(colors.color_enabled(), True)
+                for ui_color in ('off', 'auto'):
+                    with patch_config({'datalad.ui.color': ui_color}):
+                        assert_equal(colors.color_enabled(), False)
+
+#
+# In all other tests, just patch color_enabled
+#
+
+
+def test_format_msg():
+    fmt = r'a$BOLDb$RESETc$BOLDd$RESETe'
+    for enabled in (True, False):
+        with patch('datalad.support.ansi_colors.color_enabled', lambda: enabled):
+            assert_equal(colors.format_msg(fmt), 'abcde')
+            assert_equal(colors.format_msg(fmt, use_color=False), 'abcde')
+
+    with patch('datalad.support.ansi_colors.color_enabled', lambda: False):
+        for use_color in (True, False):
+            assert_equal(colors.format_msg(fmt), 'abcde')
+            assert_equal(colors.format_msg(fmt, use_color=use_color), 'abcde')
+
+    with patch('datalad.support.ansi_colors.color_enabled', lambda: True):
+        assert_equal(colors.format_msg(fmt, use_color=True), 'a\033[1mb\033[0mc\033[1md\033[0me')
+
+
+def test_color_word():
+    s = 'word'
+    green_s = '\033[1;32mword\033[0m'
+    for enabled in (True, False):
+        with patch('datalad.support.ansi_colors.color_enabled', lambda: enabled):
+            assert_equal(colors.color_word(s, colors.GREEN, force=True), green_s)
+
+    with patch('datalad.support.ansi_colors.color_enabled', lambda: True):
+        assert_equal(colors.color_word(s, colors.GREEN), green_s)
+        assert_equal(colors.color_word(s, colors.GREEN, force=False), green_s)
+
+    with patch('datalad.support.ansi_colors.color_enabled', lambda: False):
+        assert_equal(colors.color_word(s, colors.GREEN), s)
+        assert_equal(colors.color_word(s, colors.GREEN, force=False), s)
+
+
+def test_color_status():
+    # status -> (plain, colored)
+    statuses = {
+        'ok': ('ok', '\033[1;32mok\033[0m'),
+        'notneeded': ('notneeded', '\033[1;32mnotneeded\033[0m'),
+        'impossible': ('impossible', '\033[1;33mimpossible\033[0m'),
+        'error': ('error', '\033[1;31merror\033[0m'),
+        'invalid': ('invalid', 'invalid'),
+        }
+
+    for enabled in (True, False):
+        with patch('datalad.support.ansi_colors.color_enabled', lambda: enabled):
+            for status, retopts in statuses.items():
+                assert_equal(colors.color_status(status), retopts[enabled])


### PR DESCRIPTION
Checks for interactive terminal, `datalad.ui.color` configuration and `NO_COLOR` environment variable, in that order of precedence.

Closes #3404.