### PR TITLE
BF: Make load_stream() not stumble over U2028 and friends

### DIFF
--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -148,6 +148,8 @@ def load_stream(fname, compressed=None):
                 cont_line = line
             yield loads(cont_line)
             cont_line = u''
+        if cont_line:  # The last line didn't end with a new line.
+            yield cont_line
 
 
 def load_xzstream(fname):

--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -137,8 +137,17 @@ def load_stream(fname, compressed=None):
 
     with _open(fname, mode='rb') as f:
         jreader = codecs.getreader('utf-8')(f)
+        cont_line = u''
         for line in jreader:
-            yield loads(line)
+            if not line.endswith('\n'):
+                cont_line += line
+                continue
+            if cont_line:
+                cont_line += line
+            else:
+                cont_line = line
+            yield loads(cont_line)
+            cont_line = u''
 
 
 def load_xzstream(fname):

--- a/datalad/support/tests/test_json_py.py
+++ b/datalad/support/tests/test_json_py.py
@@ -1,4 +1,4 @@
-# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-; coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
@@ -37,6 +37,16 @@ def test_load_screwy_unicode(fname):
     with swallow_logs(new_level=logging.WARNING) as cml:
         eq_(load(fname), {'Authors': ['A1', 'A2']})
         assert_in('Failed to decode content', cml.out)
+
+
+@with_tempfile(content=u"""\
+{"key0": "a b"}
+{"key1": "plain"}""".encode("utf-8"))
+def test_load_unicode_line_separator(fname):
+    # See gh-3523.
+    result = list(load_stream(fname))
+    eq_(len(result), 2)
+    eq_(result[0]["key0"], u"a b")
 
 
 def test_loads():


### PR DESCRIPTION
Fixes gh-3523

Sadly, we still butcher unicode somewhere on the way from loading it in as metadata and spitting it out as a result.

Here is a dataset that has `run` records to obtain metadata, and has aggregated metadata that demos the butchered result: https://github.com/datalad-datasets/longnow-podcasts