### PR TITLE
BF: stop relying on setup.py runtime environment using platform.dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-import sys
-import platform
-import os
 from os.path import dirname
 from os.path import join as opj
 from os.path import sep as pathsep
@@ -42,25 +39,11 @@ version = get_version()
 # so we will filter manually for maximal compatibility
 datalad_pkgs = [pkg for pkg in find_packages('.') if pkg.startswith('datalad')]
 
-# keyring is a tricky one since it got split into two as of 8.0 and on older
-# systems there is a problem installing via pip (e.g. on wheezy) so for those we
-# would just ask for keyring
-keyring_requires = ['keyring>=8.0', 'keyrings.alt']
-pbar_requires = ['tqdm']
-
-dist = platform.dist()
-# Identical to definition in datalad.utils
-platform_system = platform.system().lower()
-on_windows = platform_system == 'windows'
-
-# on oldstable Debian let's ask for lower versions of keyring
-if dist[0] == 'debian' and dist[1].split('.', 1)[0] == '7':
-    keyring_requires = ['keyring<8.0']
-
 requires = {
     'core': [
         'appdirs',
         'chardet>=3.0.4',      # rarely used but small/omnipresent
+        'colorama; platform_system=="Windows"',
         'GitPython>=2.1.8',
         'iso8601',
         'humanize',
@@ -68,15 +51,15 @@ requires = {
         'mock>=1.0.1',  # mock is also used for auto.py, not only for testing
         'patool>=1.7',
         'six>=1.8.0',
+        'tqdm',
         'wrapt',
-    ] +
-    pbar_requires +
-    (['colorama'] if on_windows else []),
+    ],
     'downloaders': [
         'boto',
+        'keyring>=8.0', 'keyrings.alt',
         'msgpack',
         'requests>=1.2',
-    ] + keyring_requires,
+    ],
     'downloaders-extra': [
         'requests_ftp',
     ],

--- a/setup.py
+++ b/setup.py
@@ -6,19 +6,27 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from os.path import dirname
-from os.path import join as opj
-from os.path import sep as pathsep
-from os.path import splitext
+from os.path import (
+    dirname,
+    join as opj,
+    sep as pathsep,
+    splitext,
+)
 
-from setuptools import findall
-from setuptools import setup, find_packages
+from setuptools import (
+    findall,
+    find_packages,
+    setup,
+)
 
-from setup_support import BuildConfigInfo
-from setup_support import BuildSchema
-from setup_support import BuildManPage, setup_entry_points
-from setup_support import BuildRSTExamplesFromScripts
-from setup_support import get_version
+from setup_support import (
+    BuildConfigInfo,
+    BuildManPage,
+    BuildRSTExamplesFromScripts,
+    BuildSchema,
+    get_version,
+    setup_entry_points,
+)
 
 
 def findsome(subdir, extensions):


### PR DESCRIPTION
- colorama Windows specificity is specified via `platform_system=="Windows"`
- always demand `keyring >= 8.0`

And also simplify dependencies where there is no alternative used now:

- tqdm

If older systems with too old setuptools (debian jessie) fail to install from sources,
they might require patching away platform_system=="Windows" and python_version < "3.3"
which is already the case anyways, but while at it TODO (after dinner):
- ~~add conditioning to check for too old setuptools (not sure what version is min to support them yet) being used and avoid adding those qualifiers then. This would avoid patching e.g. for NeuroDebian backports~~ Tried, could succeed, but then it would still might require patching for liblzma so decided not to bother for now.  Note, that setuptools throws SystemExit (not just some kind of an Exception), so it had to be caught, both `install_requires` and values within `extras_require` tuned up

Closes #3417 