### PR TITLE
Prepare for git-annex's removal of direct mode

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -281,7 +281,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             # Note: If 'annex.version' is missing in .git/config for some
             # reason, we need to try to set direct mode:
             repo_version = self.config.getint("annex", "version")
-            if (repo_version is None) or (repo_version < 6):
+            if self.supports_direct_mode and \
+               (repo_version is None or repo_version < 6):
                 lgr.debug("Switching to direct mode (%s)." % self)
                 self.set_direct_mode()
             else:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -35,6 +35,7 @@ from git import GitCommandError
 from mock import patch
 import gc
 
+from datalad import cfg
 from datalad.cmd import Runner
 
 from datalad.support.external_versions import external_versions
@@ -81,6 +82,7 @@ from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import OBSCURE_FILENAME
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import skip_if
+from datalad.tests.utils import skip_if_no_direct_mode
 from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import find_files
 from datalad.tests.utils import slow
@@ -199,6 +201,7 @@ def test_AnnexRepo_is_direct_mode_gitrepo(path):
         assert_false(dm)
 
 
+@skip_if_no_direct_mode
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*')
 @with_tempfile
@@ -223,6 +226,7 @@ def test_AnnexRepo_set_direct_mode(src, dst):
         assert_false(ar.is_direct_mode(), "Switching to indirect mode failed.")
 
 
+@skip_if_no_direct_mode
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
@@ -906,6 +910,7 @@ def test_AnnexRepo_add_to_git(path):
     ok_clean_git(repo, annex=True, ignore_submodules=True)
 
 
+@skip_if_no_direct_mode
 @with_testrepos('submodule_annex', flavors=['clone'])
 def test_AnnexRepo_add_unexpected_direct_mode(path):
     # tests a special case where a submodule is in direct mode, while it's
@@ -1575,6 +1580,8 @@ def test_annex_add_no_dotfiles(path):
     assert_false(ar.is_under_annex(opj(ar.path, '.datalad', 'somefile')))
 
 
+@skip_if_no_direct_mode(
+    other_cond=cfg.getbool("datalad", "repo.direct", default=False))
 @with_tempfile
 def test_annex_version_handling_at_min_version(path):
     with set_annex_version(AnnexRepo.GIT_ANNEX_MIN_VERSION):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1575,7 +1575,7 @@ def test_annex_add_no_dotfiles(path):
 
 
 @with_tempfile
-def test_annex_version_handling(path):
+def test_annex_version_handling_at_min_version(path):
     with patch.object(AnnexRepo, 'git_annex_version', None) as cmpov, \
          patch.object(AnnexRepo, '_check_git_annex_version',
                       auto_spec=True,
@@ -1598,6 +1598,10 @@ def test_annex_version_handling(path):
             assert(ar2)
             eq_(AnnexRepo.git_annex_version, AnnexRepo.GIT_ANNEX_MIN_VERSION)
             eq_(cmpc.call_count, 1)
+
+
+@with_tempfile
+def test_annex_version_handling_bad_git_annex(path):
     with patch.object(AnnexRepo, 'git_annex_version', None) as cmpov, \
             patch.object(AnnexRepo, '_check_git_annex_version',
                          auto_spec=True,
@@ -1607,11 +1611,6 @@ def test_annex_version_handling(path):
                 external_versions, '_versions', {'cmd:annex': None}):
             eq_(AnnexRepo.git_annex_version, None)
             with assert_raises(MissingExternalDependency) as cme:
-                try:
-                    # Note: Remove to cause creation of a new instance
-                    rmtree(path)
-                except OSError:
-                    pass
                 AnnexRepo(path)
             if linux_distribution_name == 'debian':
                 assert_in("http://neuro.debian.net", str(cme.exception))

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -21,6 +21,7 @@ from ...support.annexrepo import AnnexRepo
 from ...tests.utils import (
     with_tempfile,
     create_tree,
+    set_annex_version,
     swallow_logs,
 )
 
@@ -172,7 +173,8 @@ def _test_annex_version_comparison(v, cmp_):
             return v, ""
 
     ev = ExternalVersions()
-    with patch('datalad.support.external_versions._runner', _runner()), \
+    with set_annex_version(None), \
+         patch('datalad.support.external_versions._runner', _runner()), \
          patch('datalad.support.annexrepo.external_versions',
                ExternalVersions()):
         ev['cmd:annex'] < AnnexRepo.GIT_ANNEX_MIN_VERSION

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -37,6 +37,10 @@ if on_windows:
     raise SkipTest("Can't test direct mode switch, "
                    "if direct mode is forced by OS anyway.")
 
+if not AnnexRepo.check_direct_mode_support():
+    raise SkipTest("git-annex version does not support direct mode")
+
+
 repo_version = cfg.get("datalad.repo.version", None)
 if repo_version and int(repo_version) >= 6:
     raise SkipTest("Can't test direct mode switch, "

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1549,6 +1549,24 @@ def set_date(timestamp):
         yield
 
 
+@contextmanager
+def set_annex_version(version):
+    """Override the git-annex version.
+
+    This temporarily masks the git-annex version present in external_versions
+    and make AnnexRepo forget its cached version information.
+    """
+    from datalad.support.annexrepo import AnnexRepo
+    ar_vers = AnnexRepo.git_annex_version
+    with patch.dict(
+            "datalad.support.annexrepo.external_versions._versions",
+            {"cmd:annex": version}):
+        try:
+            AnnexRepo.git_annex_version = None
+            yield
+        finally:
+            AnnexRepo.git_annex_version = ar_vers
+
 #
 # Test tags
 #

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1097,6 +1097,30 @@ def skip_direct_mode(func, method='raise'):
 
 
 @optional_args
+def skip_if_no_direct_mode(func, other_cond=True, method='raise'):
+    """Skip test if git-annex version does not support direct mode.
+
+    Parameters
+    ----------
+    func : function
+    other_cond : bool, optional
+        Skip if annex does not support direct mode AND this value is true.
+    method : str, optional
+        Passed to `skip_if`.
+    """
+    from datalad.support.annexrepo import AnnexRepo
+    unsupported = not AnnexRepo.check_direct_mode_support()
+
+    @skip_if(unsupported and other_cond,
+             msg="Direct mode unsupported by git-annex version",
+             method=method)
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        return func(*args, **kwargs)
+    return newfunc
+
+
+@optional_args
 def assert_cwd_unchanged(func, ok_to_chdir=False):
     """Decorator to test whether the current working directory remains unchanged
 


### PR DESCRIPTION
This series updates annexrepo.py and the test suite for git-annex's removal of direct mode (gh-3627).  It resolves issues that I've caught from running the test suite locally with a git-annex built from d6e1f09ed, but we'd of course want a run on Travis before merging this.