### PR TITLE
run: Fix path handling for gh-3746 and for subdirectory runs

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -491,9 +491,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     ds = require_dataset(
         dataset, check_installed=True,
         purpose='tracking outcomes of a command')
-
-    # not needed ATM
-    #refds_path = ds.path
+    ds_path = ds.path
 
     lgr.debug('tracking command output underneath %s', ds)
 
@@ -548,7 +546,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         cmd_expanded = format_command(
             ds, cmd,
             pwd=pwd,
-            dspath=ds.path,
+            dspath=ds_path,
             # Check if the command contains "{tmpdir}" to avoid creating an
             # unnecessary temporary directory in most but not all cases.
             tmpdir=mkdtemp(prefix="datalad-run-") if "{tmpdir}" in cmd else "",
@@ -608,7 +606,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         from hashlib import md5
         record_id = md5(record.encode('utf-8')).hexdigest()
         record_dir = ds.config.get('datalad.run.record-directory', default=op.join('.datalad', 'runinfo'))
-        record_path = op.join(ds.path, record_dir, record_id)
+        record_path = op.join(ds_path, record_dir, record_id)
         if not op.lexists(record_path):
             # go for compression, even for minimal records not much difference, despite offset cost
             # wrap in list -- there is just one record

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -626,9 +626,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         message if message is not None else _format_cmd_shorty(cmd_expanded),
         '"{}"'.format(record_id) if use_sidecar else record)
 
-    outputs_to_save = outputs.expand(full=True) if explicit else '.'
+    outputs_to_save = outputs.expand() if explicit else None
+    do_save = outputs_to_save is None or outputs_to_save
     if not rerun_info and cmd_exitcode:
-        if outputs_to_save:
+        if do_save:
             repo = ds.repo
             msg_path = relpath(opj(repo.path, repo.get_git_dir(repo),
                                    "COMMIT_EDITMSG"))
@@ -639,7 +640,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                      "'datalad save -d . -r -F %s'",
                      msg_path)
         raise exc
-    elif outputs_to_save:
+    elif do_save:
         # Note: Passing the resolved `ds` instead of `dataset` isn't breaking
         # path semantics because outputs_to_save is either a list of full paths
         # or ".". In the second case, we _need_ to pass an instance so that "."

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -234,6 +234,12 @@ def get_command_pwds(dataset):
     return pwd, rel_pwd
 
 
