### PR TITLE
New "standard" path resolution logic

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -222,7 +222,7 @@ def test_symlinked_relpath(path):
     with chpwd(op.join(dspath, 'd')):
         save(dataset=ds.path,
              message="committing",
-             path=op.join(op.curdir, "mike2"))
+             path="mike2")
 
         later = op.join(op.pardir, "later")
         ds.repo.add(later, git=True)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -216,14 +216,17 @@ def test_symlinked_relpath(path):
         ds.repo.add("mike1", git=True)
         ds.save(message="committing", path="./mike1")
 
-    # Let's also do in subdirectory
+    # Let's also do in subdirectory as CWD, check that relative path
+    # given to a plain command (not dataset method) are treated as
+    # relative to CWD
     with chpwd(op.join(dspath, 'd')):
-        ds.save(
-            message="committing", path=op.join(op.curdir, "mike2"))
+        save(dataset=ds.path,
+             message="committing",
+             path=op.join(op.curdir, "mike2"))
 
         later = op.join(op.pardir, "later")
         ds.repo.add(later, git=True)
-        ds.save(message="committing", path=later)
+        save(dataset=ds.path, message="committing", path=later)
 
     assert_repo_status(dspath)
 
@@ -629,7 +632,10 @@ def test_path_arg_call(path):
             ds.pathobj / 'abs.txt',
             ds.pathobj / 'rel.txt'):
         testfile.write_text(u'123')
-        save(dataset=ds.path, path=[testfile.name], to_git=True)
+        # we used to resolve relative paths against a dataset just given by
+        # a path, but we no longer do that
+        #save(dataset=ds.path, path=[testfile.name], to_git=True)
+        save(dataset=ds, path=[testfile.name], to_git=True)
 
 
 @with_tree(tree={

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -542,7 +542,13 @@ class EnsureDataset(Constraint):
         if isinstance(value, Dataset):
             return value
         elif isinstance(value, string_types):
-            return Dataset(path=value)
+            # we cannot convert to a Dataset class right here
+            # - duplicates require_dataset() later on
+            # - we need to be able to distinguish between a bound
+            #   dataset method call and a standalone call for
+            #   relative path argument disambiguation
+            #return Dataset(path=value)
+            return value
         else:
             raise ValueError("Can't create Dataset from %s." % type(value))
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -537,6 +537,10 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
 # be imported from constraints.py, which needs to be imported from dataset.py
 # for another constraint
 class EnsureDataset(Constraint):
+    """Despite its name, this constraint does not actually ensure that the
+    argument is a valid dataset, because for procedural reasons this would
+    typically duplicate subsequent checks and processing. However, it can
+    be used to achieve uniform documentation of `dataset` arguments."""
 
     def __call__(self, value):
         if isinstance(value, Dataset):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -653,7 +653,6 @@ def rev_resolve_path(path, ds=None):
             # are done next
             pass
         # we have a given datasets instance
-        # stringify in case a pathobj came in
         elif not Path(p).is_absolute():
             # we have a dataset and no abspath nor an explicit relative path ->
             # resolve it against the dataset

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -55,11 +55,10 @@ def test_EnsureDataset():
     assert_raises(ValueError, c, (1, 2, 3))
     assert_raises(ValueError, c, {"what": "ever"})
 
-    # returns Dataset, when string or Dataset passed
-    res = c(opj("some", "path"))
-    ok_(isinstance(res, Dataset))
-    ok_(isinstance(c(res), Dataset))
-    ok_(c(res) is res)
+    # let's a Dataset instance pass, but leaves a path untouched
+    test_path = opj("some", "path")
+    ok_(isinstance(c(test_path), type(test_path)))
+    ok_(isinstance(Dataset(test_path), Dataset))
 
     # Note: Ensuring that string is valid path is not
     # part of the constraint itself, so not explicitly tested here.

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -26,6 +26,7 @@ from datalad.utils import chpwd, getpwd, rmtree
 from datalad.utils import _path_
 from datalad.utils import get_dataset_root
 from datalad.utils import on_windows
+from datalad.utils import Path
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 
@@ -485,19 +486,28 @@ def test_rev_resolve_path(path):
             eq_(rev_resolve_path('.'), ut.Path(d))
             eq_(text_type(rev_resolve_path('.')), d)
 
-            eq_(text_type(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
-                op.join(d, 'bu'))
+            # there is no concept of an "explicit" relative path anymore
+            # relative is relative, regardless of the specific syntax
+            eq_(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global),
+                ds_global.pathobj / 'bu')
+            # there is no full normpath-ing or other funky resolution of
+            # parent directory back-reference
             eq_(text_type(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
-                op.join(ds_global.path, 'bu'))
+                op.join(ds_global.path, os.pardir, 'bu'))
 
-        # resolve against a dataset
-        eq_(text_type(rev_resolve_path('bu', ds=ds_local)), op.join(d, 'bu'))
-        eq_(text_type(rev_resolve_path('bu', ds=ds_global)), op.join(path, 'bu'))
-        # but paths outside the dataset are left untouched
-        eq_(text_type(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global)),
-            op.join(getpwd(), 'bu'))
+        # resolve against a dataset given as a path/str
+        # (cmdline input scenario)
+        eq_(rev_resolve_path('bu', ds=ds_local.path), Path.cwd() / 'bu')
+        eq_(rev_resolve_path('bu', ds=ds_global.path), Path.cwd() / 'bu')
+        # resolve against a dataset given as a dataset instance
+        # (object method scenario)
+        eq_(rev_resolve_path('bu', ds=ds_local), ds_local.pathobj / 'bu')
+        eq_(rev_resolve_path('bu', ds=ds_global), ds_global.pathobj / 'bu')
+        # not being inside a dataset doesn't change the resolution result
+        eq_(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global),
+            ds_global.pathobj / 'bu')
         eq_(text_type(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
-            op.normpath(op.join(getpwd(), os.pardir, 'bu')))
+            op.join(ds_global.path, os.pardir, 'bu'))
 
 
 # little brother of the test above, but actually (must) run

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -473,6 +473,11 @@ def test_rev_resolve_path(path):
         ds_local = Dataset(d)
         # no symlink resolution
         eq_(text_type(rev_resolve_path(d)), d)
