### PR TITLE
BF: AnnexRepo to deal with INFO response from annex special remotes

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2160,6 +2160,25 @@ class AnnexRepo(GitRepo, RepoInterface):
                         "Received no json output for --json command, only:\n{}"
                         .format("  ".join(others)))
                 raise exc
+
+        # A special remote might send a message via "info". This is supposed to be printed by annex but in case of
+        # `--json` is returned by annex as "{'info': '<message>'}".
+        # See https://git-annex.branchable.com/design/external_special_remote_protocol/#index5h2
+        #
+        # So, Ben thinks we should just spit it out here, since everything calling _run_annex_command_json
+        # is concerned with the actual results being returned. More over, this kind of response is special to particular
+        # special remotes rather than particular annex commands. So, likely there's nothing callers could do about it
+        # other than spitting it out.
+
+        to_remove = []
+        for obj in json_objects:
+            if len(obj.keys()) == 1 and obj['info']:
+                lgr.info(obj['info'])
+                to_remove.append(obj)
+
+        for obj in to_remove:
+            json_objects.remove(obj)
+
         return json_objects
 
     # TODO: reconsider having any magic at all and maybe just return a list/dict always

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2170,16 +2170,14 @@ class AnnexRepo(GitRepo, RepoInterface):
         # special remotes rather than particular annex commands. So, likely there's nothing callers could do about it
         # other than spitting it out.
 
-        to_remove = []
+        return_objects = []
         for obj in json_objects:
             if len(obj.keys()) == 1 and obj['info']:
                 lgr.info(obj['info'])
-                to_remove.append(obj)
+            else:
+                return_objects.append(obj)
 
-        for obj in to_remove:
-            json_objects.remove(obj)
-
-        return json_objects
+        return return_objects
 
     # TODO: reconsider having any magic at all and maybe just return a list/dict always
     @normalize_paths


### PR DESCRIPTION
`AnnexRepo`, in particular `_run_annex_command_json`  didn't handle an INFO response from a special remote (see https://git-annex.branchable.com/design/external_special_remote_protocol/#index5h2).
Fixed that.

FTR: I won't implement an entire special remote just to fake some test herein. However, it will at least be implicitly tested by https://github.com/datalad/git-annex-ria-remote.
Meaning: I think it's fine if I didn't break anything ;-)



