### PR TITLE
Use "distro" for .distribution for python >= 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,15 @@ env:
 matrix:
   include:
   # Additional custom ones
+  - python: 3.8-dev
+    dist: xenial
+    # Single run for Python 3.8
+    env:
+    # Run all tests in a single whoop here
+    # We cannot have empty -A selector, so the one which always will be fulfilled
+    - NOSE_SELECTION=
+    - NOSE_SELECTION_OP=not
+  # Additional custom ones
   - python: 3.7-dev
     # Single run for Python 3.7
     env:

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -108,12 +108,33 @@ def _describe_annex():
 def _describe_system():
     import platform as pl
     from datalad import get_encoding_info
+
+    if hasattr(pl, 'dist'):
+        dist = pl.dist()
+    else:
+        # Python 3.8 removed .dist but recommended "distro" is slow, so we
+        # try it only if needed
+        try:
+            import distro
+            dist = distro.linux_distribution(full_distribution_name=False)
+        except ImportError:
+            lgr.info(
+                "Please install 'distro' package to obtain distribution information"
+            )
+            dist = tuple()
+        except Exception as exc:
+            lgr.warning(
+                "No distribution information will be provided since 'distro' "
+                "fails to import/run: %s", exc_str(exc)
+            )
+            dist = tuple()
+
     return {
         'type': os.name,
         'name': pl.system(),
         'release': pl.release(),
         'version': pl.version(),
-        'distribution': ' '.join([_t2s(pl.dist()),
+        'distribution': ' '.join([_t2s(dist),
                                   _t2s(pl.mac_ver()),
                                   _t2s(pl.win32_ver())]).rstrip(),
         'max_path_length': get_max_path_length(getpwd()),

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ requires = {
         'appdirs',
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
+        'distro; python_version >= "3.8"',
         'GitPython>=2.1.8',
         'iso8601',
         'humanize',


### PR DESCRIPTION
Closes #3431 

Decided to depend on distro for 3.8 and beyond for now so we have a complete (albeit slow) fix

TODOs
- [ ] remove TEMP enabling tests on travis for 3.8-dev