### PR TITLE
BF: Ensure double-dashes in RST manpages show up as such (fixes gh-3672)

### DIFF
--- a/_datalad_build_support/formatters.py
+++ b/_datalad_build_support/formatters.py
@@ -171,7 +171,7 @@ class ManPageFormatter(argparse.HelpFormatter):
                     parts.append('%s %s' % (self._bold(option_string),
                                             args_string))
 
-            return ', '.join(parts)
+            return ', '.join(p.replace('--', '-\\\\-') for p in parts)
 
 
 class RSTManPageFormatter(ManPageFormatter):


### PR DESCRIPTION
This workaround makes this possible without having to wrap the entire
statement in 

```
``...``
```
(which looks weird), and without having to turn
off smart quotes in general (which looks bad elsewhere).
