### PR TITLE
BF: revert back (remove) check for path being PathRI

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -66,11 +66,6 @@ def resolve_path(path, ds=None):
     -------
     Absolute path
     """
-    # first make sure it's actually a valid path:
-    from datalad.support.network import PathRI
-    if not isinstance(RI(path), PathRI):
-        raise ValueError("%s is not a valid path" % path)
-
     path = expandpath(path, force_absolute=False)
     if is_explicit_path(path):
         # normalize path consistently between two (explicit and implicit) cases

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -65,11 +65,25 @@ from ..dataset import Dataset
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_invalid_args(path, otherpath, alienpath):
+    # source == path
     assert_raises(ValueError, clone, 'Zoidberg', path='Zoidberg')
-    # install to an invalid URL
-    assert_raises(ValueError, clone, 'Zoidberg', path='ssh://mars:Zoidberg')
-    # install to a remote location
-    assert_raises(ValueError, clone, 'Zoidberg', path='ssh://mars/Zoidberg')
+    assert_raises(ValueError, clone, 'ssh://mars/Zoidberg', path='ssh://mars/Zoidberg')
+
+    # "invalid URL" is a valid filepath... and since no clone to remote
+    # is possible - we can just assume that it is the (legit) file path
+    # which is provided, not a URL.  So both below should fail as any
+    # other clone from a non-existing source and not for the reason of
+    # "invalid something".  Behavior is similar to how Git performs - can
+    # clone into a URL-like path.
+
+    # install to an "invalid URL" path
+    res = clone('Zoidberg', path='ssh://mars:Zoidberg', on_failure='ignore')
+    assert_status('error', res)
+
+    # install to a "remote location" path
+    res = clone('Zoidberg', path='ssh://mars/Zoidberg', on_failure='ignore')
+    assert_status('error', res)
+
     # make fake dataset
     ds = create(path)
     assert_raises(IncompleteResultsError, ds.clone, '/higherup.', 'Zoidberg')

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -496,3 +496,15 @@ def test_save_partial_index(path):
     ds.repo.add("staged", git=True)
     ds.save(path="foo")
     ok_clean_git(ds.path, head_modified=["staged"])
+
+
+@with_tree({
+    'top:file': 'data',
+    'd': {'sub:file': 'data'}
+})
+def test_gh3421(path):
+    # failed to add d/sub:file
+    ds = Dataset(path).create(force=True)
+    ds.add('top:file')
+    ds.add(opj('d', 'sub:file'))
+    ok_clean_git(ds.path)

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -342,7 +342,13 @@ def _guess_ri_cls(ri):
 
     if not fields['scheme'] and not fields['hostname']:
         parts = _split_colon(ri)
-        if fields['path'] and '@' in fields['path'] or len(parts) > 1:
+        # if no illegal for username@hostname characters in the first part and
+        # we either had username@hostname or multiple :-separated parts
+        if not set(parts[0]).intersection(set('/\\#')) and (
+                fields['path'] and
+                '@' in fields['path'] or
+                len(parts) > 1
+        ):
             # user@host:path/sp1
             # or host_name: (hence parts check)
             # TODO: we need a regex to catch those really, parts check is not suff
@@ -749,7 +755,7 @@ class SSHRI(RI, RegexBasedURLMixin):
         'port',
     )
 
-    _REGEX = re.compile(r'((?P<username>\S*)@)?(?P<hostname>[^:]+)(\:(?P<path>.*))?$')
+    _REGEX = re.compile(r'((?P<username>\S*)@)?(?P<hostname>[^#/\\:]+)(\:(?P<path>.*))?$')
 
     @classmethod
     def _normalize_fields(cls, fields):

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -254,6 +254,9 @@ def test_url_samples():
     # and now implicit paths or actually they are also "URI references"
     _check_ri("f", PathRI, localpath='f', path='f')
     _check_ri("f/s1", PathRI, localpath='f/s1', path='f/s1')
+    # colons are problematic and might cause confusion into SSHRI
+    _check_ri("f/s:1", PathRI, localpath='f/s:1', path='f/s:1')
+    _check_ri("f/s:", PathRI, localpath='f/s:', path='f/s:')
     _check_ri("/f", PathRI, localpath='/f', path='/f')
     _check_ri("/f/s1", PathRI, localpath='/f/s1', path='/f/s1')
 
@@ -272,8 +275,14 @@ def test_url_samples():
     """
     $> ssh example.com/path/sp1:fname
     ssh: Could not resolve hostname example.com/path/sp1:fname: Name or service not known
+
+    edit 20190516 yoh: but this looks like a perfectly valid path.
+    SSH knows that it is not a path but its SSHRI so it can stay dumb.
+    We are trying to be smart and choose between RIs (even when we know that
+    it is e.g. a file).
     """
-    _check_ri('example.com/path/sp1:fname', SSHRI, hostname='example.com/path/sp1', path='fname')
+    _check_ri('e.com/p/sp:f', PathRI, localpath='e.com/p/sp:f', path='e.com/p/sp:f')
+    _check_ri('user@someho.st/mydir', PathRI, localpath='user@someho.st/mydir', path='user@someho.st/mydir')
 
     # SSHRIs have .port, but it is empty
     eq_(SSHRI(hostname='example.com').port, '')


### PR DESCRIPTION
Paths with : in them could get confused for SSHRI.  If we know that it
is a path, why to check/crash?  Original commit
86a05d0fb1a5b091676d0d430f11ae05476f18c4
which introduced that check unfortunately does not provide ANY information
on the initial problem it addresses, besides hinting possibly on it being related
to Windows

Closes #3421