### PR TITLE
BF(TST,workaround): do not use ; in the test archive filenames

### DIFF
--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -61,12 +61,11 @@ from ...utils import (
 from . import _get_custom_runner
 
 
-# both files will have the same content
-# fn_inarchive_obscure = 'test.dat'
-# fn_extracted_obscure = 'test2.dat'
-fn_inarchive_obscure = get_most_obscure_supported_name()
-fn_archive_obscure = fn_inarchive_obscure.replace('a', 'b') + '.tar.gz'
-fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
+from ...tests.test_archives import (
+    fn_in_archive_obscure,
+    fn_archive_obscure,
+    fn_archive_obscure_ext,
+)
 
 #import line_profiler
 #prof = line_profiler.LineProfiler()
@@ -76,13 +75,13 @@ fn_extracted_obscure = fn_inarchive_obscure.replace('a', 'z')
 # matching archive name, so it will be a/d/test.dat ... we don't want that probably
 @with_direct
 @with_tree(
-    tree=(('a.tar.gz', {'d': {fn_inarchive_obscure: '123'}}),
+    tree=(('a.tar.gz', {'d': {fn_in_archive_obscure: '123'}}),
           ('simple.txt', '123'),
-          (fn_archive_obscure, (('d', ((fn_inarchive_obscure, '123'),)),)),
-          (fn_extracted_obscure, '123')))
+          (fn_archive_obscure_ext, (('d', ((fn_in_archive_obscure, '123'),)),)),
+          (fn_archive_obscure, '123')))
 @with_tempfile()
 def test_basic_scenario(direct, d, d2):
-    fn_archive, fn_extracted = fn_archive_obscure, fn_extracted_obscure
+    fn_archive, fn_extracted = fn_archive_obscure_ext, fn_archive_obscure
     annex = AnnexRepo(d, runner=_get_custom_runner(d), direct=direct)
     annex.init_remote(
         ARCHIVES_SPECIAL_REMOTE,
@@ -91,7 +90,7 @@ def test_basic_scenario(direct, d, d2):
          ])
     assert annex.is_special_annex_remote(ARCHIVES_SPECIAL_REMOTE)
     # We want two maximally obscure names, which are also different
-    assert(fn_extracted != fn_inarchive_obscure)
+    assert(fn_extracted != fn_in_archive_obscure)
     annex.add(fn_archive)
     annex.commit(msg="Added tarball")
     annex.add(fn_extracted)
@@ -114,7 +113,7 @@ def test_basic_scenario(direct, d, d2):
 
     file_url = annexcr.get_file_url(
         archive_file=fn_archive,
-        file=fn_archive.replace('.tar.gz', '') + '/d/' + fn_inarchive_obscure)
+        file=fn_archive.replace('.tar.gz', '') + '/d/' + fn_in_archive_obscure)
 
     annex.add_url_to_file(fn_extracted, file_url, ['--relaxed'])
     annex.drop(fn_extracted)
@@ -165,7 +164,7 @@ def test_basic_scenario(direct, d, d2):
 
 
 @with_tree(
-    tree={'a.tar.gz': {'d': {fn_inarchive_obscure: '123'}}}
+    tree={'a.tar.gz': {'d': {fn_in_archive_obscure: '123'}}}
 )
 @known_failure_direct_mode  #FIXME
 def test_annex_get_from_subdir(topdir):
@@ -174,13 +173,13 @@ def test_annex_get_from_subdir(topdir):
     annex.add('a.tar.gz')
     annex.commit()
     add_archive_content('a.tar.gz', annex=annex, delete=True)
-    fpath = op.join(topdir, 'a', 'd', fn_inarchive_obscure)
+    fpath = op.join(topdir, 'a', 'd', fn_in_archive_obscure)
 
     with chpwd(op.join(topdir, 'a', 'd')):
         runner = Runner()
-        runner(['git', 'annex', 'drop', '--', fn_inarchive_obscure])  # run git annex drop
+        runner(['git', 'annex', 'drop', '--', fn_in_archive_obscure])  # run git annex drop
         assert_false(annex.file_has_content(fpath))             # and verify if file deleted from directory
-        runner(['git', 'annex', 'get', '--', fn_inarchive_obscure])   # run git annex get
+        runner(['git', 'annex', 'get', '--', fn_in_archive_obscure])   # run git annex get
         assert_true(annex.file_has_content(fpath))              # and verify if file got into directory
 
 

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -39,6 +39,17 @@ from .utils import (
 
 fn_in_archive_obscure = OBSCURE_FILENAME
 fn_archive_obscure = fn_in_archive_obscure.replace('a', 'b')
+# Debian sid version of python (3.7.5rc1) introduced a bug in mimetypes
+# Reported to cPython: https://bugs.python.org/issue38449
+import mimetypes
+mimedb = mimetypes.MimeTypes(strict=False)
+if None in mimedb.guess_type(fn_archive_obscure + '.tar.gz'):
+    from . import lgr
+    lgr.warning("Buggy Python mimetypes, replacing ; in archives test filename")
+    # fails to detect due to ;
+    fn_archive_obscure = fn_archive_obscure.replace(';', '-')
+    # verify
+    assert None not in mimedb.guess_type(fn_archive_obscure + '.tar.gz')
 fn_archive_obscure_ext = fn_archive_obscure + '.tar.gz'
 
 tree_simplearchive = dict(


### PR DESCRIPTION
Python issue: https://bugs.python.org/issue38449

Closes #3769 

TODO:
- [x] make datalad.customremotes.tests.test_archives.test_basic_scenario use that tricky name variable