### PR TITLE
RF: Make SSHConnection.open() errors actionable for callers()

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -331,6 +331,9 @@ class InstallFailedError(CommandError):
     pass
 
 
+class ConnectionOpenFailedError(CommandError):
+    """Exception to raise whenever opening a network connection fails"""
+    pass
 #
 # Downloaders
 #

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -27,7 +27,10 @@ from shlex import quote as sh_quote
 # on initial import datalad time
 # from datalad.support.network import RI, is_ssh
 
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CommandError,
+    ConnectionOpenFailedError,
+)
 from datalad.dochelpers import exc_str
 from datalad.utils import (
     auto_repr,
@@ -244,7 +247,7 @@ class SSHConnection(object):
 
         Raises
         ------
-        CommandError
+        ConnectionOpenFailedError
           When starting the SSH ControlMaster process failed.
         """
         # the socket should vanish almost instantly when the connection closes
@@ -275,7 +278,7 @@ class SSHConnection(object):
         exit_code = proc.wait()
 
         if exit_code != 0:
-            raise CommandError(
+            raise ConnectionOpenFailedError(
                 str(cmd),
                 'Failed to open SSH connection (could not start ControlMaster process)',
                 exit_code,

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -240,8 +240,7 @@ class SSHConnection(object):
         -------
         bool
           True when SSH reports success opening the connection, False when
-          the connection when a ControlMaster for an open connection already
-          exists.
+          a ControlMaster for an open connection already exists.
 
         Raises
         ------


### PR DESCRIPTION
Changes the return value semantics (see inside) and raises `CommandError` when no ControlMaster can be started. This enables to act on error on the caller side without causing spurious
warnings.

It turns the output given in gh-3450:

```
% datalad publish --to bareremote --transfer-data all
mih@datalad-test: Permission denied (publickey,password).
[WARNING] Failed to run cmd ['ssh', '-fN', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=15m', '-o', 'ControlPath=/home/mih/.cache/datalad/sockets/c5820c82', 'datalad-test']. Exit code=255
| stdout: None
| stderr: None
[ERROR  ] Cmd('/usr/lib/git-annex.linux/git') failed due to: exit code(128)
|   cmdline: /usr/lib/git-annex.linux/git fetch --progress -v bareremote
|   stderr: 'fatal: Could not read from remote repository.
|
| Please make sure you have the correct access rights
| and the repository exists.' [cmd.py:wait:412] (GitCommandError)
```

into a leaner, easier to comprehend

```
% datalad publish --to bareremote --transfer-data all
mih@datalad-test: Permission denied (publickey,password).
CommandError: command '['ssh', '-fN', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=15m', '-o', 'ControlPath=/home/mih/.cache/datalad/sockets/c5820c82', 'datalad-test']' failed with exitcode 255
Failed to open SSH connection (could not start ControlMaster process)
```

and thereby fixes gh-3450

See https://github.com/datalad/datalad/issues/3450#issuecomment-541319614 for more info on the wider implications and future work.

@adswa when this is merged, it will simplify the error captured at https://github.com/datalad-handbook/book/blame/master/docs/basics/101-135-help.rst#L166