### PR TITLE
TST: First attempt with GitHub actions for windows testing

### DIFF
--- a/.github/workflows/tests_winlatest.yml
+++ b/.github/workflows/tests_winlatest.yml
@@ -1,0 +1,47 @@
+name: Windows tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Set up environment
+      run: |
+        git config --global user.email "test@github.land"
+        git config --global user.name "GitHub Almighty"
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Set up git-annex
+      run: |
+        powershell.exe Import-Module BitsTransfer; Start-BitsTransfer -Source https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -Destination C:\\git-annex-installer.exe
+        7z x -o"C:\\Program Files\Git" C:\\git-annex-installer.exe
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install colorama
+        pip install ".[tests]"
+        pip install ".[devel-utils]"
+    - name: WTF!?
+      run: |
+        datalad wtf
+        dir
+    - name: Core tests
+      run: |
+        mkdir __testhome__
+        cd __testhome__
+        python -m nose -s -v --with-cov --cover-package datalad datalad.core.local.tests.test_create:test_create
+    # coverage report is not functional because codecov refuses to accept the
+    # report
+    - name: Coverage report
+      run: |
+        cd __testhome__
+        python -m coverage xml
+        powershell.exe Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh
+        bash codecov.sh -f coverage.xml


### PR DESCRIPTION
This works pretty well.

Caching will come too and will further lower the setup overhead: https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/m-p/30974/highlight/true#M630

Replaces: https://github.com/datalad/datalad/pull/3722

I propose to eventually replace appveyor with this approach.