### PR TITLE
RF: rev_resolve_path() -> resolve_path()

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -47,7 +47,7 @@ from datalad.distribution.dataset import (
     datasetmethod,
     EnsureDataset,
     rev_get_dataset_root,
-    rev_resolve_path,
+    resolve_path,
     path_under_rev_dataset,
     require_dataset,
 )
@@ -200,7 +200,7 @@ class Create(Interface):
                                  "no annex repo.")
 
         if path:
-            path = rev_resolve_path(path, dataset)
+            path = resolve_path(path, dataset)
 
         path = path if path \
             else getpwd() if ds is None \

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -28,7 +28,7 @@ from datalad.distribution.dataset import (
     Dataset,
     datasetmethod,
     require_dataset,
-    rev_resolve_path,
+    resolve_path,
     path_under_rev_dataset,
     rev_get_dataset_root,
 )
@@ -159,7 +159,7 @@ def _diff_cmd(
             # special case is the root dataset, always report its content
             # changes
             orig_path = str(p)
-            resolved_path = rev_resolve_path(p, dataset)
+            resolved_path = resolve_path(p, dataset)
             p = \
                 resolved_path, \
                 orig_path.endswith(op.sep) or resolved_path == ds.pathobj

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -42,7 +42,7 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
     require_dataset,
-    rev_resolve_path,
+    resolve_path,
     path_under_rev_dataset,
     rev_get_dataset_root,
 )
@@ -301,7 +301,7 @@ class Status(Interface):
                 # given path argument, before any normalization happens
                 # for further decision logic below
                 orig_path = str(p)
-                p = rev_resolve_path(p, dataset)
+                p = resolve_path(p, dataset)
                 root = rev_get_dataset_root(str(p))
                 if root is None:
                     # no root, not possibly underneath the refds

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -37,7 +37,7 @@ from ..distribution.dataset import (
     datasetmethod,
     EnsureDataset,
     require_dataset,
-    rev_resolve_path,
+    resolve_path,
 )
 from ..dochelpers import exc_str
 
@@ -216,7 +216,7 @@ class CreateSiblingGitlab(Interface):
             publish_depends=None,
             description=None,
             dryrun=False):
-        path = rev_resolve_path(assure_list(path), ds=dataset) \
+        path = resolve_path(assure_list(path), ds=dataset) \
             if path else None
 
         if project and (recursive or (path and len(path) > 1)):

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -54,7 +54,7 @@ from datalad.utils import (
 from datalad.distribution.dataset import (
     Dataset,
     datasetmethod,
-    rev_resolve_path,
+    resolve_path,
     require_dataset,
     EnsureDataset,
 )
@@ -158,7 +158,7 @@ class Clone(Interface):
                     path))
 
         if path is not None:
-            path = rev_resolve_path(path, dataset)
+            path = resolve_path(path, dataset)
 
         # Possibly do conversion from source into a git-friendly url
         # luckily GitRepo will undo any fancy file:/// url to make use of Git's
@@ -175,7 +175,7 @@ class Clone(Interface):
             # and derive the path from the source and continue
             path = _get_installationpath_from_url(source)
             # since this is a relative `path`, resolve it:
-            path = rev_resolve_path(path, dataset)
+            path = resolve_path(path, dataset)
             lgr.debug("Determined clone target path from source")
         lgr.debug("Resolved clone target path to: '%s'", path)
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -578,7 +578,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
 # New helpers, courtesy of datalad-revolution.
 
 