+        # list comes out as a list
+        eq_(rev_resolve_path([d]), [Path(d)])
+        # multiple OK
+        eq_(rev_resolve_path([d, d]), [Path(d), Path(d)])
+
         with chpwd(d):
             # be aware: knows about cwd, but this CWD has symlinks resolved
             eq_(text_type(rev_resolve_path(d).cwd()), opath)

--- a/datalad/interface/run.py
+++ b/datalad/interface/run.py
@@ -394,7 +394,7 @@ def _save_outputs(ds, to_save, msg):
     """Helper to save results after command execution is completed"""
     return Save.__call__(
         to_save,
-        dataset=ds.path,
+        dataset=ds,
         recursive=True,
         message=msg,
         return_type='generator')
@@ -437,7 +437,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         responsible for ensuring that the state of the working tree is
         appropriate for recording the command's results.
     saver : callable, optional
-        Must take a dataset instance, a list of paths to save, and a
+        Must take the value given as `dataset`, a list of paths to save, and a
         message string as arguments and must record any changes done
         to any content matching an entry in the path list. Must yield
         result dictionaries as a generator.
@@ -608,5 +608,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                      msg_path)
         raise exc
     elif outputs_to_save:
-        for r in saver(ds, outputs_to_save, msg):
+        # pass `dataset` not the resolved `ds` instance in order to
+        # keep any relative-path semantics intact for saving
+        for r in saver(dataset, outputs_to_save, msg):
             yield r


### PR DESCRIPTION
Talked about it multiple times: here it is.

Any absolute `path` given to a command is used as such. Any relative `path`is interpreted as being
relative to the CWD, **unless** an also provided `dataset` argument is a `Dataset` instance (not just a 
path to or inside a dataset).

I briefly looked into implementing this for all commands, but that seems to be a bottomless pit -- to expensive for me and for now. Instead, I implemented it for `rev_resolve_path()` that is used by all commands that already comply with the structure proposed in #3192.

- [x] implement logic change
- [x] adjust tests
- [x] add ability to process multiple paths without re-localization a dataset each and every time (immediately benefits https://github.com/datalad/datalad/pull/3429)
- [x] turn `EnsureDataset` into a NOOP with documentation purpose only. This constraint class auto instantiates Dataset objects based on command line arguments (paths), essentially disabling the ability to detect and act on the key distinction of the decision logic above.
- [x] @kyleam please double-check https://github.com/datalad/datalad/pull/3435/commits/971620ec8ddae9fe31f193e83a60a88debe40ad3
   km: Looks fine (and outputs come in as absolute paths, so string/instance for dataset would be the same anyway).
    