### PR TITLE
TST: annexrepo: Update test for "no commits" sub-repo fix in Git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,6 @@ matrix:
     env:
     - DATALAD_USE_DEFAULT_GIT=1
     - _DL_UPSTREAM_GIT=1
-    - _DL_CRON=1
   - python: 3.5
     env:
     # to test operation under root since also would consider FS "crippled" due to

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -650,18 +650,22 @@ class GitRunner(Runner):
                     lgr.log(9, "Will use default git %s", git_fpath)
                     return  # we are done - there is a default git avail.
                 # if not -- we will look for a bundled one
-
-            annex_fpath = find_executable("git-annex")
-            if not annex_fpath:
-                # not sure how to live further anyways! ;)
-                alongside = False
-            else:
-                annex_path = op.dirname(op.realpath(annex_fpath))
-                alongside = op.lexists(op.join(annex_path, 'git'))
-            GitRunner._GIT_PATH = annex_path if alongside else ''
+            GitRunner._GIT_PATH = GitRunner._get_bundled_path()
             lgr.log(9, "Will use git under %r (no adjustments to PATH if empty "
                        "string)", GitRunner._GIT_PATH)
             assert(GitRunner._GIT_PATH is not None)  # we made the decision!
+
+    @staticmethod
+    def _get_bundled_path():
+        from distutils.spawn import find_executable
+        annex_fpath = find_executable("git-annex")
+        if not annex_fpath:
+            # not sure how to live further anyways! ;)
+            alongside = False
+        else:
+            annex_path = op.dirname(op.realpath(annex_fpath))
+            alongside = op.lexists(op.join(annex_path, 'git'))
+        return annex_path if alongside else ''
 
     @staticmethod
     def get_git_environ_adjusted(env=None):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -9,6 +9,7 @@
 """Module to help maintain a registry of versions for external modules etc
 """
 import sys
+import os.path as op
 from os import linesep
 from six import string_types
 from six import binary_type
@@ -76,6 +77,16 @@ def _get_system_git_version():
     return __get_git_version(_runner)
 
 
+def _get_bundled_git_version():
+    """Return version of git bundled with git-annex.
+    """
+    path = _git_runner._get_bundled_path()
+    if path:
+        out = _runner.run([op.join(path, "git"), "version"])[0]
+        # format: git version 2.22.0
+        return out.split()[2]
+
+
 def _get_system_ssh_version():
     """Return version of ssh available system-wide
 
@@ -114,6 +125,7 @@ class ExternalVersions(object):
     CUSTOM = {
         'cmd:annex': _get_annex_version,
         'cmd:git': _get_git_version,
+        'cmd:bundled-git': _get_bundled_git_version,
         'cmd:system-git': _get_system_git_version,
         'cmd:system-ssh': _get_system_ssh_version,
     }


### PR DESCRIPTION
As of Git 2.22.0, specifically b22827045e (dir: do not traverse
repositories with no commits, 2019-04-09), 'git ls-files' now treats a
repository on an unborn branch as a repository rather than a
directory.

Fixes #3490.