### PR TITLE
RF: Blind attempt to relay status() performance boost possibility on to save()

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -192,6 +192,7 @@ class Save(Interface):
                 dataset=dataset,
                 path=path,
                 untracked=untracked_mode,
+                report_filetype=False,
                 recursive=recursive,
                 recursion_limit=recursion_limit,
                 on_failure='ignore',

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2182,7 +2182,7 @@ def check_files_split(cls, topdir):
         os.unlink(f)
         with open(f, 'w') as f:
             f.write('1')
-    dl.add(dirs)
+    dl.save(dataset=r.path, path=dirs)
 
 
 @slow  # 313s  well -- if errors out - only 3 sec


### PR DESCRIPTION
According to my current logic and assessment, the `status()` run done in
top-level `save()` does not need to inspect filetypes. The tests will show
if that is true.

If true, performance gains of the same magnitude as shown in
https://github.com/datalad/datalad/pull/3701 for `status()` also become
available for `save()`.