### PR TITLE
ENH: Config override spec sanity checks (fixes gh-3451)

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -474,6 +474,24 @@ def main(args=None):
     args_ = args or sys.argv
 
     if cmdlineargs.cfg_overrides is not None:
+        import re
+        # this expression is deliberately loose as gitconfig offers
+        # quite some flexibility -- this is just meant to catch stupid
+        # errors: we need a section, a variable, and a value at minimum
+        # otherwise we break our own config parsing helpers
+        # https://github.com/datalad/datalad/issues/3451
+        noassign_expr = re.compile(r'[^\s]+\.[^\s]+=[\S]+')
+        noassign = [
+            o
+            for o in cmdlineargs.cfg_overrides
+            if not noassign_expr.match(o)
+        ]
+        if noassign:
+            lgr.error(
+                "Configuration override without section/variable "
+                "or value assignment (must be 'section.variable=value'): %s",
+                noassign)
+            sys.exit(3)
         overrides = dict([
             (o.split('=')[0], '='.join(o.split('=')[1:]))
             for o in cmdlineargs.cfg_overrides])

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -239,6 +239,13 @@ def test_cfg_override(path):
         assert_in('datalad.dummy: this', out)
 
 
+def test_incorrect_cfg_override():
+    run_main(['-c', 'some', 'wtf'], exit_code=3)
+    run_main(['-c', 'some=', 'wtf'], exit_code=3)
+    run_main(['-c', 'some.var', 'wtf'], exit_code=3)
+    run_main(['-c', 'some.var=', 'wtf'], exit_code=3)
+
+
 def test_fail_with_short_help():
     out = StringIO()
     with assert_raises(SystemExit) as cme:


### PR DESCRIPTION
To prevent us from shooting ourselves in the foot. Without
this change, we could have specified section-less variables
that our own ConfigManager cannot handle, and don't seem to
be supported by Git either.
