### PR TITLE
Light RF of `clone()`

### DIFF
--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 from collections import OrderedDict
+from urllib.parse import unquote as urlunquote
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
@@ -26,17 +27,28 @@ from datalad.support.gitrepo import (
     GitRepo,
     GitCommandError,
 )
+from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
     EnsureKeyChoice,
 )
 from datalad.support.param import Parameter
-from datalad.support.network import get_local_file_url
-from datalad.dochelpers import exc_str
+from datalad.support.network import (
+    get_local_file_url,
+    URL,
+    RI,
+    DataLadRI,
+)
+from datalad.dochelpers import (
+    exc_str,
+    single_or_plural,
+)
 from datalad.utils import (
     rmtree,
     assure_list,
+    assure_bool,
+    knows_annex,
 )
 
 from datalad.distribution.dataset import (
@@ -48,10 +60,7 @@ from datalad.distribution.dataset import (
 )
 from datalad.distribution.utils import (
     _get_git_url_from_source,
-    _get_tracking_source,
     _get_flexible_source_candidates,
-    _handle_possible_annex_dataset,
-    _get_installationpath_from_url,
 )
 
 __docformat__ = 'restructuredtext'
@@ -309,3 +318,123 @@ class Clone(Interface):
         # subdataset clone down below will not alter the Git-state of the
         # parent
         yield get_status_dict(status='ok', **status_kwargs)
+
+
+def _handle_possible_annex_dataset(dataset, reckless, description=None):
+    """If dataset "knows annex" -- annex init it, set into reckless etc
+
+    Provides additional tune up to a possibly an annex repo, e.g.
+    "enables" reckless mode, sets up description
+    """
+    # in any case check whether we need to annex-init the installed thing:
+    if not knows_annex(dataset.path):
+        # not for us
+        return
+
+    # init annex when traces of a remote annex can be detected
+    if reckless:
+        lgr.debug(
+            "Instruct annex to hardlink content in %s from local "
+            "sources, if possible (reckless)", dataset.path)
+        dataset.config.add(
+            'annex.hardlink', 'true', where='local', reload=True)
+    lgr.debug("Initializing annex repo at %s", dataset.path)
+    # XXX this is rather convoluted, init does init, but cannot
+    # set a description without `create=True`
+    repo = AnnexRepo(dataset.path, init=True)
+    # so do manually see #1403
+    if description:
+        repo._init(description=description)
+    if reckless:
+        repo._run_annex_command('untrust', annex_options=['here'])
+
+    srs = {True: [], False: []}  # special remotes by "autoenable" key
+    remote_uuids = None  # might be necessary to discover known UUIDs
+
+    for uuid, config in repo.get_special_remotes().items():
+        sr_name = config.get('name', None)
+        sr_autoenable = config.get('autoenable', False)
+        try:
+            sr_autoenable = assure_bool(sr_autoenable)
+        except ValueError:
+            # Be resilient against misconfiguration.  Here it is only about
+            # informing the user, so no harm would be done
+            lgr.warning(
+                'Failed to process "autoenable" value %r for sibling %s in '
+                'dataset %s as bool.  You might need to enable it later '
+                'manually and/or fix it up to avoid this message in the future.',
+                sr_autoenable, sr_name, dataset.path)
+            continue
+
+        # determine either there is a registered remote with matching UUID
+        if uuid:
+            if remote_uuids is None:
+                remote_uuids = {
+                    repo.config.get('remote.%s.annex-uuid' % r)
+                    for r in repo.get_remotes()
+                }
+            if uuid not in remote_uuids:
+                srs[sr_autoenable].append(sr_name)
+
+    if srs[True]:
+        lgr.debug(
+            "configuration for %s %s added because of autoenable,"
+            " but no UUIDs for them yet known for dataset %s",
+            # since we are only at debug level, we could call things their
+            # proper names
+            single_or_plural("special remote", "special remotes", len(srs[True]), True),
+            ", ".join(srs[True]),
+            dataset.path
+        )
+
+    if srs[False]:
+        # if has no auto-enable special remotes
+        lgr.info(
+            'access to %s %s not auto-enabled, enable with:\n\t\tdatalad siblings -d "%s" enable -s %s',
+            # but since humans might read it, we better confuse them with our
+            # own terms!
+            single_or_plural("dataset sibling", "dataset siblings", len(srs[False]), True),
+            ", ".join(srs[False]),
+            dataset.path,
+            srs[False][0] if len(srs[False]) == 1 else "SIBLING",
+        )
+
+
+def _get_tracking_source(ds):
+    """Returns name and url of a potential configured source
+    tracking remote"""
+    vcs = ds.repo
+    # if we have a remote, let's check the location of that remote
+    # for the presence of the desired submodule
+
+    remote_name, tracking_branch = vcs.get_tracking_branch()
+    # TODO: better default `None`? Check where we might rely on '':
+    remote_url = ''
+    if remote_name:
+        remote_url = vcs.get_remote_url(remote_name, push=False)
+
+    return remote_name, remote_url
+
+
+def _get_installationpath_from_url(url):
+    """Returns a relative path derived from the trailing end of a URL
+
+    This can be used to determine an installation path of a Dataset
+    from a URL, analog to what `git clone` does.
+    """
+    ri = RI(url)
+    if isinstance(ri, (URL, DataLadRI)):  # decode only if URL
+        path = ri.path.rstrip('/')
+        path = urlunquote(path) if path else ri.hostname
+    else:
+        path = url
+    path = path.rstrip('/')
+    if '/' in path:
+        path = path.split('/')
+        if path[-1] == '.git':
+            path = path[-2]
+        else:
+            path = path[-1]
+    if path.endswith('.git'):
+        path = path[:-4]
+    return path

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -258,7 +258,9 @@ class Clone(Interface):
             try:
                 lgr.debug("Attempting to clone %s (%d out of %d candidates) to '%s'",
                           source_, isource_ + 1, len(candidate_sources), dest_path)
-                GitRepo.clone(path=dest_path, url=source_, create=True)
+                # TODO for now GitRepo.clone() cannot handle Path instances, and PY35
+                # doesn't make it happen seemlessly
+                GitRepo.clone(path=str(dest_path), url=source_, create=True)
                 break  # do not bother with other sources if succeeded
             except GitCommandError as e:
                 error_msgs[source_] = e
@@ -269,7 +271,9 @@ class Clone(Interface):
                               dest_path)
                     # We must not just rmtree since it might be curdir etc
                     # we should remove all files/directories under it
