### PR TITLE
BF: annexrepo: Adjust overly selective is_special_annex_remote()

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -943,17 +943,27 @@ class AnnexRepo(GitRepo, RepoInterface):
     def is_special_annex_remote(self, remote, check_if_known=True):
         """Return whether remote is a special annex remote
 
-        Decides based on the presence of diagnostic annex- options
-        for the remote
+        Decides based on the presence of an annex- option and lack of a
+        configured URL for the remote.
         """
         if check_if_known:
             if remote not in self.get_remotes():
                 raise RemoteNotAvailableError(remote)
-        sec = 'remote.{}'.format(remote)
-        for opt in ('annex-externaltype', 'annex-webdav'):
-            if self.config.has_option(sec, opt):
-                return True
-        return False
+        opts = self.config.options('remote.{}'.format(remote))
+        if "url" in opts:
+            is_special = False
+        elif any(o.startswith("annex-") for o in opts
+                 if o not in ["annex-uuid", "annex-ignore"]):
+            # It's possible that there isn't a special-remote related option
+            # (we only filter out a few common ones), but given that there is
+            # no URL it should be a good bet that this is a special remote.
+            is_special = True
+        else:
+            is_special = False
+            lgr.warning("Remote '%s' has no URL or annex- option. "
+                        "Is it mis-configured?",
+                        remote)
+        return is_special
 
     @borrowkwargs(GitRepo)
     def get_remotes(self,

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2384,6 +2384,32 @@ def test_fake_is_not_special(path):
     assert_false(ar.is_special_annex_remote("fake", check_if_known=False))
 
 
+@with_tree(tree={"remote": {}, "main": {}, "special": {}})
+def test_is_special(path):
+    rem = AnnexRepo(op.join(path, "remote"), create=True)
+    dir_arg = "directory={}".format(op.join(path, "special"))
+    rem.init_remote("imspecial",
+                    ["type=directory", "encryption=none", dir_arg])
+    ok_(rem.is_special_annex_remote("imspecial"))
+
+    ar = AnnexRepo.clone(rem.path, op.join(path, "main"))
+    assert_false(ar.is_special_annex_remote("origin"))
+
+    assert_false(ar.is_special_annex_remote("imspecial",
+                                            check_if_known=False))
+    # FIXME: ar.enable_remote() doesn't support specifying options, but we need
+    # to specify directory= here.
+    ar._run_annex_command("enableremote",
+                          annex_options=["imspecial", dir_arg])
+    ok_(ar.is_special_annex_remote("imspecial"))
+
+    # With a mis-configured remote, give warning and return false.
+    ar.config.unset("remote.origin.url", where="local")
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        assert_false(ar.is_special_annex_remote("origin"))
+        cml.assert_logged(msg=".*no URL.*", level="WARNING", regex=True)
+
+
 @with_tempfile(mkdir=True)
 def test_fake_dates(path):
     ar = AnnexRepo(path, create=True, fake_dates=True)


### PR DESCRIPTION
To decide if a remote is an annex special remote, we check whether
'annex-externaltype' or 'annex-webdav' is configured for the remote.
This mis-classifies nearly all internal special remotes (anything but
webdav) as an ordinary remote because those don't have
'annex-externaltype' configured.

There's no common annex- option for special remotes.  As the
definition of annex's findSpecialRemotes shows, each special remote is
expected to have at least an annex-TYPE option.  We could keep a list
of known internal special remotes and look for that or externaltype,
but the list of internal special remotes is a moving target.

findSpecialRemotes' documentation mentions that "special remotes don't
have a configured url", so let's instead identify them based on _not_
having a URL and having some annex- option aside from annex-uuid and
annex-ignore, two particularly common non-special-remote options.

Given that all valid Git remotes have a configured URL, this should be
a reliable classification for correctly configured remotes.  It's of
course possible to get mis-classifications if the user either removes
or adds a URL to a remote's section.

Another option would be to rely on get_special_remotes(), which calls
`git cat-file git-annex:remote.log` to get the special remotes, but
that'd be a change in behavior because it also considers remotes that
aren't enabled.  It'd also be slower:

    # This patch
    % python -m timeit -s "from datalad.support.annexrepo import AnnexRepo; ar = AnnexRepo('.')"
      "ar.is_special_annex_remote('origin')"
    10000 loops, best of 3: 143 usec per loop

    # Using get_special_remotes() in is_special_annex_remote()
    % python -m timeit -s "from datalad.support.annexrepo import AnnexRepo; ar = AnnexRepo('.')"
      "ar.is_special_annex_remote('origin')"
    100 loops, best of 3: 8.82 msec per loop

Fixes #3497.