### PR TITLE
PY3: safeguard __del__ in Annex and Git Repo to not breed useless exceptions

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -356,7 +356,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             are no longer bound"""
             try:
                 return lgr.debug(exc_str(e))
-            except AttributeError:
+            except (AttributeError, NameError):
                 return
 
         try:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -350,6 +350,15 @@ class AnnexRepo(GitRepo, RepoInterface):
             self.config.set('annex.backends', backend, where='local')
 
     def __del__(self):
+
+        def safe__del__debug(e):
+            """We might be too late in the game and either .debug or exc_str
+            are no longer bound"""
+            try:
+                return lgr.debug(exc_str(e))
+            except AttributeError:
+                return
+
         try:
             if hasattr(self, '_batched') and self._batched is not None:
                 self._batched.close()
@@ -362,12 +371,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             # thing to happen, since we check for things being None herein as
             # well as in super class __del__;
             # At least log it:
-            lgr.debug(exc_str(e))
+            safe__del__debug(e)
         try:
             super(AnnexRepo, self).__del__()
         except TypeError as e:
             # see above
-            lgr.debug(exc_str(e))
+            safe__del__debug(e)
 
     def _set_shared_connection(self, remote_name, url):
         """Make sure a remote with SSH URL uses shared connections.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -941,8 +941,8 @@ class GitRepo(RepoInterface):
                 # denied etc. So disabled 
                 #if exists(opj(self.path, '.git')):  # don't try to write otherwise
                 #    self.repo.index.write()
-        except InvalidGitRepositoryError:
-            # might have being removed and no longer valid
+        except (InvalidGitRepositoryError, AttributeError):
+            # might have being removed and no longer valid or attributes unbound
             pass
 
     def __repr__(self):


### PR DESCRIPTION
as e.g. reported in https://github.com/datalad/datalad-crawler/issues/47
