### PR TITLE
BF: Be able to get *two* files from an uninstalled subdataset

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -46,8 +46,6 @@ from datalad.support.gitrepo import (
 )
 from datalad.support.exceptions import (
     InsufficientArgumentsError,
-    InstallFailedError,
-    IncompleteResultsError,
 )
 from datalad.support.network import (
     URL,
@@ -55,7 +53,6 @@ from datalad.support.network import (
     urlquote,
 )
 from datalad.dochelpers import (
-    exc_str,
     single_or_plural,
 )
 from datalad.utils import (
@@ -70,6 +67,7 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
     require_dataset,
+    rev_get_dataset_root,
 )
 from datalad.distribution.clone import Clone
 from datalad.distribution.utils import _get_flexible_source_candidates
@@ -367,7 +365,12 @@ def _install_targetpath(
         yield dict(
             action='get',
             type='dataset',
-            path=ds.path,
+            # this cannot just be the dataset path, as the original
+            # situation of datasets avail on disk can have changed due
+            # to subdataset installation. It has to be actual subdataset
+            # it resides in, because this value is used to determine which
+            # dataset to call `annex-get` on
+            path=rev_get_dataset_root(target_path),
             status='notneeded',
             contains=[target_path],
             refds=refds_path,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -370,7 +370,8 @@ def _install_targetpath(
             # to subdataset installation. It has to be actual subdataset
             # it resides in, because this value is used to determine which
             # dataset to call `annex-get` on
-            path=rev_get_dataset_root(target_path),
+            # TODO stringification is a PY35 compatibility kludge
+            path=rev_get_dataset_root(str(target_path)),
             status='notneeded',
             contains=[target_path],
             refds=refds_path,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2535,7 +2535,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 url = posixpath.join(curdir, posix_relpath(path))
             else:
                 url = path
-        cmd += [url, path]
+        cmd += [url, Path(path).as_posix()]
         self._git_custom_command('', cmd)
         # record dataset ID if possible for comprehesive metadata on
         # dataset components within the dataset itself


### PR DESCRIPTION
Fixes gh-3356 gh-3795

For the new usage of `rev_get_dataset_root()` see #3796 