### PR TITLE
Attempt to establish benchmarks across a set of different types of "heavy" datasets

### DIFF
--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -7,6 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Benchmarks of the datalad.api functionality"""
 
+from glob import glob
 from os.path import join as opj
 
 try:
@@ -45,7 +46,10 @@ except ImportError:
 
 
 from .common import (
-    Sample222DatasetBenchmarks,
+    Heavy1Dataset,
+    Heavy1SavedDataset,
+    Sample222Dataset,
+    SampleDatasetBenchmarksBase,
     SuprocBenchmarks,
 )
 
@@ -66,7 +70,7 @@ class testds(SuprocBenchmarks):
         )
 
 
-class supers(Sample222DatasetBenchmarks):
+class supers(Sample222Dataset):
     """
     Benchmarks on common operations on collections of datasets using datalad API
     """
@@ -111,6 +115,8 @@ class supers(Sample222DatasetBenchmarks):
         for subm in self.ds.repo.get_submodules():
             self.ds.uninstall(subm.path, recursive=True, check=False)
 
+
+
     def time_remove(self):
         remove(self.ds.path, recursive=True)
 
@@ -126,3 +132,29 @@ class supers(Sample222DatasetBenchmarks):
 
     def time_status_recursive(self):
         self.ds.status(recursive=True)
+
+
+class TypicalOps(SampleDatasetBenchmarksBase):
+
+    def time_status(self):
+        self.ds.status()
+
+    def time_status_dot(self):
+        self.ds.status(['.'])
+
+    def time_status_half(self):
+        self.ds.status(self.half_paths_level0)
+
+
+
+# Mix-ins to benchmark typical operations in a variety of scenarios
+# Actual effect of any given operation would depend on the dataset in question.
+# E.g. saving "changes" in a non-dirty dataset would result in no actual
+# commit
+
+class heavy1(TypicalOps, Heavy1Dataset):
+    pass
+
+
+class heavy1saved(TypicalOps, Heavy1SavedDataset):
+    pass

--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -45,7 +45,7 @@ except ImportError:
 
 
 from .common import (
-    SampleSuperDatasetBenchmarks,
+    Sample222DatasetBenchmarks,
     SuprocBenchmarks,
 )
 
@@ -66,7 +66,7 @@ class testds(SuprocBenchmarks):
         )
 
 
-class supers(SampleSuperDatasetBenchmarks):
+class supers(Sample222DatasetBenchmarks):
     """
     Benchmarks on common operations on collections of datasets using datalad API
     """

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -17,6 +17,7 @@ from glob import glob
 
 from datalad.utils import (
     create_tree,
+    chpwd,
     getpwd,
     get_tempfile_kwargs,
     rmtree,
@@ -81,17 +82,19 @@ class SuprocBenchmarks(object):
     def _cleanup(self):
         if not self.remove_paths:
             return  # Nothing TODO
-        self.log("Cleaning up %d paths", len(self.remove_paths))
+        self.log("Cleaning up %d paths: %s",
+                 len(self.remove_paths), ', '.join(self.remove_paths))
         while self.remove_paths:
             path = self.remove_paths.pop()
-            if op.lexists(path):
-                rmtree(path)
+            #if op.lexists(path):
+            #    rmtree(path)
 
     def teardown(self):
         self._cleanup()
 
     def __del__(self):
         # We will at least try
+        # self.log("%s is being __del__'ed", self.__class__)
         try:
             self._cleanup()
         except:
@@ -99,7 +102,7 @@ class SuprocBenchmarks(object):
 
     def log(self, msg, *args):
         """Consistent benchmarks logging"""
-        print("BM: "+ str(msg % tuple(args)))
+        # print("BM: "+ str(msg % tuple(args)))
 
 
 class SampleDatasetBenchmarksBase(SuprocBenchmarks):
@@ -125,20 +128,34 @@ class SampleDatasetBenchmarksBase(SuprocBenchmarks):
     def tarfile(self):
         return '%s.tar' % self.dsname
 
-    def create_test_dataset(self):
-        """A method to be implemented in subclasses.
+    def create_test_dataset(self, path):
+        """An abstract method to be implemented in subclasses.
 
         Should return a path to the sample dataset
         """
         raise NotImplementedError()
 
+    # Apparently asv "identifies" setup_cache by its location in the code,
+    # so we cannot take advantage from delegation!  Derived classes
+    # will need to have a new setup_cache to just call _setup_cache
+    # actually doing the work delegating to their create_test_dataset
     def setup_cache(self):
