### PR TITLE
AnnexRepo.get_remotes() to actually report special remotes

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -763,13 +763,16 @@ class AnnexRepo(GitRepo, RepoInterface):
     @borrowkwargs(GitRepo)
     def get_remotes(self,
                     with_urls_only=False,
-                    exclude_special_remotes=False):
+                    exclude_special_remotes=False,
+                    exclude_disabled=True):
         """Get known (special-) remotes of the repository
 
         Parameters
         ----------
         exclude_special_remotes: bool, optional
           if True, don't return annex special remotes
+        exclude_disabled: bool, optional
+          if True, don't query annex for not (yet) enabled (special) remotes
 
         Returns
         -------
@@ -786,7 +789,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # In any case: We don't know whether there are special remotes in `remotes` already. Surely we want to find
         # special remotes only, if we are not filtering them out afterwards. But we can't fully integrate with the
         # conditional for the filtering (move into its else-clause).
-        if not exclude_special_remotes and not with_urls_only:
+        if not exclude_disabled and not exclude_special_remotes and not with_urls_only:
             annex_remotes = []
             repo_info = self.repo_info(fast=True)
             descriptions = [r["description"]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -219,7 +219,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # check for possible SSH URLs of the remotes in order to set up
         # shared connections:
-        for r in self.get_remotes():
+        for r in self.get_remotes(with_urls_only=True):
             for url in [self.get_remote_url(r),
                         self.get_remote_url(r, push=True)]:
                 if url is not None:
@@ -786,7 +786,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # In any case: We don't know whether there are special remotes in `remotes` already. Surely we want to find
         # special remotes only, if we are not filtering them out afterwards. But we can't fully integrate with the
         # conditional for the filtering (move into its else-clause).
-        if not exclude_special_remotes:
+        if not exclude_special_remotes and not with_urls_only:
             annex_remotes = []
             repo_info = self.repo_info(fast=True)
             descriptions = [r["description"]
@@ -801,11 +801,11 @@ class AnnexRepo(GitRepo, RepoInterface):
                 else:
                     annex_remotes.append(d)
 
-            if with_urls_only:
-                annex_remotes = [
-                    r for r in annex_remotes
-                    if self.config.get('remote.%s.url' % r)
-                ]
+            # if with_urls_only:
+            #     annex_remotes = [
+            #         r for r in annex_remotes
+            #         if self.config.get('remote.%s.url' % r)
+            #     ]
 
             remotes.extend([r for r in annex_remotes if r not in remotes])
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -782,13 +782,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         remotes = super(AnnexRepo, self).get_remotes(with_urls_only=with_urls_only)
 
-        # Note: the above seems fine for git remotes and special remotes, that show up in configs.
-        # However, this is insufficient to discover all annex special remotes.
-        # To find special remotes, check git-annex-info (--json), which is available via self.repo_info()
-        #
-        # In any case: We don't know whether there are special remotes in `remotes` already. Surely we want to find
-        # special remotes only, if we are not filtering them out afterwards. But we can't fully integrate with the
-        # conditional for the filtering (move into its else-clause).
+        # Note: Remotes with an url are already included in `remotes`, since by definition there's a
+        # remote.NAME.url config
         if not exclude_disabled and not exclude_special_remotes and not with_urls_only:
             annex_remotes = []
             repo_info = self.repo_info(fast=True)
@@ -803,12 +798,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                     annex_remotes.append(parts[-1][1:-1])
                 else:
                     annex_remotes.append(d)
-
-            # if with_urls_only:
-            #     annex_remotes = [
-            #         r for r in annex_remotes
-            #         if self.config.get('remote.%s.url' % r)
-            #     ]
 
             remotes.extend([r for r in annex_remotes if r not in remotes])
 


### PR DESCRIPTION
See #3664

- [x] AnnexRepo.get_remotes() to use repo_info() 
- [x] Make reporting on "non-operation" remotes optional
- [ ] test