-                    rmtree(dest_path, children_only=dest_path_existed)
+                    # TODO stringification can be removed once patlib compatible
+                    # or if PY35 is no longer supported
+                    rmtree(str(dest_path), children_only=dest_path_existed)
                 # Whenever progress reporting is enabled, as it is now,
                 # we end up without e.stderr since it is "processed" out by
                 # GitPython/our progress handler.

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -14,41 +14,47 @@ import os
 import re
 from collections import OrderedDict
 from os import listdir
-from os.path import relpath
-from os.path import pardir
-from os.path import exists
+import os.path as op
 
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
-from datalad.interface.common_opts import location_description
-# from datalad.interface.common_opts import git_opts
-# from datalad.interface.common_opts import git_clone_opts
-# from datalad.interface.common_opts import annex_opts
-# from datalad.interface.common_opts import annex_init_opts
-from datalad.interface.common_opts import reckless_opt
-from datalad.support.gitrepo import GitRepo
-from datalad.support.gitrepo import GitCommandError
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureKeyChoice
+from datalad.interface.common_opts import (
+    location_description,
+    reckless_opt,
+)
+from datalad.support.gitrepo import (
+    GitRepo,
+    GitCommandError,
+)
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+    EnsureKeyChoice,
+)
 from datalad.support.param import Parameter
 from datalad.support.network import get_local_file_url
 from datalad.dochelpers import exc_str
-from datalad.utils import rmtree
-from datalad.utils import assure_list
+from datalad.utils import (
+    rmtree,
+    assure_list,
+)
 
-from .dataset import Dataset
-from .dataset import datasetmethod
-from .dataset import resolve_path
-from .dataset import require_dataset
-from .dataset import EnsureDataset
-from .utils import _get_git_url_from_source
-from .utils import _get_tracking_source
-from .utils import _get_flexible_source_candidates
-from .utils import _handle_possible_annex_dataset
-from .utils import _get_installationpath_from_url
+from datalad.distribution.dataset import (
+    Dataset,
+    datasetmethod,
+    resolve_path,
+    require_dataset,
+    EnsureDataset,
+)
+from datalad.distribution.utils import (
+    _get_git_url_from_source,
+    _get_tracking_source,
+    _get_flexible_source_candidates,
+    _handle_possible_annex_dataset,
+    _get_installationpath_from_url,
+)
 
 __docformat__ = 'restructuredtext'
 
