### PR TITLE
cmd: Use asyncio for online processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.5
 ##1  - 3.6
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,10 +121,7 @@ we outline the workflow used by the developers:
 Development environment
 -----------------------
 
-Although we now support Python 3 (>= 3.3), primarily we still use Python 2.7
-and thus instructions below are for python 2.7 deployments.  Replace `python-{`
-with `python{,3}-{` to also install dependencies for Python 3 (e.g., if you would
-like to develop and test through tox).
+We support Python 3 only (>= 3.5).
 
 See [README.md:Dependencies](README.md#Dependencies) for basic information
 about installation of datalad itself.
@@ -133,14 +130,14 @@ since we use it to provide backports of recent fixed external modules we depend 
 
 ```sh
 apt-get install -y -q git git-annex-standalone
-apt-get install -y -q patool python-scrapy python-{appdirs,argcomplete,git,humanize,keyring,lxml,msgpack,mock,progressbar,requests,setuptools,six}
+apt-get install -y -q patool python3-scrapy python3-{appdirs,argcomplete,git,humanize,keyring,lxml,msgpack,mock,progressbar,requests,setuptools}
 ```
 
 and additionally, for development we suggest to use tox and new
 versions of dependencies from pypy:
 
 ```sh
-apt-get install -y -q python-{dev,httpretty,nose,pip,vcr,virtualenv} python-tox
+apt-get install -y -q python3-{dev,httpretty,nose,pip,vcr,virtualenv} python3-tox
 # Some libraries which might be needed for installing via pip
 apt-get install -y -q lib{ffi,ssl,curl4-openssl,xml2,xslt1}-dev
 ```

--- a/_datalad_build_support/formatters.py
+++ b/_datalad_build_support/formatters.py
@@ -270,7 +270,7 @@ class RSTManPageFormatter(ManPageFormatter):
 
 def cmdline_example_to_rst(src, out=None, ref=None):
     if out is None:
-        from six.moves import StringIO
+        from io import StringIO
         out = StringIO()
 
     # place header

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["master", "0.11.x"], // for git
+    "branches": ["drop-py2", "runner-async"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
@@ -41,7 +41,7 @@
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     // We are looking into the future now, so benchmarking 3.7
-    "pythons": ["2.7", "3.7"],
+    "pythons": ["3.7"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["drop-py2", "runner-async"], // for git
+    "branches": ["runner-async-base", "runner-async"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -131,6 +131,20 @@ class runner(SuprocBenchmarks):
                                   log_stderr='offline',  # needed to would get stuck
                                   log_online=True)
 
+    def time_heavyout_online_through(self):
+        return self.runner.run(heavyout_cmd,
+                               log_stderr='offline',  # needed to would get stuck
+                               log_online=True)
+
+    def time_heavyout_online_process(self):
+        return self.runner.run(heavyout_cmd,
+                               log_stdout=lambda s: '',
+                               log_stderr='offline',  # needed to would get stuck
+                               log_online=True)
+
+    def time_system_call(self):
+        os.system(heavyout_cmd + " >/dev/null 2>&1")
+
     # # Probably not really interesting, and good lord wobbles around 0
     # def track_overhead_heavyout_offline(self):
     #     return self._get_overhead(heavyout_cmd,

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -41,7 +41,7 @@ from datalad.utils import getpwd
 from .common import SuprocBenchmarks
 
 scripts_dir = osp.join(osp.dirname(__file__), 'scripts')
-heavyout_cmd = "{} 1000".format(osp.join(scripts_dir, 'heavyout'))
+heavyout_cmd = "{} 10000".format(osp.join(scripts_dir, 'heavyout'))
 
 class startup(SuprocBenchmarks):
     """

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -89,7 +89,7 @@ class runner(SuprocBenchmarks):
 
     unit = "% overhead"
 
-    def _get_overhead(self, cmd, nrepeats=3, **run_kwargs):
+    def _get_overhead(self, cmd, nrepeats=10, **run_kwargs):
         """Estimate overhead over running command via the simplest os.system
         and to not care about any output
         """

--- a/benchmarks/scripts/heavyout
+++ b/benchmarks/scripts/heavyout
@@ -7,4 +7,6 @@ niter = int(sys.argv[1])
 load = {i: "x" * i for i in range(10)}
 
 for i in range(niter):
-    print("I am looping already for {} iterations. Load: {}".format(i, load))
+    print("stdout: I am looping already for {} iterations. Load: {}".format(i, load))
+    print("stderr: I am looping already for {} iterations. Load: {}".format(i, load),
+          file=sys.stderr)

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -167,7 +167,7 @@ def setup_package():
 
     # Monkey patch nose so it does not ERROR out whenever code asks for fileno
     # of the output. See https://github.com/nose-devs/nose/issues/6
-    from six.moves import StringIO as OrigStringIO
+    from io import StringIO as OrigStringIO
 
     class StringIO(OrigStringIO):
         fileno = lambda self: 1

--- a/datalad/acmd.py
+++ b/datalad/acmd.py
@@ -1,0 +1,131 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Interface for running commands with `asyncio.create_subprocess_{shell,exec}`.
+
+This is intended for internal use by `cmd.Runner`.
+"""
+
+import asyncio
+from functools import partial
+import locale
+import logging
+import sys
+
+lgr = logging.getLogger('datalad.acmd')
+
+
+async def _noop():
+    return None
+
+
+async def _read_stream(stream, callback):
+    while True:
+        line = await stream.readline()
+        if line:
+            callback(line)
+        else:
+            break
+
+
+async def _run_subprocess(command, stdout_callback=None, stderr_callback=None,
+                          **kwds):
+    if kwds.get("shell"):
+        fn = partial(asyncio.create_subprocess_shell,
+                     command)
+    else:
+        fn = partial(asyncio.create_subprocess_exec,
+                     *command)
+    process = await fn(stdout=asyncio.subprocess.PIPE,
+                       stderr=asyncio.subprocess.PIPE,
+                       **kwds)
+
+    if stdout_callback is not None:
+        stdout = _read_stream(process.stdout, stdout_callback)
+    else:
+        stdout = _noop()
+
+    if stderr_callback is not None:
+        stderr = _read_stream(process.stderr, stderr_callback)
+    else:
+        stderr = _noop()
+
+    await asyncio.tasks.gather(stdout, stderr)
+    exit_code = await process.wait()
+    return exit_code
+
+
+def _write(stream, line):
+    stream.buffer.write(line)
+    stream.flush()
+
+
+def _call_with_decoded(fn):
+    encoding = locale.getpreferredencoding(False)
+
+    def wrapped(line):
+        # This decode then encode again isn't ideal, but it is done to get a
+        # consistent return value and work with the existing Runner() code.
+        # Eventually it'd probably be best for all the callbacks to be expected
+        # to return unicode.
+        res = fn(line.decode(encoding))
+        return res.encode(encoding) if res else b''
+    return wrapped
+
+
+def _collect(container, transform_fn=None):
+    if transform_fn is None:
+        fn = container.append
+    else:
+        def fn(line):
+            res = transform_fn(line)
+            if res is not None:
+                container.append(res)
+    return fn
+
+
+def run(cmd, log_stdout=True, log_stderr=True, **kwds):
+    """Run a command through `asyncio.create_subprocess_{exec,shell}`.
+
+    Parameters
+    ----------
+    cmd : list of str or str
+        A command in the same form as accepted by `cmd.Runner`.
+    log_stdout, log_stderr : bool or callable
+        If a callable, it should take a line from the stream. Any value it
+        returns will be captured as output for that stream. Otherwise, a true
+        value results in the output for that stream being captured, while a
+        false value results in the line being directly written to the stream.
+    **kwds
+        Keyword arguments passed to `create_subprocess_{exec,shell}` call.
+
+    Returns
+    -------
+    A tuple where the first item is a tuple of (stdout, stderr) byte strings
+    with captured output and the second item is the exit code of the process.
+    """
+    # Set up callbacks for each stream.
+    captured = {}
+    for name, param in [("stdout", log_stdout),
+                        ("stderr", log_stderr)]:
+        cb_key = "{}_callback".format(name)
+        if param:
+            captured[name] = []
+            if callable(param):
+                kwds[cb_key] = _collect(captured[name],
+                                        transform_fn=_call_with_decoded(param))
+            elif param:
+                kwds[cb_key] = _collect(captured[name])
+        else:
+            kwds[cb_key] = partial(_write, getattr(sys, name))
+
+    # Run command.
+    loop = asyncio.get_event_loop()
+    status = loop.run_until_complete(_run_subprocess(cmd, **kwds))
+    out = tuple(b''.join(captured.get(s, b'')) for s in ["stdout", "stderr"])
+    return out, status

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -12,7 +12,6 @@
 import sys
 # OPT delay import for expensive mock until used
 #from mock import patch
-from six import PY2
 import builtins
 
 import logging

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -154,7 +154,7 @@ class AutomagicIO(object):
                     # name/file was provided
                     file = args[0]
                 else:
-                    filearg = "name" if PY2 else "file"
+                    filearg = "file"
                     if filearg not in kwargs:
                         # so the name was missing etc, just proxy into original open call and let it puke
                         raise _EarlyExit("no name/file was given")

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -13,8 +13,7 @@ import sys
 # OPT delay import for expensive mock until used
 #from mock import patch
 from six import PY2
-import six.moves.builtins as __builtin__
-builtins_name = '__builtin__' if PY2 else 'builtins'
+import builtins
 
 import logging
 import io
@@ -97,7 +96,7 @@ class AutomagicIO(object):
           AutomagicIO supervision.
         """
         self._active = False
-        self._builtin_open = __builtin__.open
+        self._builtin_open = builtins.open
         self._io_open = io.open
         self._os_stat = os.stat
         self._builtin_exists = os.path.exists
@@ -196,7 +195,7 @@ class AutomagicIO(object):
         return origfunc(*args, **kwargs)
 
     def _proxy_open(self, *args, **kwargs):
-        return self._proxy_open_name_mode(builtins_name + '.open', self._builtin_open,
+        return self._proxy_open_name_mode('builtins.open', self._builtin_open,
                                           *args, **kwargs)
 
     def _proxy_io_open(self, *args, **kwargs):
@@ -313,7 +312,7 @@ class AutomagicIO(object):
             lgr.debug("%s already active. No action taken" % self)
             return
         # overloads
-        __builtin__.open = self._proxy_open
+        builtins.open = self._proxy_open
         io.open = self._proxy_io_open
         os.stat = self._proxy_os_stat
         os.path.exists = self._proxy_exists
@@ -330,7 +329,7 @@ class AutomagicIO(object):
         if not self.active:
             lgr.warning("%s is not active, can't deactivate" % self)
             return
-        __builtin__.open = self._builtin_open
+        builtins.open = self._builtin_open
         io.open = self._io_open
         os.stat = self._os_stat
         if h5py:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -287,7 +287,7 @@ class Runner(object):
         -------
 
         """
-        stdout, stderr = binary_type(), binary_type()
+        stdout, stderr = bytes(), bytes()
 
         log_stdout_ = _decide_to_log(log_stdout)
         log_stderr_ = _decide_to_log(log_stderr)
@@ -333,7 +333,7 @@ class Runner(object):
     def _process_remaining_output(self, stream, out_, *pargs):
         """Helper to process output which might have been obtained from popen or
         should be loaded from file"""
-        out = binary_type()
+        out = bytes()
         if isinstance(stream, file_class) and \
                 _MAGICAL_OUTPUT_MARKER in getattr(stream, 'name', ''):
             assert out_ is None, "should have gone into a file"
@@ -375,7 +375,7 @@ class Runner(object):
                 raise RuntimeError("must not get here")
             return (line + suf) if suf else line
         # it was output already directly but for code to work, return ""
-        return binary_type()
+        return bytes()
 
     def run(self, cmd, log_stdout=True, log_stderr=True, log_online=False,
             expect_stderr=False, expect_fail=False,
@@ -529,7 +529,7 @@ class Runner(object):
                 if PY3:
                     # Decoding was delayed to this point
                     def decode_if_not_None(x):
-                        return "" if x is None else binary_type.decode(x)
+                        return "" if x is None else bytes.decode(x)
                     # TODO: check if we can avoid PY3 specific here
                     out = tuple(map(decode_if_not_None, out))
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -59,13 +59,7 @@ _TEMP_std = sys.stdout, sys.stderr
 # which might be created outside and passed into Runner
 _MAGICAL_OUTPUT_MARKER = "_runneroutput_"
 
-if PY2:
-    # TODO apparently there is a recommended substitution for Python2
-    # which is a backported implementation of python3 subprocess
-    # https://pypi.python.org/pypi/subprocess32/
-    file_class = file
-else:
-    from io import IOBase as file_class
+from io import IOBase as file_class
 
 
 def _decide_to_log(v):
@@ -451,8 +445,6 @@ class Runner(object):
 
         popen_env = env or self.env
         popen_cwd = cwd or self.cwd
-        if PY2:
-            popen_cwd = assure_bytes(popen_cwd)
 
         if popen_cwd and popen_env and 'PWD' in popen_env:
             # we must have inherited PWD, but cwd was provided, so we must
@@ -806,7 +798,7 @@ class BatchedCommand(object):
         # according to the internet wisdom there is no easy way with subprocess
         self._check_process(restart=True)
         process = self._process  # _check_process might have restarted it
-        process.stdin.write(assure_bytes(entry) if PY2 else entry)
+        process.stdin.write(entry)
         process.stdin.flush()
         lgr.log(5, "Done sending.")
         still_alive, stderr = self._check_process(restart=False)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -345,7 +345,7 @@ class Runner(object):
         else:
             if out_:
                 # resolving a once in a while failing test #2185
-                if isinstance(out_, text_type):
+                if isinstance(out_, str):
                     out_ = out_.encode('utf-8')
                 for line in out_.split(linesep_bytes):
                     out += self._process_one_line(
@@ -550,7 +550,7 @@ class Runner(object):
                            "" if log_online else " out=%s" % out[0],
                            "" if log_online else " err=%s" % out[1])
                     lgr.log(9 if expect_fail else 11, msg)
-                    raise CommandError(text_type(cmd), msg, status, out[0], out[1])
+                    raise CommandError(str(cmd), msg, status, out[0], out[1])
                 else:
                     self.log("Finished running %r with status %s" % (cmd, status),
                              level=8)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -447,6 +447,10 @@ class Runner(object):
             popen_env = popen_env.copy()  # to avoid side-effects
             popen_env['PWD'] = popen_cwd
 
+        if log_online and not (log_stdout or log_stdout):
+            lgr.warning("log_online has no effect "
+                        "unless log_stdout or log_stderr is set; ignoring")
+            log_online = False
         # TODO: if outputstream is sys.stdout and that one is set to StringIO
         #       we have to "shim" it with something providing fileno().
         # This happens when we do not swallow outputs, while allowing nosetest's

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -194,7 +194,7 @@ class Runner(object):
           if cmd is neither a string nor a callable.
         """
 
-        if isinstance(cmd, string_types) or isinstance(cmd, list):
+        if isinstance(cmd, str) or isinstance(cmd, list):
             return self.run(cmd, *args, **kwargs)
         elif callable(cmd):
             return self.call(cmd, *args, **kwargs)
@@ -489,13 +489,13 @@ class Runner(object):
         if self.protocol.do_execute_ext_commands:
 
             if shell is None:
-                shell = isinstance(cmd, string_types)
+                shell = isinstance(cmd, str)
 
             if self.protocol.records_ext_commands:
                 prot_exc = None
                 prot_id = self.protocol.start_section(
                     shlex.split(cmd, posix=not on_windows)
-                    if isinstance(cmd, string_types)
+                    if isinstance(cmd, str)
                     else cmd)
             try:
                 proc = subprocess.Popen(cmd,
@@ -564,7 +564,7 @@ class Runner(object):
             if self.protocol.records_ext_commands:
                 self.protocol.add_section(shlex.split(cmd,
                                                       posix=not on_windows)
-                                          if isinstance(cmd, string_types)
+                                          if isinstance(cmd, str)
                                           else cmd, None)
             out = ("DRY", "DRY")
 
@@ -786,7 +786,7 @@ class BatchedCommand(object):
 
         and yields results for each item."""
         for entry in cmds:
-            if not isinstance(entry, string_types):
+            if not isinstance(entry, str):
                 entry = ' '.join(entry)
             yield self.proc1(entry)
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -243,12 +243,14 @@ class Runner(object):
     def _log_out(self, line):
         if line and self.log_outputs:
             self.log("stdout| " + line.rstrip('\n'))
+        return line  # Return to ease collection for asyncio callback.
 
     def _log_err(self, line, expected=False):
         if line and self.log_outputs:
             self.log("stderr| " + line.rstrip('\n'),
                      level={True: 9,
                             False: 11}[expected])
+        return line  # Return to ease collection for asyncio callback.
 
     def _get_output_online(self, proc,
                            log_stdout, log_stderr,

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -22,13 +22,6 @@ import functools
 import tempfile
 
 from collections import OrderedDict
-from six import (
-    PY3,
-    PY2,
-    string_types,
-    binary_type,
-    text_type,
-)
 from .support import path as op
 from .consts import GIT_SSH_COMMAND
 from .dochelpers import exc_str

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -363,7 +363,7 @@ class Runner(object):
             if out_type == 'stdout':
                 self._log_out(assure_unicode(line))
             elif out_type == 'stderr':
-                self._log_err(line.decode('utf-8') if PY3 else line,
+                self._log_err(line.decode('utf-8'),
                               expected)
             else:  # pragma: no cover
                 raise RuntimeError("must not get here")
@@ -518,12 +518,10 @@ class Runner(object):
                 else:
                     out = proc.communicate()
 
-                if PY3:
-                    # Decoding was delayed to this point
-                    def decode_if_not_None(x):
-                        return "" if x is None else bytes.decode(x)
-                    # TODO: check if we can avoid PY3 specific here
-                    out = tuple(map(decode_if_not_None, out))
+                # Decoding was delayed to this point
+                def decode_if_not_None(x):
+                    return "" if x is None else bytes.decode(x)
+                out = tuple(map(decode_if_not_None, out))
 
                 status = proc.poll()
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -529,12 +529,12 @@ def main(args=None):
                 # exit code as is
                 exc_msg = str(exc)
                 if exc_msg:
-                    msg = exc_msg.encode() if isinstance(exc_msg, text_type) else exc_msg
+                    msg = exc_msg.encode() if isinstance(exc_msg, str) else exc_msg
                     os.write(2, msg + b"\n")
                 if exc.stdout:
-                    os.write(1, exc.stdout.encode() if isinstance(exc.stdout, text_type) else exc.stdout)
+                    os.write(1, exc.stdout.encode() if isinstance(exc.stdout, str) else exc.stdout)
                 if exc.stderr:
-                    os.write(2, exc.stderr.encode() if isinstance(exc.stderr, text_type) else exc.stderr)
+                    os.write(2, exc.stderr.encode() if isinstance(exc.stderr, str) else exc.stderr)
                 # We must not exit with 0 code if any exception got here but
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -22,7 +22,6 @@ import sys
 import textwrap
 import os
 
-from six import text_type
 
 import datalad
 

--- a/datalad/cmdline/tests/test_formatters.py
+++ b/datalad/cmdline/tests/test_formatters.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """"""
 
-from six.moves import StringIO as SIO
+from io import StringIO as SIO
 from os.path import exists
 from nose import SkipTest
 try:

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -13,7 +13,7 @@ from datalad.tests.utils import on_windows
 
 import re
 import sys
-from six.moves import StringIO
+from io import StringIO
 from mock import patch
 
 import datalad

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -14,8 +14,6 @@ import os
 import logging
 import random
 import uuid
-from six import iteritems
-from six import text_type
 from argparse import (
     REMAINDER,
     ONE_OR_MORE,

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -272,7 +272,7 @@ class Create(Interface):
                 # into a known subdataset that is not around ATM
                 subds_status = {
                     parentds_path / k.relative_to(prepo.path)
-                    for k, v in iteritems(pstatus)
+                    for k, v in pstatus.items()
                     if v.get('type', None) == 'dataset'}
                 check_paths = [check_path]
                 check_paths.extend(check_path.parents)
@@ -406,7 +406,7 @@ class Create(Interface):
         # a dedicated argument, because it is sufficient for the cmdline
         # and unnecessary for the Python API (there could simply be a
         # subsequence ds.config.add() call)
-        for k, v in iteritems(tbds.config.overrides):
+        for k, v in tbds.config.overrides.items():
             tbds.config.add(k, v, where='local', reload=False)
 
         # all config manipulation is done -> fll reload

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -210,12 +210,12 @@ class Create(Interface):
         assert(path is not None)
 
         # prep for yield
-        res = dict(action='create', path=text_type(path),
+        res = dict(action='create', path=str(path),
                    logger=lgr, type='dataset',
                    refds=refds_path)
 
         refds = None
-        if refds_path and refds_path != text_type(path):
+        if refds_path and refds_path != str(path):
             refds = require_dataset(
                 refds_path, check_installed=True,
                 purpose='creating a subdataset')
@@ -228,7 +228,7 @@ class Create(Interface):
                     message=(
                         "dataset containing given paths is not underneath "
                         "the reference dataset %s: %s",
-                        ds, text_type(path)),
+                        ds, str(path)),
                 )
                 return
 
@@ -239,7 +239,7 @@ class Create(Interface):
         # in this location
         # it will cost some filesystem traversal though...
         parentds_path = rev_get_dataset_root(
-            op.normpath(op.join(text_type(path), os.pardir)))
+            op.normpath(op.join(str(path), os.pardir)))
         if parentds_path:
             prepo = GitRepo(parentds_path)
             parentds_path = ut.Path(parentds_path)
@@ -263,8 +263,8 @@ class Create(Interface):
                     'status': 'error',
                     'message': (
                         'collision with content in parent dataset at %s: %s',
-                        text_type(parentds_path),
-                        [text_type(c) for c in conflict])})
+                        str(parentds_path),
+                        [str(c) for c in conflict])})
                 yield res
                 return
             if not force:
