### PR TITLE
BF: Add basic import failure on `python -O` execution

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -15,6 +15,10 @@ From an interactive Python session, import `datalad.api` and inspect its
 documentation with `help`.
 """
 
+if not __debug__:
+    raise RuntimeError('DataLad cannot run in "optimized" mode, i.e. python -O')
+
+
 # For reproducible demos/tests
 import os
 _seed = os.environ.get('DATALAD_SEED', None)


### PR DESCRIPTION
This is following the advice from https://github.com/datalad/datalad/pull/2832#issuecomment-421403674 and substituting a completed https://github.com/datalad/datalad/pull/2832 that hasn't come yet.

In some sense fixes gh-2461
