### PR TITLE
RF: remove: Replace interface.save with core.local.save

### DIFF
--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -292,7 +292,6 @@ class Remove(Interface):
             return
 
         for res in Save.__call__(
-                # TODO compose hand-selected annotated paths
                 path=[ap["path"] for ap in to_save],
                 # we might have removed the reference dataset by now, recheck
                 dataset=refds_path

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -37,7 +37,7 @@ from datalad.interface.utils import path_is_under
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
-from datalad.interface.save import Save
+from datalad.core.local.save import Save
 from datalad.distribution.drop import _drop_files
 from datalad.distribution.drop import dataset_argument
 from datalad.distribution.drop import check_argument
@@ -293,7 +293,7 @@ class Remove(Interface):
 
         for res in Save.__call__(
                 # TODO compose hand-selected annotated paths
-                path=to_save,
+                path=[ap["path"] for ap in to_save],
                 # we might have removed the reference dataset by now, recheck
                 dataset=refds_path
                         if (refds_path and GitRepo.is_valid_repo(refds_path))


### PR DESCRIPTION
rev_save() has been promoted to save(), but there are still a few
places where the obsolete save() is used.  One of these spots is
remove.py, where 1c49a1f2a (MNT: interface.save: Demote and mark
obsolete, 2019-05-14) claimed the old save() is needed because
annotated paths are passed as arguments.  But instead of punting until
annotate_paths() use is dropped from remove.py (gh-3368), we can make
the call compatible with the new save() by pulling out the paths from
the annotated paths record.

In addition to dropping the internal use of an obsolete command, this
avoids spurious warnings about removed files not existing.

Closes #3441.

---

I didn't find any failures with selective testing locally.  Let's see how the full Travis build goes.