### PR TITLE
OPT: Half the number of for-each-ref calls in GitRepo.is_with_annex()

### DIFF
--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -53,9 +53,9 @@ lgr = logging.getLogger('datalad.local.subdatasets')
 valid_key = re.compile(r'^[A-Za-z][-A-Za-z0-9]*$')
 
 
-def _parse_git_submodules(ds, paths):
+def _parse_git_submodules(ds_pathobj, repo, paths):
     """All known ones with some properties"""
-    if not (ds.pathobj / ".gitmodules").exists():
+    if not (ds_pathobj / ".gitmodules").exists():
         # easy way out. if there is no .gitmodules file
         # we cannot have (functional) subdatasets
         return
@@ -63,22 +63,22 @@ def _parse_git_submodules(ds, paths):
     if paths:
         paths_outside, paths_at_or_in = partition(
             paths,
-            lambda p: ds.pathobj == p or ds.pathobj in p.parents)
-        paths = [p.relative_to(ds.pathobj) for p in paths_at_or_in]
+            lambda p: ds_pathobj == p or ds_pathobj in p.parents)
+        paths = [p.relative_to(ds_pathobj) for p in paths_at_or_in]
         if not paths:
-            if any(p for p in paths_outside if p in ds.pathobj.parents):
+            if any(p for p in paths_outside if p in ds_pathobj.parents):
                 # The dataset is directly under some specified path, so include
                 # it.
                 paths = None
             else:
                 # we had path contraints, but none matched this dataset
                 return
-    for props in ds.repo.get_submodules_(paths=paths):
+    for props in repo.get_submodules_(paths=paths):
         path = props["path"]
         if props.get('type', None) != 'dataset':
             continue
-        if ds.pathobj != ds.repo.pathobj:
-            props['path'] = ds.pathobj / path.relative_to(ds.repo.pathobj)
+        if ds_pathobj != repo.pathobj:
+            props['path'] = ds_pathobj / path.relative_to(repo.pathobj)
         else:
             props['path'] = path
         if not path.exists() or not GitRepo.is_valid_repo(str(path)):
@@ -286,10 +286,11 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                     contains, bottomup, set_property, delete_property,
                     refds_path):
     dspath = ds.path
+    repo = ds.repo
     if not GitRepo.is_valid_repo(dspath):
         return
     # put in giant for-loop to be able to yield results before completion