@@ -282,15 +282,15 @@ class Create(Interface):
                         'status': 'error',
                         'message': (
                             'collision with %s (dataset) in dataset %s',
-                            text_type(conflict[0]),
-                            text_type(parentds_path))})
+                            str(conflict[0]),
+                            str(parentds_path))})
                     yield res
                     return
 
         # important to use the given Dataset object to avoid spurious ID
         # changes with not-yet-materialized Datasets
         tbds = ds if isinstance(ds, Dataset) and \
-            ds.path == path else Dataset(text_type(path))
+            ds.path == path else Dataset(str(path))
 
         # don't create in non-empty directory without `force`:
         if op.isdir(tbds.path) and listdir(tbds.path) != [] and not force:

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -178,8 +178,7 @@ class Create(Interface):
             if isinstance(dataset, Dataset):
                 ds = dataset
             else:
-                # assure_unicode() for PY2.
-                ds = Dataset(ut.assure_unicode(dataset))
+                ds = Dataset(dataset)
             refds_path = ds.path
         else:
             ds = refds_path = None

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -13,10 +13,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import os.path as op
-from six import (
-    iteritems,
-    text_type,
-)
 from collections import OrderedDict
 from datalad.utils import (
     assure_list,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -243,7 +243,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
     paths = None if origpaths is None \
         else OrderedDict(
             (repo_path / p.relative_to(ds.pathobj), goinside)
-            for p, goinside in iteritems(origpaths)
+            for p, goinside in origpaths.items()
             if ds.pathobj in p.parents or (p == ds.pathobj and goinside)
         )
     try:
@@ -278,7 +278,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                 ref=fr,
                 key_prefix="prev_")
 
