### PR TITLE
ENH: Record the active branch of a subdataset in the parent

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -11,7 +11,7 @@
 
 import os
 from os.path import join
-from os.path import expanduser
+import re
 
 # directory containing prepared metadata of a dataset repository:
 DATALAD_DOTDIR = ".datalad"
@@ -69,3 +69,6 @@ PRE_INIT_COMMIT_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 # git/datalad configuration item to provide a token for github
 CONFIG_HUB_TOKEN_FIELD = 'hub.oauthtoken'
+
+# format of git-annex adjusted branch names
+ADJUSTED_BRANCH_EXPR = re.compile(r'^adjusted/([^(]+)\(.*\)$')

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -71,4 +71,4 @@ PRE_INIT_COMMIT_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 CONFIG_HUB_TOKEN_FIELD = 'hub.oauthtoken'
 
 # format of git-annex adjusted branch names
-ADJUSTED_BRANCH_EXPR = re.compile(r'^adjusted/([^(]+)\(.*\)$')
+ADJUSTED_BRANCH_EXPR = re.compile(r'^adjusted/(?P<name>[^(]+)\(.*\)$')

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -84,7 +84,7 @@ def test_repo_diff(path, norepo):
     create_tree(ds.path, {'new': 'empty'})
     ds.save(to_git=True)
     assert_repo_status(ds.path)
-    eq_(ds.repo.diff(fr=fr_base + '~1', to=to),
+    eq_(ds.repo.diff(fr=fr_base + '~1', to=fr_base),
         {ut.Path(ds.repo.pathobj / 'new'): {
             'state': 'added',
             'type': 'file',

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -280,8 +280,11 @@ def test_diff_recursive(path):
     ds.save('sub', recursive=True)
     ds.save()
     assert_repo_status(ds.path)
+
+    head_ref = 'master' if ds.repo.is_managed_branch() else 'HEAD'
+
     # look at the last change, only one file was added
-    res = ds.diff(fr='HEAD~1', to='HEAD')
+    res = ds.diff(fr=head_ref + '~1', to=head_ref)
     assert_result_count(_dirty_results(res), 1)
     assert_result_count(
         res, 1,
@@ -290,7 +293,7 @@ def test_diff_recursive(path):
 
     # now the exact same thing with recursion, must not be different from the
     # call above
-    res = ds.diff(recursive=True, fr='HEAD~1', to='HEAD')
+    res = ds.diff(recursive=True, fr=head_ref + '~1', to=head_ref)
     assert_result_count(_dirty_results(res), 1)
     # last change in parent
     assert_result_count(
@@ -299,7 +302,7 @@ def test_diff_recursive(path):
 
     # one further back brings in the modified subdataset, and the added file
     # within it
-    res = ds.diff(recursive=True, fr='HEAD~2', to='HEAD')
+    res = ds.diff(recursive=True, fr=head_ref + '~2', to=head_ref)
     assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -36,6 +36,7 @@ from datalad.tests.utils import (
     assert_result_count,
     OBSCURE_FILENAME,
     known_failure_githubci_win,
+    SkipTest,
 )
 
 import datalad.utils as ut
@@ -300,6 +301,9 @@ def test_diff_recursive(path):
         res, 1, action='diff', state='added', path=op.join(ds.path, 'onefile'),
         type='file')
 
+    if ds.repo.is_managed_branch():
+        raise SkipTest(
+            "Test assumption broken: https://github.com/datalad/datalad/issues/3818")
     # one further back brings in the modified subdataset, and the added file
     # within it
     res = ds.diff(recursive=True, fr=head_ref + '~2', to=head_ref)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -105,7 +105,9 @@ def test_basics(path, nodspath):
         assert_result_count(res, 1, action='add',
                             path=op.join(ds.path, 'empty'), type='file')
         assert_result_count(res, 1, action='save', path=ds.path)
-        commit_msg = ds.repo.format_commit("%B")
+        # ATTN: Use master explicitly so that this check works when we're on an
+        # adjusted branch too (e.g., when this test is executed under Windows).
+        commit_msg = ds.repo.format_commit("%B", "master")
         ok_(commit_msg.startswith('[DATALAD RUNCMD] TEST'))
         # crude test that we have a record for the PWD
         assert_in('"pwd": "."', commit_msg)
@@ -177,18 +179,24 @@ def test_sidecar(path):
 
     ds.config.set("datalad.run.record-sidecar", "false", where="local")
     ds.run("cd .> dummy1", message="sidecar config")
-    assert_in('"cmd":', ds.repo.format_commit("%B"))
+
+    def last_commit_msg():
+        # ATTN: Use master explicitly so that this check works when we're on an
+        # adjusted branch too (e.g., when this test is executed under Windows).
+        return ds.repo.format_commit("%B", "master")
+
+    assert_in('"cmd":', last_commit_msg())
 
     ds.config.set("datalad.run.record-sidecar", "true", where="local")
     ds.run("cd .> dummy2", message="sidecar config")
-    assert_not_in('"cmd":', ds.repo.format_commit("%B"))
+    assert_not_in('"cmd":', last_commit_msg())
 
     # Don't break when config.get() returns multiple values. Here it's two
     # values in .gitconfig, but a more realistic scenario is a value in
     # $repo/.git/config that overrides a setting in ~/.config/git/config.
     ds.config.add("datalad.run.record-sidecar", "false", where="local")
     ds.run("cd .> dummy3", message="sidecar config")
-    assert_in('"cmd":', ds.repo.format_commit("%B"))
+    assert_in('"cmd":', last_commit_msg())
 
 
 @with_tree(tree={"to_remove": "abc"})
@@ -333,7 +341,9 @@ def test_inject(path):
                      dataset=ds,
                      inject=True,
                      extra_info={"custom_key": "custom_field"}))
-    msg = ds.repo.format_commit("%B")
+    # ATTN: Use master explicitly so that this check works when we're on an
+    # adjusted branch too (e.g., when this test is executed under Windows).
+    msg = ds.repo.format_commit("%B", "master")
     assert_in("custom_key", msg)
     assert_in("nonsense command", msg)
 

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -382,7 +382,17 @@ def test_add_subdataset(path, other):
     # to ds
     res = ds.save(subds.path)
     assert_in_results(res, action="add", path=subds.path, refds=ds.path)
-    assert_in('dir', ds.subdatasets(result_xfm='relpaths'))
+    res = ds.subdatasets()
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1,
+        # essentials
+        path=op.join(ds.path, 'dir'),
+        gitmodule_url='./dir',
+        gitmodule_name='dir',
+        # but also the branch, by default
+        gitmodule_branch='master',
+    )
     #  create another one
     other = create(other)
     # install into superdataset, but don't add

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -143,7 +143,9 @@ def test_save_message_file(path):
                        "msg": "add foo"})
     ds.repo.add("foo")
     ds.save(message_file=op.join(ds.path, "msg"))
