### PR TITLE
TST: Let actions run on 'pull_request' events

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,6 +1,6 @@
 name: Benchmarks
 
-on: [push]
+on: [pull_request]
 
 jobs:
   vs-master:

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -1,6 +1,6 @@
 name: Docs
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -1,6 +1,6 @@
 name: Win2019 tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Running them on 'push' will cause actions to run in the repo
that has been pushed into. However, in almost all cases we
want to see the result in the base repo.

Moreover, I feel better to not kick of users of computing
for each push that doesn't happen in a PR.
