### PR TITLE
ENH(TST,BK): test_v7_detached_get to excercise a fixed in recent (7.20190708+git36-g32d526164-1) annex

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -66,6 +66,7 @@ from datalad.tests.utils import assert_not_equal
 from datalad.tests.utils import assert_equal
 from datalad.tests.utils import assert_true
 from datalad.tests.utils import eq_
+from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_git_config_not_empty
 from datalad.tests.utils import ok_annex_get
@@ -967,6 +968,7 @@ def test_AnnexRepo_get(src, dst):
     ok_file_has_content(testfile_abs, "content to be annex-addurl'd", strip=True)
 
 
+@known_failure_direct_mode  #FIXME https://github.com/datalad/datalad/pull/3542#issuecomment-513791662
 @with_tree(tree={'file.dat': 'content'})
 @with_tempfile
 def test_v7_detached_get(opath, path):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -967,6 +967,24 @@ def test_AnnexRepo_get(src, dst):
     ok_file_has_content(testfile_abs, "content to be annex-addurl'd", strip=True)
 
 
+@with_tree(tree={'file.dat': 'content'})
+@with_tempfile
+def test_v7_detached_get(opath, path):
+    # http://git-annex.branchable.com/bugs/get_fails_to_place_v7_unlocked_file_content_into_the_file_tree_in_v7_in_repo_with_detached_HEAD/
+    origin = AnnexRepo(opath, create=True, version=7)
+    GitRepo.add(origin, 'file.dat')  # force direct `git add` invocation
+    origin.commit('added')
+
+    AnnexRepo.clone(opath, path)
+    repo = AnnexRepo(path)
+    # test getting in a detached HEAD
+    repo.checkout('HEAD^{}')
+    repo._run_annex_command('upgrade')  # TODO: .upgrade ?
+
+    repo.get('file.dat')
+    ok_file_has_content(op.join(repo.path, 'file.dat'), "content")
+
+
 # TODO:
 #def init_remote(self, name, options):
 #def enable_remote(self, name):


### PR DESCRIPTION
Will fail first on travis, then whenever https://github.com/datalad/datalad/pull/3541 passes and I upload new annex to neurodebian proper, rerun the tests and should get green, and then we merge