+def _is_nonexistent_path(result):
+    return (result.get("action") == "get" and
+            result.get("status") == "impossible" and
+            result.get("message") == "path does not exist")
+
+
 def _install_and_reglob(dset, gpaths):
     """Install globbed subdatasets and repeat.
 
@@ -285,9 +291,7 @@ def prepare_inputs(dset, inputs, extra_inputs=None):
         for res in _install_and_reglob(dset, gp):
             yield res
         for res in dset.get(gp.expand(full=True), on_failure="ignore"):
-            if res.get("action") == "get" and \
-                    res.get("status") == "impossible" and \
-                    res.get("message") == "path does not exist":
+            if _is_nonexistent_path(res):
                 # MIH why just a warning if given inputs are not valid?
                 lgr.warning("Input does not exist: %s", res["path"])
             else:

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -260,7 +260,7 @@ def _install_and_reglob(dset, gpaths):
         for res in dset.install(dirs_new,
                                 result_xfm=None, return_type='generator',
                                 on_failure="ignore"):
-            if res.get("state") == "absent":
+            if _is_nonexistent_path(res):
                 lgr.debug("Skipping install of non-existent path: %s",
                           res["path"])
             else:

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -285,7 +285,10 @@ def prepare_inputs(dset, inputs, extra_inputs=None):
         for res in _install_and_reglob(dset, gp):
             yield res
         for res in dset.get(gp.expand(full=True), on_failure="ignore"):
-            if res.get("state") == "absent":
+            if res.get("action") == "get" and \
+                    res.get("status") == "impossible" and \
+                    res.get("message") == "path does not exist":
+                # MIH why just a warning if given inputs are not valid?
                 lgr.warning("Input does not exist: %s", res["path"])
             else:
                 yield res

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -238,7 +238,11 @@ def test_run_from_subds_gh3551(path):
             status="ok")
     assert_repo_status(ds.path)
     subds = Dataset(op.join(ds.path, subds_path))
-    ok_(subds.repo.file_has_content("f"))
+    ok_exists(op.join(subds.path, "f"))
+    if not on_windows:  # FIXME
+        # This check fails on Windows:
+        # https://github.com/datalad/datalad/pull/3747/checks?check_run_id=248506560#step:8:254
+        ok_(subds.repo.file_has_content("f"))
 
 
 @slow  # ~10s

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -62,6 +62,7 @@ from datalad.tests.utils import (
     assert_not_in,
     swallow_logs,
     swallow_outputs,
+    known_failure,
     known_failure_appveyor,
     known_failure_windows,
     slow,
@@ -353,6 +354,8 @@ def test_run_cmdline_disambiguation(path):
                 "echo --version", path, expected_exit=None)
 
 
+# https://github.com/datalad/datalad/pull/3746#issuecomment-538425192
+@known_failure
 @with_tempfile(mkdir=True)
 def test_run_path_semantics(path):
     # Test that we follow path resolution from gh-3435: paths are relative to

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -602,8 +602,11 @@ class Get(Interface):
                 dataset=dataset,
                 # always come from the top to get sensible generator behavior
                 bottomup=False,
-                recursive=recursive,
-                recursion_limit=recursion_limit,
+                # when paths are given, they will constrain the recursion
+                # automatically, and we need to enable recursion so we can
+                # location path in subdatasets several levels down
+                recursive=True if path else recursive,
+                recursion_limit=None if path else recursion_limit,
                 return_type='generator',
                 on_failure='ignore'):
             if sdsres.get('type', None) != 'dataset':

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -384,6 +384,7 @@ def _install_targetpath(
             path=ds.path,
             status='notneeded',
             contains=[target_path],
+            refds=refds_path,
         )
     else:
         # we don't have it yet. is it in a subdataset?
@@ -401,6 +402,7 @@ def _install_targetpath(
                 action='get',
                 path=str(target_path),
                 status='impossible',
+                refds=refds_path,
                 message='path does not exist',
             )
             return

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -290,7 +290,7 @@ def _install_necessary_subdatasets(
         # report installation, whether it helped or not
         yield get_status_dict(
             'install', ds=sd, status='ok', logger=lgr, refds=refds_path,
-            message=("Installed subdataset in order to get %s", path))
+            message=("Installed subdataset in order to get %s", str(path)))
 
         # now check whether the just installed subds brought us any closer to
         # the target path

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -12,58 +12,67 @@
 
 import logging
 
-from os.path import join as opj
-from os.path import relpath
+import os.path as op
 
 from datalad.interface.base import Interface
-from datalad.interface.annotate_paths import AnnotatePaths
-from datalad.interface.annotate_paths import annotated2content_by_ds
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
-from datalad.interface.results import get_status_dict
-from datalad.interface.results import results_from_paths
-from datalad.interface.results import annexjson2result
-from datalad.interface.results import count_results
-from datalad.interface.results import success_status_map
-from datalad.interface.results import results_from_annex_noinfo
-from datalad.interface.common_opts import recursion_flag
-# from datalad.interface.common_opts import git_opts
-# from datalad.interface.common_opts import annex_opts
-# from datalad.interface.common_opts import annex_get_opts
-from datalad.interface.common_opts import location_description
-from datalad.interface.common_opts import jobs_opt
-from datalad.interface.common_opts import reckless_opt
-from datalad.interface.common_opts import verbose
-from datalad.support.constraints import EnsureInt
-from datalad.support.constraints import EnsureChoice
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureNone
+from datalad.interface.results import (
+    get_status_dict,
+    results_from_paths,
+    annexjson2result,
+    count_results,
+    success_status_map,
+    results_from_annex_noinfo,
+)
+from datalad.interface.common_opts import (
+    recursion_flag,
+    location_description,
+    jobs_opt,
+    reckless_opt,
+)
+from datalad.interface.results import is_ok_dataset
+from datalad.support.constraints import (
+    EnsureInt,
+    EnsureChoice,
+    EnsureStr,
+    EnsureNone,
+)
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import (
     GitRepo,
     _fixup_submodule_dotgit_setup,
 )
-from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import InstallFailedError
-from datalad.support.exceptions import IncompleteResultsError
-from datalad.support.network import URL
-from datalad.support.network import RI
-from datalad.support.network import urlquote
-from datalad.dochelpers import exc_str
-from datalad.dochelpers import single_or_plural
-from datalad.utils import get_dataset_root
-from datalad.utils import with_pathsep as _with_sep
-from datalad.utils import unique
-from datalad.utils import path_startswith
-from datalad.utils import path_is_subpath
+from datalad.support.exceptions import (
+    InsufficientArgumentsError,
+    InstallFailedError,
+    IncompleteResultsError,
+)
+from datalad.support.network import (
+    URL,
+    RI,
+    urlquote,
+)
+from datalad.dochelpers import (
+    exc_str,
+    single_or_plural,
+)
+from datalad.utils import (
+    unique,
+    Path,
+)
 
-from .dataset import Dataset
-from .dataset import EnsureDataset
-from .dataset import datasetmethod
-from .clone import Clone
-from .utils import _get_flexible_source_candidates
-from .utils import _get_tracking_source
+from datalad.local.subdatasets import Subdatasets
+
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.distribution.clone import Clone
+from datalad.distribution.utils import _get_flexible_source_candidates
 
 __docformat__ = 'restructuredtext'
 
@@ -145,7 +154,7 @@ def _install_subds_from_flexible_source(
         ds, sm_path, sm_url)
 
     # prevent inevitable exception from `clone`
-    dest_path = opj(ds.path, sm_path)
+    dest_path = op.join(ds.path, sm_path)
     clone_urls = [src for src in clone_urls if src != dest_path]
 
     if not clone_urls:
@@ -247,15 +256,11 @@ def _install_necessary_subdatasets(
     path: str
     reckless: bool
     """
