### PR TITLE
BF: annexrepo: Skip empty lines when expecting one output line

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1161,7 +1161,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # see https://git-annex.branchable.com/todo/output_of_wanted___40__and_possibly_group_etc__41___should_not_be_polluted_with___34__informational__34___messages/
         lines_ = [
             l for l in lines
-            if not re.search(
+            if l and not re.search(
                 r'\((merging .* into git-annex|recording state ).*\.\.\.\)', l
             )
         ]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1165,7 +1165,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                 r'\((merging .* into git-annex|recording state ).*\.\.\.\)', l
             )
         ]
-        assert(len(lines_) <= 1)
+
+        if len(lines_) > 1:
+            raise AssertionError("Expected one line but got {}".format(lines_))
         return lines_[0] if lines_ else None
 
     def _is_direct_mode_from_config(self):


### PR DESCRIPTION
When the git-annex version used on AppVeyor went from git-annex
7.20190731-gc131c0f0c to 7.20190912-g05bc37910,
test_update.test_multiway_merge started to fail.  The failure occurs
in _run_simple_annex_command(), which asserts that it gets no more
than one line.  The unexpected extra lines seem to be coming from
empty lines:

  https://ci.appveyor.com/project/mih/datalad/builds/27446423#L684

_run_simple_annex_command() already filters the output lines to remove
some informational messages from git-annex.  Update that condition to
remove empty lines as well.

Fixes #3675.

---

Note that the failing test from #3675 is skipped on AppVeyor for 0.11.x because it is incompatible with direct mode.  To make sure this failure is resolved on master, I've pushed a scratch branch that sits on top of master and has the same non-empty-line condition from this PR:

  https://ci.appveyor.com/project/mih/datalad/builds/27446747

(Edit: The build above passed.)