### PR TITLE
DOC+TST: gitrepo: Document get_tags() order change from eed2ca6f6

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2677,8 +2677,9 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
           Each item is a dictionary with information on a tag. At present
           this includes 'hexsha', and 'name', where the latter is the string
           label of the tag, and the former the hexsha of the object the tag
-          is attached to. The list is sorted by commit date, with the most
-          recent commit being the last element.
+          is attached to. The list is sorted by the creator date (committer
+          date for lightweight tags and tagger date for annotated tags), with
+          the most recent commit being the last element.
         """
         tags = [
             dict(

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2676,7 +2676,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         list
           Each item is a dictionary with information on a tag. At present
           this includes 'hexsha', and 'name', where the latter is the string
-          label of the tag, and the format the hexsha of the object the tag
+          label of the tag, and the former the hexsha of the object the tag
           is attached to. The list is sorted by commit date, with the most
           recent commit being the last element.
         """

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1329,7 +1329,8 @@ def test_get_tags(path):
 
     # Explicitly override the committer date because tests may set it to a
     # fixed value, but we want to check that the returned tags are sorted by
-    # the committer date.
+    # the date the tag (for annotaged tags) or commit (for lightweight tags)
+    # was created.
     with patch.dict("os.environ", {"GIT_COMMITTER_DATE":
                                    "Thu, 07 Apr 2005 22:13:13 +0200"}):
         create_tree(gr.path, {'file': ""})
@@ -1353,7 +1354,10 @@ def test_get_tags(path):
         gr.add('file')
         gr.commit(msg="changed")
 
-    gr.tag("annotated", message="annotation")
+    with patch.dict("os.environ", {"GIT_COMMITTER_DATE":
+                                   "Fri, 09 Apr 2005 22:13:13 +0200"}):
+        gr.tag("annotated", message="annotation")
+    # The annotated tag happened later, so it comes last.
     tags2 = tags1 + [{'name': 'annotated', 'hexsha': gr.get_hexsha()}]
     eq_(gr.get_tags(), tags2)
     eq_(gr.describe(), tags2[1]['name'])


### PR DESCRIPTION
```
Prior to the for_each_ref_() series (gh-3705), get_tags() returned
tags sorted by the committer date.  For annotated tags, this means
they were sorted by the object pointed to rather than the tagger date.
Following gh-3705, the sorted value is by for-each-ref's "creatordate"
field (which exists so that lightweight and annotated tags can be
sorted together), and annotated tags are now sorted based on the
tagger date.

This change seems harmless enough.  No current callers in the code
base rely on annotated tags being sorted by committer date, and it
seems unlikely that outside callers rely on this behavior.  But it
does mean that test_get_tags needs to patch GIT_COMMITTER_DATE when
creating annotated tags so that the tagger date is not affected by the
environment of the test run.

If we really want to preserve the old behavior, note that using
"committerdate" (as originally done by gh-3705's bb17d0ede) is not
correct.  It will sort lightweight tags by their committer date and
leave annotated tags sorted alphabetically at the top of the list.
Instead we'd have to use a more involved approach, such as including
both "committerdate" and the dereferenced "*committerdate" as fields
and sorting by whichever value is non-empty for a given entry.
```