### PR TITLE
ENH: (More) comprehensive AnnexRepo.fsck() (fixes gh-3514)

### DIFF
--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -491,9 +491,6 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
         [{k: v for k, v in i.items() if k != 'note'}
          for i in source.repo.fsck(remote='target')])
     eq_(target.fsck(), source.repo.fsck(remote='target'))
-    # --all doesn't reveal anything else
-    eq_([dict(f, file=None, note=None) for f in target.fsck()],
-        [dict(f, note=None) for f in source.repo.fsck(limit=all)])
 
 
 @skip_if_on_windows  # create_sibling incompatible with win servers

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -163,6 +163,8 @@ def test_publish_simple(origin, src_path, dst_path):
     ok_(set(source.repo.get_branch_commits("git-annex")).issubset(
         set(target.get_branch_commits("git-annex"))))
 
+    eq_(source.repo.fsck(), source.repo.fsck(remote='target'))
+
 
 @with_testrepos('basic_git', flavors=['local'])
 @with_tempfile(mkdir=True)
@@ -482,6 +484,16 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
     # and empty again if we try again
     res = source.publish(to="target")
     assert_result_count(res, 1, status='notneeded', path=source.path)
+
+    # data integrity check looks identical from all perspectives
+    # minus "note" statements from git-annex
+    eq_(source.repo.fsck(),
+        [{k: v for k, v in i.items() if k != 'note'}
+         for i in source.repo.fsck(remote='target')])
+    eq_(target.fsck(), source.repo.fsck(remote='target'))
+    # --all doesn't reveal anything else
+    eq_([dict(f, file=None, note=None) for f in target.fsck()],
+        [dict(f, note=None) for f in source.repo.fsck(limit=all)])
 
 
 @skip_if_on_windows  # create_sibling incompatible with win servers

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2785,8 +2785,59 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return None
 
-    def fsck(self):
-        self._run_annex_command('fsck')
+    def fsck(self, paths=None, remote=None, fast=False, incremental=False,
+             limit=None, annex_options=None, git_options=None):
+        """Front-end for git-annex fsck
+
+        Parameters
+        ----------
+        paths : list
+          Limit operation to specific paths.
+        remote : str
+          If given, the identified remote will be fsck'ed instead of the
+          local repository.
+        fast : bool
+          If True, typically means that no actual content is being verified,
+          but tests are limited to the presence of files.
+        incremental : bool or {'continue'} or SCHEDULE
+          If given, `fsck` is called with `--incremental`. If 'continue',
+          `fsck` is additionally called with `--more`, and any other argument
+          is given to `--incremental-schedule`.
+        limit : str or all
+          If the functor `all` is given, `fsck` is called with `--all`. Any
+          other value is passed on to `--branch`.
+        """
+        args = [] if annex_options is None else list(annex_options)
+        if fast:
+            args.append('--fast')
+        if limit:
+            # looks funky, but really is a test if the `all` function was passed
+            # alternatives would have been 1) a dedicated argument (would need
+            # a check for mutual exclusivity with --branch), or 2) a str-type
+            # special values that has no meaning in Git and is less confusing
+            if limit is all:
+                args.append('--all')
+            else:
+                args.append('--branch={}'.format(limit))
+        if remote:
+            args.append('--from={}'.format(remote))
+        if incremental == 'continue':
+            args.append('--more')
+        elif incremental:
+            args.append('--incremental')
+            if not (incremental is True):
+                args.append('--incremental-schedule={}'.format(incremental))
+        return self._run_annex_command_json(
+            'fsck',
+            files=paths,
+            git_options=git_options,
+            opts=args,
+            # next two are to avoid warnings and errors due to an fsck
+            # finding any issues -- those will be reported in the
+            # JSON results, and can be acted upon
+            expect_stderr=True,
+            expect_fail=True,
+        )
 
     # TODO: we probably need to override get_file_content, since it returns the
     # symlink's target instead of the actual content.

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2785,8 +2785,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return None
 
-    def fsck(self, paths=None, remote=None, fast=False, incremental=False,
-             limit=None, annex_options=None, git_options=None):
+    # comment out presently unnecessary functionality, bring back once needed
+    #def fsck(self, paths=None, remote=None, fast=False, incremental=False,
+    #         limit=None, annex_options=None, git_options=None):
+    def fsck(self, paths=None, remote=None, fast=False,
+             annex_options=None, git_options=None):
         """Front-end for git-annex fsck
 
         Parameters
@@ -2799,34 +2802,34 @@ class AnnexRepo(GitRepo, RepoInterface):
         fast : bool
           If True, typically means that no actual content is being verified,
           but tests are limited to the presence of files.
-        incremental : bool or {'continue'} or SCHEDULE
-          If given, `fsck` is called with `--incremental`. If 'continue',
-          `fsck` is additionally called with `--more`, and any other argument
-          is given to `--incremental-schedule`.
-        limit : str or all
-          If the functor `all` is given, `fsck` is called with `--all`. Any
-          other value is passed on to `--branch`.
         """
+        #incremental : bool or {'continue'} or SCHEDULE
+        #  If given, `fsck` is called with `--incremental`. If 'continue',
+        #  `fsck` is additionally called with `--more`, and any other argument
+        #  is given to `--incremental-schedule`.
+        #limit : str or all
+        #  If the function `all` is given, `fsck` is called with `--all`. Any
+        #  other value is passed on to `--branch`.
         args = [] if annex_options is None else list(annex_options)
         if fast:
             args.append('--fast')
-        if limit:
-            # looks funky, but really is a test if the `all` function was passed
-            # alternatives would have been 1) a dedicated argument (would need
-            # a check for mutual exclusivity with --branch), or 2) a str-type
-            # special values that has no meaning in Git and is less confusing
-            if limit is all:
-                args.append('--all')
-            else:
-                args.append('--branch={}'.format(limit))
         if remote:
             args.append('--from={}'.format(remote))
-        if incremental == 'continue':
-            args.append('--more')
-        elif incremental:
-            args.append('--incremental')
-            if not (incremental is True):
-                args.append('--incremental-schedule={}'.format(incremental))
+        #if limit:
+        #    # looks funky, but really is a test if the `all` function was passed
+        #    # alternatives would have been 1) a dedicated argument (would need
+        #    # a check for mutual exclusivity with --branch), or 2) a str-type
+        #    # special values that has no meaning in Git and is less confusing
+        #    if limit is all:
+        #        args.append('--all')
+        #    else:
+        #        args.append('--branch={}'.format(limit))
+        #if incremental == 'continue':
+        #    args.append('--more')
+        #elif incremental:
+        #    args.append('--incremental')
+        #    if not (incremental is True):
+        #        args.append('--incremental-schedule={}'.format(incremental))
         return self._run_annex_command_json(
             'fsck',
             files=paths,

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1319,6 +1319,7 @@ def test_annex_drop(src, dst):
     assert_false(ar.file_has_content(testfile))
     ar.get(testfile)
     ok_(ar.file_has_content(testfile))
+    eq_(len([f for f in ar.fsck(fast=True) if f['file'] == testfile]), 1)
 
     # drop file by name:
     result = ar.drop([testfile])


### PR DESCRIPTION
This merely lifts the implementation from https://github.com/datalad/git-annex-ria-remote/blob/09a3eec05d89e2bb26f7ea2038d3e1aedd1ffe48/ria_remote/tests/utils.py#L32
and adds some docs.

A smoke test will come, likely infused into existing tests. I have no immediate plans to test the more exotic parts (scheduled incremental, etc).