### PR TITLE
create: Allow forcibly creating a subdataset

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -247,9 +247,9 @@ class Create(Interface):
                 untracked='no',
                 # limit query to target path for a potentially massive speed-up
                 paths=[check_path.relative_to(parentds_path)])
-            if any(
-                    check_path == p or check_path in p.parents
-                    for p in pstatus):
+            if (not pstatus.get(check_path, {}).get("type") == "dataset" and
+                any(check_path == p or check_path in p.parents
+                    for p in pstatus)):
                 # redo the check in a slower fashion, it is already broken
                 # let's take our time for a proper error message
                 conflict = [

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -263,24 +263,25 @@ class Create(Interface):
                         [text_type(c) for c in conflict])})
                 yield res
                 return
-            # another set of check to see whether the target path is pointing
-            # into a known subdataset that is not around ATM
-            subds_status = {
-                parentds_path / k.relative_to(prepo.path)
-                for k, v in iteritems(pstatus)
-                if v.get('type', None) == 'dataset'}
-            check_paths = [check_path]
-            check_paths.extend(check_path.parents)
-            if any(p in subds_status for p in check_paths):
-                conflict = [p for p in check_paths if p in subds_status]
-                res.update({
-                    'status': 'error',
-                    'message': (
-                        'collision with %s (dataset) in dataset %s',
-                        text_type(conflict[0]),
-                        text_type(parentds_path))})
-                yield res
-                return
+            if not force:
+                # another set of check to see whether the target path is pointing
+                # into a known subdataset that is not around ATM
+                subds_status = {
+                    parentds_path / k.relative_to(prepo.path)
+                    for k, v in iteritems(pstatus)
+                    if v.get('type', None) == 'dataset'}
+                check_paths = [check_path]
+                check_paths.extend(check_path.parents)
+                if any(p in subds_status for p in check_paths):
+                    conflict = [p for p in check_paths if p in subds_status]
+                    res.update({
+                        'status': 'error',
+                        'message': (
+                            'collision with %s (dataset) in dataset %s',
+                            text_type(conflict[0]),
+                            text_type(parentds_path))})
+                    yield res
+                    return
 
         # important to use the given Dataset object to avoid spurious ID
         # changes with not-yet-materialized Datasets

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -126,6 +126,26 @@ def test_create_raises(path, outside_path):
 
 
 @with_tempfile
+def test_create_force_subds(path):
+    ds = Dataset(path).create()
+    subds = ds.create("subds")
+    # We get an error when trying calling create in an existing subdataset
+    assert_in_results(
+        subds.create(force=False, **raw),
+        status="error")
+    # ... but we can force it
+    assert_in_results(
+        subds.create(force=True, **raw),
+        status="ok")
+    # ... even if it is uninstalled.
+    subds.uninstall()
+    ok_(not subds.is_installed())
+    assert_in_results(
+        subds.create(force=True, **raw),
+        status="ok")
+
+
+@with_tempfile
 @with_tempfile
 def test_create_curdir(path, path2):
     with chpwd(path, mkdir=True):

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -88,9 +88,9 @@ def test_create_raises(path, outside_path):
     assert_in_results(
         ds.create(obscure_ds, **raw),
         status='error',
-        message=('collision with content in parent dataset at %s: %s',
-                 ds.path,
-                 [text_type(ds.pathobj / obscure_ds)]),
+        message=('collision with %s (dataset) in dataset %s',
+                 text_type(ds.pathobj / obscure_ds),
+                 ds.path)
     )
 
     # now deinstall the sub and fail trying to create a new one at the
@@ -101,9 +101,9 @@ def test_create_raises(path, outside_path):
     assert_in_results(
         ds.create(obscure_ds, **raw),
         status='error',
-        message=('collision with content in parent dataset at %s: %s',
-                 ds.path,
-                 [text_type(ds.pathobj / obscure_ds)]),
+        message=('collision with %s (dataset) in dataset %s',
+                 text_type(ds.pathobj / obscure_ds),
+                 ds.path)
     )
     assert_in_results(
         ds.create(op.join(obscure_ds, 'subsub'), **raw),

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -117,9 +117,8 @@ def test_is_installed(src, path):
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, status='error', path=subds.path,
-        message=(
-            'collision with content in parent dataset at %s: %s',
-            ds.path, [subds.path]))
+        message=('collision with %s (dataset) in dataset %s',
+                 subds.path, ds.path))
     # get the submodule
     # This would init so there is a .git file with symlink info, which is
     # as we agreed is more pain than gain, so let's use our install which would


### PR DESCRIPTION
For top-level datasets, --force can be used to ignore the "is
empty directory?" check.  Make --force also disable the "is
subdataset?" check because this is consistent with the non-subdataset
behavior and was the behavior before the "rev-create -> create"
rewrite.

Fixes #3549.

---

I'm not sure that `create --force <existing subdataset>` is something we need to support, but I also don't see any harm in supporting it.
