### PR TITLE
TST: Skip part of test_direct_cfg when direct mode is unsupported

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -128,6 +128,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     # 7          -- annex makes v7 mode default on crippled systems. We demand it for consistent operation
     GIT_ANNEX_MIN_VERSION = '7'
     git_annex_version = None
+    supports_direct_mode = None
 
     # Class wide setting to allow insecure URLs. Used during testing, since
     # git annex 6.20180626 those will by default be not allowed for security
@@ -545,6 +546,22 @@ class AnnexRepo(GitRepo, RepoInterface):
         elif ver < cls.GIT_ANNEX_MIN_VERSION:
             raise OutdatedExternalDependency(ver_present=ver, **exc_kwargs)
         cls.git_annex_version = ver
+
+    @classmethod
+    def check_direct_mode_support(cls):
+        """Does git-annex version support direct mode?
+
+        The result is cached at `cls.supports_direct_mode`.
+
+        Returns
+        -------
+        bool
+        """
+        if cls.supports_direct_mode is None:
+            if cls.git_annex_version is None:
+                cls._check_git_annex_version()
+            cls.supports_direct_mode = cls.git_annex_version <= "7.20190819"
+        return cls.supports_direct_mode
 
     @staticmethod
     def get_size_from_key(key):

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -70,6 +70,10 @@ def test_direct_cfg(path1, path2):
     # check if we somehow didn't reset the flag
     assert not ar.is_direct_mode()
 
+    if not ar.check_direct_mode_support():
+        raise SkipTest(
+            "Rest of test requires direct mode support in git-annex")
+
     if ar.config.obtain("datalad.repo.version") >= 6:
         raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
     # and if repo existed before and was in direct mode, we fail too


### PR DESCRIPTION
I failed to adjust one test on master for a git-annex without direct mode support, as shown by the failing test here: https://travis-ci.org/datalad/datalad/jobs/581799658
