### PR TITLE
ENH: addurls: Add --cfg-proc option that is passed to create()

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -692,6 +692,12 @@ class Addurls(Interface):
             action="store_true",
             doc="""Try to add a version ID to the URL. This currently only has
             an effect on URLs for AWS S3 buckets."""),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Pass this [PY: cfg_proc PY][CMD: --cfg_proc CMD] value when
+            calling `create` to make datasets."""),
     )
 
     @staticmethod
@@ -700,7 +706,8 @@ class Addurls(Interface):
     def __call__(dataset, urlfile, urlformat, filenameformat,
                  input_type="ext", exclude_autometa=None, meta=None,
                  message=None, dry_run=False, fast=False, ifexists=None,
-                 missing_value=None, save=True, version_urls=False):
+                 missing_value=None, save=True, version_urls=False,
+                 cfg_proc=None):
         # Temporarily work around gh-2269.
         url_file = urlfile
         url_format, filename_format = urlformat, filenameformat
@@ -766,7 +773,8 @@ class Addurls(Interface):
         if not dataset.repo:
             # Populate a new dataset with the URLs.
             for r in dataset.create(result_xfm=None,
-                                    return_type='generator'):
+                                    return_type='generator',
+                                    cfg_proc=cfg_proc):
                 yield r
 
         annex_options = ["--fast"] if fast else []
@@ -778,6 +786,7 @@ class Addurls(Interface):
                     spath)
             else:
                 for r in dataset.create(spath, result_xfm=None,
+                                        cfg_proc=cfg_proc,
                                         return_type='generator'):
                     yield r
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -415,8 +415,9 @@ class TestAddurls(object):
     @with_tempfile(mkdir=True)
     def test_addurls_create_newdataset(self, path):
         dspath = os.path.join(path, "ds")
-        addurls(dspath, self.json_file, "{url}", "{name}")
-        for fname in ["a", "b", "c"]:
+        addurls(dspath, self.json_file, "{url}", "{name}",
+                cfg_proc=["yoda"])
+        for fname in ["a", "b", "c", "code"]:
             ok_exists(os.path.join(dspath, fname))
 
     @with_tempfile(mkdir=True)
@@ -428,7 +429,8 @@ class TestAddurls(object):
                 label = "save" if save else "nosave"
                 ds.addurls(self.json_file, "{url}",
                            "{subdir}-" + label + "//{name}",
-                           save=save)
+                           save=save,
+                           cfg_proc=["yoda"])
 
                 subdirs = ["{}-{}".format(d, label) for d in ["foo", "bar"]]
                 subdir_files = dict(zip(subdirs, [["a", "c"], ["b"]]))
@@ -436,7 +438,8 @@ class TestAddurls(object):
                 for subds, fnames in subdir_files.items():
                     for fname in fnames:
                         ok_exists(op.join(subds, fname))
-
+                # cfg_proc was applied generated subdatasets.
+                ok_exists(op.join(subds, "code"))
                 if save:
                     assert_repo_status(path)
                 else:


### PR DESCRIPTION
This allows callers to perform arbitrary configuration of the
generated datasets.

---

- [x] add test