### PR TITLE
NF: GitRepo.for_each_ref_()

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1270,13 +1270,27 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                       pattern=None, points_at=None, sort=None, count=None):
         """Wrapper for `git for-each-ref`
 
+        Please see manual page git-for-each-ref(1) for a complete overview
+        of its functionality. Only a subset of it is supported by this
+        wrapper.
+
         Parameters
         ----------
-        fields : list or str
-        pattern : list or str
-        points_at : str
-        sort : list or str
-        count : int
+        fields : iterable or str
+          Used to compose a NULL-delimited specification for for-each-ref's
+          --format option. The default field list reflects the standard
+          behavior of for-each-ref when not --format option is given
+        pattern : list or str, optional
+          If provided, report only refs that match at least one of the given
+          patterns.
+        points_at : str, optional
+          Only list refs which points at the given object.
+        sort : list or str, optional
+          Field name(s) to sort-by. If multiple fields are given, the last one
+          becomes the primary key. Prefix any field name with '-' to sort in
+          descending order.
+        count : int, optional
+          Stop iteration after the given number of matches.
 
         Yields
         ------

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1729,8 +1729,8 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
 
         return [
-            b['refname'][11:]  # strip 'refs/heads/'
-            for b in self.for_each_ref_(fields='refname', pattern='refs/heads')
+            b['refname:strip=2']
+            for b in self.for_each_ref_(fields='refname:strip=2', pattern='refs/heads')
         ]
 
     def get_remote_branches(self):
@@ -1747,8 +1747,8 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         # currently this is done in collection
 
         return [
-            b['refname'][13:]  # strip 'refs/remotes/'
-            for b in self.for_each_ref_(fields='refname', pattern='refs/remotes')
+            b['refname:strip=2']
+            for b in self.for_each_ref_(fields='refname:strip=2', pattern='refs/remotes')
         ]
 
     def get_remotes(self, with_urls_only=False):
@@ -2720,11 +2720,11 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
         tags = [
             dict(
-                name=t['refname:lstrip=2'],
+                name=t['refname:strip=2'],
                 hexsha=t['object'] if t['object'] else t['objectname'],
             )
             for t in self.for_each_ref_(
-                fields=['refname:lstrip=2', 'objectname', 'object'],
+                fields=['refname:strip=2', 'objectname', 'object'],
                 pattern='refs/tags',
                 sort='taggerdate')
         ]

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1279,7 +1279,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         fields : iterable or str
           Used to compose a NULL-delimited specification for for-each-ref's
           --format option. The default field list reflects the standard
-          behavior of for-each-ref when not --format option is given
+          behavior of for-each-ref when the --format option is not given.
         pattern : list or str, optional
           If provided, report only refs that match at least one of the given
           patterns.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2726,7 +2726,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             for t in self.for_each_ref_(
                 fields=['refname:strip=2', 'objectname', 'object'],
                 pattern='refs/tags',
-                sort='taggerdate')
+                sort='creatordate')
         ]
         if output:
             return [t[output] for t in tags]

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2718,16 +2718,15 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
           is attached to. The list is sorted by commit date, with the most
           recent commit being the last element.
         """
-        tag_objs = sorted(
-            self.repo.tags,
-            key=lambda t: t.commit.committed_date
-        )
         tags = [
-            {
-                'name': t.name,
-                'hexsha': t.commit.hexsha
-             }
-            for t in tag_objs
+            dict(
+                name=t['refname:lstrip=2'],
+                hexsha=t['object'] if t['object'] else t['objectname'],
+            )
+            for t in self.for_each_ref_(
+                fields=['refname:lstrip=2', 'objectname', 'object'],
+                pattern='refs/tags',
+                sort='taggerdate')
         ]
         if output:
             return [t[output] for t in tags]

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -196,7 +196,7 @@ def tag_dates(repo, pattern=""):
     """
     for rec in repo.for_each_ref_(
             fields=['objectname', 'taggerdate:raw'],
-            pattern='refs/heads/' + pattern):
+            pattern='refs/tags/' + pattern):
         if not rec['taggerdate:raw']:
             # There's not a tagger date. It's not an annotated tag.
             continue

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -194,16 +194,13 @@ def tag_dates(repo, pattern=""):
     -------
     A generator object that returns a tuple with the tag hexsha and timestamp.
     """
-    out, _ = repo._git_custom_command(
-        None,
-        ["git", "for-each-ref", "--format=%(objectname) %(taggerdate:raw)"
-         "refs/tags/" + pattern])
-    for line in out.splitlines():
-        fields = line.split()
-        if len(fields) != 3:
+    for rec in repo.for_each_ref_(
+            fields=['objectname', 'taggerdate:raw'],
+            pattern='refs/heads/' + pattern):
+        if not rec['taggerdate:raw']:
             # There's not a tagger date. It's not an annotated tag.
             continue
-        yield fields[0], int(fields[1])
+        yield rec['objectname'], int(rec['taggerdate:raw'].split()[0])
 
 
 def log_dates(repo, revs=None):


### PR DESCRIPTION
Work towards gh-3703

- [x] `for_each_ref()` helper
- [x] actually fix #3703
- [x] figure out why `repodates` test fails
       km: 477e23a85 fixes the test_repodates.py:test_check_dates failure.

It seems that the present code doesn't conveniently handle things like annotated tags that point to an actual commit we are interested in, but actually have a separate `objectname` (or SHA1).