-    eq_(ds.repo.format_commit("%s"),
+    # ATTN: Use master explicitly so that this check works when we're on an
+    # adjusted branch too (e.g., when this test is executed under Windows).
+    eq_(ds.repo.format_commit("%s", "master"),
         "add foo")
 
 

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -310,7 +310,7 @@ class Install(Interface):
                 'install', path=path, status='impossible', logger=lgr,
                 source_url=source, refds=refds_path,
                 message="installation `source` and destination `path` are identical. "
-                "If you are trying to add a subdataset simply use the `add` command")
+                "If you are trying to add a subdataset simply use the `save` command")
             return
 
         # resolve the target location (if local) against the provided dataset

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -133,6 +133,9 @@ def test_fs_traverse(topdir):
             assert_equal(brokenlink['size']['total'], '3 Bytes')
 
 
+# underlying code cannot deal with adjusted branches
+# https://github.com/datalad/datalad/pull/3817
+@known_failure_githubci_win
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '123',

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -15,6 +15,7 @@ from datalad.tests.utils import (
     assert_equal, assert_raises, assert_in, assert_false,
     assert_not_in, ok_startswith,
     serve_path_via_http,
+    known_failure_githubci_win,
 )
 from os.path import join as opj
 

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -814,7 +814,7 @@ def test_rerun_explicit(path):
 
 # underlying code cannot deal with adjusted branches
 # https://github.com/datalad/datalad/pull/3817
-@known_failure_githubci_win
+@known_failure_windows
 @with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c",
                  "subdir": {}})
 def test_placeholders(path):

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -812,6 +812,9 @@ def test_rerun_explicit(path):
         ds.rerun(onto="", since="", explicit=True)
 
 
