### PR TITLE
BF: save: Honor on_failure

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -196,7 +196,14 @@ class Save(Interface):
                 untracked=untracked_mode,
                 recursive=recursive,
                 recursion_limit=recursion_limit,
+                on_failure='ignore',
                 result_renderer='disabled'):
+            if s['status'] == 'error':
+                # Downstream code can't do anything with these. Let the caller
+                # decide their fate.
+                yield s
+                continue
+
             # fish out status dict for this parent dataset
             ds_status = paths_by_ds.get(s['parentds'], {})
             # reassemble path status info as repo.status() would have made it

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -690,3 +690,18 @@ def test_bf3285(path):
     # subdataset.
     ds.save("foo")
     assert_repo_status(ds.path, untracked=[subds.path])
+
+
+@with_tree({"outside": "",
+            "ds": {"within": ""}})
+def test_on_failure_continue(path):
+    ds = Dataset(op.join(path, "ds")).create(force=True)
+    # save() calls status() in a way that respects on_failure.
+    assert_in_results(
+        ds.save(path=[op.join(path, "outside"),
+                      op.join(path, "ds", "within")],
+                on_failure="ignore"),
+        action="status",
+        status="error")
+    # save() continued despite the failure and saved ds/within.
+    assert_repo_status(ds.path)


### PR DESCRIPTION
save() calls status() with the default on_failure value of "continue",
which means that---regardless of the on_failure value specified for
save()---status() always raises an IncompleteResultsError exception
when a failure occurs and then save() aborts.  Make save() call
status() with on_failure="ignore" so that the *save* caller gets to
decide what to do in the case of a failure.

Note that this results in some double reporting:

    [ERROR  ] path not underneath this dataset [status(...)]
    save(error): ../b [path not underneath this dataset]

But if save() were to just swallow the result so that only the log
message is shown, an on_failure value of "continue" or "stop" would
not raise an IncompleteResultsError exception or exit on the command
line with a non-zero status.