### PR TITLE
Use `git status` for dirty and reference `datalad status` in {,re}run's dirty message

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -477,8 +477,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 'run',
                 ds=ds,
                 status='impossible',
-                message=('unsaved modifications present, '
-                         'cannot detect changes by command'))
+                message=(
+                    'clean dataset required to detect changes from command; '
+                    'use `datalad status` to inspect unsaved changes'))
             return
 
     cmd = normalize_command(cmd)

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -191,8 +191,9 @@ class Rerun(Interface):
                 'run',
                 ds=ds,
                 status='impossible',
-                message=('unsaved modifications present, '
-                         'cannot detect changes by command'))
+                message=(
+                    'clean dataset required to detect changes from command; '
+                    'use `datalad status` to inspect unsaved changes'))
             return
 
         if not ds.repo.get_hexsha():

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2286,6 +2286,8 @@ class GitRepo(RepoInterface):
         stdout, _ = self._git_custom_command(
             [],
             ["git", "status", "--porcelain",
+             # Ensure the result isn't influenced by status.showUntrackedFiles.
+             "--untracked-files=normal",
              # Ensure the result isn't influenced by diff.ignoreSubmodules.
              "--ignore-submodules=none"])
         return bool(stdout.strip())

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1739,13 +1739,15 @@ def test_AnnexRepo_dirty(path):
     repo.commit("file2.txt annexed")
     ok_(not repo.dirty)
 
-    # TODO: unlock/modify
+    repo.unlock("file2.txt")
+    # Unlocking the file is seen as a modification when we're not already in an
+    # adjusted branch (for this test, that would be the case if we're on a
+    # crippled filesystem).
+    ok_(repo.dirty ^ repo.is_managed_branch())
+    repo.save()
+    ok_(not repo.dirty)
 
-    # TODO: submodules
 
-
-# TODO: test dirty
-# TODO: GitRep.dirty
 # TODO: test/utils ok_clean_git
 
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -847,6 +847,16 @@ def test_GitRepo_dirty(path):
     # User configuration doesn't affect .dirty's answer.
     repo.config.set("diff.ignoreSubmodules", "all", where="local")
     ok_(repo.dirty)
+    # GitRepo.commit currently can't handle this setting, so remove it for the
+    # save() calls below.
+    repo.config.unset("diff.ignoreSubmodules", where="local")
+    subm.save()
+    repo.save()
+    ok_(not repo.dirty)
+
+    repo.config.set("status.showUntrackedFiles", "no", where="local")
+    create_tree(repo.path, {"untracked_dir": {"a": "a"}})
+    ok_(repo.dirty)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -836,7 +836,17 @@ def test_GitRepo_dirty(path):
     os.mkdir(op.join(path, "empty", "empty-again"))
     ok_(not repo.dirty)
 
-    # TODO: submodules
+    subm = GitRepo(repo.pathobj / "subm", create=True)
+    (subm.pathobj / "subfile").write_text(u"")
+    subm.save()
+    repo.save()
+    ok_(not repo.dirty)
+    (subm.pathobj / "subfile").write_text(u"changed")
+    ok_(repo.dirty)
+
+    # User configuration doesn't affect .dirty's answer.
+    repo.config.set("diff.ignoreSubmodules", "all", where="local")
+    ok_(repo.dirty)
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
This PR implements the proposal in https://github.com/datalad/datalad/issues/3342#issuecomment-495974665.