### PR TITLE
BF: subdatasets: Fix recursion when path is specified

### DIFF
--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -58,7 +58,7 @@ def test_get_subdatasets(path):
     eq_([(r['parentds'], r['path']) for r in ds.subdatasets()],
         [(path, opj(path, 'sub dataset1')),
          (path, opj(path, dots))])
-    eq_(ds.subdatasets(recursive=True, result_xfm='relpaths'), [
+    all_subs = [
         'sub dataset1',
         'sub dataset1/2',
         'sub dataset1/sub sub dataset1',
@@ -66,7 +66,16 @@ def test_get_subdatasets(path):
         'sub dataset1/sub sub dataset1/subm 1',
         'sub dataset1/subm 1',
         dots,
-    ])
+    ]
+    eq_(ds.subdatasets(recursive=True, result_xfm='relpaths'), all_subs)
+    with chpwd(text_type(ds.pathobj)):
+        # imitate cmdline invocation w/ no dataset argument
+        eq_(subdatasets(dataset=None,
+                        path=[],
+                        recursive=True,
+                        result_xfm='relpaths'),
+            all_subs)
+
     # redo, but limit to specific paths
     eq_(
         ds.subdatasets(
@@ -77,6 +86,19 @@ def test_get_subdatasets(path):
             'sub dataset1/sub sub dataset1',
             'sub dataset1/sub sub dataset1/2',
             'sub dataset1/sub sub dataset1/subm 1',
+        ]
+    )
+    eq_(
+        ds.subdatasets(
+            path=['sub dataset1'],
+            recursive=True, result_xfm='relpaths'),
+        [
+            'sub dataset1',
+            'sub dataset1/2',
+            'sub dataset1/sub sub dataset1',
+            'sub dataset1/sub sub dataset1/2',
+            'sub dataset1/sub sub dataset1/subm 1',
+            'sub dataset1/subm 1',
         ]
     )
     with chpwd(text_type(ds.pathobj / 'subdir')):


### PR DESCRIPTION
_parse_git_submodules() returns early without yielding submodules if a
dataset's path does not equal or contain a supplied path.  This is
problematic when operating recursively because, if a directory
containing more than one level of subdatasets is given, the path is
the parent---not child---of the dataset, but it should still be
included in the output.  Add this condition to
_parse_git_submodules().

Fixes #3509.

---

I'm not sure this is the best or cleanest approach, but at the very least it provides tests and additional information for gh-3509.  And, while I haven't looked at gh-3508 closely, I see it includes an optimized get_parent_paths() helper, so that may be of use here.
