### PR TITLE
create: Two path handling fixes

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -176,6 +176,9 @@ class Create(Interface):
             fake_dates=False,
             cfg_proc=None
     ):
+        if dataset and not isinstance(dataset, Dataset):
+            dataset = Dataset(dataset)
+            refds_path = dataset.path
         refds_path = dataset.path if hasattr(dataset, 'path') else dataset
 
         # two major cases

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -211,7 +211,7 @@ class Create(Interface):
                    refds=refds_path)
 
         refds = None
-        if refds_path and refds_path != path:
+        if refds_path and refds_path != text_type(path):
             refds = require_dataset(
                 refds_path, check_installed=True,
                 purpose='creating a subdataset')

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -176,10 +176,11 @@ class Create(Interface):
             fake_dates=False,
             cfg_proc=None
     ):
-        if dataset and not isinstance(dataset, Dataset):
-            dataset = Dataset(dataset)
-            refds_path = dataset.path
-        refds_path = dataset.path if hasattr(dataset, 'path') else dataset
+        if dataset:
+            ds = dataset if isinstance(dataset, Dataset) else Dataset(dataset)
+            refds_path = ds.path
+        else:
+            ds = refds_path = None
 
         # two major cases
         # 1. we got a `dataset` -> we either want to create it (path is None),
@@ -195,10 +196,10 @@ class Create(Interface):
                                  "no annex repo.")
 
         if path:
-            path = rev_resolve_path(path, dataset)
+            path = rev_resolve_path(path, ds)
 
         path = path if path \
-            else getpwd() if dataset is None \
+            else getpwd() if ds is None \
             else refds_path
 
         # we know that we need to create a dataset at `path`
@@ -223,7 +224,7 @@ class Create(Interface):
                     message=(
                         "dataset containing given paths is not underneath "
                         "the reference dataset %s: %s",
-                        dataset, text_type(path)),
+                        ds, text_type(path)),
                 )
                 return
 
@@ -283,8 +284,8 @@ class Create(Interface):
 
         # important to use the given Dataset object to avoid spurious ID
         # changes with not-yet-materialized Datasets
-        tbds = dataset if isinstance(dataset, Dataset) and \
-            dataset.path == path else Dataset(text_type(path))
+        tbds = ds if isinstance(ds, Dataset) and \
+            ds.path == path else Dataset(text_type(path))
 
         # don't create in non-empty directory without `force`:
         if op.isdir(tbds.path) and listdir(tbds.path) != [] and not force:

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -225,6 +225,13 @@ def test_create_sub_gh3463(path):
     assert_repo_status(ds.path)
 
 
+@with_tempfile(mkdir=True)
+def test_create_dataset_same_as_path(path):
+    with chpwd(path):
+        ds = create(dataset=".", path=".")
+    assert_repo_status(ds.path)
+
+
 @with_tempfile
 def test_create_sub_dataset_dot_no_path(path):
     ds = Dataset(path)

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -225,6 +225,26 @@ def test_create_sub_gh3463(path):
     assert_repo_status(ds.path)
 
 
+@with_tempfile
+def test_create_sub_dataset_dot_no_path(path):
+    ds = Dataset(path)
+    ds.create()
+
+    # Test non-bound call.
+    sub0_path = text_type(ds.pathobj / "sub0")
+    os.mkdir(sub0_path)
+    with chpwd(sub0_path):
+        subds0 = create(dataset=".")
+    assert_repo_status(ds.path, untracked=[subds0.path])
+    assert_repo_status(subds0.path)
+
+    # Test command-line invocation directly (regression from gh-3484).
+    sub1_path = text_type(ds.pathobj / "sub1")
+    os.mkdir(sub1_path)
+    Runner(cwd=sub1_path)(["datalad", "create", "-d."])
+    assert_repo_status(ds.path, untracked=[subds0.path, sub1_path])
+
+
 # windows failure triggered by
 # File "C:\Miniconda35\envs\test-environment\lib\site-packages\datalad\tests\utils.py", line 421, in newfunc
 #    rmtemp(d)


### PR DESCRIPTION

  * Fix subdataset `datalad create -d.` case from #3484.
  * Fix dataset-path comparison check for `datalad create -d APATH APATH`.