-    for path, props in iteritems(diff_state):
+    for path, props in diff_state.items():
         pathinds = str(ds.pathobj / path.relative_to(repo_path))
         yield dict(
             props,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -162,12 +162,12 @@ def _diff_cmd(
             # content (e.g. 'ds/')
             # special case is the root dataset, always report its content
             # changes
-            orig_path = text_type(p)
+            orig_path = str(p)
             resolved_path = rev_resolve_path(p, dataset)
             p = \
                 resolved_path, \
                 orig_path.endswith(op.sep) or resolved_path == ds.pathobj
-            str_path = text_type(p[0])
+            str_path = str(p[0])
             root = rev_get_dataset_root(str_path)
             if root is None:
                 # no root, not possibly underneath the refds
@@ -259,7 +259,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
         yield dict(
             path=ds.path,
             status='impossible',
-            message=text_type(e),
+            message=str(e),
         )
         return
 
@@ -279,7 +279,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                 key_prefix="prev_")
 
     for path, props in iteritems(diff_state):
-        pathinds = text_type(ds.pathobj / path.relative_to(repo_path))
+        pathinds = str(ds.pathobj / path.relative_to(repo_path))
         yield dict(
             props,
             path=pathinds,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -22,7 +22,7 @@ from os.path import relpath
 from tempfile import mkdtemp
 
 from six.moves import map
-from six.moves import shlex_quote
+from shlex import quote as shlex_quote
 
 from datalad.core.local.save import Save
 

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -392,8 +392,6 @@ def _execute_command(command, pwd, expected_exit=None):
         lgr.info("== Command start (output follows) =====")
         runner.run(
             command,
-            # immediate output
-            log_online=True,
             # not yet sure what we should do with the command output
             # IMHO `run` itself should be very silent and let the command talk
             log_stdout=False,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -21,7 +21,6 @@ from os.path import normpath
 from os.path import relpath
 from tempfile import mkdtemp
 
-from six.moves import map
 from shlex import quote as shlex_quote
 
 from datalad.core.local.save import Save

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -276,7 +276,7 @@ class Save(Interface):
                     # version
                     for k in ('path', 'refds'):
                         if k in res:
-                            res[k] = text_type(
+                            res[k] = str(
                                 # recode path back to dataset path anchor
                                 pds.pathobj / res[k].relative_to(
                                     pds.repo.pathobj)

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -208,7 +208,7 @@ class Save(Interface):
             ds_status = paths_by_ds.get(s['parentds'], {})
             # reassemble path status info as repo.status() would have made it
             ds_status[ut.Path(s['path'])] = \
-                {k: v for k, v in iteritems(s)
+                {k: v for k, v in s.items()
                  if k not in (
                      'path', 'parentds', 'refds', 'status', 'action',
                      'logger')}
@@ -226,11 +226,11 @@ class Save(Interface):
         # sort the datasets into (potentially) disjoint hierarchies,
         # or a single one, if a reference dataset was given
         dataset_hierarchies = get_tree_roots(discovered_datasets)
-        for rootds, children in iteritems(dataset_hierarchies):
+        for rootds, children in dataset_hierarchies.items():
             edges = {}
             discover_dataset_trace_to_targets(
                 rootds, children, [], edges, includeds=children)
-            for superds, subdss in iteritems(edges):
+            for superds, subdss in edges.items():
                 superds_status = paths_by_ds.get(superds, {})
                 for subds in subdss:
                     # TODO actually start from an entry that may already
@@ -255,7 +255,7 @@ class Save(Interface):
                 # cumbersome symlink handling without context in the
                 # lower levels
                 pds.repo.pathobj / p.relative_to(pdspath): props
-                for p, props in iteritems(paths_by_ds.pop(pdspath))}
+                for p, props in paths_by_ds.pop(pdspath).items()}
             start_commit = pds.repo.get_hexsha()
             if not all(p['state'] == 'clean' for p in pds_status.values()):
                 for res in pds.repo.save_(

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -13,8 +13,6 @@
 __docformat__ = 'restructuredtext'
 
 import logging
-from six import iteritems
-from six import text_type
 
 from datalad.interface.base import (
     Interface,

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -129,7 +129,7 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried,
             init=status,
             eval_availability=annexinfo in ('availability', 'all'),
             ref=None)
-    for path, props in iteritems(status):
+    for path, props in status.items():
         cpath = ds.pathobj / path.relative_to(repo_path)
         yield dict(
             props,

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -392,10 +392,7 @@ class Status(Interface):
         refds = res.get('refds', None)
         refds = refds if kwargs.get('dataset', None) is not None \
             or refds == os.getcwd() else None
-        # Note: We have to force unicode for res['path'] because
-        # interface.utils encodes it on py2 before passing it to
-        # custom_result_renderer().
-        path = assure_unicode(res['path']) if refds is None \
+        path = res['path'] if refds is None \
             else str(ut.Path(res['path']).relative_to(refds))
         type_ = res.get('type', res.get('type_src', ''))
         max_len = len('untracked')

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -14,10 +14,6 @@ __docformat__ = 'restructuredtext'
 import logging
 import os
 import os.path as op
-from six import (
-    iteritems,
-    text_type,
-)
 from collections import OrderedDict
 
 from datalad.utils import (

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -133,14 +133,14 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried,
         cpath = ds.pathobj / path.relative_to(repo_path)
         yield dict(
             props,
-            path=text_type(cpath),
+            path=str(cpath),
             # report the dataset path rather than the repo path to avoid
             # realpath/symlink issues
             parentds=ds.path,
         )
         queried.add(ds.pathobj)
         if recursion_limit and props.get('type', None) == 'dataset':
-            subds = Dataset(text_type(cpath))
+            subds = Dataset(str(cpath))
             if subds.is_installed():
                 for r in _yield_status(
                         subds,
@@ -289,9 +289,9 @@ class Status(Interface):
                 # it is important to capture the exact form of the
                 # given path argument, before any normalization happens
                 # for further decision logic below
-                orig_path = text_type(p)
+                orig_path = str(p)
                 p = rev_resolve_path(p, dataset)
-                root = rev_get_dataset_root(text_type(p))
+                root = rev_get_dataset_root(str(p))
                 if root is None:
                     # no root, not possibly underneath the refds
                     yield dict(
@@ -303,7 +303,7 @@ class Status(Interface):
                         logger=lgr)
                     continue
                 else:
-                    if dataset and root == text_type(p) and \
+                    if dataset and root == str(p) and \
                             not (orig_path.endswith(op.sep) or
                                  orig_path == "."):
                         # the given path is pointing to a dataset
@@ -343,7 +343,7 @@ class Status(Interface):
                 # nothing we support handling any further
                 # there is only a single refds
                 yield dict(
-                    path=text_type(qdspath),
+                    path=str(qdspath),
                     refds=ds.path,
                     action='status',
                     status='error',
@@ -363,7 +363,7 @@ class Status(Interface):
             if qdspath in queried:
                 # do not report on a single dataset twice
                 continue
-            qds = Dataset(text_type(qdspath))
+            qds = Dataset(str(qdspath))
             for r in _yield_status(
                     qds,
                     qpaths,
@@ -400,7 +400,7 @@ class Status(Interface):
         # interface.utils encodes it on py2 before passing it to
         # custom_result_renderer().
         path = assure_unicode(res['path']) if refds is None \
-            else text_type(ut.Path(res['path']).relative_to(refds))
+            else str(ut.Path(res['path']).relative_to(refds))
         type_ = res.get('type', res.get('type_src', ''))
         max_len = len('untracked')
         state = res.get('state', 'unknown')

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -92,7 +92,7 @@ def test_create_raises(path, outside_path):
         ds.create(obscure_ds, **raw),
         status='error',
         message=('collision with %s (dataset) in dataset %s',
-                 text_type(ds.pathobj / obscure_ds),
+                 str(ds.pathobj / obscure_ds),
                  ds.path)
     )
 
@@ -105,14 +105,14 @@ def test_create_raises(path, outside_path):
         ds.create(obscure_ds, **raw),
         status='error',
         message=('collision with %s (dataset) in dataset %s',
-                 text_type(ds.pathobj / obscure_ds),
+                 str(ds.pathobj / obscure_ds),
                  ds.path)
     )
     assert_in_results(
         ds.create(op.join(obscure_ds, 'subsub'), **raw),
         status='error',
         message=('collision with %s (dataset) in dataset %s',
-                 text_type(ds.pathobj / obscure_ds),
+                 str(ds.pathobj / obscure_ds),
                  ds.path)
     )
     os.makedirs(op.join(ds.path, 'down'))
@@ -124,7 +124,7 @@ def test_create_raises(path, outside_path):
         status='error',
         message=('collision with content in parent dataset at %s: %s',
                  ds.path,
-                 [text_type(ds.pathobj / 'down' / 'someotherfile.tst')]),
+                 [str(ds.pathobj / 'down' / 'someotherfile.tst')]),
     )
 
 
@@ -261,7 +261,7 @@ def test_create_sub_dataset_dot_no_path(path):
     ds.create()
 
     # Test non-bound call.
-    sub0_path = text_type(ds.pathobj / "sub0")
+    sub0_path = str(ds.pathobj / "sub0")
     os.mkdir(sub0_path)
     with chpwd(sub0_path):
         subds0 = create(dataset=".")
@@ -269,7 +269,7 @@ def test_create_sub_dataset_dot_no_path(path):
     assert_repo_status(subds0.path)
 
     # Test command-line invocation directly (regression from gh-3484).
-    sub1_path = text_type(ds.pathobj / "sub1")
+    sub1_path = str(ds.pathobj / "sub1")
     os.mkdir(sub1_path)
     Runner(cwd=sub1_path)(["datalad", "create", "-d."])
     assert_repo_status(ds.path, untracked=[subds0.path, sub1_path])

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -25,7 +25,6 @@ from datalad.distribution.dataset import (
 from datalad.api import create
 from datalad.support.exceptions import CommandError
 from datalad.utils import (
-    assure_bytes,
     chpwd,
     _path_,
 )
@@ -473,8 +472,5 @@ def check_create_obscure(create_kwargs, path):
 
 def test_create_with_obscure_name():
     fname = OBSCURE_FILENAME
-    if PY2:
-        # Mimic how it comes in on the command-line.
-        fname = assure_bytes(OBSCURE_FILENAME)
     yield check_create_obscure, {"path": fname}
     yield check_create_obscure, {"dataset": fname}

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -16,8 +16,6 @@ from datalad.tests.utils import known_failure_windows
 import os
 import os.path as op
 
-from six import PY2
-from six import text_type
 
 from datalad.distribution.dataset import (
     Dataset

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from six import text_type
 import os
 import os.path as op
 from datalad.support.exceptions import (

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -326,7 +326,7 @@ def test_path_diff(_path, linkpath):
         # technical reasons (annex using it for something in some mode)
         # should be reported as the thing it is representing (i.e.
         # a file)
-        if 'link2' in text_type(res['path']):
+        if 'link2' in str(res['path']):
             assert res['type'] == 'symlink', res
         else:
             assert res['type'] != 'symlink', res
@@ -354,7 +354,7 @@ def test_path_diff(_path, linkpath):
     rpath = op.join('subds_modified', 'subds_lvl1_modified',
                     u'{}_directory_untracked'.format(OBSCURE_FILENAME))
     apathobj = ds.pathobj / rpath
-    apath = text_type(apathobj)
+    apath = str(apathobj)
     for p in (rpath, apath, None):
         if p is None:
             # change into the realpath of the dataset and

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -23,7 +23,6 @@ from os import (
 )
 import sys
 
-from six import PY2
 from mock import patch
 
 from datalad.utils import (

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -332,7 +332,7 @@ def test_run_cmdline_disambiguation(path):
 
         # And a twist on above: Our parser mishandles --version (gh-3067),
         # treating 'datalad run CMD --version' as 'datalad --version'.
-        version_stream = "err" if PY2 else "out"
+        version_stream = "out"
         with swallow_outputs() as cmo:
             with assert_raises(SystemExit) as cm:
                 main(["datalad", "run", "echo", "--version"])

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -10,9 +10,6 @@
 
 import os
 import os.path as op
-from six import iteritems
-from six import PY2
-from six import text_type
 
 from datalad.utils import (
     on_windows,

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -16,7 +16,6 @@ from six import text_type
 
 from datalad.utils import (
     on_windows,
-    assure_bytes,
     assure_list,
     rmtree,
 )
@@ -736,9 +735,6 @@ def test_on_failure_continue(path):
 def test_save_obscure_name(path):
     ds = Dataset(path).create(force=True)
     fname = OBSCURE_FILENAME
-    if PY2:
-        # Mimic how the path will come in from the command line.
-        fname = assure_bytes(fname)
     # Just check that we don't fail with a unicode error.
     with swallow_outputs():
         ds.save(path=fname, result_renderer="default")

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -363,7 +363,7 @@ def test_add_files(path):
                 assert_result_count(result, 1, path=str(ds.pathobj / a))
             status = ds.repo.get_content_annexinfo(
                 ut.Path(p) for p in assure_list(arg[0]))
-        for f, p in iteritems(status):
+        for f, p in status.items():
             if arg[1]:
                 assert p.get('key', None) is None, f
             else:

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -360,7 +360,7 @@ def test_add_files(path):
         else:
             result = ds.save(arg[0], to_git=arg[1])
             for a in assure_list(arg[0]):
-                assert_result_count(result, 1, path=text_type(ds.pathobj / a))
+                assert_result_count(result, 1, path=str(ds.pathobj / a))
             status = ds.repo.get_content_annexinfo(
                 ut.Path(p) for p in assure_list(arg[0]))
         for f, p in iteritems(status):
@@ -488,7 +488,7 @@ def test_gh1597_simpler(path):
 def test_update_known_submodule(path):
     def get_baseline(p):
         ds = Dataset(p).create()
-        sub = create(text_type(ds.pathobj / 'sub'))
+        sub = create(str(ds.pathobj / 'sub'))
         assert_repo_status(ds.path, untracked=['sub'])
         return ds
     # attempt one

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -9,7 +9,6 @@
 """Test status command"""
 
 import os.path as op
-from six import text_type
 import datalad.utils as ut
 
 from datalad.utils import (

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -108,7 +108,7 @@ def test_status_nods(path, otherpath):
 def test_status(_path, linkpath):
     # do the setup on the real path, not the symlink, to have its
     # bugs not affect this test of status()
-    ds = get_deeply_nested_structure(text_type(_path))
+    ds = get_deeply_nested_structure(str(_path))
     if has_symlink_capability():
         # make it more complicated by default
         ut.Path(linkpath).symlink_to(_path, target_is_directory=True)
@@ -128,10 +128,10 @@ def test_status(_path, linkpath):
     assert_result_count(
         ds.status(annex='all'),
         1,
-        path=text_type(ds.pathobj / 'subdir' / 'annexed_file.txt'),
+        path=str(ds.pathobj / 'subdir' / 'annexed_file.txt'),
         key='MD5E-s5--275876e34cf609db118f3d84b799a790.txt',
         has_content=True,
-        objloc=text_type(ds.repo.pathobj / '.git' / 'annex' / 'objects' /
+        objloc=str(ds.repo.pathobj / '.git' / 'annex' / 'objects' /
         # hashdir is different on windows
         ('f33' if on_windows else '7p') /
         ('94b' if on_windows else 'gp') /
@@ -147,7 +147,7 @@ def test_status(_path, linkpath):
         # technical reasons (annex using it for something in some mode)
         # should be reported as the thing it is representing (i.e.
         # a file)
-        if 'link2' in text_type(res['path']):
+        if 'link2' in str(res['path']):
             assert res['type'] == 'symlink', res
         else:
             assert res['type'] != 'symlink', res
@@ -175,7 +175,7 @@ def test_status(_path, linkpath):
     rpath = op.join('subds_modified', 'subds_lvl1_modified',
                     OBSCURE_FILENAME + u'_directory_untracked')
     apathobj = ds.pathobj / rpath
-    apath = text_type(apathobj)
+    apath = str(apathobj)
     # ds.repo.pathobj will have the symlink resolved
     arealpath = ds.repo.pathobj / rpath
     # TODO include explicit relative path in test

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -19,7 +19,6 @@ import sys
 
 from ..support.path import exists, join as opj, realpath, dirname, lexists
 
-from six.moves import range
 from urllib.parse import urlparse
 
 import logging

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -20,7 +20,7 @@ import sys
 from ..support.path import exists, join as opj, realpath, dirname, lexists
 
 from six.moves import range
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import logging
 lgr = logging.getLogger('datalad.customremotes')

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -37,11 +37,6 @@ def check_basic_scenario(url, d):
         whereis1 = annex.whereis('3versions_allversioned.txt', output='full')
         eq_(len(whereis1), 2)  # here and datalad
         annex.drop('3versions_allversioned.txt')
-        if PY2:
-            pass  # stopped appearing within the test  TODO
-            #assert_in('100%', cmo.err)  # we do provide our progress indicator
-        else:
-            pass  # TODO:  not sure what happened but started to fail for me on my laptop under tox
     whereis2 = annex.whereis('3versions_allversioned.txt', output='full')
     eq_(len(whereis2), 1)  # datalad
 

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -171,7 +171,7 @@ def test_dryrun(path):
     assert_result_count(
         res, 1, path=ctlg['c1'].path, type='dataset', status='ok',
         # http://site/group/dir--dir--dir--name.git
-        project='secret/{}'.format(text_type(
+        project='secret/{}'.format(str(
             ctlg['c1'].pathobj.relative_to(ctlg['root'].pathobj)).replace(
                 os.sep, '--')),
     )
@@ -188,14 +188,14 @@ def test_dryrun(path):
     assert_result_count(
         res, 1, path=ctlg['c1'].path, type='dataset', status='ok',
         # http://site/base--dir--dir--dir--name.git
-        project='secret--{}'.format(text_type(
+        project='secret--{}'.format(str(
             ctlg['c1'].pathobj.relative_to(ctlg['root'].pathobj)).replace(
                 os.sep, '--')),
     )
 
     # the results do not depend on explicitly given datasets, if we just enter
     # the parent dataset we get the same results
-    with chpwd(text_type(ctlg['root'].pathobj / 'subdir')):
+    with chpwd(str(ctlg['root'].pathobj / 'subdir')):
         rel_res = create_sibling_gitlab(path=os.curdir, dryrun=True)
         eq_(res, rel_res)
     # and again the same results if we are in a subdataset and point to a parent

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -8,9 +8,6 @@
 """Test create publication target on gitlab"""
 
 import os
-from six import (
-    text_type,
-)
 
 # this must import ok with and without gitlab
 from datalad.api import (

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -382,7 +382,7 @@ class Add(Interface):
                 except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(
                         ds=subds, status='error',
-                        message=getattr(e, 'stderr', None) or text_type(e),
+                        message=getattr(e, 'stderr', None) or str(e),
                         **dict(common_report, **ap))
                     continue
                 # queue for saving using the updated annotated path

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -21,7 +21,6 @@ from os.path import normpath
 from os.path import pardir
 from os.path import relpath
 
-from six import text_type
 
 from datalad.utils import assure_unicode
 from datalad.utils import unique

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -153,7 +153,7 @@ def _create_dataset_sibling(
                 try:
                     # ds_name is unicode which makes _msg unicode so we must be
                     # unicode-ready
-                    err_str = text_type(e.stderr)
+                    err_str = str(e.stderr)
                 except UnicodeDecodeError:
                     err_str = e.stderr.decode(errors='replace')
                 _msg += " And it fails to rmdir (%s)." % (err_str.strip(),)
@@ -218,7 +218,7 @@ def _create_dataset_sibling(
         # Either repository existed before or a new directory was created for it,
         # set its group to a desired one if was provided with the same chgrp
         ssh("chgrp -R {} {}".format(
-            sh_quote(text_type(group)),
+            sh_quote(str(group)),
             sh_quote(remoteds_path)))
     # don't (re-)initialize dataset if existing == reconfigure
     if not only_reconfigure:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -11,7 +11,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from six import text_type
 from distutils.version import LooseVersion
 from glob import glob
 import logging

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -44,7 +44,6 @@ from datalad.support.network import RI
 from datalad.support.exceptions import InvalidAnnexRepositoryError
 
 import datalad.utils as ut
-from datalad.utils import assure_unicode
 from datalad.utils import getpwd
 from datalad.utils import optional_args, expandpath, is_explicit_path
 from datalad.utils import get_dataset_root
@@ -488,7 +487,7 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
     The decorator has no effect on the actual function decorated with it.
     """
     if not name:
-        name = f.func_name if PY2 else f.__name__
+        name = f.__name__
 
     @wrapt.decorator
     def apply_func(wrapped, instance, args, kwargs):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -581,8 +581,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dataset = Dataset(dataset)
 
     if dataset is None:  # possible scenario of cmdline calls
-        # assure_unicode() can be dropped once we drop PY2.
-        dspath = assure_unicode(get_dataset_root(getpwd()))
+        dspath = get_dataset_root(getpwd())
         if not dspath:
             raise NoDatasetArgumentFound("No dataset found")
         dataset = Dataset(dspath)

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -540,7 +540,7 @@ class EnsureDataset(Constraint):
     def __call__(self, value):
         if isinstance(value, Dataset):
             return value
-        elif isinstance(value, string_types):
+        elif isinstance(value, str):
             # we cannot convert to a Dataset class right here
             # - duplicates require_dataset() later on
             # - we need to be able to distinguish between a bound
@@ -694,7 +694,7 @@ def rev_resolve_path(path, ds=None):
         # pathlib docs for why this is the only sane choice in the
         # face of the possibility of symlinks in the path
         out.append(p)
-    return out[0] if isinstance(path, (string_types, PurePath)) else out
+    return out[0] if isinstance(path, (str, PurePath)) else out
 
 
 def path_under_rev_dataset(ds, path):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -130,7 +130,7 @@ class Dataset(object, metaclass=Flyweight):
 
         # mirror what is happening in __init__
         if isinstance(path, ut.PurePath):
-            path = text_type(path)
+            path = str(path)
 
         # Custom handling for few special abbreviations
         path_ = path
@@ -174,7 +174,7 @@ class Dataset(object, metaclass=Flyweight):
           yet.
         """
         if isinstance(path, ut.PurePath):
-            path = text_type(path)
+            path = str(path)
         self._path = path
         self._repo = None
         self._id = None
@@ -700,7 +700,7 @@ def rev_resolve_path(path, ds=None):
 def path_under_rev_dataset(ds, path):
     ds_path = ds.pathobj
     try:
-        rpath = text_type(ut.Path(path).relative_to(ds_path))
+        rpath = str(ut.Path(path).relative_to(ds_path))
         if not rpath.startswith(op.pardir):
             # path is already underneath the dataset
             return path
@@ -708,7 +708,7 @@ def path_under_rev_dataset(ds, path):
         # whatever went wrong, we gotta play save
         pass
 
-    root = rev_get_dataset_root(text_type(path))
+    root = rev_get_dataset_root(str(path))
     while root is not None and not ds_path.samefile(root):
         # path and therefore root could be relative paths,
         # hence in the next round we cannot use dirname()
@@ -718,7 +718,7 @@ def path_under_rev_dataset(ds, path):
         root = rev_get_dataset_root(op.join(root, op.pardir))
     if root is None:
         return None
-    return ds_path / op.relpath(text_type(path), root)
+    return ds_path / op.relpath(str(path), root)
 
 
 # XXX this is a copy of the change proposed in

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -86,8 +86,7 @@ def resolve_path(path, ds=None):
     return normpath(opj(top_path, path))
 
 
-@add_metaclass(Flyweight)
-class Dataset(object):
+class Dataset(object, metaclass=Flyweight):
     """Representation of a DataLad dataset/repository
 
     This is the core data type of DataLad: a representation of a dataset.

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -20,10 +20,6 @@ from os.path import pardir
 from os.path import realpath
 from os.path import relpath
 from weakref import WeakValueDictionary
-from six import PY2
-from six import string_types
-from six import text_type
-from six import add_metaclass
 import wrapt
 
 from datalad import cfg

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -16,7 +16,7 @@ import logging
 import os
 import os.path as op
 
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -205,7 +205,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             name="local_target_alt",
             sshurl="ssh://localhost",
             target_dir=target_path)
-    ok_(text_type(cm.exception).startswith(
+    ok_(str(cm.exception).startswith(
         "Target path %s already exists. And it fails to rmdir" % target_path))
     if src_is_annex:
         target_description = AnnexRepo(target_path, create=False).get_description()

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -16,7 +16,6 @@ from os import chmod
 import stat
 import re
 from os.path import join as opj, exists, basename
-from six import text_type
 
 from ..dataset import Dataset
 from datalad.api import publish, install, create_sibling

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -478,7 +478,7 @@ def test_rev_resolve_path(path):
     for d in (opath,) if on_windows else (opath, lpath):
         ds_local = Dataset(d)
         # no symlink resolution
-        eq_(text_type(rev_resolve_path(d)), d)
+        eq_(str(rev_resolve_path(d)), d)
         # list comes out as a list
         eq_(rev_resolve_path([d]), [Path(d)])
         # multiple OK
@@ -486,7 +486,7 @@ def test_rev_resolve_path(path):
 
         with chpwd(d):
             # be aware: knows about cwd, but this CWD has symlinks resolved
-            eq_(text_type(rev_resolve_path(d).cwd()), opath)
+            eq_(str(rev_resolve_path(d).cwd()), opath)
             # using pathlib's `resolve()` will resolve any
             # symlinks
             # also resolve `opath`, as on old windows systems the path might
@@ -495,7 +495,7 @@ def test_rev_resolve_path(path):
             eq_(rev_resolve_path('.').resolve(), ut.Path(opath).resolve())
             # no norming, but absolute paths, without resolving links
             eq_(rev_resolve_path('.'), ut.Path(d))
-            eq_(text_type(rev_resolve_path('.')), d)
+            eq_(str(rev_resolve_path('.')), d)
 
             # there is no concept of an "explicit" relative path anymore
             # relative is relative, regardless of the specific syntax
@@ -503,7 +503,7 @@ def test_rev_resolve_path(path):
                 ds_global.pathobj / 'bu')
             # there is no full normpath-ing or other funky resolution of
             # parent directory back-reference
-            eq_(text_type(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
+            eq_(str(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
                 op.join(ds_global.path, os.pardir, 'bu'))
 
         # resolve against a dataset given as a path/str
@@ -517,7 +517,7 @@ def test_rev_resolve_path(path):
         # not being inside a dataset doesn't change the resolution result
         eq_(rev_resolve_path(op.join(os.curdir, 'bu'), ds=ds_global),
             ds_global.pathobj / 'bu')
-        eq_(text_type(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
+        eq_(str(rev_resolve_path(op.join(os.pardir, 'bu'), ds=ds_global)),
             op.join(ds_global.path, os.pardir, 'bu'))
 
 
@@ -526,7 +526,7 @@ def test_rev_resolve_path(path):
 @with_tempfile(mkdir=True)
 def test_rev_resolve_path_symlink_edition(path):
     deepest = ut.Path(path) / 'one' / 'two' / 'three'
-    deepest_str = text_type(deepest)
+    deepest_str = str(deepest)
     os.makedirs(deepest_str)
     with chpwd(deepest_str):
         # direct absolute

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -14,7 +14,6 @@ import shutil
 import os.path as op
 from os.path import join as opj, abspath, normpath, relpath, exists
 
-from six import text_type
 
 from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
 from ..dataset import rev_resolve_path

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -17,7 +17,7 @@ from os.path import isabs
 from os.path import normpath
 import posixpath
 
-from six.moves.urllib.parse import unquote as urlunquote
+from urllib.parse import unquote as urlunquote
 
 from ..dochelpers import single_or_plural
 from datalad.support.annexrepo import GitRepo

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -553,7 +553,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
             downloaded_size = len(content)
 
             # now that we know size based on encoded content, let's decode into string type
-            if PY3 and isinstance(content, bytes) and decode:
+            if isinstance(content, bytes) and decode:
                 content = content.decode()
             # downloaded_size = os.stat(temp_filepath).st_size
 

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -487,10 +487,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
         if self._cache is None:
             # TODO: move this all logic outside into a dedicated caching beast
             lgr.info("Initializing cache for fetches")
-            if PY2:
-                import anydbm as dbm
-            else:
-                import dbm
+            import dbm
             # Initiate cache.
             # Very rudimentary caching for now, might fail many ways
             cache_dir = cfg.obtain('datalad.locations.cache')

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -71,8 +71,7 @@ class DownloaderSession(object):
 
 
 @auto_repr
-@add_metaclass(ABCMeta)
-class BaseDownloader(object):
+class BaseDownloader(object, metaclass=ABCMeta):
     """Base class for the downloaders"""
 
     _DEFAULT_AUTHENTICATOR = None

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -556,7 +556,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
             downloaded_size = len(content)
 
             # now that we know size based on encoded content, let's decode into string type
-            if PY3 and isinstance(content, binary_type) and decode:
+            if PY3 and isinstance(content, bytes) and decode:
                 content = content.decode()
             # downloaded_size = os.stat(temp_filepath).st_size
 

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -193,7 +193,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                             lgr.error(
                                 "Interface is non interactive, so we are "
                                 "reraising: %s" % exc_str(e))
-                            reraise(*exc_info)
+                            raise e
                         self._enter_credentials(
                             url,
                             denied_msg=access_denied,

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -20,10 +20,6 @@ import time
 from abc import ABCMeta, abstractmethod
 import os.path as op
 from os.path import exists, join as opj, isdir
-from six import PY2
-from six import binary_type, PY3
-from six import add_metaclass
-from six import reraise
 
 
 from .. import cfg

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -58,9 +58,9 @@ if lgr.getEffectiveLevel() <= 1:
     # These two lines enable debugging at httplib level (requests->urllib3->http.client)
     # You will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
     # The only thing missing will be the response.body which is not logged.
-    from six.moves import http_client
+    import http.client
     # TODO: nohow wrapped with logging, plain prints (heh heh), so formatting will not be consistent
-    http_client.HTTPConnection.debuglevel = 1
+    http.client.HTTPConnection.debuglevel = 1
 
     # for requests we can define logging properly
     requests_log = LoggerHelper(logtarget="requests.packages.urllib3").get_initialized_logger()
@@ -374,7 +374,7 @@ class HTTPDownloaderSession(DownloaderSession):
         if f is None:
             # no file to download to
             # TODO: actually strange since it should have been decoded then...
-            f = BytesIO()
+            f = io.BytesIO()
 
         # must use .raw to be able avoiding decoding/decompression while downloading
         # to a file

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -17,7 +17,6 @@ import requests.auth
 # from urllib3.exceptions import MaxRetryError, NewConnectionError
 
 import io
-from six import BytesIO
 from time import sleep
 
 from ..utils import assure_list_from_str, assure_dict_from_str

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -11,7 +11,6 @@
 
 from glob import glob
 from logging import getLogger
-from six import iteritems
 
 import os
 import re

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -16,7 +16,7 @@ from six import iteritems
 import os
 import re
 from os.path import dirname, abspath, join as pathjoin
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from collections import OrderedDict
 
 from .base import NoneAuthenticator, NotImplementedAuthenticator

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -11,7 +11,7 @@
 
 import re
 
-from six.moves.urllib.parse import urlsplit, unquote as urlunquote
+from urllib.parse import urlsplit, unquote as urlunquote
 
 from ..utils import auto_repr
 from ..utils import assure_dict_from_str

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -14,7 +14,7 @@ from six import PY3
 import re
 
 import os
-import six.moves.builtins as __builtin__
+import builtins
 from os.path import join as opj
 
 from datalad.downloaders.tests.utils import get_test_providers
@@ -142,7 +142,7 @@ def test_HTTPDownloader_basic(toppath, topurl):
     # XXX obscure mocking since impossible to mock write alone
     # and it still results in some warning being spit out
     with swallow_logs(), \
-         patch.object(__builtin__, 'open', fake_open(write_=_raise_IOError)):
+         patch.object(builtins, 'open', fake_open(write_=_raise_IOError)):
         assert_raises(DownloadError, download, furl, tfpath, overwrite=True)
 
     # incomplete download scenario - should have 3 tries

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -10,7 +10,6 @@
 
 import time
 from calendar import timegm
-from six import PY3
 import re
 
 import os

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -38,8 +38,7 @@ from ...tests.utils import with_memory_keyring
 
 # BTW -- mock_open is not in mock on wheezy (Debian 7.x)
 try:
-    if PY3:
-        raise ImportError("Not yet ready apparently: https://travis-ci.org/datalad/datalad/jobs/111659666")
+    raise ImportError("Not yet ready apparently: https://travis-ci.org/datalad/datalad/jobs/111659666")
     import httpretty
 except (ImportError, AttributeError):
     # Attribute Error happens with newer httpretty and older ssl module

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -45,7 +45,7 @@ except (ImportError, AttributeError):
     # Attribute Error happens with newer httpretty and older ssl module
     # https://github.com/datalad/datalad/pull/2623
     class NoHTTPPretty(object):
-       __bool__ = __nonzero__ = lambda s: False
+       __bool__ = lambda s: False
        activate = lambda s, t: t
     httpretty = NoHTTPPretty()
 

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -318,7 +318,7 @@ class AddArchiveContent(Interface):
             annex.always_commit = annex.fake_dates_enabled
 
             if annex_options:
-                if isinstance(annex_options, string_types):
+                if isinstance(annex_options, str):
                     annex_options = shlex.split(annex_options)
 
             leading_dir = earchive.get_leading_directory(

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -514,7 +514,7 @@ class AddArchiveContent(Interface):
                 annex.precommit()  # so batched ones close and files become annex symlinks etc
                 precommitted = True
                 if any(r.get('state', None) != 'clean'
-                       for p, r in iteritems(annex.status(untracked='no'))):
+                       for p, r in annex.status(untracked='no').items()):
                     annex.commit(
                         "Added content extracted from %s %s\n\n%s" %
                         (origin, archive_rpath, commit_stats.as_str(mode='full')),

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -45,11 +45,6 @@ from ..utils import get_dataset_root
 
 from datalad.customremotes.base import init_datalad_remote
 
-from six import (
-    string_types,
-    iteritems,
-)
-
 from ..log import logging
 lgr = logging.getLogger('datalad.interfaces.add_archive_content')
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -25,7 +25,6 @@ from collections import (
     defaultdict,
     OrderedDict,
 )
-from six import iteritems
 
 from ..ui import ui
 from ..dochelpers import exc_str

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -499,7 +499,7 @@ class DefaultOutputRenderer(object):
         if isinstance(v, list):
             return [cls._dict_to_nadict(x) for x in v]
         elif isinstance(v, dict):
-            return nadict((k, cls._dict_to_nadict(x)) for k, x in iteritems(v))
+            return nadict((k, cls._dict_to_nadict(x)) for k, x in v.items())
         else:
             return v
 

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -20,8 +20,8 @@ from os.path import curdir, isfile, islink, isdir, realpath
 from os.path import relpath
 from os import lstat
 
-from six.moves.urllib.request import urlopen, Request
-from six.moves.urllib.error import HTTPError
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
 
 from ..utils import auto_repr
 from .base import Interface

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -177,8 +177,7 @@ def _guess_exec(script_file):
                 # does not exist; there's nothing to detect at all
                 return {'type': None, 'template': None, 'state': None}
         else:
-            from six import reraise
-            reraise(e)
+            raise e
 
     # TODO check for exec permission and rely on interpreter
     if is_exec:

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -20,7 +20,7 @@ from os import (
     remove,
 )
 
-from six.moves import StringIO
+from io import StringIO
 from mock import patch
 
 from datalad.utils import (

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -15,7 +15,6 @@ __docformat__ = 'restructuredtext'
 import os
 from os.path import join as opj
 
-from six import text_type
 
 from datalad.distribution.dataset import Dataset
 from datalad.api import create

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -181,27 +181,27 @@ def test_unlock_directory(path):
     else:
         assert_repo_status(ds.path, modified=[dirpath / "a", dirpath / "b"])
     ds.save()
-    ds.drop(text_type(dirpath / "a"), check=False)
-    assert_false(ds.repo.file_has_content(text_type(dirpath / "a")))
+    ds.drop(str(dirpath / "a"), check=False)
+    assert_false(ds.repo.file_has_content(str(dirpath / "a")))
 
     # Unlocking without an explicit non-directory path doesn't fail if one of
     # the directory's files doesn't have content.
     res = ds.unlock(path="dir")
     assert_not_in_results(res, action="unlock",
-                          path=text_type(dirpath_abs / "a"))
+                          path=str(dirpath_abs / "a"))
     if is_managed_branch:
         assert_not_in_results(res, action="unlock",
-                              path=text_type(dirpath_abs / "b"))
+                              path=str(dirpath_abs / "b"))
     else:
         assert_in_results(res, action="unlock", status="ok",
-                          path=text_type(dirpath_abs / "b"))
+                          path=str(dirpath_abs / "b"))
         assert_repo_status(ds.path, modified=[dirpath / "b"])
 
     # If we explicitly provide a path that lacks content, we get a result
     # for it.
     assert_in_results(ds.unlock(path=dirpath / "a", on_failure="ignore"),
                       action="unlock", status="impossible",
-                      path=text_type(dirpath_abs / "a"))
+                      path=str(dirpath_abs / "a"))
 
 
 @with_tree(tree={"untracked": "untracked",
@@ -230,4 +230,4 @@ def test_unlock_cant_unlock(path):
             ds.unlock(path=f, on_failure="ignore"),
             action="unlock",
             status=status,
-            path=text_type(ds.pathobj / f))
+            path=str(ds.pathobj / f))

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -17,7 +17,6 @@ import logging
 
 import os.path as op
 
-from six import text_type
 
 from datalad.core.local.status import Status
 from datalad.support.constraints import EnsureStr

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -95,7 +95,7 @@ class Unlock(Interface):
             for p in set(path).difference(set(paths_lexist)):
                 yield get_status_dict(
                     status="impossible",
-                    path=text_type(p),
+                    path=str(p),
                     type="file",
                     message="path does not exist",
                     **res_kwargs)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -27,8 +27,6 @@ from os.path import relpath
 from os.path import sep
 from os.path import split as psplit
 from itertools import chain
-from six import PY2
-from six import text_type
 
 import json
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -509,9 +509,9 @@ def default_result_renderer(res):
             # in `res` to bytes, so it's easiest to work with bytes here rather
             # than converting everything back to unicode.
             if not isinstance(path, str):  # pathlib
-                path = assure_bytes(text_type(path))
+                path = assure_bytes(str(path))
         else:
-            path = text_type(path)
+            path = str(path)
         ui.message('{action}({status}): {path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
                 status=ac.color_status(res['status']),

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -36,7 +36,6 @@ import json
 from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
 from datalad.utils import path_startswith
 from datalad.utils import path_is_subpath
-from datalad.utils import assure_bytes
 from datalad.utils import assure_unicode
 from datalad.utils import getargspec
 from datalad.support.gitrepo import GitRepo
@@ -50,7 +49,6 @@ from datalad.support.constraints import Constraint
 from datalad.ui import ui
 import datalad.support.ansi_colors as ac
 
-from datalad.interface.base import Interface
 from datalad.interface.base import default_logchannels
 from datalad.interface.base import get_allargs_as_kwargs
 from datalad.interface.common_opts import eval_params
@@ -304,30 +302,8 @@ def eval_results(func):
         # incl. defaults and args given as positionals
         allkwargs = get_allargs_as_kwargs(wrapped, args, kwargs)
         # determine class, the __call__ method of which we are decorating:
-        # Ben: Note, that this is a bit dirty in PY2 and imposes restrictions on
-        # when and how to use eval_results as well as on how to name a command's
-        # module and class. As of now, we are inline with these requirements as
-        # far as I'm aware.
         mod = sys.modules[wrapped.__module__]
-        if PY2:
-            # we rely on:
-            # - decorated function is method of a subclass of Interface
-            # - the name of the class matches the last part of the module's name
-            #   if converted to lower
-            # for example:
-            # ..../where/ever/mycommand.py:
-            # class MyCommand(Interface):
-            #     @eval_results
-            #     def __call__(..)
-            command_class_names = \
-                [i for i in mod.__dict__
-                 if type(mod.__dict__[i]) == type and
-                 issubclass(mod.__dict__[i], Interface) and
-                 i.lower().startswith(wrapped.__module__.split('.')[-1].replace('datalad_', '').replace('_', ''))]
-            assert len(command_class_names) == 1, (command_class_names, mod.__name__)
-            command_class_name = command_class_names[0]
-        else:
-            command_class_name = wrapped.__qualname__.split('.')[-2]
+        command_class_name = wrapped.__qualname__.split('.')[-2]
         _func_class = mod.__dict__[command_class_name]
         lgr.debug("Determined class of decorated function: %s", _func_class)
 
@@ -504,14 +480,7 @@ def eval_results(func):
 def default_result_renderer(res):
     if res.get('status', None) != 'notneeded':
         path = res['path']
-        if PY2:
-            # On Python 2 _process_results() has already converted all unicode
-            # in `res` to bytes, so it's easiest to work with bytes here rather
-            # than converting everything back to unicode.
-            if not isinstance(path, str):  # pathlib
-                path = assure_bytes(str(path))
-        else:
-            path = str(path)
+        path = str(path)
         ui.message('{action}({status}): {path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
                 status=ac.color_status(res['status']),
@@ -538,11 +507,6 @@ def _process_results(
             # XXX Yarik has to no clue on how to track the origin of the
             # record to figure out WTF, so he just skips it
             continue
-
-        if PY2:
-            for k, v in res.items():
-                if isinstance(v, unicode):
-                    res[k] = v.encode('utf-8')
 
         actsum = action_summary.get(res['action'], {})
         if res['status']:
@@ -611,11 +575,6 @@ def _process_results(
                             res, exc_str(e))
         else:
             raise ValueError('unknown result renderer "{}"'.format(result_renderer))
-
-        if PY2:
-            for k, v in res.items():
-                if isinstance(v, str):
-                    res[k] = v.decode('utf-8')
 
         if result_xfm:
             res = result_xfm(res)

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -84,7 +84,7 @@ def _parse_git_submodules(ds, paths):
             props['path'] = ds.pathobj / path.relative_to(ds.repo.pathobj)
         else:
             props['path'] = path
-        if not path.exists() or not GitRepo.is_valid_repo(text_type(path)):
+        if not path.exists() or not GitRepo.is_valid_repo(str(path)):
             props['state'] = 'absent'
         # TODO kill this after some time. We used to do custom things here
         # and gitshasum was called revision. Be nice and duplicate for a bit
@@ -257,7 +257,7 @@ class Subdatasets(Interface):
                 refds_path):
             # a boat-load of ancient code consumes this and is ignorant of
             # Path objects
-            r['path'] = text_type(r['path'])
+            r['path'] = str(r['path'])
             # without the refds_path cannot be rendered/converted relative
             # in the eval_results decorator
             r['refds'] = refds_path
@@ -316,7 +316,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                         **dict(
                             sm,
                             refds_relpath=sm['path'].relative_to(refds_path),
-                            refds_relname=text_type(
+                            refds_relname=str(
                                 sm['path'].relative_to(refds_path)
                             ).replace(os.sep, '-')))
                 try:
@@ -324,7 +324,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                         '', ['git', 'config', '--file', '.gitmodules',
                              '--replace-all',
                              'submodule.{}.{}'.format(sm['gitmodule_name'], prop),
-                             text_type(val),
+                             str(val),
                             ]
                     )
                 except CommandError as e:  # pragma: no cover

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -14,9 +14,6 @@ __docformat__ = 'restructuredtext'
 import logging
 import re
 import os
-from six import (
-    text_type,
-)
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -9,7 +9,6 @@
 
 
 import os
-from six import text_type
 from os.path import (
     join as opj,
     relpath,

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -41,7 +41,7 @@ from datalad.tests.utils import (
 def test_get_subdatasets(path):
     ds = Dataset(path)
     # one more subdataset with a name that could ruin config option parsing
-    dots = text_type(Path('subdir') / '.lots.of.dots.')
+    dots = str(Path('subdir') / '.lots.of.dots.')
     ds.create(dots)
     eq_(ds.subdatasets(recursive=True, fulfilled=False, result_xfm='relpaths'), [
         'sub dataset1'
@@ -68,7 +68,7 @@ def test_get_subdatasets(path):
         dots,
     ]
     eq_(ds.subdatasets(recursive=True, result_xfm='relpaths'), all_subs)
-    with chpwd(text_type(ds.pathobj)):
+    with chpwd(str(ds.pathobj)):
         # imitate cmdline invocation w/ no dataset argument
         eq_(subdatasets(dataset=None,
                         path=[],
@@ -101,14 +101,14 @@ def test_get_subdatasets(path):
             'sub dataset1/subm 1',
         ]
     )
-    with chpwd(text_type(ds.pathobj / 'subdir')):
+    with chpwd(str(ds.pathobj / 'subdir')):
         # imitate cmdline invocation w/ no dataset argument
         # -> curdir limits the query, when no info is given
         eq_(subdatasets(dataset=None,
                         path=[],
                         recursive=True,
                         result_xfm='paths'),
-            [text_type(ds.pathobj / dots)]
+            [str(ds.pathobj / dots)]
         )
         # but with a dataset explicitly given, even if just as a path,
         # curdir does no limit the query

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -13,10 +13,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import os
-from six.moves import (
-    filter,
-    map,
-)
 
 from os import makedirs
 from os import listdir

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -25,11 +25,6 @@ try:
 except ImportError:  # Python <= 3.3
     from collections import Mapping
 
-from six import (
-    binary_type,
-    string_types,
-    iteritems,
-)
 from datalad import cfg
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.base import Interface

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -408,7 +408,7 @@ def _filter_metadata_fields(d, maxsize=None, blacklist=None):
     if maxsize:
         d = {k: v for k, v in iteritems(d)
              if k.startswith('@') or (len(str(v)
-                                      if not isinstance(v, string_types + (binary_type,))
+                                      if not isinstance(v, (str, bytes,))
                                       else v) <= maxsize)}
     if len(d) != len(orig_keys):
         lgr.info(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -129,7 +129,7 @@ def _load_xz_json_stream(fpath, cache=None):
         cache = {}
     obj = cache.get(
         fpath,
-        {s['path']: {k: v for k, v in iteritems(s) if k != 'path'}
+        {s['path']: {k: v for k, v in s.items() if k != 'path'}
          # take out the 'path' from the payload
          for s in load_xzstream(fpath)} if op.lexists(fpath) else {})
     cache[fpath] = obj
@@ -403,10 +403,10 @@ def _filter_metadata_fields(d, maxsize=None, blacklist=None):
             maxsize, blacklist, len(d))
     orig_keys = set(d.keys())
     if blacklist:
-        d = {k: v for k, v in iteritems(d)
+        d = {k: v for k, v in d.items()
              if k.startswith('@') or not any(bl.match(k) for bl in blacklist)}
     if maxsize:
-        d = {k: v for k, v in iteritems(d)
+        d = {k: v for k, v in d.items()
              if k.startswith('@') or (len(str(v)
                                       if not isinstance(v, (str, bytes,))
                                       else v) <= maxsize)}
@@ -623,7 +623,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
                     valtype=EnsureBool()):
                 # go through content metadata and inject report of unique keys
                 # and values into `dsmeta`
-                for k, v in iteritems(meta):
+                for k, v in meta.items():
                     if k in dsmeta.get(mtype_key, {}):
                         # if the dataset already has a dedicated idea
                         # about a key, we skip it from the unique list
@@ -665,7 +665,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
 
             def _ensure_serializable(val):
                 if isinstance(val, ReadOnlyDict):
-                    return {k: _ensure_serializable(v) for k, v in iteritems(val)}
+                    return {k: _ensure_serializable(v) for k, v in val.items()}
                 if isinstance(val, (tuple, list)):
                     return [_ensure_serializable(v) for v in val]
                 else:
@@ -676,7 +676,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
                     for i in sorted(
                         v,
                         key=_unique_value_key)] if v is not None else None
-                for k, v in iteritems(unique_cm)
+                for k, v in unique_cm.items()
                 # v == None (disable unique, but there was a value at some point)
                 # otherwise we only want actual values, and also no single-item-lists
                 # of a non-value
@@ -762,7 +762,7 @@ class ReadOnlyDict(Mapping):
     def __hash__(self):
         if self._hash is None:
             h = 0
-            for key, value in iteritems(self._dict):
+            for key, value in self._dict.items():
                 h ^= hash((key, _val2hashable(value)))
             self._hash = h
         return self._hash

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -215,7 +215,7 @@ def _search_from_virgin_install(dataset, query):
                           % DEFAULT_DATASET_PATH):
                     pass
                 else:
-                    reraise(*exc_info)
+                    raise exc_info[1]
             else:
                 raise NoDatasetArgumentFound(
                     "No DataLad dataset found at current location. "
@@ -234,7 +234,7 @@ def _search_from_virgin_install(dataset, query):
                 "label '///'"
             )
         else:
-            reraise(*exc_info)
+            raise exc_info[1]
 
         lgr.info(
             "Performing search using DataLad superdataset %r",

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -23,11 +23,6 @@ from os.path import join as opj, exists
 from os.path import relpath
 from os.path import normpath
 import sys
-from six import (
-    reraise,
-    iteritems,
-    PY2,
-)
 from time import time
 
 from datalad import cfg

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -766,10 +766,7 @@ class _EGrepCSSearch(_Search):
 
         for k in sorted(keys):
             if mode == 'name':
-                from datalad.utils import assure_bytes
-                # without assure_bytes UnicodeEncodeError in PY2 when
-                # output is piped into e.g. grep
-                print(assure_bytes(k) if PY2 else k)
+                print(k)
                 continue
 
             # do a bit more

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -726,7 +726,7 @@ class _EGrepCSSearch(_Search):
             t0 = time()
             matches = {(q['query'] if isinstance(q, dict) else q, k):
                        q['query'].search(v) if isinstance(q, dict) else q.search(v)
-                       for k, v in iteritems(doc)
+                       for k, v in doc.items()
                        for q in query
                        if not isinstance(q, dict) or q['field'].match(k)}
             dt = time() - t0
@@ -836,7 +836,7 @@ class _EGrepCSSearch(_Search):
             # no stringification of values for speed
             idxd = _meta2autofield_dict(meta, val2str=False)
 
-            for k, kvals in iteritems(idxd):
+            for k, kvals in idxd.items():
                 # TODO deal with conflicting definitions when available
                 keys[k].ndatasets += 1
                 if mode == 'name':

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -24,7 +24,7 @@ from six import (
     string_types,
     text_type,
 )
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datalad.distribution.dataset import rev_resolve_path
 from datalad.dochelpers import exc_str

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -20,10 +20,6 @@ import os
 import re
 import string
 
-from six import (
-    string_types,
-    text_type,
-)
 from urllib.parse import urlparse
 
 from datalad.distribution.dataset import rev_resolve_path

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -95,7 +95,7 @@ class Formatter(string.Formatter):
             return super(Formatter, self).get_value(
                 key, args, kwargs)
 
-        if self.missing is not None and isinstance(value, string_types):
+        if self.missing is not None and isinstance(value, str):
             return value or self.missing
         return value
 
@@ -290,7 +290,7 @@ def _get_placeholder_exception(exc, msg_prefix, known):
     """Recast KeyError as a ValueError with close-match suggestions.
     """
     value = exc.args[0]
-    if isinstance(value, string_types):
+    if isinstance(value, str):
         sugmsg = get_suggestions_msg(value, known)
     else:
         sugmsg = "Out-of-bounds or unsupported index."

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -564,7 +564,7 @@ def add_meta(rows):
             yield dict(
                 action='add',
                 # decorator dies with Path()
-                path=text_type(ds.pathobj / filename),
+                path=str(ds.pathobj / filename),
                 type='file',
                 status=res_status,
                 parentds=ds.path,
@@ -790,7 +790,7 @@ class Addurls(Interface):
                                   message="not an annex repo")
             return
 
-        url_file = text_type(rev_resolve_path(url_file, dataset))
+        url_file = str(rev_resolve_path(url_file, dataset))
 
         if input_type == "ext":
             extension = os.path.splitext(url_file)[1]

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -269,8 +269,7 @@ def _read(stream, input_type):
         import json
         try:
             rows = json.load(stream)
-        except getattr(json.decoder, "JSONDecodeError", ValueError) as e:
-            # ^ py2 compatibility kludge.
+        except json.decoder.JSONDecodeError as e:
             raise ValueError(
                 "Failed to read JSON from stream {}: {}"
                 .format(stream, exc_str(e)))

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -641,7 +641,7 @@ class TestAddurls(object):
         for in_type in ["csv", "json"]:
             with assert_raises(IncompleteResultsError) as exc:
                 ds.addurls(in_file, "{url}", "{name}", input_type=in_type)
-            assert_in("Failed to read", text_type(exc.exception))
+            assert_in("Failed to read", str(exc.exception))
 
     @with_tree({"in.csv": "url,name,subdir",
                 "in.json": "[]"})

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -19,7 +19,6 @@ import tempfile
 from mock import patch
 
 from io import StringIO
-from six import text_type
 
 from datalad.api import addurls, Dataset, subdatasets
 import datalad.plugin.addurls as au

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -18,7 +18,7 @@ import tempfile
 
 from mock import patch
 
-from six.moves import StringIO
+from io import StringIO
 from six import text_type
 
 from datalad.api import addurls, Dataset, subdatasets

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -22,7 +22,6 @@ from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.utils import (
     assure_unicode,
-    assure_bytes,
     getpwd,
     unlink,
 )
@@ -404,7 +403,7 @@ class WTF(Interface):
     def custom_result_renderer(res, **kwargs):
         from datalad.ui import ui
         out = _render_report(res)
-        ui.message(assure_bytes(out) if PY2 else out)
+        ui.message(out)
 
 
 def _render_report(res):

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -16,7 +16,6 @@ import os.path as op
 from functools import partial
 from collections import OrderedDict
 
-from six import PY2
 
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2906,7 +2906,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         matches = list(set(chain.from_iterable(
             [
                 [r['description'] for r in remotes if match(r)]
-                for k, remotes in iteritems(info)
+                for k, remotes in info.items()
                 if k.endswith(' repositories')
             ]
         )))
@@ -3100,7 +3100,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     def _mark_content_availability(self, info):
         objectstore = self.pathobj.joinpath(
             self.path, GitRepo.get_git_dir(self), 'annex', 'objects')
-        for f, r in iteritems(info):
+        for f, r in info.items():
             if 'key' not in r or 'has_content' in r:
                 # not annexed or already processed
                 continue
@@ -3269,7 +3269,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             # https://github.com/datalad/datalad/issues/2955
             # check if there are any and pass them to git-add
             symlinks_toadd = {
-                p: props for p, props in iteritems(files)
+                p: props for p, props in files.items()
                 if props.get('type', None) == 'symlink'}
             if symlinks_toadd:
                 for r in GitRepo._save_add(
@@ -3279,7 +3279,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     yield r
             # trim `files` of symlinks
             files = {
-                p: props for p, props in iteritems(files)
+                p: props for p, props in files.items()
                 if props.get('type', None) != 'symlink'}
 
         expected_additions = None

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2992,7 +2992,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             # we can be lazy
             files = assure_list(files)
         else:
-            if isinstance(files, text_type):
+            if isinstance(files, str):
                 files = [files]
             # anything else is assumed to be an iterable (e.g. a generator)
         if batch is False:
@@ -3124,7 +3124,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 if testpath.exists():
                     r.pop('hashdirlower', None)
                     r.pop('hashdirmixed', None)
-                    r['objloc'] = text_type(testpath)
+                    r['objloc'] = str(testpath)
                     r['has_content'] = True
                     break
 
@@ -3194,7 +3194,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             cmd = 'find'
             # stringify any pathobjs
             if paths:
-                files = [text_type(p) for p in paths]
+                files = [str(p) for p in paths]
             else:
                 opts.extend(['--include', '*'])
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -59,7 +59,7 @@ from datalad.utils import swallow_logs
 from datalad.utils import assure_list
 from datalad.utils import _path_
 from datalad.utils import CMD_MAX_ARG
-from datalad.utils import assure_unicode, assure_bytes
+from datalad.utils import assure_unicode
 from datalad.utils import make_tempfile
 from datalad.utils import partition
 from datalad.utils import unlink
@@ -1772,8 +1772,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 lgr.debug("Not batching addurl call "
                           "because fake dates are enabled")
             files_opt = '--file=%s' % file_
-            if PY2:
-                files_opt = assure_bytes(files_opt)
             out_json = self._run_annex_command_json(
                 'addurl',
                 opts=options + [files_opt] + [url],

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1958,7 +1958,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             initiate or continue with a batched run of annex dropkey, instead of just
             calling a single git annex dropkey command
         """
-        keys = [keys] if isinstance(keys, string_types) else keys
+        keys = [keys] if isinstance(keys, str) else keys
 
         options = options[:] if options else []
         options += ['--force']
@@ -2700,7 +2700,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         stdout, stderr
         """
         cmd = shlex.split(cmd_str + " " + " ".join(files), posix=not on_windows) \
-            if isinstance(cmd_str, string_types) \
+            if isinstance(cmd_str, str) \
             else cmd_str + files
 
         if self.fake_dates_enabled:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -39,10 +39,6 @@ from subprocess import Popen, PIPE
 from multiprocessing import cpu_count
 from weakref import WeakValueDictionary
 
-from six import string_types, PY2
-from six import iteritems
-from six import text_type
-from six.moves import filter
 from git import InvalidGitRepositoryError
 
 from datalad import ssh_manager

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -27,7 +27,7 @@ from .path import (
     sep as opsep,
 )
 from six import next, PY2
-from six.moves.urllib.parse import unquote as urlunquote
+from urllib.parse import unquote as urlunquote
 
 import string
 import random

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -162,10 +162,9 @@ def decompress_file(archive, dir_, leading_directories='strip'):
         patoolib.util.check_existing_filename(dir_, onlyfiles=False)
         # Call protected one to avoid the checks on existence on unixified path
         outdir = unixify_path(dir_)
-        if not PY2:
-            # should be supplied in PY3 to avoid b''
-            outdir = assure_unicode(outdir)
-            archive = assure_unicode(archive)
+        # should be supplied in PY3 to avoid b''
+        outdir = assure_unicode(outdir)
+        archive = assure_unicode(archive)
 
         format_compression = patoolib.get_archive_format(archive)
         if format_compression == ('gzip', None):

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -26,7 +26,6 @@ from .path import (
     realpath,
     sep as opsep,
 )
-from six import next, PY2
 from urllib.parse import unquote as urlunquote
 
 import string

--- a/datalad/support/cache.py
+++ b/datalad/support/cache.py
@@ -10,7 +10,6 @@
 """
 
 from collections import OrderedDict
-from six import PY2
 
 from functools import lru_cache
 

--- a/datalad/support/cache.py
+++ b/datalad/support/cache.py
@@ -12,10 +12,7 @@
 from collections import OrderedDict
 from six import PY2
 
-if PY2:
-    from ._lru_cache2 import lru_cache
-else:
-    from functools import lru_cache
+from functools import lru_cache
 
 
 # based on http://stackoverflow.com/a/2437645/1265472

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -11,7 +11,6 @@
 __docformat__ = 'restructuredtext'
 
 import re
-from six.moves import map
 
 
 def _strip_typerepr(s):
@@ -81,7 +80,6 @@ class EnsureDType(Constraint):
         self._dtype = dtype
 
     def __call__(self, value):
-        from six import binary_type, text_type
         if hasattr(value, '__iter__') and \
                 not (isinstance(value, (bytes, str))):
             return list(map(self._dtype, value))
@@ -163,7 +161,6 @@ class EnsureBool(Constraint):
     True: '1', 'yes', 'on', 'enable', 'true'
     """
     def __call__(self, value):
-        from six import binary_type, text_type
         if isinstance(value, bool):
             return value
         elif isinstance(value, (bytes, str)):
@@ -200,7 +197,6 @@ class EnsureStr(Constraint):
         super(EnsureStr, self).__init__()
 
     def __call__(self, value):
-        from six import binary_type, text_type
         if not isinstance(value, (bytes, str)):
             # do not perform a blind conversion ala str(), as almost
             # anything can be converted and the result is most likely

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -83,7 +83,7 @@ class EnsureDType(Constraint):
     def __call__(self, value):
         from six import binary_type, text_type
         if hasattr(value, '__iter__') and \
-                not (isinstance(value, (binary_type, text_type))):
+                not (isinstance(value, (binary_type, str))):
             return list(map(self._dtype, value))
         else:
             return self._dtype(value)
@@ -166,7 +166,7 @@ class EnsureBool(Constraint):
         from six import binary_type, text_type
         if isinstance(value, bool):
             return value
-        elif isinstance(value, (binary_type, text_type)):
+        elif isinstance(value, (binary_type, str)):
             value = value.lower()
             if value in ('0', 'no', 'off', 'disable', 'false'):
                 return False
@@ -201,7 +201,7 @@ class EnsureStr(Constraint):
 
     def __call__(self, value):
         from six import binary_type, text_type
-        if not isinstance(value, (binary_type, text_type)):
+        if not isinstance(value, (binary_type, str)):
             # do not perform a blind conversion ala str(), as almost
             # anything can be converted and the result is most likely
             # unintended

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -83,7 +83,7 @@ class EnsureDType(Constraint):
     def __call__(self, value):
         from six import binary_type, text_type
         if hasattr(value, '__iter__') and \
-                not (isinstance(value, (binary_type, str))):
+                not (isinstance(value, (bytes, str))):
             return list(map(self._dtype, value))
         else:
             return self._dtype(value)
@@ -166,7 +166,7 @@ class EnsureBool(Constraint):
         from six import binary_type, text_type
         if isinstance(value, bool):
             return value
-        elif isinstance(value, (binary_type, str)):
+        elif isinstance(value, (bytes, str)):
             value = value.lower()
             if value in ('0', 'no', 'off', 'disable', 'false'):
                 return False
@@ -201,7 +201,7 @@ class EnsureStr(Constraint):
 
     def __call__(self, value):
         from six import binary_type, text_type
-        if not isinstance(value, (binary_type, str)):
+        if not isinstance(value, (bytes, str)):
             # do not perform a blind conversion ala str(), as almost
             # anything can be converted and the result is most likely
             # unintended

--- a/datalad/support/cookies.py
+++ b/datalad/support/cookies.py
@@ -84,8 +84,6 @@ class CookiesDB(object):
 
     def _get_provider(self, url):
         tld = get_tld(url)
-        if PY2:
-            return tld.encode()
         return tld
 
     def __getitem__(self, url):

--- a/datalad/support/cookies.py
+++ b/datalad/support/cookies.py
@@ -13,7 +13,6 @@ import shelve
 import pickle
 import appdirs
 import os.path
-from six import PY2
 
 from .network import get_tld
 from datalad.dochelpers import exc_str

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -139,7 +139,6 @@ class FileNotInRepositoryError(FileNotInAnnexError):
     pass
 
 
-@six.python_2_unicode_compatible
 class InvalidGitReferenceError(ValueError):
     """Thrown if provided git reference is invalid
     """

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -12,7 +12,6 @@
 import re
 from os import linesep
 
-import six
 
 
 class CommandError(RuntimeError):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -177,7 +177,7 @@ class ExternalVersions(object):
         if isinstance(version, (tuple, list)):
             #  Generate string representation
             version = ".".join(str(x) for x in version)
-        elif isinstance(version, binary_type):
+        elif isinstance(version, bytes):
             version = version.decode()
         elif isinstance(version, str):
             pass

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -11,8 +11,6 @@
 import sys
 import os.path as op
 from os import linesep
-from six import string_types
-from six import binary_type
 
 from distutils.version import LooseVersion
 

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -179,7 +179,7 @@ class ExternalVersions(object):
             version = ".".join(str(x) for x in version)
         elif isinstance(version, binary_type):
             version = version.decode()
-        elif isinstance(version, string_types):
+        elif isinstance(version, str):
             pass
         else:
             version = None
@@ -193,7 +193,7 @@ class ExternalVersions(object):
         # when ran straight in its source code -- fails to discover nipy's version.. TODO
         #if module == 'nipy':
         #    import pdb; pdb.set_trace()
-        if not isinstance(module, string_types):
+        if not isinstance(module, str):
             modname = module.__name__
         else:
             modname = module

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -64,7 +64,6 @@ from datalad.config import ConfigManager
 import datalad.utils as ut
 from datalad.utils import Path
 from datalad.utils import PurePosixPath
-from datalad.utils import assure_bytes
 from datalad.utils import assure_list
 from datalad.utils import optional_args
 from datalad.utils import on_windows
@@ -736,7 +735,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 # `repo` passed with `create`, which doesn't make sense
                 raise TypeError("argument 'repo' must not be used with 'create'")
             self._repo = self._create_empty_repo(
-                assure_bytes(path) if PY2 else path,
+                path,
                 create_sanity_checks, **git_opts)
         else:
             # Note: We used to call gitpy.Repo(path) here, which potentially
@@ -842,9 +841,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             # InvalidGitRepositoryError:
             self._repo = self.cmd_call_wrapper(
                 Repo,
-                # Encode path on Python 2 because, as of v2.1.11, GitPython's
-                # Repo will pass the path to str() otherwise.
-                assure_bytes(self.path) if PY2 else self.path)
+                self.path)
             lgr.log(8, "Using existing Git repository at %s", self.path)
 
         # inject git options into GitPython's git call wrapper:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -38,12 +38,6 @@ import posixpath
 from functools import wraps
 from weakref import WeakValueDictionary
 
-from six import PY2
-from six import string_types
-from six import text_type
-from six import add_metaclass
-from six import iteritems
-from six import PY2
 import git as gitpy
 from git import RemoteProgress
 from gitdb.exc import BadName

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -294,7 +294,7 @@ def normalize_paths(func, match_return_type=True, map_filenames_back=False,
             else lambda rpath, filepath: filepath
 
         if files:
-            if isinstance(files, string_types) or not files:
+            if isinstance(files, str) or not files:
                 files_new = [normalize(self.path, files)]
                 single_file = True
             elif isinstance(files, list):
@@ -1541,7 +1541,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
         if revrange is None:
             revrange = []
-        elif isinstance(revrange, string_types):
+        elif isinstance(revrange, str):
             revrange = [revrange]
 
         cmd = ["git", "log", "--format={}".format(fmt)]
@@ -1593,7 +1593,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
           If no merge-base for given commits, or specified treeish doesn't
           exist, None returned
         """
-        if isinstance(commitishes, string_types):
+        if isinstance(commitishes, str):
             commitishes = [commitishes]
         if not commitishes:
             raise ValueError("Provide at least a single value")
@@ -1850,7 +1850,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
 
         # ensure cmd_str becomes a well-formed list:
-        if isinstance(cmd_str, string_types):
+        if isinstance(cmd_str, str):
             cmd = shlex.split(cmd_str, posix=not on_windows)
         else:
             cmd = cmd_str[:]  # we will modify in-place

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1771,14 +1771,10 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         content_str = self.repo.commit(branch).tree[file_].data_stream.read()
 
         # in python3 a byte string is returned. Need to convert it:
-        from six import PY3
-        if PY3:
-            conv_str = u''
-            for b in bytes(content_str):
-                conv_str += chr(b)
-            return conv_str.splitlines()
-        else:
-            return content_str.splitlines()
+        conv_str = u''
+        for b in bytes(content_str):
+            conv_str += chr(b)
+        return conv_str.splitlines()
         # TODO: keep splitlines?
 
     def _get_files_history(self, files, branch='HEAD'):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -561,8 +561,7 @@ class GitPythonProgressBar(RemoteProgress):
 Submodule = namedtuple("Submodule", ["name", "path", "url"])
 
 
-@add_metaclass(Flyweight)
-class GitRepo(RepoInterface):
+class GitRepo(RepoInterface, metaclass=Flyweight):
     """Representation of a git repository
 
     """

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -599,7 +599,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
 
         # mirror what is happening in __init__
         if isinstance(path, ut.PurePath):
-            path = text_type(path)
+            path = str(path)
 
         # Sanity check for argument `path`:
         # raise if we cannot deal with `path` at all or
@@ -2353,7 +2353,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
         return [
             '{}{}'.format(
-                text_type(p.relative_to(self.pathobj)),
+                str(p.relative_to(self.pathobj)),
                 os.sep if props['type'] != 'file' else ''
             )
             for p, props in iteritems(self.status(
@@ -2467,7 +2467,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                           "in an upcoming release",
                           DeprecationWarning)
             xs = (Submodule(name=p["gitmodule_name"],
-                            path=text_type(p["path"].relative_to(self.pathobj)),
+                            path=str(p["path"].relative_to(self.pathobj)),
                             url=p["gitmodule_url"])
                   for p in xs)
 
@@ -3017,7 +3017,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             # convert unconditionally
             paths = [ut.PurePosixPath(p) for p in paths]
 
-        path_strs = list(map(text_type, paths)) if paths else None
+        path_strs = list(map(str, paths)) if paths else None
 
         # this will not work in direct mode, but everything else should be
         # just fine
@@ -3069,7 +3069,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 # we don't want it to scream on stdout
                 expect_fail=True)
         except CommandError as exc:
-            if "fatal: Not a valid object name" in text_type(exc):
+            if "fatal: Not a valid object name" in str(exc):
                 raise InvalidGitReferenceError(ref)
             raise
         lgr.debug('Done query repo: %s', cmd)
@@ -3148,12 +3148,12 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 if get_link_target and inf['type'] == 'symlink' and \
                         ((ref is None and '.git/annex/objects' in \
                           ut.Path(
-                            get_link_target(text_type(self.pathobj / path))
+                            get_link_target(str(self.pathobj / path))
                           ).as_posix()) or \
                          (ref and \
                           '.git/annex/objects' in get_link_target(
                               u'{}:{}'.format(
-                                  ref, text_type(path))))
+                                  ref, str(path))))
                         ):
                     # report annex symlink pointers as file, their
                     # symlink-nature is a technicality that is dependent
@@ -3319,7 +3319,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                     self.pathobj.joinpath(ut.PurePosixPath(p))
                     for p in self._git_custom_command(
                         # low-level code cannot handle pathobjs
-                        [text_type(p) for p in paths] if paths else None,
+                        [str(p) for p in paths] if paths else None,
                         ['git', 'ls-files', '-z', '-m'])[0].split('\0')
                     if p)
                 _cache[key] = modified
@@ -3438,7 +3438,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
 
         # loop over all subdatasets and look for additional modifications
         for f, st in iteritems(status):
-            f = text_type(f)
+            f = str(f)
             if 'state' in st or not st['type'] == 'dataset':
                 # no business here
                 continue
@@ -3532,7 +3532,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
 
         # TODO remove pathobj stringification when commit() can
         # handle it
-        to_commit = [text_type(f.relative_to(self.pathobj))
+        to_commit = [str(f.relative_to(self.pathobj))
                      for f, props in iteritems(status)] \
                     if partial_commit else None
         if not partial_commit or to_commit:
@@ -3612,7 +3612,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         to_remove = [
             # TODO remove pathobj stringification when delete() can
             # handle it
-            text_type(f.relative_to(self.pathobj))
+            str(f.relative_to(self.pathobj))
             for f, props in iteritems(status)
             if props.get('state', None) == 'deleted' and
             # staged deletions have a gitshasum reported for them
@@ -3664,7 +3664,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             for cand_sm in to_add_submodules:
                 try:
                     self.add_submodule(
-                        text_type(cand_sm.relative_to(self.pathobj)),
+                        str(cand_sm.relative_to(self.pathobj)),
                         url=None, name=None)
                 except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(
@@ -3691,7 +3691,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             # without a partial commit an AnnexRepo would ignore any submodule
             # path in its add helper, hence `git add` them explicitly
             to_stage_submodules = {
-                text_type(f.relative_to(self.pathobj)): props
+                str(f.relative_to(self.pathobj)): props
                 for f, props in iteritems(status)
                 if props.get('state', None) in ('modified', 'untracked')
                 and props.get('type', None) == 'dataset'}
@@ -3740,7 +3740,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         to_add = {
             # TODO remove pathobj stringification when add() can
             # handle it
-            text_type(f.relative_to(self.pathobj)): props
+            str(f.relative_to(self.pathobj)): props
             for f, props in iteritems(status)
             if (props.get('state', None) in ('modified', 'untracked') and
                 f not in to_add_submodules)}

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -56,8 +56,6 @@ class GlobbedPaths(object):
     def __bool__(self):
         return bool(self._maybe_dot or self.expand())
 
-    __nonzero__ = __bool__  # py2
-
     def _get_sub_patterns(self, pattern):
         """Extract sub-patterns from the leading path of `pattern`.
 

--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -12,7 +12,6 @@
 
 import io
 import codecs
-from six import PY2
 from os.path import (
     dirname,
     exists,

--- a/datalad/support/lzma.py
+++ b/datalad/support/lzma.py
@@ -10,8 +10,6 @@
 """
 from __future__ import absolute_import
 
-from six import PY2
-
 exc1 = ''
 try:
     try:

--- a/datalad/support/lzma.py
+++ b/datalad/support/lzma.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 from six import PY2
-from ..log import lgr
 
 exc1 = ''
 try:
@@ -20,13 +19,4 @@ try:
     except ImportError as exc1:
         import backports.lzma as lzma
 except Exception as exc2:
-    if PY2 and 'undefined symbol: lzma_alone_encoder' in str(exc1):
-        lgr.error(
-            "lzma fails to import and a typical problem is installation "
-            "of pyliblzma via pip while pkg-config utility is missing. "
-            "If you did installed it using pip, please "
-            "1) pip uninstall pyliblzma; "
-            "2) install pkg-config (e.g. apt-get install pkg-config on "
-            "Debian-based systems); "
-            "3) pip install pyliblzma again.")
     raise

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -244,9 +244,9 @@ def same_website(url_rec, u_rec):
     u_rec: ParseResult
       record for new url
     """
-    if isinstance(url_rec, string_types):
+    if isinstance(url_rec, str):
         url_rec = urlparse(url_rec)
-    if isinstance(u_rec, string_types):
+    if isinstance(u_rec, str):
         u_rec = urlparse(u_rec)
     return (url_rec.netloc == u_rec.netloc)
     # todo: collect more of sample cases.

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -27,8 +27,6 @@ from os.path import join as opj
 from os.path import dirname
 from ntpath import splitdrive as win_splitdrive
 
-from six import string_types
-from six import iteritems
 from urllib.parse import urlsplit
 from urllib.request import Request
 from urllib.parse import unquote as urlunquote

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -29,13 +29,13 @@ from ntpath import splitdrive as win_splitdrive
 
 from six import string_types
 from six import iteritems
-from six.moves.urllib.parse import urlsplit
-from six.moves.urllib.request import Request
-from six.moves.urllib.parse import unquote as urlunquote
-from six.moves.urllib.parse import urljoin, urlparse, urlsplit, urlunparse, ParseResult
-from six.moves.urllib.parse import parse_qsl
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.error import URLError
+from urllib.parse import urlsplit
+from urllib.request import Request
+from urllib.parse import unquote as urlunquote
+from urllib.parse import urljoin, urlparse, urlsplit, urlunparse, ParseResult
+from urllib.parse import parse_qsl
+from urllib.parse import urlencode
+from urllib.error import URLError
 
 from datalad.dochelpers import exc_str
 from datalad.utils import on_windows
@@ -52,9 +52,9 @@ from datalad.support.cache import lru_cache
 # strings. "~" is now included in the set of reserved characters.
 # For consistency we will provide urlquote
 if sys.version_info >= (3, 7):
-    from six.moves.urllib.parse import quote as urlquote
+    from urllib.parse import quote as urlquote
 else:
-    from six.moves.urllib.parse import quote as _urlquote
+    from urllib.parse import quote as _urlquote
 
     def urlquote(url, safe='/', **kwargs):
         safe += '~'

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -495,12 +495,9 @@ class RI(object):
     # location
     #
 
-    def __nonzero__(self):
+    def __bool__(self):
         fields = self._fields
         return any(fields.values())
-
-    # for PY3
-    __bool__ = __nonzero__
 
     #
     # Helpers to deal with internal structures and conversions

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -42,7 +42,6 @@ from datalad import consts
 from datalad import cfg
 from datalad.support.cache import lru_cache
 
-# TODO not sure what needs to use `six` here yet
 # !!! Lazily import requests where needed -- needs 30ms or so
 # import requests
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -736,7 +736,7 @@ class RegexBasedURLMixin(object):
                    " Did you intent to use '///'?" if url_str.startswith('//') else '')
             )
         fields = cls._get_blank_fields()
-        fields.update({k: v for k, v in iteritems(re_match.groupdict()) if v})
+        fields.update({k: v for k, v in re_match.groupdict().items() if v})
         cls._normalize_fields(fields)
         return fields
 

--- a/datalad/support/protocol.py
+++ b/datalad/support/protocol.py
@@ -18,8 +18,7 @@ import time
 lgr = logging.getLogger('datalad.protocol')
 
 
-@add_metaclass(ABCMeta)
-class ProtocolInterface(object):
+class ProtocolInterface(object, metaclass=ABCMeta):
     """Interface class for protocols used by the Runner.
 
     Implementations of this interface are supposed to store one section per

--- a/datalad/support/protocol.py
+++ b/datalad/support/protocol.py
@@ -10,7 +10,6 @@
 """
 
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six import add_metaclass
 from os import linesep
 import logging
 import time

--- a/datalad/support/repo.py
+++ b/datalad/support/repo.py
@@ -43,10 +43,8 @@ class Flyweight(type):
     Example:
 
     from weakref import WeakValueDictionary
-    from six import add_metaclass
 
-    @add_metaclass(Flyweight)
-    class MyFlyweightClass(object):
+    class MyFlyweightClass(object, metaclass=Flyweight):
 
         _unique_instances = WeakValueDictionary()
 

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -264,7 +264,7 @@ def check_dates(repo, timestamp=None, which="newer", revs=None,
     -------
     A dict that reports newer timestamps.
     """
-    if isinstance(repo, string_types):
+    if isinstance(repo, str):
         repo = GitRepo(repo, create=False)
 
     if timestamp is None:

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -14,7 +14,6 @@ import operator
 import re
 import time
 
-from six import string_types
 
 from datalad.log import log_progress
 from datalad.support.exceptions import CommandError

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -33,7 +33,7 @@ from datalad.support.exceptions import (
     AnonymousAccessDeniedError,
 )
 
-from six.moves.urllib.request import urlopen, Request
+from urllib.request import urlopen, Request
 
 
 try:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -473,7 +473,7 @@ class SSHManager(object):
             Path(cfg.obtain('datalad.locations.cache')) / 'sockets'
         self._socket_dir.mkdir(exist_ok=True, parents=True)
         try:
-            os.chmod(text_type(self._socket_dir), 0o700)
+            os.chmod(str(self._socket_dir), 0o700)
         except OSError as exc:
             lgr.warning(
                 "Failed to (re)set permissions on the %s. "

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -22,7 +22,6 @@ import tempfile
 # importing the quote function here so it can always be imported from this
 # module
 from shlex import quote as sh_quote
-from six import text_type
 
 # !!! Do not import network here -- delay import, allows to shave off 50ms or so
 # on initial import datalad time

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -21,7 +21,7 @@ from subprocess import Popen
 import tempfile
 # importing the quote function here so it can always be imported from this
 # module
-from six.moves import shlex_quote as sh_quote
+from shlex import quote as sh_quote
 from six import text_type
 
 # !!! Do not import network here -- delay import, allows to shave off 50ms or so

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -18,7 +18,7 @@ import re
 def get_replacement_dict(rules):
     """Given a string with replacement rules, produces a dict of from: to"""
 
-    if isinstance(rules, (binary_type, str)):
+    if isinstance(rules, (bytes, str)):
         rules = [rules]
 
     pairs = OrderedDict()

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -11,7 +11,6 @@
 __docformat__ = 'restructuredtext'
 
 from collections import OrderedDict
-from six import binary_type, text_type
 import re
 
 

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -18,7 +18,7 @@ import re
 def get_replacement_dict(rules):
     """Given a string with replacement rules, produces a dict of from: to"""
 
-    if isinstance(rules, (binary_type, text_type)):
+    if isinstance(rules, (binary_type, str)):
         rules = [rules]
 
     pairs = OrderedDict()

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -29,8 +29,8 @@ from nose.tools import assert_not_is_instance
 
 from six import text_type
 
-from six.moves.urllib.parse import urljoin
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urljoin
+from urllib.parse import urlsplit
 
 import git
 from git import GitCommandError

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -27,7 +27,6 @@ from os.path import exists
 from shutil import copyfile
 from nose.tools import assert_not_is_instance
 
-from six import text_type
 
 from urllib.parse import urljoin
 from urllib.parse import urlsplit

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1098,9 +1098,9 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     rm2 = AnnexRepo(remote_2_path, create=False)
 
     # check whether we are the first to use these sockets:
-    socket_1 = opj(text_type(ssh_manager.socket_dir),
+    socket_1 = opj(str(ssh_manager.socket_dir),
                    get_connection_hash('datalad-test', bundled=True))
-    socket_2 = opj(text_type(ssh_manager.socket_dir),
+    socket_2 = opj(str(ssh_manager.socket_dir),
                    get_connection_hash('localhost', bundled=True))
     datalad_test_was_open = exists(socket_1)
     localhost_was_open = exists(socket_2)
@@ -1116,7 +1116,7 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ar = AnnexRepo(repo_path, create=False)
 
     # connection to 'datalad-test' should be known to ssh manager:
-    assert_in(socket_1, list(map(text_type, ssh_manager._connections)))
+    assert_in(socket_1, list(map(str, ssh_manager._connections)))
     # but socket was not touched:
     if datalad_test_was_open:
         ok_(exists(socket_1))
@@ -1153,7 +1153,7 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ar.add_remote('ssh-remote-2', "ssh://localhost" + remote_2_path)
 
     # now, this connection to localhost was requested:
-    assert_in(socket_2, list(map(text_type, ssh_manager._connections)))
+    assert_in(socket_2, list(map(str, ssh_manager._connections)))
     # but socket was not touched:
     if localhost_was_open:
         # FIXME: occasionally(?) fails in V6:

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -34,10 +34,10 @@ from nose.tools import (
 from nose import SkipTest
 from six import PY3
 
-if PY3:
-    # just to ease testing
-    def cmp(a, b):
-        return (a > b) - (a < b)
+
+# just to ease testing
+def cmp(a, b):
+    return (a > b) - (a < b)
 
 
 def test_external_versions_basic():

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -32,7 +32,6 @@ from nose.tools import (
     assert_raises, assert_in
 )
 from nose import SkipTest
-from six import PY3
 
 
 # just to ease testing

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -159,8 +159,8 @@ def test_compare_content_info(path):
     wt = ds.repo.get_content_info(ref=None)
     assert_dict_equal(
         wt,
-        {f: {k: v for k, v in iteritems(p) if k != 'bytesize'}
-         for f, p in iteritems(ds.repo.get_content_info(ref='HEAD'))}
+        {f: {k: v for k, v in p.items() if k != 'bytesize'}
+         for f, p in ds.repo.get_content_info(ref='HEAD').items()}
     )
 
 

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -8,7 +8,6 @@
 """Test file info getters"""
 
 
-from six import iteritems
 import os.path as op
 import datalad.utils as ut
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -526,7 +526,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 
     remote_repo = GitRepo(remote_path, create=False)
     url = "ssh://localhost" + op.abspath(remote_path)
-    socket_path = op.join(text_type(ssh_manager.socket_dir),
+    socket_path = op.join(str(ssh_manager.socket_dir),
                           get_connection_hash('localhost', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
@@ -539,7 +539,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     ok_clean_git(repo)
 
     # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, list(map(text_type, ssh_manager._connections)))
+    assert_in(socket_path, list(map(str, ssh_manager._connections)))
     # and socket was created:
     ok_(op.exists(socket_path))
 
@@ -555,7 +555,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
 
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + op.abspath(remote_path)
-    socket_path = op.join(text_type(ssh_manager.socket_dir),
+    socket_path = op.join(str(ssh_manager.socket_dir),
                           get_connection_hash('localhost', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
@@ -575,7 +575,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     ok_clean_git(repo.path, annex=False)
 
     # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, list(map(text_type, ssh_manager._connections)))
+    assert_in(socket_path, list(map(str, ssh_manager._connections)))
     # and socket was created:
     ok_(op.exists(socket_path))
 
@@ -591,7 +591,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
 
     remote_repo = GitRepo(remote_path, create=True)
     url = "ssh://localhost" + op.abspath(remote_path)
-    socket_path = op.join(text_type(ssh_manager.socket_dir),
+    socket_path = op.join(str(ssh_manager.socket_dir),
                           get_connection_hash('localhost', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
@@ -612,7 +612,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     assert_in("ssh-remote/ssh-test", [commit.remote_ref.name for commit in pushed])
 
     # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, list(map(text_type, ssh_manager._connections)))
+    assert_in(socket_path, list(map(str, ssh_manager._connections)))
     # and socket was created:
     ok_(op.exists(socket_path))
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -20,7 +20,6 @@ import os.path as op
 
 import sys
 
-from six import text_type
 
 from datalad import get_encoding_info
 from datalad.cmd import Runner

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -46,19 +46,19 @@ def _test_save_all(path, repocls):
     # make sure we get a 'delete' result for each deleted file
     eq_(
         set(r['path'] for r in res if r['action'] == 'delete'),
-        {k for k, v in iteritems(orig_status) if k.name == 'file_deleted'}
+        {k for k, v in orig_status.items() if k.name == 'file_deleted'}
     )
     saved_status = ds.repo.status(untracked='all')
     # we still have an entry for everything that did not get deleted
     # intentionally
     eq_(
-        len([f for f, p in iteritems(orig_status)
+        len([f for f, p in orig_status.items()
              if not f.match('*_deleted')]),
         len(saved_status))
     # everything but subdataset entries that contain untracked content,
     # or modified subsubdatasets is now clean, a repo simply doesn touch
     # other repos' private parts
-    for f, p in iteritems(saved_status):
+    for f, p in saved_status.items():
         if p.get('state', None) != 'clean':
             assert f.match('subds_modified'), f
     return ds
@@ -87,7 +87,7 @@ def test_save_to_git(path):
     ds.repo.save(paths=['file_ingit'], git=True)
     ds.repo.save(paths=['file_inannex'])
     assert_repo_status(ds.repo)
-    for f, p in iteritems(ds.repo.annexstatus()):
+    for f, p in ds.repo.annexstatus().items():
         eq_(p['state'], 'clean')
         if f.match('*ingit'):
             assert_not_in('key', p, f)

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -7,7 +7,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test saveds fuction"""
 
-from six import iteritems
 
 from datalad.tests.utils import (
     assert_in,

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -17,7 +17,6 @@ from mock import patch
 
 from nose import SkipTest
 
-from six import text_type
 
 from datalad.support.external_versions import external_versions
 from datalad.utils import Path

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -81,7 +81,7 @@ def test_ssh_open_close(tfile1):
 
     manager = SSHManager()
 
-    path = opj(text_type(manager.socket_dir),
+    path = opj(str(manager.socket_dir),
                get_connection_hash('localhost', bundled=True))
     # TODO: facilitate the test when it didn't exist
     existed_before = exists(path)
@@ -118,9 +118,9 @@ def test_ssh_manager_close():
     manager = SSHManager()
 
     # check for previously existing sockets:
-    existed_before_1 = exists(opj(text_type(manager.socket_dir),
+    existed_before_1 = exists(opj(str(manager.socket_dir),
                                   get_connection_hash('localhost')))
-    existed_before_2 = exists(opj(text_type(manager.socket_dir),
+    existed_before_2 = exists(opj(str(manager.socket_dir),
                                   get_connection_hash('datalad-test')))
 
     manager.get_connection('ssh://localhost').open()
@@ -132,16 +132,16 @@ def test_ssh_manager_close():
         manager.get_connection('ssh://localhost').close()
         manager.get_connection('ssh://localhost').open()
 
-    ok_(exists(opj(text_type(manager.socket_dir),
+    ok_(exists(opj(str(manager.socket_dir),
                    get_connection_hash('localhost', bundled=True))))
-    ok_(exists(opj(text_type(manager.socket_dir),
+    ok_(exists(opj(str(manager.socket_dir),
                    get_connection_hash('datalad-test', bundled=True))))
 
     manager.close()
 
-    still_exists_1 = exists(opj(text_type(manager.socket_dir),
+    still_exists_1 = exists(opj(str(manager.socket_dir),
                                 get_connection_hash('localhost')))
-    still_exists_2 = exists(opj(text_type(manager.socket_dir),
+    still_exists_2 = exists(opj(str(manager.socket_dir),
                                 get_connection_hash('datalad-test')))
 
     eq_(existed_before_1, still_exists_1)
@@ -217,8 +217,8 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
 
     # and now a quick smoke test for get
     togetfile = Path(targetdir) / '2|g>e"t.t&x;t'
-    togetfile.write_text(text_type('something'))
-    ssh.get(opj(remote_url, text_type(togetfile)), sourcedir)
+    togetfile.write_text(str('something'))
+    ssh.get(opj(remote_url, str(togetfile)), sourcedir)
     ok_((Path(sourcedir) / '2|g>e"t.t&x;t').exists())
 
     ssh.close()
@@ -250,7 +250,7 @@ def test_ssh_custom_identity_file():
                 ssh = manager.get_connection('ssh://localhost')
                 cmd_out, _ = ssh("echo blah")
                 expected_socket = op.join(
-                    text_type(manager.socket_dir),
+                    str(manager.socket_dir),
                     get_connection_hash("localhost", identity_file=ifile,
                                         bundled=True))
                 ok_(exists(expected_socket))
@@ -289,6 +289,6 @@ def test_bundle_invariance(path):
     for flag in (True, False):
         assert_false(testfile.exists())
         ssh = manager.get_connection(remote_url, use_remote_annex_bundle=flag)
-        ssh('cd .>{}'.format(text_type(testfile)))
+        ssh('cd .>{}'.format(str(testfile)))
         ok_(testfile.exists())
         testfile.unlink()

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import sys
-from six.moves import StringIO
+from io import StringIO
 from nose.tools import assert_raises, assert_equal
 
 from mock import patch

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -9,8 +9,9 @@
 import sys
 import json
 
-from six.moves.urllib.request import Request, urlopen
-from six.moves.urllib.error import HTTPError
+from urllib.request import Request
+from urllib.request import urlopen
+from urllib.error import HTTPError
 
 from datalad.support.exceptions import (
     AccessDeniedError,

--- a/datalad/support/third/nosetester.py
+++ b/datalad/support/third/nosetester.py
@@ -196,7 +196,7 @@ class NoseTester(object):
         '''
         argv = [__file__, self.package_path, '-s']
         if label and label != 'full':
-            if not isinstance(label, basestring):
+            if not isinstance(label, str):
                 raise TypeError('Selection label should be a string')
             if label == 'fast':
                 label = 'not slow'
@@ -371,7 +371,7 @@ class NoseTester(object):
 
         _warn_opts = dict(develop=(Warning,),
                           release=())
-        if isinstance(raise_warnings, basestring):
+        if isinstance(raise_warnings, str):
             raise_warnings = _warn_opts[raise_warnings]
 
         # Filter out some deprecation warnings inside nose 1.3.7 when run

--- a/datalad/support/third/nosetester.py
+++ b/datalad/support/third/nosetester.py
@@ -9,7 +9,6 @@ from __future__ import division, absolute_import, print_function
 import os
 import sys
 import warnings
-from six import string_types as basestring
 #from numpy.compat import basestring
 
 

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -10,7 +10,7 @@
 import sys
 
 from mock import patch
-from six.moves import StringIO
+from io import StringIO
 from tempfile import NamedTemporaryFile
 from nose.tools import assert_raises, assert_equal
 

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -15,7 +15,7 @@ from os.path import join as opj, dirname
 
 from mock import patch
 
-from six.moves import StringIO
+from io import StringIO
 from .utils import with_testrepos
 from .utils import assert_raises, eq_, ok_, assert_false, assert_true
 from .utils import swallow_outputs

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -324,17 +324,3 @@ def test_runner_stdin(path):
     with swallow_outputs() as cmo, open(op.join(path, "test_input.txt"), "r") as fake_input:
         runner.run(['cat'], log_stdout=False, stdin=fake_input)
         assert_in("whatever", cmo.out)
-
-
-def test_process_remaining_output():
-    runner = Runner()
-    out = u"""\
-s
-п
-"""
-    out_bytes = out.encode('utf-8')
-    target = u"s{ls}п{ls}".format(ls=os.linesep).encode('utf-8')
-    args = ['stdout', None, False, False]
-    #  probably #2185
-    eq_(runner._process_remaining_output(None, out_bytes, *args), target)
-    eq_(runner._process_remaining_output(None, out, *args), target)

--- a/datalad/tests/test_constraints.py
+++ b/datalad/tests/test_constraints.py
@@ -140,17 +140,13 @@ def test_range():
     # this should always work
     assert_equal(c(3.0), 3.0)
 
-    # Python 3 raises an TypeError if incompatible types are compared,
-    # whereas Python 2 raises a ValueError
-    type_error = TypeError if sys.version_info[0] >= 3 else ValueError
-
     # this should always fail
     assert_raises(ValueError, lambda: c(2.9999999))
     assert_raises(ValueError, lambda: c(77))
-    assert_raises(type_error, lambda: c('fail'))
-    assert_raises(type_error, lambda: c((3, 4)))
+    assert_raises(TypeError, lambda: c('fail'))
+    assert_raises(TypeError, lambda: c((3, 4)))
     # since no type checks are performed
-    assert_raises(type_error, lambda: c('7'))
+    assert_raises(TypeError, lambda: c('7'))
 
     # Range doesn't have to be numeric
     c = ct.EnsureRange(min="e", max="qqq")

--- a/datalad/tests/test_constraints.py
+++ b/datalad/tests/test_constraints.py
@@ -236,4 +236,4 @@ def test_both():
 
 def test_type_str():
     assert_equal(ct._type_str((str,)), 'str')
-    assert_equal(ct._type_str(str), 'basestring' if PY2 else 'str')
+    assert_equal(ct._type_str(str), 'str')

--- a/datalad/tests/test_constraints.py
+++ b/datalad/tests/test_constraints.py
@@ -236,4 +236,4 @@ def test_both():
 
 def test_type_str():
     assert_equal(ct._type_str((str,)), 'str')
-    assert_equal(ct._type_str(string_types), 'basestring' if PY2 else 'str')
+    assert_equal(ct._type_str(str), 'basestring' if PY2 else 'str')

--- a/datalad/tests/test_constraints.py
+++ b/datalad/tests/test_constraints.py
@@ -12,7 +12,6 @@
 import sys
 import os
 from os.path import isabs, abspath, join as opj, normpath
-from six import string_types, PY2
 
 from ..support import constraints as ct
 from ..support.gitrepo import GitRepo

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -11,7 +11,6 @@ import platform
 import sys
 import os
 import random
-import traceback
 import logging
 
 try:
@@ -292,8 +291,6 @@ def test_ok_generator():
     def gen(a, b=1):  # pragma: no cover
         yield a+b
     # not sure how to determine if xrange is a generator
-    if PY2:
-        assert_raises(AssertionError, ok_generator, xrange(2))
     assert_raises(AssertionError, ok_generator, range(2))
     assert_raises(AssertionError, ok_generator, gen)
     ok_generator(gen(1))
@@ -361,12 +358,6 @@ def test_assert_cwd_unchanged_not_masking_exceptions():
         with assert_raises(ValueError) as cm:
             do_chdir_value_error()
         # retrospect exception
-        if PY2:
-            # could not figure out how to make it legit for PY3
-            # but on manual try -- works, and exception traceback is not masked out
-            exc_info = sys.exc_info()
-            assert_in('raise ValueError("error exception")', traceback.format_exception(*exc_info)[-2])
-
         eq_(orig_cwd, os.getcwd(),
             "assert_cwd_unchanged didn't return us back to %s" % orig_cwd)
         assert_in("Mitigating and changing back", cml.out)

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -25,7 +25,7 @@ from os.path import exists, join as opj, basename
 
 from six import PY2, PY3
 from six import text_type
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 from mock import patch
 from nose.tools import assert_in, assert_not_in, assert_true

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -22,8 +22,6 @@ except ImportError:  # pragma: no cover
 from glob import glob
 from os.path import exists, join as opj, basename
 
-from six import PY2, PY3
-from six import text_type
 from urllib.request import urlopen
 
 from mock import patch

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -398,8 +398,8 @@ def _test_serve_path_via_http(test_fpath, tmp_dir):  # pragma: no cover
         raise SkipTest("Can't convert back/forth using %s encoding"
                        % filesysencoding)
 
-    test_fpath_full = text_type(os.path.join(tmp_dir, test_fpath))
-    test_fpath_dir = text_type(os.path.dirname(test_fpath_full))
+    test_fpath_full = str(os.path.join(tmp_dir, test_fpath))
+    test_fpath_dir = str(os.path.dirname(test_fpath_full))
 
     if not os.path.exists(test_fpath_dir):
         os.makedirs(test_fpath_dir)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -16,8 +16,6 @@ import shutil
 import sys
 import logging
 from mock import patch
-from six import PY3
-from six import text_type
 import builtins
 
 from operator import itemgetter

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -18,7 +18,7 @@ import logging
 from mock import patch
 from six import PY3
 from six import text_type
-import six.moves.builtins as __builtin__
+import builtins
 
 from operator import itemgetter
 from os.path import dirname, normpath, pardir, basename
@@ -881,7 +881,7 @@ def test_safe_print():
         if called[0] == 1:
             raise UnicodeEncodeError('crap', u"", 0, 1, 'whatever')
 
-    with patch.object(__builtin__, 'print', _print):
+    with patch.object(builtins, 'print', _print):
         safe_print("bua")
     assert_equal(called[0], 2)
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -282,14 +282,13 @@ def _check_setup_exceptionhook(interactive):
             except Exception as e:  # RuntimeError:
                 type_, value_, tb_ = sys.exc_info()
             our_exceptionhook(type_, value_, tb_)
-            if PY3:
-                # Happens under tox environment but not in manually crafted
-                # ones -- not yet sure what it is about but --dbg does work
-                # with python3 so lettting it skip for now
-                raise SkipTest(
-                    "TODO: Not clear why in PY3 calls cleanup if we try to "
-                    "access the beast"
-                )
+            # Happens under tox environment but not in manually crafted
+            # ones -- not yet sure what it is about but --dbg does work
+            # with python3 so lettting it skip for now
+            raise SkipTest(
+                "TODO: Not clear why in PY3 calls cleanup if we try to "
+                "access the beast"
+            )
             assert_in('Traceback (most recent call last)', cmo.err)
             assert_in('in _check_setup_exceptionhook', cmo.err)
             if interactive:

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -728,9 +728,9 @@ def test_memoized_generator():
 
 
 def test_assure_unicode():
-    ok_(isinstance(assure_unicode("m"), text_type))
-    ok_(isinstance(assure_unicode('grandchild_äöü東'), text_type))
-    ok_(isinstance(assure_unicode(u'grandchild_äöü東'), text_type))
+    ok_(isinstance(assure_unicode("m"), str))
+    ok_(isinstance(assure_unicode('grandchild_äöü東'), str))
+    ok_(isinstance(assure_unicode(u'grandchild_äöü東'), str))
     eq_(assure_unicode('grandchild_äöü東'), u'grandchild_äöü東')
     # now, non-utf8
     # Decoding could be deduced with high confidence when the string is
@@ -743,7 +743,7 @@ def test_assure_unicode():
     eq_(assure_unicode(mom_iso8859, confidence=0.5), u'mamá')
     # but when we mix, it does still guess something allowing to decode:
     mixedin = mom_koi8r + u'東'.encode('iso2022_jp') + u'東'.encode('utf-8')
-    ok_(isinstance(assure_unicode(mixedin), text_type))
+    ok_(isinstance(assure_unicode(mixedin), str))
     # but should fail if we request high confidence result:
     with assert_raises(ValueError):
         assure_unicode(mixedin, confidence=0.9)
@@ -753,8 +753,8 @@ def test_assure_unicode():
 
 
 def test_pathlib_unicode():
-    eq_(text_type(Path("a")), u"a")
-    eq_(text_type(Path(u"β")), u"β")
+    eq_(str(Path("a")), u"a")
+    eq_(str(Path(u"β")), u"β")
 
 
 def test_as_unicode():

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -32,8 +32,8 @@ from difflib import unified_diff
 from contextlib import contextmanager
 from mock import patch
 
-from six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler
-from six.moves.BaseHTTPServer import HTTPServer
+from http.server import SimpleHTTPRequestHandler
+from http.server import HTTPServer
 from six import reraise
 from six.moves import map
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -399,7 +399,7 @@ def ok_file_has_content(path, content, strip=False, re_=False,
     with open_func(path, 'rb') as f:
         file_content = f.read()
 
-    if isinstance(content, text_type):
+    if isinstance(content, str):
         file_content = assure_unicode(file_content)
 
     if os.linesep != '\n':
@@ -1741,7 +1741,7 @@ def get_deeply_nested_structure(path):
         }
     )
     create_tree(
-        text_type(ds.pathobj / 'subds_modified' / 'subds_lvl1_modified'),
+        str(ds.pathobj / 'subds_modified' / 'subds_lvl1_modified'),
         {OBSCURE_FILENAME + u'_directory_untracked': {"untraced_file": ""}}
     )
     (ut.Path(subds.path) / 'subdir').mkdir()

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1127,7 +1127,7 @@ def assert_cwd_unchanged(func, ok_to_chdir=False):
                                  "CWD changed from %s to %s" % (cwd_before, cwd_after))
 
         if exc_info is not None:
-            reraise(*exc_info)
+            raise exc_info[1]
 
         return ret
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -704,7 +704,7 @@ def _get_testrepos_uris(regex, flavors):
             _nested_submodule_annex_test_repo.create()
             _inner_submodule_annex_test_repo.create()
     uris = []
-    for name, spec in iteritems(_TESTREPOS):
+    for name, spec in _TESTREPOS.items():
         if not re.match(regex, name):
             continue
         uris += [spec[x] for x in set(spec.keys()).intersection(flavors)]
@@ -1547,7 +1547,7 @@ def assert_repo_status(path, annex=None, untracked_mode='normal', **kwargs):
     for state in ('added', 'untracked', 'deleted', 'modified'):
         oktobefound = sorted(r.pathobj.joinpath(ut.PurePosixPath(p))
                              for p in kwargs.get(state, []))
-        state_files = sorted(k for k, v in iteritems(status)
+        state_files = sorted(k for k, v in status.items()
                              if v.get('state', None) == state)
         eq_(state_files, oktobefound,
             'unexpected content of state "%s": %r != %r'

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -23,9 +23,6 @@ import logging
 import random
 import socket
 import warnings
-from six import PY2, text_type, iteritems
-from six import binary_type
-from six import string_types
 from fnmatch import fnmatch
 import time
 from difflib import unified_diff
@@ -34,8 +31,6 @@ from mock import patch
 
 from http.server import SimpleHTTPRequestHandler
 from http.server import HTTPServer
-from six import reraise
-from six.moves import map
 
 from functools import wraps
 from os.path import exists, realpath, join as opj, pardir, split as pathsplit, curdir

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1185,7 +1185,7 @@ def assert_dict_equal(d1, d2):
     for k in set(d1).intersection(d2):
         same = True
         try:
-            if isinstance(d1[k], string_types):
+            if isinstance(d1[k], str):
                 # do not compare types for string types to avoid all the hassle
                 # with the distinction of str and unicode in PY3, and simple
                 # test for equality

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -11,7 +11,6 @@ import os
 import tempfile
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 from os.path import dirname, join as opj, exists, pardir
 
 from ..support.gitrepo import GitRepo

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -40,8 +40,7 @@ with open(remote_file_path, "w") as f:
 os.close(remote_file_fd)
 
 
-@add_metaclass(ABCMeta)
-class TestRepo(object):
+class TestRepo(object, metaclass=ABCMeta):
 
     REPO_CLASS = None  # Assign to the class to be used in the subclass
 

--- a/datalad/ui/base.py
+++ b/datalad/ui/base.py
@@ -19,8 +19,7 @@ from ..utils import auto_repr
 
 
 @auto_repr
-@add_metaclass(ABCMeta)
-class InteractiveUI(object):
+class InteractiveUI(object, metaclass=ABCMeta):
     """Semi-abstract class for interfaces to implement interactive UI"""
 
     @abstractmethod

--- a/datalad/ui/base.py
+++ b/datalad/ui/base.py
@@ -13,7 +13,6 @@
 __docformat__ = 'restructuredtext'
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from ..utils import auto_repr
 

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -27,7 +27,6 @@ import getpass
 # from mock import patch
 from collections import deque
 from copy import copy
-from six import PY2
 
 from ..utils import auto_repr
 from ..utils import on_windows

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -277,7 +277,7 @@ class IPythonUI(DialogUI):
         if not hidden:
             self.out.write(prompt)
             self.out.flush()
-            return (raw_input if PY2 else input)()
+            return input()
         else:
             return getpass.getpass(prompt=prompt)
 

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -10,7 +10,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from six import PY2
 from io import StringIO
 import builtins
 

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -12,7 +12,7 @@ __docformat__ = 'restructuredtext'
 
 from six import PY2
 from io import StringIO
-import six.moves.builtins as __builtin__
+import builtins
 
 from mock import (
     call,
@@ -33,7 +33,7 @@ from datalad.ui.progressbars import progressbars
 
 def patch_input(**kwargs):
     """A helper to provide mocked cm patching input function which was renamed in PY3"""
-    return patch.object(__builtin__, 'raw_input' if PY2 else 'input', **kwargs)
+    return patch.object(builtins, 'raw_input' if PY2 else 'input', **kwargs)
 
 
 def patch_getpass(**kwargs):

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -11,7 +11,7 @@
 __docformat__ = 'restructuredtext'
 
 from six import PY2
-from six.moves import StringIO
+from io import StringIO
 import six.moves.builtins as __builtin__
 
 from mock import (

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -33,7 +33,7 @@ from datalad.ui.progressbars import progressbars
 
 def patch_input(**kwargs):
     """A helper to provide mocked cm patching input function which was renamed in PY3"""
-    return patch.object(builtins, 'raw_input' if PY2 else 'input', **kwargs)
+    return patch.object(builtins, 'input', **kwargs)
 
 
 def patch_getpass(**kwargs):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -695,7 +695,9 @@ def assure_dict_from_str(s, **kwargs):
 
 
 def assure_bytes(s, encoding='utf-8'):
-    """Convert/encode unicode to str (PY2) or bytes (PY3) if of 'str'
+    """Convert/encode unicode string to bytes.
+
+    If `s` isn't a string, return it as is.
 
     Parameters
     ----------
@@ -708,7 +710,9 @@ def assure_bytes(s, encoding='utf-8'):
 
 
 def assure_unicode(s, encoding=None, confidence=None):
-    """Convert/decode to unicode (PY2) or str (PY3) if of 'binary_type'
+    """Convert/decode bytestring to unicode.
+
+    If `s` isn't a bytestring, return it as is.
 
     Parameters
     ----------

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -10,7 +10,7 @@
 import collections
 import hashlib
 import re
-import six.moves.builtins as __builtin__
+import builtins
 import time
 
 try:
@@ -1169,7 +1169,7 @@ def swallow_outputs():
 
     from .ui import ui
     # preserve -- they could have been mocked already
-    oldprint = getattr(__builtin__, 'print')
+    oldprint = getattr(builtins, 'print')
     oldout, olderr = sys.stdout, sys.stderr
     olduiout = ui.out
     adapter = StringIOAdapter()
@@ -1177,12 +1177,12 @@ def swallow_outputs():
     try:
         sys.stdout, sys.stderr = adapter.handles
         ui.out = adapter.handles[0]
-        setattr(__builtin__, 'print', fake_print)
+        setattr(builtins, 'print', fake_print)
 
         yield adapter
     finally:
         sys.stdout, sys.stderr, ui.out = oldout, olderr, olduiout
-        setattr(__builtin__, 'print',  oldprint)
+        setattr(builtins, 'print',  oldprint)
         adapter.cleanup()
 
 
@@ -1927,7 +1927,7 @@ def slash_join(base, extension):
 def safe_print(s):
     """Print with protection against UTF-8 encoding errors"""
     # A little bit of dance to be able to test this code
-    print_f = getattr(__builtin__, "print")
+    print_f = getattr(builtins, "print")
     try:
         print_f(s)
     except UnicodeEncodeError:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -560,7 +560,7 @@ def escape_filename(filename):
 def encode_filename(filename):
     """Encode unicode filename
     """
-    if isinstance(filename, text_type):
+    if isinstance(filename, str):
         return filename.encode(sys.getfilesystemencoding())
     else:
         return filename
@@ -573,7 +573,7 @@ def decode_input(s):
     If fails -- issue warning and decode allowing for errors
     being replaced
     """
-    if isinstance(s, text_type):
+    if isinstance(s, str):
         return s
     else:
         encoding = sys.stdin.encoding or 'UTF-8'
@@ -635,13 +635,13 @@ def assure_iter(s, cls, copy=False, iterate=True):
     copy: bool, optional
       If correct iterable is passed, it would generate its shallow copy
     iterate: bool, optional
-      If it is not a list, but something iterable (but not a text_type)
+      If it is not a list, but something iterable (but not a str)
       iterate over it.
     """
 
     if isinstance(s, cls):
         return s if not copy else shallow_copy(s)
-    elif isinstance(s, text_type):
+    elif isinstance(s, str):
         return cls((s,))
     elif iterate and hasattr(s, '__iter__'):
         return cls(s)
@@ -660,7 +660,7 @@ def assure_list(s, copy=False, iterate=True):
     copy: bool, optional
       If list is passed, it would generate a shallow copy of the list
     iterate: bool, optional
-      If it is not a list, but something iterable (but not a text_type)
+      If it is not a list, but something iterable (but not a str)
       iterate over it.
     """
     return assure_iter(s, list, copy=copy, iterate=iterate)
@@ -711,14 +711,14 @@ def assure_dict_from_str(s, **kwargs):
 
 
 def assure_bytes(s, encoding='utf-8'):
-    """Convert/encode unicode to str (PY2) or bytes (PY3) if of 'text_type'
+    """Convert/encode unicode to str (PY2) or bytes (PY3) if of 'str'
 
     Parameters
     ----------
     encoding: str, optional
       Encoding to use.  "utf-8" is the default
     """
-    if not isinstance(s, text_type):
+    if not isinstance(s, str):
         return s
     return s.encode(encoding)
 
@@ -801,12 +801,12 @@ def as_unicode(val, cast_types=object):
     """
     if val is None:
         return u''
-    elif isinstance(val, text_type):
+    elif isinstance(val, str):
         return val
     elif isinstance(val, unicode_srctypes):
         return assure_unicode(val)
     elif isinstance(val, cast_types):
-        return text_type(val)
+        return str(val)
     else:
         raise TypeError(
             "Value %r is not of any of known or provided %s types"

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -359,23 +359,12 @@ def is_explicit_path(path):
 
 # handle this dance once, and import pathlib from here
 # in all other places
-if PY2:
-    from pathlib2 import (
-        Path,
-        PurePath,
-        PurePosixPath,
-    )
 
-    def _unicode_path(pathobj):
-        return assure_unicode(str(pathobj))
-
-    PurePath.__unicode__ = _unicode_path
-else:
-    from pathlib import (
-        Path,
-        PurePath,
-        PurePosixPath,
-    )
+from pathlib import (
+    Path,
+    PurePath,
+    PurePosixPath,
+)
 
 
 def rotree(path, ro=True, chmod_files=True):
@@ -1521,7 +1510,7 @@ class chpwd(object):
             self._mkdir = False
         lgr.debug("chdir %r -> %r %s", self._prev_pwd, path, logsuffix)
         os.chdir(path)  # for grep people -- ok, to chdir here!
-        os.environ['PWD'] = assure_bytes(path) if PY2 else path
+        os.environ['PWD'] = path
 
     def __enter__(self):
         # nothing more to do really, chdir was in the constructor
@@ -1998,8 +1987,8 @@ def read_csv_lines(fname, dialect=None, readahead=16384, **kwargs):
                 )
                 dialect = 'excel-tab'
 
-    kw = {} if PY2 else dict(encoding='utf-8')
-    with open(fname, 'rb' if PY2 else 'r', **kw) as tsvfile:
+    kw = dict(encoding='utf-8')
+    with open(fname, 'r', **kw) as tsvfile:
         # csv.py doesn't do Unicode; encode temporarily as UTF-8:
         csv_reader = csv.reader(
             tsvfile,

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -50,8 +50,6 @@ from os.path import dirname
 from os.path import split as psplit
 import posixpath
 
-
-from six import PY2, text_type, binary_type, string_types
 from shlex import quote as shlex_quote
 
 # from datalad.dochelpers import get_docstring_split

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -52,7 +52,7 @@ import posixpath
 
 
 from six import PY2, text_type, binary_type, string_types
-from six.moves import shlex_quote
+from shlex import quote as shlex_quote
 
 # from datalad.dochelpers import get_docstring_split
 from datalad.consts import TIMESTAMP_FMT

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -732,7 +732,7 @@ def assure_unicode(s, encoding=None, confidence=None):
       A value between 0 and 1, so if guessing of encoding is of lower than
       specified confidence, ValueError is raised
     """
-    if not isinstance(s, binary_type):
+    if not isinstance(s, bytes):
         return s
     if encoding is None:
         # Figure out encoding, defaulting to 'utf-8' which is our common
@@ -1679,7 +1679,7 @@ def make_tempfile(content=None, wrapped=None, **tkwargs):
     filename = realpath(filename)
 
     if content:
-        with open(filename, 'w' + ('b' if isinstance(content, binary_type) else '')) as f:
+        with open(filename, 'w' + ('b' if isinstance(content, bytes) else '')) as f:
             f.write(content)
 
     if __debug__:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -58,10 +58,7 @@ from shlex import quote as shlex_quote
 from datalad.consts import TIMESTAMP_FMT
 
 
-if PY2:
-    unicode_srctypes = string_types
-else:
-    unicode_srctypes = string_types + (bytes,)
+unicode_srctypes = str, bytes
 
 
 lgr = logging.getLogger("datalad.utils")
@@ -772,7 +769,7 @@ def assure_bool(s):
 
     to recognize on,True,yes as True, off,False,no as False
     """
-    if isinstance(s, string_types):
+    if isinstance(s, str):
         if s.isdigit():
             return bool(int(s))
         sl = s.lower()

--- a/runner-asyncio-notes.org
+++ b/runner-asyncio-notes.org
@@ -1,0 +1,38 @@
+
+* BlockingIOError wakeup messages
+
+When running some tests (e.g., test_gitrepo.py), the test pass but
+there are lots of errors like this
+
+#+begin_quote
+  Exception ignored when trying to write to the signal wakeup fd:
+  BlockingIOError: [Errno 11] Resource temporarily unavailable
+#+end_quote
+
+For more information, see [[https://bugs.python.org/issue21595][here]], where it was somewhat mitigated but
+not solved.
+
+I've blindly tried various ways of cleaning things up with asyncio,
+but haven't been able to stumble onto anything that removes the error.
+
+* parameter interaction
+
+| log_online | log_stdout | log_stderr |   | stdout is | stderr is |
+|------------+------------+------------+---+-----------+-----------|
+| False      | False      | False      |   | displayed | displayed |
+| False      | True       | False      |   | captured  | displayed |
+| False      | True       | True       |   | captured  | captured  |
+| False      | False      | True       |   | displayed | captured  |
+| True       | False      | False      |   | displayed | displayed |
+| True       | True       | False      |   | captured  | displayed |
+| True       | True       | True       |   | captured  | captured  |
+| True       | False      | True       |   | displayed | captured  |
+
+My understanding is that, if log_STREAM is ~True~, the output to the
+stream is captured and logged based on ~datalad.log.cmd.outputs~.  If
+log_STREAM is a callable, output lines are captured but not logged.
+And if log_STREAM is false, lines are written directly to the stream.
+
+~log_online~ influences how the output is processed, but it doesn't
+influcence whether the output is captured.  That comes down to
+log_STREAM.

--- a/setup.py
+++ b/setup.py
@@ -164,5 +164,8 @@ datalad_setup(
             findsome(opj('distribution', 'tests'), {'yaml'}) +
             findsome(opj('metadata', 'tests', 'data'), {'mp3', 'jpg', 'pdf'})
     },
+    classifiers=[
+        'Programming Language :: Python :: 3 :: Only'
+    ],
     **setup_kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ datalad_setup(
     install_requires=
         requires['core'] + requires['downloaders'] +
         requires['publish'] + requires['metadata'],
+    python_requires='>=3.5',
     extras_require=requires,
     cmdclass=cmdclass,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,8 @@ requires = {
         'fasteners',
         'mock>=1.0.1',  # mock is also used for auto.py, not only for testing
         'patool>=1.7',
-        'six>=1.8.0',
         'tqdm',
         'wrapt',
-        'pathlib2; python_version < "3.0"',  # brought to you by revolution1
     ],
     'downloaders': [
         'boto',
@@ -63,12 +61,6 @@ requires = {
         'vcrpy',
     ],
     'metadata': [
-        # lzma is included in python since 3.3
-        # We now support backports.lzma as well (besides AutomagicIO), but since
-        # there is not way to define an alternative here (AFAIK, yoh), we will
-        # use pyliblzma as the default for now.  Patch were you would prefer
-        # backports.lzma instead
-        'pyliblzma; python_version < "3.3"',
         'simplejson',
         'whoosh',
     ],


### PR DESCRIPTION
This is a very much work-in-progress series that tinkers with using asyncio for our Runner's online processing.  It sits on top of the drop-py2 branch (gh-3629).

I've run some tests locally, but I haven't checked that the whole suite passes.  If those pass, hopefully this can serve as a base to start plugging into some benchmarks.

One thing to note is that running test_gitrepo.py (and probably other tests) leads to a flood of `BlockingIOError` messages, though the tests still pass.  There's a bit more information about that in the [notes][0] of the temporary tip commit.

Edit: Also, as the failing AppVeyor tests indicate, Windows needs special consideration: https://ci.appveyor.com/project/mih/datalad/builds/27322011/job/872d49m3kubwiqg8

[0]: https://github.com/datalad/datalad/blob/8a1780defeca1e2b67cdb072989dcd0b23697212/runner-asyncio-notes.org#L2

Re: #3262
