### PR TITLE
ENH: create: assure cfg_proc is list

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -37,7 +37,10 @@ from datalad.support.constraints import (
     EnsureKeyChoice,
 )
 from datalad.support.param import Parameter
-from datalad.utils import getpwd
+from datalad.utils import (
+    getpwd,
+    assure_list,
+)
 
 from datalad.distribution.dataset import (
     Dataset,
@@ -205,6 +208,9 @@ class Create(Interface):
 
         # we know that we need to create a dataset at `path`
         assert(path is not None)
+
+        # assure cfg_proc is a list (relevant if used via Python API)
+        cfg_proc = assure_list(cfg_proc)
 
         # prep for yield
         res = dict(action='create', path=str(path),
@@ -426,7 +432,7 @@ class Create(Interface):
             _status=add_to_git,
         )
 
-        for cfg_proc_ in cfg_proc or []:
+        for cfg_proc_ in cfg_proc:
             for r in tbds.run_procedure('cfg_' + cfg_proc_):
                 yield r
 


### PR DESCRIPTION
This uses ``assure_list`` to ensure that ``cfg_proc`` is a list. Else, something like this happens when using the Python API and ``cfp_proc='<proc_name>'``

```python
create(path='/tmp/t8', cfg_proc='text2git')                                                     
[INFO   ] Creating a new annex repo at /tmp/t8 
[WARNING] Cannot find procedure with name 'cfg_t' [run_procedure(cfg_t)]                                
```
