### PR TITLE
RF+BF: make cookies db access/closing more robust

### DIFF
--- a/datalad/support/tests/test_cookies.py
+++ b/datalad/support/tests/test_cookies.py
@@ -36,4 +36,3 @@ def test_no_blows(cookiesdir):
     """
     rmtree(cookiesdir)
     cookies.close()
-    # cookies.close()

--- a/datalad/support/tests/test_cookies.py
+++ b/datalad/support/tests/test_cookies.py
@@ -34,5 +34,10 @@ def test_no_blows(cookiesdir):
 
     on Debian (python 3.7.3~rc1-1) I just get a warning: BDB3028 /home/yoh/.tmp/datalad_temp_test_no_blows58tdg67s/mycookies.db: unable to flush: No such file or directory
     """
-    rmtree(cookiesdir)
+    try:
+        rmtree(cookiesdir)
+    except OSError:
+        # on NFS directory might still be open, so .nfs* lock file would prevent
+        # removal, but it shouldn't matter and .close should succeed
+        pass
     cookies.close()

--- a/datalad/support/tests/test_cookies.py
+++ b/datalad/support/tests/test_cookies.py
@@ -1,0 +1,39 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from .. import path as op
+from ..cookies import CookiesDB
+from ...utils import rmtree
+from ...tests.utils import (
+    assert_equal,
+    with_tempfile,
+)
+
+
+@with_tempfile(mkdir=True)
+def test_no_blows(cookiesdir):
+    cookies = CookiesDB(op.join(cookiesdir, 'mycookies'))
+    # set the cookie
+    cookies['best'] = 'mine'
+    assert_equal(cookies['best'], 'mine')
+    """
+    Somehow this manages to trigger on conda but not on debian for me
+    File "/home/yoh/anaconda-2018.12-3.7/envs/test-gitpython/lib/python3.7/shelve.py", line 125, in __setitem__
+        self.dict[key.encode(self.keyencoding)] = f.getvalue()
+    File "/home/yoh/anaconda-2018.12-3.7/envs/test-gitpython/lib/python3.7/dbm/dumb.py", line 216, in __setitem__
+        self._index[key] = self._setval(pos, val)
+    File "/home/yoh/anaconda-2018.12-3.7/envs/test-gitpython/lib/python3.7/dbm/dumb.py", line 178, in _setval
+        with _io.open(self._datfile, 'rb+') as f:
+        FileNotFoundError: [Errno 2] No such file or directory: '/home/yoh/.tmp/datalad_temp_test_no_blowsalnsw_wk/mycookies.dat'
+
+    on Debian (python 3.7.3~rc1-1) I just get a warning: BDB3028 /home/yoh/.tmp/datalad_temp_test_no_blows58tdg67s/mycookies.db: unable to flush: No such file or directory
+    """
+    rmtree(cookiesdir)
+    cookies.close()
+    # cookies.close()


### PR DESCRIPTION
While running tests under some conda environment, there were errors while closing
cookies DB. Could not reproduce in the native Debian environment with similarishish
Python.  With these changes, cookies_db is a property so it gets properly
loadded before setting any value. And also we catch exceptions upon
close and report them as a warning if there were some cookies to store.

Unfortunately Python in conda env still prints directly the entire traceback, and
on Debian some error message even before throwing the exception so you could see something like

    $> DATALAD_LOG_LEVEL=INFO python -m nose -s -v datalad/support/tests/test_cookies.py
    datalad.support.tests.test_cookies.test_no_blows ... [WARNING] Failed to save possibly updated 1 cookies (best): [Errno 2] No such file or directory: '/home/yoh/.tmp/datalad_temp_test_no_blows1_rmfcb2/mycookies.dat' [dumb.py:_setval:178]
    Exception ignored in: <function _Database.close at 0x7f1fe46872f0>
    Traceback (most recent call last):
      File "/home/yoh/anaconda-2018.12-3.7/envs/test-gitpython/lib/python3.7/dbm/dumb.py", line 284, in close
        self._commit()
      File "/home/yoh/anaconda-2018.12-3.7/envs/test-gitpython/lib/python3.7/dbm/dumb.py", line 135, in _commit
        with self._io.open(self._dirfile, 'w', encoding="Latin-1") as f:
    FileNotFoundError: [Errno 2] No such file or directory: '/home/yoh/.tmp/datalad_temp_test_no_blows1_rmfcb2/mycookies.dir'
    ok