-        ds_path = self.create_test_dataset()
-        self.log("Setup cache ds path %s. CWD: %s", ds_path, getpwd())
+        raise NotImplementedError()
+        # in subclasses should be
+        # return self._setup_cache()
+
+    def _setup_cache(self):
+        self.log("%s.setup_cache for %s ran in %s", self, self.dsname, getpwd())
+        # according to https://asv.readthedocs.io/en/stable/writing_benchmarks.html
+        # setup_cache is executed in a temporary directory.
+        # yoh thought to use some "guaranteed to be temp" directory but
+        # it is hard/impossible to then store it across instances.
+        # So all code below assumes that PWD is already a sensible one to create
+        # temp structures in
+        dspath = self.dsname
         # Will store into a tarfile since otherwise install -r is way too slow
         # to be invoked for every benchmark
-        # Store full path since apparently setup is not ran in that directory
-        self.tarfile = op.realpath(self.tarfile)
+        self.create_test_dataset(dspath)
         with tarfile.open(self.tarfile, "w") as tar:
             # F.CK -- Python tarfile can't later extract those because key dirs are
             # read-only.  For now just a workaround - make it all writeable
@@ -148,7 +165,7 @@ class SampleDatasetBenchmarksBase(SuprocBenchmarks):
         rmtree(self.dsname)
 
     def setup(self):
