### PR TITLE
ENH: exit with dedicated 99 exit code if installed annex is newer than -devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -269,7 +269,7 @@ before_install:
   - if [ ! -z "${_DL_UPSTREAM_GITPYTHON:-}" ]; then pip install https://github.com/gitpython-developers/GitPython/archive/master.zip; fi
   - if [ ! -z "${_DL_UPSTREAM_GITANNEX:-}" ]; then sudo tools/ci/install-annex-snapshot.sh; sudo ln -s `find /usr/local/lib/git-annex.linux -maxdepth 1 -type f -perm /+x` /usr/local/bin/; else sudo eatmydata apt-get install git-annex-standalone ; fi
   # Install optionally -devel version of annex, and if goes wrong (we have most recent), exit right away
-  - if [ ! -z "${_DL_DEVEL_ANNEX:-}" ]; then tools/ci/prep-travis-devel-annex.sh || exit 0; fi
+  - if [ ! -z "${_DL_DEVEL_ANNEX:-}" ]; then tools/ci/prep-travis-devel-annex.sh || { ex="$?"; if [ "$ex" -eq 99 ]; then exit 0; else exit "$ex"; fi; }; fi
   # Optionally install the latest Git.  Exit code 100 indicates that bundled is same as the latest.
   - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then
       sudo tools/ci/install-latest-git.sh || { [ $? -eq 100 ] && exit 0; } || exit 1;

--- a/tools/ci/prep-travis-devel-annex.sh
+++ b/tools/ci/prep-travis-devel-annex.sh
@@ -15,5 +15,5 @@ if dpkg --compare-versions "$devel_annex_version" gt "$current_annex_version"; t
     sudo apt-get install "git-annex-standalone=$devel_annex_version"
 else
     echo "I: devel version $devel_annex_version is not newer than installed $current_annex_version"
-    exit 1
+    exit 99
 fi


### PR DESCRIPTION
I found this change lingering in the bf-annex-devel-run branch (e.g. used in #3466 ) intended to test
development version of annex from debian-devel of neurodebian.  It was to solve
the ambiguity of tools/ci/prep-travis-devel-annex.sh exiting with non-0 for other
reasons and thus us just skipping the run (marking it green)
