### PR TITLE
OPT: maintain cache of discovered subdatasets in the loop of annotate_paths

### DIFF
--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -563,6 +563,16 @@ class AnnotatePaths(Interface):
             # re-append the preserved paths:
             requested_paths = chain(requested_paths, iter(preserved_paths))
 
+        # Possibly to be used "cache" of known subdatasets per each parent
+        # to avoid re-querying subdatasets per each path.  The assumption here
+        # is that the list of sub-datasets for a given parent should not change
+        # through the execution of this loop, which (hypothetically) could be
+        # incorrect while annotating paths for some commands.
+        # TODO: verify this assumption and possibly add an argument to turn
+        #  caching off if/when needed, or provide some other way to invalidate
+        #  it
+        subdss_cache = {}
+
         # do not loop over unique(), this could be a list of dicts
         # we avoid duplicates manually below via `reported_paths`
         for path in requested_paths:
@@ -669,9 +679,15 @@ class AnnotatePaths(Interface):
                 # a dataset (without this info) -> record whether this is a known subdataset
                 # to its parent
                 containing_ds = Dataset(parent)
-                subdss = containing_ds.subdatasets(
-                    fulfilled=None, recursive=False,
-                    result_xfm=None, result_filter=None, return_type='list')
+                # Possibly "cache" the list of known subdss for parents we
+                # have encountered so far
+                if parent in subdss_cache:
+                    subdss = subdss_cache[parent]
+                else:
+                    subdss = containing_ds.subdatasets(
+                        fulfilled=None, recursive=False,
+                        result_xfm=None, result_filter=None, return_type='list')
+                    subdss_cache[parent] = subdss
                 if path in [s['path'] for s in subdss]:
                     if path_type == 'directory' or not lexists(path):
                         # first record that it isn't here, if just a dir or not here at all

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -10,6 +10,8 @@
 
 """
 
+import logging
+
 from datalad.tests.utils import known_failure_direct_mode
 
 from copy import deepcopy
@@ -27,6 +29,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import slow
+from datalad.tests.utils import swallow_logs
 
 
 from datalad.distribution.dataset import Dataset
@@ -105,6 +108,13 @@ def test_annotate_paths(dspath, nodspath):
             [{k: v for k, v in ap.items()
               if k not in ('registered_subds', 'raw_input', 'orig_request', 'refds')}
              for ap in annotate_paths(dataset='b', recursive=True)])
+
+        # when we point to a list of directories, there should be no
+        # multiple rediscoveries of the subdatasets
+        with swallow_logs(new_level=logging.DEBUG) as cml:
+            annotate_paths(path=['a', 'b'])
+            eq_(cml.out.count('Resolved dataset for subdataset reporting/modification'), 1)
+
     # now do it again, pointing to the ds directly
     res = ds.annotate_paths(on_failure='ignore')
     # no request, no refds, but otherwise the same


### PR DESCRIPTION
Otherwise there is a rediscovery of subdatasets for EVERY path provided to annotate_paths even when they all belong to the same parent dataset.

Closes: #3567 

TODOs:
- [x] verify that nothing is broken at least according to the tests.  As is mentioned in the code comment, because of its "generator" nature, if annotate_path is called from within some loop altering the list of submodules, cache could get invalidated.  If there is such a usage case we should probably add some kind of sensing of mtime for .gitmodules of the parent or add an explicit argument to not retain this cache, but then things will get slow again whenever not needed
- [x] see and report if any notable effect on benchmarks
- [x] verify that it helps in a real use case which "inspired" this fix
- (not here) we really should add a benchmark suite operating on a set of paths within a bigger dataset across a variety of commands
