### PR TITLE
TST: Don't assume default annex repo version is v5

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -121,6 +121,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     GIT_ANNEX_MIN_VERSION = '6.20180913'
     git_annex_version = None
     supports_direct_mode = None
+    repository_versions = None
 
     # Class wide setting to allow insecure URLs. Used during testing, since
     # git annex 6.20180626 those will by default be not allowed for security
@@ -798,6 +799,30 @@ class AnnexRepo(GitRepo, RepoInterface):
                 cls._check_git_annex_version()
             cls.supports_direct_mode = cls.git_annex_version <= "7.20190819"
         return cls.supports_direct_mode
+
+    @classmethod
+    def check_repository_versions(cls):
+        """Get information on supported and upgradable repository versions.
+
+        The result is cached at `cls.repository_versions`.
+
+        Returns
+        -------
+        dict
+          supported -> list of supported versions (int)
+          upgradable -> list of upgradable versions (int)
+        """
+        if cls.repository_versions is None:
+            from datalad.cmd import Runner
+            key_remap = {
+                "supported repository versions": "supported",
+                "upgrade supported from repository versions": "upgradable"}
+            out, _ = Runner().run(["git", "annex", "version"])
+            kvs = (ln.split(":", 1) for ln in out.splitlines())
+            cls.repository_versions = {
+                key_remap[k]: list(map(int, v.strip().split()))
+                for k, v in kvs if k in key_remap}
+        return cls.repository_versions
 
     @staticmethod
     def get_size_from_key(key):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1146,7 +1146,10 @@ class GitRepo(RepoInterface):
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(
                 files,
-                ['git', 'add'] + assure_list(git_options) +
+                # Set annex.largefiles to prevent storing files in annex when
+                # GitRepo() is instantiated with a v6+ annex repo.
+                ['git', '-c', 'annex.largefiles=nothing', 'add'] +
+                assure_list(git_options) +
                 to_options(update=update) + ['--verbose']
             )
             # get all the entries

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1326,10 +1326,12 @@ def test_repo_version(path1, path2, path3):
         version = annex.repo.config_reader().get_value('annex', 'version')
         eq_(version, v6_lands_on)
 
-        # parameter `version` still has priority over default config:
-        annex = AnnexRepo(path3, create=True, version=5)
-        version = annex.repo.config_reader().get_value('annex', 'version')
-        eq_(version, 5)
+        # Assuming specified version is a supported version...
+        if 5 in supported_versions:
+            # ...parameter `version` still has priority over default config:
+            annex = AnnexRepo(path3, create=True, version=5)
+            version = annex.repo.config_reader().get_value('annex', 'version')
+            eq_(version, 5)
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1315,16 +1315,16 @@ def test_repo_version(path1, path2, path3):
     annex = AnnexRepo(path1, create=True, version=6)
     ok_clean_git(path1, annex=True)
     version = annex.repo.config_reader().get_value('annex', 'version')
-    # TODO: Since git-annex 7.20181031, v6 repos upgrade to v7. Once that
-    # version or later is our minimum required version, update this test and
-    # the one below to eq_(version, 7).
-    assert_in(version, [6, 7])
+    # Since git-annex 7.20181031, v6 repos upgrade to v7.
+    supported_versions = AnnexRepo.check_repository_versions()["supported"]
+    v6_lands_on = next(i for i in supported_versions if i >= 6)
+    eq_(version, v6_lands_on)
 
     # default from config item (via env var):
     with patch.dict('os.environ', {'DATALAD_REPO_VERSION': '6'}):
         annex = AnnexRepo(path2, create=True)
         version = annex.repo.config_reader().get_value('annex', 'version')
-        assert_in(version, [6, 7])
+        eq_(version, v6_lands_on)
 
         # parameter `version` still has priority over default config:
         annex = AnnexRepo(path3, create=True, version=5)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1466,3 +1466,13 @@ def test_duecredit(path):
         assert_in('Data management and distribution platform', outs)
     else:
         eq_(outs, '')
