### PR TITLE
save: Update for "no commits" sub-repo fix in Git

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -81,10 +81,10 @@ class Save(Interface):
         % dataset save -d <path_to_dataset> --version-tag bestyet
 
     .. note::
-      For performance reasons, any Git repository without an initial commit
-      located inside a Dataset is ignored, and content underneath it will be
-      saved to the respective superdataset. DataLad datasets always have an
-      initial commit, hence are not affected by this behavior.
+      Before Git v2.22, any Git repository without an initial commit located
+      inside a Dataset is ignored, and content underneath it will be saved to
+      the respective superdataset. DataLad datasets always have an initial
+      commit, hence are not affected by this behavior.
     """
     # note above documents that out behavior is like that of `git add`, but
     # does not explicitly mention the connection to keep it simple.

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -656,19 +656,23 @@ def test_surprise_subds(path):
     somerepo = AnnexRepo(path=op.join(path, 'd1', 'subrepo'), create=True)
     # a proper subdataset
     subds = create(op.join(path, 'd2', 'subds'), force=True)
+
+    # If subrepo is an adjusted branch, it would have a commit, making most of
+    # this test irrelevant because it is about the unborn branch edge case.
+    adjusted = somerepo.is_managed_branch()
+
     # save non-recursive
     ds.save(recursive=False)
     # the content of both subds and subrepo are not added to their
     # respective parent as no --recursive was given
     assert_repo_status(subds.path, untracked=['subfile'])
     assert_repo_status(somerepo.path, untracked=['subfile'])
-    # however, while the subdataset is added (and reported as modified
-    # because it content is still untracked) the subrepo
-    # cannot be added (it has no commit)
-    # worse: its untracked file add been added to the superdataset
-    # XXX the next conditional really says: if the subrepo is not in an
-    # adjusted branch: #datalad/3178 (that would have a commit)
-    if not on_windows:
+
+    if not adjusted:  # adjusted branch: #datalad/3178 (that would have a commit)
+        # however, while the subdataset is added (and reported as modified
+        # because it content is still untracked) the subrepo
+        # cannot be added (it has no commit)
+        # worse: its untracked file add been added to the superdataset
         assert_repo_status(ds.path, modified=['d2/subds'])
         assert_in(ds.repo.pathobj / 'd1' / 'subrepo' / 'subfile',
                   ds.repo.get_content_info())

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -668,7 +668,14 @@ def test_surprise_subds(path):
     assert_repo_status(subds.path, untracked=['subfile'])
     assert_repo_status(somerepo.path, untracked=['subfile'])
 
-    if not adjusted:  # adjusted branch: #datalad/3178 (that would have a commit)
+    if adjusted:
+        # adjusted branch: #datalad/3178 (that would have a commit)
+        modified = [subds.pathobj, somerepo.pathobj]
+        untracked = []
+        assert_repo_status(ds.path, modified=modified, untracked=untracked)
+        assert_not_in(ds.repo.pathobj / 'd1' / 'subrepo' / 'subfile',
+                      ds.repo.get_content_info())
+    else:
         # however, while the subdataset is added (and reported as modified
         # because it content is still untracked) the subrepo
         # cannot be added (it has no commit)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3522,6 +3522,7 @@ class GitRepo(RepoInterface):
                           for f, props in iteritems(status)
                           if props.get('state', None) == 'untracked' and
                           props.get('type', None) == 'directory']
+        to_add_submodules = []
         if untracked_dirs:
             to_add_submodules = [sm for sm, sm_props in iteritems(
                 self.get_content_info(
@@ -3612,7 +3613,8 @@ class GitRepo(RepoInterface):
             # handle it
             text_type(f.relative_to(self.pathobj)): props
             for f, props in iteritems(status)
-            if props.get('state', None) in ('modified', 'untracked')}
+            if (props.get('state', None) in ('modified', 'untracked') and
+                f not in to_add_submodules)}
         if to_add:
             lgr.debug(
                 '%i path(s) to add to %s %s',


### PR DESCRIPTION
```
Saving an untracked sub-repository without a commit checked out [0]
results in an ugly state: the sub-repository is _not_ added as a
submodule but its untracked files are added as blobs in the
_superdataset_.  This is not usually an issue for datasets because
these get initial commits on creation, so we documented this as a
known issue rather than introducing additional checks that would come
with a performance penalty.

The core problem is a combination of 'git submodule add' accepting a
sub-repository on an unborn branch and 'git ls-files' considering such
a sub-repository a directory rather than a repository.  Both issues
are fixed in Git 2.22.0 [1].  Update the documentation note and tests
accordingly.

[0] Usually this is just a repository without any commits, but it
    could be repository that has commits but is currently on an unborn
    branch.
[1] https://public-inbox.org/git/20190409230737.26809-1-kyle@kyleam.com/
    Commits e13811189b and b22827045e.
```

Re: #3139

---

Marking as "do not merge" because there's a temporary commit to enable the Travis run with the latest Git and because this needs and sits on top of gh-3470.