### PR TITLE
RF+BF: make github tests skip if there is no vcr library

### DIFF
--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -57,7 +57,7 @@ def use_cassette(name, *args, **kwargs):
 
     TODO: RF local aspect so could be used in other places as well
     """
-    kwargs['skip_if_no_vcr'] = kwargs.get('skip_if_no_vcr', True)
+    kwargs.setdefault('skip_if_no_vcr', True)
     return use_cassette_(op.join(FIXTURES_PATH, name + '.yaml'), *args, **kwargs)
 
 

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -53,10 +53,11 @@ FIXTURES_PATH = op.join(op.dirname(__file__), 'vcr_cassettes')
 
 
 def use_cassette(name, *args, **kwargs):
-    """Adapter to store fixtures locally
+    """Adapter to store fixtures locally and skip if there is no vcr
 
-    TODO: RF so could be used in other places as well
+    TODO: RF local aspect so could be used in other places as well
     """
+    kwargs['skip_if_no_vcr'] = kwargs.get('skip_if_no_vcr', True)
     return use_cassette_(op.join(FIXTURES_PATH, name + '.yaml'), *args, **kwargs)
 
 


### PR DESCRIPTION
Since we are providing fake token they have no chance to work correctly
if there is no vcr library.  So better to skip those tests if no vcr library.

I have ran into it while running  datalad test  on datalad installed in
conda, but without having all test requirements installed
