### PR TITLE
ENH: subdatasets(contains=...) will report matching paths in result

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -431,6 +431,17 @@ class Dataset(object, metaclass=Flyweight):
         #       (meaning: registered as submodule)?
         path = self.path
         sds_path = path if topmost else None
+
+        def res_filter(res):
+            return res.get('status') == 'ok' and res.get('type') == 'dataset'
+
+        def subds_contains_path(ds, path):
+            return path in sds.subdatasets(recursive=False,
+                                           contains=path,
+                                           result_filter=res_filter,
+                                           on_failure='ignore',
+                                           result_xfm='paths')
+
         while path:
             # normalize the path after adding .. so we guaranteed to not
             # follow into original directory if path itself is a symlink
@@ -446,10 +457,7 @@ class Dataset(object, metaclass=Flyweight):
                 if not sds.id:
                     break
             if registered_only:
-                if path not in sds.subdatasets(
-                        recursive=False,
-                        contains=path,
-                        result_xfm='paths'):
+                if not subds_contains_path(sds, path):
                     break
 
             # That was a good candidate

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -247,9 +247,15 @@ def _install_necessary_subdatasets(
     path: str
     reckless: bool
     """
+
+    def subds_result_filter(res):
+        return res.get('status') == 'ok' and res.get('type') == 'dataset'
+
     # figuring out what dataset to start with, --contains limits --recursive
     # to visit only subdataset on the trajectory to the target path
-    subds_trail = ds.subdatasets(contains=path, recursive=True)
+    subds_trail = ds.subdatasets(contains=path, recursive=True,
+                                 on_failure="ignore",
+                                 result_filter=subds_result_filter)
     if not subds_trail:
         # there is not a single known subdataset (installed or not)
         # for this path -- job done
@@ -283,7 +289,9 @@ def _install_necessary_subdatasets(
 
         # now check whether the just installed subds brought us any closer to
         # the target path
-        subds_trail = sd.subdatasets(contains=path, recursive=False)
+        subds_trail = sd.subdatasets(contains=path, recursive=False,
+                                     on_failure='ignore',
+                                     result_filter=subds_result_filter)
         if not subds_trail:
             # no (newly available) subdataset get's us any closer
             return

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -231,17 +231,20 @@ def test_get_subdatasets(path):
          'sub dataset1/sub sub dataset1/subm 1'])
     # but it has to be a subdataset, otherwise no match
     # which is what get_containing_subdataset() used to do
-    eq_(ds.subdatasets(contains=ds.path), [])
-    # no error if contains is bullshit
-    eq_(ds.subdatasets(recursive=True,
-                       contains='errrr_nope',
-                       result_xfm='paths'),
-        [])
-    # TODO maybe at a courtesy bullshit detector some day
-    eq_(ds.subdatasets(recursive=True,
-                       contains=opj(pardir, 'errrr_nope'),
-                       result_xfm='paths'),
-        [])
+    assert_status('impossible',
+                  ds.subdatasets(contains=ds.path, on_failure='ignore'))
+
+    # 'impossible' if contains is bullshit
+    assert_status('impossible',
+                  ds.subdatasets(recursive=True,
+                                 contains='impossible_yes',
+                                 on_failure='ignore'))
+
+    assert_status('impossible',
+                  ds.subdatasets(recursive=True,
+                                 contains=opj(pardir, 'impossible_yes'),
+                                 on_failure='ignore'))
+
     eq_(ds.subdatasets(
         recursive=True,
         contains=[target_sub, 'sub dataset1/2'],


### PR DESCRIPTION
Sorting paths (for locally present content, and unavailable stuff) into
containing (present) datasets is a key task for helper code such as
annotate_paths(). This change equips `subdatasets()` with the ability
to make similar reports by including a 'contains' property in its
results whenever a respective set of paths has been provided.
Such a result looks like this:

```
{
  "action": "subdataset",
  "contains": [
    "/tmp/datalad_temp_test_get_in_unavailable_subdatasetdzceqobr/sub1/sub2"
  ],
  "gitmodule_datalad-id": "1b1e4b70-e472-11e9-9214-f0d5bf7b5561",
  "gitmodule_name": "sub1",
  "gitmodule_url": "./sub1",
  "gitshasum": "15428154a3573488503151ddc42051281221e8f8",
  "parentds": "/tmp/datalad_temp_test_get_in_unavailable_subdatasetdzceqobr",
  "path": "/tmp/datalad_temp_test_get_in_unavailable_subdatasetdzceqobr/sub1",
  "refds": "/tmp/datalad_temp_test_get_in_unavailable_subdatasetdzceqobr",
  "revision": "15428154a3573488503151ddc42051281221e8f8",
  "state": "absent",
  "status": "ok",
  "type": "dataset"
}
```

where paths are reported as a 'contains' list with fully resolved items.

This seems like a useful feature on its own, but is part of a move towards fixing #3368 and #3469