-
-    def subds_result_filter(res):
-        return res.get('status') == 'ok' and res.get('type') == 'dataset'
-
     # figuring out what dataset to start with, --contains limits --recursive
     # to visit only subdataset on the trajectory to the target path
     subds_trail = ds.subdatasets(contains=path, recursive=True,
                                  on_failure="ignore",
-                                 result_filter=subds_result_filter)
+                                 result_filter=is_ok_dataset)
     if not subds_trail:
         # there is not a single known subdataset (installed or not)
         # for this path -- job done
@@ -269,7 +274,7 @@ def _install_necessary_subdatasets(
         try:
             sd = _install_subds_from_flexible_source(
                 Dataset(cur_subds['parentds']),
-                relpath(cur_subds['path'], start=cur_subds['parentds']),
+                op.relpath(cur_subds['path'], start=cur_subds['parentds']),
                 cur_subds['gitmodule_url'],
                 reckless,
                 description=description)
@@ -291,7 +296,7 @@ def _install_necessary_subdatasets(
         # the target path
         subds_trail = sd.subdatasets(contains=path, recursive=False,
                                      on_failure='ignore',
-                                     result_filter=subds_result_filter)
+                                     result_filter=is_ok_dataset)
         if not subds_trail:
             # no (newly available) subdataset get's us any closer
             return
@@ -305,16 +310,16 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
         return
     # install using helper that give some flexibility regarding where to
     # get the module from
+
     for sub in ds.subdatasets(
-            return_type='generator', result_renderer='disabled'):
+            path=start,
+            return_type='generator',
+            result_renderer='disabled'):
         subds = Dataset(sub['path'])
         if sub.get('gitmodule_datalad-recursiveinstall', '') == 'skip':
             lgr.debug(
                 "subdataset %s is configured to be skipped on recursive installation",
                 sub['path'])
-            continue
-        if start is not None and not path_is_subpath(subds.path, start):
-            # this one we can ignore, not underneath the start path
             continue
         if sub.get('state', None) != 'absent':
             # dataset was already found to exist
@@ -328,7 +333,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
             try:
                 subds = _install_subds_from_flexible_source(
                     ds,
-                    relpath(sub['path'], start=ds.path),
+                    op.relpath(sub['path'], start=ds.path),
                     sub['gitmodule_url'],
                     reckless,
                     description=description)
@@ -350,6 +355,146 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                 reckless=reckless,
                 refds_path=refds_path):
             yield res