-def rev_resolve_path(path, ds=None):
+def resolve_path(path, ds=None):
     """Resolve a path specification (against a Dataset location)
 
     Any path is returned as an absolute path. If, and only if, a dataset
@@ -666,6 +666,9 @@ def rev_resolve_path(path, ds=None):
         # face of the possibility of symlinks in the path
         out.append(p)
     return out[0] if isinstance(path, (str, PurePath)) else out
+
+# TODO keep this around for a while so that extensions can be updated
+rev_resolve_path = resolve_path
 
 
 def path_under_rev_dataset(ds, path):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -18,7 +18,6 @@ from os.path import join as opj
 from os.path import normpath, isabs
 from os.path import pardir
 from os.path import realpath
-from os.path import relpath
 from weakref import WeakValueDictionary
 import wrapt
 
@@ -41,9 +40,8 @@ from datalad.support.exceptions import InvalidAnnexRepositoryError
 
 import datalad.utils as ut
 from datalad.utils import getpwd
-from datalad.utils import optional_args, expandpath, is_explicit_path
+from datalad.utils import optional_args
 from datalad.utils import get_dataset_root
-from datalad.utils import dlabspath
 from datalad.utils import Path
 from datalad.utils import PurePath
 from datalad.utils import assure_list
@@ -51,34 +49,6 @@ from datalad.utils import assure_list
 
 lgr = logging.getLogger('datalad.dataset')
 lgr.log(5, "Importing dataset")
-
-
-# TODO: use the same piece for resolving paths against Git/AnnexRepo instances
-#       (see normalize_path)
-def resolve_path(path, ds=None):
-    """Resolve a path specification (against a Dataset location)
-
-    Any explicit path (absolute or relative) is returned as an absolute path.
-    In case of an explicit relative path, the current working directory is
-    used as a reference. Any non-explicit relative path is resolved against
-    as dataset location, i.e. considered relative to the location of the
-    dataset. If no dataset is provided, the current working directory is
-    used.
-
-    Returns
-    -------
-    Absolute path
-    """
-    path = expandpath(path, force_absolute=False)
-    if is_explicit_path(path):
-        # normalize path consistently between two (explicit and implicit) cases
-        return dlabspath(path, norm=True)
-
-    # no dataset given, use CWD as reference
-    # note: abspath would disregard symlink in CWD
-    top_path = getpwd() \
-        if ds is None else ds.path if isinstance(ds, Dataset) else ds
-    return normpath(opj(top_path, path))
 
 
 class Dataset(object, metaclass=Flyweight):

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -44,7 +44,7 @@ from datalad.dochelpers import exc_str
 
 from datalad.distribution.dataset import (
     datasetmethod,
-    rev_resolve_path,
+    resolve_path,
     require_dataset,
     EnsureDataset,
 )
@@ -308,7 +308,7 @@ class Install(Interface):
                 #      a peculiar use-case IMHO
                 # TODO Stringification can be removed once PY35 is no longer
                 # supported
-                path = str(rev_resolve_path(path_ri.localpath, dataset))
+                path = str(resolve_path(path_ri.localpath, dataset))
                 # any `path` argument that point to something local now
                 # resolved and is no longer a URL
             except ValueError:

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -10,20 +10,18 @@
 """
 
 import os
-import shutil
 import os.path as op
-from os.path import join as opj, abspath, normpath, relpath, exists
+from os.path import join as opj, abspath, relpath
 
 
-from ..dataset import Dataset, EnsureDataset, resolve_path, require_dataset
+from ..dataset import Dataset, EnsureDataset, require_dataset
 from ..dataset import rev_resolve_path
 from datalad import cfg
 from datalad.api import create
 from datalad.api import get
 import datalad.utils as ut
-from datalad.utils import chpwd, getpwd, rmtree
+from datalad.utils import chpwd, rmtree
 from datalad.utils import _path_
-from datalad.utils import get_dataset_root
 from datalad.utils import on_windows
 from datalad.utils import Path
 from datalad.support.gitrepo import GitRepo
@@ -32,8 +30,7 @@ from datalad.support.annexrepo import AnnexRepo
 from nose.tools import ok_, eq_, assert_false, assert_equal, assert_true, \
     assert_is_instance, assert_is_none, assert_is_not, assert_is_not_none
 from datalad.tests.utils import SkipTest
-from datalad.tests.utils import with_tempfile, assert_in, with_tree, with_testrepos
-from datalad.tests.utils import assert_cwd_unchanged
+from datalad.tests.utils import with_tempfile, with_testrepos
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import assert_is
@@ -42,7 +39,6 @@ from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import OBSCURE_FILENAME
 
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import PathKnownToRepositoryError
 
 
 def test_EnsureDataset():
@@ -62,32 +58,6 @@ def test_EnsureDataset():
 
     # Note: Ensuring that string is valid path is not
     # part of the constraint itself, so not explicitly tested here.
