### PR TITLE
BF: create: Run cfg procedures before saving reference dataset

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -425,6 +425,10 @@ class Create(Interface):
             _status=add_to_git,
         )
 
+        for cfg_proc_ in cfg_proc or []:
+            for r in tbds.run_procedure('cfg_' + cfg_proc_):
+                yield r
+
         # the next only makes sense if we saved the created dataset,
         # otherwise we have no committed state to be registered
         # in the parent
@@ -438,11 +442,6 @@ class Create(Interface):
 
         res.update({'status': 'ok'})
         yield res
-
-        for cfg_proc_ in cfg_proc or []:
-            for r in tbds.run_procedure('cfg_' + cfg_proc_):
-                yield r
-
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):  # pragma: more cover

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -409,7 +409,7 @@ def test_create_withcfg(path):
         dataset=path,
         cfg_proc=['yoda'])
     assert_repo_status(path)
-    assert((ds.pathobj / 'README.md').exists())
+    assert (ds.pathobj / 'README.md').exists()
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -411,6 +411,12 @@ def test_create_withcfg(path):
     assert_repo_status(path)
     assert (ds.pathobj / 'README.md').exists()
 
+    # If we are creating a dataset within a reference dataset, we save _after_
+    # the procedure runs.
+    ds.create('subds', cfg_proc=['yoda'])
+    assert_repo_status(path)
+    assert (ds.pathobj / 'subds' / 'README.md').exists()
+
 
 @with_tempfile(mkdir=True)
 def test_create_fake_dates(path):


### PR DESCRIPTION
When a dataset is explicitly specified together with a --cfg-proc
procedure, the created subdataset shows up as modified in the
reference dataset because cfg_* procedures create a commit with their
changes.  Save the reference dataset after running procedures so that
we register the up-to-date version of the subdataset.

Fixes #3591.