+
+
+def _install_targetpath(
+        ds,
+        target_path,
+        recursive,
+        recursion_limit,
+        reckless,
+        refds_path,
+        description):
+    """Helper to install as many subdatasets as needed to verify existence
+    of a target path
+
+    Parameters
+    ==========
+    ds : Dataset
+      Locally available dataset that contains the target path
+    target_path : Path
+    """
+    # if it is an empty dir, it could still be a subdataset that is missing
+    if (target_path.is_dir() and any(target_path.iterdir())) or \
+            (not target_path.is_dir()
+             and (target_path.is_symlink() or target_path.exists())):
+        yield dict(
+            action='get',
+            type='dataset',
+            path=ds.path,
+            status='notneeded',
+            contains=[target_path],
+        )
+    else:
+        # we don't have it yet. is it in a subdataset?
+        for res in _install_necessary_subdatasets(
+                ds, target_path, reckless, refds_path, description=description):
+            if (target_path.is_symlink() or target_path.exists()):
+                # this dataset brought the path, mark for annex
+                # processing outside
+                res['contains'] = [target_path]
+            # just spit it out
+            yield res
+        if not (target_path.is_symlink() or target_path.exists()):
+            # looking for subdatasets did not help -> all hope is lost
+            yield dict(
+                action='get',
+                path=str(target_path),
+                status='impossible',
+                message='path does not exist',
+            )
+            return
+    # we have the target path
+    if not (recursive
+            #and not recursion_limit == 'existing' \
+            and target_path.is_dir()):
+        # obtain any subdatasets underneath the paths given
+        # a non-directory cannot have content underneath
+        return
+    if recursion_limit == 'existing':
+        for res in ds.subdatasets(
+                fulfilled=True,
+                path=target_path,
+                recursive=recursive,
+                recursion_limit=recursion_limit,
+                return_type='generator'):
+            res.update(
+                contains=[Path(res['path'])],
+                action='get',
+                status='notneeded',
+            )
+            yield res
+        return
+    lgr.info(
+        "Installing %s%s recursively",
+        ds,
+        (" underneath %s" % target_path
+         if ds.path != target_path
+         else ""))
+    for res in _recursive_install_subds_underneath(
+            ds,
+            # target_path was explicitly given as input
+            # we count recursions from the input, hence we
+            # can start with the full number
+            recursion_limit,
+            reckless,
+            # TODO keep Path when RF is done
+            start=str(target_path),
+            refds_path=refds_path,
+            description=description):
+        # yield immediately so errors could be acted upon
+        # outside, before we continue
+        res.update(
+            action='get',
+            contains=[Path(res['path'])],
+        )
+        yield res
+
+
+def _get_targetpaths(ds, content, refds_path, source, jobs):
+    # not ready for Path instances...
+    content = [str(c) for c in content]
+    # hand over to git-annex, get files content,
+    # report files in git as 'notneeded' to get
+    ds_repo = ds.repo
+    # needs to be an annex to get content
+    if not isinstance(ds_repo, AnnexRepo):
+        for r in results_from_paths(
+                content, status='notneeded',
+                message="no dataset annex, content already present",
+                action='get', logger=lgr,
+                refds=refds_path):
+            yield r
+        return
+    respath_by_status = {}
+    for res in ds_repo.get(
+            content,
+            options=['--from=%s' % source] if source else [],
+            jobs=jobs):
+        res = annexjson2result(res, ds, type='file', logger=lgr,
+                               refds=refds_path)
+        success = success_status_map[res['status']]
+        # TODO: in case of some failed commands (e.g. get) there might
+        # be no path in the record.  yoh has only vague idea of logic
+        # here so just checks for having 'path', but according to
+        # results_from_annex_noinfo, then it would be assumed that
+        # `content` was acquired successfully, which is not the case
+        if 'path' in res:
+            respath_by_status[success] = \
+                respath_by_status.get(success, []) + [res['path']]
+        yield res
+
+    for r in results_from_annex_noinfo(
+            ds,
+            content,
+            respath_by_status,
+            dir_fail_msg='could not get some content in %s %s',
+            noinfo_dir_msg='nothing to get from %s',
+            noinfo_file_msg='already present',
+            action='get',
+            logger=lgr,
+            refds=refds_path):
+        yield r
 
 
 @build_doc
