### PR TITLE
RF: ls-files only on provided paths (if given)

### DIFF
--- a/benchmarks/support/path.py
+++ b/benchmarks/support/path.py
@@ -1,0 +1,40 @@
+# Import functions to be tested with _ suffix and name the suite after the
+# original function so we could easily benchmark it e.g. by
+#    asv run --python=same -b get_parent_paths
+# without need to discover what benchmark to use etc
+
+from datalad.support.path import get_parent_paths as get_parent_paths_
+
+from ..common import SuprocBenchmarks
+
+class get_parent_paths(SuprocBenchmarks):
+
+    def setup(self):
+        # prepare some more or less realistic with a good number of paths
+        # and some hierarchy of submodules
+        self.nfiles = 40  # per each construct
+        self.nsubmod = 30  # at two levels
+        self.toplevel_submods = sorted(['submod%d' % i for i in range(self.nsubmod)])
+        self.posixpaths = \
+            ['file%d' % i for i in range(self.nfiles)] + \
+            ['subdir/anotherfile%d' % i for i in range(self.nfiles)]
+        for submod in range(self.nsubmod):
+            self.posixpaths += \
+                ['submod%d/file%d' % (submod, i) for i in range(self.nfiles)] + \
+                ['subdir/submod%d/file%d' % (submod, i) for i in range(self.nfiles)] + \
+                ['submod/sub%d/file%d' % (submod, i) for i in range(self.nfiles)]
+
+    def time_no_submods(self):
+        assert get_parent_paths_(self.posixpaths, [], True) == []
+
+    def time_one_submod_toplevel(self):
+        get_parent_paths_(self.posixpaths, ['submod9'], True)
+
+    def time_one_submod_subdir(self):
+        get_parent_paths_(self.posixpaths, ['subdir/submod9'], True)
+
+    def time_allsubmods_toplevel_only(self):
+        get_parent_paths_(self.posixpaths, self.toplevel_submods, True)
+
+    def time_allsubmods_toplevel(self):
+        get_parent_paths_(self.posixpaths, self.toplevel_submods)

--- a/benchmarks/support/path.py
+++ b/benchmarks/support/path.py
@@ -14,7 +14,7 @@ class get_parent_paths(SuprocBenchmarks):
         # and some hierarchy of submodules
         self.nfiles = 40  # per each construct
         self.nsubmod = 30  # at two levels
-        self.toplevel_submods = sorted(['submod%d' % i for i in range(self.nsubmod)])
+        self.toplevel_submods = ['submod%d' % i for i in range(self.nsubmod)]
         self.posixpaths = \
             ['file%d' % i for i in range(self.nfiles)] + \
             ['subdir/anotherfile%d' % i for i in range(self.nfiles)]

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -14,7 +14,6 @@ __docformat__ = 'restructuredtext'
 import logging
 import re
 import os
