### PR TITLE
BF+RF: unlock: Rewrite using status()

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -285,7 +285,7 @@ def _unlock_or_remove(dset, paths):
     if existing:
         for res in dset.unlock(existing, on_failure="ignore"):
             if res["status"] == "impossible":
-                if "no content" in res["message"]:
+                if "cannot unlock" in res["message"]:
                     for rem_res in dset.remove(res["path"],
                                                check=False, save=False):
                         yield rem_res

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -217,16 +217,17 @@ def test_unlock_cant_unlock(path):
         # See managed branch note in previous test_unlock_directory.
         modified=[] if ds.repo.is_managed_branch() else ["already_unlocked"],
         untracked=["untracked"])
-    files = ["regular_git", "untracked"]
+    expected = {"regular_git": "notneeded",
+                "untracked": "impossible"}
     if not ds.repo.supports_unlocked_pointers:
         # Don't add "already_unlocked" in v6+ because unlocked files are still
         # reported as having content and still passed to unlock. If we can
         # reliably distinguish v6+ unlocked files in status's output, we should
         # consider reporting a "notneeded" result.
-        files.append("already_unlocked")
-    for f in files:
+        expected["already_unlocked"] = "notneeded"
+    for f, status in expected.items():
         assert_in_results(
             ds.unlock(path=f, on_failure="ignore"),
             action="unlock",
-            status="impossible",
+            status=status,
             path=text_type(ds.pathobj / f))

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -219,10 +219,10 @@ def test_unlock_cant_unlock(path):
         untracked=["untracked"])
     files = ["regular_git", "untracked"]
     if not ds.repo.supports_unlocked_pointers:
-        # Don't add "already_unlocked" in v6+ because unlocked are still
+        # Don't add "already_unlocked" in v6+ because unlocked files are still
         # reported as having content and still passed to unlock. If we can