@@ -110,11 +116,6 @@ class Clone(Interface):
             doc="""Alternative sources to be tried if a dataset cannot
             be obtained from the main `source`""",
             constraints=EnsureStr() | EnsureNone()),
-        # TODO next ones should be there, but cannot go anywhere
-        # git_opts=git_opts,
-        # git_clone_opts=git_clone_opts,
-        # annex_opts=annex_opts,
-        # annex_init_opts=annex_init_opts,
     )
 
     @staticmethod
@@ -127,11 +128,6 @@ class Clone(Interface):
             description=None,
             reckless=False,
             alt_sources=None):
-            # TODO next ones should be there, but cannot go anywhere
-            # git_opts=None,
-            # git_clone_opts=None,
-            # annex_opts=None,
-            # annex_init_opts=None
 
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
@@ -187,7 +183,7 @@ class Clone(Interface):
             refds=refds_path, source_url=source_url)
 
         # important test! based on this `rmtree` will happen below after failed clone
-        if exists(dest_path) and listdir(dest_path):
+        if op.exists(dest_path) and listdir(dest_path):
             if destination_dataset.is_installed():
                 # check if dest was cloned from the given source before
                 # this is where we would have installed this from
@@ -211,7 +207,7 @@ class Clone(Interface):
                 **status_kwargs)
             return
 
