### PR TITLE
TST: travis: Uncomment -container build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,19 +183,14 @@ matrix:
     - NOSE_SELECTION_OP=not
     - NOSE_SELECTION=
 
-  # TODO: The current release of datalad-container (0.3.1) is
-  # incompatible with the current DataLad.  Uncomment this once the
-  # following change makes it into a release:
-  # https://github.com/datalad/datalad-container/pull/73
-  #
-  # - python: 3.5
-  #   # test with extension datalad-container
-  #   env:
-  #   - BUILD_DATALAD_EXTENSION=datalad-container
-  #   - TESTS_TO_PERFORM=datalad_container
-  #   # Use a selector that will always be true.
-  #   - NOSE_SELECTION_OP=not
-  #   - NOSE_SELECTION=
+  - python: 3.5
+    # test with extension datalad-container
+    env:
+    - BUILD_DATALAD_EXTENSION=datalad-container
+    - TESTS_TO_PERFORM=datalad_container
+    # Use a selector that will always be true.
+    - NOSE_SELECTION_OP=not
+    - NOSE_SELECTION=
 
   # TODO: The current release of datalad-revolution (0.9.0) is
   # incompatible with the current DataLad.  Uncomment this after the

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,9 +192,9 @@ matrix:
     - NOSE_SELECTION_OP=not
     - NOSE_SELECTION=
 
-  # TODO: The current release of datalad-revolution (0.9.0) is
-  # incompatible with the current DataLad.  Uncomment this after the
-  # next -revolution release, which will include 1a7c21b.
+  # TODO: The current release of datalad-revolution (0.10.0) is
+  # incompatible with the current DataLad.  Uncomment this onnce a
+  # -revolution release has 13b01c2 and PR 128.
   #
   # - python: 3.5
   #   # test with extension datalad-revolution


### PR DESCRIPTION
Both of these have had releases that contain the necessary
compatibility fixes.  The crawler is now the only extension that
unreleased (and unmerged) compatibility fixes (crawler PR 41).