@@ -417,15 +562,7 @@ class Get(Interface):
             for file handles from being obtained CMD]"""),
         description=location_description,
         reckless=reckless_opt,
-        # git_opts=git_opts,
-        # annex_opts=annex_opts,
-        # annex_get_opts=annex_get_opts,
-        jobs=jobs_opt,
-        verbose=verbose)
-
-    # Note: May be use 'git annex find --not --in here' to have a list of all
-    # files to actually get and give kind of a progress in terms of number
-    # files processed ...
+        jobs=jobs_opt)
 
     @staticmethod
     @datasetmethod(name='get')
@@ -439,21 +576,8 @@ class Get(Interface):
             get_data=True,
             description=None,
             reckless=False,
-            #git_opts=None,
-            #annex_opts=None,
-            #annex_get_opts=None,
             jobs='auto',
-            verbose=False,
     ):
-        # IMPLEMENTATION CONCEPT:
-        #
-        # 1. Sort the world into existing handles and the rest
-        # 2. Try locate missing handles (obtain subdatasets along the way)
-        # 3. Expand into subdatasets with recursion enables (potentially
-        #    obtain even more subdatasets
-        # 4. Shoot info of which handles to get in each subdataset to,
-        #    git-annex, once at the very end
-
         refds_path = Interface.get_refds_path(dataset)
         if not (dataset or path):
             raise InsufficientArgumentsError(
@@ -462,200 +586,112 @@ class Get(Interface):
             # act on the whole dataset if nothing else was specified
             path = refds_path
 
-        # remember which results we already reported, to avoid duplicates
-        yielded_ds = []
-        to_get = []
-        unavailable_paths = []
-        for ap in AnnotatePaths.__call__(
-                path=path,
-                dataset=refds_path,
+        # we have to have a single dataset to operate on
+        refds = require_dataset(
+            dataset, check_installed=True, purpose='get content')
+
+        content_by_ds = {}
+        # use subdatasets() to discover any relevant content that is not
+        # already present in the root dataset (refds)
+        for sdsres in Subdatasets.__call__(
+                contains=path,
+                # maintain path argument semantics and pass in dataset arg
+                # as is
+                dataset=dataset,
+                # always come from the top to get sensible generator behavior
+                bottomup=False,
                 recursive=recursive,
                 recursion_limit=recursion_limit,
-                action='get',
-                # NOTE: Do not act upon unavailable paths yet! Done below after
-                # testing which ones could be obtained
-                unavailable_path_status='',
-                nondataset_path_status='impossible',
                 return_type='generator',
                 on_failure='ignore'):
-            if ap.get('status', None):
-                # we know what to report already
-                yield ap
+            if sdsres.get('type', None) != 'dataset':
+                # if it is not about a 'dataset' it is likely content in
+                # the root dataset
+                if sdsres.get('status', None) == 'impossible' and \
+                        sdsres.get('message', None) == \
+                        'path not contained in any matching subdataset':
+                    target_path = Path(sdsres['path'])
+                    if refds.pathobj != target_path and \
+                            refds.pathobj not in target_path.parents:
+                        yield dict(
+                            action='get',
+                            path=str(target_path),
+                            status='error',
+                            message=('path not associated with dataset',
+                                     refds),
+                        )
+                        continue
+                    # check if we need to obtain anything underneath this path
+                    # the subdataset() call above will only look _until_ it
+                    # hits the targetpath
+                    for res in _install_targetpath(
+                            refds,
+                            Path(sdsres['path']),
+                            recursive,
+                            recursion_limit,
+                            reckless,
+                            refds_path,
+                            description):
+                        # fish out the datasets that 'contains' a targetpath
+                        # and store them for later
+                        if res.get('status', None) in ('ok', 'notneeded') and \
+                                'contains' in res:
+                            dsrec = content_by_ds.get(res['path'], set())
+                            dsrec.update(res['contains'])
+                            content_by_ds[res['path']] = dsrec
+                        if res.get('status', None) != 'notneeded':
+                            # all those messages on not having installed anything
+                            # are a bit pointless
+                            # "notneeded" for annex get comes below
+                            yield res
+                else:
+                    # dunno what this is, send upstairs
+                    yield sdsres
+                # must continue for both conditional branches above
+                # the rest is about stuff in real subdatasets
                 continue
-            if ap.get('state', None) == 'absent' and ap.get('raw_input', False):
-                # if this wasn't found, but directly requested, queue for further
-                # exploration
-                unavailable_paths.append(ap)
-                continue
-            if ap.get('type', None) == 'dataset' and \
-                    GitRepo.is_valid_repo(ap['path']) and \
-                    not ap['path'] == refds_path:
-                # do not report what hasn't arived yet
-                # also do not report the base dataset that is already
-                # present -- no surprise
-                yield dict(ap, status='notneeded', logger=lgr,
-                           message='already installed')
-                yielded_ds.append(ap['path'])
-                ap['process_content'] = get_data
-            to_get.append(ap)
-
-        # explore the unknown
-        for ap in sorted(unavailable_paths, key=lambda x: x['path']):
-            lgr.debug("Investigate yet unavailable path %s", ap)
-            # how close can we get?
-            dspath = ap.get('parentds', get_dataset_root(ap['path']))
-            if dspath is None:
-                # nothing we can do for this path
-                continue
-            lgr.debug("Found containing dataset %s for path %s", dspath, ap['path'])
-            ds = Dataset(dspath)
-            # now actually obtain whatever is necessary to get to this path
-            containing_ds = [dspath]
-            for res in _install_necessary_subdatasets(
-                    ds, ap['path'], reckless, refds_path, description=description):
-                # yield immediately so errors could be acted upon outside, before
-                # we continue
-                if not (res['type'] == 'dataset' and res['path'] in yielded_ds):
-                    # unless we reported on this dataset before
-                    if res['type'] == 'dataset':
-                        # make a record, recursive below might now want to report
-                        # a 'notneeded'
-                        yielded_ds.append(res['path'])
-                    yield res
-                # update to the current innermost dataset
-                containing_ds.append(res['path'])
-
-            if len(containing_ds) < 2:
-                # no subdataset was installed, hence if the path was unavailable
-                # before it still is, no need to bother git annex
-                ap.update(status='impossible',
-                          message='path does not exist')
-                yield ap
-                continue
-            # important to only do the next for the innermost subdataset
-            # as the `recursive` logic below relies on that!
-            # set the correct parent, for a dataset this would be the second-last
-            # reported subdataset
-            ap.update(parentds=containing_ds[-1])
-            if containing_ds[-1] == ap['path']:
-                # the path actually refers to the last installed dataset
-                ap.update(parentds=containing_ds[-2],
-                          process_content=get_data,
-                          type='dataset')
-            to_get.append(ap)
-
-        # results of recursive installation of yet undiscovered datasets
-        rec_get = []
-        if recursive and not recursion_limit == 'existing':
-            # obtain any subdatasets underneath the paths given inside the
-            # subdatasets that we know already exist
-            # unless we do not want recursion into not-yet-installed datasets
-            for ap in sorted(to_get, key=lambda x: x['path']):
-                if ap['type'] not in ('dataset', 'directory') or not ap.get('raw_input', False):
-                    # a non-directory cannot have content underneath
-                    # also we do NOT want to recurse into anything that was specifically
-                    # requested, to avoid duplication
-                    continue
-                subds = Dataset(ap['path'] if ap['type'] == 'dataset' else ap['parentds'])
-                lgr.info(
-                    "Installing %s%s recursively",
-                    subds,
-                    (" underneath %s" % ap['path']
-                     if subds.path != ap['path']
-                     else ""))
-                for res in _recursive_install_subds_underneath(
-                        subds,
-                        # `ap['path']` was explicitly given as input
-                        # we count recursions from the input, hence we
-                        # can start with the full number
+            # instance of the closest existing dataset for this result
+            ds = Dataset(sdsres['parentds']
+                         if sdsres.get('state', None) == 'absent'
+                         else sdsres['path'])
+            assert 'contains' in sdsres
+            # explore the unknown
+            for target_path in sdsres.get('contains', []):
+                # essentially the same as done above for paths in the root
+                # dataset, but here we are starting from the closest
+                # discovered subdataset
+                for res in _install_targetpath(
+                        ds,
+                        Path(target_path),
+                        recursive,
                         recursion_limit,
                         reckless,
-                        start=ap['path'],
-                        refds_path=refds_path,
-                        description=description):
-                    # yield immediately so errors could be acted upon
-                    # outside, before we continue
-                    if not (res['type'] == 'dataset' and res['path'] in yielded_ds):
-                        # unless we reported on this dataset before
-                        if res['type'] == 'dataset':
-                            # make a record
-                            yielded_ds.append(res['path'])
-                    yield res
-                    if not (res['status'] == 'ok' and res['type'] == 'dataset'):
-                        # not a dataset that was just installed, we just reported it
-                        # upstairs, and can ignore it from now on
-                        continue
-                    # paranoia, so popular these days...
-                    assert GitRepo.is_valid_repo(res['path'])
-                    # keep a copy of the install record for `get` later on
-                    get_ap = {k: v for k, v in res.items()
-                              if not k == 'status'}
-                    get_ap['process_content'] = get_data
-                    rec_get.append(get_ap)
+                        refds_path,
+                        description):
+                    if res.get('status', None) in ('ok', 'notneeded') and \
+                            'contains' in res:
+                        dsrec = content_by_ds.get(res['path'], set())
+                        dsrec.update(res['contains'])
+                        content_by_ds[res['path']] = dsrec
+                    if res.get('status', None) != 'notneeded':
+                        # all those messages on not having installed anything
+                        # are a bit pointless
+                        # "notneeded" for annex get comes below
+                        yield res
 
         if not get_data:
             # done already
             return
 
-        # merge the two AP lists
-        to_get.extend(rec_get)
-
-        # sort into datasets
-        content_by_ds, ds_props, completed, nondataset_paths = \
-            annotated2content_by_ds(
-                to_get,
-                refds_path=refds_path)
-        assert(not completed)
-
-        # hand over to git-annex, get files content,
-        # report files in git as 'notneeded' to get
-        for ds_path in sorted(content_by_ds.keys()):
-            ds = Dataset(ds_path)
-            ds_repo = ds.repo
-            # grab content, ignore subdataset entries
-            content = [ap['path'] for ap in content_by_ds[ds_path]
-                       if ap.get('type', None) != 'dataset' or ap['path'] == ds.path]
-            if not content:
-                # cut this short should there be nothing
-                continue
-            # needs to be an annex to get content
-            if not isinstance(ds_repo, AnnexRepo):
-                for r in results_from_paths(
-                        content, status='notneeded',
-                        message="no dataset annex, content already present",
-                        action='get', logger=lgr,
-                        refds=refds_path):
-                    yield r
-                continue
-            respath_by_status = {}
-            for res in ds_repo.get(
+        # and now annex-get, this could all be done in parallel now
+        for ds, content in content_by_ds.items():
+            for res in _get_targetpaths(
+                    Dataset(ds),
                     content,
-                    options=['--from=%s' % source] if source else [],
-                    jobs=jobs):
-                res = annexjson2result(res, ds, type='file', logger=lgr,
-                                       refds=refds_path)
-                success = success_status_map[res['status']]
-                # TODO: in case of some failed commands (e.g. get) there might
-                # be no path in the record.  yoh has only vague idea of logic
-                # here so just checks for having 'path', but according to
-                # results_from_annex_noinfo, then it would be assumed that
-                # `content` was acquired successfully, which is not the case
-                if 'path' in res:
-                    respath_by_status[success] = \
-                        respath_by_status.get(success, []) + [res['path']]
+                    refds.path,
+                    source,
+                    jobs):
                 yield res
-
-            for r in results_from_annex_noinfo(
-                    ds,
-                    content,
-                    respath_by_status,
-                    dir_fail_msg='could not get some content in %s %s',
-                    noinfo_dir_msg='nothing to get from %s',
-                    noinfo_file_msg='already present',
-                    action='get',
-                    logger=lgr,
-                    refds=refds_path):
-                yield r
 
     @staticmethod
     def custom_result_summary_renderer(res):

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -663,7 +663,7 @@ def test_install_recursive_repeat(src, path):
     ok_(subsub.is_installed() is False)
 
     # install again, now with data and recursive, but recursion_limit 1:
-    result = get(os.curdir, dataset=path, recursive=True, recursion_limit=1,
+    result = get(path, dataset=path, recursive=True, recursion_limit=1,
                  result_xfm='datasets')
     # top-level dataset was not reobtained
     assert_not_in(top_ds, result)
@@ -695,12 +695,15 @@ def test_install_skip_list_arguments(src, path, path_outside):
     # good and bad results together
     ok_(isinstance(result, list))
     eq_(len(result), 4)
-    # check that we have an 'impossible' status for both invalid args
+    # check that we have an 'impossible/error' status for both invalid args
     # but all the other tasks have been accomplished
-    for skipped, msg in [(opj(ds.path, 'not_existing'), "path does not exist"),
-                         (path_outside, "path not associated with any dataset")]:
-        assert_result_count(
-            result, 1, status='impossible', message=msg, path=skipped)
+    assert_result_count(
+        result, 1, status='impossible', message="path does not exist",
+        path=opj(ds.path, 'not_existing'))
+    assert_result_count(
+        result, 1, status='error',
+        message=("path not associated with dataset", ds),
+        path=path_outside)
     for sub in [Dataset(opj(path, 'subm 1')), Dataset(opj(path, '2'))]:
         assert_result_count(
             result, 1, status='ok',

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -466,7 +466,8 @@ def test_remove_recursive_2(tdir):
     # fails in some cases https://github.com/datalad/datalad/issues/1573
     with chpwd(tdir):
         install('///labs')
-        install('labs/tarr/face_place')
+        with chpwd('labs'):
+            install('tarr/face_place')
         remove(dataset='labs', recursive=True)
 
 

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -275,7 +275,8 @@ def is_result_matching_pathsource_argument(res, **kwargs):
     if respath in paths:
         # absolute match, pretty sure we want this
         return True
-    elif kwargs.get('dataset', None) and YieldRelativePaths()(res) in paths:
+    elif isinstance(kwargs.get('dataset', None), Dataset) and \
+            YieldRelativePaths()(res) in paths:
         # command was called with a reference dataset, and a relative
         # path of a result matches in input argument -- not 100% exhaustive
         # test, but could be good enough

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -365,8 +365,8 @@ def test_recurseinto(dspath, dest):
     # explicitly -- must get it installed
     dest = install(source=ds.path, path=dest)
     res = dest.get(['.', opj('b', 'bb')], get_data=False, recursive=True)
-    assert_result_count(res, 8)
-    assert_result_count(res, 8, type='dataset')
+    assert_result_count(res, 7)
+    assert_result_count(res, 7, type='dataset')
     assert_result_count(res, 1, type='dataset',
                         path=opj(dest.path, 'b', 'bb'))
     assert(Dataset(opj(dest.path, 'b', 'bb')).is_installed())

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -754,6 +754,7 @@ def test_run_inputs_outputs(src, path):
                         strip=True)
 
 
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_run_inputs_no_annex_repo(path):
     ds = Dataset(path).create(no_annex=True)

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -67,6 +67,7 @@ from datalad.tests.utils import (
     assert_not_in,
     swallow_logs,
     swallow_outputs,
+    known_failure,
     known_failure_appveyor,
     known_failure_windows,
     known_failure_githubci_win,
@@ -582,6 +583,8 @@ def test_rerun_script(path):
                   cmout.getvalue().splitlines())
 
 
+# https://github.com/datalad/datalad/pull/3746#issuecomment-538425192
+@known_failure
 @slow  # ~10s
 @known_failure_githubci_win
 @known_failure_appveyor

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -583,8 +583,6 @@ def test_rerun_script(path):
                   cmout.getvalue().splitlines())
 
 
-# https://github.com/datalad/datalad/pull/3746#issuecomment-538425192
-@known_failure
 @slow  # ~10s
 @known_failure_githubci_win
 @known_failure_appveyor

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -403,10 +403,7 @@ def _dump_extracted_metadata(agginto_ds, aggfrom_ds, db, to_save, force_extracti
         # make sure all the to-be-moved metadata records are present
         # locally
         aggfrom_ds.get(
-            # prep annotated path records to speed up the call
-            path=[dict(path=op.join(aggfrom_ds.path, p),
-                       parentds=aggfrom_ds.path,
-                       type='file')
+            path=[op.join(aggfrom_ds.path, p)
                   for p in objrelpaths.values()],
             result_renderer='disabled')
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -290,8 +290,7 @@ def query_aggregated_metadata(reporton, ds, aps, recursive=False,
             'Verifying/achieving local availability of %i metadata objects',
             len(objfiles))
         if objfiles:
-            get(path=[dict(path=op.join(agg_base_path, of),
-                           parentds=ds.path, type='file')
+            get(path=[op.join(agg_base_path, of)
                       for of in objfiles if of],
                 dataset=ds,
                 result_renderer='disabled')


### PR DESCRIPTION
This sits on top of gh-3746 and should fix the run failures (including hopefully the Windows one; edit: that was [too hopeful][1]).  Here's the [restricted diff][0].  This series could be merged into that PR or merged into master following that PR.  Or, if desired, I can separate this series from that one, though there will end up being at least be some minor conflicts to deal with.

This fixes gh-3551.  The added test, based off of the examples in that issue, will run on Windows, so it might need a compatibility fixup.

[0]: https://github.com/datalad/datalad/compare/89467b9c4ef12bba69e8212941fb9df6ea53091c...kyleam:run-go-unbound

[1]:  https://github.com/datalad/datalad/pull/3747/checks?check_run_id=248506600#step:8:374