### PR TITLE
sshrun: Provide all expected GIT_SSH_COMMAND parameters

### DIFF
--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -103,7 +103,7 @@ class SSHConnection(object):
         self._remote_props = {}
         self._opened_by_us = False
 
-    def __call__(self, cmd, stdin=None, log_output=True):
+    def __call__(self, cmd, options=None, stdin=None, log_output=True):
         """Executes a command on the remote.
 
         It is the callers responsibility to properly quote commands
@@ -114,6 +114,11 @@ class SSHConnection(object):
         ----------
         cmd: str
           command to run on the remote
+        options : list of str, optional
+          Additional options to pass to the `-o` flag of `ssh`. Note: Many
+          (probably most) of the available configuration options should not be
+          set here because they can critically change the properties of the
+          connection. This exists to allow options like SendEnv to be set.
 
         Returns
         -------
@@ -144,6 +149,9 @@ class SSHConnection(object):
         # we cannot perform any sort of escaping, because it will limit
         # what we can do on the remote, e.g. concatenate commands with '&&'
         ssh_cmd = ["ssh"] + self._ssh_args
+        for opt in options or []:
+            ssh_cmd.extend(["-o", opt])
+
         ssh_cmd += [self.sshri.as_str()] \
             + [cmd]
 

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -52,6 +52,16 @@ class SSHRun(Interface):
         port=Parameter(
             args=("-p", '--port'),
             doc="port to connect to on the remote host"),
+        ipv4=Parameter(
+            args=("-4",),
+            dest="ipv4",
+            doc="use IPv4 addresses only",
+            action="store_true"),
+        ipv6=Parameter(
+            args=("-6",),
+            dest="ipv6",
+            doc="use IPv6 addresses only",
+            action="store_true"),
         options=Parameter(
             args=("-o",),
             metavar="OPTION",
@@ -66,13 +76,14 @@ class SSHRun(Interface):
     )
 
     @staticmethod
-    def __call__(login, cmd, port=None, options=None, no_stdin=False):
+    def __call__(login, cmd, port=None, ipv4=False, ipv6=False, options=None,
+                 no_stdin=False):
         lgr.debug("sshrun invoked: login=%r, cmd=%r, port=%r, options=%r, "
-                  "no_stdin=%r",
-                  login, cmd, port, options, no_stdin)
+                  "ipv4=%r, ipv6=%r, no_stdin=%r",
+                  login, cmd, port, options, ipv4, ipv6, no_stdin)
         # Perspective workarounds for git-annex invocation, see
         # https://github.com/datalad/datalad/issues/1456#issuecomment-292641319
-        
+
         if cmd.startswith("'") and cmd.endswith("'"):
             lgr.debug(
                 "Detected additional level of quotations in %r so performing "
@@ -90,7 +101,17 @@ class SSHRun(Interface):
         sshurl = 'ssh://{}{}'.format(
             login,
             ':{}'.format(port) if port else '')
-        ssh = ssh_manager.get_connection(sshurl)
+
+        if ipv4 and ipv6:
+            raise ValueError("Cannot force both IPv4 and IPv6")
+        elif ipv4:
+            force_ip = 4
+        elif ipv6:
+            force_ip = 6
+        else:
+            force_ip = None
+
+        ssh = ssh_manager.get_connection(sshurl, force_ip=force_ip)
         # TODO: /dev/null on windows ;)  or may be could be just None?
         stdin_ = open('/dev/null', 'r') if no_stdin else sys.stdin
         try:

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -52,6 +52,12 @@ class SSHRun(Interface):
         port=Parameter(
             args=("-p", '--port'),
             doc="port to connect to on the remote host"),
+        options=Parameter(
+            args=("-o",),
+            metavar="OPTION",
+            dest="options",
+            doc="configuration option passed to SSH",
+            action="append"),
         no_stdin=Parameter(
             args=("-n",),
             action="store_true",
@@ -60,9 +66,10 @@ class SSHRun(Interface):
     )
 
     @staticmethod
-    def __call__(login, cmd, port=None, no_stdin=False):
-        lgr.debug("sshrun invoked: login=%r, cmd=%r, port=%r, no_stdin=%r",
-                  login, cmd, port, no_stdin)
+    def __call__(login, cmd, port=None, options=None, no_stdin=False):
+        lgr.debug("sshrun invoked: login=%r, cmd=%r, port=%r, options=%r, "
+                  "no_stdin=%r",
+                  login, cmd, port, options, no_stdin)
         # Perspective workarounds for git-annex invocation, see
         # https://github.com/datalad/datalad/issues/1456#issuecomment-292641319
         
@@ -87,7 +94,8 @@ class SSHRun(Interface):
         # TODO: /dev/null on windows ;)  or may be could be just None?
         stdin_ = open('/dev/null', 'r') if no_stdin else sys.stdin
         try:
-            out, err = ssh(cmd, stdin=stdin_, log_output=False)
+            out, err = ssh(cmd, stdin=stdin_, log_output=False,
+                           options=options)
         finally:
             if no_stdin:
                 stdin_.close()

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -61,7 +61,8 @@ class SSHRun(Interface):
 
     @staticmethod
     def __call__(login, cmd, port=None, no_stdin=False):
-        lgr.debug("sshrun invoked: %r %r %r %r", login, cmd, port, no_stdin)
+        lgr.debug("sshrun invoked: login=%r, cmd=%r, port=%r, no_stdin=%r",
+                  login, cmd, port, no_stdin)
         # Perspective workarounds for git-annex invocation, see
         # https://github.com/datalad/datalad/issues/1456#issuecomment-292641319
         

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -13,6 +13,7 @@ from nose.tools import assert_raises, assert_equal
 
 from mock import patch
 
+from datalad.api import sshrun
 from datalad.cmd import Runner
 from datalad.cmdline.main import main
 
@@ -70,3 +71,23 @@ def test_ssh_option():
             main(["datalad", "sshrun", "-oSendEnv=LC_DATALAD_HACK",
                   "localhost", "echo $LC_DATALAD_HACK"])
             assert_equal(cmo.out.strip(), "hackbert")
+
+
+@skip_if_on_windows
+@skip_ssh
+def test_ssh_ipv4_6_incompatible():
+    with assert_raises(SystemExit):
+        main(["datalad", "sshrun", "-4", "-6", "localhost", "true"])
+
+
+@skip_if_on_windows
+@skip_ssh
+def test_ssh_ipv4_6():
+    # This should fail with a RuntimeError if a version is not supported (we're
+    # not bothering to check what localhost supports), but if the processing
+    # fails, it should be something else.
+    for kwds in [{"ipv4": True}, {"ipv6": True}]:
+        try:
+            sshrun("localhost", "true", **kwds)
+        except RuntimeError:
+            pass


### PR DESCRIPTION
This PR adjusts sshrun and sshconnector to fix the failure from gh-3596.  This was originally observed with datalad-neuroimaging's nipype_workshop_dataset.sh example on Travis.  As mentioned in gh-3596, I don't understand why our create_sibling() tests don't trigger the same failure in the Travis/Xenial environment.  I've started a -neuroimaging [build][0] that uses this PR branch, and that appears to fix the failure ([example 1][1], [example 2][2]).  Note that there are other (hopefully unrelated) failures on python 2.

[0]: https://travis-ci.org/datalad/datalad-neuroimaging/builds/575614640
[1]: https://travis-ci.org/datalad/datalad-neuroimaging/jobs/575614641#L1441
[2]: https://travis-ci.org/datalad/datalad-neuroimaging/jobs/575614643#L1445
