### PR TITLE
BF: cmd: Don't leave unread lines on stream when logging online

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -322,6 +322,14 @@ class Runner(object):
                 time.sleep(0.001)
 
         # Handle possible remaining output
+        if log_stdout_ and log_stderr_:
+            # If Popen was called with more than two pipes, calling
+            # communicate() after we partially read the stream will return
+            # empty output.
+            stdout += self._process_remaining_output(
+                outputstream, proc.stdout.read(), *stdout_args)
+            stderr += self._process_remaining_output(
+                errstream, proc.stderr.read(), *stderr_args)
         stdout_, stderr_ = proc.communicate()
         # ??? should we condition it on log_stdout in {'offline'} ???
         stdout += self._process_remaining_output(outputstream, stdout_, *stdout_args)

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -29,6 +29,7 @@ from .utils import (
     SkipTest,
     skip_if_on_windows,
     with_tempfile,
+    with_tree,
     assert_cwd_unchanged,
     swallow_outputs,
     swallow_logs,
@@ -338,3 +339,38 @@ s
     #  probably #2185
     eq_(runner._process_remaining_output(None, out_bytes, *args), target)
     eq_(runner._process_remaining_output(None, out, *args), target)
+
+
+@with_tree({"infile": "\n".join(map(str, range(10))) + "\n"})
+def test_runner_remaining_output_two_pipes(path):
+    from ..support.gitrepo import GitRepo
+    GitRepo(path, create=True)
+    runner = GitRunner(cwd=path)
+    # The particular command doesn't matter. The one below is the command where
+    # I first noticed the issue, and it reliably triggers it on my end. The
+    # command should have multiple lines and be slow enough that it passes the
+    # initial `proc.poll() is None` condition.
+    cmd = ["git", "count-objects", "-v"]
+    expected, _ = runner(cmd, log_online=False,
+                         log_stdout=True, log_stderr=False)
+
+    # log_stderr=True would fail (at least on Python 3.7) without a workaround.
+    for log_stderr in [False, True]:
+        eq_(expected,
+            runner(cmd, log_online=True, log_stdout=True,
+                   log_stderr=log_stderr)[0])
+
+    if on_windows:
+        raise SkipTest("Remaining part of test uses `cat`")
+
+    cmd = ["cat"]
+    with open(op.join(path, "infile")) as fh:
+        expected, _ = runner(cmd, log_online=False, stdin=fh,
+                             log_stdout=True, log_stderr=False)
+
+    # As with above, log_stderr=True would fail without a workaround.
+    for log_stderr in [False, True]:
+        with open(op.join(path, "infile")) as fh:
+            eq_(expected,
+                runner(cmd, log_online=True, stdin=fh,
+                       log_stdout=True, log_stderr=log_stderr)[0])


### PR DESCRIPTION
Now that we have a branch that drops Python 2, I've been looking into using asyncio in the runner.  Much of that so far has been trying to wrap my head around how the different parameters of Runner.run() interact.  While doing this, I realized that some output lines were being lost.

---

```
When the Runner is called with log_online=True and we're logging
either stdout or stderr, the readline() call for the stream happens
under a `while proc.poll() is None`.  After that block, we may have
uncaptured output, either because the process was already finished by
the time we got to the proc.poll() condition or because each iteration
reads only a single line.  To collect this output, communicate() is
called.

However, communicate() may return an empty string even when there is
uncaptured output and appears to reliably do so if

  (1) we've called readline() on the stream
  (2) both stdout and stderr are set to subprocess.PIPE
  (3) we're running under Python 3

The second condition likely involves the fact that subprocess.py has
an optimization to avoid using threads if the number of pipes is below
two.

For example, try

    import subprocess as sp
    p = sp.Popen(["printf", "one\ntwo\n"], stdout=sp.PIPE, stderr=sp.PIPE)
    print(p.stdout.readline())
    print(p.communicate())

"two\n" is not included in the output returned by communicate().

To work around this, gather these remaining lines with a direct read()
call rather than relying on communicate() when we're using a pipe for
bother stdout and stderr.
```