### PR TITLE
BF: explicitely terminate the Popen process if exception (e.g. KeyboardInterrupt)

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -563,6 +563,13 @@ class Runner(object):
                     self.log("Finished running %r with status %s" % (cmd, status),
                              level=8)
 
+            except CommandError:
+                # do not bother with reacting to "regular" CommandError
+                # exceptions.  Somehow if we also terminate here for them
+                # some processes elsewhere might stall:
+                # see https://github.com/datalad/datalad/pull/3794
+                raise
+
             except BaseException as exc:
                 exc_info = sys.exc_info()
                 # KeyboardInterrupt is subclass of BaseException
@@ -580,7 +587,7 @@ class Runner(object):
 
             finally:
                 # Those streams are for us to close if we asked for a PIPE
-                # TODO -- assure closing the files import pdb; pdb.set_trace()
+                # TODO -- assure closing the files
                 _cleanup_output(outputstream, proc.stdout)
                 _cleanup_output(errstream, proc.stderr)
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -28,6 +28,7 @@ from six import (
     string_types,
     binary_type,
     text_type,
+    reraise,
 )
 from .support import path as op
 from .consts import GIT_SSH_COMMAND
@@ -561,6 +562,22 @@ class Runner(object):
                 else:
                     self.log("Finished running %r with status %s" % (cmd, status),
                              level=8)
+
+            except BaseException as exc:
+                exc_info = sys.exc_info()
+                # KeyboardInterrupt is subclass of BaseException
+                lgr.debug("Terminating process for %s upon exception: %s",
+                          cmd, exc_str(exc))
+                try:
+                    # there are still possible (although unlikely) cases when
+                    # we fail to interrupt but we
+                    # should not crash if we fail to terminate the process
+                    proc.terminate()
+                except BaseException as exc2:
+                    lgr.warning("Failed to terminate process for %s: %s",
+                                cmd, exc_str(exc2))
+                reraise(*exc_info)
+
             finally:
                 # Those streams are for us to close if we asked for a PIPE
                 # TODO -- assure closing the files import pdb; pdb.set_trace()

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -12,7 +12,10 @@
 import re
 from os import linesep
 
+import six
 
+
+@six.python_2_unicode_compatible
 class CommandError(RuntimeError):
     """Thrown if a command call fails.
     """


### PR DESCRIPTION
Otherwise it was observed (#3613) that batched parallel `git annex get` instances might still remain
running consuming bandwidth and resources.

I have added try/except around .terminate() call itself, although it might be
an overkill since in normal scenarios I do not expect that to fail.

I have tested locally by interrupting `datalad get` invocations, and it seems to do the trick!

Closes #3613

TODOs
- [ ] test  ~~well, could be done, even if only for smoke testing that code logic, but wasn't in the best traditions of the fast progress~~ I think I will not be lazy, making a test