### PR TITLE
TST: cmd: Fix call that hard codes parameterized test value

### DIFF
--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -229,7 +229,7 @@ def check_runner_heavy_output(log_online):
     #do it again with capturing:
     with swallow_logs():
         ret = runner.run(cmd,
-                         log_online=True, log_stderr=True, log_stdout=True,
+                         log_online=log_online, log_stderr=True, log_stdout=True,
                          expect_stderr=True)
 
     if log_online:


### PR DESCRIPTION
test_runner_heavy_output() is parameterized by log_online value, but
one call hard codes log_online to True.