-        # reliably distinguish unlocked files status's output, we should
-        # consider report a "notneeded" result.
+        # reliably distinguish v6+ unlocked files in status's output, we should
+        # consider reporting a "notneeded" result.
         files.append("already_unlocked")
     for f in files:
         assert_in_results(

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -103,7 +103,7 @@ class Unlock(Interface):
             return
 
         # Collect information on the paths to unlock.
-        to_unlock = defaultdict(list)  # ds => paths
+        to_unlock = defaultdict(list)  # ds => paths (relative to ds)
         for res in Status()(
                 # ATTN: it is vital to pass the `dataset` argument as it,
                 # and not a dataset instance in order to maintain the path
@@ -121,7 +121,8 @@ class Unlock(Interface):
                 continue
             has_content = res.get("has_content")
             if has_content:
-                to_unlock[res["parentds"]].append(res["path"])
+                parentds = res["parentds"]
+                to_unlock[parentds].append(op.relpath(res["path"], parentds))
             elif paths_nondir and Path(res["path"]) in paths_nondir:
                 if has_content is False:
                     msg = "no content present"

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -128,8 +128,8 @@ class Unlock(Interface):
                 elif res["state"] == "untracked":
                     msg = "untracked"
                 else:
-                    # TODO: Anyway to distinguish between a regular git file
-                    # and an unlocked annex file?
+                    # This is either a regular git file or an unlocked annex
+                    # file.
                     msg = "non-annex file"
                 yield get_status_dict(
                     status="impossible",

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -126,14 +126,17 @@ class Unlock(Interface):
             elif paths_nondir and Path(res["path"]) in paths_nondir:
                 if has_content is False:
                     msg = "no content present"
+                    status = "impossible"
                 elif res["state"] == "untracked":
                     msg = "untracked"
+                    status = "impossible"
                 else:
                     # This is either a regular git file or an unlocked annex
                     # file.
                     msg = "non-annex file"
+                    status = "notneeded"
                 yield get_status_dict(
-                    status="impossible",
+                    status=status,
                     path=res["path"],
                     type="file",
                     message="{}; cannot unlock".format(msg),

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 from collections import defaultdict
 import logging
 
-from os.path import join as opj
+import os.path as op
 
 from six import text_type
 
@@ -143,7 +143,7 @@ class Unlock(Interface):
             ds = Dataset(ds_path)
             for r in ds.repo.unlock(files):
                 yield get_status_dict(
-                    path=opj(ds.path, r),
+                    path=op.join(ds.path, r),
                     status='ok',
                     type='file',
                     **res_kwargs)

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -12,25 +12,29 @@
 
 __docformat__ = 'restructuredtext'
 
+from collections import defaultdict
 import logging
 
 from os.path import join as opj
 
+from six import text_type
+
+from datalad.core.local.status import Status
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
-from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
-from datalad.interface.annotate_paths import AnnotatePaths
-from datalad.interface.annotate_paths import annotated2content_by_ds
+from datalad.distribution.dataset import require_dataset
+from datalad.distribution.dataset import rev_resolve_path
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
+from datalad.utils import assure_list
+from datalad.utils import Path
 
 from .base import Interface
 
@@ -54,8 +58,7 @@ class Unlock(Interface):
             args=("-d", "--dataset"),
             doc=""""specify the dataset to unlock files in. If
             no dataset is given, an attempt is made to identify the dataset
-            based on the current working directory. If the latter fails, an
-            attempt is made to identify the dataset based on `path` """,
+            based on the current working directory.""",
             constraints=EnsureDataset() | EnsureNone()),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
@@ -69,97 +72,76 @@ class Unlock(Interface):
             dataset=None,
             recursive=False,
             recursion_limit=None):
+        refds = require_dataset(dataset, check_installed=True,
+                                purpose="unlocking")
 
-        if path is None and dataset is None:
-            raise InsufficientArgumentsError(
-                "insufficient arguments for unlocking: needs at least "
-                "a dataset or a path to unlock.")
+        # Before passing the results to status()
+        #   * record explicitly specified non-directory paths so that we can
+        #     decide whether to yield a result for reported paths
+        #   * filter out and yield results for paths that don't exist
+        paths_nondir = set()
+        paths_lexist = None
+        if path:
+            path = rev_resolve_path(assure_list(path), ds=dataset)
+            paths_lexist = []
+            for p in path:
+                if p.exists() or p.is_symlink():
+                    paths_lexist.append(p)
+                if not p.is_dir():
+                    paths_nondir.add(p)
 
-        refds_path = Interface.get_refds_path(dataset)
-        res_kwargs = dict(action='unlock', logger=lgr, refds=refds_path)
+        res_kwargs = dict(action='unlock', logger=lgr, refds=refds.path)
+        if path:
+            for p in set(path).difference(set(paths_lexist)):
+                yield get_status_dict(
+                    status="impossible",
+                    path=text_type(p),
+                    type="file",
+                    message="path does not exist",
+                    **res_kwargs)
+        if not (paths_lexist or paths_lexist is None):
+            return
 
-        to_process = []
-        for ap in AnnotatePaths.__call__(
-                dataset=refds_path,
-                path=path,
+        # Collect information on the paths to unlock.
+        to_unlock = defaultdict(list)  # ds => paths
+        for res in Status()(
+                # ATTN: it is vital to pass the `dataset` argument as it,
+                # and not a dataset instance in order to maintain the path
+                # semantics between here and the status() call
+                dataset=dataset,
+                path=paths_lexist,
+                untracked="normal" if paths_nondir else "no",
+                annex="availability",
                 recursive=recursive,
                 recursion_limit=recursion_limit,
-                action='unlock',
-                unavailable_path_status='impossible',
-                unavailable_path_msg="path does not exist",
-                nondataset_path_status='impossible',
-                modified=None,
-                return_type='generator',
-                on_failure='ignore'):
-            if ap.get('status', None):
-                # this is done
-                yield ap
+                result_renderer='disabled',
+                on_failure="ignore"):
+            if res["action"] != "status" or res["status"] != "ok":
+                yield res
                 continue
-            if ap.get('type', 'dataset') == 'dataset':
-                # this is a dataset
-                ap['process_content'] = True
-            to_process.append(ap)
-
-        content_by_ds, ds_props, completed, nondataset_paths = \
-            annotated2content_by_ds(
-                to_process,
-                refds_path=refds_path)
-        assert(not completed)
-
-        for ds_path in sorted(content_by_ds.keys()):
-            ds = Dataset(ds_path)
-            content = content_by_ds[ds_path]
-
-            # no annex, no unlock:
-            if not isinstance(ds.repo, AnnexRepo):
-                for ap in content:
-                    ap['status'] = 'notneeded'
-                    ap['message'] = "not annex'ed, nothing to unlock"
-                    ap.update(res_kwargs)
-                    yield ap
-                continue
-
-            # only files in annex with their content present:
-            files = [ap['path'] for ap in content]
-            to_unlock = []
-            for ap, under_annex, has_content in \
-                zip(content,
-                    ds.repo.is_under_annex(files),
-                    ds.repo.file_has_content(files)):
-
-                # TODO: what about directories? Make sure, there is no
-                # situation like no file beneath with content or everything in
-                # git, that leads to a CommandError
-                # For now pass to annex:
-                from os.path import isdir
-                if isdir(ap['path']):
-                    to_unlock.append(ap)
-                    continue
-
-                # Note, that `file_has_content` is (planned to report) True on
-                # files in git. Therefore order matters: First check for annex!
-                if under_annex:
-                    if has_content:
-                        to_unlock.append(ap)
-                    # no content, no unlock:
-                    else:
-                        ap['status'] = 'impossible'
-                        ap['message'] = "no content present, can't unlock"
-                        ap.update(res_kwargs)
-                        yield ap
-                # file in git, no unlock:
+            has_content = res.get("has_content")
+            if has_content:
+                to_unlock[res["parentds"]].append(res["path"])
+            elif paths_nondir and Path(res["path"]) in paths_nondir:
+                if has_content is False:
+                    msg = "no content present"
+                elif res["state"] == "untracked":
+                    msg = "untracked"
                 else:
-                    ap['status'] = 'notneeded'
-                    ap['message'] = "not controlled by annex, nothing to unlock"
-                    ap.update(res_kwargs)
-                    yield ap
+                    # TODO: Anyway to distinguish between a regular git file
+                    # and an unlocked annex file?
+                    msg = "non-annex file"
+                yield get_status_dict(
+                    status="impossible",
+                    path=res["path"],
+                    type="file",
+                    message="{}; cannot unlock".format(msg),
+                    **res_kwargs)
 
-            # don't call annex-unlock with no path, if this is this case because
-            # nothing survived the filtering above
-            if content and not to_unlock:
-                continue
-
-            for r in ds.repo.unlock([ap['path'] for ap in to_unlock]):
+        # Do the actual unlocking.
+        for ds_path, files in to_unlock.items():
+            ds = Dataset(ds_path)
+            for r in ds.repo.unlock(files):
                 yield get_status_dict(
                     path=opj(ds.path, r),
                     status='ok',

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -28,6 +28,7 @@ from os.path import sep
 from os.path import split as psplit
 from itertools import chain
 from six import PY2
+from six import text_type
 
 import json
 
@@ -494,12 +495,11 @@ def eval_results(func):
 
 def default_result_renderer(res):
     if res.get('status', None) != 'notneeded':
+        path = text_type(res['path'])
         ui.message('{action}({status}): {path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
                 status=ac.color_status(res['status']),
-                path=relpath(res['path'],
-                             res['refds']) if res.get('refds', None) else res[
-                    'path'],
+                path=relpath(path, res['refds']) if res.get('refds') else path,
                 type=' ({})'.format(
                         ac.color_word(res['type'], ac.MAGENTA)
                 ) if 'type' in res else '',

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1378,23 +1378,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             return entries[0]
 
     @normalize_paths
-    def lock(self, files, options=None):
-        """undo unlock
-
-        Use  this to undo an unlock command if you don't want to modify the
-        files any longer, or have made modifications you want to discard.
-
-        Parameters
-        ----------
-        files: list of str
-        options: list of str
-        """
-
-        options = options[:] if options else []
-        self._run_annex_command('lock', annex_options=options, files=files)
-        # note: there seems to be no output by annex if success.
-
-    @normalize_paths
     def unlock(self, files, options=None):
         """unlock files for modification
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1378,26 +1378,22 @@ class AnnexRepo(GitRepo, RepoInterface):
             return entries[0]
 
     @normalize_paths
-    def unlock(self, files, options=None):
+    def unlock(self, files):
         """unlock files for modification
 
         Parameters
         ----------
         files: list of str
-        options: list of str
 
         Returns
         -------
         list of str
           successfully unlocked files
         """
-
-        options = options[:] if options else []
-
         # TODO: catch and parse output if failed (missing content ...)
         std_out, std_err = \
             self._run_annex_command(
-                'unlock', annex_options=options, files=files
+                'unlock', files=files
             )
 
         return [line.split()[1]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1381,6 +1381,10 @@ class AnnexRepo(GitRepo, RepoInterface):
     def unlock(self, files):
         """unlock files for modification
 
+        Note: This method is silent about errors in unlocking a file (e.g, the
+        file has not content). Use the higher-level interface.unlock to get
+        more informative reporting.
+
         Parameters
         ----------
         files: list of str
@@ -1390,15 +1394,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         list of str
           successfully unlocked files
         """
-        # TODO: catch and parse output if failed (missing content ...)
-        std_out, std_err = \
-            self._run_annex_command(
-                'unlock', files=files
-            )
-
-        return [line.split()[1]
-                for line in std_out.splitlines()
-                if line.split()[0] == 'unlock' and line.split()[-1] == 'ok']
+        if not files:
+            return
+        return [j["file"] for j in
+                self._run_annex_command_json("unlock", files=files)
+                if j["success"]]
 
     def adjust(self, options=None):
         """enter an adjusted branch


### PR DESCRIPTION
```
If a file without content is passed to unlock(), it yields a
result (with a status of "impossible") saying that the file doesn't
have content.  But if the files without content weren't explicitly
provided as paths (e.g., no path was given or a directory containing
the files was given as the path), then files without content lead to a
CommandError from the underlying 'git annex unlock' call.  (Or in v6+,
they lead to the pointer being unlocked which is inconsistent with the
error given when a file is explicitly specified in v6+ and also
potentially confusing to callers.)

To fix the "no paths specified, missing content" behavior, rely on the
information provided by status() to restrict the unlock calls to files
with content.  This fix raises the question of how to report files
without content when the path isn't explicitly given.  Because
'datalad unlock' at the dataset or a directory level could potentially
lead to a lot of results, avoid reporting "can't unlock" results when
explicit paths aren't given.  Doing this at the __call__ level rather
than as a result filter means we can do the faster status(...,
untracked=no") query unless explicit, non-directory paths are given.

Aside from the fix above, this tries to match the behavior of the
previous unlock().  The main behavioral change, shown by the test
updates, is that unlock() no longer infers the dataset from a path
when the current working directory is outside a dataset and no dataset
is explicitly given.  This behavioral change is consistent with, for
example, distribution.add vs core.local.save.

This nudges annotate_paths() closer to retirement (gh-3368).
```