-        if dataset is not None and relpath(path, start=dataset.path).startswith(pardir):
+        if dataset is not None and op.relpath(path, start=dataset.path).startswith(op.pardir):
             yield get_status_dict(
                 status='error',
                 message=("clone target path '%s' not in specified target dataset '%s'",
@@ -231,7 +227,7 @@ class Clone(Interface):
             else ''
         lgr.info("Cloning %s%s into '%s'",
                  source, candidates_str, dest_path)
-        dest_path_existed = exists(dest_path)
+        dest_path_existed = op.exists(dest_path)
         error_msgs = OrderedDict()  # accumulate all error messages formatted per each url
         for isource_, source_ in enumerate(candidate_sources):
             try:
@@ -243,7 +239,7 @@ class Clone(Interface):
                 error_msgs[source_] = e
                 lgr.debug("Failed to clone from URL: %s (%s)",
                           source_, exc_str(e))
-                if exists(dest_path):
+                if op.exists(dest_path):
                     lgr.debug("Wiping out unsuccessful clone attempt at: %s",
                               dest_path)
                     # We must not just rmtree since it might be curdir etc

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -18,11 +18,7 @@ from datalad.tests.utils import (
 
 import logging
 import os
-from os.path import join as opj
-from os.path import isdir
-from os.path import exists
-from os.path import basename
-from os.path import dirname
+import os.path as op
 from os import mkdir
 from os import chmod
 
@@ -91,7 +87,7 @@ def test_invalid_args(path, otherpath, alienpath):
     ds = create(path)
     assert_raises(IncompleteResultsError, ds.clone, '/higherup.', 'Zoidberg')
     # make real dataset, try to install outside
-    ds_target = create(opj(otherpath, 'target'))
+    ds_target = create(op.join(otherpath, 'target'))
     assert_raises(ValueError, ds_target.clone, ds.path, path=ds.path)
     assert_status('error', ds_target.clone(ds.path, path=alienpath, on_failure='ignore'))
 
@@ -110,7 +106,7 @@ def test_clone_crcns(tdir, ds_path):
     ds = create(ds_path)
     crcns = ds.clone("///crcns", result_xfm='datasets', return_type='item-or-list')
     ok_(crcns.is_installed())
-    eq_(crcns.path, opj(ds_path, "crcns"))
+    eq_(crcns.path, op.join(ds_path, "crcns"))
     assert_in(crcns.path, ds.subdatasets(result_xfm='paths'))
 
 
@@ -122,7 +118,7 @@ def test_clone_datasets_root(tdir):
     with chpwd(tdir):
         ds = clone("///", result_xfm='datasets', return_type='item-or-list')
         ok_(ds.is_installed())
-        eq_(ds.path, opj(tdir, get_datasets_topdir()))
+        eq_(ds.path, op.join(tdir, get_datasets_topdir()))
 
         # do it a second time:
         res = clone("///", on_failure='ignore')
@@ -132,7 +128,7 @@ def test_clone_datasets_root(tdir):
         assert_status('notneeded', res)
 
         # and a third time into an existing something, that is not a dataset:
-        with open(opj(tdir, 'sub', 'a_file.txt'), 'w') as f:
+        with open(op.join(tdir, 'sub', 'a_file.txt'), 'w') as f:
             f.write("something")
 
         res = clone('///', path="sub", on_failure='ignore')
@@ -204,7 +200,7 @@ def test_clone_dataset_from_just_source(url, path):
 @with_tempfile(mkdir=True)
 def test_clone_dataladri(src, topurl, path):
     # make plain git repo
-    ds_path = opj(src, 'ds')
+    ds_path = op.join(src, 'ds')
     gr = GitRepo(ds_path, create=True)
     gr.add('test.txt')
     gr.commit('demo')
@@ -214,7 +210,7 @@ def test_clone_dataladri(src, topurl, path):
         ds = clone('///ds', path, result_xfm='datasets', return_type='item-or-list')
     eq_(ds.path, path)
     ok_clean_git(path, annex=False)
-    ok_file_has_content(opj(path, 'test.txt'), 'some')
+    ok_file_has_content(op.join(path, 'test.txt'), 'some')
 
 
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
@@ -246,7 +242,7 @@ def test_clone_into_dataset(source, top_path):
 
     subds = ds.clone(source, "sub",
                      result_xfm='datasets', return_type='item-or-list')
-    ok_(isdir(opj(subds.path, '.git')))
+    ok_(op.isdir(op.join(subds.path, '.git')))
     ok_(subds.is_installed())
     assert_in('sub', ds.subdatasets(fulfilled=True, result_xfm='relpaths'))
     # sub is clean:
@@ -261,7 +257,7 @@ def test_clone_into_dataset(source, top_path):
     ok_clean_git(ds.path, untracked=['dummy.txt'])
     subds_ = ds.clone(source, "sub2",
                       result_xfm='datasets', return_type='item-or-list')
-    eq_(subds_.path, opj(ds.path, "sub2"))  # for paranoid yoh ;)
+    eq_(subds_.path, op.join(ds.path, "sub2"))  # for paranoid yoh ;)
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
@@ -273,7 +269,7 @@ def test_notclone_known_subdataset(src, path):
                result_xfm='datasets', return_type='item-or-list')
 
     # subdataset not installed:
-    subds = Dataset(opj(path, 'subm 1'))
+    subds = Dataset(op.join(path, 'subm 1'))
     assert_false(subds.is_installed())
     assert_in('subm 1', ds.subdatasets(fulfilled=False, result_xfm='relpaths'))
     assert_not_in('subm 1', ds.subdatasets(fulfilled=True, result_xfm='relpaths'))
@@ -318,8 +314,8 @@ def test_reckless(path, top_path):
 @with_tempfile
 def test_install_source_relpath(src, dest):
     create(src)
-    src_ = basename(src)
-    with chpwd(dirname(src)):
+    src_ = op.basename(src)
+    with chpwd(op.dirname(src)):
         clone(src_, dest)
 
 

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -18,46 +18,53 @@ from datalad.tests.utils import (
 
 import logging
 import os
+from os import (
+    mkdir,
+    chmod,
+)
 import os.path as op
-from os import mkdir
-from os import chmod
 
 from mock import patch
 
-from datalad.api import create
-from datalad.api import clone
-from datalad.utils import chpwd
-from datalad.utils import _path_
-from datalad.utils import on_windows
+from datalad.api import (
+    create,
+    clone,
+)
+from datalad.utils import (
+    chpwd,
+    _path_,
+    on_windows,
+)
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.cmd import Runner
-from datalad.tests.utils import create_tree
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import with_testrepos
-from datalad.tests.utils import eq_
-from datalad.tests.utils import ok_
-from datalad.tests.utils import assert_false
-from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_message
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import assert_result_values_equal
-from datalad.tests.utils import ok_startswith
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import serve_path_via_http
-from datalad.tests.utils import swallow_logs
-from datalad.tests.utils import use_cassette
-from datalad.tests.utils import skip_if_no_network
-from datalad.tests.utils import skip_if
-from ..clone import _get_installationpath_from_url
-
-from ..dataset import Dataset
+from datalad.tests.utils import (
+    create_tree,
+    with_tempfile,
+    assert_in,
+    with_tree,
+    with_testrepos,
+    eq_,
+    ok_,
+    assert_false,
+    ok_file_has_content,
+    assert_not_in,
+    assert_raises,
+    assert_status,
+    assert_message,
+    assert_result_count,
+    assert_result_values_equal,
+    ok_startswith,
+    ok_clean_git,
+    serve_path_via_http,
+    swallow_logs,
+    use_cassette,
+    skip_if_no_network,
+    skip_if,
+)
+from datalad.distribution.clone import _get_installationpath_from_url
+from datalad.distribution.dataset import Dataset
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -59,6 +59,7 @@ from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import use_cassette
 from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import skip_if
+from ..clone import _get_installationpath_from_url
 
 from ..dataset import Dataset
 
@@ -367,3 +368,29 @@ def test_autoenabled_remote_msg(path):
         res = clone('///repronim/containers', path)
         assert_status('ok', res)
         assert_not_in("not auto-enabled", cml.out)
+
+
+def test_installationpath_from_url():
+    for p in ('lastbit',
+              'lastbit/',
+              '/lastbit',
+              'lastbit.git',
+              'lastbit.git/',
+              'http://example.com/lastbit',
+              'http://example.com/lastbit.git',
+              'http://lastbit:8000'
+              ):
+        eq_(_get_installationpath_from_url(p), 'lastbit')
+    # we need to deal with quoted urls
+    for url in (
+        # although some docs say that space could've been replaced with +
+        'http://localhost:8000/+last%20bit',
+        'http://localhost:8000/%2Blast%20bit',
+        '///%2Blast%20bit',
+        '///d1/%2Blast%20bit',
+        '///d1/+last bit',
+    ):
+        eq_(_get_installationpath_from_url(url), '+last bit')
+    # and the hostname alone
+    eq_(_get_installationpath_from_url("http://hostname"), 'hostname')
+    eq_(_get_installationpath_from_url("http://hostname/"), 'hostname')

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -75,38 +75,11 @@ from datalad.utils import _path_
 from datalad.utils import rmtree
 
 from ..dataset import Dataset
-from ..utils import _get_installationpath_from_url
 from ..utils import _get_git_url_from_source
 
 ###############
 # Test helpers:
 ###############
-
-
-def test_installationpath_from_url():
-    for p in ('lastbit',
-              'lastbit/',
-              '/lastbit',
-              'lastbit.git',
-              'lastbit.git/',
-              'http://example.com/lastbit',
-              'http://example.com/lastbit.git',
-              'http://lastbit:8000'
-              ):
-        eq_(_get_installationpath_from_url(p), 'lastbit')
-    # we need to deal with quoted urls
-    for url in (
-        # although some docs say that space could've been replaced with +
-        'http://localhost:8000/+last%20bit',
-        'http://localhost:8000/%2Blast%20bit',
-        '///%2Blast%20bit',
-        '///d1/%2Blast%20bit',
-        '///d1/+last bit',
-    ):
-        eq_(_get_installationpath_from_url(url), '+last bit')
-    # and the hostname alone
-    eq_(_get_installationpath_from_url("http://hostname"), 'hostname')
-    eq_(_get_installationpath_from_url("http://hostname/"), 'hostname')
 
 
 def test_get_git_url_from_source():

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -17,16 +17,10 @@ from os.path import isabs
 from os.path import normpath
 import posixpath
 
-from urllib.parse import unquote as urlunquote
-
-from ..dochelpers import single_or_plural
-from datalad.support.annexrepo import GitRepo
-from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import DataLadRI
 from datalad.support.network import URL
 from datalad.support.network import RI
 from datalad.support.network import PathRI
-from datalad.utils import knows_annex, assure_bool
 
 
 lgr = logging.getLogger('datalad.distribution.utils')
@@ -49,22 +43,6 @@ def _get_git_url_from_source(source):
     else:
         source = str(source_ri)
     return source
-
-
-def _get_tracking_source(ds):
-    """Returns name and url of a potential configured source
-    tracking remote"""
-    vcs = ds.repo
-    # if we have a remote, let's check the location of that remote
-    # for the presence of the desired submodule
-
-    remote_name, tracking_branch = vcs.get_tracking_branch()
-    # TODO: better default `None`? Check where we might rely on '':
-    remote_url = ''
-    if remote_name:
-        remote_url = vcs.get_remote_url(remote_name, push=False)
-
-    return remote_name, remote_url
 
 
 def _get_flexible_source_candidates(src, base_url=None, alternate_suffix=True):
@@ -124,107 +102,3 @@ def _get_flexible_source_candidates(src, base_url=None, alternate_suffix=True):
     # outisde
 
     return candidates
-
-
-def _handle_possible_annex_dataset(dataset, reckless, description=None):
-    """If dataset "knows annex" -- annex init it, set into reckless etc
-
-    Provides additional tune up to a possibly an annex repo, e.g.
-    "enables" reckless mode, sets up description
-    """
-    # in any case check whether we need to annex-init the installed thing:
-    if not knows_annex(dataset.path):
-        # not for us
-        return
-
-    # init annex when traces of a remote annex can be detected
-    if reckless:
-        lgr.debug(
-            "Instruct annex to hardlink content in %s from local "
-            "sources, if possible (reckless)", dataset.path)
-        dataset.config.add(
-            'annex.hardlink', 'true', where='local', reload=True)
-    lgr.debug("Initializing annex repo at %s", dataset.path)
-    # XXX this is rather convoluted, init does init, but cannot
-    # set a description without `create=True`
-    repo = AnnexRepo(dataset.path, init=True)
-    # so do manually see #1403
-    if description:
-        repo._init(description=description)
-    if reckless:
-        repo._run_annex_command('untrust', annex_options=['here'])
-
-    srs = {True: [], False: []}  # special remotes by "autoenable" key
-    remote_uuids = None  # might be necessary to discover known UUIDs
-
-    for uuid, config in repo.get_special_remotes().items():
-        sr_name = config.get('name', None)
-        sr_autoenable = config.get('autoenable', False)
-        try:
-            sr_autoenable = assure_bool(sr_autoenable)
-        except ValueError:
-            # Be resilient against misconfiguration.  Here it is only about
-            # informing the user, so no harm would be done
-            lgr.warning(
-                'Failed to process "autoenable" value %r for sibling %s in '
-                'dataset %s as bool.  You might need to enable it later '
-                'manually and/or fix it up to avoid this message in the future.',
-                sr_autoenable, sr_name, dataset.path)
-            continue
-
-        # determine either there is a registered remote with matching UUID
-        if uuid:
-            if remote_uuids is None:
-                remote_uuids = {
-                    repo.config.get('remote.%s.annex-uuid' % r)
-                    for r in repo.get_remotes()
-                }
-            if uuid not in remote_uuids:
-                srs[sr_autoenable].append(sr_name)
-
-    if srs[True]:
-        lgr.debug(
-            "configuration for %s %s added because of autoenable,"
-            " but no UUIDs for them yet known for dataset %s",
-            # since we are only at debug level, we could call things their
-            # proper names
-            single_or_plural("special remote", "special remotes", len(srs[True]), True),
-            ", ".join(srs[True]),
-            dataset.path
-        )
-
-    if srs[False]:
-        # if has no auto-enable special remotes
-        lgr.info(
-            'access to %s %s not auto-enabled, enable with:\n\t\tdatalad siblings -d "%s" enable -s %s',
-            # but since humans might read it, we better confuse them with our
-            # own terms!
-            single_or_plural("dataset sibling", "dataset siblings", len(srs[False]), True),
-            ", ".join(srs[False]),
-            dataset.path,
-            srs[False][0] if len(srs[False]) == 1 else "SIBLING",
-        )
-
-
-def _get_installationpath_from_url(url):
-    """Returns a relative path derived from the trailing end of a URL
-
-    This can be used to determine an installation path of a Dataset
-    from a URL, analog to what `git clone` does.
-    """
-    ri = RI(url)
-    if isinstance(ri, (URL, DataLadRI)):  # decode only if URL
-        path = ri.path.rstrip('/')
-        path = urlunquote(path) if path else ri.hostname
-    else:
-        path = url
-    path = path.rstrip('/')
-    if '/' in path:
-        path = path.split('/')
-        if path[-1] == '.git':
-            path = path[-2]
-        else:
-            path = path[-1]
-    if path.endswith('.git'):
-        path = path[:-4]
-    return path


### PR DESCRIPTION
- [x] use correct helper for current relpath semantics
- [x] move internal helpers into `clone.py` (also move tests)
- [x] apply current formatting patterns