-        self.log("Setup ran in %s, existing paths: %s", getpwd(), glob('*'))
+        self.log("%s.setup ran in %s, existing paths: %s", self, getpwd(), glob('*'))
 
         tempdir = tempfile.mkdtemp(
             **get_tempfile_kwargs({}, prefix="bm")
@@ -164,19 +181,127 @@ class SampleDatasetBenchmarksBase(SuprocBenchmarks):
         self.__class__.ds_count += 1
         self.ds = Dataset(epath_unique)
         self.repo = self.ds.repo
+
+        self.paths_level0 = paths = sorted(glob('*'))
+        assert len(paths) >= 2
+        self.half_paths_level0 = paths[:len(paths) // 2]
+
         self.log("Finished setup for %s", tempdir)
 
 
-class Sample222DatasetBenchmarks(SuprocBenchmarks):
+class SavedDataset(object):
+    """Class to mix-in to assure that created dataset is saved and not dirty.
+
+    In a mix-in should come first among classes so its .create_test_dataset
+    is called before the actual one producing a dataset
+    """
+
+    def create_test_dataset(self, path):
+        super(SavedDataset, self).create_test_dataset(path)
+        ds = Dataset(path)
+        assert ds.repo.dirty  # Otherwise no sense to mix this class in
+        ds.save('.')
+        assert not ds.repo.dirty  # we should be all clean
+
+    # This mix-in shouldn't bother with setup_cache since just a mix-in
+
+
+class Sample222Dataset(SampleDatasetBenchmarksBase):
     """Our benchmark setup which uses create_test_dataset with 2/-2/-2
     configuration.
     """
 
     dsname = 'testds1'
 
-    def create_test_dataset(self):
-        return create_test_dataset(
-            self.dsname
+    def create_test_dataset(self, path):
+        create_test_dataset(
+            path
             , spec='2/-2/-2'
             , seed=0
-        )[0]
+        )
+
+    def setup_cache(self):
+        return self._setup_cache()
+
+
+class Heavy1Dataset(SampleDatasetBenchmarksBase):
+    """Setup a relatively heavy dataset in number of files. It will loosely
+    mimic having a collection of .fsf files and corresponding .feat directories.
+    Ending up with ~1,000 files, some of which are text some annexed.
+    """
+
+    dsname = 'testds-heavy1'
+
+    def create_test_dataset(self, path):
+        from datalad.distribution.dataset import require_dataset
+
+        ds = Dataset(path).create()
+        # place .dat to to annex
+        ds.repo.set_gitattributes([
+            ('*.dat', {'annex.largefiles': "anything"})])
+
+        git_attributes_file = op.join(ds.path, '.gitattributes')
+        ds.save(
+            git_attributes_file,
+            message="Instruct annex to add text files to Git")
+
+        # Initiate initial one with following feat directories
+        self._create_tree(path, range(10))
+        # Dataset is not saved on purpose so we could implement benchmarks.
+        # Mix-in SavedDataset
+
+    def setup_cache(self):
+        return self._setup_cache()
+
+    def _create_tree(
+            self,
+            path,
+            feat_indexes=range(10),
+            subdirs=('logs', 'reg', 'reg_standard', 'stats', 'custom_timing_files'),
+            files_indexes=range(10),
+            txt_content_fmt="content{file_index}",
+            fsf_content_fmt="design for {feat_index}",
+            seed=0
+            ):
+        """
+
+        Parameters
+        ----------
+        path
+        feat_indexes: iterable of int, optional
+          List of indexes for feat directories. If already exists, might then
+          be "rewritten"
+        files_indexes: iterable of int, optional
+          Which "indexed" files within subdirectories to create
+        subdirs: iterable of str
+          Subdirectories within each .feat one.
+        seed: None or int
+          If None - no reseeding will be done
+        """
+        import numpy as np
+        if seed is not None:
+            np.random.seed(seed)
+
+        tree = {}
+        for feat_index in feat_indexes:
+            # 50/50 in binary vs text files. All small
+            subtree = {}
+            for subdir in subdirs:
+                subsubtree = {}
+                for file_index in files_indexes:
+                    prefix = "file%03d." % file_index
+                    subsubtree[prefix + 'txt'] = txt_content_fmt.format(**locals())
+                    subsubtree[prefix + 'dat'] = np.random.bytes(file_index)  # grow in size, since why not?
+                subtree[subdir] = subsubtree
+            tree.update(
+                {'sub-%03d.fsf' % feat_index: fsf_content_fmt.format(**locals()),
+                 'sub-%03d.feat' % feat_index: subtree}
+            )
+            create_tree(path, tree)
+
+
+class Heavy1SavedDataset(SavedDataset, Heavy1Dataset):
+    dsname = Heavy1Dataset.dsname + '-saved'
+
+    def setup_cache(self):
+        return self._setup_cache()

--- a/benchmarks/repo.py
+++ b/benchmarks/repo.py
@@ -8,15 +8,15 @@
 """Benchmarks of the basic repos (Git/Annex) functionality"""
 
 from .common import (
-    Sample222DatasetBenchmarks,
+    Sample222Dataset,
     SuprocBenchmarks,
 )
 
 
-# TODO: probably Sample222DatasetBenchmarks is not the best for these benchmarks
+# TODO: probably Sample222Dataset is not the best for these benchmarks
 #       but we are yet to make it parametric so we could sweep through a set
 #       of typical scenarios
-class gitrepo(Sample222DatasetBenchmarks):
+class gitrepo(Sample222Dataset):
 
     def time_get_content_info(self):
         info = self.repo.get_content_info()

--- a/benchmarks/repo.py
+++ b/benchmarks/repo.py
@@ -8,15 +8,15 @@
 """Benchmarks of the basic repos (Git/Annex) functionality"""
 
 from .common import (
-    SampleSuperDatasetBenchmarks,
+    Sample222DatasetBenchmarks,
     SuprocBenchmarks,
 )
 
 
-# TODO: probably SampleSuperDatasetBenchmarks is not the best for these benchmarks
+# TODO: probably Sample222DatasetBenchmarks is not the best for these benchmarks
 #       but we are yet to make it parametric so we could sweep through a set
 #       of typical scenarios
-class gitrepo(SampleSuperDatasetBenchmarks):
+class gitrepo(Sample222DatasetBenchmarks):
 
     def time_get_content_info(self):
         info = self.repo.get_content_info()

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2240,6 +2240,8 @@ def create_tree(path, tree, archives_leading_dir=True, remove_existing=False):
                     archives_leading_dir=archives_leading_dir,
                     remove_existing=remove_existing)
         else:
+            # TODO: rm if exists since might fail if file was annexed
+            # and we do not want to remove an entire tree first
             open_func = open
             if full_name.endswith('.gz'):
                 open_func = gzip.open


### PR DESCRIPTION
A semi-failed attempt to introduce benchmarking of common operations across a collection of datasets.
With this approach I thought to take advantage of multiple inheritance and mix in different datasets and states while then mix-ing in also corresponding benchmarks.

It is ugly and probably not the way to go because

- `setup_cache` taking care about creating a tarball with a dataset instance is identified by asv simply by location in the code -- leads to fragile need to replicate `setup_cache` in each subclass: https://github.com/airspeed-velocity/asv/issues/880
- we cannot make asv  to ignore a to be mixed in (like `TypicalOps` here) class defining benchmarks, so it would try running them and fail

Since then I discovered that there are ways to "parametrize" benchmarks: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#parameterized-benchmarks .  So similarly to what we do in `@with_testrepos` I guess we just need to establish some "lazy" benchmark datasets generator, and then tests classes would be parametrized with the name of the dataset to use, and ask `self.datasets[name]` to get it in the `setup`, possibly eliminating the need for `setup_cache`.  We would just need to track them and remove `atexit`.  Really close to what we already do in `@with_testrepos`

So submitting this PR as a draft and not intended to be merged