+
+
+@with_tree({"foo": "foo"})
+def test_gitrepo_add_to_git_with_annex_v7(path):
+    from datalad.support.annexrepo import AnnexRepo
+    ar = AnnexRepo(path, create=True, version=7)
+    gr = GitRepo(path)
+    gr.add("foo")
+    gr.commit(msg="c1")
+    assert_false(ar.is_under_annex("foo"))

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1061,14 +1061,21 @@ def known_failure_windows(func):
 
 @optional_args
 def skip_v6_or_later(func, method='raise'):
-    """Skips tests if datalad is configured to use v6 mode or later
-    (e.g., DATALAD_REPO_VERSION=6)
+    """Skip tests if v6 or later will be used as the default repo version.
+
+    The default repository version is controlled by the configured value of
+    DATALAD_REPO_VERSION and whether v5 repositories are supported by the
+    installed git-annex.
     """
 
     from datalad import cfg
-    version = cfg.obtain("datalad.repo.version")
+    from datalad.support.annexrepo import AnnexRepo
 
-    @skip_if(version >= 6, msg="Skip test in v6+ test run", method=method)
+    version = cfg.obtain("datalad.repo.version")
+    info = AnnexRepo.check_repository_versions()
+
+    @skip_if(version >= 6 or 5 not in info["supported"],
+             msg="Skip test in v6+ test run", method=method)
     @wraps(func)
     @attr('skip_v6_or_later')
     @attr('v6_or_later')

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -987,14 +987,20 @@ def known_failure(func):
 def known_failure_v6_or_later(func):
     """Test decorator marking a test as known to fail in a v6+ test run
 
-    If datalad.repo.version is set to 6 or later behaves like `known_failure`.
+    If the default repository version is 6 or later behaves like `known_failure`.
     Otherwise the original (undecorated) function is returned.
+    The default repository version is controlled by the configured value of
+    DATALAD_REPO_VERSION and whether v5 repositories are supported by the
+    installed git-annex.
     """
 
     from datalad import cfg
+    from datalad.support.annexrepo import AnnexRepo
 
     version = cfg.obtain("datalad.repo.version")
-    if version and version >= 6:
+    info = AnnexRepo.check_repository_versions()
+
+    if (version and version >= 6) or 5 not in info["supported"]:
 
         @known_failure
         @wraps(func)

--- a/docs/examples/3rdparty_analysis_workflow.sh
+++ b/docs/examples/3rdparty_analysis_workflow.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# SKIP_IN_V6
 
 set -e
 
@@ -116,7 +115,8 @@ datalad get src/forrest_structural/sub-01/anat/sub-01_T1w.nii.gz
 #%
 
 mkdir code
-echo "file src/forrest_structural/sub-01/anat/sub-*_T1w.nii.gz > result.txt" > code/run_analysis.sh
+echo "echo 'Start of really useful results' > result.txt" > code/run_analysis.sh
+echo "file src/forrest_structural/sub-01/anat/sub-*_T1w.nii.gz >> result.txt" >> code/run_analysis.sh
 
 #%
 # In order to definitively document which data file his analysis needs at this
@@ -216,7 +216,8 @@ datalad get result.txt
 # She can modify Bob's code to help him with his analysis...
 #%
 
-echo "file src/forrest_structural/sub-*/anat/sub-*_T1w.nii.gz > result.txt" > code/run_analysis.sh
+echo "echo 'Start of improved results' > result.txt" > code/run_analysis.sh
+echo "file src/forrest_structural/sub-*/anat/sub-*_T1w.nii.gz >> result.txt" >> code/run_analysis.sh
 
 #%
 # ... and execute it.


### PR DESCRIPTION
This PR fixes test failures that I found locally when running with a git-annex built from annex's v7-default branch (b421004d75).  I'm marking it as a draft because before merging we should have a Travis run with a git-annex version that auto-upgrades v5 repositories.

On a throw-away merge of this PR's branch into master, the datalad/core tests passed for me, but master's tests may need additional fixes elsewhere.

Closes #3628.

---

- [x] Verify that this branch passes on Travis with a version of git-annex that defaults to v7 repos (that change ~is currently in annex's v7-default branch~ has been released and is now included in the latest git-annex release, 7.20190912).