-    for sm in _parse_git_submodules(ds, paths):
+    for sm in _parse_git_submodules(ds.pathobj, repo, paths):
         contains_hits = []
         if contains:
             contains_hits = [
@@ -308,7 +309,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
             # first deletions
             for dprop in assure_list(delete_property):
                 try:
-                    out, err = ds.repo._git_custom_command(
+                    out, err = repo._git_custom_command(
                         '', ['git', 'config', '--file', '.gitmodules',
                              '--unset-all',
                              'submodule.{}.{}'.format(sm['gitmodule_name'], dprop),
@@ -340,7 +341,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                                 sm['path'].relative_to(refds_path)
                             ).replace(os.sep, '-')))
                 try:
-                    out, err = ds.repo._git_custom_command(
+                    out, err = repo._git_custom_command(
                         '', ['git', 'config', '--file', '.gitmodules',
                              '--replace-all',
                              'submodule.{}.{}'.format(sm['gitmodule_name'], prop),
@@ -366,7 +367,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
 
                 # also add to the info we just read above
                 sm['gitmodule_{}'.format(prop)] = val
-            Dataset(dspath).save(
+            ds.save(
                 '.gitmodules', to_git=True,
                 message='[DATALAD] modified subdataset properties')
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -996,20 +996,13 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             self._cfg = ConfigManager(dataset=self, dataset_only=False)
         return self._cfg
 
-    def is_with_annex(self, only_remote=False):
-        """Return True if GitRepo (assumed) at the path has remotes with git-annex branch
-
-        Parameters
-        ----------
-        only_remote: bool, optional
-            Check only remote (no local branches) for having git-annex branch
+    def is_with_annex(self):
+        """Report if GitRepo (assumed) has (remotes with) a git-annex branch
         """
-        return any((b.endswith('/git-annex') or
-                    'annex/direct' in b
-                    for b in self.get_remote_branches())) or \
-            ((not only_remote) and
-             any((b == 'git-annex' or 'annex/direct' in b
-                  for b in self.get_branches())))
+        return any(
+            b['refname:strip=2'] == 'git-annex' or b['refname:strip=2'].endswith('/git-annex')
+            for b in self.for_each_ref_(fields='refname:strip=2', pattern=['refs/heads', 'refs/remotes'])
+        )
 
     @classmethod
     def get_toppath(cls, path, follow_up=True, git_options=None):


### PR DESCRIPTION
This addresses some aspect of gh-3766

It also removes an unused feature to limit the check to remote branches.
Even the crawler doesn't use it.

It also removes an explicit check for a direct mode related branch name,
that doesn't seem to be relevant, even for direct mode repos, and
@bpoldrack oldrack also had no memory on when exactly this could happen. Given
that we do not support it anymore, I decided to remove the additional
complexity.

Here is the updated profile (compare to https://github.com/datalad/datalad/issues/3766#issuecomment-540937940)

![image](https://user-images.githubusercontent.com/136479/66632273-5915b880-ec08-11e9-81a6-ba2766e21017.png)

```
       before           after         ratio
     [6ad8d02f]       [91bc32fa]
     <bm/merge-target>       <bm/pr>   
       1.75±0.07s       1.46±0.05s    ~0.83  api.supers.time_createadd
-      2.78±0.06s       1.89±0.04s     0.68  api.supers.time_createadd_to_dataset
       10.2±0.06s       7.55±0.02s    ~0.74  api.supers.time_installr
-        286±10ms          208±7ms     0.73  api.supers.time_ls
-      3.08±0.07s       2.17±0.01s     0.70  api.supers.time_ls_recursive
-      3.23±0.03s       2.37±0.02s     0.73  api.supers.time_ls_recursive_long_all
-        965±10ms          873±7ms     0.90  api.supers.time_status
-      2.01±0.05s       1.65±0.03s     0.82  api.supers.time_status_recursive
-         250±7ms          156±3ms     0.62  api.supers.time_subdatasets
-        795±20ms         537±10ms     0.68  api.supers.time_subdatasets_recursive
-         220±2ms          150±3ms     0.68  api.supers.time_subdatasets_recursive_first
       7.75±0.08s        4.92±0.1s    ~0.64  api.supers.time_uninstall
-        890±20ms         756±10ms     0.85  api.testds.time_create_test_dataset1
-      5.03±0.03s       4.31±0.05s     0.86  api.testds.time_create_test_dataset2x2
      2.22±0.06ms       2.28±0.1ms     1.03  core.runner.time_echo
      2.43±0.04ms      2.36±0.04ms     0.97  core.runner.time_echo_gitrunner
-            1.03             0.86     0.83  core.runner.track_overhead_100ms
+           63.58            85.15     1.34  core.runner.track_overhead_echo
-            6.55            -1.46    -0.22  core.runner.track_overhead_heavyout
-             3.9             3.22     0.83  core.runner.track_overhead_heavyout_online_process
-           28.16            25.04     0.89  core.runner.track_overhead_heavyout_online_through
         620±20ms         607±10ms     0.98  core.startup.time_help_np
          148±2ms          143±5ms     0.97  core.startup.time_import
          559±6ms         534±20ms     0.96  core.startup.time_import_api
       17.3±0.6ms         17.4±1ms     1.00  repo.gitrepo.time_get_content_info
       7.85±0.4ms       8.12±0.5ms     1.03  support.path.get_parent_paths.time_allsubmods_toplevel
       6.66±0.2ms       7.51±0.5ms    ~1.13  support.path.get_parent_paths.time_allsubmods_toplevel_only
         349±10ns         352±20ns     1.01  support.path.get_parent_paths.time_no_submods
       5.95±0.2ms       5.90±0.3ms     0.99  support.path.get_parent_paths.time_one_submod_subdir
       6.01±0.2ms       6.30±0.5ms     1.05  support.path.get_parent_paths.time_one_submod_toplevel
        33.9±0.2s       32.7±0.07s     0.97  usecases.study_forrest.time_make_studyforrest_mockup
```