### PR TITLE
RF: 'assure_*()' -> 'ensure_*()', fixes #3779

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -34,8 +34,8 @@ from .support.protocol import (
 from .utils import (
     on_windows,
     get_tempfile_kwargs,
-    assure_unicode,
-    assure_bytes,
+    ensure_unicode,
+    ensure_bytes,
     unlink,
     auto_repr,
 )
@@ -356,13 +356,13 @@ class Runner(object):
             lgr.log(3, "Processing provided line")
         if line and log_is_callable:
             # Let it be processed
-            line = log_(assure_unicode(line))
+            line = log_(ensure_unicode(line))
             if line is not None:
                 # we are working with binary type here
-                line = assure_bytes(line)
+                line = ensure_bytes(line)
         if line:
             if out_type == 'stdout':
-                self._log_out(assure_unicode(line))
+                self._log_out(ensure_unicode(line))
             elif out_type == 'stderr':
                 self._log_err(line.decode('utf-8'),
                               expected)
@@ -689,7 +689,7 @@ class GitRunner(Runner):
             cmd, env=self.get_git_environ_adjusted(env), *args, **kwargs)
         # All communication here will be returned as unicode
         # TODO: do that instead within the super's run!
-        return assure_unicode(out), assure_unicode(err)
+        return ensure_unicode(out), ensure_unicode(err)
 
 
 def readline_rstripped(stdout):
@@ -807,7 +807,7 @@ class BatchedCommand(object):
         #       it is just a "get"er - we could resend it few times
         # The default output_proc expects a single line output.
         # TODO: timeouts etc
