### PR TITLE
Fix warnings from py3.8 test run

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -76,7 +76,7 @@ class HelpAction(argparse.Action):
             opt_args_str = '*Global options*'
             pos_args_str = '*Commands*'
             # tune up usage -- default one is way too heavy
-            helpstr = re.sub('^[uU]sage: .*?\n\s*\n',
+            helpstr = re.sub(r'^[uU]sage: .*?\n\s*\n',
                              'Usage: datalad [global-opts] command [command-opts]\n\n',
                              helpstr,
                              flags=re.MULTILINE | re.DOTALL)

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -432,7 +432,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
                     # we want to publish the underlying branch
                     current_branch = current_branch[12:]
                 match_adjusted = re.match(
-                    'adjusted/(.*)\([a-z]*\)',
+                    r'adjusted/(.*)\([a-z]*\)',
                     current_branch)
                 if match_adjusted:
                     # adjusted/master(...)

--- a/datalad/distribution/subdatasets.py
+++ b/datalad/distribution/subdatasets.py
@@ -118,7 +118,7 @@ def _parse_git_submodules(dspath):
 
 @build_doc
 class Subdatasets(Interface):
-    """Report subdatasets and their properties.
+    r"""Report subdatasets and their properties.
 
     The following properties are reported (if possible) for each matching
     subdataset record.

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -106,7 +106,7 @@ def _indent(text, istr=_rst_indentstr):
     return '\n'.join(istr + s for s in text.split('\n'))
 
 
-__parameters_str_re = re.compile("[\n^]\s*:?Parameters?:?\s*\n(:?\s*-+\s*\n)?")
+__parameters_str_re = re.compile(r"[\n^]\s*:?Parameters?:?\s*\n(:?\s*-+\s*\n)?")
 """regexp to match :Parameter: and :Parameters: stand alone in a line
 or
 Parameters
@@ -154,8 +154,8 @@ def _split_out_parameters(initdoc):
            textwrap.dedent(result[2]).strip('\n')
 
 
-__re_params = re.compile('(?:\n\S.*?)+$')
-__re_spliter1 = re.compile('\n(?=\S)')
+__re_params = re.compile(r'(?:\n\S.*?)+$')
+__re_spliter1 = re.compile(r'\n(?=\S)')
 __re_spliter2 = re.compile('[\n:]')
 
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -204,28 +204,28 @@ def alter_interface_docs_for_api(docs):
     docs = dedent_docstring(docs)
     # clean cmdline sections
     docs = re.sub(
-        '\|\| CMDLINE \>\>.*?\<\< CMDLINE \|\|',
+        r'\|\| CMDLINE \>\>.*?\<\< CMDLINE \|\|',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        '\[CMD:\s[^\[\]]*\sCMD\]',
+        r'\[CMD:\s[^\[\]]*\sCMD\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\[PY:\s([^\[\]]*)\sPY\]',
+        r'\[PY:\s([^\[\]]*)\sPY\]',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| PYTHON \>\>(.*?)\<\< PYTHON \|\|',
+        r'\|\| PYTHON \>\>(.*?)\<\< PYTHON \|\|',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
+        r'\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -241,23 +241,23 @@ def alter_interface_docs_for_cmdline(docs):
     docs = dedent_docstring(docs)
     # clean cmdline sections
     docs = re.sub(
-        '\|\| PYTHON \>\>.*?\<\< PYTHON \|\|',
+        r'\|\| PYTHON \>\>.*?\<\< PYTHON \|\|',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        '\[PY:\s[^\[\]]*\sPY\]',
+        r'\[PY:\s[^\[\]]*\sPY\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\[CMD:\s([^\[\]]*)\sCMD\]',
+        r'\[CMD:\s([^\[\]]*)\sCMD\]',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| CMDLINE \>\>(.*?)\<\< CMDLINE \|\|',
+        r'\|\| CMDLINE \>\>(.*?)\<\< CMDLINE \|\|',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -271,19 +271,19 @@ def alter_interface_docs_for_cmdline(docs):
     # give option at all, but specifying `None` explicitly is practically
     # impossible
     docs = re.sub(
-        ',\sor\svalue\smust\sbe\s`None`',
+        r',\sor\svalue\smust\sbe\s`None`',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     # capitalize variables and remove backticks to uniformize with
     # argparse output
     docs = re.sub(
-        '`\S*`',
+        r'`\S*`',
         lambda match: match.group(0).strip('`').upper(),
         docs)
     # clean up sphinx API refs
     docs = re.sub(
-        '\~datalad\.api\.\S*',
+        r'\~datalad\.api\.\S*',
         lambda match: "`{0}`".format(match.group(0)[13:]),
         docs)
     # Remove RST paragraph markup
@@ -293,7 +293,7 @@ def alter_interface_docs_for_cmdline(docs):
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
+        r'\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)

--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -23,7 +23,7 @@ from datalad.metadata.extractors.base import BaseMetadataExtractor
 from datalad.utils import assure_unicode
 
 
-xmp_field_re = re.compile('^([^\[\]]+)(\[\d+\]|)(/?.*|)')
+xmp_field_re = re.compile(r'^([^\[\]]+)(\[\d+\]|)(/?.*|)')
 
 
 class MetadataExtractor(BaseMetadataExtractor):

--- a/datalad/plugin/export_to_figshare.py
+++ b/datalad/plugin/export_to_figshare.py
@@ -55,7 +55,7 @@ class FigshareRESTLaison(object):
 
         r = m(url_, data=data, headers=headers)
         status_code = r.status_code
-        if (success is not "donotcheck") and \
+        if (success != "donotcheck") and \
                 ((success and status_code not in success)
                  or (not success and status_code >= 400)):
             msg = "Got return code %(status_code)s for %(m)s(%(url_)s." \

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1121,7 +1121,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         lines_ = [
             l for l in lines
             if not re.search(
-                '\((merging .* into git-annex|recording state ).*\.\.\.\)', l
+                r'\((merging .* into git-annex|recording state ).*\.\.\.\)', l
             )
         ]
         assert(len(lines_) <= 1)

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -112,15 +112,15 @@ patoolib.util.run = _patool_run
 # patool
 
 DECOMPRESSORS = {
-    '\.(tar\.bz|tbz)$': 'tar -xjvf %(file)s -C %(dir)s',
-    '\.(tar\.xz)$': 'tar -xJvf %(file)s -C %(dir)s',
-    '\.(tar\.gz|tgz)$': 'tar -xzvf %(file)s -C %(dir)s',
-    '\.(zip)$': 'unzip %(file)s -d %(dir)s',
+    r'\.(tar\.bz|tbz)$': 'tar -xjvf %(file)s -C %(dir)s',
+    r'\.(tar\.xz)$': 'tar -xJvf %(file)s -C %(dir)s',
+    r'\.(tar\.gz|tgz)$': 'tar -xzvf %(file)s -C %(dir)s',
+    r'\.(zip)$': 'unzip %(file)s -d %(dir)s',
 }
 
 
 def unixify_path(path):
-    """On windows convert paths from drive:\d\file to /drive/d/file
+    r"""On windows convert paths from drive:\d\file to /drive/d/file
 
     This overcomes problems with various cmdline tools we are to use,
     such as tar etc

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -17,7 +17,7 @@ from six.moves import map as map
 def _strip_typerepr(s):
     """Strip away <class '...'> and <type '...'> decorations for docstrings
     """
-    return re.sub("<(class|type) '(\S+)'>", r'\2', s)
+    return re.sub(r"<(class|type) '(\S+)'>", r'\2', s)
 
 
 def _type_str(t):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -626,7 +626,7 @@ class URL(RI):
         # Forcing '' instead of None since those properties (.hostname), .password,
         # .username return None if not available and we decided to uniformize
         if is_ipv6:
-            rem = re.match('\[(?P<hostname>.*)\]:(?P<port>\d+)', hostname_port)
+            rem = re.match(r'\[(?P<hostname>.*)\]:(?P<port>\d+)', hostname_port)
             if rem:
                 hostname, port = rem.groups()
                 port = int(port)

--- a/datalad/support/param.py
+++ b/datalad/support/param.py
@@ -17,7 +17,7 @@ from inspect import getargspec
 
 from .constraints import expand_constraint_spec
 
-_whitespace_re = re.compile('\n\s+|^\s+')
+_whitespace_re = re.compile(r'\n\s+|^\s+')
 
 
 class Parameter(object):

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -43,12 +43,12 @@ def get_replacement_dict(rules):
 
 
 def apply_replacement_rules(rules, s):
-    """Apply replacement rules specified as a single string
+    r"""Apply replacement rules specified as a single string
 
     Examples
     --------
 
-    >>> apply_replacement_rules(r'/my_(.*)\.dat/your_\\1.dat.gz', 'd/my_pony.dat')
+    >>> apply_replacement_rules(r'/my_(.*)\.dat/your_\1.dat.gz', 'd/my_pony.dat')
     'd/your_pony.dat.gz'
 
     Parameters

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -252,8 +252,8 @@ def sorted_files(dout):
                        for r, d, files in os.walk(dout)
                        if not '.git' in r], []))
 
-_VCS_REGEX = '%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (dirsep, dirsep)
-_DATALAD_REGEX = '%s\.(?:datalad)(?:%s|$)' % (dirsep, dirsep)
+_VCS_REGEX = r'%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (dirsep, dirsep)
+_DATALAD_REGEX = r'%s\.(?:datalad)(?:%s|$)' % (dirsep, dirsep)
 
 
 def find_files(regex, topdir=curdir, exclude=None, exclude_vcs=True, exclude_datalad=False, dirs=False):
@@ -488,7 +488,7 @@ def file_basename(name, return_ext=False):
     not a digit, so we could get rid of .tar.gz etc
     """
     bname = basename(name)
-    fbname = re.sub('(\.[a-zA-Z_]\S{1,4}){0,2}$', '', bname)
+    fbname = re.sub(r'(\.[a-zA-Z_]\S{1,4}){0,2}$', '', bname)
     if return_ext:
         return fbname, bname[len(fbname) + 1:]
     else:
@@ -1216,7 +1216,7 @@ def swallow_logs(new_level=None, file_=None, name='datalad'):
             from datalad.tests.utils import assert_in
 
             if regex:
-                match = '\[%s\] ' % level if level else "\[\S+\] "
+                match = r'\[%s\] ' % level if level else r"\[\S+\] "
             else:
                 match = '[%s] ' % level if level else ''
 

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -30,7 +30,7 @@ if lexists(opj(projdir, '.git')):
         # Note: Popen does not support `with` way correctly in 2.7
         #
         git = Popen(
-            ['git', 'describe', '--abbrev=4', '--dirty', '--match', '[0-9]*\.*'],
+            ['git', 'describe', '--abbrev=4', '--dirty', '--match', r'[0-9]*\.*'],
             stdout=PIPE, stderr=PIPE,
             cwd=projdir
         )


### PR DESCRIPTION
The Python 3.8 Travis run from gh-3406 spit out a bunch of new SyntaxWarnings.  This PR addresses those.  Hopefully it catches all of them, but I'm making these changes without running 3.8 locally, so I'll likely need to adjust after seeing what Travis says.  (The tip commit adds a temporary 3.8 run to Travis.)

Closes #3418.

