### PR TITLE
More fixes to dataset argument handling

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -48,8 +48,8 @@ from datalad.distribution.dataset import datasetmethod
 
 from datalad.utils import assure_bytes
 from datalad.utils import assure_unicode
-# Rename get_dataset_pwds for the benefit of containers_run.
-from datalad.utils import get_dataset_pwds as get_command_pwds
+from datalad.utils import get_dataset_root
+from datalad.utils import getpwd
 from datalad.utils import SequenceFormatter
 
 lgr = logging.getLogger('datalad.core.local.run')
@@ -201,6 +201,39 @@ class Run(Interface):
                              message=message,
                              sidecar=sidecar):
             yield r
+
+
+def get_command_pwds(dataset):
+    """Return the current directory for the dataset.
+
+    Parameters
+    ----------
+    dataset : Dataset
+
+    Returns
+    -------
+    A tuple, where the first item is the absolute path of the pwd and the
+    second is the pwd relative to the dataset's path.
+    """
+    if dataset:
+        pwd = dataset.path
+        rel_pwd = op.curdir
+    else:
+        # act on the whole dataset if nothing else was specified
+
+        # Follow our generic semantic that if dataset is specified,
+        # paths are relative to it, if not -- relative to pwd
+        pwd = getpwd()
+        # Pass pwd to get_dataset_root instead of os.path.curdir to handle
+        # repos whose leading paths have a symlinked directory (see the
+        # TMPDIR="/var/tmp/sym link" test case).
+        dataset = get_dataset_root(pwd)
+
+        if dataset:
+            rel_pwd = relpath(pwd, dataset)
+        else:
+            rel_pwd = pwd  # and leave handling to caller
+    return pwd, rel_pwd
 
 
 def _install_and_reglob(dset, gpaths):

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -368,7 +368,7 @@ def test_run_path_semantics(path):
     with chpwd(ds0_subdir):
         run("cd .> one", dataset="..")
         run("cd .> one", outputs=["one"], dataset=ds0.path)
-    ok_(ds0.repo.file_has_content(op.join(ds0_subdir, "one")))
+    ok_exists(op.join(ds0_subdir, "one"))
     assert_repo_status(ds0.path)
 
     # Specify string dataset argument, running from another dataset ...
@@ -381,7 +381,7 @@ def test_run_path_semantics(path):
     with chpwd(ds1_subdir):
         run("cd .> {}".format(op.join(ds0.path, "two")),
             dataset=ds0.path)
-    ok_(ds0.repo.file_has_content("two"))
+    ok_exists(op.join(ds0.path, "two"))
     assert_repo_status(ds0.path)
 
     # ... producing output file in specified dataset and passing output file as
@@ -390,11 +390,12 @@ def test_run_path_semantics(path):
         out = op.join(ds0.path, "three")
         run("cd .> {}".format(out), dataset=ds0.path, explicit=True,
             outputs=[op.relpath(out, ds1_subdir)])
-    ok_(ds0.repo.file_has_content("three"))
+    ok_exists(op.join(ds0.path, "three"))
     assert_repo_status(ds0.path)
 
     # ... producing output file outside of specified dataset, leaving it
     # untracked in the other dataset
+    assert_repo_status(ds1.path)
     with chpwd(ds1_subdir):
         run("cd .> four", dataset=ds0.path)
     assert_repo_status(ds1.path, untracked=[ds1_subdir])
@@ -403,5 +404,5 @@ def test_run_path_semantics(path):
     # for the run is the specified dataset.
     with chpwd(ds1_subdir):
         run("cd .> five", dataset=ds0)
-    ok_(ds0.repo.file_has_content("five"))
+    ok_exists(op.join(ds0.path, "five"))
     assert_repo_status(ds0.path)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -351,3 +351,57 @@ def test_run_cmdline_disambiguation(path):
                 main(["datalad", "run", "--", "echo", "--version"])
             exec_cmd.assert_called_once_with(
                 "echo --version", path, expected_exit=None)
