### PR TITLE
Remove repo.git.CMD usage outside of repo modules

### DIFF
--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -402,11 +402,10 @@ def test_create_fake_dates(path):
     # Another instance detects the fake date configuration.
     ok_(Dataset(path).repo.fake_dates_enabled)
 
-    first_commit = ds.repo.repo.commit(
-        ds.repo.get_revisions(options=["--reverse", "--all"])[0])
+    first_commit = ds.repo.get_revisions(options=["--reverse", "--all"])[0]
 
     eq_(ds.config.obtain("datalad.fake-dates-start") + 1,
-        first_commit.committed_date)
+        int(ds.repo.format_commit("%ct", first_commit)))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -403,7 +403,7 @@ def test_create_fake_dates(path):
     ok_(Dataset(path).repo.fake_dates_enabled)
 
     first_commit = ds.repo.repo.commit(
-        ds.repo.repo.git.rev_list("--reverse", "--all").split()[0])
+        ds.repo.get_revisions(options=["--reverse", "--all"])[0])
 
     eq_(ds.config.obtain("datalad.fake-dates-start") + 1,
         first_commit.committed_date)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -144,7 +144,7 @@ def test_save_message_file(path):
                        "msg": "add foo"})
     ds.repo.add("foo")
     ds.save(message_file=op.join(ds.path, "msg"))
