### PR TITLE
ENH+NF: Better `git tag` support

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -297,6 +297,8 @@ class Save(Interface):
                 yield dsres
                 continue
             try:
+                # method requires str
+                version_tag = str(version_tag)
                 pds_repo.tag(version_tag)
                 dsres.update(
                     status='ok',

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2746,12 +2746,6 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             ['git', 'symbolic-ref' if symbolic else 'update-ref', ref, value]
         )
 
-    def _tag(self, args):
-        return self._git_custom_command(
-            '', ['git', 'tag'] + args,
-            check_fake_dates=True
-        )
-
     def tag(self, tag, message=None, commit=None, options=None):
         """Tag a commit
 
@@ -2773,7 +2767,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         # TODO: call in save.py complains about extensive logging. When does it
         # happen in what way? Figure out, whether to just silence it or raise or
         # whatever else.
-        args = []
+        args = ['tag']
         if message:
             args += ['-m', message]
         if options is not None:
@@ -2781,17 +2775,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         args.append(tag)
         if commit:
             args.append(commit)
-        self._tag(args)
-
-    def delete_tags(self, tags):
-        """Delete one or more tags
-
-        Parameters
-        ----------
-        tags : list
-          Names of tags to delete.
-        """
-        self._tag(['-d'] + tags)
+        self.call_git(args)
 
     def get_tags(self, output=None):
         """Get list of tags

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1368,6 +1368,25 @@ def test_get_tags(path):
     eq_(gr.describe(commitish=first_commit), None)
     eq_(gr.describe(commitish=first_commit, tags=True), tags1[0]['name'])
 
+    gr.tag('specific', commit='HEAD~1')
+    eq_(gr.get_hexsha('specific'), gr.get_hexsha('HEAD~1'))
+    assert_in('specific', gr.get_tags(output='name'))
+
+    # retag a different commit
+    assert_raises(CommandError, gr.tag, 'specific', commit='HEAD')
+    # force it
+    gr.tag('specific', commit='HEAD', options=['-f'])
+    eq_(gr.get_hexsha('specific'), gr.get_hexsha('HEAD'))
+
+    # delete
+    gr.delete_tags(['specific'])
+    eq_(gr.get_tags(), tags2)
+    # more than one
+    gr.tag('one')
+    gr.tag('two')
+    gr.delete_tags(['one', 'two'])
+    eq_(gr.get_tags(), tags2)
+
 
 @with_tree(tree={'1': ""})
 def test_get_commit_date(path):

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1379,12 +1379,12 @@ def test_get_tags(path):
     eq_(gr.get_hexsha('specific'), gr.get_hexsha('HEAD'))
 
     # delete
-    gr.delete_tags(['specific'])
+    gr.call_git(['tag', '-d', 'specific'])
     eq_(gr.get_tags(), tags2)
     # more than one
     gr.tag('one')
     gr.tag('two')
-    gr.delete_tags(['one', 'two'])
+    gr.call_git(['tag', '-d', 'one', 'two'])
     eq_(gr.get_tags(), tags2)
 
 


### PR DESCRIPTION
- [x] tag commits other than HEAD
- [x] special operations like force-update a tag etc.,
      i.e. pass arbitrary command options
- [x] RF based on gh-3791 