### PR TITLE
RF: update() no longer uses AnnotatePaths

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -76,15 +76,6 @@ def test_update_simple(origin, src_path, dst_path):
     source.save(path="update.txt", message="Added update.txt")
     ok_clean_git(src_path)
 
-    # fail when asked to update a non-dataset
-    assert_status(
-        'impossible',
-        source.update("update.txt", on_failure='ignore'))
-    # fail when asked to update a something non-existent
-    assert_status(
-        'impossible',
-        source.update("nothere", on_failure='ignore'))
-
     # update without `merge` only fetches:
     assert_status('ok', dest.update())
     # modification is not known to active branch:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -109,7 +109,6 @@ class Update(Interface):
             lgr.warning('update(fetch_all=...) called. Option has no effect, and will be removed')
 
         refds = require_dataset(dataset, check_installed=True, purpose='updating')
-        refds_path = Interface.get_refds_path(dataset)
 
         save_paths = []
 
@@ -123,7 +122,7 @@ class Update(Interface):
             repo = ds.repo
             # prepare return value
             # TODO reuse AP for return props
-            res = get_status_dict('update', ds=ds, logger=lgr, refds=refds_path)
+            res = get_status_dict('update', ds=ds, logger=lgr, refds=refds.path)
             # get all remotes which have references (would exclude
             # special remotes)
             remotes = repo.get_remotes(
@@ -175,7 +174,7 @@ class Update(Interface):
             yield res
             save_paths.append(ds.path)
         if recursive:
-            save_paths = [p for p in save_paths if p != refds_path]
+            save_paths = [p for p in save_paths if p != refds.path]
             if not save_paths:
                 return
             lgr.debug(

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -34,14 +34,9 @@ from datalad.interface.common_opts import (
 from datalad.distribution.dataset import require_dataset
 
 from .dataset import (
-    Dataset,
     EnsureDataset,
     datasetmethod,
 )
-
-# needed API commands
-import datalad.distribution.subdatasets
-import datalad.core.local.save
 
 lgr = logging.getLogger('datalad.distribution.update')
 


### PR DESCRIPTION
This also introduce slight changes in the API semantics, by removing
needless flexibility (ie. specifying a to-be-updated dataset either
via -d or as a path). Multi-seed recursive operation is also no longer
supported, in line with previous changes.

The PATH arg is now only used to constrain the updating of subdatasets
in recursive mode.

ping gh-3368
