### PR TITLE
annexrepo: Try to avoid silent bugs when processing json output

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -55,6 +55,10 @@ class MissingExternalDependency(RuntimeError):
         return to_str
 
 
+class BrokenExternalDependency(RuntimeError):
+    """Some particular functionality is broken with this dependency."""
+
+
 class DeprecatedError(RuntimeError):
     """To raise whenever a deprecated entirely feature is used"""
     def __init__(self, new=None, version=None, msg=''):


### PR DESCRIPTION
Report non-json output from --json commands to replace silent failures, in particular #3513, with more informative messages.