### PR TITLE
Github CI based Windows tests

### DIFF
--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -1,0 +1,64 @@
+name: Win2019 tests
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: windows-2019
+
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [
+            datalad.core,
+            datalad.customremotes,
+            datalad.distributed,
+            datalad.distribution,
+            datalad.downloaders,
+            datalad.interface,
+            datalad.local,
+            datalad.metadata,
+            datalad.plugin,
+            datalad.support,
+            datalad.tests,
+            datalad.ui datalad.cmdline
+        ]
+    steps:
+    - name: Set up environment
+      run: |
+        git config --global user.email "test@github.land"
+        git config --global user.name "GitHub Almighty"
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Set up git-annex
+      run: |
+        powershell.exe Import-Module BitsTransfer; Start-BitsTransfer -Source https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -Destination C:\\git-annex-installer.exe
+        7z x -o"C:\\Program Files\Git" C:\\git-annex-installer.exe
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install colorama
+        pip install ".[tests]"
+        pip install ".[devel-utils]"
+    - name: WTF!?
+      run: |
+        datalad wtf
+        dir
+    - name: ${{ matrix.module }} tests
+      run: |
+        mkdir -p __testhome__
+        cd __testhome__
+        python -m nose -s -v --with-cov --cover-package datalad ${{ matrix.module }}
+    # coverage report is not functional because codecov refuses to accept the
+    # report
+    #- name: Coverage report
+    #  run: |
+    #    cd __testhome__
+    #    python -m coverage xml
+    #    powershell.exe Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh
+    #    bash codecov.sh -f coverage.xml

--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -10,19 +10,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # group modules to get a job runtime of ~15min
         module: [
             datalad.core,
-            datalad.customremotes,
-            datalad.distributed,
+            datalad.local datalad.distributed datalad.support,
+            datalad.customremotes datalad.downloaders datalad.plugin,
             datalad.distribution,
-            datalad.downloaders,
             datalad.interface,
-            datalad.local,
-            datalad.metadata,
-            datalad.plugin,
-            datalad.support,
-            datalad.tests,
-            datalad.ui datalad.cmdline
+            datalad.metadata datalad.tests datalad.ui datalad.cmdline
         ]
     steps:
     - name: Set up environment

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -34,6 +34,7 @@ from datalad.tests.utils import (
     chpwd,
     assert_result_count,
     OBSCURE_FILENAME,
+    known_failure_githubci_win,
 )
 
 import datalad.utils as ut
@@ -296,6 +297,8 @@ def test_diff_recursive(path):
         action='diff', state='modified', path=sub.path, type='dataset')
 
 
