### PR TITLE
addurls: Fixes to subpath handling

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -176,7 +176,7 @@ def get_subpaths(filename):
 
     spaths = []
     for part in filename.split("//")[:-1]:
-        path = os.path.join(*(spaths + [part]))
+        path = os.path.join(spaths[-1], part) if spaths else part
         spaths.append(path)
     return filename.replace("//", os.path.sep), spaths
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -373,6 +373,24 @@ def add_extra_filename_values(filename_format, rows, urls, dry_run):
                          "Finished requesting file names")
 
 
+def sort_paths(paths):
+    """Sort `paths` by directory level and then alphabetically.
+
+    Parameters
+    ----------
+    paths : iterable of str
+
+    Returns
+    -------
+    Generator of sorted paths.
+    """
+    def level_and_name(p):
+        return p.count(os.path.sep), p
+
+    for path in sorted(paths, key=level_and_name):
+        yield path
+
+
 def extract(stream, input_type, url_format="{0}", filename_format="{1}",
             exclude_autometa=None, meta=None,
             dry_run=False, missing_value=None):
@@ -440,7 +458,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
         RepFormatter(colidx_to_name, missing_value).format,
         filename_format)
     subpaths = _format_filenames(format_filename, rows_with_url, infos)
-    return infos, subpaths
+    return infos, list(sort_paths(subpaths))
 
 
 @with_result_progress("Adding URLs")

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -126,6 +126,11 @@ def test_get_subpaths():
             (op.join("p1//p2", "p3//n"),
              (op.join("p1", "p2", "p3", "n"),
               ["p1", op.join("p1", "p2", "p3")])),
+            (op.join("p1//p2", "p3//p4", "p5//", "n"),
+             (op.join("p1", "p2", "p3", "p4", "p5", "n"),
+              ["p1",
+               op.join("p1", "p2", "p3"),
+               op.join("p1", "p2", "p3", "p4", "p5")])),
             ("//n", (op.sep + "n", [""])),
             ("n//", ("n" + op.sep, ["n"]))]:
         eq_(au.get_subpaths(fname), expect)

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -12,6 +12,7 @@
 import json
 import logging
 import os
+import os.path as op
 import tempfile
 
 from mock import patch
@@ -117,12 +118,16 @@ def test_clean_meta_args():
 
 
 def test_get_subpaths():
-    for fname, expect in [("no/dbl/slash", ("no/dbl/slash", [])),
-                          ("p1//n", ("p1/n", ["p1"])),
-                          ("p1//p2/p3//n", ("p1/p2/p3/n",
-                                            ["p1", "p1/p2/p3"])),
-                          ("//n", ("/n", [""])),
-                          ("n//", ("n/", ["n"]))]:
+    for fname, expect in [
+            (op.join("no", "dbl", "slash"),
+             (op.join("no", "dbl", "slash"), [])),
+            ("p1//n",
+             (op.join("p1", "n"), ["p1"])),
+            (op.join("p1//p2", "p3//n"),
+             (op.join("p1", "p2", "p3", "n"),
+              ["p1", op.join("p1", "p2", "p3")])),
+            ("//n", (op.sep + "n", [""])),
+            ("n//", ("n" + op.sep, ["n"]))]:
         eq_(au.get_subpaths(fname), expect)
 
 


### PR DESCRIPTION
This series addresses the subdataset issues we hit on the last call.

The remaining issue discussed on that call was that it seemed like a subdirectory needed to exist for `annex addurl --file <subdir>/file`, but that's not the case when I test locally (either with `git annex addurl` or `datalad addurls`) and I don't see anything in annex's history that suggests that it was a recent change.  I think that might have actually been related to one of the issues here, but please provide details here if you can trigger it on your end.