### PR TITLE
Promote rev_save to save

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -426,7 +426,7 @@ class Create(Interface):
         if isinstance(dataset, Dataset) and dataset.path != tbds.path:
             # we created a dataset in another dataset
             # -> make submodule
-            for r in dataset.rev_save(
+            for r in dataset.save(
                     path=tbds.path,
             ):
                 yield r

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -134,7 +134,7 @@ class Save(Interface):
     )
 
     @staticmethod
-    @datasetmethod(name='rev_save')
+    @datasetmethod(name='save')
     @eval_results
     def __call__(path=None, message=None, dataset=None,
                  version_tag=None,

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -69,16 +69,16 @@ class Save(Interface):
       Save any content underneath the current directory, without altering
       any potential subdataset (use --recursive for that)::
 
-        % datalad rev-save .
+        % datalad save .
 
       Save any modification of known dataset content, but leave untracked
       files (e.g. temporary files) untouched::
 
-        % dataset rev-save -u -d <path_to_dataset>
+        % dataset save -u -d <path_to_dataset>
 
       Tag the most recent saved state of a dataset::
 
-        % dataset rev-save -d <path_to_dataset> --version-tag bestyet
+        % dataset save -d <path_to_dataset> --version-tag bestyet
 
     .. note::
       For performance reasons, any Git repository without an initial commit

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -114,7 +114,7 @@ def test_create_raises(path, outside_path):
     os.makedirs(op.join(ds.path, 'down'))
     with open(op.join(ds.path, 'down', "someotherfile.tst"), 'w') as f:
         f.write("someother")
-    ds.rev_save()
+    ds.save()
     assert_in_results(
         ds.create('down', **raw),
         status='error',
@@ -230,14 +230,14 @@ def test_create_subdataset_hierarchy_from_top(path):
     ok_(subsubds.is_installed())
     ok_(subsubds.repo.dirty)
     ok_(ds.id != subds.id != subsubds.id)
-    ds.rev_save(updated=True, recursive=True)
+    ds.save(updated=True, recursive=True)
     # 'file*' in each repo was untracked before and should remain as such
     # (we don't want a #1419 resurrection
     ok_(ds.repo.dirty)
     ok_(subds.repo.dirty)
     ok_(subsubds.repo.dirty)
     # if we add these three, we should get clean
-    ds.rev_save([
+    ds.save([
         'file1',
         op.join(subds.path, 'file2'),
         op.join(subsubds.path, 'file3')])
@@ -259,7 +259,7 @@ def test_nested_create(path):
     os.makedirs(op.join(ds.path, 'lvl1', 'empty'))
     with open(op.join(lvl2path, 'file'), 'w') as f:
         f.write('some')
-    ok_(ds.rev_save())
+    ok_(ds.save())
     # Empty directories are filtered out.
     assert_repo_status(ds.path, untracked=[])
     # later create subdataset in a fresh dir

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -40,7 +40,7 @@ from datalad.tests.utils import (
 import datalad.utils as ut
 from datalad.distribution.dataset import Dataset
 from datalad.api import (
-    rev_save as save,
+    save,
     create,
     diff,
 )
@@ -73,7 +73,7 @@ def test_repo_diff(path, norepo):
     eq_(ds.repo.diff('HEAD', None, paths=['THIS']), {})
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
-    ds.rev_save(to_git=True)
+    ds.save(to_git=True)
     assert_repo_status(ds.path)
     eq_(ds.repo.diff(fr='HEAD~1', to='HEAD'),
         {ut.Path(ds.repo.pathobj / 'new'): {
@@ -100,7 +100,7 @@ def test_repo_diff(path, norepo):
     eq_(ds.repo.diff(fr='HEAD', to=None, paths=['other']), {})
 
     # make clean
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
 
     # untracked stuff
@@ -160,7 +160,7 @@ def test_diff(path, norepo):
     assert_result_count(_dirty_results(ds.diff(path='THIS', fr='HEAD')), 0)
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
-    ds.rev_save(to_git=True)
+    ds.save(to_git=True)
     assert_repo_status(ds.path)
     res = _dirty_results(ds.diff(fr='HEAD~1'))
     assert_result_count(res, 1)
@@ -190,7 +190,7 @@ def test_diff(path, norepo):
     ds.repo.add('.', git=True)
     # no change in diff, staged is not commited
     assert_result_count(_dirty_results(ds.diff()), 1)
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
     assert_result_count(_dirty_results(ds.diff()), 0)
 
@@ -260,8 +260,8 @@ def test_diff_recursive(path):
         action='diff', state='untracked', path=op.join(sub.path, 'twofile'),
         type='file')
     # intentional save in two steps to make check below easier
-    ds.rev_save('sub', recursive=True)
-    ds.rev_save()
+    ds.save('sub', recursive=True)
+    ds.save()
     assert_repo_status(ds.path)
     # look at the last change, only one file was added
     res = ds.diff(fr='HEAD~1', to='HEAD')

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -43,7 +43,7 @@ from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CommandError
 from datalad.api import (
-    rev_save as save,
+    save,
     create,
     install,
 )
@@ -65,14 +65,14 @@ def test_save(path):
     ds.repo.add("new_file.tst", git=True)
     ok_(ds.repo.dirty)
 
-    ds.rev_save(message="add a new file")
+    ds.save(message="add a new file")
     assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
 
     with open(op.join(path, "new_file.tst"), "w") as f:
         f.write("modify")
 
     ok_(ds.repo.dirty)
-    ds.rev_save(message="modified new_file.tst")
+    ds.save(message="modified new_file.tst")
     assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # save works without ds and files given in the PWD
@@ -95,10 +95,10 @@ def test_save(path):
         with open(op.join(path, fn), "w") as f:
             f.write(fn)
 
-    ds.rev_save([op.join(path, f) for f in files])
+    ds.save([op.join(path, f) for f in files])
     # superfluous call to save (alll saved it already), should not fail
     # but report that nothing was saved
-    assert_status('notneeded', ds.rev_save(message="set of new files"))
+    assert_status('notneeded', ds.save(message="set of new files"))
     assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # create subdataset
@@ -107,10 +107,10 @@ def test_save(path):
     # modify subds
     with open(op.join(subds.path, "some_file.tst"), "w") as f:
         f.write("something")
-    subds.rev_save()
+    subds.save()
     assert_repo_status(subds.path, annex=isinstance(subds.repo, AnnexRepo))
     # ensure modified subds is committed
-    ds.rev_save()
+    ds.save()
     assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
 
     # now introduce a change downstairs
@@ -118,13 +118,13 @@ def test_save(path):
     assert_repo_status(subds.path, annex=isinstance(subds.repo, AnnexRepo))
     ok_(ds.repo.dirty)
     # and save via subdataset path
-    ds.rev_save('subds', version_tag='new_sub')
+    ds.save('subds', version_tag='new_sub')
     assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))
     tags = ds.repo.get_tags()
     ok_(len(tags) == 1)
     eq_(tags[0], dict(hexsha=ds.repo.get_hexsha(), name='new_sub'))
     # fails when retagged, like git does
-    res = ds.rev_save(version_tag='new_sub', on_failure='ignore')
+    res = ds.save(version_tag='new_sub', on_failure='ignore')
     assert_status('error', res)
     assert_result_count(
         res, 1,
@@ -137,12 +137,12 @@ def test_save(path):
 def test_save_message_file(path):
     ds = Dataset(path).create()
     with assert_raises(ValueError):
-        ds.rev_save("blah", message="me", message_file="and me")
+        ds.save("blah", message="me", message_file="and me")
 
     create_tree(path, {"foo": "x",
                        "msg": "add foo"})
     ds.repo.add("foo")
-    ds.rev_save(message_file=op.join(ds.path, "msg"))
+    ds.save(message_file=op.join(ds.path, "msg"))
     eq_(ds.repo.repo.git.show("--format=%s", "--no-patch"),
         "add foo")
 
@@ -154,7 +154,7 @@ def test_renamed_file():
         create_tree(path, {'old': ''})
         ds.repo.add('old')
         ds.repo._git_custom_command(['old', 'new'], ['git', 'mv'])
-        ds.rev_save(recursive=recursive)
+        ds.save(recursive=recursive)
         assert_repo_status(path)
 
     for recursive in False,:  #, True TODO when implemented
@@ -171,7 +171,7 @@ def test_subdataset_save(path):
         "untracked": 'ignore',
         'sub': {
             "new": "wanted"}})
-    sub.rev_save('new')
+    sub.save('new')
     # defined state: one untracked, modified (but clean in itself) subdataset
     assert_repo_status(sub.path)
     assert_repo_status(parent.path, untracked=['untracked'], modified=['sub'])
@@ -183,7 +183,7 @@ def test_subdataset_save(path):
     # `save -u .` saves the state change in the subdataset,
     # but leaves any untracked content alone
     with chpwd(parent.path):
-        assert_status('ok', parent.rev_save(updated=True))
+        assert_status('ok', parent.save(updated=True))
     assert_repo_status(parent.path, untracked=['untracked'])
 
     # get back to the original modified state and check that -S behaves in
@@ -191,7 +191,7 @@ def test_subdataset_save(path):
     create_tree(parent.path, {
         'sub': {
             "new2": "wanted2"}})
-    sub.rev_save('new2')
+    sub.save('new2')
     assert_repo_status(parent.path, untracked=['untracked'], modified=['sub'])
 
 
@@ -214,16 +214,16 @@ def test_symlinked_relpath(path):
     # in the root of ds
     with chpwd(dspath):
         ds.repo.add("mike1", git=True)
-        ds.rev_save(message="committing", path="./mike1")
+        ds.save(message="committing", path="./mike1")
 
     # Let's also do in subdirectory
     with chpwd(op.join(dspath, 'd')):
-        ds.rev_save(
+        ds.save(
             message="committing", path=op.join(op.curdir, "mike2"))
 
         later = op.join(op.pardir, "later")
         ds.repo.add(later, git=True)
-        ds.rev_save(message="committing", path=later)
+        ds.save(message="committing", path=later)
 
     assert_repo_status(dspath)
 
@@ -236,19 +236,19 @@ def test_bf1886(path):
     assert_repo_status(parent.path)
     # create a symlink pointing down to the subdataset, and add it
     os.symlink('sub', op.join(parent.path, 'down'))
-    parent.rev_save('down')
+    parent.save('down')
     assert_repo_status(parent.path)
     # now symlink pointing up
     os.makedirs(op.join(parent.path, 'subdir', 'subsubdir'))
     os.symlink(op.join(op.pardir, 'sub'), op.join(parent.path, 'subdir', 'up'))
-    parent.rev_save(op.join('subdir', 'up'))
+    parent.save(op.join('subdir', 'up'))
     # 'all' to avoid the empty dir being listed
     assert_repo_status(parent.path, untracked_mode='all')
     # now symlink pointing 2xup, as in #1886
     os.symlink(
         op.join(op.pardir, op.pardir, 'sub'),
         op.join(parent.path, 'subdir', 'subsubdir', 'upup'))
-    parent.rev_save(op.join('subdir', 'subsubdir', 'upup'))
+    parent.save(op.join('subdir', 'subsubdir', 'upup'))
     assert_repo_status(parent.path)
     # simulatenously add a subds and a symlink pointing to it
     # create subds, but don't register it
@@ -256,7 +256,7 @@ def test_bf1886(path):
     os.symlink(
         op.join(op.pardir, op.pardir, 'sub2'),
         op.join(parent.path, 'subdir', 'subsubdir', 'upup2'))
-    parent.rev_save(['sub2', op.join('subdir', 'subsubdir', 'upup2')])
+    parent.save(['sub2', op.join('subdir', 'subsubdir', 'upup2')])
     assert_repo_status(parent.path)
     # full replication of #1886: the above but be in subdir of symlink
     # with no reference dataset
@@ -279,7 +279,7 @@ def test_gh2043p1(path):
     # this tests documents the interim agreement on what should happen
     # in the case documented in gh-2043
     ds = Dataset(path).create(force=True)
-    ds.rev_save('1')
+    ds.save('1')
     assert_repo_status(ds.path, untracked=['2', '3'])
     ds.unlock('1')
     assert_repo_status(
@@ -328,7 +328,7 @@ def test_encoding(path):
     ds = Dataset(path).create(force=True)
     ds.repo.add(staged)
     assert_repo_status(ds.path, added=[staged], untracked=[untracked])
-    ds.rev_save(updated=True)
+    ds.save(updated=True)
     assert_repo_status(ds.path, untracked=[untracked])
 
 
@@ -348,10 +348,10 @@ def test_add_files(path):
                 (test_list_4, False)]:
         # special case 4: give the dir:
         if arg[0] == test_list_4:
-            result = ds.rev_save('dir', to_git=arg[1])
+            result = ds.save('dir', to_git=arg[1])
             status = ds.repo.annexstatus(['dir'])
         else:
-            result = ds.rev_save(arg[0], to_git=arg[1])
+            result = ds.save(arg[0], to_git=arg[1])
             for a in assure_list(arg[0]):
                 assert_result_count(result, 1, path=text_type(ds.pathobj / a))
             status = ds.repo.get_content_annexinfo(
@@ -377,7 +377,7 @@ def test_add_subdataset(path, other):
     assert_not_in('dir', ds.subdatasets(result_xfm='relpaths'))
     # but with a base directory we add the dataset subds as a subdataset
     # to ds
-    res = ds.rev_save(subds.path)
+    res = ds.save(subds.path)
     assert_in_results(res, action="add", path=subds.path, refds=ds.path)
     assert_in('dir', ds.subdatasets(result_xfm='relpaths'))
     #  create another one
@@ -389,7 +389,7 @@ def test_add_subdataset(path, other):
     ok_(other_clone.is_installed)
     assert_not_in('other', ds.subdatasets(result_xfm='relpaths'))
     # now add, it should pick up the source URL
-    ds.rev_save('other')
+    ds.save('other')
     # and that is why, we can reobtain it from origin
     ds.uninstall('other')
     ok_(not other_clone.is_installed())
@@ -412,10 +412,10 @@ def test_add_mimetypes(path):
     ds.repo.commit('added attributes to git explicitly')
     # now test that those files will go into git/annex correspondingly
     # WINDOWS FAILURE NEXT
-    __not_tested__ = ds.rev_save(['file.txt', 'empty'])
+    __not_tested__ = ds.save(['file.txt', 'empty'])
     assert_repo_status(path, untracked=['file2.txt'])
     # But we should be able to force adding file to annex when desired
-    ds.rev_save('file2.txt', to_git=False)
+    ds.save('file2.txt', to_git=False)
     # check annex file status
     annexinfo = ds.repo.get_content_annexinfo()
     for path, in_annex in (
@@ -450,7 +450,7 @@ def test_gh1597(path):
     with open(op.join(ds.path, '.gitmodules'), 'a') as f:
         f.write('\n')
     assert_repo_status(ds.path, modified=['.gitmodules'])
-    ds.rev_save('.gitmodules')
+    ds.save('.gitmodules')
     # must not come under annex mangement
     assert_not_in(
         'key',
@@ -463,7 +463,7 @@ def test_gh1597_simpler(path):
     # same goes for .gitattributes
     with open(op.join(ds.path, '.gitignore'), 'a') as f:
         f.write('*.swp\n')
-    ds.rev_save('.gitignore')
+    ds.save('.gitignore')
     assert_repo_status(ds.path)
     # put .gitattributes in some subdir and add all, should also go into Git
     attrfile = op.join ('subdir', '.gitattributes')
@@ -471,7 +471,7 @@ def test_gh1597_simpler(path):
         [('*', dict(mycustomthing='this'))],
         attrfile)
     assert_repo_status(ds.path, untracked=[attrfile], untracked_mode='all')
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
     # no annex key, not in annex
     assert_not_in(
@@ -494,7 +494,7 @@ def test_update_known_submodule(path):
 
     # attempt two, same as above but call add via reference dataset
     ds = get_baseline(op.join(path, 'w_ref'))
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     assert_repo_status(ds.path)
 
 
@@ -509,7 +509,7 @@ def test_add_recursive(path):
     # next one make the parent dirty
     subsub = sub2.create('subsub')
     assert_repo_status(parent.path, modified=['sub2'])
-    res = parent.rev_save()
+    res = parent.save()
     assert_repo_status(parent.path)
 
     # now add content deep in the hierarchy
@@ -518,7 +518,7 @@ def test_add_recursive(path):
 
     # recursive add should not even touch sub1, because
     # it knows that it is clean
-    res = parent.rev_save(recursive=True)
+    res = parent.save(recursive=True)
     # the key action is done
     assert_result_count(
         res, 1, path=op.join(subsub.path, 'new'), action='add', status='ok')
@@ -568,7 +568,7 @@ def test_remove_subds(path):
         path=op.join(ds.path, 'sub'),
         state='deleted')
     # a single call to save() must fix up the mess
-    assert_status('ok', ds.rev_save())
+    assert_status('ok', ds.save())
     assert_repo_status(ds.path)
 
 
@@ -577,22 +577,22 @@ def test_partial_unlocked(path):
     # https://github.com/datalad/datalad/issues/1651
     ds = create(path)
     (ds.pathobj / 'normal.txt').write_text(u'123')
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
     ds.unlock('normal.txt')
-    ds.rev_save()
+    ds.save()
     # mixed git and git-annex'ed files
     (ds.pathobj / 'ingit.txt').write_text(u'234')
-    ds.rev_save(to_git=True)
+    ds.save(to_git=True)
     (ds.pathobj / 'culprit.txt').write_text(u'345')
     (ds.pathobj / 'ingit.txt').write_text(u'modified')
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
     # but now a change in the attributes
     ds.unlock('culprit.txt')
     ds.repo.set_gitattributes([
         ('*', {'annex.largefiles': 'nothing'})])
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
 
 
@@ -602,7 +602,7 @@ def test_save_partial_commit_shrinking_annex(path):
     # This is a variation on the test above. The main difference is that there
     # are other staged changes in addition to the unlocked filed.
     ds = create(path, force=True)
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
     ds.unlock(path="foo")
     create_tree(ds.path, tree={"foo": "a", "staged": ""},
@@ -612,13 +612,13 @@ def test_save_partial_commit_shrinking_annex(path):
     # GitRepo.save_) drops the pathspec if there are no staged changes.
     ds.repo.add("staged", git=True)
     if ds.repo.supports_unlocked_pointers:
-        ds.rev_save(path="foo")
+        ds.save(path="foo")
         assert_repo_status(ds.path, added=["staged"])
     else:
-        # Unlike save, rev_save doesn't handle a partial commit if there were
-        # other staged changes.
+        # Unlike the obsolete interface.save, save doesn't handle a partial
+        # commit if there were other staged changes.
         with assert_raises(CommandError) as cm:
-            ds.rev_save(path="foo")
+            ds.save(path="foo")
         assert_in("partial commit", str(cm.exception))
 
 
@@ -653,7 +653,7 @@ def test_surprise_subds(path):
     # a proper subdataset
     subds = create(op.join(path, 'd2', 'subds'), force=True)
     # save non-recursive
-    ds.rev_save(recursive=False)
+    ds.save(recursive=False)
     # the content of both subds and subrepo are not added to their
     # respective parent as no --recursive was given
     assert_repo_status(subds.path, untracked=['subfile'])
@@ -682,5 +682,5 @@ def test_bf3285(path):
     subds = create(ds.repo.pathobj.joinpath("subds"))
     # Explicitly saving a path does not save an untracked, unspecified
     # subdataset.
-    ds.rev_save("foo")
+    ds.save("foo")
     assert_repo_status(ds.path, untracked=[subds.path])

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -273,7 +273,7 @@ def check_observe_tqdm(topdir, topurl, outdir):
     for f in '1.tar.gz', '2.tar.gz':
         with chpwd(outdir):
             ds.repo.add_url_to_file(f, topurl + f)
-            ds.rev_save(f)
+            ds.save(f)
             add_archive_content(f, delete=True, drop_after=True)
     files = glob.glob(op.join(outdir, '*'))
     ds.drop(files) # will not drop tarballs

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """High-level interface for adding dataset components
 
+Note: This module is obsolete. Use core.local.save instead.
 """
 
 import logging
@@ -101,6 +102,10 @@ def _discover_subdatasets_recursively(
 @build_doc
 class Add(Interface):
     """Add files/directories to an existing dataset.
+
+
+    *Note*: This is an obsolete interface. Use datalad.api.save or Dataset.save
+     instead.
 
     Typically, files and directories to be added to a dataset would be placed
     into a directory of a dataset, and subsequently this command can be used to

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -289,7 +289,7 @@ class Clone(Interface):
         if dataset is not None:
             # we created a dataset in another dataset
             # -> make submodule
-            for r in dataset.rev_save(
+            for r in dataset.save(
                     dest_path,
                     return_type='generator',
                     result_filter=None,

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -289,8 +289,8 @@ class Clone(Interface):
         if dataset is not None:
             # we created a dataset in another dataset
             # -> make submodule
-            for r in dataset.add(
-                    dest_path, save=True, ds2super=True,
+            for r in dataset.rev_save(
+                    dest_path,
                     return_type='generator',
                     result_filter=None,
                     result_xfm=None,

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -84,7 +84,7 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
 
     """
     # we apparently can't import api functionality within api
-    from datalad.api import rev_save
+    from datalad.api import save
     # To simplify managing all the file paths etc
     if not isabs(path):
         path = abspath(path)
@@ -119,7 +119,7 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
 
     if ds:
         assert ds.is_installed()
-        out = rev_save(
+        out = save(
             path,
             dataset=ds,
         )

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -321,7 +321,7 @@ def _get_submodules(dspath, fulfilled, recursive, recursion_limit,
                     val)
                 # also add to the info we just read above
                 sm['gitmodule_{}'.format(prop)] = val
-            Dataset(dspath).rev_save(
+            Dataset(dspath).save(
                 '.gitmodules', to_git=True,
                 message='[DATALAD] modified subdataset properties')
             # let go of resources, locks, ...

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -172,7 +172,7 @@ def test_add_recursive(path):
     # next one make the parent dirty
     subsub = sub2.create('subsub')
     ok_clean_git(parent.path, index_modified=['sub2'])
-    res = parent.rev_save()
+    res = parent.save()
     ok_clean_git(parent.path)
 
     # now add content deep in the hierarchy

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -490,7 +490,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     url = 'localhost:%s' % dst_relpath
     ds = Dataset(src_path).create()
     create_tree(ds.path, {'sub.dat': 'lots of data'})
-    ds.rev_save('sub.dat')
+    ds.save('sub.dat')
     ds.create_sibling(url, ui=True)
     published = ds.publish(to='localhost', transfer_data='all')
     assert_result_count(published, 1, path=opj(ds.path, 'sub.dat'))
@@ -516,7 +516,7 @@ def test_replace_and_relative_sshpath(src_path, dst_path):
     # and one more test since in above test it would not puke ATM but just
     # not even try to copy since it assumes that file is already there
     create_tree(ds.path, {'sub2.dat': 'more data'})
-    ds.rev_save('sub2.dat')
+    ds.save('sub2.dat')
     published3 = ds.publish(to='localhost', transfer_data='none')  # we publish just git
     assert_result_count(published3, 0, path=opj(ds.path, 'sub2.dat'))
     # now publish "with" data, which should also trigger the hook!
@@ -557,7 +557,7 @@ def _test_target_ssh_inherit(standardgroup, ui, src_path, target_path):
     for levels in range(nlevels):
         subds = parent_ds.create('sub')
         create_tree(subds.path, {'sub.dat': 'lots of data'})
-        parent_ds.rev_save('sub', recursive=True)
+        parent_ds.save('sub', recursive=True)
         ok_file_under_git(subds.path, 'sub.dat', annexed=True)
         parent_ds = subds
         subdss.append(subds)

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -184,7 +184,7 @@ def test_subdatasets(path):
     eq_(ds.subdatasets(), [])
     # create some file and commit it
     open(os.path.join(ds.path, 'test'), 'w').write('some')
-    ds.rev_save(path='test', message="Hello!", version_tag=1)
+    ds.save(path='test', message="Hello!", version_tag=1)
     assert_true(ds.is_installed())
     # Assuming that tmp location was not under a super-dataset
     eq_(ds.get_superdataset(), None)
@@ -202,7 +202,7 @@ def test_subdatasets(path):
     eq_(subds.path, ds.subdatasets(result_xfm='paths')[0])
     eq_(subdss, ds.subdatasets(recursive=True))
     eq_(subdss, ds.subdatasets(fulfilled=True))
-    ds.rev_save(message="with subds", version_tag=2)
+    ds.save(message="with subds", version_tag=2)
     ds.recall_state(1)
     assert_true(ds.is_installed())
     eq_(ds.subdatasets(), [])

--- a/datalad/distribution/tests/test_dataset_api.py
+++ b/datalad/distribution/tests/test_dataset_api.py
@@ -23,7 +23,7 @@ from ...tests.utils import (
 def test_datasetmethod_bound(path):
     ds = Dataset(path)
     # should be automagically imported/picked up if not bound already
-    assert ds.add  # simplest, intfspec only 2 entries
+    assert ds.create  # simplest, intfspec only 2 entries
     assert ds.download_url  # 3 entries, with dash
     assert ds.create_sibling_github  # 3 entries, 2 dashes
     assert ds.aggregate_metadata  # module name is called "aggregate"

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -57,7 +57,7 @@ def _make_dataset_hierarchy(path):
     with open(opj(origin_sub3.path, 'file_in_annex.txt'), "w") as f:
         f.write('content3')
     origin_sub4 = origin_sub3.create('sub4')
-    origin.rev_save(recursive=True)
+    origin.save(recursive=True)
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
 
@@ -108,7 +108,7 @@ def test_get_invalid_call(path, file_outside):
     ds.create(no_annex=True)
     with open(opj(path, "some.txt"), "w") as f:
         f.write("whatever")
-    ds.rev_save("some.txt", to_git=True, message="Initial commit.")
+    ds.save("some.txt", to_git=True, message="Initial commit.")
 
     # make it an annex (remove indicator file that create has placed
     # in the dataset to make it possible):
@@ -122,7 +122,7 @@ def test_get_invalid_call(path, file_outside):
     # yoh:  but now we would need to add it to annex since clever code first
     # checks what needs to be fetched at all
     create_tree(path, {'annexed.dat': 'some'})
-    ds.rev_save("annexed.dat")
+    ds.save("annexed.dat")
     ds.repo.drop("annexed.dat", options=['--force'])
     with assert_raises(RemoteNotAvailableError) as ce:
         ds.get("annexed.dat", source='MysteriousRemote')
@@ -169,7 +169,7 @@ def test_get_multiple_files(path, url, ds_dir):
 
     # prepare origin
     origin = Dataset(path).create(force=True)
-    origin.rev_save(file_list, message="initial")
+    origin.save(file_list, message="initial")
 
     ds = install(
         ds_dir, source=path,
@@ -208,7 +208,7 @@ def test_get_recurse_dirs(o_path, c_path):
 
     # prepare source:
     origin = Dataset(o_path).create(force=True)
-    origin.rev_save()
+    origin.save()
 
     ds = install(
         c_path, source=o_path,
@@ -376,9 +376,9 @@ def test_get_mixed_hierarchy(src, path):
         f.write('no idea')
     with open(opj(origin_sub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
-    origin.rev_save('file_in_git.txt', to_git=True)
-    origin_sub.rev_save('file_in_annex.txt')
-    origin.rev_save()
+    origin.save('file_in_git.txt', to_git=True)
+    origin_sub.save('file_in_annex.txt')
+    origin.save()
 
     # now, install that thing:
     ds, subds = install(
@@ -422,7 +422,7 @@ def test_get_autoresolve_recurse_subdatasets(src, path):
     origin_subsub = origin_sub.create('subsub')
     with open(opj(origin_subsub.path, 'file_in_annex.txt'), "w") as f:
         f.write('content')
-    origin.rev_save(recursive=True)
+    origin.save(recursive=True)
 
     ds = install(
         path, source=src,

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -442,7 +442,7 @@ def test_install_into_dataset(source, top_path):
     ok_clean_git(subds.path, annex=None)
     # top is too:
     ok_clean_git(ds.path, annex=None)
-    ds.rev_save(message='addsub')
+    ds.save(message='addsub')
     # now it is:
     ok_clean_git(ds.path, annex=None)
 
@@ -459,7 +459,7 @@ def test_install_into_dataset(source, top_path):
     # and then decide to add it
     create(_path_(top_path, 'sub3'))
     ok_clean_git(ds.path, untracked=['dummy.txt', 'sub3/'])
-    ds.rev_save('sub3')
+    ds.save('sub3')
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
@@ -482,7 +482,7 @@ def test_failed_install_multiple(top_path):
 
     # install doesn't add existing submodules -- add does that
     ok_clean_git(ds.path, annex=None, untracked=['ds1/', 'ds3/'])
-    ds.rev_save(['ds1', 'ds3'])
+    ds.save(['ds1', 'ds3'])
     ok_clean_git(ds.path, annex=None)
     # those which succeeded should be saved now
     eq_(ds.subdatasets(result_xfm='relpaths'), ['crcns', 'ds1', 'ds3'])
@@ -532,14 +532,14 @@ def test_implicit_install(src, dst):
     origin_subsub = origin_sub.create("subsub")
     with open(opj(origin_top.path, "file1.txt"), "w") as f:
         f.write("content1")
-    origin_top.rev_save("file1.txt")
+    origin_top.save("file1.txt")
     with open(opj(origin_sub.path, "file2.txt"), "w") as f:
         f.write("content2")
-    origin_sub.rev_save("file2.txt")
+    origin_sub.save("file2.txt")
     with open(opj(origin_subsub.path, "file3.txt"), "w") as f:
         f.write("content3")
-    origin_subsub.rev_save("file3.txt")
-    origin_top.rev_save(recursive=True)
+    origin_subsub.save("file3.txt")
+    origin_top.save(recursive=True)
 
     # first, install toplevel:
     ds = install(dst, source=src)
@@ -647,7 +647,7 @@ def test_install_recursive_repeat(src, path):
     sub1_src = top_src.create('sub 1', force=True)
     sub2_src = top_src.create('sub 2', force=True)
     subsub_src = sub1_src.create('subsub', force=True)
-    top_src.rev_save(recursive=True)
+    top_src.save(recursive=True)
     ok_clean_git(top_src.path)
 
     # install top level:
@@ -761,7 +761,7 @@ def test_install_noautoget_data(src, path):
     sub1_src = Dataset(opj(src, 'sub 1')).create(force=True)
     sub2_src = Dataset(opj(src, 'sub 2')).create(force=True)
     top_src = Dataset(src).create(force=True)
-    top_src.rev_save(recursive=True)
+    top_src.save(recursive=True)
 
     # install top level:
     # don't filter implicitly installed subdataset to check them for content
@@ -815,7 +815,7 @@ def test_install_consistent_state(src, dest, dest2, dest3):
 
     # and progress subsub2 forward to stay really thorough
     put_file_under_git(subsub2.path, 'file.dat', content="data")
-    subsub2.rev_save(message="added a file")  # above function does not commit
+    subsub2.save(message="added a file")  # above function does not commit
 
     # just installing a submodule -- apparently different code/logic
     # but also the same story should hold - we should install the version pointed

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -145,8 +145,8 @@ def test_publish_simple(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.rev_save(opj(src_path, 'test_mod_file'), to_git=True,
-               message="Modified.")
+    source.save(opj(src_path, 'test_mod_file'), to_git=True,
+                message="Modified.")
     ok_clean_git(source.repo, annex=None)
 
     res = publish(dataset=source, to='target', result_xfm='datasets')
@@ -202,7 +202,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
         f.write("Some additional stuff.")
-    source.rev_save(opj(src_path, 'test_mod_file'), to_git=True,
+    source.save(opj(src_path, 'test_mod_file'), to_git=True,
                message="Modified.")
     ok_clean_git(source.repo, annex=None)
 
@@ -334,12 +334,12 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # add to subdataset, does not alter super dataset!
     # MIH: use `to_git` because original test author used
     # and explicit `GitRepo.add` -- keeping this for now
-    Dataset(sub2.path).rev_save('file.txt', to_git=True)
+    Dataset(sub2.path).save('file.txt', to_git=True)
 
     # Let's now update one subm
     create_tree(sub2.path, {'file.dat': 'content'})
     # add to subdataset, without reflecting the change in its super(s)
-    Dataset(sub2.path).rev_save('file.dat')
+    Dataset(sub2.path).save('file.dat')
 
     # note: will publish to origin here since that is what it tracks
     res_ = publish(dataset=source, recursive=True, on_failure='ignore')
@@ -377,7 +377,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 
     # Let's save those present changes and publish while implying "since last
     # merge point"
-    source.rev_save(message="Changes in subm2")
+    source.save(message="Changes in subm2")
     # and test if it could deduce the remote/branch to push to
     source.config.set('branch.master.remote', 'target', where='local')
     with chpwd(source.path):
@@ -538,7 +538,7 @@ def test_publish_depends(
     ok_clean_git(src_path)
     # introduce change in source
     create_tree(src_path, {'probe1': 'probe1'})
-    source.rev_save('probe1')
+    source.save('probe1')
     ok_clean_git(src_path)
     # only the source has the probe
     ok_file_has_content(opj(src_path, 'probe1'), 'probe1')
@@ -606,7 +606,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 
     # some content modification of the superdataset
     create_tree(src_path, {'probe1': 'probe1'})
-    source.rev_save('probe1')
+    source.save('probe1')
     ok_clean_git(src_path)
 
     # create the target(s):
@@ -632,7 +632,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
-    ds.rev_save('1')
+    ds.save('1')
     ds.create_sibling('ssh://localhost:%s/subdir' % desttop,
                       name='target',
                       target_url=desturl + 'subdir/.git')
@@ -659,7 +659,7 @@ def test_gh1763(src, target1, target2):
         publish_depends='target1')
     # a file to annex
     create_tree(src.path, {'probe1': 'probe1'})
-    src.rev_save('probe1', to_git=False)
+    src.save('probe1', to_git=False)
     # make sure the probe is annexed, not straight in Git
     assert_in('probe1', src.repo.get_annexed_files(with_content_only=True))
     # publish to target2, must handle dependency

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -224,11 +224,11 @@ def test_uninstall_subdataset(src, dst):
 def test_uninstall_multiple_paths(path):
     ds = Dataset(path).create(force=True)
     subds = ds.create('deep', force=True)
-    subds.rev_save(recursive=True)
+    subds.save(recursive=True)
     ok_clean_git(subds.path)
     # needs to be able to add a combination of staged files, modified submodule,
     # and untracked files
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(ds.path)
     # drop content of all 'kill' files
     topfile = 'kill'
@@ -272,7 +272,7 @@ def test_uninstall_dataset(path):
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
     # make sure there is any key
     ok_(len(ds.repo.get_file_key('one')))
@@ -304,11 +304,11 @@ def test_uninstall_recursive(path):
     subds = ds.create('deep', force=True)
     # we add one file, but we get a response for the requested
     # directory too
-    res = subds.rev_save()
+    res = subds.save()
     assert_result_count(res, 1, action='add', status='ok', type='file')
     assert_result_count(res, 1, action='save', status='ok', type='dataset')
     # save all -> all clean
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(subds.path)
     ok_clean_git(ds.path)
     # now uninstall in subdataset through superdataset
@@ -387,7 +387,7 @@ def test_kill(path):
     testfile = opj(ds.path, "file.dat")
     with open(testfile, 'w') as f:
         f.write("load")
-    ds.rev_save("file.dat")
+    ds.save("file.dat")
     subds = ds.create('deep1')
     eq_(sorted(ds.subdatasets(result_xfm='relpaths')), ['deep1'])
     ok_clean_git(ds.path)
@@ -470,7 +470,7 @@ def test_failon_nodrop(path):
     # of top-level datasets
     sub = ds.create('sub')
     create_tree(sub.path, {'test': 'content'})
-    ds.rev_save(opj('sub', 'test'))
+    ds.save(opj('sub', 'test'))
     ok_clean_git(ds.path)
     eq_(['test'], sub.repo.get_annexed_files(with_content_only=True))
     # we put one file into the dataset's annex, no redundant copies
@@ -526,7 +526,7 @@ def test_drop_nocrash_absent_subds(path):
 @with_tree({'one': 'one', 'two': 'two', 'three': 'three'})
 def test_remove_more_than_one(path):
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(path)
     # ensure #1912 stays resolved
     ds.remove(['one', 'two'], check=False)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -73,7 +73,7 @@ def test_update_simple(origin, src_path, dst_path):
     # modify origin:
     with open(opj(src_path, "update.txt"), "w") as f:
         f.write("Additional content")
-    source.rev_save(path="update.txt", message="Added update.txt")
+    source.save(path="update.txt", message="Added update.txt")
     ok_clean_git(src_path)
 
     # fail when asked to update a non-dataset
@@ -118,9 +118,9 @@ def test_update_simple(origin, src_path, dst_path):
 
     # and now test recursive update with merging in differences
     create_tree(opj(source.path, '2'), {'load.dat': 'heavy'})
-    source.rev_save(opj('2', 'load.dat'),
-               message="saving changes within subm2",
-               recursive=True)
+    source.save(opj('2', 'load.dat'),
+                message="saving changes within subm2",
+                recursive=True)
     assert_result_count(
         dest.update(merge=True, recursive=True), 2,
         status='ok', type='dataset')
@@ -138,7 +138,7 @@ def test_update_git_smoke(src_path, dst_path):
         dst_path, source=src_path,
         result_xfm='datasets', return_type='item-or-list')
     create_tree(ds.path, {'file.dat': '123'})
-    ds.rev_save('file.dat')
+    ds.save('file.dat')
     assert_result_count(
         target.update(recursive=True, merge=True), 1,
         status='ok', type='dataset')
@@ -213,7 +213,7 @@ def test_update_fetch_all(src, remote_1, remote_2):
 def test_newthings_coming_down(originpath, destpath):
     origin = GitRepo(originpath, create=True)
     create_tree(originpath, {'load.dat': 'heavy'})
-    Dataset(originpath).rev_save('load.dat')
+    Dataset(originpath).save('load.dat')
     ds = install(
         source=originpath, path=destpath,
         result_xfm='datasets', return_type='item-or-list')
@@ -296,7 +296,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     # re-introduce at origin
     osm1 = origin.create(sname)
     create_tree(osm1.path, {'load.dat': 'heavy'})
-    origin.rev_save(opj(osm1.path, 'load.dat'))
+    origin.save(opj(osm1.path, 'load.dat'))
     assert_result_count(ds.update(merge=True), 1, status='ok', type='dataset')
     # grab new content of uninstall subdataset, right away
     ds.get(opj(ds.path, sname, 'load.dat'))
@@ -304,7 +304,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
 
     # modify ds and subds at origin
     create_tree(origin.path, {'mike': 'this', sname: {'probe': 'little'}})
-    origin.rev_save(recursive=True)
+    origin.save(recursive=True)
     ok_clean_git(origin.path)
 
     # updates for both datasets should come down the pipe
@@ -335,7 +335,7 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     # install separate dataset as a submodule
     ds.install(source=otherds.path, path='other')
     create_tree(otherds.path, {'brand': 'new'})
-    otherds.rev_save()
+    otherds.save()
     ok_clean_git(otherds.path)
     # pull in changes
     res = ds.update(merge=True, recursive=True)
@@ -357,7 +357,7 @@ def test_reobtain_data(originpath, destpath):
     assert_result_count(ds.update(merge=True, reobtain_data=True), 1)
     # content
     create_tree(origin.path, {'load.dat': 'heavy'})
-    origin.rev_save(opj(origin.path, 'load.dat'))
+    origin.save(opj(origin.path, 'load.dat'))
     # update does not bring data automatically
     assert_result_count(ds.update(merge=True, reobtain_data=True), 1)
     assert_in('load.dat', ds.repo.get_annexed_files())
@@ -367,7 +367,7 @@ def test_reobtain_data(originpath, destpath):
     ok_file_has_content(opj(ds.path, 'load.dat'), 'heavy')
     # new content at origin
     create_tree(origin.path, {'novel': 'but boring'})
-    origin.rev_save()
+    origin.save()
     # update must not bring in data for new file
     result = ds.update(merge=True, reobtain_data=True)
     assert_in_results(result, action='get', status='notneeded')
@@ -378,7 +378,7 @@ def test_reobtain_data(originpath, destpath):
     # modify content at origin
     os.remove(opj(origin.path, 'load.dat'))
     create_tree(origin.path, {'load.dat': 'light'})
-    origin.rev_save()
+    origin.save()
     # update must update file with existing data, but leave empty one alone
     res = ds.update(merge=True, reobtain_data=True)
     assert_result_count(res, 2)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -193,7 +193,7 @@ class Update(Interface):
             lgr.debug(
                 'Subdatasets where updated state may need to be '
                 'saved in the parent dataset: %s', save_paths)
-            for r in Dataset(refds_path).rev_save(
+            for r in Dataset(refds_path).save(
                     path=save_paths,
                     recursive=False,
                     message='[DATALAD] Save updated subdatasets'):

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -40,7 +40,6 @@ _group_dataset = (
          'CreateSiblingGithub',
          'create-sibling-github'),
         ('datalad.interface.unlock', 'Unlock', 'unlock'),
-        ('datalad.interface.save', 'Save', 'save'),
     ])
 
 _group_metadata = (

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -40,6 +40,7 @@ _group_dataset = (
          'CreateSiblingGithub',
          'create-sibling-github'),
         ('datalad.interface.unlock', 'Unlock', 'unlock'),
+        ('datalad.core.local.save', 'Save', 'save'),
     ])
 
 _group_metadata = (
@@ -88,7 +89,6 @@ _group_future = (
     'Commands of the future',
     [
         ('datalad.core.local.run', 'Run', 'rev-run', 'rev_run'),
-        ('datalad.core.local.save', 'Save', 'rev-save', 'rev_save'),
         ('datalad.core.local.status', 'Status', 'status'),
     ])
 

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -156,7 +156,7 @@ class DownloadURL(Interface):
 URLs:
   {}""".format("\n  ".join(urls))
 
-            for r in ds.rev_save(downloaded_paths, message=msg):
+            for r in ds.save(downloaded_paths, message=msg):
                 yield r
 
             if isinstance(ds.repo, AnnexRepo):

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -604,7 +604,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 ofh.write(assure_bytes(msg))
             lgr.info("The command had a non-zero exit code. "
                      "If this is expected, you can save the changes with "
-                     "'datalad rev-save -d . -r -F %s'",
+                     "'datalad save -d . -r -F %s'",
                      msg_path)
         raise exc
     elif outputs_to_save:

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -8,6 +8,9 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """For now just a wrapper for Dataset.save()
 
+
+Note: This module is obsolete and will be removed once internal code no longer
+uses it. Use core.local.save instead.
 """
 
 __docformat__ = 'restructuredtext'
@@ -152,6 +155,9 @@ def save_dataset(
 class Save(Interface):
     """Save the current state of a dataset
 
+    *Note*: This is an obsolete interface and will be removed once internal
+     code no longer uses it. Use datalad.api.save or Dataset.save instead.
+
     Saving the state of a dataset records changes that have been made to it.
     This change record is annotated with a user-provided description.
     Optionally, an additional tag, such as a version, can be assigned to the
@@ -207,7 +213,7 @@ class Save(Interface):
     )
 
     @staticmethod
-    @datasetmethod(name='save')
+    @datasetmethod(name='_save')
     @eval_results
     def __call__(message=None, path=None, dataset=None,
                  all_updated=True, version_tag=None,

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -73,7 +73,7 @@ def test_invalid_call(path):
 def test_annotate_paths(dspath, nodspath):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(ds.path)
 
     with chpwd(dspath):
@@ -219,7 +219,7 @@ def test_get_modified_subpaths(path):
     suba = ds.create('ba', force=True)
     subb = ds.create('bb', force=True)
     subsub = ds.create(opj('bb', 'bba', 'bbaa'), force=True)
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(path)
 
     orig_base_commit = ds.repo.repo.commit().hexsha
@@ -232,7 +232,7 @@ def test_get_modified_subpaths(path):
 
     # modify one subdataset
     create_tree(subsub.path, {'added': 'test'})
-    subsub.rev_save('added')
+    subsub.save('added')
 
     # it will replace the requested path with the path of the closest
     # submodule that is modified
@@ -255,7 +255,7 @@ def test_get_modified_subpaths(path):
         type='dataset')
 
     # now save uptop, this will the new state of subb, but keep suba dirty
-    ds.rev_save(subb.path, recursive=True)
+    ds.save(subb.path, recursive=True)
     # now if we ask for what was last saved, we only get the new state of subb
     assert_result_count(
         get_modified_subpaths(
@@ -274,7 +274,7 @@ def test_get_modified_subpaths(path):
         type='dataset', path=suba.path)
 
     # add/save everything, become clean
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(path)
     # nothing is reported as modified
     assert_result_count(
@@ -322,13 +322,13 @@ def test_get_modified_subpaths(path):
 def test_recurseinto(dspath, dest):
     # make fresh dataset hierarchy
     ds = make_demo_hierarchy_datasets(dspath, demo_hierarchy)
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     # label intermediate dataset as 'norecurseinto'
     res = Dataset(opj(ds.path, 'b')).subdatasets(
         contains='bb',
         set_property=[('datalad-recursiveinstall', 'skip')])
     assert_result_count(res, 1, path=opj(ds.path, 'b', 'bb'))
-    ds.rev_save('b', recursive=True)
+    ds.save('b', recursive=True)
     ok_clean_git(ds.path)
 
     # recursive install, should skip the entire bb branch

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -64,7 +64,7 @@ def test_diff(path, norepo):
     assert_result_count(ds._diff(path='THIS', revision='HEAD'), 0)
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
-    ds.rev_save(to_git=True)
+    ds.save(to_git=True)
     ok_clean_git(ds.path)
     res = ds._diff(revision='HEAD~1')
     assert_result_count(res, 1)
@@ -97,7 +97,7 @@ def test_diff(path, norepo):
     assert_result_count(
         ds._diff(revision='HEAD'), 1,
         action='diff', path=opj(ds.path, 'new'), state='modified')
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
 
     # untracked stuff
@@ -157,11 +157,11 @@ def test_diff_recursive(path):
     assert_result_count(res, 1, action='diff', state='modified', path=sub.path, type='dataset')
     assert_result_count(res, 1, action='diff', state='untracked', path=opj(sub.path, 'twofile'), type='file')
     # save sub
-    sub.rev_save()
+    sub.save()
     # save sub in parent
-    ds.rev_save(sub.path)
+    ds.save(sub.path)
     # save addition in parent
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
     # look at the last change, only one file was added
     res = ds._diff(revision='HEAD~1..HEAD')
@@ -200,10 +200,10 @@ def test_diff_helper(path):
     sub_clean = ds.create('sub_clean', force=True)
     # proper submodule, but commited modifications not commited in parent
     sub_modified = ds.create('sub_modified', force=True)
-    sub_modified.rev_save('modified')
+    sub_modified.save('modified')
     # proper submodule with untracked changes
     sub_dirty = ds.create('sub_dirty', force=True)
-    ds.rev_save(['clean', 'modified'])
+    ds.save(['clean', 'modified'])
     ds.unlock('modified')
     with open(opj(ds.path, 'modified'), 'w') as f:
         f.write('modified_content')

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -146,13 +146,13 @@ def test_ls_json(topdir, topurl):
     # create some file and commit it
     with open(opj(ds.path, 'subdsfile.txt'), 'w') as f:
         f.write('123')
-    ds.rev_save(path='subdsfile.txt', message="Hello!", version_tag=1)
+    ds.save(path='subdsfile.txt', message="Hello!", version_tag=1)
 
     # add a subdataset
     ds.install('subds', source=topdir)
 
     subdirds = ds.create(_path_('dir/subds2'), force=True)
-    subdirds.rev_save('file')
+    subdirds.save('file')
 
     git = GitRepo(opj(topdir, 'dir', 'subgit'), create=True)                    # create git repo
     git.add(opj(topdir, 'dir', 'subgit', 'fgit.txt'))                           # commit to git to init git repo
@@ -165,8 +165,8 @@ def test_ls_json(topdir, topurl):
     git.add('fgit.txt')              # commit to git to init git repo
     git.commit()
     # annex.add doesn't add submodule, so using ds.add
-    ds.rev_save(opj('dir', 'subgit'))                        # add the non-dataset git repo to annex
-    ds.rev_save('dir')                                  # add to annex (links)
+    ds.save(opj('dir', 'subgit'))                   # add the non-dataset git repo to annex
+    ds.save('dir')                                  # add to annex (links)
     ds.drop(opj('dir', 'subdir', 'file2.txt'), check=False)  # broken-link
 
     # register "external" submodule  by installing and uninstalling it

--- a/datalad/interface/tests/test_run.py
+++ b/datalad/interface/tests/test_run.py
@@ -241,7 +241,7 @@ def test_rerun(path, nodspath):
     # Make a non-run commit.
     with open(op.join(path, "nonrun-file"), "w") as f:
         f.write("foo")
-    ds.rev_save("nonrun-file")
+    ds.save("nonrun-file")
     # Now rerun the buried command.
     ds.rerun(revision="HEAD~", message="rerun buried")
     eq_('xxx\n', open(probe_path).read())
@@ -273,7 +273,7 @@ def test_rerun(path, nodspath):
     ds.repo.checkout("HEAD~3", options=["-b", "topic"])
     with open(op.join(path, "topic-file"), "w") as f:
         f.write("topic")
-    ds.rev_save("topic-file")
+    ds.save("topic-file")
     ds.repo.checkout("master")
     ds.repo.merge("topic")
     assert_repo_status(ds.path)
@@ -445,7 +445,7 @@ def test_run_failure(path):
     msgfile = op.join(path, ds.repo.get_git_dir(ds.repo), "COMMIT_EDITMSG")
     ok_exists(msgfile)
 
-    ds.rev_save(recursive=True, message_file=msgfile)
+    ds.save(recursive=True, message_file=msgfile)
     assert_repo_status(ds.path)
     neq_(hexsha_initial, ds.repo.get_hexsha())
 
@@ -478,7 +478,7 @@ def test_run_failure(path):
 @with_tree(tree={"to_remove": "abc"})
 def test_run_save_deletion(path):
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     ds.run("{} to_remove".format("del" if on_windows else "rm"))
     assert_repo_status(ds.path)
 
@@ -509,7 +509,7 @@ def test_rerun_branch(path):
 
     with open(op.join(path, "nonrun-file"), "w") as f:
         f.write("foo")
-    ds.rev_save("nonrun-file")
+    ds.save("nonrun-file")
 
     # Rerun the commands on a new branch that starts at the parent
     # commit of the first run.
@@ -555,7 +555,7 @@ def test_rerun_cherry_pick(path):
     ds.run('echo abc > runfile')
     with open(op.join(path, "nonrun-file"), "w") as f:
         f.write("foo")
-    ds.rev_save("nonrun-file")
+    ds.save("nonrun-file")
 
     for onto, action in [("HEAD", "skip"), ("prerun", "pick")]:
         results = ds.rerun(since="prerun", onto=onto)
@@ -570,7 +570,7 @@ def test_rerun_outofdate_tree(path):
     output_file = op.join(path, "out")
     with open(input_file, "w") as f:
         f.write("abc\ndef")
-    ds.rev_save("foo", to_git=True)
+    ds.save("foo", to_git=True)
     # Create inital run.
     ds.run('grep def foo > out')
     eq_('def\n', open(output_file).read())
@@ -649,7 +649,7 @@ def test_new_or_modified(path):
     # Check out an orphan branch so that we can test the "one commit
     # in a repo" case.
     ds.repo.checkout("orph", options=["--orphan"])
-    ds.rev_save()
+    ds.save()
     assert_false(ds.repo.dirty)
     assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
     # Diffing doesn't fail when the branch contains a single commit.
@@ -672,7 +672,7 @@ def test_new_or_modified(path):
         f.write("updated 1")
     with open(op.join(path, "d/to_modify"), "w") as f:
         f.write("updated 2")
-    ds.rev_save(["to_modify", "d/to_modify"])
+    ds.save(["to_modify", "d/to_modify"])
 
     eq_(set(get_new_or_modified(ds, "HEAD")),
         {"to_modify", op.join("d", "to_modify")})
@@ -744,9 +744,9 @@ def test_run_inputs_outputs(src, path):
                   ("s0", "s1_1"),
                   ("s0", "ss"),
                   ("s0",)]:
-        Dataset(op.join(*((src,) + subds))).create(force=True).rev_save()
+        Dataset(op.join(*((src,) + subds))).create(force=True).save()
     src_ds = Dataset(src).create(force=True)
-    src_ds.rev_save()
+    src_ds.save()
 
     ds = install(path, source=src,
                  result_xfm='datasets', return_type='item-or-list')
@@ -785,7 +785,7 @@ def test_run_inputs_outputs(src, path):
     inputs = ["a.dat", "b.dat", "c.txt", "d.txt"]
     create_tree(ds.path, {i: i for i in inputs})
 
-    ds.rev_save()
+    ds.save()
     ds.repo.copy_to(inputs, remote="origin")
     ds.repo.drop(inputs, options=["--force"])
 
@@ -805,7 +805,7 @@ def test_run_inputs_outputs(src, path):
     # --input can be passed a subdirectory.
     create_tree(ds.path, {"subdir": {"a": "subdir a",
                                      "b": "subdir b"}})
-    ds.rev_save("subdir")
+    ds.save("subdir")
     ds.repo.copy_to(["subdir/a", "subdir/b"], remote="origin")
     ds.repo.drop("subdir", options=["--force"])
     ds.run("cd .> subdir-dummy", inputs=[op.join(ds.path, "subdir")])
@@ -824,7 +824,7 @@ def test_run_inputs_outputs(src, path):
     # On rerun, we get all files, even those that weren't in the tree at the
     # time of the run.
     create_tree(ds.path, {"after-dot-run": "after-dot-run content"})
-    ds.rev_save()
+    ds.save()
     ds.repo.copy_to(["after-dot-run"], remote="origin")
     ds.repo.drop(["after-dot-run"], options=["--force"])
     ds.rerun("HEAD^")
@@ -912,7 +912,7 @@ def test_run_explicit(path):
 
     create_tree(ds.path, {"dirt_untracked": "untracked",
                           "dirt_modified": "modified"})
-    ds.rev_save("dirt_modified", to_git=True)
+    ds.save("dirt_modified", to_git=True)
     with open(op.join(path, "dirt_modified"), "a") as ofh:
         ofh.write(", more")
 
@@ -960,7 +960,7 @@ def test_run_explicit(path):
                  "subdir": {}})
 def test_placeholders(path):
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     assert_repo_status(ds.path)
     # ATTN windows is sensitive to spaces before redirect symbol
     ds.run("echo {inputs}>{outputs}", inputs=[".", "*.in"], outputs=["c.out"])
@@ -1028,7 +1028,7 @@ def test_placeholders(path):
                  "foo blah.txt": "f"})
 def test_inputs_quotes_needed(path):
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     cmd = "import sys; open(sys.argv[-1], 'w').write('!'.join(sys.argv[1:]))"
     # The string form of a command works fine when the inputs/outputs have
     # spaces ...

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -53,11 +53,11 @@ def test_invalid_call(path):
     'code': {'datalad_test_proc.py': """\
 import sys
 import os.path as op
-from datalad.api import rev_save, Dataset
+from datalad.api import save, Dataset
 
 with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('hello\\n')
-rev_save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
+save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 """}})
 @with_tempfile
 def test_basics(path, super_path):
@@ -71,7 +71,7 @@ def test_basics(path, super_path):
         'code',
         where='dataset')
     # commit this procedure config for later use in a clone:
-    ds.rev_save(op.join('.datalad', 'config'))
+    ds.save(op.join('.datalad', 'config'))
     # configure dataset to run the demo procedure prior to the clean command
     ds.config.add(
         'datalad.clean.proc-pre',
@@ -142,7 +142,7 @@ def test_procedure_discovery(path, super_path):
         'datalad.clean.proc-pre',
         'datalad_test_proc',
         where='dataset')
-    ds.rev_save(op.join('.datalad', 'config'))
+    ds.save(op.join('.datalad', 'config'))
 
     # run discovery on the dataset:
     ps = ds.run_procedure(discover=True)
@@ -204,11 +204,11 @@ def test_procedure_discovery(path, super_path):
     'code': {'datalad_test_proc.py': """\
 import sys
 import os.path as op
-from datalad.api import rev_save, Dataset
+from datalad.api import save, Dataset
 
 with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('{}\\n'.format(sys.argv[2]))
-rev_save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
+save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
 """}})
 def test_configs(path):
 

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -29,7 +29,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import ok_
 from datalad.api import create
-from datalad.api import rev_save
+from datalad.api import save as rev_save
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_testrepos
 from datalad.tests.utils import with_tempfile

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -139,7 +139,7 @@ def make_demo_hierarchy_datasets(path, tree, parent=None):
 def test_save_hierarchy(path):
     # this test doesn't use API`remove` to avoid circularities
     ds = make_demo_hierarchy_datasets(path, demo_hierarchy)
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(ds.path)
     ds_bb = Dataset(opj(ds.path, 'b', 'bb'))
     ds_bba = Dataset(opj(ds_bb.path, 'bba'))
@@ -150,7 +150,7 @@ def test_save_hierarchy(path):
         ok_(d.repo.dirty)
     # need to give file specifically, otherwise it will simply just preserve
     # staged changes
-    ds_bb.rev_save(path=opj(ds_bbaa.path, 'file_bbaa'))
+    ds_bb.save(path=opj(ds_bbaa.path, 'file_bbaa'))
     # it has saved all changes in the subtrees spanned
     # by the given datasets, but nothing else
     for d in (ds_bb, ds_bba, ds_bbaa):
@@ -163,7 +163,7 @@ def test_save_hierarchy(path):
     db = Dataset(opj(d.path, 'db'))
     db.repo.remove('file_db')
     # generator
-    d.rev_save(recursive=True)
+    d.save(recursive=True)
     for d in (d, da, db):
         ok_clean_git(d.path)
     ok_(ds.repo.dirty)
@@ -181,7 +181,7 @@ def test_save_hierarchy(path):
     ca.repo.remove('file_ca')
     d = Dataset(opj(ds.path, 'd'))
     d.repo.remove('file_d')
-    ds.rev_save(
+    ds.save(
         # append trailing slashes to the path to indicate that we want to
         # have the staged content in the dataset saved, rather than only the
         # subdataset state in the respective superds.
@@ -317,7 +317,7 @@ def test_discover_ds_trace(path, otherdir):
     # we have to check whether we get the correct hierarchy, as the test
     # subject is also involved in this
     assert_true(exists(opj(db, 'file_db')))
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(ds.path)
     # now two datasets which are not available locally, but we
     # know about them (e.g. from metadata)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -101,8 +101,8 @@ def handle_dirty_dataset(ds, mode, msg=None):
     elif mode == 'save-before':
         if not ds.is_installed():
             raise RuntimeError('dataset {} is not yet installed'.format(ds))
-        from datalad.interface.save import Save
-        Save.__call__(dataset=ds, message=msg)
+        from datalad.core.local.save import Save
+        Save.__call__(dataset=ds, message=msg, updated=True)
     else:
         raise ValueError("unknown if-dirty mode '{}'".format(mode))
 

--- a/datalad/metadata/extractors/tests/test_audio.py
+++ b/datalad/metadata/extractors/tests/test_audio.py
@@ -48,7 +48,7 @@ def test_audio(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'audio.mp3'),
         path)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -22,7 +22,7 @@ from nose.tools import assert_equal
 @with_tree(tree={'file.dat': ''})
 def check_api(no_annex, path):
     ds = Dataset(path).create(force=True, no_annex=no_annex)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
 
     processed_extractors, skipped_extractors = [], []

--- a/datalad/metadata/extractors/tests/test_datacite_xml.py
+++ b/datalad/metadata/extractors/tests/test_datacite_xml.py
@@ -68,7 +68,7 @@ def test_get_metadata(path1, path2):
     for p in (path1, path2):
         print('PATH')
         ds = create(p, force=True)
-        ds.rev_save()
+        ds.save()
         meta = MetadataExtractor(
                 ds,
                 _get_metadatarelevant_paths(ds, []))._get_dataset_metadata()

--- a/datalad/metadata/extractors/tests/test_exif.py
+++ b/datalad/metadata/extractors/tests/test_exif.py
@@ -81,7 +81,7 @@ def test_exif(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'exif.jpg'),
         path)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_image.py
+++ b/datalad/metadata/extractors/tests/test_image.py
@@ -44,7 +44,7 @@ def test_image(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'exif.jpg'),
         path)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/extractors/tests/test_rfc822.py
+++ b/datalad/metadata/extractors/tests/test_rfc822.py
@@ -42,7 +42,7 @@ DOI: 10.5281/zenodo.48421
 def test_get_metadata(path):
 
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     meta = MetadataExtractor(ds, [])._get_dataset_metadata()
     assert_equal(
         dumps(meta, sort_keys=True, indent=2),

--- a/datalad/metadata/extractors/tests/test_xmp.py
+++ b/datalad/metadata/extractors/tests/test_xmp.py
@@ -49,7 +49,7 @@ def test_xmp(path):
     copy(
         opj(dirname(dirname(dirname(__file__))), 'tests', 'data', 'xmp.pdf'),
         path)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
     res = ds.aggregate_metadata()
     assert_status('ok', res)

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -61,12 +61,12 @@ def test_basic_aggregate(path):
     sub = base.create('sub', force=True)
     #base.metadata(sub.path, init=dict(homepage='this'), apply2global=True)
     subsub = base.create(opj('sub', 'subsub'), force=True)
-    base.rev_save(recursive=True)
+    base.save(recursive=True)
     ok_clean_git(base.path)
     # we will first aggregate the middle dataset on its own, this will
     # serve as a smoke test for the reuse of metadata objects later on
     sub.aggregate_metadata()
-    base.rev_save()
+    base.save()
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -152,7 +152,7 @@ def test_reaggregate_with_unavailable_objects(path):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = base.create(opj('sub', 'subsub'), force=True)
-    base.rev_save(recursive=True)
+    base.save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -186,7 +186,7 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = base.create(opj('sub', 'subsub'), force=True)
-    base.rev_save(recursive=True)
+    base.save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -220,7 +220,7 @@ def test_publish_aggregated(path):
         f.write(
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     base.create('sub', force=True)
-    base.rev_save(recursive=True)
+    base.save(recursive=True)
     ok_clean_git(base.path)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
@@ -267,7 +267,7 @@ def test_aggregate_removal(path):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = sub.create(opj('subsub'), force=True)
-    base.rev_save(recursive=True)
+    base.save(recursive=True)
     base.aggregate_metadata(recursive=True, update_mode='all')
     ok_clean_git(base.path)
     res = base.metadata(get_aggregates=True)
@@ -302,7 +302,7 @@ def test_update_strategy(path):
             '** annex.largefiles=nothing\nmetadata/objects/** annex.largefiles=anything\n')
     sub = base.create('sub', force=True)
     subsub = sub.create(opj('subsub'), force=True)
-    base.rev_save(recursive=True)
+    base.save(recursive=True)
     ok_clean_git(base.path)
     # we start clean
     for ds in base, sub, subsub:
@@ -356,7 +356,7 @@ def test_partial_aggregation(path):
     ds = Dataset(path).create(force=True)
     sub1 = ds.create('sub1', force=True)
     sub2 = ds.create('sub2', force=True)
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
 
     # if we aggregate a path(s) and say to recurse, we must not recurse into
     # the dataset itself and aggregate others
@@ -390,7 +390,7 @@ def test_partial_aggregation(path):
     sub1.unlock('here')
     with open(opj(sub1.path, 'here'), 'w') as f:
         f.write('fresh')
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(path)
     # TODO for later
     # test --since with non-incremental

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -114,7 +114,7 @@ def test_aggregation(path):
     subsubds = subds.create('subsub', force=True)
     subsubds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                         where='dataset')
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     ok_clean_git(ds.path)
     # aggregate metadata from all subdatasets into any superdataset, including
     # intermediate ones
@@ -218,7 +218,7 @@ def test_ignore_nondatasets(path):
         assert_true(Dataset(subm_path).is_installed())
         assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         # making it a submodule has no effect either
-        ds.rev_save(subpath)
+        ds.save(subpath)
         assert_equal(len(ds.subdatasets()), n_subm + 1)
         assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         n_subm += 1
@@ -237,7 +237,7 @@ def test_get_aggregates_fails(path):
 @with_tempfile(mkdir=True)
 def test_bf2458(src, dst):
     ds = Dataset(src).create(force=True)
-    ds.rev_save(to_git=False)
+    ds.save(to_git=False)
 
     # no clone (empty) into new dst
     clone = install(source=ds.path, path=dst)

--- a/datalad/metadata/tests/test_extract_metadata.py
+++ b/datalad/metadata/tests/test_extract_metadata.py
@@ -47,7 +47,7 @@ def test_ds_extraction(path):
 
     ds = Dataset(path).create()
     copy(testpath, path)
-    ds.rev_save()
+    ds.save()
     ok_clean_git(ds.path)
 
     res = extract_metadata(

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -197,7 +197,7 @@ def test_within_ds_file_search(path):
         copy(
             opj(dirname(dirname(__file__)), 'tests', 'data', src),
             opj(path, dst))
-    ds.rev_save()
+    ds.save()
     ok_file_under_git(path, opj('stim', 'stim1.mp3'), annexed=True)
     # If it is not under annex, below addition of metadata silently does
     # not do anything

--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -144,7 +144,7 @@ see the DataLad documentation at: http://docs.datalad.org
                 type='file',
                 action='add_readme')
 
-        for r in dataset.rev_save(
+        for r in dataset.save(
                 filename,
                 message='[DATALAD] added README',
                 result_filter=None,

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -137,7 +137,7 @@ class NoAnnex(Interface):
             attrfile=gitattr_file)
         yield dict(res_kwargs, status='ok')
 
-        for r in dataset.rev_save(
+        for r in dataset.save(
                 gitattr_file,
                 to_git=True,
                 message="[DATALAD] exclude paths from annex'ing",

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -308,7 +308,7 @@ def test_addurls_dry_run(path):
                        {"url": "URL/c.dat", "name": "c", "subdir": "foo"}],
                       jfh)
 
-        ds.rev_save(message="setup")
+        ds.save(message="setup")
 
         with swallow_logs(new_level=logging.INFO) as cml:
             ds.addurls(json_file,
@@ -407,7 +407,7 @@ class TestAddurls(object):
             ds.unlock("a")
             with open("a", "w") as ofh:
                 ofh.write("changed")
-            ds.rev_save("a")
+            ds.save("a")
 
             assert_raises(IncompleteResultsError,
                           ds.addurls,
@@ -449,7 +449,7 @@ class TestAddurls(object):
 
             # Now save the "--nosave" changes and check that we have
             # all the subdatasets.
-            ds.rev_save()
+            ds.save()
             eq_(set(subdatasets(ds, recursive=True,
                                 result_xfm="relpaths")),
                 {"foo-save", "bar-save", "foo-nosave", "bar-nosave"})

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -45,7 +45,7 @@ def test_failure(path):
 @with_tree(_dataset_template)
 def test_archive(path):
     ds = Dataset(opj(path, 'ds')).create(force=True)
-    ds.rev_save()
+    ds.save()
     committed_date = ds.repo.get_commit_date()
     default_outname = opj(path, 'datalad_{}.tar.gz'.format(ds.id))
     with chpwd(path):
@@ -96,7 +96,7 @@ def test_archive(path):
 @with_tree(_dataset_template)
 def test_zip_archive(path):
     ds = Dataset(opj(path, 'ds')).create(force=True, no_annex=True)
-    ds.rev_save()
+    ds.save()
     with chpwd(path):
         ds.export_archive(filename='my', archivetype='zip')
         assert_true(os.path.exists('my.zip'))

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -126,10 +126,10 @@ def test_no_annex(path):
             'notinannex': 'othercontent'},
          'README': 'please'})
     # add inannex pre configuration
-    ds.rev_save(opj('code', 'inannex'))
+    ds.save(opj('code', 'inannex'))
     no_annex(pattern=['code/**', 'README'], dataset=ds)
     # add inannex and README post configuration
-    ds.rev_save([opj('code', 'notinannex'), 'README'])
+    ds.save([opj('code', 'notinannex'), 'README'])
     ok_clean_git(ds.path)
     # one is annex'ed, the other is not, despite no change in add call
     # importantly, also .gitattribute is not annexed
@@ -159,7 +159,7 @@ _ds_template = {
 @with_tree(_ds_template)
 def test_add_readme(path):
     ds = Dataset(path).create(force=True)
-    ds.rev_save()
+    ds.save()
     ds.aggregate_metadata()
     ok_clean_git(ds.path)
     assert_status('ok', ds.add_readme())

--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -26,7 +26,7 @@ for nt in sys.argv[2:]:
         where='dataset',
         reload=False)
 
-ds.rev_save(
+ds.save(
     path=op.join(ds.path, DATASET_CONFIG_FILE),
     message="Configure metadata type(s)",
 )

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -18,7 +18,7 @@ if not attrs.get('*', {}).get(
         ('*', {'annex.largefiles': annex_largefiles})])
 
 git_attributes_file = op.join(ds.path, '.gitattributes')
-ds.rev_save(
+ds.save(
     git_attributes_file,
     message="Instruct annex to add text files to Git",
 )

--- a/datalad/resources/procedures/cfg_yoda.py
+++ b/datalad/resources/procedures/cfg_yoda.py
@@ -61,6 +61,6 @@ ds.repo.set_gitattributes(
 
 # leave clean
 # TODO only commit actually changed/added files
-ds.rev_save(
+ds.save(
     message="Apply YODA dataset setup",
 )

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -172,7 +172,7 @@ def test_subds_path(path):
     assert_repo_status(path)
     with (subds.pathobj / 'some.txt').open('w') as f:
         f.write(u'test')
-    ds.rev_save(recursive=True)
+    ds.save(recursive=True)
     assert_repo_status(path)
 
     # querying the toplevel dataset repo for a subdspath should
@@ -191,7 +191,7 @@ def test_report_absent_keys(path):
     # create an annexed file
     testfile = ds.pathobj / 'dummy'
     testfile.write_text(u'nothing')
-    ds.rev_save()
+    ds.save()
     # present in a full report and in a partial report
     # based on worktree of HEAD ref
     for ai in (

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1580,7 +1580,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
                 'file_dropped_clean': 'file_dropped_clean',
             }
         )
-    ds.rev_save()
+    ds.save()
     if isinstance(ds.repo, AnnexRepo):
         # some files straight in git
         create_tree(
@@ -1594,7 +1594,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
                 'file_ingit_modified': 'file_ingit_clean',
             }
         )
-        ds.rev_save(to_git=True)
+        ds.save(to_git=True)
         ds.drop([
             'file_dropped_clean',
             op.join('subdir', 'file_dropped_clean')],
@@ -1622,7 +1622,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
         pdspath,
         {'file_clean': 'file_ingit_clean'}
     )
-    Dataset(pdspath).rev_save()
+    Dataset(pdspath).save()
     assert_repo_status(pdspath)
     # staged subds, and files
     create(op.join(ds.path, 'subds_added'))
@@ -1709,9 +1709,9 @@ def get_deeply_nested_structure(path):
     ds = Dataset(path).create()
     (ds.pathobj / 'subdir').mkdir()
     (ds.pathobj / 'subdir' / 'annexed_file.txt').write_text(u'dummy')
-    ds.rev_save()
+    ds.save()
     (ds.pathobj / 'subdir' / 'git_file.txt').write_text(u'dummy')
-    ds.rev_save(to_git=True)
+    ds.save(to_git=True)
     # a subtree of datasets
     subds = ds.create('subds_modified')
     # another dataset, plus an additional dir in it
@@ -1731,7 +1731,7 @@ def get_deeply_nested_structure(path):
     )
     (ut.Path(subds.path) / 'subdir').mkdir()
     (ut.Path(subds.path) / 'subdir' / 'annexed_file.txt').write_text(u'dummy')
-    subds.rev_save()
+    subds.save()
     (ds.pathobj / 'directory_untracked').mkdir()
     # symlink farm #1
     # symlink to annexed file

--- a/datalad/tests/utils_testdatasets.py
+++ b/datalad/tests/utils_testdatasets.py
@@ -68,7 +68,7 @@ def make_studyforrest_mockup(path):
         create_tree(
             aligned.path,
             {'modification{}.txt'.format(i): 'unique{}'.format(i)})
-        aligned.rev_save()
+        aligned.save()
     # finally aggregate data
     aggregate = public.create('aggregate', description='aggregate data')
     aggregate.clone(source=aligned.path, path=opj('src', 'aligned'), reckless=True)

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -104,5 +104,4 @@ Commands of the future
    :maxdepth: 1
 
    generated/man/datalad-rev-run
-   generated/man/datalad-rev-save
    generated/man/datalad-status


### PR DESCRIPTION
* Rework a few spots that depend on interface.save-specific things to use rev_save.

* Remove interface.save from interface list and rename the dataset method
  to _save).  Ripping it out entirely will take more work (see 1c49a1f2a).

* Rename rev_save to save.

Re: #3368
