### PR TITLE
don't annex empty files after cfg_text2git,  fixes #3663

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -343,9 +343,9 @@ class Create(Interface):
                 attrs = tbrepo.get_gitattributes('.')
                 # some basic protection against useless duplication
                 # on rerun with --force
-                if not attrs.get('.', {}).get('annex.largefiles', None) == '(not(mimetype=text/*))':
+                if not attrs.get('.', {}).get('annex.largefiles', None) == '(not((mimetype=text/*)or(smallerthan=0.001kb)))':
                     tbrepo.set_gitattributes([
-                        ('*', {'annex.largefiles': '(not(mimetype=text/*))'})])
+                        ('*', {'annex.largefiles': '(not((mimetype=text/*)or(smallerthan=0.001kb)))'})])
                     add_to_git.append('.gitattributes')
 
         if native_metadata_type is not None:

--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -343,9 +343,9 @@ class Create(Interface):
                 attrs = tbrepo.get_gitattributes('.')
                 # some basic protection against useless duplication
                 # on rerun with --force
-                if not attrs.get('.', {}).get('annex.largefiles', None) == '(not((mimetype=text/*)or(smallerthan=0.001kb)))':
+                if not attrs.get('.', {}).get('annex.largefiles', None) == '(not(mimetype=text/*)and(largerthan=0))':
                     tbrepo.set_gitattributes([
-                        ('*', {'annex.largefiles': '(not((mimetype=text/*)or(smallerthan=0.001kb)))'})])
+                        ('*', {'annex.largefiles': '(not(mimetype=text/*)and(largerthan=0))'})])
                     add_to_git.append('.gitattributes')
 
         if native_metadata_type is not None:

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -334,7 +334,7 @@ def test_create_text_no_annex(path):
     import re
     ok_file_has_content(
         _path_(path, '.gitattributes'),
-        content='\* annex\.largefiles=\(not\(mimetype=text/\*\)\)',
+        content='\* annex\.largefiles=\(not\(\(mimetype=text/\*\)or\(smallerthan=0.001kb\)\)\)',
         re_=True,
         match=False,
         flags=re.MULTILINE
@@ -344,13 +344,12 @@ def test_create_text_no_annex(path):
     create_tree(path,
         {
             't': 'some text',
-            'b': ''  # empty file is not considered to be a text file
-                     # should we adjust the rule to consider only non empty files?
+            'b': ''  # Empty file is considered text file.
         }
     )
     ds.add(['t', 'b'])
     ok_file_under_git(path, 't', annexed=False)
-    ok_file_under_git(path, 'b', annexed=True)
+    ok_file_under_git(path, 'b', annexed=False)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -334,7 +334,7 @@ def test_create_text_no_annex(path):
     import re
     ok_file_has_content(
         _path_(path, '.gitattributes'),
-        content='\* annex\.largefiles=\(not\(\(mimetype=text/\*\)or\(smallerthan=0.001kb\)\)\)',
+        content='\* annex\.largefiles=\(not\(mimetype=text/\*\)and\(largerthan=0\)\)',
         re_=True,
         match=False,
         flags=re.MULTILINE

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -34,6 +34,7 @@ from datalad.tests.utils import OBSCURE_FILENAME
 from datalad.tests.utils import on_windows
 from datalad.tests.utils import known_failure_direct_mode
 from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils import skip_if_on_windows
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import (
     CommandError,
@@ -347,3 +348,18 @@ def test_quoting(path):
             "datalad run-procedure just2args \"with ' sing\" 'with \" doub'")
         with assert_raises(CommandError):
             runner.run("datalad run-procedure just2args 'still-one arg'")
+
+@skip_if_on_windows
+@with_tempfile
+def test_text2git_empty(path):
+    """
+    Tests that empty files are not annexed in a ds configured with text2git.
+    """
+    ds = Dataset(path).create(force=True)
+    ds.run_procedure('cfg_text2git')
+    ok_clean_git(ds.path)
+    # create an empty file, no extension
+    open(op.join(path, 'emptyfile'), 'a').close()
+    ds.save(message="add empty file")
+    # check that it's not annexed
+    assert_false(ds.repo.is_under_annex("emptyfile"))

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -10,7 +10,7 @@ ds = require_dataset(
     check_installed=True,
     purpose='configuration')
 
-annex_largefiles = '(not(mimetype=text/*))'
+annex_largefiles = '(not((mimetype=text/*)or(smallerthan=0.001kb)))'
 attrs = ds.repo.get_gitattributes('*')
 if not attrs.get('*', {}).get(
         'annex.largefiles', None) == annex_largefiles:

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -10,7 +10,7 @@ ds = require_dataset(
     check_installed=True,
     purpose='configuration')
 
-annex_largefiles = '(not((mimetype=text/*)or(smallerthan=0.001kb)))'
+annex_largefiles = '(not(mimetype=text/*)and(largerthan=0))'
 attrs = ds.repo.get_gitattributes('*')
 if not attrs.get('*', {}).get(
         'annex.largefiles', None) == annex_largefiles:


### PR DESCRIPTION
As noted in #3663, in a dataset configured with ``cfg_text2git``, empty files are being annexed. This PR adds the additional rule to not regard empty files (mimetype ``inode/x-empty``) as a largefile to the ``.gitattributes`` configuration ``cfg_text2git`` provides.
Additionally, it adds a small test for this.

It's WIP because I want to see whether any test fail as @kyleam noted in #3663:

> I suppose one tricky part about testing cfg_text2git is that the behavior depends on git-annex being built with the MagicMime flag. But assuming MagicMime support should be fine because neurodebian's git-annex has it and it looks like conda's does now too. If it ends up being a problem down the road, we can skip the test based on the git annex version output.