+# underlying code cannot deal with adjusted branches
+# https://github.com/datalad/datalad/pull/3817
+@known_failure_githubci_win
 @with_tree(tree={"a.in": "a", "b.in": "b", "c.out": "c",
                  "subdir": {}})
 def test_placeholders(path):

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -55,6 +55,9 @@ _dataset_hierarchy_template = {
 }"""}}}}
 
 
+# underlying code cannot deal with adjusted branches
+# https://github.com/datalad/datalad/pull/3817
+@known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 def test_basic_aggregate(path):
     # TODO give datasets some more metadata to actually aggregate stuff
@@ -297,6 +300,9 @@ def test_aggregate_removal(path):
     assert_result_count(res, 1)
 
 
+# underlying code cannot deal with adjusted branches
+# https://github.com/datalad/datalad/pull/3817
+@known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 def test_update_strategy(path):
     base = Dataset(opj(path, 'origin')).create(force=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3447,7 +3447,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         branch = self.get_active_branch()
         adjusted_match = ADJUSTED_BRANCH_EXPR.match(branch if branch else '')
         if adjusted_match:
-            orig_branch = adjusted_match.group(1)
+            orig_branch = adjusted_match.group('name')
             synced_branch = 'synced/{}'.format(orig_branch)
             had_synced_branch = synced_branch in self.get_branches()
             lgr.debug(

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -66,7 +66,10 @@ from datalad.config import (
     _parse_gitconfig_dump
 )
 
-from datalad.consts import GIT_SSH_COMMAND
+from datalad.consts import (
+    GIT_SSH_COMMAND,
+    ADJUSTED_BRANCH_EXPR,
+)
 from datalad.dochelpers import exc_str
 import datalad.utils as ut
 from datalad.utils import (

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2669,7 +2669,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         # parent
         # gitpy.Submodule.add(self.repo, name, path, url=url, branch=branch)
         # going git native instead
-        cmd = ['git', 'submodule', 'add', '--name', name]
+        cmd = ['submodule', 'add', '--name', name]
         if branch is not None:
             cmd += ['-b', branch]
         if url is None:
@@ -2695,15 +2695,14 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             else:
                 url = path
         cmd += [url, Path(path).as_posix()]
-        self._git_custom_command('', cmd)
+        self.call_git(cmd)
         # record dataset ID if possible for comprehesive metadata on
         # dataset components within the dataset itself
         subm_id = GitRepo(op.join(self.path, path)).config.get(
             'datalad.dataset.id', None)
         if subm_id:
-            self._git_custom_command(
-                '',
-                ['git', 'config', '--file', '.gitmodules', '--replace-all',
+            self.call_git(
+                ['config', '--file', '.gitmodules', '--replace-all',
                  'submodule.{}.datalad-id'.format(name), subm_id])
         # ensure supported setup
         _fixup_submodule_dotgit_setup(self, path)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3839,13 +3839,17 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 if sm_props.get('type', None) == 'directory']
             to_add_submodules = _prune_deeper_repos(to_add_submodules)
             for cand_sm in to_add_submodules:
+                branch = self.get_active_branch()
+                adjusted_match = ADJUSTED_BRANCH_EXPR.match(
+                    branch if branch else '')
                 try:
                     self.add_submodule(
                         str(cand_sm.relative_to(self.pathobj)),
                         url=None,
                         name=None,
-                        branch=self.get_active_branch()
-                        )
+                        branch=adjusted_match.group('name') if adjusted_match
+                        else branch
+                    )
                 except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(
                         action='add_submodule',

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3842,7 +3842,10 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 try:
                     self.add_submodule(
                         str(cand_sm.relative_to(self.pathobj)),
-                        url=None, name=None)
+                        url=None,
+                        name=None,
+                        branch=self.get_active_branch()
+                        )
                 except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(
                         action='add_submodule',


### PR DESCRIPTION
This brings us closer to gh-1424

- [x] do not record the name of adjusted branches: https://github.com/datalad/datalad/pull/3817/checks?check_run_id=267367157#step:8:280
- [x] figure out why `git annex sync` blows up on windows (was https://github.com/datalad/datalad/issues/3824 and is fixed)
- [x] proposed handling involves a commit, which invalidates a bunch of test expectations.