### PR TITLE
ENH: downloaders: Ensure directories for target exist

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -18,6 +18,7 @@ import sys
 import time
 
 from abc import ABCMeta, abstractmethod
+import os.path as op
 from os.path import exists, join as opj, isdir
 from six import PY2
 from six import binary_type, PY3
@@ -402,6 +403,13 @@ class BaseDownloader(object):
                     "It will be overriden" % temp_filepath)
                 # TODO.  also logic below would clean it up atm
 
+            download_dir = op.dirname(temp_filepath)
+            if download_dir and not exists(download_dir):
+                # We use the "not exist then makedirs" pattern across our
+                # codebase. This is racy in a way that is unlikely to matter
+                # here, but when we drop Python 2, we might as well switch the
+                # code below to use exist_ok=True.
+                os.makedirs(download_dir)
             with open(temp_filepath, 'wb') as fp:
                 # TODO: url might be a bit too long for the beast.
                 # Consider to improve to make it animated as well, or shorten here

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -117,6 +117,11 @@ def test_HTTPDownloader_basic(toppath, topurl):
     download(furl, tfpath)
     ok_file_has_content(tfpath, 'abc')
 
+    # download() creates leading directories if needed.
+    subdir_tfpath = opj(toppath, "l1", "l2", "file-downloaded.dat")
+    download(furl, subdir_tfpath)
+    ok_file_has_content(subdir_tfpath, 'abc')
+
     # see if fetch works correctly
     assert_equal(downloader.fetch(furl), 'abc')
 

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -114,6 +114,11 @@ def test_download_url_dataset(toppath, topurl, path):
     ds.download_url([opj(topurl, "file3.txt")], save=False)
     assert_false(ds.repo.file_has_content("file3.txt"))
 
+    # Leading paths for target are created if needed.
+    subdir_target = opj("l1", "l2", "f")
+    ds.download_url([opj(topurl, "file1.txt")], path=subdir_target)
+    ok_(ds.repo.file_has_content(subdir_target))
+
     subdir_path = opj(path, "subdir")
     os.mkdir(subdir_path)
     with chpwd(subdir_path):


### PR DESCRIPTION
download_url() doesn't check that leading directories for a target
exist, resulting in a failing .download() call, but it's reasonable
for a download_url() caller to expect that directories will be created
if needed, especially given `git annex addurl --file ...` does so.
Ensuring target directories exist seems desirable for all .download()
callers, so handle it within downloaders/base.py rather than in
download_url().

Fixes #3642.
