### PR TITLE
TST: Reenable testrepo setup for windows tests

### DIFF
--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -755,9 +755,6 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
     @wraps(t)
     @attr('with_testrepos')
     def newfunc(*arg, **kw):
-        if on_windows:
-            raise SkipTest("Testrepo setup is broken on Windows")
-
         # TODO: would need to either avoid this "decorator" approach for
         # parametric tests or again aggregate failures like sweepargs does
         flavors_ = _get_resolved_flavors(flavors)


### PR DESCRIPTION
With the testrepo setup presumably usable on windows now, reenable the related tests to see how much fixing is TODO.