### PR TITLE
TST: travis: Drop "-dev" suffix from py3.7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
 matrix:
   include:
   # Additional custom ones
-  - python: 3.7-dev
+  - python: 3.7
     # Single run for Python 3.7
     env:
     # Run all tests in a single whoop here


### PR DESCRIPTION
When Travis switched its default distribution from Trusty to Xenial,
our 3.7-dev build started to error with a segfault.  The reason for
this isn't clear, but a plain 3.7 build doesn't [0] show the segfault,
so let's use that instead.

[0]: https://travis-ci.org/datalad/datalad/builds/545360524

Fixes #3477.