### PR TITLE
RF: Standardize on rev_get_dataset_root() -> get_dataset_root()

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -40,13 +40,13 @@ from datalad.support.param import Parameter
 from datalad.utils import (
     getpwd,
     assure_list,
+    get_dataset_root,
 )
 
 from datalad.distribution.dataset import (
     Dataset,
     datasetmethod,
     EnsureDataset,
-    rev_get_dataset_root,
     resolve_path,
     path_under_rev_dataset,
     require_dataset,
@@ -241,7 +241,7 @@ class Create(Interface):
         # a potentially absent/uninstalled subdataset of the parent
         # in this location
         # it will cost some filesystem traversal though...
-        parentds_path = rev_get_dataset_root(
+        parentds_path = get_dataset_root(
             op.normpath(op.join(str(path), os.pardir)))
         if parentds_path:
             prepo = GitRepo(parentds_path)

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -17,6 +17,7 @@ from collections import OrderedDict
 from datalad.utils import (
     assure_list,
     assure_unicode,
+    get_dataset_root,
 )
 from datalad.interface.base import (
     Interface,
@@ -30,7 +31,6 @@ from datalad.distribution.dataset import (
     require_dataset,
     resolve_path,
     path_under_rev_dataset,
-    rev_get_dataset_root,
 )
 
 from datalad.support.constraints import (
@@ -164,7 +164,7 @@ def _diff_cmd(
                 resolved_path, \
                 orig_path.endswith(op.sep) or resolved_path == ds.pathobj
             str_path = str(p[0])
-            root = rev_get_dataset_root(str_path)
+            root = get_dataset_root(str_path)
             if root is None:
                 # no root, not possibly underneath the refds
                 yield dict(

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -20,6 +20,7 @@ from datalad.utils import (
     assure_list,
     assure_unicode,
     bytes2human,
+    get_dataset_root,
 )
 from datalad.interface.base import (
     Interface,
@@ -44,7 +45,6 @@ from datalad.distribution.dataset import (
     require_dataset,
     resolve_path,
     path_under_rev_dataset,
-    rev_get_dataset_root,
 )
 
 import datalad.utils as ut
@@ -302,7 +302,7 @@ class Status(Interface):
                 # for further decision logic below
                 orig_path = str(p)
                 p = resolve_path(p, dataset)
-                root = rev_get_dataset_root(str(p))
+                root = get_dataset_root(str(p))
                 if root is None:
                     # no root, not possibly underneath the refds
                     yield dict(
@@ -321,7 +321,7 @@ class Status(Interface):
                         # distinguish rsync-link syntax to identify
                         # the dataset as whole (e.g. 'ds') vs its
                         # content (e.g. 'ds/')
-                        super_root = rev_get_dataset_root(op.dirname(root))
+                        super_root = get_dataset_root(op.dirname(root))
                         if super_root:
                             # the dataset identified by the path argument
                             # is contained in a superdataset, and no

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -58,6 +58,7 @@ from datalad.dochelpers import (
 from datalad.utils import (
     unique,
     Path,
+    get_dataset_root,
 )
 
 from datalad.local.subdatasets import Subdatasets
@@ -67,7 +68,6 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
     require_dataset,
-    rev_get_dataset_root,
 )
 from datalad.distribution.clone import Clone
 from datalad.distribution.utils import _get_flexible_source_candidates
@@ -371,7 +371,7 @@ def _install_targetpath(
             # it resides in, because this value is used to determine which
             # dataset to call `annex-get` on
             # TODO stringification is a PY35 compatibility kludge
-            path=rev_get_dataset_root(str(target_path)),
+            path=get_dataset_root(str(target_path)),
             status='notneeded',
             contains=[target_path],
             refds=refds_path,


### PR DESCRIPTION
A `rev_get_dataset_root` symbol remains in place to allow for peaceful transition of code that was already using it.

Fixes gh-3796
