### PR TITLE
ENH: wtf -S to specify which sections to query/display (by default -- all)

### DIFF
--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -21,6 +21,8 @@ from datalad.api import wtf
 from datalad.api import no_annex
 from datalad.plugin.wtf import _HIDDEN
 
+from ..wtf import SECTION_CALLABLES
+
 from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
@@ -92,6 +94,26 @@ def test_wtf(path):
         wtf(dataset=ds.path, sensitive='all')
         assert_not_in(_HIDDEN, cmo.out)  # all is shown
         assert_in('user.name: ', cmo.out)
+
+    # Sections selection
+    #
+    # If we ask for no sections and there is no dataset
+    with chpwd(path):
+        with swallow_outputs() as cmo:
+            wtf(sections=[])
+            assert_not_in('## dataset', cmo.out)
+            for s in SECTION_CALLABLES:
+                assert_not_in('## %s' % s.lower(), cmo.out.lower())
+
+    # ask for a selected set
+    secs = ['configuration', 'git-annex']
+    with chpwd(path):
+        with swallow_outputs() as cmo:
+            wtf(sections=secs)
+            for s in SECTION_CALLABLES:
+                (assert_in if s in secs else assert_not_in)(
+                    '## %s' % s.lower(), cmo.out.lower()
+                )
 
     skip_if_no_module('pyperclip')
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -117,6 +117,13 @@ def test_wtf(path):
             # order should match our desired one, not alphabetical
             assert cmo.out.index('## git-annex') < cmo.out.index('## configuration')
 
+    # not achievable from cmdline is to pass an empty list of sections.
+    with chpwd(path):
+        with swallow_outputs() as cmo:
+            wtf(sections=[])
+            eq_(cmo.out.rstrip(), '# WTF')
+
+    # should result only in '# WTF'
     skip_if_no_module('pyperclip')
 
     # verify that it works correctly in the env/platform

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -106,7 +106,7 @@ def test_wtf(path):
                 assert_not_in('## %s' % s.lower(), cmo.out.lower())
 
     # ask for a selected set
-    secs = ['configuration', 'git-annex']
+    secs = ['git-annex', 'configuration']
     with chpwd(path):
         with swallow_outputs() as cmo:
             wtf(sections=secs)
@@ -114,6 +114,8 @@ def test_wtf(path):
                 (assert_in if s in secs else assert_not_in)(
                     '## %s' % s.lower(), cmo.out.lower()
                 )
+            # order should match our desired one, not alphabetical
+            assert cmo.out.index('## git-annex') < cmo.out.index('## configuration')
 
     skip_if_no_module('pyperclip')
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -20,6 +20,7 @@ from datalad.dochelpers import exc_str
 from datalad.api import wtf
 from datalad.api import no_annex
 from datalad.plugin.wtf import _HIDDEN
+from datalad.version import __version__
 
 from ..wtf import SECTION_CALLABLES
 
@@ -31,6 +32,7 @@ from datalad.tests.utils import create_tree
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import ok_startswith
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_if_no_module
@@ -122,6 +124,12 @@ def test_wtf(path):
         with swallow_outputs() as cmo:
             wtf(sections=[])
             eq_(cmo.out.rstrip(), '# WTF')
+
+    # and we could decorate it nicely for embedding e.g. into github issues
+    with swallow_outputs() as cmo:
+        wtf(sections=['dependencies'], decor='html_details')
+        ok_startswith(cmo.out, '<details><summary>DataLad %s WTF' % __version__)
+        assert_in('## dependencies', cmo.out)
 
     # should result only in '# WTF'
     skip_if_no_module('pyperclip')

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -368,7 +368,7 @@ class WTF(Interface):
                 'pyperclip', msg="It is needed to be able to use clipboard")
             import pyperclip
             report = _render_report(res)
-            pyperclip.copy(report)
+            pyperclip.copy(assure_bytes(report))
             ui.message("WTF information of length %s copied to clipboard"
                        % len(report))
         yield res

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -300,7 +300,7 @@ class WTF(Interface):
             metavar="SECTION",
             constraints=EnsureChoice(*sorted(SECTION_CALLABLES)) | EnsureNone(),
             doc="""section to include.  If not set, all sections.
-            [CMD: This option can be given multiple times. CMD]."""),
+            [CMD: This option can be given multiple times. CMD]"""),
         decor=Parameter(
             args=("-D", "--decor"),
             constraints=EnsureChoice('html_details') | EnsureNone(),

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -283,11 +283,13 @@ class WTF(Interface):
             information (credentials, names, etc.).  If 'some', the fields
             which are known to be sensitive will still be masked out"""),
         sections=Parameter(
-            args=("-S", "--sections"),
+            args=("-S", "--section"),
+            action='append',
+            dest='sections',
             metavar="SECTION",
-            nargs="*",
             constraints=EnsureChoice(*sorted(SECTION_CALLABLES)) | EnsureNone(),
-            doc="""sections to include.  If not set, all sections."""),
+            doc="""section to include.  If not set, all sections. This option
+            can be given more than once to include multiple sections."""),
         clipboard=Parameter(
             args=("-c", "--clipboard",),
             action="store_true",


### PR DESCRIPTION
`-S dependencies`   is probably one of the most useful, but unfortunately it is not including concise versioning of datalad and datalad extensions, which are all heavy sections...
