### PR TITLE
ENH: publish - choose a remote with a url, ask interactively to clarify if multiple

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -570,14 +570,13 @@ def _test_target_ssh_inherit(standardgroup, ui, src_path, target_path):
         Dataset(opj(*([target_path] + ['sub'] * (i+1))))
         for i in range(nlevels)
     ]
-    # since we do not have yet/thus have not used an option to record to publish
-    # to that sibling by default (e.g. --set-upstream), if we run just ds.publish
-    # -- should fail
+    # since we have only a single sibling with a URL, we will publish to it
     assert_result_count(
         ds.publish(on_failure='ignore'),
         1,
-        status='impossible',
-        message='No target sibling configured for default publication, please specific via --to')
+        status='ok'
+    )
+
     ds.publish(to=remote)  # should be ok, non recursive; BUT it (git or us?) would
                   # create an empty sub/ directory
     assert_postupdate_hooks(target_path, installed=ui)


### PR DESCRIPTION
I think we should use capabilities of the interactive UI more, whenever we detect running in interactive mode.  E.g. so far I have not heard much of questions and WTF statements about e.g. export-to-figshare which is highly interactive.  But users do come back inquiring about various warnings and errors we spit out when cmdline specification is "not good enough".
So in this PR I am trying to resolve a specific complaint/question about unclear error `publish` reports whenever multiple remotes/siblings could be used for publishing.

- in the case where there is no tracking remote yet specified, I switched from considering remotes with `push` spec to remotes with a `url`.  Main rationale -- remotes established by `create-sibling` have no `push` refspec.

In the long run we should even consider **all** remotes, since publish could be intended to publish to special remotes (so there would be no tracking branch established etc).

- I also listed candidate remotes in the warning message (in case of non-interactive interface)

- ui import is delayed, since otherwise not used much in the publish. But I am ok to move it out


TODOs:
- [ ] targetted unittest
- [ ] reincarnate test for inability to publish when multiple remotes present, may be test added above could do that