### PR TITLE
Introduce datalad.log.result-level config switch

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -192,6 +192,17 @@ definitions = {
             'title': 'Used for control the verbosity of logs printed to '
                      'stdout while running datalad commands/debugging'}),
     },
+    'datalad.log.result-level': {
+        'ui': ('question', {
+               'title': 'Log level for command result messages',
+               'text': "Overrides the default behavior of logging 'impossible' "
+                       "results as a warning, 'error' results as errors, and "
+                       "everything else as 'debug' with a single alternative "
+                       "log level"}),
+        'type': EnsureChoice('debug', 'info', 'warning', 'error'),
+        # None keeps the default behavior
+        'default': 'None',
+    },
     'datalad.log.name': {
         'ui': ('question', {
             'title': 'Include name of the log target in the log line'}),

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -332,6 +332,8 @@ def eval_results(func):
         # TODO remove this conditional branch entirely, done outside
         if not result_renderer:
             result_renderer = dlcfg.get('datalad.api.result-renderer', None)
+        # look for potential override of logging behavior
+        result_log_level = dlcfg.get('datalad.log.result-level', None)
         # wrap the filter into a helper to be able to pass additional arguments
         # if the filter supports it, but at the same time keep the required interface
         # as minimal as possible. Also do this here, in order to avoid this test
@@ -400,6 +402,7 @@ def eval_results(func):
                             _func_class, action_summary,
                             on_failure, incomplete_results,
                             result_renderer, result_xfm, result_filter,
+                            result_log_level,
                             **_kwargs):
                         yield r
 
@@ -414,7 +417,8 @@ def eval_results(func):
                     wrapped(*_args, **_kwargs),
                     _func_class, action_summary,
                     on_failure, incomplete_results,
-                    result_renderer, result_xfm, _result_filter, **_kwargs):
+                    result_renderer, result_xfm, _result_filter,
+                    result_log_level, **_kwargs):
                 yield r
                 # collect if summary is desired
                 if do_custom_result_summary:
@@ -432,7 +436,7 @@ def eval_results(func):
                             _func_class, action_summary,
                             on_failure, incomplete_results,
                             result_renderer, result_xfm, result_filter,
-                            **_kwargs):
+                            result_log_level, **_kwargs):
                         yield r
 
             # result summary before a potential exception
@@ -504,7 +508,8 @@ def default_result_renderer(res):
 def _process_results(
         results, cmd_class,
         action_summary, on_failure, incomplete_results,
-        result_renderer, result_xfm, result_filter, **kwargs):
+        result_renderer, result_xfm, result_filter,
+        result_log_level, **kwargs):
     # private helper pf @eval_results
     # loop over results generated from some source and handle each
     # of them according to the requested behavior (logging, rendering, ...)
@@ -525,7 +530,11 @@ def _process_results(
         res_lgr = res.pop('logger', None)
         if isinstance(res_lgr, logging.Logger):
             # didn't get a particular log function, go with default
-            res_lgr = getattr(res_lgr, default_logchannels[res['status']])
+            res_lgr = getattr(
+                res_lgr,
+                default_logchannels[res['status']]
+                if result_log_level is None
+                else result_log_level)
         if res_lgr and 'message' in res:
             msg = res['message']
             msgargs = None

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -523,19 +523,20 @@ def _process_results(
         if res['status']:
             actsum[res['status']] = actsum.get(res['status'], 0) + 1
             action_summary[res['action']] = actsum
-        ## log message, if a logger was given
+        ## log message, if there is one and a logger was given
+        msg = res.get('message', None)
         # remove logger instance from results, as it is no longer useful
         # after logging was done, it isn't serializable, and generally
         # pollutes the output
         res_lgr = res.pop('logger', None)
-        if isinstance(res_lgr, logging.Logger):
-            # didn't get a particular log function, go with default
-            res_lgr = getattr(
-                res_lgr,
-                default_logchannels[res['status']]
-                if result_log_level is None
-                else result_log_level)
-        if res_lgr and 'message' in res:
+        if msg and res_lgr:
+            if isinstance(res_lgr, logging.Logger):
+                # didn't get a particular log function, go with default
+                res_lgr = getattr(
+                    res_lgr,
+                    default_logchannels[res['status']]
+                    if result_log_level is None
+                    else result_log_level)
             msg = res['message']
             msgargs = None
             if isinstance(msg, tuple):


### PR DESCRIPTION
Setting this will cause messages included in command results (which are independently rendered as part of a result) to go to the identified log level (debug, info, warning, error). This can be used to alter the default behavior to have 'impossible' results cause a 'warning' log message and 'error' results yield an 'error' log message.

The default setup leads to cluttered output and double messaging. Setting this switch to 'debug' hides all result logging and emphasizes final results over intermediate events (where an 'error' may or may not be an indication of a problem in the big picture of a command execution).

- [x] fixes gh-3752

Exemplary impact:

was
```
% datalad install http://example.com/nothere
[INFO   ] Cloning http://example.com/nothere [1 other candidates] into '/tmp/nothere' 
[ERROR  ] Failed to clone from any candidate source URL. Encountered errors per each url were: (OrderedDict([('http://example.com/nothere', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://example.com/nothere /tmp/nothere [cmd.py:wait:412]"), ('http://example.com/nothere/.git', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://example.com/nothere/.git /tmp/nothere [cmd.py:wait:412]")]),) [install(/tmp/nothere)] 
install(error): /tmp/nothere (dataset) [Failed to clone from any candidate source URL. Encountered errors per each url were: (OrderedDict([('http://example.com/nothere', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://example.com/nothere /tmp/nothere [cmd.py:wait:412]"), ('http://example.com/nothere/.git', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://example.com/nothere/.git /tmp/nothere [cmd.py:wait:412]")]),)]
```

is

```
% datalad -c datalad.log.result-level=debug install http://example.com/nothere
[INFO   ] Cloning http://example.com/nothere [1 other candidates] into '/tmp/nothere' 
install(error): /tmp/nothere (dataset) [Failed to clone from any candidate source URL. Encountered errors per each url were: (OrderedDict([('http://example.com/nothere', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://example.com/nothere /tmp/nothere [cmd.py:wait:412]"), ('http://example.com/nothere/.git', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://example.com/nothere/.git /tmp/nothere [cmd.py:wait:412]")]),)]
```