### PR TITLE
OPT: use find --in ., not --in here to gain 3x speed up on some cases

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1383,7 +1383,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         if not key:
             expected_downloads, fetch_files = self._get_expected_files(
-                files, ['--not', '--in', 'here'],
+                files, ['--not', '--in', '.'],
                 merge_annex_branches=False  # interested only in local info
             )
         else:
@@ -2751,7 +2751,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 args.append('-)')
 
             if with_content_only:
-                args.extend(['--in', 'here'])
+                args.extend(['--in', '.'])
         out, err = self._run_annex_command(
             'find', annex_options=args, merge_annex_branches=False
         )
@@ -3296,7 +3296,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # is the verb (copy, copy) or (get, put) and remote ('here', remote)?
         if '--key' not in options:
             expected_copys, copy_files = self._get_expected_files(
-                files, ['--in', 'here', '--not', '--in', remote])
+                files, ['--in', '.', '--not', '--in', remote])
         else:
             copy_files = files
             assert(len(files) == 1)


### PR DESCRIPTION
Originally found while timing effects of a PR:
  https://github.com/datalad/datalad/pull/3570#issuecomment-517084987
Similar change is now done also on git-annex level in
  d1a0c7b16fcd41f74def394a55c32f67340670b7
but to not wait for its new release, adjusting our
find invocations

TODOs
- [x] verify nothing is broken
- [x] no effect on our existing benchmarks?
- [x] time up that use case in #3570