-from os.path import relpath
 from six import (
     iteritems,
     text_type,
@@ -48,9 +47,6 @@ from datalad.utils import (
     partition,
     PurePosixPath,
 )
-
-# API commands
-import datalad.core.local.save
 
 from datalad.distribution.dataset import (
     EnsureDataset,

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -285,3 +285,17 @@ def test_get_subdatasets_types(path):
     ds.create('true')
     # no types casting should happen
     eq_(ds.subdatasets(result_xfm='relpaths'), ['1', 'true'])
+
+
+@with_tempfile
+def test_parent_on_unborn_branch(path):
+    from datalad.support.gitrepo import GitRepo
+    ds = Dataset(GitRepo(path, create=True).path)
+    assert_false(ds.repo.get_hexsha())
+
+    subrepo = GitRepo(opj(path, "sub"), create=True)
+    subrepo.commit(msg="c", options=["--allow-empty"])
+
+    ds.repo.add_submodule(path="sub")
+    eq_(ds.subdatasets(result_xfm='relpaths'),
+        ["sub"])

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2405,6 +2405,18 @@ class GitRepo(RepoInterface):
         return out
 
     def get_submodules_(self, paths=None):
+        """Yield submodules in this repository.
+
+        Parameters
+        ----------
+        paths : list(pathlib.PurePath), optional
+            Restrict submodules to those under `paths`.
+
+        Returns
+        -------
+        A generator that yields a dictionary with information for each
+        submodule.
+        """
         if not (self.pathobj / ".gitmodules").exists():
             return
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3046,7 +3046,7 @@ class GitRepo(RepoInterface):
             if path_strs:
                 # we need to get their within repo elements since ls-tree
                 # for paths within submodules returns nothing!
-                # see https://www.spinics.net/lists/git/msg362459.html
+                # see https://public-inbox.org/git/20190703193305.GF21553@hopa.kiewit.dartmouth.edu/T/#u
                 submodules = [s.path for s in self.get_submodules()]
                 path_strs = get_parent_paths(path_strs, submodules)
         else:

--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -145,9 +145,9 @@ def get_parent_paths(paths, parents, only_with_parents=False):
 
     Returns
     -------
-    A sorted list of paths where some entries replaced with their "parents"
-    without duplicates.  So for 'a/b' and 'a/c' with a being among parents, there
-    will be a single 'a'
+    A list of paths (without duplicaates), where some entries replaced with
+    their "parents" without duplicates.  So for 'a/b' and 'a/c' with a being
+    among parents, there will be a single 'a'
     """
     # Let's do an early check even though then we would skip the checks on paths
     # being relative etc
@@ -173,7 +173,8 @@ def get_parent_paths(paths, parents, only_with_parents=False):
     # Could be an ordered dict but no need
     parent_lengths = [(l, parent_lengths[l]) for l in sorted(parent_lengths, reverse=True)]
 
-    res = set()
+    res = []
+    seen = set()
 
     for path in paths:  # O(len(paths)) - unavoidable but could be parallelized!
         # Sanity check -- should not be too expensive
@@ -183,13 +184,17 @@ def get_parent_paths(paths, parents, only_with_parents=False):
                 continue  # no directory deep enough
             candidate_parent = path[:parent_length]
             if candidate_parent in parents_:  # O(log(len(parents))) but expected one less due to per length handling
-                res.add(candidate_parent)
+                if candidate_parent not in seen:
+                    res.append(candidate_parent)
+                    seen.add(candidate_parent)
                 break  # it is!
         else:  # no hits
             if not only_with_parents:
-                res.add(path)
+                if path not in seen:
+                    res.append(path)
+                    seen.add(path)
 
-    return sorted(res)  # TODO: keep it as set?  should we retain original order?
+    return res
 
 
 def _get_parent_paths_check(path):

--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -15,6 +15,9 @@ One of the reasons is also to robustify operation with unicode filenames
 import os
 import os.path as op
 
+# to not pollute API importing as _
+from collections import defaultdict as _defaultdict
+
 from functools import wraps
 from itertools import dropwhile
 
@@ -111,3 +114,86 @@ def split_ext(filename):
     file_parts = parts[:1] + tail[::-1]
     ext_parts = parts[1+len(tail):]
     return ".".join(file_parts), "." + ".".join(ext_parts)
+
+
+def get_parent_paths(paths, parents, only_with_parents=False):
+    """Given a list of children paths, return their parent paths among parents
+    or their own path if there is no known parent. A path is also considered its
+    own parent (haven't you watched Predestination?) ;)
+
+    All paths should be POSIX, relative, and not pointing outside (not starting
+    with ../)
+
+    Accent is made on performance to avoid O(len(paths) * len(parents))
+    runtime.  ATM should be typically less than O(len(paths) * len(log(parents)))
+
+    Initial intended use - for a list of paths in the repository
+    to provide their paths as files/submodules known to that repository, to
+    overcome difference in ls-tree and ls-files, where ls-files outputs nothing
+    for paths within submodules.
+    It is coded, so it could later be applied even whenever there are nested
+    parents, e.g. parents = ['sub', 'sub/sub'] and then the "deepest" parent
+    is selected
+
+    Parameters
+    ----------
+    parents: list of str
+    paths: list of str
+    only_with_parents: bool, optional
+      If set to True, return a list of only parent paths where that path had
+      a parent
+
+    Returns
+    -------
+    A sorted list of paths where some entries replaced with their "parents"
+    without duplicates.  So for 'a/b' and 'a/c' with a being among parents, there
+    will be a single 'a'
+    """
+    # Let's do an early check even though then we would skip the checks on paths
+    # being relative etc
+    if not parents:
+        return [] if only_with_parents else paths
+
+    # We will create a lookup for known parent lengths
+    parents = set(parents)  # O(log(len(parents))) lookup
+
+    # rely on path[:n] be quick, and len(parent_lengths) << len(parents)
+    # when len(parents) is large.  We will also bail checking any parent of
+    # the length if at that length path has no directory boundary ('/').
+    #
+    # Create mapping for each length of
+    # parent path to list of parents with that length
+    parent_lengths = _defaultdict(set)
+    for parent in parents:
+        _get_parent_paths_check(parent)
+        parent_lengths[len(parent)].add(parent)
+
+    # Make it ordered in the descending order so we select the deepest/longest parent
+    # and store them as sets for faster lookup.
+    # Could be an ordered dict but no need
+    parent_lengths = [(l, parent_lengths[l]) for l in sorted(parent_lengths, reverse=True)]
+
+    res = set()
+
+    for path in paths:  # O(len(paths)) - unavoidable but could be parallelized!
+        # Sanity check -- should not be too expensive
+        _get_parent_paths_check(path)
+        for parent_length, parents_ in parent_lengths:  # O(len(parent_lengths))
+            if (len(path) < parent_length) or (len(path) > parent_length and path[parent_length] != '/'):
+                continue  # no directory deep enough
+            candidate_parent = path[:parent_length]
+            if candidate_parent in parents_:  # O(log(len(parents))) but expected one less due to per length handling
+                res.add(candidate_parent)
+                break  # it is!
+        else:  # no hits
+            if not only_with_parents:
+                res.add(path)
+
+    return sorted(res)  # TODO: keep it as set?  should we retain original order?
+
+
+def _get_parent_paths_check(path):
+    """A little helper for get_parent_paths"""
+    if isabs(path) or path.startswith(pardir + sep) or path.startswith(curdir + sep):
+        raise ValueError("Expected relative within directory paths, got %r" % path)
+

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1012,6 +1012,16 @@ def test_GitRepo_get_submodules():
     raise SkipTest("TODO")
 
 
+@with_tempfile
+def test_get_submodules_parent_on_unborn_branch(path):
+    repo = GitRepo(path, create=True)
+    subrepo = GitRepo(op.join(path, "sub"), create=True)
+    subrepo.commit(msg="s", options=["--allow-empty"])
+    repo.add_submodule(path="sub")
+    eq_([s.name for s in repo.get_submodules()],
+        ["sub"])
+
+
 def test_kwargs_to_options():
 
     class Some(object):


### PR DESCRIPTION
Intends to at least partially address https://github.com/datalad/datalad/issues/3506
where in a repository with lots of already tracked files, adding more files by providing
their paths would lead only to the heavy CPU load due to paths matching then performed
on DataLad level instead of restricting initial query to  git ls-files  only to the paths
of interest.

Locally I have ran all datalad/core tests and no failures were detected.  This is a PR to see if it would potentially cause some breakage elsewhere.

TODOs
- [ ] make sure nothing is broken
- [x] benchmark