-
-
-@assert_cwd_unchanged
-@with_tempfile(mkdir=True)
-def test_resolve_path(somedir):
-
-    abs_path = abspath(somedir)  # just to be sure
-    rel_path = "some"
-    expl_path_cur = opj(os.curdir, rel_path)
-    expl_path_par = opj(os.pardir, rel_path)
-
-    eq_(resolve_path(abs_path), abs_path)
-
-    current = getpwd()
-    # no Dataset => resolve using cwd:
-    eq_(resolve_path(abs_path), abs_path)
-    eq_(resolve_path(rel_path), opj(current, rel_path))
-    eq_(resolve_path(expl_path_cur), normpath(opj(current, expl_path_cur)))
-    eq_(resolve_path(expl_path_par), normpath(opj(current, expl_path_par)))
-
-    # now use a Dataset as reference:
-    ds = Dataset(abs_path)
-    eq_(resolve_path(abs_path, ds), abs_path)
-    eq_(resolve_path(rel_path, ds), opj(abs_path, rel_path))
-    eq_(resolve_path(expl_path_cur, ds), normpath(opj(current, expl_path_cur)))
-    eq_(resolve_path(expl_path_par, ds), normpath(opj(current, expl_path_par)))
 
 
 # TODO: test remember/recall more extensive?

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -36,7 +36,7 @@ from datalad.support.constraints import (
     EnsureChoice,
 )
 from datalad.distribution.dataset import Dataset
-from datalad.distribution.dataset import rev_resolve_path
+from datalad.distribution.dataset import resolve_path
 from datalad.plugin import _get_plugins
 from datalad.plugin import _load_plugin
 
@@ -683,7 +683,7 @@ class Interface(object):
         refds_path = dataset.path if isinstance(dataset, Dataset) \
             else Dataset(dataset).path
         if refds_path:
-            refds_path = str(rev_resolve_path(refds_path))
+            refds_path = str(resolve_path(refds_path))
         return refds_path
 
 

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -26,7 +26,7 @@ from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
-from datalad.distribution.dataset import rev_resolve_path
+from datalad.distribution.dataset import resolve_path
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
@@ -81,7 +81,7 @@ class Unlock(Interface):
         paths_nondir = set()
         paths_lexist = None
         if path:
-            path = rev_resolve_path(assure_list(path), ds=dataset)
+            path = resolve_path(assure_list(path), ds=dataset)
             paths_lexist = []
             for p in path:
                 if p.exists() or p.is_symlink():

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -44,7 +44,7 @@ from datalad.utils import (
 from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
-    rev_resolve_path,
+    resolve_path,
 )
 
 lgr = logging.getLogger('datalad.local.subdatasets')
@@ -221,7 +221,7 @@ class Subdatasets(Interface):
         # no constraints given -> query subdatasets under curdir
         if not path and dataset is None:
             path = os.curdir
-        paths = [rev_resolve_path(p, dataset) for p in assure_list(path)] \
+        paths = [resolve_path(p, dataset) for p in assure_list(path)] \
             if path else None
 
         ds = require_dataset(
@@ -247,7 +247,7 @@ class Subdatasets(Interface):
                         "key '%s' is invalid (alphanumeric plus '-' only, must "
                         "start with a letter)" % k)
         if contains:
-            contains = [rev_resolve_path(c, dataset) for c in assure_list(contains)]
+            contains = [resolve_path(c, dataset) for c in assure_list(contains)]
         contains_hits = set()
         for r in _get_submodules(
                 ds, paths, fulfilled, recursive, recursion_limit,

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -22,7 +22,7 @@ import string
 
 from urllib.parse import urlparse
 
-from datalad.distribution.dataset import rev_resolve_path
+from datalad.distribution.dataset import resolve_path
 from datalad.dochelpers import exc_str
 from datalad.log import log_progress, with_result_progress
 from datalad.interface.base import Interface
@@ -785,7 +785,7 @@ class Addurls(Interface):
                                   message="not an annex repo")
             return
 
-        url_file = str(rev_resolve_path(url_file, dataset))
+        url_file = str(resolve_path(url_file, dataset))
 
         if input_type == "ext":
             extension = os.path.splitext(url_file)[1]


### PR DESCRIPTION
Fixes gh-3778

Old function is now an internal helper of `annotate_paths()`, and the tests have moved their as well. A more extensive test suite for the "new" function was already in place.