### PR TITLE
BF: create() path semantics (fixes gh-3748)

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -197,7 +197,7 @@ class Create(Interface):
                                  "no annex repo.")
 
         if path:
-            path = rev_resolve_path(path, ds)
+            path = rev_resolve_path(path, dataset)
 
         path = path if path \
             else getpwd() if ds is None \


### PR DESCRIPTION
Now with a more comprehensive test.