### PR TITLE
BF: run_procedure: do not hardcode python executable (fixes gh-3623)

### DIFF
--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -35,6 +35,7 @@ from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.utils import on_windows
 
 from datalad.utils import assure_list
 import datalad.support.ansi_colors as ac
@@ -190,8 +191,9 @@ def _guess_exec(script_file):
                 'template': u'bash "{script}" "{ds}" {args}',
                 'state': state}
     elif script_file.endswith('.py'):
+        ex = sys.executable if on_windows else shlex_quote(sys.executable)
         return {'type': u'python_script',
-                'template': u'%s "{script}" "{ds}" {args}' % shlex_quote(sys.executable),
+                'template': u'%s "{script}" "{ds}" {args}' % ex,
                 'state': state}
     else:
         return {'type': None, 'template': None, 'state': None}

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -16,6 +16,7 @@ import logging
 from glob import iglob
 from argparse import REMAINDER
 import os
+import sys
 import os.path as op
 import stat
 
@@ -189,7 +190,7 @@ def _guess_exec(script_file):
                 'state': state}
     elif script_file.endswith('.py'):
         return {'type': u'python_script',
-                'template': u'python "{script}" "{ds}" {args}',
+                'template': u'%s "{script}" "{ds}" {args}' % sys.executable,
                 'state': state}
     else:
         return {'type': None, 'template': None, 'state': None}

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -15,6 +15,7 @@ import logging
 
 from glob import iglob
 from argparse import REMAINDER
+from six.moves import shlex_quote
 import os
 import sys
 import os.path as op
@@ -190,7 +191,7 @@ def _guess_exec(script_file):
                 'state': state}
     elif script_file.endswith('.py'):
         return {'type': u'python_script',
-                'template': u'%s "{script}" "{ds}" {args}' % sys.executable,
+                'template': u'%s "{script}" "{ds}" {args}' % shlex_quote(sys.executable),
                 'state': state}
     else:
         return {'type': None, 'template': None, 'state': None}


### PR DESCRIPTION
Stay within the same Python version to avoid crash or undesired behavior
when PY2 is called from PY3 with missing or outdated PY2 versions of
datalad.
