### PR TITLE
BF: create: Restore saving behavior for --dataset

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -423,10 +423,10 @@ class Create(Interface):
         # the next only makes sense if we saved the created dataset,
         # otherwise we have no committed state to be registered
         # in the parent
-        if isinstance(dataset, Dataset) and dataset.path != tbds.path:
+        if isinstance(refds, Dataset) and refds.path != tbds.path:
             # we created a dataset in another dataset
             # -> make submodule
-            for r in dataset.save(
+            for r in refds.save(
                     path=tbds.path,
             ):
                 yield r

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -209,6 +209,21 @@ def test_create_sub(path):
     assert_in("third", ds.subdatasets(result_xfm='relpaths'))
 
 
+@with_tempfile
+def test_create_sub_gh3463(path):
+    ds = Dataset(path)
+    ds.create()
+
+    # Test non-bound call.
+    with chpwd(ds.path):
+        create("subds0", dataset=".")
+    assert_repo_status(ds.path)
+
+    # Test command-line invocation directly.
+    Runner(cwd=ds.path)(["datalad", "create", "-d.", "subds1"])
+    assert_repo_status(ds.path)
+
+
 # windows failure triggered by
 # File "C:\Miniconda35\envs\test-environment\lib\site-packages\datalad\tests\utils.py", line 421, in newfunc
 #    rmtemp(d)


### PR DESCRIPTION
As of fc25ac55d (BF: Do not duplicate/auto-convert dataset args to
instances, 2019-05-20), EnsureDataset returns a string rather than a
dataset when given a string.  This introduced a regression in creating
and then saving a subdataset to the parent dataset from the command
line (e.g., `datalad create -d. subds`) because downstream code
expects the dataset to be a dataset instance.  Update that code to use
refds, which is the Dataset instance for the dataset argument.

Fixes #3463.