### PR TITLE
RF: disable wrapt workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -295,7 +295,7 @@ script:
   - mkdir -p __testhome__
   - cd __testhome__
   # Run tests
-  - WRAPT_DISABLE_EXTENSIONS=1 http_proxy=
+  - http_proxy=
     PATH=$PWD/../tools/coverage-bin:$PATH
     $NOSE_WRAPPER `which nosetests` $NOSE_OPTS
       -A "$NOSE_SELECTION_OP($NOSE_SELECTION)"


### PR DESCRIPTION
According to https://github.com/datalad/datalad/pull/3405
we likely no longer hit it.  If we hit it again - it would also be useful
to know, possibly to test devel branch of wrapt (currently 1.11.1-4-g03e90ab)