### PR TITLE
addurls: Fix handling of relative URL-FILE

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -22,7 +22,7 @@ from six import (
 )
 from six.moves.urllib.parse import urlparse
 
-from datalad.distribution.dataset import resolve_path
+from datalad.distribution.dataset import rev_resolve_path
 from datalad.dochelpers import exc_str
 from datalad.log import log_progress, with_result_progress
 from datalad.interface.base import Interface
@@ -762,7 +762,7 @@ class Addurls(Interface):
                                   message="not an annex repo")
             return
 
-        url_file = resolve_path(url_file, dataset)
+        url_file = text_type(rev_resolve_path(url_file, dataset))
 
         if input_type == "ext":
             extension = os.path.splitext(url_file)[1]

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -461,8 +461,8 @@ class TestAddurls(object):
                 for subds, fnames in subdir_files.items():
                     for fname in fnames:
                         ok_exists(op.join(subds, fname))
-                # cfg_proc was applied generated subdatasets.
-                ok_exists(op.join(subds, "code"))
+                    # cfg_proc was applied generated subdatasets.
+                    ok_exists(op.join(subds, "code"))
                 if save:
                     assert_repo_status(path)
                 else:

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -452,9 +452,9 @@ class TestAddurls(object):
         # The input file is relative to the current working directory, as
         # with other commands.
         check("subdir0", None, "in.json")
-        # The input file (without a leading "./") is relative to the dataset if
-        # any dataset argument is given, even a string.
-        check("subdir1", ds.path, op.join("subdir1", "in.json"))
+        # Likewise the input file is relative to the current working directory
+        # if a string dataset argument is given.
+        check("subdir1", ds.path, "in.json")
 
     @with_tempfile(mkdir=True)
     def test_addurls_create_newdataset(self, path):


### PR DESCRIPTION
Follow conventions (different on master and 0.11.x) for taking URL-FILE as relative to the specified dataset.

This PR is against master, but it has a 0.11.x component.  I've pushed that 0.11.x-based branch to a scratch branch so that we can check [its Travis build][tb].  If all looks good, I'll merge the 0.11.x-bits to 0.11.x after this PR is merged to master.

[tb]: https://travis-ci.org/datalad/datalad/builds/567119012

Closes #3580.