+# https://github.com/datalad/datalad/issues/3725
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 @with_tempfile()
 def test_path_diff(_path, linkpath):

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -46,6 +46,7 @@ from ...tests.utils import (
     swallow_outputs,
     swallow_logs,
     serve_path_via_http,
+    known_failure_githubci_win,
 )
 from ...cmd import Runner, GitRunner
 from ...utils import (
@@ -70,6 +71,7 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 
 # TODO: with_tree ATM for archives creates this nested top directory
 # matching archive name, so it will be a/d/test.dat ... we don't want that probably
+@known_failure_githubci_win
 @with_tree(
     tree=(('a.tar.gz', {'d': {fn_inarchive_obscure: '123'}}),
           ('simple.txt', '123'),
@@ -157,6 +159,7 @@ def test_basic_scenario(d, d2):
     # verify that we can't drop a file if archive key was dropped and online archive was removed or changed size! ;)
 
 
+@known_failure_githubci_win
 @with_tree(
     tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
 )
@@ -176,6 +179,7 @@ def test_annex_get_from_subdir(topdir):
         assert_true(annex.file_has_content(fpath))              # and verify if file got into directory
 
 
+@known_failure_githubci_win
 def test_get_git_environ_adjusted():
     gitrunner = GitRunner()
     env = {"GIT_DIR": "../../.git", "GIT_WORK_TREE": "../../", "TEST_VAR": "Exists"}
@@ -287,6 +291,7 @@ def check_observe_tqdm(topdir, topurl, outdir):
         sleep(0.1)
 
 
+@known_failure_githubci_win
 @with_tempfile
 def test_link_file_load(tempfile):
     tempfile2 = tempfile + '_'

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -25,6 +25,7 @@ from datalad.tests.utils import (
     assert_raises,
     eq_,
     with_tempfile,
+    known_failure_githubci_win,
 )
 
 
@@ -51,6 +52,7 @@ def _get_nested_collections(path):
 
 
 # doesn't actually need gitlab and exercises most of the decision logic
+@known_failure_githubci_win
 @with_tempfile
 def test_dryrun(path):
     ctlg = _get_nested_collections(path)

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -39,6 +39,7 @@ from datalad.tests.utils import SkipTest
 from datalad.tests.utils import skip_if_on_windows
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import OBSCURE_FILENAME
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.utils import chpwd
 
 from ..dataset import Dataset
@@ -86,6 +87,7 @@ tree_arg = dict(tree={'test.txt': 'some',
                       'dir2': {'testindir3': 'someother3'}})
 
 
+@known_failure_githubci_win
 @with_tree(**tree_arg)
 def test_add_files(path):
     ds = Dataset(path)
@@ -137,6 +139,7 @@ def test_add_files(path):
         ok_(unstaged.isdisjoint(indexed))
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_update_known_submodule(path):
     def get_baseline(p):
@@ -161,6 +164,7 @@ def test_update_known_submodule(path):
     ok_clean_git(ds.path)
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_add_recursive(path):
     # make simple hierarchy
@@ -192,6 +196,7 @@ def test_add_recursive(path):
     ok_clean_git(parent.path)
 
 
+@known_failure_githubci_win
 @with_tree(**tree_arg)
 def test_add_dirty_tree(path):
     ds = Dataset(path)
@@ -379,6 +384,7 @@ def test_add_subdataset(path, other):
     ok_(other_clone.is_installed)
 
 
+@known_failure_githubci_win
 @with_tree(tree={
     'file.txt': 'some text',
     'empty': '',

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -16,6 +16,7 @@ from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.utils import swallow_logs
 from datalad.utils import swallow_outputs
 from datalad.utils import chpwd
@@ -68,6 +69,7 @@ def test_new_relpath(topdir):
         ok_clean_git(ds, annex=False)
 
 
+@known_failure_githubci_win
 @with_tempfile()
 def test_hierarchy(topdir):
     # GH 1178

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -70,6 +70,7 @@ from datalad.tests.utils import usecase
 from datalad.tests.utils import get_datasets_topdir
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.utils import _path_
 from datalad.utils import rmtree
 
@@ -168,7 +169,8 @@ def test_insufficient_args():
     assert_raises(InsufficientArgumentsError, install, None)
     assert_raises(InsufficientArgumentsError, install, None, description="some")
 
-
+# ValueError: path is on mount 'D:', start on mount 'C:
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_invalid_args(path):
     assert_raises(IncompleteResultsError, install, 'Zoidberg', source='Zoidberg')

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -42,6 +42,7 @@ from datalad.tests.utils import create_tree
 from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import use_cassette
 from datalad.tests.utils import usecase
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.utils import chpwd
 from datalad.utils import _path_
 from datalad.support.external_versions import external_versions
@@ -215,6 +216,7 @@ def test_uninstall_subdataset(src, dst):
         ok_(exists(subds.path))
 
 
+@known_failure_githubci_win
 @with_tree({
     'deep': {
         'dir': {
@@ -269,6 +271,7 @@ def test_uninstall_dataset(path):
     ok_(not exists(ds.path))
 
 
+@known_failure_githubci_win
 @with_tree({'one': 'test', 'two': 'test', 'three': 'test2'})
 def test_remove_file_handle_only(path):
     ds = Dataset(path).create(force=True)
@@ -298,6 +301,7 @@ def test_remove_file_handle_only(path):
     ok_(ds.repo.dirty)
 
 
+@known_failure_githubci_win
 @with_tree({'deep': {'dir': {'test': 'testcontent'}}})
 def test_uninstall_recursive(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -19,6 +19,7 @@ from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import eq_
 from datalad.tests.utils import assert_raises
+from datalad.tests.utils import known_failure_githubci_win
 
 from datalad.utils import (
     on_windows,
@@ -26,6 +27,7 @@ from datalad.utils import (
 )
 
 
+@known_failure_githubci_win
 def test_get_flexible_source_candidates():
     f = _get_flexible_source_candidates
     # for http and https (dummy transport) we should get /.git source added

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -34,6 +34,7 @@ from ...tests.utils import with_fake_cookies_db
 from ...tests.utils import skip_if_no_network
 from ...tests.utils import with_testsui
 from ...tests.utils import with_memory_keyring
+from ...tests.utils import known_failure_githubci_win
 
 # BTW -- mock_open is not in mock on wheezy (Debian 7.x)
 try:
@@ -105,6 +106,7 @@ def test_process_www_authenticate():
                  [])
 
 
+@known_failure_githubci_win
 @with_tree(tree=[('file.dat', 'abc')])
 @serve_path_via_http
 def test_HTTPDownloader_basic(toppath, topurl):
@@ -311,6 +313,7 @@ def test_authenticate_external_portals():
 test_authenticate_external_portals.tags = ['external-portal', 'network']
 
 
+@known_failure_githubci_win
 @skip_if_no_network
 def test_download_ftp():
     try:

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -28,6 +28,7 @@ from ...tests.utils import ok_archives_caches
 from ...tests.utils import slow
 from ...tests.utils import assert_re_in
 from datalad.tests.utils import assert_result_values_cond
+from datalad.tests.utils import known_failure_githubci_win
 
 from ...support.annexrepo import AnnexRepo
 from ...support.exceptions import FileNotInRepositoryError
@@ -70,6 +71,7 @@ treeargs = dict(
 )
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**treeargs)
 @serve_path_via_http()
@@ -160,6 +162,7 @@ tree4uargs = dict(
 )
 
 
+@known_failure_githubci_win
 @slow  # 29.4293s
 #  apparently fails only sometimes in PY3, but in a way that's common in V6
 @assert_cwd_unchanged(ok_to_chdir=True)
@@ -299,6 +302,7 @@ def test_add_archive_content(path_orig, url, repo_path):
     assert exists(opj(repo.path, repo.get_contentlocation(key_1tar)))
 
 
+@known_failure_githubci_win
 @integration
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree1args)
@@ -320,6 +324,7 @@ def test_add_archive_content_strip_leading(path_orig, url, repo_path):
         ok_archives_caches(repo.path, 0)
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(tree={"1.zip": {"dir": {"bar": "blah"}, "foo": "blahhhhh"}})
 def test_add_archive_content_zip(repo_path):
@@ -334,6 +339,7 @@ def test_add_archive_content_zip(repo_path):
         ok_archives_caches(repo.path, 0)
 
 
+@known_failure_githubci_win
 @with_tree(tree={"ds": {"1.tar.gz": {"foo": "abc"}},
                  "notds": {"2.tar.gz": {"bar": "def"}}})
 def test_add_archive_content_absolute_path(path):
@@ -353,6 +359,7 @@ def test_add_archive_content_absolute_path(path):
                             annex=repo)
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree4uargs)
 def test_add_archive_use_archive_dir(repo_path):
@@ -405,11 +412,13 @@ class TestAddArchiveOptions():
         self.annex.precommit()  # so we close any outstanding batch process etc
         rmtemp(self.annex.path)
 
+    @known_failure_githubci_win
     def test_add_delete(self):
         # To test that .tar gets removed
         add_archive_content('1.tar', annex=self.annex, strip_leading_dirs=True, delete=True)
         assert_false(lexists(opj(self.annex.path, '1.tar')))
 
+    @known_failure_githubci_win
     def test_add_archive_leading_dir(self):
         import os
         os.mkdir(opj(self.annex.path, 'sub'))
@@ -426,6 +435,7 @@ class TestAddArchiveOptions():
         )
         ok_file_under_git(self.annex.path, opj('sub', '123', 'file.txt'), annexed=True)
 
+    @known_failure_githubci_win
     def test_add_delete_after_and_drop(self):
         # To test that .tar gets removed
         # but that new stuff was added to annex repo.  We know the key since default
@@ -461,6 +471,7 @@ class TestAddArchiveOptions():
         # there should be no .datalad temporary files hanging around
         self.assert_no_trash_left_behind()
 
+    @known_failure_githubci_win
     def test_add_delete_after_and_drop_subdir(self):
         os.mkdir(opj(self.annex.path, 'subdir'))
         mv_out = self.annex._git_custom_command(
@@ -513,6 +524,7 @@ class TestAddArchiveOptions():
             []
         )
 
+    @known_failure_githubci_win
     def test_override_existing_under_git(self):
         create_tree(self.annex.path, {'1.dat': 'load2'})
         self.annex.add('1.dat', git=True)

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import create_tree
 from datalad.tests.utils import slow
 from datalad.tests.utils import swallow_logs
+from datalad.tests.utils import known_failure_githubci_win
 
 
 from datalad.distribution.dataset import Dataset
@@ -221,6 +222,7 @@ def test_annotate_paths(dspath, nodspath):
     eq_(orig_res, res_recursion_again)
 
 
+@known_failure_githubci_win
 @slow  # 11.0891s
 @with_tree(demo_hierarchy['b'])
 def test_get_modified_subpaths(path):

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -32,6 +32,7 @@ from datalad.tests.utils import ok_
 from datalad.tests.utils import eq_
 from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_result_count
+from datalad.tests.utils import known_failure_githubci_win
 
 
 @known_failure_windows
@@ -45,6 +46,7 @@ def test_magic_number():
     eq_(out.strip(), PRE_INIT_COMMIT_SHA)
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_diff(path, norepo):
@@ -134,6 +136,7 @@ def test_diff(path, norepo):
         res, 1, state='added', path=opj(ds.path, 'deep', 'down2'), type='file')
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_diff_recursive(path):
     ds = Dataset(path).create()

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -24,6 +24,7 @@ from ...tests.utils import assert_not_in
 from ...tests.utils import assert_in_results
 from ...tests.utils import with_tree
 from ...tests.utils import serve_path_via_http
+from ...tests.utils import known_failure_githubci_win
 
 
 def test_download_url_exceptions():
@@ -50,6 +51,7 @@ def test_download_url_exceptions():
         assert_in('http://example.com/bogus', msg)
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged
 @with_tree(tree=[
     ('file1.txt', 'abc'),
@@ -150,6 +152,7 @@ def test_download_url_dataset(toppath, topurl, path):
     assert_false((ds.pathobj / "file8.txt").exists())
 
 
+@known_failure_githubci_win
 @with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})
 @serve_path_via_http
 @with_tempfile(mkdir=True)

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -69,6 +69,7 @@ from datalad.tests.utils import (
     swallow_outputs,
     known_failure_appveyor,
     known_failure_windows,
+    known_failure_githubci_win,
     slow,
 )
 
@@ -275,6 +276,7 @@ def test_rerun_just_one_commit(path):
                   report=True, return_type="list")
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_run_failure(path):
     ds = Dataset(path).create()
@@ -581,6 +583,7 @@ def test_rerun_script(path):
 
 
 @slow  # ~10s
+@known_failure_githubci_win
 @known_failure_appveyor
 # ^ Issue only happens on appveyor, Python itself implodes. Cannot be
 #   reproduced on a real win7 box

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -43,6 +43,7 @@ from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_result_values_equal
 from datalad.tests.utils import skip_v6_or_later
 from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils import known_failure_githubci_win
 
 
 save = Save.__call__
@@ -119,6 +120,7 @@ def test_save(path):
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
 
+@known_failure_githubci_win
 @with_tempfile()
 def test_recursive_save(path):
     ds = Dataset(path).create()
@@ -267,6 +269,7 @@ def test_recursive_save(path):
                  'saving sub')
 
 
+@known_failure_githubci_win
 @with_tempfile()
 def test_save_message_file(path):
     ds = Dataset(path).create()
@@ -281,6 +284,7 @@ def test_save_message_file(path):
                  u"add β")
 
 
+@known_failure_githubci_win
 def test_renamed_file():
     @with_tempfile()
     def check_renamed_file(recursive, no_annex, path):
@@ -415,6 +419,7 @@ def test_bf1886(path):
     ok_clean_git(parent.path)
 
 
+@known_failure_githubci_win
 @with_tree({
     '1': '',
     '2': '',
@@ -444,6 +449,7 @@ def test_gh2043p1(path):
     skip_v6_or_later(method='pass')(ok_clean_git)(ds.path)
 
 
+@known_failure_githubci_win
 @with_tree({
     'staged': 'staged',
     'untracked': 'untracked'})
@@ -459,6 +465,7 @@ def test_bf2043p2(path):
 
 
 # https://github.com/datalad/datalad/issues/3087
+@known_failure_githubci_win
 @with_tree({
     'sdir1': {'foo': 'foo'},
     'sdir2': {'foo': 'foo'},
@@ -494,6 +501,7 @@ def test_save_partial_index(path):
     ok_clean_git(ds.path, head_modified=["staged"])
 
 
+@known_failure_githubci_win
 @with_tree({
     'top:file': 'data',
     'd': {'sub:file': 'data'}

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -39,6 +39,7 @@ from datalad.tests.utils import (
     assert_not_in_results,
     assert_result_count,
     assert_status,
+    known_failure_githubci_win,
 )
 
 
@@ -163,6 +164,7 @@ def test_unlock(path):
         eq_("change content again", f.read())
 
 
+@known_failure_githubci_win
 @with_tree(tree={"dir": {"a": "a", "b": "b"}})
 def test_unlock_directory(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -14,6 +14,7 @@ from datalad.api import Dataset
 from datalad.utils import on_osx
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import known_failure_githubci_win
 
 from nose import SkipTest
 from nose.tools import assert_equal
@@ -72,10 +73,12 @@ def check_api(no_annex, path):
             " to load:\n%s" % ("\n".join(skipped_extractors)))
 
 
+@known_failure_githubci_win
 def test_api_git():
     # should tollerate both pure git and annex repos
     yield check_api, True
 
 
+@known_failure_githubci_win
 def test_api_annex():
     yield check_api, False

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -27,6 +27,7 @@ from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_githubci_win
 
 
 def _assert_metadata_empty(meta):
@@ -92,6 +93,7 @@ def test_basic_aggregate(path):
 
 
 # tree puts aggregate metadata structures on two levels inside a dataset
+@known_failure_githubci_win
 @with_tree(tree={
     '.datalad': {
         'metadata': {
@@ -143,6 +145,7 @@ def test_aggregate_query(path):
 
 
 # this is for gh-1971
+@known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 def test_reaggregate_with_unavailable_objects(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
@@ -176,6 +179,7 @@ def test_reaggregate_with_unavailable_objects(path):
     )
 
 
+@known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 @with_tempfile(mkdir=True)
 def test_aggregate_with_unavailable_objects_from_subds(path, target):

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -38,6 +38,7 @@ from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_re_in
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetArgumentFound
 from datalad.support.gitrepo import GitRepo
@@ -95,6 +96,7 @@ def _compare_metadata_helper(origres, compds):
                 eq_(ores[i], cres[i])
 
 
+@known_failure_githubci_win
 @slow  # ~16s
 @with_tree(tree=_dataset_hierarchy_template)
 def test_aggregation(path):
@@ -248,6 +250,7 @@ def test_bf2458(src, dst):
     eq_(clone.repo.whereis('dummy'), [ds.config.get('annex.uuid')])
 
 
+@known_failure_githubci_win
 def test_get_containingds_from_agginfo():
     eq_(None, _get_containingds_from_agginfo({}, 'any'))
     # direct hit returns itself

--- a/datalad/metadata/tests/test_extract_metadata.py
+++ b/datalad/metadata/tests/test_extract_metadata.py
@@ -23,6 +23,7 @@ from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import known_failure_githubci_win
 
 from datalad.support.exceptions import IncompleteResultsError
 
@@ -37,6 +38,7 @@ def test_error(path):
         assert_raises(ValueError, extract_metadata, types=['bogus__'], files=[testpath])
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_ds_extraction(path):
     from datalad.tests.utils import SkipTest
@@ -76,6 +78,7 @@ def test_ds_extraction(path):
         assert_in('xmp', r['metadata'])
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_file_extraction(path):
     from datalad.tests.utils import SkipTest

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -32,6 +32,7 @@ from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import patch_config
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import eq_
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.support.exceptions import NoDatasetArgumentFound
 
 from datalad.api import search
@@ -178,6 +179,7 @@ def test_search_non_dataset(tdir):
     assert_in("datalad create --force", str(cme.exception))
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_within_ds_file_search(path):
     try:

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -32,6 +32,7 @@ from datalad.tests.utils import assert_repo_status
 from datalad.tests.utils import eq_, ok_exists
 from datalad.tests.utils import create_tree, with_tempfile, HTTPPath
 from datalad.tests.utils import with_tree
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.utils import get_tempfile_kwargs, rmtemp
 
 
@@ -232,6 +233,7 @@ def json_stream(data):
     return stream
 
 
+@known_failure_githubci_win
 def test_extract():
     info, subpaths = au.extract(
         json_stream(ST_DATA["rows"]), "json",

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -38,6 +38,7 @@ from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import skip_if_no_module
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import OBSCURE_FILENAME
+from datalad.tests.utils import known_failure_githubci_win
 
 
 broken_plugin = """garbage"""
@@ -158,6 +159,7 @@ def test_wtf(topdir):
         assert_in("cmd:annex:", pyperclip.paste())  # but the content is there
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_no_annex(path):
     ds = create(path)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -85,6 +85,7 @@ from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import find_files
 from datalad.tests.utils import slow
 from datalad.tests.utils import set_annex_version
+from datalad.tests.utils import known_failure_githubci_win
 
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import CommandNotAvailableError
@@ -172,6 +173,7 @@ def test_AnnexRepo_crippled_filesystem(src, dst):
     assert_false(ar.is_crippled_fs())
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 def test_AnnexRepo_is_direct_mode(path):
@@ -181,6 +183,7 @@ def test_AnnexRepo_is_direct_mode(path):
         ar.is_direct_mode())
 
 
+@known_failure_githubci_win
 @with_tempfile()
 def test_AnnexRepo_is_direct_mode_gitrepo(path):
     repo = GitRepo(path, create=True)
@@ -331,6 +334,7 @@ def test_AnnexRepo_is_under_annex(batch, src, annex_path):
         [False])
 
 
+@known_failure_githubci_win
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
                  ('about2.txt', 'more abouts'),
                  ('d', {'sub.txt': 'more stuff'})))
@@ -944,6 +948,7 @@ def test_AnnexRepo_get_contentlocation():
         yield _test_AnnexRepo_get_contentlocation, batch
 
 
+@known_failure_githubci_win
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
                  ('about2.txt', 'more abouts'),
                  ('about2_.txt', 'more abouts_'),
@@ -1814,6 +1819,7 @@ def test_wanted(path):
     eq_(ar1.get_preferred_content('wanted'), 'standard')
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_AnnexRepo_metadata(path):
     # prelude
@@ -2062,6 +2068,7 @@ def test_error_reporting(path):
 
 # http://git-annex.branchable.com/bugs/cannot_commit___34__annex_add__34__ed_modified_file_which_switched_its_largefile_status_to_be_committed_to_git_now/#comment-bf70dd0071de1bfdae9fd4f736fd1ec
 # https://github.com/datalad/datalad/issues/1651
+@known_failure_githubci_win
 @with_tree(tree={
     '.gitattributes': "** annex.largefiles=(largerthan=4b)",
     'alwaysbig': 'a'*10,
@@ -2185,6 +2192,7 @@ def check_files_split(cls, topdir):
     dl.add(dirs)
 
 
+@known_failure_githubci_win
 @slow  # 313s  well -- if errors out - only 3 sec
 def test_files_split():
     for cls in GitRepo, AnnexRepo:

--- a/datalad/support/tests/test_cookies.py
+++ b/datalad/support/tests/test_cookies.py
@@ -13,9 +13,11 @@ from ...utils import rmtree
 from ...tests.utils import (
     assert_equal,
     with_tempfile,
+    known_failure_githubci_win,
 )
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_no_blows(cookiesdir):
     cookies = CookiesDB(op.join(cookiesdir, 'mycookies'))

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -18,6 +18,7 @@ from datalad.tests.utils import (
     assert_in,
     assert_not_in,
     assert_raises,
+    known_failure_githubci_win,
 )
 
 from datalad.distribution.dataset import Dataset
@@ -28,6 +29,7 @@ from datalad.tests.utils import (
 )
 
 
+@known_failure_githubci_win
 @with_tempfile
 def test_get_content_info(path):
     repo = GitRepo(path)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -47,6 +47,7 @@ from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import known_failure_githubci_win
 from datalad.utils import rmtree
 from datalad.tests.utils_testrepos import BasicAnnexTestRepo
 from datalad.utils import getpwd, chpwd
@@ -762,6 +763,7 @@ def test_GitRepo_get_files(url, path):
     eq_(set([filename]), branch_files.difference(local_files))
 
 
+@known_failure_githubci_win
 @with_tree(tree={
     'd1': {'f1': 'content1',
            'f2': 'content2'},

--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -20,6 +20,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import eq_
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import with_tree
+from datalad.tests.utils import known_failure_githubci_win
 
 
 def test_globbedpaths_get_sub_patterns():
@@ -47,6 +48,7 @@ def test_globbedpaths_get_sub_patterns():
         eq_(gp._get_sub_patterns(pat), expected)
 
 
+@known_failure_githubci_win
 @with_tree(tree={"1.txt": "",
                  "2.dat": "",
                  "3.txt": "",

--- a/datalad/support/tests/test_locking.py
+++ b/datalad/support/tests/test_locking.py
@@ -23,9 +23,16 @@
 """
 import os.path as op
 from ..locking import lock_if_check_fails
-from datalad.tests.utils import ok_exists, with_tempfile, ok_, eq_
+from datalad.tests.utils import (
+    ok_exists,
+    with_tempfile,
+    ok_,
+    eq_,
+    known_failure_githubci_win,
+)
 
 
+@known_failure_githubci_win
 @with_tempfile
 def test_lock_if_check_fails(tempfile):
     # basic test, should never try to lock so filename is not important

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -19,6 +19,7 @@ from datalad.tests.utils import assert_re_in
 from datalad.tests.utils import assert_in
 from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import SkipTest
+from datalad.tests.utils import known_failure_githubci_win
 
 from ..network import same_website, dlurljoin
 from ..network import get_tld
@@ -189,6 +190,7 @@ def test_url_base():
         eq_(purl.as_str(), 'http://example.com/')
 
 
+@known_failure_githubci_win
 def test_url_samples():
     _check_ri("http://example.com", URL, scheme='http', hostname="example.com")
     # "complete" one for classical http

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -14,6 +14,7 @@ from datalad.tests.utils import (
     create_tree,
     with_tempfile,
     eq_,
+    known_failure_githubci_win,
 )
 
 from datalad.distribution.dataset import Dataset
@@ -63,11 +64,13 @@ def _test_save_all(path, repocls):
     return ds
 
 
+@known_failure_githubci_win
 @with_tempfile
 def test_gitrepo_save_all(path):
     _test_save_all(path, GitRepo)
 
 
+@known_failure_githubci_win
 @with_tempfile
 def test_annexrepo_save_all(path):
     _test_save_all(path, AnnexRepo)

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -16,6 +16,7 @@ from nose.tools import assert_raises, assert_equal
 
 from .. import __main__, __version__
 from ..auto import AutomagicIO
+from datalad.tests.utils import known_failure_githubci_win
 
 
 @patch('sys.stdout', new_callable=StringIO)
@@ -31,6 +32,8 @@ def test_main_version(stdout):
     assert_raises(SystemExit, __main__.main, ['__main__.py', '--version'])
     assert_equal(stdout.getvalue().rstrip(), "datalad %s" % __version__)
 
+
+@known_failure_githubci_win
 @patch.object(AutomagicIO, 'activate')
 @patch('sys.stdout', new_callable=StringIO)
 def test_main_run_a_script(stdout, mock_activate):

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -15,6 +15,7 @@ from .utils import (
     assert_true, assert_false, eq_,
     with_tree, with_tempfile, swallow_outputs, on_windows,
     ok_file_has_content,
+    known_failure_githubci_win,
 )
 from .utils import assert_equal
 
@@ -85,6 +86,7 @@ def check_decompress_file(leading_directories, path):
         eq_(f.read(), '3 load')
 
 
+@known_failure_githubci_win
 def test_decompress_file():
     yield check_decompress_file, None
     yield check_decompress_file, 'strip'
@@ -109,6 +111,7 @@ def check_compress_dir(ext, path, name):
     assert_true(exists(opj(name_extracted, 'd1', 'd2', 'f1')))
 
 
+@known_failure_githubci_win
 def test_compress_dir():
     yield check_compress_dir, '.tar.gz'
     yield check_compress_dir, '.tar'
@@ -147,11 +150,13 @@ def check_compress_file(ext, annex, path, name):
     ok_file_has_content(_filepath, 'content')
 
 
+@known_failure_githubci_win
 def test_compress_file():
     for annex in True, False:
         yield check_compress_file, '.gz', annex
 
 
+@known_failure_githubci_win
 @with_tree(**tree_simplearchive)
 def test_ExtractedArchive(path):
     archive = opj(path, fn_archive_obscure_ext)

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -19,6 +19,7 @@ from io import StringIO
 from .utils import with_testrepos
 from .utils import assert_raises, eq_, ok_, assert_false, assert_true
 from .utils import swallow_outputs
+from datalad.tests.utils import known_failure_githubci_win
 
 from ..auto import AutomagicIO
 
@@ -187,6 +188,7 @@ def test_proxying_open_h5py():
     yield _test_proxying_open, generate_hdf5, verify_hdf5
 
 
+@known_failure_githubci_win
 def test_proxying_open_regular():
     def generate_dat(f):
         with open(f, "w") as f:
@@ -199,6 +201,7 @@ def test_proxying_open_regular():
     yield _test_proxying_open, generate_dat, verify_dat
 
 
+@known_failure_githubci_win
 def test_proxying_io_open_regular():
 
     def generate_dat(f):
@@ -212,6 +215,7 @@ def test_proxying_io_open_regular():
     yield _test_proxying_open, generate_dat, verify_dat
 
 
+@known_failure_githubci_win
 def test_proxying_lzma_LZMAFile():
     def generate_dat(f):
         with LZMAFile(f, "w") as f:
@@ -245,6 +249,7 @@ def test_proxying_open_nibabel():
     yield _test_proxying_open, generate_nii, verify_nii
 
 
+@known_failure_githubci_win
 def test_proxying_os_stat():
     from os.path import exists
     def generate_dat(f):

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -37,6 +37,7 @@ from .utils import (
     on_windows,
     lgr,
     OBSCURE_FILENAME,
+    known_failure_githubci_win,
 )
 
 from ..cmd import (
@@ -47,6 +48,7 @@ from ..support.exceptions import CommandError
 from ..support.protocol import DryRunProtocol
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner_dry(tempfile):
@@ -72,6 +74,7 @@ def test_runner_dry(tempfile):
     assert_equal("args=('foo', 'bar')", dry[1]['command'][1])
 
 
+@known_failure_githubci_win
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner(tempfile):
@@ -150,6 +153,7 @@ def test_runner_instance_callable_wet():
     eq_(ret, os.path.join('foo', 'bar'))
 
 
+@known_failure_githubci_win
 def test_runner_log_stderr():
 
     runner = Runner(log_outputs=True)
@@ -175,6 +179,7 @@ def test_runner_log_stderr():
                           "stderr| stderr-Message should not be logged")
 
 
+@known_failure_githubci_win
 def test_runner_log_stdout():
     # TODO: no idea of how to check correct logging via any kind of
     # assertion yet.
@@ -327,6 +332,7 @@ def test_runner_stdin(path):
         assert_in("whatever", cmo.out)
 
 
+@known_failure_githubci_win
 def test_process_remaining_output():
     runner = Runner()
     out = u"""\

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -32,6 +32,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import ok_endswith
 from datalad.tests.utils import assert_re_in
+from datalad.tests.utils import known_failure_githubci_win
 
 # pretend we are in interactive mode so we could check if coloring is
 # disabled
@@ -140,6 +141,7 @@ def test_traceback():
     ok_endswith(tb1, "...>test_log:%s" % (",".join([str(tb_line)]*100)))
 
 
+@known_failure_githubci_win
 def test_color_formatter():
 
     # want to make sure that coloring doesn't get "stuck"

--- a/datalad/tests/test_protocols.py
+++ b/datalad/tests/test_protocols.py
@@ -24,8 +24,10 @@ from ..support.gitrepo import GitRepo
 from ..cmd import Runner
 from .utils import with_tempfile
 from .utils import swallow_logs
+from .utils import known_failure_githubci_win
 
 
+@known_failure_githubci_win
 @with_tempfile
 def test_protocol_commons(protocol_file):
 

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -40,7 +40,8 @@ from .utils import (
     swallow_outputs, swallow_logs,
     on_windows, assert_raises, assert_cwd_unchanged, serve_path_via_http,
     ok_symlink, assert_true, ok_good_symlink, ok_broken_symlink,
-    ok_file_under_git
+    ok_file_under_git,
+    known_failure_githubci_win,
 )
 from .utils import ok_generator
 from .utils import assert_dict_equal
@@ -202,6 +203,7 @@ def test_with_tempfile_specified_prefix(d1):
     ok_('test_with_tempfile_specified_prefix' not in d1)
 
 
+@known_failure_githubci_win
 def test_get_most_obscure_supported_name():
     n = get_most_obscure_supported_name()
     if platform.system() in ('Linux', 'Darwin'):
@@ -421,6 +423,8 @@ def _test_serve_path_via_http(test_fpath, tmp_dir):  # pragma: no cover
     test_path_and_url()
 
 
+# just look at the path specs...
+@known_failure_githubci_win
 def test_serve_path_via_http():
     for test_fpath in ['test1.txt',
                        'test_dir/test2.txt',
@@ -437,6 +441,7 @@ def test_serve_path_via_http():
         yield _test_serve_path_via_http, test_fpath
 
 
+@known_failure_githubci_win
 def test_without_http_proxy():
 
     @without_http_proxy

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -95,7 +95,8 @@ from .utils import skip_if_no_module
 from .utils import (
     probe_known_failure, skip_known_failure, known_failure, known_failure_v6,
     skip_if,
-    ok_file_has_content
+    ok_file_has_content,
+    known_failure_githubci_win,
 )
 from .utils import OBSCURE_FILENAME
 
@@ -502,6 +503,7 @@ def test_any_re_search():
     assert_false(any_re_search(['^b', 'bab'], 'ab'))
 
 
+@known_failure_githubci_win
 def test_find_files():
     tests_dir = dirname(__file__)
     proj_dir = normpath(opj(dirname(__file__), pardir))
@@ -528,6 +530,7 @@ def test_find_files():
         ok_startswith(basename(f), 'test_')
 
 
+@known_failure_githubci_win
 @with_tree(tree={
     '.git': {
         '1': '2'
@@ -678,6 +681,7 @@ def test_path_():
         eq_(_path_(p, 'd'), 'a/b/c/d')
 
 
+@known_failure_githubci_win
 def test_get_timestamp_suffix():
     # we need to patch temporarily TZ
     import time
@@ -769,6 +773,7 @@ def test_as_unicode():
     assert_in("1 is not of any of known or provided", str(cme.exception))
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_path_prefix(path):
     eq_(get_path_prefix('/d1/d2', '/d1/d2'), '')
@@ -836,6 +841,7 @@ def test_get_dataset_root(path):
         eq_(get_dataset_root(fname), os.curdir)
 
 
+@known_failure_githubci_win
 def test_path_startswith():
     ok_(path_startswith('/a/b', '/a'))
     ok_(path_startswith('/a/b', '/a/b'))
@@ -851,6 +857,7 @@ def test_path_startswith():
     assert_raises(ValueError, path_startswith, '/a/b', 'a')
 
 
+@known_failure_githubci_win
 def test_path_is_subpath():
     ok_(path_is_subpath('/a/b', '/a'))
     ok_(path_is_subpath('/a/b/c', '/a'))

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1058,6 +1058,20 @@ def known_failure_appveyor(func):
     return func
 
 
+def known_failure_githubci_win(func):
+    """Test decorator for a known test failure on Github's Windows CI
+    """
+    if 'GITHUB_WORKFLOW' in os.environ and on_windows:
+        @known_failure
+        @wraps(func)
+        @attr('known_failure_githubci_win')
+        @attr('githubci_win')
+        def dm_func(*args, **kwargs):
+            return func(*args, **kwargs)
+        return dm_func
+    return func
+
+
 # ### ###
 # END known failure decorators
 # ### ###


### PR DESCRIPTION
In comparions to appveyor setup:

- more modern OS (win2019 server)
- PY37 not PY35 (ie. appveyor is no longer a blocker for making PY36 minimum dep)
- runs more tests
- no SSH setup (yet), but SSH pretty much not functional anyways
- no unicode related tests are running, because the whole encoding issue is shadowing other bugs (encoding can later be tackled in with a proper PY3 approach)
- each failing tests is individually marked as such (need to go through them one by one and want to see it in the code)

The checks won't run until one of these PR has made it into master. But here is the outcome for this branch shown in my fork: https://github.com/mih/datalad/pull/32/checks