+
+
+@with_tempfile(mkdir=True)
+def test_run_path_semantics(path):
+    # Test that we follow path resolution from gh-3435: paths are relative to
+    # dataset if a dataset instance is given and relative to the current
+    # working directory otherwise.
+
+    ds0 = Dataset(op.join(path, "ds0")).create()
+    ds0_subdir = op.join(ds0.path, "s0")
+    os.mkdir(ds0_subdir)
+
+    # Although not useful, we can specify `dataset` as a string that lines up
+    # with the one from the current directory.
+    with chpwd(ds0_subdir):
+        run("cd .> one", dataset="..")
+        run("cd .> one", outputs=["one"], dataset=ds0.path)
+    ok_(ds0.repo.file_has_content(op.join(ds0_subdir, "one")))
+    assert_repo_status(ds0.path)
+
+    # Specify string dataset argument, running from another dataset ...
+
+    ds1 = Dataset(op.join(path, "ds1")).create()
+    ds1_subdir = op.join(ds1.path, "s1")
+    os.mkdir(ds1_subdir)
+
+    # ... producing output file in specified dataset
+    with chpwd(ds1_subdir):
+        run("cd .> {}".format(op.join(ds0.path, "two")),
+            dataset=ds0.path)
+    ok_(ds0.repo.file_has_content("two"))
+    assert_repo_status(ds0.path)
+
+    # ... producing output file in specified dataset and passing output file as
+    # relative to current directory
+    with chpwd(ds1_subdir):
+        out = op.join(ds0.path, "three")
+        run("cd .> {}".format(out), dataset=ds0.path, explicit=True,
+            outputs=[op.relpath(out, ds1_subdir)])
+    ok_(ds0.repo.file_has_content("three"))
+    assert_repo_status(ds0.path)
+
+    # ... producing output file outside of specified dataset, leaving it
+    # untracked in the other dataset
+    with chpwd(ds1_subdir):
+        run("cd .> four", dataset=ds0.path)
+    assert_repo_status(ds1.path, untracked=[ds1_subdir])
+
+    # If we repeat above with an instance instead of the string, the directory
+    # for the run is the specified dataset.
+    with chpwd(ds1_subdir):
+        run("cd .> five", dataset=ds0)
+    ok_(ds0.repo.file_has_content("five"))
+    assert_repo_status(ds0.path)

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -299,7 +299,7 @@ class Add(Interface):
             discovered = {}
             discover_dataset_trace_to_targets(
                 # from here
-                dataset.path,
+                dataset.path if isinstance(dataset, Dataset) else dataset,
                 # to any dataset we are aware of
                 subds_to_add.keys(),
                 [],

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -668,10 +668,10 @@ class Publish(Interface):
         #    # act on the whole dataset if nothing else was specified
         #    path = dataset.path if isinstance(dataset, Dataset) else dataset
 
-        if not dataset and not path:
+        if not (isinstance(dataset, Dataset) or (dataset is None and path)):
             # try to find a dataset in PWD
             dataset = require_dataset(
-                None, check_installed=True, purpose='publishing')
+                dataset, check_installed=True, purpose='publishing')
 
         if since and not dataset:
             raise InsufficientArgumentsError(

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -459,3 +459,13 @@ def test_bf2541(path):
     with chpwd(ds.path):
         res = add('.', recursive=True)
     ok_clean_git(ds.path)
+
+
+@with_tree(tree={'foobert': ''})
+def test_add_string_dataset_arg(path):
+    ds = create(path, force=True)
+    assert_repo_status(ds.path, untracked=["foobert"])
+    # We don't fail if a string, rather than dataset instance, is passed.
+    with chpwd(ds.path):
+        add(dataset=".", path=".")
+    assert_repo_status(ds.path)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -388,6 +388,9 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     assert_status(('ok', 'notneeded'), res_)
     assert_result_count(res_, 1, status='ok', path=source.path, type='dataset')
 
+    # Don't fail when a string is passed as `dataset` and since="".
+    assert_status("notneeded", publish(since='', dataset=source.path))
+
 
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -132,12 +132,12 @@ class NoAnnex(Interface):
                 return
 
         gitattr_file = opj(gitattr_dir, '.gitattributes')
-        dataset.repo.set_gitattributes(
+        ds.repo.set_gitattributes(
             [(p, {'annex.largefiles': 'nothing'}) for p in pattern],
             attrfile=gitattr_file)
         yield dict(res_kwargs, status='ok')
 
-        for r in dataset.save(
+        for r in ds.save(
                 gitattr_file,
                 to_git=True,
                 message="[DATALAD] exclude paths from annex'ing",

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -166,7 +166,7 @@ def test_no_annex(path):
          'README': 'please'})
     # add inannex pre configuration
     ds.save(opj('code', 'inannex'))
-    no_annex(pattern=['code/**', 'README'], dataset=ds)
+    no_annex(pattern=['code/**', 'README'], dataset=ds.path)
     # add inannex and README post configuration
     ds.save([opj('code', 'notinannex'), 'README'])
     ok_clean_git(ds.path)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1788,39 +1788,6 @@ def get_dataset_root(path):
     return None
 
 
-def get_dataset_pwds(dataset):
-    """Return the current directory for the dataset.
-
-    Parameters
-    ----------
-    dataset : Dataset
-
-    Returns
-    -------
-    A tuple, where the first item is the absolute path of the pwd and the
-    second is the pwd relative to the dataset's path.
-    """
-    if dataset:
-        pwd = dataset.path
-        rel_pwd = curdir
-    else:
-        # act on the whole dataset if nothing else was specified
-
-        # Follow our generic semantic that if dataset is specified,
-        # paths are relative to it, if not -- relative to pwd
-        pwd = getpwd()
-        # Pass pwd to get_dataset_root instead of os.path.curdir to handle
-        # repos whose leading paths have a symlinked directory (see the
-        # TMPDIR="/var/tmp/sym link" test case).
-        dataset = get_dataset_root(pwd)
-
-        if dataset:
-            rel_pwd = relpath(pwd, dataset)
-        else:
-            rel_pwd = pwd  # and leave handling to caller
-    return pwd, rel_pwd
-
-
 # ATM used in datalad_crawler extension, so do not remove yet
 def try_multiple(ntrials, exception, base, f, *args, **kwargs):
     """Call f multiple times making exponentially growing delay between the calls"""


### PR DESCRIPTION
I noticed that `add -d.` was failing from the command line because the code assumes `dataset` comes in as an instance.  (It doesn't as of fc25ac55d.)  Since we've hit into similar issues (gh-3488 and gh-3471), I tried to do a more thorough pass of the commands.  (Ideally we would test the string dataset case for each command that takes a `dataset` argument, but for now I just checked with manual testing and code inspection.)  That caught issues in `publish` and `no_annex`.  And as mentioned in gh-3471, `run` also needs an update for the new path handling.

This PR addresses these "dataset now can come in as a string" issues, as well as updates `run` to follow the relative path handling described in gh-3435.

<details>
<summary>Inspected commands</summary>

#### Resolved by previous PRs

- [X] datalad/core/local/create.py
  gh-3488
- [X] datalad/interface/download_url.py
  gh-3471

#### Fixed by this PR

- [X] datalad/core/local/run.py
- [X] datalad/distribution/add.py
- [X] datalad/distribution/publish.py
- [X] datalad/plugin/no_annex.py

#### Checked and look ok

- [X] datalad/core/local/save.py
- [X] datalad/core/local/status.py
- [X] datalad/distributed/create_sibling_gitlab.py
- [X] datalad/distribution/clone.py
- [X] datalad/distribution/create_sibling_github.py
- [X] datalad/distribution/create_sibling.py
- [X] datalad/distribution/drop.py
- [X] datalad/distribution/get.py
- [X] datalad/distribution/install.py
- [X] datalad/distribution/remove.py
- [X] datalad/distribution/siblings.py
- [X] datalad/distribution/uninstall.py
- [X] datalad/distribution/update.py
- [X] datalad/interface/annotate_paths.py
- [X] datalad/interface/clean.py
- [X] datalad/interface/diff.py
  unexposed and only callers use with dataset instance
- [X] datalad/interface/rerun.py
- [X] datalad/interface/run_procedure.py
- [X] datalad/interface/save.py
  unsure but is unexposed and obsolete, with only callers using as
  bound method
- [X] datalad/interface/unlock.py
- [X] datalad/local/subdatasets.py
- [X] datalad/metadata/aggregate.py
- [X] datalad/metadata/extract_metadata.py
- [X] datalad/metadata/metadata.py
- [X] datalad/metadata/search.py
- [X] datalad/plugin/add_readme.py
- [X] datalad/plugin/addurls.py
- [X] datalad/plugin/export_archive.py
- [X] datalad/plugin/export_to_figshare.py
- [X] datalad/plugin/wtf.py

</details>