-        stdout = assure_unicode(self.output_proc(process.stdout)) \
+        stdout = ensure_unicode(self.output_proc(process.stdout)) \
             if not process.stdout.closed else None
         if stderr:
             lgr.warning("Received output in stderr: %r", stderr)

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -31,7 +31,7 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
 from ..utils import (
-    assure_unicode,
+    ensure_unicode,
     chpwd,
     get_suggestions_msg,
     on_msys_tainted_paths,
@@ -139,7 +139,7 @@ def setup_parser(
     parser.add_argument(
         '-f', '--output-format', dest='common_output_format',
         default='default',
-        type=assure_unicode,
+        type=ensure_unicode,
         metavar="{default,json,json_pp,tailored,'<template>'}",
         help="""select format for returned command results. 'default' give one line
         per result reporting action, status, path and an optional message;

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -39,7 +39,7 @@ from datalad.support.constraints import (
 from datalad.support.param import Parameter
 from datalad.utils import (
     getpwd,
-    assure_list,
+    ensure_list,
 )
 
 from datalad.distribution.dataset import (
@@ -210,7 +210,7 @@ class Create(Interface):
         assert(path is not None)
 
         # assure cfg_proc is a list (relevant if used via Python API)
-        cfg_proc = assure_list(cfg_proc)
+        cfg_proc = ensure_list(cfg_proc)
 
         # prep for yield
         res = dict(action='create', path=str(path),

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -15,8 +15,8 @@ import logging
 import os.path as op
 from collections import OrderedDict
 from datalad.utils import (
-    assure_list,
-    assure_unicode,
+    ensure_list,
+    ensure_unicode,
 )
 from datalad.interface.base import (
     Interface,
@@ -115,8 +115,8 @@ class Diff(Interface):
         for r in _diff_cmd(
                 ds=ds,
                 dataset=dataset,
-                fr=assure_unicode(fr),
-                to=assure_unicode(to),
+                fr=ensure_unicode(fr),
+                to=ensure_unicode(to),
                 constant_refs=False,
                 path=path,
                 annex=annex,
@@ -150,7 +150,7 @@ def _diff_cmd(
     if path:
         ps = []
         # sort any path argument into the respective subdatasets
-        for p in sorted(assure_list(path)):
+        for p in sorted(ensure_list(path)):
             # it is important to capture the exact form of the
             # given path argument, before any normalization happens
             # distinguish rsync-link syntax to identify

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -51,8 +51,8 @@ from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
-from datalad.utils import assure_bytes
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_bytes
+from datalad.utils import ensure_unicode
 from datalad.utils import chpwd
 from datalad.utils import get_dataset_root
 from datalad.utils import getpwd
@@ -365,7 +365,7 @@ def normalize_command(command):
     """Convert `command` to the string representation.
     """
     if isinstance(command, list):
-        command = list(map(assure_unicode, command))
+        command = list(map(ensure_unicode, command))
         if len(command) == 1 and command[0] != "--":
             # This is either a quoted compound shell command or a simple
             # one-item command. Pass it as is.
@@ -384,7 +384,7 @@ def normalize_command(command):
                 command = command[1:]
             command = " ".join(shlex_quote(c) for c in command)
     else:
-        command = assure_unicode(command)
+        command = ensure_unicode(command)
     return command
 
 
@@ -662,7 +662,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             msg_path = relpath(opj(repo.path, repo.get_git_dir(repo),
                                    "COMMIT_EDITMSG"))
             with open(msg_path, "wb") as ofh:
-                ofh.write(assure_bytes(msg))
+                ofh.write(ensure_bytes(msg))
             lgr.info("The command had a non-zero exit code. "
                      "If this is expected, you can save the changes with "
                      "'datalad save -d . -r -F %s'",

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -35,7 +35,7 @@ from datalad.support.constraints import (
 )
 from datalad.support.exceptions import CommandError
 from datalad.utils import (
-    assure_list,
+    ensure_list,
 )
 import datalad.utils as ut
 
@@ -145,7 +145,7 @@ class Save(Interface):
             raise ValueError(
                 "Both a message and message file were specified for save()")
 
-        path = assure_list(path)
+        path = ensure_list(path)
 
         if message_file:
             with open(message_file) as mfh:

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -17,8 +17,8 @@ import os.path as op
 from collections import OrderedDict
 
 from datalad.utils import (
-    assure_list,
-    assure_unicode,
+    ensure_list,
+    ensure_unicode,
     bytes2human,
 )
 from datalad.interface.base import (
@@ -296,7 +296,7 @@ class Status(Interface):
         paths_by_ds = OrderedDict()
         if path:
             # sort any path argument into the respective subdatasets
-            for p in sorted(map(assure_unicode, assure_list(path))):
+            for p in sorted(map(ensure_unicode, ensure_list(path))):
                 # it is important to capture the exact form of the
                 # given path argument, before any normalization happens
                 # for further decision logic below

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -26,7 +26,7 @@ import sys
 from mock import patch
 
 from datalad.utils import (
-    assure_unicode,
+    ensure_unicode,
     chpwd,
     on_windows,
 )
@@ -316,7 +316,7 @@ def test_inputs_quotes_needed(path):
         list(sorted([OBSCURE_FILENAME + u".t", "bar.txt", "foo blah.txt"])) +
         ["out0"])
     with open(op.join(path, "out0")) as ifh:
-        eq_(assure_unicode(ifh.read()), expected)
+        eq_(ensure_unicode(ifh.read()), expected)
     # ... but the list form of a command does not. (Don't test this failure
     # with the obscure file name because we'd need to know its composition to
     # predict the failure.)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -13,7 +13,7 @@ import os.path as op
 
 from datalad.utils import (
     on_windows,
-    assure_list,
+    ensure_list,
     rmtree,
 )
 from datalad.tests.utils import (
@@ -355,10 +355,10 @@ def test_add_files(path):
             status = ds.repo.annexstatus(['dir'])
         else:
             result = ds.save(arg[0], to_git=arg[1])
-            for a in assure_list(arg[0]):
+            for a in ensure_list(arg[0]):
                 assert_result_count(result, 1, path=str(ds.pathobj / a))
             status = ds.repo.get_content_annexinfo(
-                ut.Path(p) for p in assure_list(arg[0]))
+                ut.Path(p) for p in ensure_list(arg[0]))
         for f, p in status.items():
             if arg[1]:
                 assert p.get('key', None) is None, f

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -28,7 +28,7 @@ from ..support.locking import lock_if_check_fails
 from ..support.path import exists
 from ..utils import getpwd
 from ..utils import unique
-from ..utils import assure_bytes
+from ..utils import ensure_bytes
 from ..utils import unlink
 from .base import AnnexCustomRemote
 from .main import main as super_main
@@ -257,7 +257,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 # if for testing we want to force getting the archive extracted
                 # _ = self.cache.assure_extracted(self._get_key_path(akey)) # TEMP
                 efile = self.cache[akey_path].get_extracted_filename(afile)
-                efile = assure_bytes(efile)
+                efile = ensure_bytes(efile)
 
                 if exists(efile):
                     size = os.stat(efile).st_size

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -31,7 +31,7 @@ from ..support.external_versions import external_versions
 from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 from ..dochelpers import exc_str
-from ..utils import assure_unicode
+from ..utils import ensure_unicode
 from ..utils import getargspec
 
 
@@ -117,7 +117,7 @@ send () {
             lgr.debug("Commenting out previous entries")
             # comment out all the past entries
             with open(_file, 'rb') as f:
-                entries = list(map(assure_unicode, f.readlines()))
+                entries = list(map(ensure_unicode, f.readlines()))
             for i in range(len(self.HEADER.split(os.linesep)), len(entries)):
                 e = entries[i]
                 if e.startswith('recv ') or e.startswith('send '):

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -31,7 +31,7 @@ from ..support.constraints import (
     EnsureStr,
 )
 from ..utils import (
-    assure_list,
+    ensure_list,
 )
 from ..distribution.dataset import (
     datasetmethod,
@@ -216,7 +216,7 @@ class CreateSiblingGitlab(Interface):
             publish_depends=None,
             description=None,
             dryrun=False):
-        path = rev_resolve_path(assure_list(path), ds=dataset) \
+        path = rev_resolve_path(ensure_list(path), ds=dataset) \
             if path else None
 
         if project and (recursive or (path and len(path) > 1)):

--- a/datalad/distribution/add.py
+++ b/datalad/distribution/add.py
@@ -22,7 +22,7 @@ from os.path import pardir
 from os.path import relpath
 
 
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.utils import unique
 from datalad.utils import get_dataset_root
 from datalad.interface.base import Interface
@@ -212,7 +212,7 @@ class Add(Interface):
 
         if message_file:
             with open(message_file, "rb") as mfh:
-                message = assure_unicode(mfh.read())
+                message = ensure_unicode(mfh.read())
 
         to_add = []
         subds_to_add = {}

--- a/datalad/distribution/add_sibling.py
+++ b/datalad/distribution/add_sibling.py
@@ -12,7 +12,7 @@
 __docformat__ = 'restructuredtext'
 
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 
 
 # TODO the only reason this function is still here is that #1544
@@ -25,7 +25,7 @@ def _check_deps(repo, deps):
     ValueError
       if any of the deps is an unknown remote
     """
-    unknown_deps = set(assure_list(deps)).difference(repo.get_remotes())
+    unknown_deps = set(ensure_list(deps)).difference(repo.get_remotes())
     if unknown_deps:
         raise ValueError(
             'unknown sibling(s) specified as publication dependency: %s'

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -37,7 +37,7 @@ from datalad.support.param import Parameter
 from datalad.support.network import get_local_file_url
 from datalad.dochelpers import exc_str
 from datalad.utils import rmtree
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 
 from .dataset import Dataset
 from .dataset import datasetmethod
@@ -223,7 +223,7 @@ class Clone(Interface):
         # and hopefully be more robust than git clone
         candidate_sources = []
         # combine all given sources (incl. alternatives), maintain order
-        for s in [source] + assure_list(alt_sources):
+        for s in [source] + ensure_list(alt_sources):
             candidate_sources.extend(_get_flexible_source_candidates(s))
         candidates_str = \
             " [%d other candidates]" % (len(candidate_sources) - 1) \

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -51,7 +51,7 @@ from datalad.support.param import Parameter
 from datalad.utils import make_tempfile
 from datalad.utils import _path_
 from datalad.utils import slash_join
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
@@ -546,7 +546,7 @@ class CreateSibling(Interface):
                 # make sure dependencies are valid
                 # TODO: inherit -- we might want to automagically create
                 # those dependents as well???
-                unknown_deps = set(assure_list(publish_depends)).difference(checkds_remotes)
+                unknown_deps = set(ensure_list(publish_depends)).difference(checkds_remotes)
                 if unknown_deps:
                     ap['status'] = 'error'
                     ap['message'] = (

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -33,7 +33,7 @@ from ..support.constraints import (
     EnsureStr,
 )
 from ..utils import (
-    assure_list,
+    ensure_list,
 )
 from .dataset import (
     datasetmethod,
@@ -222,7 +222,7 @@ class CreateSiblingGithub(Interface):
     @staticmethod
     def result_renderer_cmdline(res, args):
         from datalad.ui import ui
-        res = assure_list(res)
+        res = ensure_list(res)
         if args.dryrun:
             ui.message('DRYRUN -- Anticipated results:')
         if not len(res):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -46,7 +46,7 @@ from datalad.utils import get_dataset_root
 from datalad.utils import dlabspath
 from datalad.utils import Path
 from datalad.utils import PurePath
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 
 
 lgr = logging.getLogger('datalad.dataset')
@@ -643,7 +643,7 @@ def rev_resolve_path(path, ds=None):
         ds = require_dataset(
             ds, check_installed=False, purpose='path resolution')
     out = []
-    for p in assure_list(path):
+    for p in ensure_list(path):
         if ds is None or not got_ds_instance:
             # no dataset at all or no instance provided -> CWD is always the reference
             # nothing needs to be done here. Path-conversion and absolutification

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -18,7 +18,7 @@ from os.path import join as opj
 from os.path import isabs
 from os.path import normpath
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone
 from datalad.support.exceptions import InsufficientArgumentsError
@@ -80,7 +80,7 @@ def _drop_files(ds, paths, check, noannex_iserror=False, **kwargs):
         kwargs['action'] = 'drop'
     # always need to make sure that we pass a list
     # `normalize_paths` decorator will otherwise screw all logic below
-    paths = assure_list(paths)
+    paths = ensure_list(paths)
     if not hasattr(ds.repo, 'drop'):
         for p in paths:
             r = get_status_dict(

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -41,7 +41,7 @@ from datalad.support.param import Parameter
 from datalad.support.network import RI
 from datalad.support.network import PathRI
 from datalad.support.network import is_datalad_compat_ri
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.dochelpers import exc_str
 from datalad.dochelpers import single_or_plural
 
@@ -160,7 +160,7 @@ class Install(Interface):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`
-        path = assure_list(path)
+        path = ensure_list(path)
 
         if not source and not path:
             raise InsufficientArgumentsError(

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -36,7 +36,7 @@ from datalad.support.sshconnector import sh_quote
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.network import URL, RI, SSHRI, is_ssh
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.dochelpers import exc_str
 
 from .dataset import EnsureDataset
@@ -266,7 +266,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     depvar = 'remote.{}.datalad-publish-depends'.format(remote)
     # list of remotes that are publication dependencies for the
     # target remote
-    publish_depends = assure_list(ds.config.get(depvar, []))
+    publish_depends = ensure_list(ds.config.get(depvar, []))
 
     # remote might be set to be ignored by annex, or we might not even know yet its uuid
     # make sure we are up-to-date on this topic on all affected remotes, before

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -63,7 +63,7 @@ from datalad.distribution.dataset import (
 )
 from datalad.distribution.update import Update
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     slash_join,
 )
 from datalad.dochelpers import exc_str
@@ -427,7 +427,7 @@ def _configure_remote(
 
         if publish_depends:
             # Check if all `deps` remotes are known to the `repo`
-            unknown_deps = set(assure_list(publish_depends)).difference(
+            unknown_deps = set(ensure_list(publish_depends)).difference(
                 known_remotes)
             if unknown_deps:
                 result_props['status'] = 'error'
@@ -493,7 +493,7 @@ def _configure_remote(
                 # config vars are incremental, so make sure we start from
                 # scratch
                 ds.config.unset(depvar, where='local', reload=False)
-            for d in assure_list(publish_depends):
+            for d in ensure_list(publish_depends):
                 lgr.info(
                     'Configure additional publication dependency on "%s"',
                     d)
@@ -503,7 +503,7 @@ def _configure_remote(
         if publish_by_default:
             if dfltvar in ds.config:
                 ds.config.unset(dfltvar, where='local', reload=False)
-            for refspec in assure_list(publish_by_default):
+            for refspec in ensure_list(publish_by_default):
                 lgr.info(
                     'Configure additional default publication refspec "%s"',
                     refspec)

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -17,7 +17,7 @@ from datalad.api import (
     Dataset,
 )
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     chpwd,
 )
 from datalad.tests.utils import (
@@ -170,7 +170,7 @@ def check_integration1(login, keyring,
 
     ds = Dataset(path).create()
     if oauthtokens:
-        for oauthtoken in assure_list(oauthtokens):
+        for oauthtoken in ensure_list(oauthtokens):
             ds.config.add('hub.oauthtoken', oauthtoken, where='local')
 
     # so we do not pick up local repo configuration/token

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -42,7 +42,7 @@ from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import slow
 from datalad.utils import with_pathsep
 from datalad.utils import chpwd
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.utils import rmtree
 
 from ..dataset import Dataset

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -26,7 +26,7 @@ from datalad.support.network import DataLadRI
 from datalad.support.network import URL
 from datalad.support.network import RI
 from datalad.support.network import PathRI
-from datalad.utils import knows_annex, assure_bool
+from datalad.utils import knows_annex, ensure_bool
 
 
 lgr = logging.getLogger('datalad.distribution.utils')
@@ -161,7 +161,7 @@ def _handle_possible_annex_dataset(dataset, reckless, description=None):
         sr_name = config.get('name', None)
         sr_autoenable = config.get('autoenable', False)
         try:
-            sr_autoenable = assure_bool(sr_autoenable)
+            sr_autoenable = ensure_bool(sr_autoenable)
         except ValueError:
             # Be resilient against misconfiguration.  Here it is only about
             # informing the user, so no harm would be done

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -19,7 +19,7 @@ import requests.auth
 import io
 from time import sleep
 
-from ..utils import assure_list_from_str, assure_dict_from_str
+from ..utils import ensure_list_from_str, ensure_dict_from_str
 from ..dochelpers import borrowkwargs
 
 from ..ui import ui
@@ -137,9 +137,9 @@ class HTTPBaseAuthenticator(Authenticator):
         """
         super(HTTPBaseAuthenticator, self).__init__(**kwargs)
         self.url = url
-        self.failure_re = assure_list_from_str(failure_re)
-        self.success_re = assure_list_from_str(success_re)
-        self.session_cookies = assure_list_from_str(session_cookies)
+        self.failure_re = ensure_list_from_str(failure_re)
+        self.success_re = ensure_list_from_str(success_re)
+        self.session_cookies = ensure_list_from_str(session_cookies)
 
     def authenticate(self, url, credential, session, update=False):
         # we should use specified URL for this authentication first
@@ -254,7 +254,7 @@ class HTMLFormAuthenticator(HTTPBaseAuthenticator):
           Passed to super class HTTPBaseAuthenticator
         """
         super(HTMLFormAuthenticator, self).__init__(**kwargs)
-        self.fields = assure_dict_from_str(fields)
+        self.fields = ensure_dict_from_str(fields)
         self.tagid = tagid
 
     def _post_credential(self, credentials, post_url, session):

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -33,7 +33,7 @@ from ..support.configparserinc import SafeConfigParserWithIncludes
 from ..support.external_versions import external_versions
 from ..support.network import RI
 from ..support import path
-from ..utils import assure_list_from_str
+from ..utils import ensure_list_from_str
 from ..utils import auto_repr
 from ..utils import get_dataset_root
 
@@ -87,7 +87,7 @@ class Provider(object):
 
         """
         self.name = name
-        self.url_res = assure_list_from_str(url_res)
+        self.url_res = ensure_list_from_str(url_res)
         self.credential = credential
         self.authenticator = authenticator
         self._downloader = downloader
@@ -294,7 +294,7 @@ class Providers(object):
             authenticator = None
 
         # bringing url_re to "standard" format of a list and populating _providers_ordered
-        url_res = assure_list_from_str(items.pop('url_re', []))
+        url_res = ensure_list_from_str(items.pop('url_re', []))
         assert url_res, "current implementation relies on having url_re defined"
 
         credential = items.pop('credential', None)

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -14,7 +14,7 @@ import re
 from urllib.parse import urlsplit, unquote as urlunquote
 
 from ..utils import auto_repr
-from ..utils import assure_dict_from_str
+from ..utils import ensure_dict_from_str
 from ..dochelpers import borrowkwargs
 from ..support.network import get_url_straight_filename
 from ..support.network import rfc2822_to_epoch, iso8601_to_epoch
@@ -168,7 +168,7 @@ class S3Downloader(BaseDownloader):
             filepath = urlunquote(filepath)
         # TODO: needs replacement to assure_ since it doesn't
         # deal with non key=value
-        return rec.netloc, filepath, assure_dict_from_str(rec.query, sep='&') or {}
+        return rec.netloc, filepath, ensure_dict_from_str(rec.query, sep='&') or {}
 
     def _establish_session(self, url, allow_old=True):
         """

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -40,7 +40,7 @@ from ..support.stats import ActivityStats
 from ..cmdline.helpers import get_repo_instance
 from ..utils import getpwd, rmtree, file_basename
 from ..utils import md5sum
-from ..utils import assure_tuple_or_list
+from ..utils import ensure_tuple_or_list
 from ..utils import get_dataset_root
 
 from datalad.customremotes.base import init_datalad_remote
@@ -204,9 +204,9 @@ class AddArchiveContent(Interface):
         annex
         """
         if exclude:
-            exclude = assure_tuple_or_list(exclude)
+            exclude = ensure_tuple_or_list(exclude)
         if rename:
-            rename = assure_tuple_or_list(rename)
+            rename = ensure_tuple_or_list(rename)
 
         # TODO: actually I see possibly us asking user either he wants to convert
         # his git repo into annex

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -47,7 +47,7 @@ from datalad.utils import get_dataset_root
 from datalad.utils import with_pathsep as _with_sep
 from datalad.utils import path_startswith
 from datalad.utils import path_is_subpath
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
 
@@ -520,7 +520,7 @@ class AnnotatePaths(Interface):
         # goal: structure in a way that makes most information on any path
         # available in a single pass, at the cheapest possible cost
         reported_paths = {}
-        requested_paths = assure_list(path)
+        requested_paths = ensure_list(path)
 
         if modified is not None:
             # modification detection would silently kill all nondataset paths

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -109,12 +109,12 @@ def _get_untracked_content(dspath, report_untracked, paths=None):
             # nothing to filter
             paths = None
 
-    from datalad.utils import assure_unicode
+    from datalad.utils import ensure_unicode
 
     for line in stdout.split('\0'):
         if not line:
             continue
-        line = assure_unicode(line)
+        line = ensure_unicode(line)
         if not line.startswith('?? '):
             # nothing untracked, ignore, task of `diff`
             continue

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -20,7 +20,7 @@ from ..interface.common_opts import nosave_opt
 from ..interface.common_opts import save_message_opt
 from ..interface.results import get_status_dict
 from ..interface.utils import eval_results
-from ..utils import assure_list_from_str
+from ..utils import ensure_list_from_str
 from ..distribution.dataset import Dataset
 from ..distribution.dataset import datasetmethod
 from ..distribution.dataset import EnsureDataset
@@ -104,7 +104,7 @@ class DownloadURL(Interface):
         if isinstance(dataset, Dataset):
             path = op.normpath(op.join(ds.path, path or op.curdir))
 
-        urls = assure_list_from_str(urls)
+        urls = ensure_list_from_str(urls)
 
         if len(urls) > 1 and path and not op.isdir(path):
             yield get_status_dict(

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -21,7 +21,7 @@ from os.path import relpath
 from os.path import abspath
 from os.path import normpath
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     with_pathsep as _with_sep,
     path_is_subpath,
     PurePosixPath,
@@ -106,7 +106,7 @@ def results_from_paths(paths, action=None, type=None, logger=None, refds=None,
     generator
 
     """
-    for p in assure_list(paths):
+    for p in ensure_list(paths):
         yield get_status_dict(
             action, path=p, type=type, logger=logger, refds=refds,
             status=status, message=(message, p) if '%s' in message else message)
@@ -245,7 +245,7 @@ def count_results(res, **kwargs):
 
 def only_matching_paths(res, **kwargs):
     # TODO handle relative paths by using a contained 'refds' value
-    paths = assure_list(kwargs.get('path', []))
+    paths = ensure_list(kwargs.get('path', []))
     respath = res.get('path', None)
     return respath in paths
 
@@ -265,7 +265,7 @@ def is_result_matching_pathsource_argument(res, **kwargs):
         # otherwise this is not what we are looking for
         return source == res.get('source_url', None)
     # the only thing left is a potentially heterogeneous list of paths/URLs
-    paths = assure_list(kwargs.get('path', []))
+    paths = ensure_list(kwargs.get('path', []))
     # three cases left:
     # 1. input arg was an absolute path -> must match 'path' property
     # 2. input arg was relative to a dataset -> must match refds/relpath

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -36,7 +36,7 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetArgumentFound
 from datalad.utils import maybe_shlex_quote
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 import datalad.support.ansi_colors as ac
 
 from datalad.core.local.run import Run
@@ -118,13 +118,13 @@ def _get_procedure_implementation(name='*', ds=None):
     # 1. check system and user account for procedure
     for loc in (cfg.obtain('datalad.locations.user-procedures'),
                 cfg.obtain('datalad.locations.system-procedures')):
-        for dir in assure_list(loc):
+        for dir in ensure_list(loc):
             for m, n in _get_file_match(dir, name):
                 yield (m, n,) + _get_proc_config(n)
     # 2. check dataset for procedure
     if ds is not None and ds.is_installed():
         # could be more than one
-        dirs = assure_list(
+        dirs = ensure_list(
                 ds.config.obtain('datalad.locations.dataset-procedures'))
         for dir in dirs:
             # TODO `get` dirs if necessary

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -22,7 +22,7 @@ from os.path import relpath
 from os.path import lexists
 
 
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.utils import unique
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import EnsureStr
@@ -232,7 +232,7 @@ class Save(Interface):
 
         if message_file:
             with open(message_file, "rb") as mfh:
-                message = assure_unicode(mfh.read())
+                message = ensure_unicode(mfh.read())
 
         to_process = []
         got_nothing = True

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 import datalad
 from .base import Interface
 from datalad.interface.base import build_doc
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from ..support.param import Parameter
 
 import logging
@@ -63,7 +63,7 @@ class Test(Interface):
             from pkg_resources import iter_entry_points
             module = ['datalad']
             module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
-        module = assure_list(module)
+        module = ensure_list(module)
         lgr.info('Starting test run for module(s): %s', module)
         for mod in module:
             datalad.test(module=mod, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -32,7 +32,7 @@ from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.utils import Path
 
 from .base import Interface
@@ -81,7 +81,7 @@ class Unlock(Interface):
         paths_nondir = set()
         paths_lexist = None
         if path:
-            path = rev_resolve_path(assure_list(path), ds=dataset)
+            path = rev_resolve_path(ensure_list(path), ds=dataset)
             paths_lexist = []
             for p in path:
                 if p.exists() or p.is_symlink():

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -35,7 +35,7 @@ import json
 from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge conflict is not upon us
 from datalad.utils import path_startswith
 from datalad.utils import path_is_subpath
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.utils import getargspec
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import IncompleteResultsError
@@ -223,7 +223,7 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
     filematch = False
     if isdir(basepath):
         for p in listdir(basepath):
-            p = assure_unicode(opj(basepath, p))
+            p = ensure_unicode(opj(basepath, p))
             if not isdir(p):
                 if p in targetpaths:
                     filematch = True

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -37,7 +37,7 @@ from datalad.distribution.dataset import (
 from datalad.support.gitrepo import GitRepo
 from datalad.dochelpers import exc_str
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     partition,
 )
 
@@ -221,7 +221,7 @@ class Subdatasets(Interface):
         # no constraints given -> query subdatasets under curdir
         if not path and dataset is None:
             path = os.curdir
-        paths = [rev_resolve_path(p, dataset) for p in assure_list(path)] \
+        paths = [rev_resolve_path(p, dataset) for p in ensure_list(path)] \
             if path else None
 
         ds = require_dataset(
@@ -247,7 +247,7 @@ class Subdatasets(Interface):
                         "key '%s' is invalid (alphanumeric plus '-' only, must "
                         "start with a letter)" % k)
         if contains:
-            contains = [rev_resolve_path(c, dataset) for c in assure_list(contains)]
+            contains = [rev_resolve_path(c, dataset) for c in ensure_list(contains)]
         contains_hits = set()
         for r in _get_submodules(
                 ds, paths, fulfilled, recursive, recursion_limit,
@@ -307,7 +307,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                    for p in paths)
         if to_report and (set_property or delete_property):
             # first deletions
-            for dprop in assure_list(delete_property):
+            for dprop in ensure_list(delete_property):
                 try:
                     out, err = repo._git_custom_command(
                         '', ['git', 'config', '--file', '.gitmodules',
@@ -329,7 +329,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                 # also kick from the info we just read above
                 sm.pop('gitmodule_{}'.format(dprop), None)
             # and now setting values
-            for sprop in assure_list(set_property):
+            for sprop in ensure_list(set_property):
                 prop, val = sprop
                 if val.startswith('<') and val.endswith('>') and '{' in val:
                     # expand template string

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -73,7 +73,7 @@ from datalad.support.path import split_ext
 from datalad.utils import (
     path_is_subpath,
     all_same,
-    assure_list,
+    ensure_list,
 )
 
 lgr = logging.getLogger('datalad.metadata.aggregate')
@@ -444,7 +444,7 @@ def _extract_metadata(agginto_ds, aggfrom_ds, db, to_save, objid, metasources,
     # paths to extract from
     relevant_paths = sorted(_get_metadatarelevant_paths(aggfrom_ds, subds_relpaths))
     # get extractors to engage from source dataset
-    nativetypes = ['datalad_core', 'annex'] + assure_list(get_metadata_type(aggfrom_ds))
+    nativetypes = ['datalad_core', 'annex'] + ensure_list(get_metadata_type(aggfrom_ds))
     # store esssential extraction config in dataset record
     agginfo['extractors'] = nativetypes
     agginfo['datalad_version'] = datalad.__version__
@@ -917,7 +917,7 @@ class AggregateMetaData(Interface):
         # it really doesn't work without a dataset
         ds = require_dataset(
             dataset, check_installed=True, purpose='metadata aggregation')
-        path = assure_list(path)
+        path = ensure_list(path)
         if not path:
             # then current/reference dataset is "aggregated"
             # We should not add ds.path always since then --recursive would

--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -20,7 +20,7 @@ from datalad.log import log_progress
 from libxmp.utils import file_to_dict
 from datalad.metadata.definitions import vocabulary_id
 from datalad.metadata.extractors.base import BaseMetadataExtractor
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 
 
 xmp_field_re = re.compile(r'^([^\[\]]+)(\[\d+\]|)(/?.*|)')
@@ -87,7 +87,7 @@ class MetadataExtractor(BaseMetadataExtractor):
                         # we'll catch the actuall array values later
                         continue
                     # normalize value
-                    val = assure_unicode(val)
+                    val = ensure_unicode(val)
                     # non-breaking space
                     val = val.replace(u"\xa0", ' ')
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -56,7 +56,7 @@ from datalad.distribution.dataset import (
     require_dataset,
 )
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     path_is_subpath,
     path_startswith,
     as_unicode,
@@ -469,7 +469,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
             )
 
     # pull out potential metadata field blacklist config settings
-    blacklist = [re.compile(bl) for bl in assure_list(ds.config.obtain(
+    blacklist = [re.compile(bl) for bl in ensure_list(ds.config.obtain(
         'datalad.metadata.aggregate-ignore-fields',
         default=[]))]
     # enforce size limits
@@ -1084,4 +1084,4 @@ class Metadata(Interface):
                           if k not in ('tag', '@context', '@id'))
                  if meta else ' -' if 'metadata' in res else ' aggregated',
             tags='' if 'tag' not in meta else ' [{}]'.format(
-                 ','.join(assure_list(meta['tag'])))))
+                 ','.join(ensure_list(meta['tag'])))))

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -39,8 +39,8 @@ from datalad.support.constraints import EnsureInt
 
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
 from datalad.utils import (
-    assure_list, assure_iter, unicode_srctypes, as_unicode,
-    assure_unicode,
+    ensure_list, ensure_iter, unicode_srctypes, as_unicode,
+    ensure_unicode,
     get_suggestions_msg,
     unique,
 )
@@ -293,7 +293,7 @@ class _WhooshSearch(_Search):
         self._mk_parser()
         # for convenience we accept any number of args-words from the
         # shell and put them together to a single string here
-        querystr = ' '.join(assure_list(query))
+        querystr = ' '.join(ensure_list(query))
         # this gives a formal whoosh query
         wquery = self.parser.parse(querystr)
         return wquery
@@ -449,7 +449,7 @@ class _WhooshSearch(_Search):
                 old_ds_rpath = admin['path']
                 admin['id'] = res.get('dsid', None)
 
-            doc.update({k: assure_unicode(v) for k, v in admin.items()})
+            doc.update({k: ensure_unicode(v) for k, v in admin.items()})
             lgr.debug("Adding document to search index: {}".format(doc))
             # inject into index
             idx.add_document(**doc)
@@ -515,7 +515,7 @@ class _WhooshSearch(_Search):
             for i, hit in enumerate(hits):
                 annotated_hit = dict(
                     path=normpath(opj(self.ds.path, hit['path'])),
-                    query_matched={assure_unicode(k): assure_unicode(v)
+                    query_matched={ensure_unicode(k): ensure_unicode(v)
                                    if isinstance(v, unicode_srctypes) else v
                                    for k, v in hit.matched_terms()},
                     parentds=normpath(
@@ -776,8 +776,8 @@ class _EGrepCSSearch(_Search):
             #     try:
             #         return '{}'.format(s)
             #     except UnicodeEncodeError:
-            #         return assure_unicode(s).encode('utf-8')
-            stat.uvals_str = assure_unicode(
+            #         return ensure_unicode(s).encode('utf-8')
+            stat.uvals_str = ensure_unicode(
                 "{} unique values: {}".format(
                     len(stat.uvals), ', '.join(map(repr, uvals))))
             if mode == 'short':
@@ -834,7 +834,7 @@ class _EGrepCSSearch(_Search):
                 if mode == 'name':
                     continue
                 try:
-                    kvals_set = assure_iter(kvals, set)
+                    kvals_set = ensure_iter(kvals, set)
                 except TypeError:
                     # TODO: may be do show hashable ones???
                     nunhashable = sum(
@@ -848,7 +848,7 @@ class _EGrepCSSearch(_Search):
         return keys
 
     def get_query(self, query):
-        query = assure_list(query)
+        query = ensure_list(query)
         simple_fieldspec = re.compile(r"(?P<field>\S*?):(?P<query>.*)")
         quoted_fieldspec = re.compile(r"'(?P<field>[^']+?)':(?P<query>.*)")
         query_rec_matches = [

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -25,7 +25,7 @@ from datalad.metadata.metadata import (
     _get_containingds_from_agginfo,
 )
 from datalad.utils import chpwd
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.tests.utils import with_tree, with_tempfile
 from datalad.tests.utils import slow
 from datalad.tests.utils import assert_status
@@ -148,7 +148,7 @@ def test_aggregation(path):
     for name in ('MOTHER_äöü東', 'child_äöü東', 'grandchild_äöü東'):
         assert_true(
             sum([s['metadata']['frictionless_datapackage']['name'] \
-                    == assure_unicode(name) for s in origres
+                    == ensure_unicode(name) for s in origres
                  if s['type'] == 'dataset']))
 
     # now clone the beast to simulate a new user installing an empty dataset

--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -64,7 +64,7 @@ class AddReadme(Interface):
         lgr = logging.getLogger('datalad.plugin.add_readme')
 
         from datalad.distribution.dataset import require_dataset
-        from datalad.utils import assure_list
+        from datalad.utils import ensure_list
 
         dataset = require_dataset(dataset, check_installed=True,
                                   purpose='add README')
@@ -103,11 +103,11 @@ class AddReadme(Interface):
         for label, content in (
                 ('', meta.get('description', meta.get('shortdescription', ''))),
                 ('Author{}'.format('s' if isinstance(meta.get('author', None), list) else ''),
-                    u'\n'.join([u'- {}'.format(a) for a in assure_list(meta.get('author', []))])),
+                    u'\n'.join([u'- {}'.format(a) for a in ensure_list(meta.get('author', []))])),
                 ('Homepage', meta.get('homepage', '')),
                 ('Reference', meta.get('citation', '')),
                 ('License', meta.get('license', '')),
-                ('Keywords', u', '.join([u'`{}`'.format(k) for k in assure_list(meta.get('tag', []))])),
+                ('Keywords', u', '.join([u'`{}`'.format(k) for k in ensure_list(meta.get('tag', []))])),
                 ('Funding', meta.get('fundedby', '')),
                 ):
             if label and content:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -34,7 +34,7 @@ from datalad.support.network import get_url_filename
 from datalad.support.path import split_ext
 from datalad.support.s3 import get_versioned_url
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     get_suggestions_msg,
     unlink,
 )
@@ -442,7 +442,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
     for each row in `stream` and the second item a list subdataset paths,
     sorted breadth-first.
     """
-    meta = assure_list(meta)
+    meta = ensure_list(meta)
 
     rows, colidx_to_name = _read(stream, input_type)
     if not rows:

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -86,9 +86,9 @@ class NoAnnex(Interface):
         from os import makedirs as makedirsfx
         from datalad.distribution.dataset import require_dataset
         from datalad.support.annexrepo import AnnexRepo
-        from datalad.utils import assure_list
+        from datalad.utils import ensure_list
 
-        pattern = assure_list(pattern)
+        pattern = ensure_list(pattern)
         ds = require_dataset(dataset, check_installed=True,
                              purpose='no_annex configuration')
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -23,7 +23,7 @@ from datalad.version import __version__
 
 from ..wtf import SECTION_CALLABLES
 
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
@@ -86,7 +86,7 @@ def test_wtf(topdir):
         assert_in('## configuration', cmo.out)
         assert_in('## dataset', cmo.out)
         assert_in(u'path: {}'.format(ds.path),
-                  assure_unicode(cmo.out))
+                  ensure_unicode(cmo.out))
 
     # and if we run with all sensitive
     for sensitive in ('some', True):

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.utils import (
-    assure_unicode,
+    ensure_unicode,
     getpwd,
     unlink,
 )
@@ -80,8 +80,8 @@ def get_max_path_length(top_path=None, maxl=1000):
 def _describe_datalad():
 
     return {
-        'version': assure_unicode(__version__),
-        'full_version': assure_unicode(__full_version__),
+        'version': ensure_unicode(__version__),
+        'full_version': ensure_unicode(__full_version__),
     }
 
 
@@ -360,7 +360,7 @@ class WTF(Interface):
         infos = OrderedDict()
         res = get_status_dict(
             action='wtf',
-            path=ds.path if ds else assure_unicode(op.abspath(op.curdir)),
+            path=ds.path if ds else ensure_unicode(op.abspath(op.curdir)),
             type='dataset' if ds else 'directory',
             status='ok',
             logger=lgr,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -52,10 +52,10 @@ from datalad.utils import nothing_cm
 from datalad.utils import auto_repr
 from datalad.utils import on_windows
 from datalad.utils import swallow_logs
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.utils import _path_
 from datalad.utils import CMD_MAX_ARG
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.utils import make_tempfile
 from datalad.utils import partition
 from datalad.utils import unlink
@@ -1750,7 +1750,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                                content=content, no_content=not content,
                                all=all,
                                fast=fast))
-        args.extend(assure_list(remotes))
+        args.extend(ensure_list(remotes))
         self._run_annex_command('sync', annex_options=args)
 
     @normalize_path
@@ -1956,12 +1956,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             raise InsufficientArgumentsError("drop() requires at least to "
                                              "specify 'files' or 'options'")
 
-        options = assure_list(options)
+        options = ensure_list(options)
 
         if key:
             # we can't drop multiple in 1 line, and there is no --batch yet, so
             # one at a time
-            files = assure_list(files)
+            files = ensure_list(files)
             options = options + ['--key']
             res = [
                 self._run_annex_command_json(
@@ -2275,7 +2275,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 % (output, ', '.join(map(repr, OUTPUTS)))
             )
 
-        options = assure_list(options, copy=True)
+        options = ensure_list(options, copy=True)
         if key:
             kwargs = {'opts': options + ["--key"] + files}
         else:
@@ -2523,7 +2523,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         self.precommit()
 
         if files:
-            files = assure_list(files)
+            files = ensure_list(files)
 
             # Raise FileNotInRepositoryError if `files` aren't tracked.
             super(AnnexRepo, self).commit(
@@ -3082,7 +3082,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             return
         if batch is False:
             # we can be lazy
-            files = assure_list(files)
+            files = ensure_list(files)
         else:
             if isinstance(files, str):
                 files = [files]
@@ -3147,7 +3147,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """Like set_metadata() but returns a generator"""
 
         def _genspec(expr, d):
-            return [expr.format(k, v) for k, vs in d.items() for v in assure_list(vs)]
+            return [expr.format(k, v) for k, vs in d.items() for v in ensure_list(vs)]
 
         args = []
         spec = []

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -34,7 +34,7 @@ import random
 from .locking import lock_if_check_fails
 from ..utils import (
     any_re_search,
-    assure_bytes,
+    ensure_bytes,
     chpwd,
     rmdir,
     unlink,
@@ -73,7 +73,7 @@ from ..cmd import Runner
 from ..consts import ARCHIVES_TEMP_DIR
 from ..utils import rmtree
 from ..utils import get_tempfile_kwargs
-from ..utils import assure_unicode
+from ..utils import ensure_unicode
 
 from ..utils import on_windows
 
@@ -155,15 +155,15 @@ def decompress_file(archive, dir_, leading_directories='strip'):
         os.makedirs(dir_)
 
     with swallow_outputs() as cmo:
-        archive = assure_bytes(archive)
-        dir_ = assure_bytes(dir_)
+        archive = ensure_bytes(archive)
+        dir_ = ensure_bytes(dir_)
         patoolib.util.check_existing_filename(archive)
         patoolib.util.check_existing_filename(dir_, onlyfiles=False)
         # Call protected one to avoid the checks on existence on unixified path
         outdir = unixify_path(dir_)
         # should be supplied in PY3 to avoid b''
-        outdir = assure_unicode(outdir)
-        archive = assure_unicode(archive)
+        outdir = ensure_unicode(outdir)
+        archive = ensure_unicode(archive)
 
         format_compression = patoolib.get_archive_format(archive)
         if format_compression == ('gzip', None):
@@ -259,7 +259,7 @@ def _get_cached_filename(archive):
     """
     #return "%s_%s" % (basename(archive), hashlib.md5(archive).hexdigest()[:5])
     # per se there is no reason to maintain any long original name here.
-    archive_cached = hashlib.md5(assure_bytes(realpath(archive))).hexdigest()[:10]
+    archive_cached = hashlib.md5(ensure_bytes(realpath(archive))).hexdigest()[:10]
     lgr.debug("Cached directory for archive %s is %s", archive, archive_cached)
     return archive_cached
 
@@ -477,7 +477,7 @@ class ExtractedArchive(object):
         assert (exists(path))
         # create a stamp
         with open(self.stamp_path, 'wb') as f:
-            f.write(assure_bytes(self._archive))
+            f.write(ensure_bytes(self._archive))
         # assert that stamp mtime is not older than archive's directory
         assert (self.is_extracted)
 
@@ -500,7 +500,7 @@ class ExtractedArchive(object):
         path_len = len(path) + (len(os.sep) if not path.endswith(os.sep) else 0)
         for root, dirs, files in os.walk(path):  # TEMP
             for name in files:
-                yield assure_unicode(opj(root, name)[path_len:])
+                yield ensure_unicode(opj(root, name)[path_len:])
 
     def get_leading_directory(self, depth=None, consider=None, exclude=None):
         """Return leading directory of the content within archive

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -27,13 +27,13 @@ class CommandError(RuntimeError):
         self.stderr = stderr
 
     def __str__(self):
-        from datalad.utils import assure_unicode
+        from datalad.utils import ensure_unicode
         to_str = "%s: " % self.__class__.__name__
         if self.cmd:
             to_str += "command '%s'" % (self.cmd,)
         if self.code:
             to_str += " failed with exitcode %d" % self.code
-        to_str += "\n%s" % assure_unicode(self.msg)
+        to_str += "\n%s" % ensure_unicode(self.msg)
         return to_str
 
 

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -13,7 +13,7 @@ from ..consts import CONFIG_HUB_TOKEN_FIELD
 from ..dochelpers import exc_str
 from ..downloaders.credentials import UserPassword
 from ..ui import ui
-from ..utils import unique, assure_list, assure_tuple_or_list
+from ..utils import unique, assure_list, ensure_tuple_or_list
 
 from .exceptions import (
     AccessDeniedError,
@@ -310,7 +310,7 @@ def _make_github_repos(
                     dryrun)
                 # output will contain whatever is returned by _make_github_repo
                 # but with a dataset prepended to the record
-                res.append((ds,) + assure_tuple_or_list(res_))
+                res.append((ds,) + ensure_tuple_or_list(res_))
             except gh.BadCredentialsException as e:
                 if res:
                     # so we have succeeded with at least one repo already -

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -58,14 +58,14 @@ from datalad.config import ConfigManager
 import datalad.utils as ut
 from datalad.utils import Path
 from datalad.utils import PurePosixPath
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.utils import optional_args
 from datalad.utils import on_windows
 from datalad.utils import getpwd
 from datalad.utils import posix_relpath
-from datalad.utils import assure_dir
+from datalad.utils import ensure_dir
 from datalad.utils import generate_file_chunks
-from ..utils import assure_unicode
+from ..utils import ensure_unicode
 
 # imports from same module:
 from .external_versions import external_versions
@@ -1094,7 +1094,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         # there is no other way then to collect all files into a list
         # at this point, because we need to pass them at once to a single
         # `git add` call
-        files = [_normalize_path(self.path, f) for f in assure_list(files) if f]
+        files = [_normalize_path(self.path, f) for f in ensure_list(files) if f]
 
         if not (files or git_options or update):
             # wondering why just a warning? in cmdline this is also not an error
@@ -1108,7 +1108,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 # Set annex.largefiles to prevent storing files in annex when
                 # GitRepo() is instantiated with a v6+ annex repo.
                 ['git', '-c', 'annex.largefiles=nothing', 'add'] +
-                assure_list(git_options) +
+                ensure_list(git_options) +
                 to_options(update=update) + ['--verbose']
             )
             # get all the entries
@@ -1150,7 +1150,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         modes when ran through proxy
         """
         return [{u'file': f, u'success': True}
-                for f in re.findall("'(.*)'[\n$]", assure_unicode(stdout))]
+                for f in re.findall("'(.*)'[\n$]", ensure_unicode(stdout))]
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, recursive=False, **kwargs):
@@ -1248,7 +1248,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
         if not fields:
             raise ValueError('no `fields` provided, refuse to proceed')
-        fields = assure_list(fields)
+        fields = ensure_list(fields)
         cmd = [
             "git",
             "for-each-ref",
@@ -1259,10 +1259,10 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         if points_at:
             cmd.append('--points-at={}'.format(points_at))
         if sort:
-            for k in assure_list(sort):
+            for k in ensure_list(sort):
                 cmd.append('--sort={}'.format(k))
         if pattern:
-            cmd += assure_list(pattern)
+            cmd += ensure_list(pattern)
         if count:
             cmd.append('--count={:d}'.format(count))
 
@@ -2834,7 +2834,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
           name and value items. Attribute values are either True or False,
           for set and unset attributes, or are the literal attribute value.
         """
-        path = assure_list(path)
+        path = ensure_list(path)
         cmd = ["git", "check-attr", "-z", "--all"]
         if index_only:
             cmd.append('--cached')
@@ -3717,7 +3717,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(
                 list(files.keys()),
-                ['git', 'add'] + assure_list(git_opts) + ['--verbose']
+                ['git', 'add'] + ensure_list(git_opts) + ['--verbose']
             )
             # get all the entries
             for r in self._process_git_get_output(*add_out):
@@ -3774,7 +3774,7 @@ def _fixup_submodule_dotgit_setup(ds, relativepath):
     src_dotgit = opj(path, src_dotgit)
     # move .git
     from os import rename, listdir, rmdir
-    assure_dir(subds_dotgit)
+    ensure_dir(subds_dotgit)
     for dot_git_entry in listdir(src_dotgit):
         rename(opj(src_dotgit, dot_git_entry),
                opj(subds_dotgit, dot_git_entry))

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -13,7 +13,7 @@ import glob
 import logging
 import os.path as op
 
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.utils import chpwd
 from datalad.utils import getpwd
 from datalad.utils import partition
@@ -45,7 +45,7 @@ class GlobbedPaths(object):
             self._maybe_dot = []
             self._paths = {"patterns": [], "sub_patterns": {}}
         else:
-            patterns = list(map(assure_unicode, patterns))
+            patterns = list(map(ensure_unicode, patterns))
             patterns, dots = partition(patterns, lambda i: i.strip() == ".")
             self._maybe_dot = ["."] if list(dots) else []
             self._paths = {

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -37,7 +37,7 @@ from urllib.error import URLError
 
 from datalad.dochelpers import exc_str
 from datalad.utils import on_windows
-from datalad.utils import assure_dir, assure_bytes, assure_unicode, map_items
+from datalad.utils import ensure_dir, ensure_bytes, ensure_unicode, map_items
 from datalad import consts
 from datalad import cfg
 from datalad.support.cache import lru_cache
@@ -511,7 +511,7 @@ class RI(object):
             v = fields.get(f)
             if isinstance(v, dict):
 
-                ev = urlencode(map_items(assure_bytes, v))
+                ev = urlencode(map_items(ensure_bytes, v))
                 # / is reserved char within query
                 if f == 'fragment' and '%2F' not in str(v):
                     # but seems to be ok'ish within the fragment which is
@@ -656,7 +656,7 @@ class URL(RI):
         """Helper around parse_qs to strip unneeded 'list'ing etc and return a dict of key=values"""
         if not s:
             return {}
-        out = map_items(assure_unicode, OrderedDict(parse_qsl(s, 1)))
+        out = map_items(ensure_unicode, OrderedDict(parse_qsl(s, 1)))
         if not auto_delist:
             return out
         for k in out:
@@ -971,7 +971,7 @@ def get_cached_url_content(url, name=None, fetcher=None, maxage=None):
             fetcher = providers.fetch
 
         doc = fetcher(url)
-        assure_dir(dirname(doc_fname))
+        ensure_dir(dirname(doc_fname))
         # use pickle to store the entire request result dict
         pickle.dump(doc, open(doc_fname, 'wb'))
         lgr.debug("stored result of request to '{}' in {}".format(url, doc_fname))

--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -22,7 +22,7 @@ from functools import wraps
 from itertools import dropwhile
 
 from ..utils import (
-    assure_bytes,
+    ensure_bytes,
     getpwd,
 )
 
@@ -34,7 +34,7 @@ def _get_unicode_robust_version(f):
         try:
             return f(*args, **kwargs)
         except UnicodeEncodeError:
-            return f(assure_bytes(*args, **kwargs))
+            return f(ensure_bytes(*args, **kwargs))
     doc = getattr(f, '__doc__', None)
     # adjust only if __doc__ is not completely absent (None)
     if doc is not None:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -35,7 +35,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import (
     auto_repr,
     Path,
-    assure_list,
+    ensure_list,
     on_windows,
 )
 from datalad.cmd import Runner
@@ -348,7 +348,7 @@ class SSHConnection(object):
         self.open()
         scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
         # add source filepath(s) to scp command
-        scp_cmd += assure_list(source)
+        scp_cmd += ensure_list(source)
         # add destination path
         scp_cmd += ['%s:%s' % (
             self.sshri.hostname,
@@ -387,7 +387,7 @@ class SSHConnection(object):
         scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
         # add source filepath(s) to scp command, prefixed with the remote host
         scp_cmd += ["%s:%s" % (self.sshri.hostname, _quote_filename_for_scp(s))
-                    for s in assure_list(source)]
+                    for s in ensure_list(source)]
         # add destination path
         scp_cmd += [destination]
         return self.runner.run(scp_cmd)
@@ -580,8 +580,8 @@ class SSHManager(object):
           If specified, only the path(s) provided would be considered
         """
         if self._connections:
-            from datalad.utils import assure_list
-            ctrl_paths = assure_list(ctrl_path)
+            from datalad.utils import ensure_list
+            ctrl_paths = ensure_list(ctrl_path)
             to_close = [c for c in self._connections
                         # don't close if connection wasn't opened by SSHManager
                         if self._connections[c].ctrl_path

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -17,7 +17,7 @@ from datalad.support.exceptions import (
     AccessDeniedError,
     AccessFailedError,
 )
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 
 
 class LORISTokenGenerator(object):
@@ -44,7 +44,7 @@ class LORISTokenGenerator(object):
         except HTTPError:
             raise AccessDeniedError("Could not authenticate into LORIS")
 
-        str_response = assure_unicode(response.read())
+        str_response = ensure_unicode(response.read())
         data = json.loads(str_response)
         return data["token"]
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -37,7 +37,7 @@ from ..utils import line_profile
 from ..utils import not_supported_on_windows
 from ..utils import file_basename
 from ..utils import expandpath, is_explicit_path
-from ..utils import assure_unicode
+from ..utils import ensure_unicode
 from ..utils import knows_annex
 from ..utils import any_re_search
 from ..utils import unique
@@ -81,12 +81,12 @@ from datalad.tests.utils import nok_, assert_re_in
 from .utils import with_tempfile, assert_in, with_tree
 from .utils import SkipTest
 from .utils import assert_cwd_unchanged, skip_if_on_windows
-from .utils import assure_dict_from_str, assure_list_from_str
-from .utils import assure_unicode
+from .utils import ensure_dict_from_str, ensure_list_from_str
+from .utils import ensure_unicode
 from .utils import as_unicode
-from .utils import assure_bool
-from .utils import assure_iter
-from .utils import assure_list
+from .utils import ensure_bool
+from .utils import ensure_iter
+from .utils import ensure_list
 from .utils import ok_generator
 from .utils import assert_not_in
 from .utils import assert_raises
@@ -434,53 +434,53 @@ def test_auto_repr():
     assert_equal(buga().some(), "some")
 
 
-def test_assure_iter():
+def test_ensure_iter():
     s = {1}
-    assert assure_iter(None, set) == set()
-    assert assure_iter(1, set) == s
-    assert assure_iter(1, list) == [1]
-    assert assure_iter(s, set) is s
-    assert assure_iter(s, set, copy=True) is not s
+    assert ensure_iter(None, set) == set()
+    assert ensure_iter(1, set) == s
+    assert ensure_iter(1, list) == [1]
+    assert ensure_iter(s, set) is s
+    assert ensure_iter(s, set, copy=True) is not s
 
 
-def test_assure_list_copy():
+def test_ensure_list_copy():
     l = [1]
-    assert assure_list(l) is l
-    assert assure_list(l, copy=True) is not l
+    assert ensure_list(l) is l
+    assert ensure_list(l, copy=True) is not l
 
 
-def test_assure_list_from_str():
-    assert_equal(assure_list_from_str(''), None)
-    assert_equal(assure_list_from_str([]), None)
-    assert_equal(assure_list_from_str('somestring'), ['somestring'])
-    assert_equal(assure_list_from_str('some\nmultiline\nstring'), ['some', 'multiline', 'string'])
-    assert_equal(assure_list_from_str(['something']), ['something'])
-    assert_equal(assure_list_from_str(['a', 'listof', 'stuff']), ['a', 'listof', 'stuff'])
+def test_ensure_list_from_str():
+    assert_equal(ensure_list_from_str(''), None)
+    assert_equal(ensure_list_from_str([]), None)
+    assert_equal(ensure_list_from_str('somestring'), ['somestring'])
+    assert_equal(ensure_list_from_str('some\nmultiline\nstring'), ['some', 'multiline', 'string'])
+    assert_equal(ensure_list_from_str(['something']), ['something'])
+    assert_equal(ensure_list_from_str(['a', 'listof', 'stuff']), ['a', 'listof', 'stuff'])
 
 
-def test_assure_dict_from_str():
-    assert_equal(assure_dict_from_str(''), None)
-    assert_equal(assure_dict_from_str({}), None)
+def test_ensure_dict_from_str():
+    assert_equal(ensure_dict_from_str(''), None)
+    assert_equal(ensure_dict_from_str({}), None)
     target_dict = dict(
         __ac_name='{user}', __ac_password='{password}',
         cookies_enabled='', submit='Log in'
     )
     string = '__ac_name={user}\n__ac_password={password}\nsubmit=Log ' \
                'in\ncookies_enabled='
-    assert_equal(assure_dict_from_str(string), target_dict)
-    assert_equal(assure_dict_from_str(
+    assert_equal(ensure_dict_from_str(string), target_dict)
+    assert_equal(ensure_dict_from_str(
         target_dict),
         target_dict)
 
 
-def test_assure_bool():
+def test_ensure_bool():
     for values, t in [
         (['True', 1, '1', 'yes', 'on'], True),
         (['False', 0, '0', 'no', 'off'], False)
     ]:
         for v in values:
-            eq_(assure_bool(v), t)
-    assert_raises(ValueError, assure_bool, "unknown")
+            eq_(ensure_bool(v), t)
+    assert_raises(ValueError, ensure_bool, "unknown")
 
 
 def test_generate_chunks():
@@ -728,29 +728,29 @@ def test_memoized_generator():
     eq_([], list(g2_))
 
 
-def test_assure_unicode():
-    ok_(isinstance(assure_unicode("m"), str))
-    ok_(isinstance(assure_unicode('grandchild_äöü東'), str))
-    ok_(isinstance(assure_unicode(u'grandchild_äöü東'), str))
-    eq_(assure_unicode('grandchild_äöü東'), u'grandchild_äöü東')
+def test_ensure_unicode():
+    ok_(isinstance(ensure_unicode("m"), str))
+    ok_(isinstance(ensure_unicode('grandchild_äöü東'), str))
+    ok_(isinstance(ensure_unicode(u'grandchild_äöü東'), str))
+    eq_(ensure_unicode('grandchild_äöü東'), u'grandchild_äöü東')
     # now, non-utf8
     # Decoding could be deduced with high confidence when the string is
     # really encoded in that codepage
     mom_koi8r = u"мама".encode('koi8-r')
-    eq_(assure_unicode(mom_koi8r), u"мама")
-    eq_(assure_unicode(mom_koi8r, confidence=0.9), u"мама")
+    eq_(ensure_unicode(mom_koi8r), u"мама")
+    eq_(ensure_unicode(mom_koi8r, confidence=0.9), u"мама")
     mom_iso8859 = u'mamá'.encode('iso-8859-1')
-    eq_(assure_unicode(mom_iso8859), u'mamá')
-    eq_(assure_unicode(mom_iso8859, confidence=0.5), u'mamá')
+    eq_(ensure_unicode(mom_iso8859), u'mamá')
+    eq_(ensure_unicode(mom_iso8859, confidence=0.5), u'mamá')
     # but when we mix, it does still guess something allowing to decode:
     mixedin = mom_koi8r + u'東'.encode('iso2022_jp') + u'東'.encode('utf-8')
-    ok_(isinstance(assure_unicode(mixedin), str))
+    ok_(isinstance(ensure_unicode(mixedin), str))
     # but should fail if we request high confidence result:
     with assert_raises(ValueError):
-        assure_unicode(mixedin, confidence=0.9)
+        ensure_unicode(mixedin, confidence=0.9)
     # For other, non string values, actually just returns original value
     # TODO: RF to actually "assure" or fail??  For now hardcoding that assumption
-    assert assure_unicode(1) is 1
+    assert ensure_unicode(1) is 1
 
 
 def test_pathlib_unicode():
@@ -1179,7 +1179,7 @@ def test_get_open_files(p):
                  stdout=PIPE,
                  cwd=subd)
     # Assure that it started and we read the OK
-    eq_(assure_unicode(proc.stdout.readline().strip()), u"OK")
+    eq_(ensure_unicode(proc.stdout.readline().strip()), u"OK")
     assert time() - t0 < 5 # that we were not stuck waiting for process to finish
     eq_(get_open_files(p)[op.realpath(subd)].pid, proc.pid)
     eq_(get_open_files(subd)[op.realpath(subd)].pid, proc.pid)

--- a/datalad/tests/test_version.py
+++ b/datalad/tests/test_version.py
@@ -15,7 +15,7 @@ from ..version import (
     __hardcoded_version__,
 )
 from ..support import path as op
-from ..utils import assure_unicode
+from ..utils import ensure_unicode
 from .utils import (
     assert_equal,
     assert_greater,
@@ -44,7 +44,7 @@ def test__version__():
             if not line.startswith(b'## '):
                 # The first section header we hit, must be our changelog entry
                 continue
-            reg = regex.match(assure_unicode(line))
+            reg = regex.match(ensure_unicode(line))
             if not reg:  # first one at that level is the one
                 raise AssertionError(
                     "Following line must have matched our regex: %r" % line)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -395,7 +395,7 @@ def ok_file_has_content(path, content, strip=False, re_=False,
         file_content = f.read()
 
     if isinstance(content, str):
-        file_content = assure_unicode(file_content)
+        file_content = ensure_unicode(file_content)
 
     if os.linesep != '\n':
         # for consistent comparisons etc. Apparently when reading in `b` mode
@@ -1242,8 +1242,8 @@ def assert_status(label, results):
     `label` can be a sequence, in which case status must be one of the items
     in this sequence.
     """
-    label = assure_list(label)
-    results = assure_list(results)
+    label = ensure_list(label)
+    results = ensure_list(results)
     for i, r in enumerate(results):
         try:
             assert_in('status', r)
@@ -1262,7 +1262,7 @@ def assert_message(message, results):
     This only tests the message template string, and not a formatted message
     with args expanded.
     """
-    for r in assure_list(results):
+    for r in ensure_list(results):
         assert_in('message', r)
         m = r['message'][0] if isinstance(r['message'], tuple) else r['message']
         assert_equal(m, message)
@@ -1271,7 +1271,7 @@ def assert_message(message, results):
 def assert_result_count(results, n, **kwargs):
     """Verify specific number of results (matching criteria, if any)"""
     count = 0
-    results = assure_list(results)
+    results = ensure_list(results)
     for r in results:
         if not len(kwargs):
             count += 1
@@ -1291,7 +1291,7 @@ def assert_in_results(results, **kwargs):
     """Verify that the particular combination of keys and values is found in
     one of the results"""
     found = False
-    for r in assure_list(results):
+    for r in ensure_list(results):
         if all(k in r and r[k] == v for k, v in kwargs.items()):
             found = True
     assert found, "Found no desired result (%s) among %s" % (repr(kwargs), repr(results))
@@ -1300,7 +1300,7 @@ def assert_in_results(results, **kwargs):
 def assert_not_in_results(results, **kwargs):
     """Verify that the particular combination of keys and values is not in any
     of the results"""
-    for r in assure_list(results):
+    for r in ensure_list(results):
         assert any(k not in r or r[k] != v for k, v in kwargs.items())
 
 
@@ -1322,7 +1322,7 @@ def assert_result_values_cond(results, prop, cond):
     prop: str
     cond: callable
     """
-    for r in assure_list(results):
+    for r in ensure_list(results):
         ok_(cond(r[prop]),
             msg="r[{prop}]: {value}".format(prop=prop, value=r[prop]))
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -168,7 +168,7 @@ def get_func_kwargs_doc(func):
 
 def any_re_search(regexes, value):
     """Return if any of regexes (list or str) searches succesfully for value"""
-    for regex in assure_tuple_or_list(regexes):
+    for regex in ensure_tuple_or_list(regexes):
         if re.search(regex, value):
             return True
     return False
@@ -600,7 +600,7 @@ else:
         # Runner().run(['touch', '-h', '-d', '@%s' % mtime, filepath])
 
 
-def assure_tuple_or_list(obj):
+def ensure_tuple_or_list(obj):
     """Given an object, wrap into a tuple if not list or tuple
     """
     if isinstance(obj, (list, tuple)):
@@ -608,7 +608,12 @@ def assure_tuple_or_list(obj):
     return (obj,)
 
 
-def assure_iter(s, cls, copy=False, iterate=True):
+def assure_tuple_or_list(obj):
+    lgr.warning("assure_tuple_or_list() has been renamed to ensure_tuple_or_list().")
+    return ensure_tuple_or_list(obj)
+
+
+def ensure_iter(s, cls, copy=False, iterate=True):
     """Given not a list, would place it into a list. If None - empty list is returned
 
     Parameters
@@ -635,7 +640,12 @@ def assure_iter(s, cls, copy=False, iterate=True):
         return cls((s,))
 
 
-def assure_list(s, copy=False, iterate=True):
+def assure_iter(s, cls, copy=False, iterate=True):
+    lgr.warning("assure_iter() has been renamed to ensure_iter().")
+    return ensure_iter(s, cls, copy, iterate)
+
+
+def ensure_list(s, copy=False, iterate=True):
     """Given not a list, would place it into a list. If None - empty list is returned
 
     Parameters
@@ -647,10 +657,15 @@ def assure_list(s, copy=False, iterate=True):
       If it is not a list, but something iterable (but not a str)
       iterate over it.
     """
-    return assure_iter(s, list, copy=copy, iterate=iterate)
+    return ensure_iter(s, list, copy=copy, iterate=iterate)
 
 
-def assure_list_from_str(s, sep='\n'):
+def assure_list(s, copy=False, iterate=True):
+    lgr.warning("assure_list() has been renamed to ensure_list().")
+    return ensure_list(s, copy, iterate)
+
+
+def ensure_list_from_str(s, sep='\n'):
     """Given a multiline string convert it to a list of return None if empty
 
     Parameters
@@ -666,7 +681,12 @@ def assure_list_from_str(s, sep='\n'):
     return s.split(sep)
 
 
-def assure_dict_from_str(s, **kwargs):
+def assure_list_from_str(s, sep='\n'):
+    lgr.warning("assure_list_from_str() has been renamed to ensure_list_from_str().")
+    return ensure_list_from_str(s, sep)
+
+
+def ensure_dict_from_str(s, **kwargs):
     """Given a multiline string with key=value items convert it to a dictionary
 
     Parameters
@@ -683,7 +703,7 @@ def assure_dict_from_str(s, **kwargs):
         return s
 
     out = {}
-    for value_str in assure_list_from_str(s, **kwargs):
+    for value_str in ensure_list_from_str(s, **kwargs):
         if '=' not in value_str:
             raise ValueError("{} is not in key=value format".format(repr(value_str)))
         k, v = value_str.split('=', 1)
@@ -694,7 +714,12 @@ def assure_dict_from_str(s, **kwargs):
     return out
 
 
-def assure_bytes(s, encoding='utf-8'):
+def assure_dict_from_str(s, **kwargs):
+    lgr.warning("assure_dict_from_str() has been renamed to ensure_dict_from_str().")
+    return ensure_dict_from_str(s, **kwargs)
+
+
+def ensure_bytes(s, encoding='utf-8'):
     """Convert/encode unicode string to bytes.
 
     If `s` isn't a string, return it as is.
@@ -709,7 +734,12 @@ def assure_bytes(s, encoding='utf-8'):
     return s.encode(encoding)
 
 
-def assure_unicode(s, encoding=None, confidence=None):
+def assure_bytes(s, encoding='utf-8'):
+    lgr.warning("assure_bytes() has been renamed to ensure_bytes().")
+    return ensure_bytes(s, encoding)
+
+
+def ensure_unicode(s, encoding=None, confidence=None):
     """Convert/decode bytestring to unicode.
 
     If `s` isn't a bytestring, return it as is.
@@ -755,7 +785,12 @@ def assure_unicode(s, encoding=None, confidence=None):
         return s.decode(encoding)
 
 
-def assure_bool(s):
+def assure_unicode(s, encoding=None, confidence=None):
+    lgr.warning("assure_unicode() has been renamed to ensure_unicode().")
+    return ensure_unicode(s, encoding, confidence)
+
+
+def ensure_bool(s):
     """Convert value into boolean following convention for strings
 
     to recognize on,True,yes as True, off,False,no as False
@@ -773,11 +808,16 @@ def assure_bool(s):
     return bool(s)
 
 
+def assure_bool(s):
+    lgr.warning("assure_bool() has been renamed to ensure_bool().")
+    return ensure_bool(s)
+
+
 def as_unicode(val, cast_types=object):
     """Given an arbitrary value, would try to obtain unicode value of it
     
     For unicode it would return original value, for python2 str or python3
-    bytes it would use assure_unicode, for None - an empty (unicode) string,
+    bytes it would use ensure_unicode, for None - an empty (unicode) string,
     and for any other type (see `cast_types`) - would apply the unicode 
     constructor.  If value is not an instance of `cast_types`, TypeError
     is thrown
@@ -792,7 +832,7 @@ def as_unicode(val, cast_types=object):
     elif isinstance(val, str):
         return val
     elif isinstance(val, unicode_srctypes):
-        return assure_unicode(val)
+        return ensure_unicode(val)
     elif isinstance(val, cast_types):
         return str(val)
     else:
@@ -864,7 +904,7 @@ def map_items(func, v):
     No type checking of values passed to func is done, so `func`
     should be resilient to values which it should not handle
 
-    Initial usecase - apply_recursive(url_fragment, assure_unicode)
+    Initial usecase - apply_recursive(url_fragment, ensure_unicode)
     """
     # map all elements within item
     return v.__class__(
@@ -918,8 +958,8 @@ def generate_file_chunks(files, cmd=None):
     cmd: str or list of str, optional
       Command to account for as well
     """
-    files = assure_list(files)
-    cmd = assure_list(cmd)
+    files = ensure_list(files)
+    cmd = ensure_list(cmd)
 
     maxl = max(map(len, files)) if files else 0
     chunk_size = max(
@@ -1367,7 +1407,7 @@ def setup_exceptionhook(ipython=False):
         sys.excepthook = _datalad_pdb_excepthook
 
 
-def assure_dir(*args):
+def ensure_dir(*args):
     """Make sure directory exists.
 
     Joins the list of arguments to an os-specific path to the desired
@@ -1377,6 +1417,11 @@ def assure_dir(*args):
     if not exists(dirname):
         os.makedirs(dirname)
     return dirname
+
+
+def assure_dir(*args):
+    lgr.warning("assure_dir() has been renamed to ensure_dir().")
+    return ensure_dir(*args)
 
 
 def updated(d, update):
@@ -1727,7 +1772,7 @@ def get_logfilename(dspath, cmd='datalad'):
     """
     assert(exists(dspath))
     assert(isdir(dspath))
-    ds_logdir = assure_dir(dspath, '.git', 'datalad', 'logs')  # TODO: use WEB_META_LOG whenever #789 merged
+    ds_logdir = ensure_dir(dspath, '.git', 'datalad', 'logs')  # TODO: use WEB_META_LOG whenever #789 merged
     return opj(ds_logdir, 'crawl-%s.log' % get_timestamp_suffix())
 
 
@@ -2000,7 +2045,7 @@ def read_csv_lines(fname, dialect=None, readahead=16384, **kwargs):
         header = None
         for row in csv_reader:
             # decode UTF-8 back to Unicode, cell by cell:
-            row_unicode = map(assure_unicode, row)
+            row_unicode = map(ensure_unicode, row)
             if header is None:
                 header = list(row_unicode)
             else:
@@ -2232,7 +2277,7 @@ def create_tree(path, tree, archives_leading_dir=True, remove_existing=False):
             if full_name.endswith('.gz'):
                 open_func = gzip.open
             with open_func(full_name, "wb") as f:
-                f.write(assure_bytes(load, 'utf-8'))
+                f.write(ensure_bytes(load, 'utf-8'))
         if executable:
             os.chmod(full_name, os.stat(full_name).st_mode | stat.S_IEXEC)
 
@@ -2242,7 +2287,7 @@ def get_suggestions_msg(values, known, sep="\n        "):
     """
     import difflib
     suggestions = []
-    for value in assure_list(values):  # might not want to do it if we change presentation below
+    for value in ensure_list(values):  # might not want to do it if we change presentation below
         suggestions += difflib.get_close_matches(value, known)
     suggestions = unique(suggestions)
     msg = "Did you mean any of these?"


### PR DESCRIPTION
This refactors every helper in ``datalad/utils.py`` that is named ``assure_*`` to ``ensure_*`` :smile: 

For backward compatibility I have done this (example):

```python

def assure_list(s, copy=False, iterate=True):
    lgr.warning("assure_list() has been renamed to ensure_list().")
    return ensure_list(s, copy, iterate)

```

I won't be disappointed if you don't want this PR, feel free to disregard and  keep ``assure_*`` :smile:

Fixes #3779