### PR TITLE
ENH: More human readable error on clone failure

### DIFF
--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -279,8 +279,7 @@ def test_notclone_known_subdataset(src, path):
     # clone is not meaningful
     res = ds.clone('subm 1', on_failure='ignore')
     assert_status('error', res)
-    assert_message('Failed to clone from any candidate source URL. '
-                   'Encountered errors per each url were: %s',
+    assert_message('Failed to clone from all attempted sources: %s',
                    res)
     # get does the job
     res = ds.get(path='subm 1', get_data=False)
@@ -301,8 +300,7 @@ def test_failed_clone(dspath):
     res = ds.clone("http://nonexistingreallyanything.datalad.org/bla", "sub",
                    on_failure='ignore')
     assert_status('error', res)
-    assert_message('Failed to clone from any candidate source URL. '
-                   'Encountered errors per each url were: %s',
+    assert_message('Failed to clone from all attempted sources: %s',
                    res)
 
 


### PR DESCRIPTION
A very common reason for such an error is a simple typo in a URL. This change turns:

```
$ datalad install http://github/datalad/datalad-neuroimaging.git
install(error): /tmp/datalad-neuroimaging (dataset) [Failed to clone from any candidate source URL. Encountered errors per each url were: (OrderedDict([('http://github/datalad/datalad-neuroimaging.git', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://github/datalad/datalad-neuroimaging.git /tmp/datalad-neuroimaging [cmd.py:wait:418]"), ('http://github/datalad/datalad-neuroimaging.git/.git', "Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)\n  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://github/datalad/datalad-neuroimaging.git/.git /tmp/datalad-neuroimaging [cmd.py:wait:418]")]),)]
```

which is verbose, but highly redundant and ultimately not very unformative, into

```
$ datalad install http://github/datalad/datalad-neuroimaging.git
install(error): /tmp/datalad-neuroimaging (dataset) [Failed to clone from all attempted sources: ['http://github.com/datalad/datalad-neuroimaging.git', 'http://github.com/datalad/datalad-neuroimaging.git/.git']]
```

which is arguably more likely to help a user realize what was happening and hence fixes gh-3380

In case a more informative exception is encountered (has stderr or stdout), the output would be something like:

```
install(error): /tmp/datalad-neuroimaging (dataset) [Failed to clone from any candidate source URL. Encountered errors per each url were:
- http://github.com/datalad/datalad-neuroimaging.git
  Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(1)
  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://github.com/datalad/datalad-neuroimaging.git /tmp/datalad-neuroimaging
- http://github.com/datalad/datalad-neuroimaging.git/.git
  Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(1)
  cmdline: /usr/lib/git-annex.linux/git clone --progress -v http://github.com/datalad/datalad-neuroimaging.git/.git /tmp/datalad-neuroimaging]
```

although I was not able to get `clone` to actually produce such an exception. But it doesn't cost much, so let's keep it in.

Note that the above output is conditioned upon `datalad.log.result-level=debug`. In the default case, the error is shown twice in identical form, as before and requested by https://github.com/datalad/datalad/issues/3752#issuecomment-538664929 until something better is available.

@adswa Once this is merged, we can update https://github.com/datalad-handbook/book/blame/master/docs/basics/101-135-help.rst#L169 to the new error message