-    eq_(ds.repo.repo.git.show("--format=%s", "--no-patch"),
+    eq_(ds.repo.format_commit("%s"),
         "add foo")
 
 

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -285,7 +285,7 @@ def test_remove_file_handle_only(path):
     ok_(exists(path_two))
     # remove one handle, should not affect the other
     ds.remove('two', check=False, message="custom msg")
-    eq_(ds.repo.repo.head.commit.message.rstrip(), "custom msg")
+    eq_(ds.repo.format_commit("%B").rstrip(), "custom msg")
     eq_(rpath_one, realpath(opj(ds.path, 'one')))
     ok_(exists(rpath_one))
     ok_(not exists(path_two))

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -232,7 +232,7 @@ class Rerun(Interface):
         else:
             revrange = "{}..{}".format(since, revision)
 
-        if ds.repo.repo.git.rev_list("--merges", revrange, "--"):
+        if ds.repo.get_revisions(revrange, options=["--merges"]):
             yield get_status_dict(
                 "run", ds=ds, status="error",
                 message="cannot rerun history with merge commits")
@@ -273,7 +273,7 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
     In the standard case, the information in these results will be used to
     actually re-execute the commands.
     """
-    revs = dset.repo.repo.git.rev_list("--reverse", revrange, "--").split()
+    revs = dset.repo.get_revisions(revrange, options=["--reverse"])
     try:
         results = _revs_as_results(dset, revs)
     except ValueError as exc:

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -222,7 +222,7 @@ def test_get_modified_subpaths(path):
     ds.save(recursive=True)
     ok_clean_git(path)
 
-    orig_base_commit = ds.repo.repo.commit().hexsha
+    orig_base_commit = ds.repo.get_hexsha()
 
     # nothing was modified compared to the status quo, output must be empty
     eq_([],

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -99,7 +99,7 @@ def test_rerun(path, nodspath):
     eq_('xx\n', open(probe_path).read())
 
     # Rerunning from a subdataset skips the command.
-    _, sub_info = get_run_info(ds, sub.repo.repo.head.commit.message)
+    _, sub_info = get_run_info(ds, sub.repo.format_commit("%B"))
     eq_(ds.id, sub_info["dsid"])
     assert_result_count(
         sub.rerun(return_type="list", on_failure="ignore"),

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -269,7 +269,7 @@ def test_rerun_just_one_commit(path):
     # Check out an orphan branch so that we can test the "one commit
     # in a repo" case.
     ds.repo.checkout("orph", options=["--orphan"])
-    ds.repo.repo.git.reset("--hard")
+    ds.repo._git_custom_command(None, ["git", "reset", "--hard"])
     ds.repo.config.reload()
 
     ds.run('echo static-content > static')
@@ -695,7 +695,7 @@ def test_run_inputs_outputs(src, path):
             eq_(fh.read(), " appended\n" )
 
     # --input can be combined with --output.
-    ds.repo.repo.git.reset("--hard", "HEAD~2")
+    ds.repo._git_custom_command(None, ["git", "reset", "--hard", "HEAD~2"])
     ds.run("echo ' appended' >>a.dat", inputs=["a.dat"], outputs=["a.dat"])
     if not on_windows:
         # MIH doesn't yet understand how to port this

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -203,8 +203,7 @@ def test_rerun_onto(path):
          ds.repo.get_hexsha("static"))
     ok_(all(r["state"] == "clean" for r in ds.diff(fr="HEAD", to="static")))
     for revrange in ["..static", "static.."]:
-        assert_result_count(
-            ds.repo.repo.git.rev_list(revrange).split(), 1)
+        eq_(len(ds.repo.repo.git.rev_list(revrange).split()), 1)
 
     # Unlike the static change, if we run the ever-growing change on
     # top of itself, we end up with a new commit.
@@ -220,8 +219,7 @@ def test_rerun_onto(path):
         ds.rerun(since="static^", onto="")
     ok_(ds.repo.get_active_branch() is None)
     for revrange in ["..master", "master.."]:
-        assert_result_count(
-            ds.repo.repo.git.rev_list(revrange).split(), 3)
+        eq_(len(ds.repo.repo.git.rev_list(revrange).split()), 3)
 
     # An empty `onto` means use the parent of the first revision that
     # has a run command.
@@ -275,13 +273,13 @@ def test_rerun_just_one_commit(path):
     ds.repo.config.reload()
 
     ds.run('echo static-content > static')
-    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+    eq_(len(ds.repo.repo.git.rev_list("HEAD").split()), 1)
 
     # Rerunning with just one commit doesn't raise an error ...
     ds.rerun()
     # ... but we're still at one commit because the content didn't
     # change.
-    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+    eq_(len(ds.repo.repo.git.rev_list("HEAD").split()), 1)
 
     # We abort rather than trying to do anything when --onto='' and
     # --since='' are given together and the first commit contains a
@@ -382,8 +380,7 @@ def test_rerun_branch(path):
     # parent commit that is used to generate the commit ID may be set when
     # running the tests, which would result in two commits rather than three.
     for revrange in ["rerun..master", "master..rerun"]:
-        assert_result_count(
-            ds.repo.repo.git.rev_list(revrange).split(), 3)
+        eq_(len(ds.repo.repo.git.rev_list(revrange).split()), 3)
     eq_(ds.repo.get_merge_base(["master", "rerun"]),
         ds.repo.get_hexsha("prerun"))
 
@@ -393,10 +390,8 @@ def test_rerun_branch(path):
     eq_(ds.repo.get_active_branch(), "rerun2")
     eq_('xxxx\n', open(outfile).read())
 
-    assert_result_count(
-        ds.repo.repo.git.rev_list("master..rerun2").split(), 2)
-    assert_result_count(
-        ds.repo.repo.git.rev_list("rerun2..master").split(), 0)
+    eq_(len(ds.repo.repo.git.rev_list("master..rerun2").split()), 2)
+    eq_(len(ds.repo.repo.git.rev_list("rerun2..master").split()), 0)
 
     # Using an existing branch name fails.
     ds.repo.checkout("master")
@@ -509,7 +504,7 @@ def test_new_or_modified(path):
     ds.repo.checkout("orph", options=["--orphan"])
     ds.save()
     assert_false(ds.repo.dirty)
-    assert_result_count(ds.repo.repo.git.rev_list("HEAD").split(), 1)
+    eq_(len(ds.repo.repo.git.rev_list("HEAD").split()), 1)
     # Diffing doesn't fail when the branch contains a single commit.
     assert_in("to_modify", get_new_or_modified(ds, "HEAD"))
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -362,8 +362,7 @@ class TestAddurls(object):
         ds = Dataset(path).create(force=True)
 
         def get_annex_commit_counts():
-            return int(
-                ds.repo.repo.git.rev_list("--count", "git-annex").strip())
+            return len(ds.repo.get_revisions("git-annex"))
 
         n_annex_commits = get_annex_commit_counts()
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1511,6 +1511,40 @@ class GitRepo(RepoInterface):
                 return None
             raise
 
+    def get_revisions(self, revrange=None, fmt="%H", options=None):
+        """Return list of revisions in `revrange`.
+
+        Parameters
+        ----------
+        revrange : str or list of str or None, optional
+            Revisions or revision ranges to walk. If None, revision defaults to
+            HEAD unless a revision-modifying option like `--all` or
+            `--branches` is included in `options`.
+        fmt : string, optional
+            Format accepted by `--format` option of `git log`. This should not
+            contain new lines because the output is split on new lines.
+        options : list of str, optional
+            Options to pass to `git log`.  This should not include `--format`.
+
+        Returns
+        -------
+        List of revisions (str), formatted according to `fmt`.
+        """
+        if revrange is None:
+            revrange = []
+        elif isinstance(revrange, string_types):
+            revrange = [revrange]
+
+        cmd = ["git", "log", "--format={}".format(fmt)]
+        cmd.extend((options or []) + revrange + ["--"])
+        try:
+            stdout, _ = self._git_custom_command(None, cmd, expect_fail=True)
+        except CommandError as e:
+            if "does not have any commits" in e.stderr:
+                return []
+            raise
+        return stdout.splitlines()
+
     def commit_exists(self, commitish):
         """Does `commitish` exist in the repo?
 

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -195,10 +195,11 @@ def tag_dates(repo, pattern=""):
     -------
     A generator object that returns a tuple with the tag hexsha and timestamp.
     """
-    lines = repo.repo.git.for_each_ref(
-        "refs/tags/" + pattern,
-        format="%(objectname) %(taggerdate:raw)").splitlines()
-    for line in lines:
+    out, _ = repo._git_custom_command(
+        None,
+        ["git", "for-each-ref", "--format=%(objectname) %(taggerdate:raw)"
+         "refs/tags/" + pattern])
+    for line in out.splitlines():
         fields = line.split()
         if len(fields) != 3:
             # There's not a tagger date. It's not an annotated tag.

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -188,12 +188,12 @@ def log_dates(repo, revs=None):
     A generator object that returns a tuple with the commit hexsha, author
     timestamp, and committer timestamp.
     """
-    revs = revs or ["--branches"]
+    opts = [] if revs else ["--branches"]
     try:
-        for line in repo.repo.git.log(*revs, format="%H %at %ct").splitlines():
+        for line in repo.get_revisions(revs, fmt="%H %at %ct", options=opts):
             hexsha, author_timestamp, committer_timestamp = line.split()
             yield hexsha, int(author_timestamp), int(committer_timestamp)
-    except GitCommandError as e:
+    except CommandError as e:
         # With some Git versions, calling `git log --{all,branches,remotes}` in
         # a repo with no commits may signal an error.
         if "does not have any commits yet" not in e.stderr:

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -112,8 +112,8 @@ def branch_blobs_in_tree(repo, branch):
     entry per blob is yielded).
     """
     seen_blobs = set()
-    git = repo.repo.git
-    out = git.ls_tree(branch, z=True, r=True)
+    out, _ = repo._git_custom_command(
+        None, ["git", "ls-tree", "-z", "-r", branch])
     if out:
         lines = out.strip("\0").split("\0")
         num_lines = len(lines)

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -39,9 +39,10 @@ def branch_blobs(repo, branch):
     git = repo.repo.git
     # Note: This might be nicer with rev-list's --filter and
     # --filter-print-omitted, but those aren't available until Git v2.16.
-    lines = git.rev_list(branch, objects=True).splitlines()
+    out_rev, _ = repo._git_custom_command(
+        None, ["git", "rev-list", "--objects"] + [branch])
     # Trees and blobs have an associated path printed.
-    objects = (ln.split() for ln in lines)
+    objects = (ln.split() for ln in out_rev.splitlines())
     blob_trees = [obj for obj in objects if len(obj) == 2]
 
     num_objects = len(blob_trees)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1994,7 +1994,9 @@ def test_fake_dates(path):
     for commit in ar.get_branch_commits("git-annex"):
         eq_(timestamp, commit.committed_date)
     assert_in("timestamp={}s".format(timestamp),
-              ar.repo.git.cat_file("blob", "git-annex:uuid.log"))
+              ar._git_custom_command(
+                  None,
+                  ["git", "cat-file", "blob", "git-annex:uuid.log"])[0])
 
 
 def test_get_size_from_perc_complete():

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1502,3 +1502,46 @@ def test_duecredit(path):
         assert_in('Data management and distribution platform', outs)
     else:
         eq_(outs, '')
+
+
+@with_tempfile(mkdir=True)
+def test_GitRepo_get_revisions(path):
+    gr = GitRepo(path, create=True)
+
+    def commit(msg):
+        gr.commit(msg=msg, options=["--allow-empty"])
+
+    # We catch the error and return empty if the current branch doesn't have a
+    # commit checked out.
+    eq_(gr.get_revisions(), [])
+
+    # But will raise if on a bad ref name, including an unborn branch.
+    with assert_raises(CommandError):
+        gr.get_revisions("master")
+
+    # By default, we query HEAD.
+    commit("1")
+    eq_(len(gr.get_revisions()), 1)
+
+    gr.checkout("other", options=["-b"])
+    commit("2")
+
+    # We can also query branch by name.
+    eq_(len(gr.get_revisions("master")), 1)
+    eq_(len(gr.get_revisions("other")), 2)
+
+    # "name" is sugar for ["name"].
+    eq_(gr.get_revisions("master"),
+        gr.get_revisions(["master"]))
+
+    gr.checkout("master")
+    commit("3")
+    eq_(len(gr.get_revisions("master")), 2)
+    # We can pass multiple revisions...
+    eq_(len(gr.get_revisions(["master", "other"])), 3)
+    # ... or options like --all and --branches
+    eq_(gr.get_revisions(["master", "other"]),
+        gr.get_revisions(options=["--all"]))
+
+    # Ranges are supported.
+    eq_(gr.get_revisions("master.."), [])

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -252,7 +252,7 @@ def test_GitRepo_commit(path):
     gr.commit("Testing GitRepo.commit().")
     ok_clean_git(gr)
     eq_("Testing GitRepo.commit().{}".format(linesep),
-        gr.repo.head.commit.message)
+        gr.format_commit("%B"))
 
     with open(op.join(path, filename), 'w') as f:
         f.write("changed content")

--- a/datalad/support/tests/utils.py
+++ b/datalad/support/tests/utils.py
@@ -21,7 +21,7 @@ def check_repo_deals_with_inode_change(class_, path, temp_store):
     repo.commit(msg="some load")
 
     # requesting HEAD info from
-    hexsha = repo.repo.head.object.hexsha
+    hexsha = repo.get_hexsha()
 
     # move everything to store
     import os
@@ -50,9 +50,9 @@ def check_repo_deals_with_inode_change(class_, path, temp_store):
 
     # The following two accesses fail in issue #1512:
     # 1. requesting HEAD info from old instance
-    hexsha = repo.repo.head.object.hexsha
+    hexsha = repo.get_hexsha()
 
     # 2. get a "new" instance and requesting HEAD
     repo2 = class_(path)
-    hexsha2 = repo2.repo.head.object.hexsha
+    hexsha2 = repo2.get_hexsha()
 


### PR DESCRIPTION
Prompted by renewed interest in `git worktree` compatibility (gh-3528), this is a second round of GitPython pruning (following gh-2902).  It removes all uses of `repo.git.CMD` outside of `{git,annex}repo.py`.  It also does a few other easy replacements of things like `.hexsha`, but there are still places that GitPython is used outside of the repo classes.  I'll update the checkboxes at gh-2879.
