### PR TITLE
CHANGELOG.md: First batch for 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ bet we will fix some bugs and make a world even a better place.
 - `AnnexRepo.is_special_annex_remote` was too selective in what it
   considered to be a special remote.  ([#3499][])
 
+- We now provide information about unexpected output when git-annex is
+  called with `--json`.  ([#3516][])
+
 ### Enhancements and new features
 
 - For calls to git and git-annex, we disable automatic garbage
@@ -1371,3 +1374,4 @@ publishing
 [#3493]: https://github.com/datalad/datalad/issues/3493
 [#3498]: https://github.com/datalad/datalad/issues/3498
 [#3499]: https://github.com/datalad/datalad/issues/3499
+[#3516]: https://github.com/datalad/datalad/issues/3516

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,24 @@ bet we will fix some bugs and make a world even a better place.
 
 ### Fixes
 
-?
+- Our tests needed various adjustments to keep up with upstream
+  changes in Travis and Git. ([#3479][]) ([#3492][]) ([#3493][])
+
+- `AnnexRepo.is_special_annex_remote` was too selective in what it
+  considered to be a special remote.  ([#3499][])
 
 ### Enhancements and new features
 
-?
+- For calls to git and git-annex, we disable automatic garbage
+  collection due to past issues with GitPython's state becoming stale,
+  but doing so results in a larger .git/objects/ directory that isn't
+  cleaned up until garbage collection is triggered outside of DataLad.
+  Tests with the latest GitPython didn't reveal any state issues, so
+  we've re-enabled automatic garbage collection.  ([#3458][])
+
+- [rerun][] learned an `--explicit` flag, which it relays to its calls
+  to [run][[]].  This makes it possible to call `rerun` in a dirty
+  working tree ([#3498][]).
 
 
 ## 0.11.5 (May 23, 2019) -- stability is not overrated
@@ -1352,3 +1365,9 @@ publishing
 [#3425]: https://github.com/datalad/datalad/issues/3425
 [#3439]: https://github.com/datalad/datalad/issues/3439
 [#3440]: https://github.com/datalad/datalad/issues/3440
+[#3458]: https://github.com/datalad/datalad/issues/3458
+[#3479]: https://github.com/datalad/datalad/issues/3479
+[#3492]: https://github.com/datalad/datalad/issues/3492
+[#3493]: https://github.com/datalad/datalad/issues/3493
+[#3498]: https://github.com/datalad/datalad/issues/3498
+[#3499]: https://github.com/datalad/datalad/issues/3499


### PR DESCRIPTION
<details>
<summary>Changes from 0.11.5</summary>

```
# Generated with
#   git log --format="?  %s%n   %h^-1" --reverse --first-parent 0.11.5..origin/0.11.x
#
#
# ?  = unprocessed and undecided
# -  = decided not to include
# +  = included
# +* = included, but might still be bits that should be added

-  Show must go on
   fd857f4bc^-1
-  BF(TST): skip vcr based github tests if no network
   d977cc661^-1
-  DOC: wtf: Add missing parenthesis to parameter description
   78c72ec23^-1
-  DOC: adjusted 0.10.0 changelog entry to mention when --fake-dates was added
   d8050c83a^-1
-  ENH(TST): adding one more condition (for nd80) to skip testing for url to be in error msg
   fe772763a^-1
+  Merge pull request #3458 from yarikoptic/enh-bring-gc-back
   e6fe78f15^-1
+  Merge pull request #3479 from kyleam/travis-drop-37-dev
   aef2b8af8^-1
+  Merge pull request #3492 from kyleam/webui-subrepo-nocommits
   23b4441d1^-1
+  Merge pull request #3494 from kyleam/xenial-upstream-git
   27b9aa493^-1
+  Merge pull request #3493 from kyleam/annexrepo-status-nocommits
   114798099^-1
+  Merge pull request #3499 from kyleam/special-remote-check
   9a65227bb^-1
```

Also includes entry for unmerged gh-3498.

</details>

