### PR TITLE
TST(appveyor): run: Disable gc.auto for erroring test

### DIFF
--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -135,6 +135,9 @@ def test_basics(path, nodspath):
             assert_in("No command given", cml.out)
 
 
+@known_failure_appveyor
+# ^ For an unknown reason, appveyor started failing after we removed
+#   receive.autogc=0 and gc.auto=0 from our common git options (gh-3482).
 @with_tempfile(mkdir=True)
 def test_py2_unicode_command(path):
     # Avoid OBSCURE_FILENAME to avoid windows-breakage (gh-2929).

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -63,11 +63,11 @@ from datalad.tests.utils import (
     assert_not_in,
     swallow_logs,
     swallow_outputs,
+    known_failure_appveyor,
     known_failure_windows,
     slow,
     with_testrepos,
     OBSCURE_FILENAME,
-    SkipTest,
 )
 
 
@@ -194,11 +194,9 @@ def test_run_save_deletion(path):
     assert_repo_status(ds.path)
 
 
+@known_failure_appveyor  # causes appveyor (only) to crash, reason unknown
 @with_tempfile(mkdir=True)
 def test_run_from_subds(path):
-    if 'APPVEYOR' in os.environ:
-        raise SkipTest('test causes appveyor (only) to crash, reason unknown')
-
     subds = Dataset(path).create().create("sub")
     subds.run("cd .> foo")
     assert_repo_status(subds.path)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -32,9 +32,9 @@ from datalad.tests.utils import (
     eq_,
     ok_,
     chpwd,
+    known_failure_appveyor,
     known_failure_windows,
     OBSCURE_FILENAME,
-    SkipTest,
 )
 from datalad.distribution.tests.test_add import tree_arg
 
@@ -436,13 +436,11 @@ def test_add_mimetypes(path):
             assert_not_in('key', annexinfo[p], p)
 
 
+@known_failure_appveyor
+# ^ Issue only happens on appveyor, Python itself implodes. Cannot be
+#   reproduced on a real windows box.
 @with_tempfile(mkdir=True)
 def test_gh1597(path):
-    if 'APPVEYOR' in os.environ:
-        # issue only happens on appveyor, Python itself implodes
-        # cannot be reproduced on a real windows box
-        raise SkipTest(
-            'this test causes appveyor to crash, reason unknown')
     ds = Dataset(path).create()
     sub = ds.create('sub')
     res = ds.subdatasets()

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -67,9 +67,9 @@ from datalad.tests.utils import (
     assert_not_in,
     swallow_logs,
     swallow_outputs,
+    known_failure_appveyor,
     known_failure_windows,
     slow,
-    SkipTest,
 )
 
 
@@ -581,6 +581,9 @@ def test_rerun_script(path):
 
 
 @slow  # ~10s
+@known_failure_appveyor
+# ^ Issue only happens on appveyor, Python itself implodes. Cannot be
+#   reproduced on a real win7 box
 @with_tree(tree={"input.dat": "input",
                  "extra-input.dat": "extra input",
                  "s0": {"s1_0": {"s2": {"a.dat": "a",
@@ -590,12 +593,6 @@ def test_rerun_script(path):
                         "ss": {"e.dat": "e"}}})
 @with_tempfile(mkdir=True)
 def test_run_inputs_outputs(src, path):
-    if 'APPVEYOR' in os.environ:
-        # issue only happens on appveyor, Python itself implodes
-        # cannot be reproduced on a real win7 box
-        raise SkipTest(
-            'test causes appveyor (only) to crash, reason unknown')
-
     for subds in [("s0", "s1_0", "s2"),
                   ("s0", "s1_1", "s2"),
                   ("s0", "s1_0"),

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1042,6 +1042,21 @@ def known_failure_windows(func):
         return dm_func
     return func
 
+
+def known_failure_appveyor(func):
+    """Test decorator marking a test as known to fail on AppVeyor.
+    """
+    if 'APPVEYOR' in os.environ:
+        @known_failure
+        @wraps(func)
+        @attr('known_failure_appveyor')
+        @attr('appveyor')
+        def dm_func(*args, **kwargs):
+            return func(*args, **kwargs)
+        return dm_func
+    return func
+
+
 # ### ###
 # END known failure decorators
 # ### ###


### PR DESCRIPTION
When 203aa652a (RF: remove receive.autogc=0 and gc.auto=0 options to
git calls, 2019-05-24) was merged to master, test_py2_unicode_command
started to fail on AppVeyor.  Work around this by configuring
gc.auto=0 for that test's repository.  (This assumes gc.auto but not
receive.autogc is the culprit, since the test does not interact with a
remote.)

Another option would be to revert 203aa652a, but let's avoid doing
that until it's clear that there are more widespread issues.

Closes #3482.