### PR TITLE
BF: Don't discover directory as procedure

### DIFF
--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -181,7 +181,7 @@ def _guess_exec(script_file):
             reraise(e)
 
     # TODO check for exec permission and rely on interpreter
-    if is_exec:
+    if is_exec and not os.path.isdir(script_file):
         return {'type': u'executable',
                 'template': u'{script} {ds} {args}',
                 'state': state}

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -125,7 +125,10 @@ from datalad.api import add, Dataset
 with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('hello\\n')
 add(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
-"""}})
+""",
+             'testdir': {}
+
+             }})
 @with_tempfile
 def test_procedure_discovery(path, super_path):
     with chpwd(path):
@@ -173,6 +176,8 @@ def test_procedure_discovery(path, super_path):
         len(ps))
     # dataset's procedure needs to be in the results
     assert_in_results(ps, path=op.join(ds.path, 'code', 'datalad_test_proc.py'))
+    # a subdir shouldn't be considered a procedure just because it's "executable"
+    assert_not_in_results(ps, path=op.join(ds.path, 'code', 'testdir'))
 
     # make it a subdataset and try again:
     super = Dataset(super_path).create()


### PR DESCRIPTION
Closes #3792

We used to discover a directory at the configured procedure location as an actual procedure based on its executable flag.