### PR TITLE
ENH: Standardized way to add examples to commands

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -97,7 +97,7 @@ def setup_parser(
     # delay since it can be a heavy import
     from ..interface.base import dedent_docstring, get_interface_groups, \
         get_cmdline_command_name, alter_interface_docs_for_cmdline, \
-        load_interface, get_cmd_doc
+        load_interface, get_cmd_doc, get_cmd_ex
     # setup cmdline args parser
     parts = {}
     # main parser
@@ -304,6 +304,9 @@ def setup_parser(
                 intf_doc = get_cmd_doc(_intf)
                 parser_args['description'] = alter_interface_docs_for_cmdline(
                     intf_doc)
+                if hasattr(_intf, '_examples_'):
+                    intf_ex = alter_interface_docs_for_cmdline(get_cmd_ex(_intf))
+                    parser_args['description'] += intf_ex
             subparser = subparsers.add_parser(cmd_name, add_help=False, **parser_args)
             # our own custom help for all commands
             helpers.parser_add_common_opt(subparser, 'help')

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -105,6 +105,28 @@ class Create(Interface):
         EnsureKeyChoice('action', ('create',)) & \
         EnsureKeyChoice('status', ('ok', 'notneeded'))
 
+    _examples_ = [
+        dict(text="""Create a dataset 'mydataset' in the current directory""",
+             code_py="create(path='mydataset')",
+             code_cmd="datalad create mydataset",
+             setup_py="python -c 'from datalad.api import create, remove'",
+             setup_cmd="datalad create mydataset",
+             teardown_py="remove(path='mydataset')",
+             teardown_cmd="datalad remove mydataset"),
+        dict(text="""Apply the text2git procedure upon creation of a dataset""",
+             code_py="create(path='mydataset', cfg_proc='text2git')",
+             code_cmd="datalad create -c text2git mydataset"),
+        dict(text="""Create a subdataset in the root of an existing dataset""",
+             code_py="create(dataset='.', path='mysubdataset')",
+             code_cmd="datalad create -d . mysubdataset"),
+        dict(text="Create a dataset in an existing, non-empty directory",
+             code_py="create(force=True, path='.')",
+             code_cmd="datalad create --force"),
+        dict(text="Create a plain Git repository",
+             code_py="create(path='mydataset', no_annex=True)",
+             code_cmd="datalad create --no-annex"),
+    ]
+
     _params_ = dict(
         path=Parameter(
             args=("path",),

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -108,11 +108,7 @@ class Create(Interface):
     _examples_ = [
         dict(text="""Create a dataset 'mydataset' in the current directory""",
              code_py="create(path='mydataset')",
-             code_cmd="datalad create mydataset",
-             setup_py="python -c 'from datalad.api import create, remove'",
-             setup_cmd="datalad create mydataset",
-             teardown_py="remove(path='mydataset')",
-             teardown_cmd="datalad remove mydataset"),
+             code_cmd="datalad create mydataset"),
         dict(text="""Apply the text2git procedure upon creation of a dataset""",
              code_py="create(path='mydataset', cfg_proc='text2git')",
              code_cmd="datalad create -c text2git mydataset"),

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -134,23 +134,26 @@ class Run(Interface):
         dict(text="""Run a command and specify a directory as a dependency
              for the run. The contents of the dependency will be retrieved
              prior to running the script""",
-             code_cmd="datalad run -m 'run my script' --input 'data/\*' "
+             code_cmd="datalad run -m 'run my script' --input 'data/*' "
              "'code/script.sh'",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs='data/\*')"),
+             "inputs='data/*')"),
         dict(text="""Run an executable script and specify output files of the
              script to be unlocked prior to running the script""",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs='data/\*', outputs='output_dir')",
-             code_cmd="datalad run -m 'run my script' --input 'data/\*' "
-             "--output 'output_dir/\*' 'code/script.sh'"),
+             "inputs='data/*', outputs='output_dir')",
+             code_cmd="datalad run -m 'run my script' --input 'data/*' "
+             "--output 'output_dir/*' 'code/script.sh'"),
         dict(text="Specify multiple inputs and outputs",
-             code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs=['data/\*', 'datafile.txt'], outputs=['output_dir', "
-             "'outfile.txt'])",
-             code_cmd="datalad run -m 'run my script' --input 'data/\*' "
-             "--input 'datafile.txt' --output 'output_dir/\*' --output "
-             "'outfile.txt' 'code/script.sh'")
+             code_py="""\
+             ds.run(cmd='code/script.sh',
+                    message='run my script',
+                    inputs=['data/*', 'datafile.txt'],
+                    outputs=['output_dir', 'outfile.txt'])""",
+             code_cmd="""\
+             datalad run -m 'run my script' --input 'data/*'
+               --input 'datafile.txt' --output 'output_dir/*' --output
+               'outfile.txt' 'code/script.sh'""")
     ]
 
     _params_ = dict(

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -127,6 +127,32 @@ class Run(Interface):
 
         % datalad run "echo my name is {name} >me"
     """
+    _examples_ = [
+        dict(text="Run an executable script and record the impact on a dataset",
+             code_py="ds.run(message='run my script', cmd='code/script.sh')",
+             code_cmd="datalad run -m 'run my script' 'code/script.sh'"),
+        dict(text="""Run a command and specify a directory as a dependency
+             for the run. The contents of the dependency will be retrieved
+             prior to running the script""",
+             code_cmd="datalad run -m 'run my script' --input 'data/*' "
+             "'code/script.sh'",
+             code_py="ds.run(cmd='code/script.sh', message='run my script', "
+             "inputs='data/*')"),
+        dict(text="""Run an executable script and specify output files of the
+             script to be unlocked prior to running the script""",
+             code_py="ds.run(cmd='code/script.sh', message='run my script', "
+             "inputs='data/*', outputs='output_dir')",
+             code_cmd="datalad run -m 'run my script' --input 'data/*' --output "
+             "'output_dir/* 'code/script.sh'"),
+        dict(text="Specify multiple inputs and outputs",
+             code_py="ds.run(cmd='code/script.sh', message='run my script', "
+             "inputs=['data/*', 'datafile.txt'], outputs=['output_dir', "
+             "'outfile.txt'])",
+             code_cmd="datalad run -m 'run my script' --input 'data/*' "
+             "--input 'datafile.txt' --output 'output_dir/* --output "
+             "'outfile.txt' 'code/script.sh'")
+    ]
+
     _params_ = dict(
         cmd=Parameter(
             args=("cmd",),

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -134,22 +134,22 @@ class Run(Interface):
         dict(text="""Run a command and specify a directory as a dependency
              for the run. The contents of the dependency will be retrieved
              prior to running the script""",
-             code_cmd="datalad run -m 'run my script' --input 'data/*' "
+             code_cmd="datalad run -m 'run my script' --input 'data/\*' "
              "'code/script.sh'",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs='data/*')"),
+             "inputs='data/\*')"),
         dict(text="""Run an executable script and specify output files of the
              script to be unlocked prior to running the script""",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs='data/*', outputs='output_dir')",
-             code_cmd="datalad run -m 'run my script' --input 'data/*' --output "
-             "'output_dir/* 'code/script.sh'"),
+             "inputs='data/\*', outputs='output_dir')",
+             code_cmd="datalad run -m 'run my script' --input 'data/\*' "
+             "--output 'output_dir/\*' 'code/script.sh'"),
         dict(text="Specify multiple inputs and outputs",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs=['data/*', 'datafile.txt'], outputs=['output_dir', "
+             "inputs=['data/\*', 'datafile.txt'], outputs=['output_dir', "
              "'outfile.txt'])",
-             code_cmd="datalad run -m 'run my script' --input 'data/*' "
-             "--input 'datafile.txt' --output 'output_dir/* --output "
+             code_cmd="datalad run -m 'run my script' --input 'data/\*' "
+             "--input 'datafile.txt' --output 'output_dir/\*' --output "
              "'outfile.txt' 'code/script.sh'")
     ]
 

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -87,6 +87,31 @@ class Save(Interface):
     # note above documents that out behavior is like that of `git add`, but
     # does not explicitly mention the connection to keep it simple.
 
+    _examples_ = [
+        dict(text="""Save any content underneath the current directory, without
+             altering any potential subdataset""",
+             code_py="ds.save()",
+             code_cmd="datalad save ."),
+        dict(text="""Save specific content in the dataset""",
+             code_py="ds.save(path='myfile.txt')",
+             code_cmd="datalad save myfile.txt"),
+        dict(text="""Attach a commit message to save""",
+             code_py="ds.save(path='myfile.txt', message='add a file')",
+             code_cmd="datalad save -m 'add file' myfile.txt"),
+        dict(text="""Save any content underneath the current directory, and
+             recurse into any potential subdatasets""",
+             code_py="ds.save(recursive=True)",
+             code_cmd="datalad save . --recursive"),
+        dict(text="""Save any modification of known dataset content in the
+             current directory, but leave untracked files (e.g. temporary files)
+             untouched""",
+             code_py="""ds.save(updated=True, path='.')""",
+             code_cmd="""datalad save -u -d ."""),
+        dict(text="Tag the most recent saved state of a dataset",
+             code_py="ds.save(version_tag='bestyet')",
+             code_cmd="datalad save -d . --version-tag 'bestyet'"),
+    ]
+
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -62,22 +62,6 @@ class Save(Interface):
     saved state. Such tag enables straightforward retrieval of past versions at
     a later point in time.
 
-    Examples:
-
-      Save any content underneath the current directory, without altering
-      any potential subdataset (use --recursive for that)::
-
-        % datalad save .
-
-      Save any modification of known dataset content, but leave untracked
-      files (e.g. temporary files) untouched::
-
-        % dataset save -u -d <path_to_dataset>
-
-      Tag the most recent saved state of a dataset::
-
-        % dataset save -d <path_to_dataset> --version-tag bestyet
-
     .. note::
       Before Git v2.22, any Git repository without an initial commit located
       inside a Dataset is ignored, and content underneath it will be saved to

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -225,6 +225,31 @@ class Status(Interface):
     # make the custom renderer the default one, as the global default renderer
     # does not yield meaningful output for this command
     result_renderer = 'tailored'
+    _examples_ = [
+        dict(text="""Report on the state of a dataset""",
+             code_py="ds.status()",
+             code_cmd="datalad status"),
+        dict(text="""Report on the state of a dataset and all subdatasets""",
+             code_py="ds.status(recursive=True)",
+             code_cmd="datalad status --recursive"),
+        dict(text="""Address a subdataset record in a superdataset without
+             causing a status query for the state _within_ the subdataset
+             itself""",
+             code_py="ds.status(path='mysubdataset')",
+             code_cmd="datalad status --dataset . mysubdataset"),
+        dict(text="""Get a status query for the state within the subdataset
+             without causing a status query for the superdataset (using trailing
+             path separator in the query path):""",
+             code_py="ds.status(path='mysubdataset')",
+             code_cmd="datalad status --dataset . mysubdataset/"),
+        dict(text="""Report on the state of a subdataset in a superdataset and
+             on the state within the subdataset""",
+             code_py=" ds.status(path=['mysubdataset', 'mysubdataset/'])",
+             code_cmd="datalad status --dataset . mysubdataset mysubdataset/"),
+        dict(text="""Report the file size of annexed content in a dataset""",
+             code_py="ds.status(annex=True)",
+             code_cmd="datalad status --annex")
+    ]
 
     _params_ = dict(
         _common_diffstatus_params,

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -140,6 +140,21 @@ class Drop(Interface):
         ~/some/dataset$ datalad drop --recursive
 
     """
+    _examples_ = [
+        dict(text="Drop single file content",
+             code_py="drop('path/to/file')",
+             code_cmd="datalad drop <path/to/file>"),
+        dict(text="Drop all file content in the current dataset",
+             code_py="drop('.')",
+             code_cmd="datalad drop"),
+        dict(text="Drop all file content in a dataset and all its subdatasets",
+             code_py="drop(dataset='.', recursive=True)",
+             code_cmd="datalad drop --dataset <path/to/dataset> --recursive"),
+        dict(text="""Disable check to assure the configured minimum number of
+             remote sources for dropped data""",
+             code_py="drop(path='path/to/content', check=False)",
+             code_cmd="datalad drop <path/to/content> --nocheck"),
+    ]
     _action = 'drop'
 
     _params_ = dict(

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -511,6 +511,17 @@ class Get(Interface):
       Power-user info: This command uses :command:`git annex get` to fulfill
       file handles.
     """
+    _examples_ = [
+        dict(text="Get a single file",
+             code_py="get('path/to/file')",
+             code_cmd="datalad get <path/to/file>"),
+        dict(text="Get contents of a directory",
+             code_py="get('path/to/dir/')",
+             code_cmd="datalad get <path/to/dir/>"),
+        dict(text="Get all contents of the current dataset and its subdatasets",
+             code_py="get(dataset='.', recursive=True)",
+             code_cmd="datalad get . --recursive"),
+    ]
 
     _params_ = dict(
         dataset=Parameter(

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -96,6 +96,33 @@ class Install(Interface):
     # datasets
     result_filter = is_result_matching_pathsource_argument
 
+    _examples_ = [
+        dict(text="Install a dataset from Github into the current directory",
+             code_py="install("
+             "source='https://github.com/datalad-datasets/longnow"
+             "-podcasts.git')",
+             code_cmd="datalad install "
+             "https://github.com/datalad-datasets/longnow-podcasts.git"),
+        dict(text="Install a dataset as a subdataset into the current dataset",
+             code_py="install(dataset='.', "
+             "source='https://github.com/datalad-datasets/longnow-podcasts.git')",
+             code_cmd="datalad install -d . "
+             "--source='https://github.com/datalad-datasets/longnow-podcasts.git'"),
+        dict(text="Install a dataset, and get all contents right away",
+             code_py="install(source="
+             "'https://github.com/datalad-datasets/longnow-podcasts.git', "
+             "get_data=True')",
+             code_cmd="datalad install --get-data "
+             "--source https://github.com/datalad-datasets/longnow-podcasts.git"),
+        dict(text="Install a dataset with all its subdatasets",
+             code_py="install("
+             "source='https://github.com/datalad-datasets/longnow-podcasts.git', "
+             "recursive=True)",
+             code_cmd="datalad install "
+             "https://github.com/datalad-datasets/longnow-podcasts.git "
+             "--recursive"),
+    ]
+
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -108,7 +108,7 @@ class Install(Interface):
              "source='https://github.com/datalad-datasets/longnow-podcasts.git')",
              code_cmd="datalad install -d . "
              "--source='https://github.com/datalad-datasets/longnow-podcasts.git'"),
-        dict(text="Install a dataset, and get all contents right away",
+        dict(text="Install a dataset, and get all content right away",
              code_py="install(source="
              "'https://github.com/datalad-datasets/longnow-podcasts.git', "
              "get_data=True')",

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -307,12 +307,6 @@ def alter_interface_docs_for_cmdline(docs):
         lambda match: match.group(0)[3:-2].upper(),
         docs,
         flags=re.MULTILINE)
-    # remove RST simple code block markup (::) with single colon
-    docs = re.sub(
-        r'::$',
-        ':',
-        docs,
-        flags=re.MULTILINE)
     docs = re.sub(
         r'\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -307,6 +307,12 @@ def alter_interface_docs_for_cmdline(docs):
         lambda match: match.group(0)[3:-2].upper(),
         docs,
         flags=re.MULTILINE)
+    # remove RST simple code block markup (::) with single colon
+    docs = re.sub(
+        r'::$',
+        ':',
+        docs,
+        flags=re.MULTILINE)
     docs = re.sub(
         r'\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -180,6 +180,19 @@ def get_cmd_doc(interface):
     return intf_doc
 
 
+def get_cmd_ex(interface):
+    """Return the examples for the command defined by 'interface'.
+
+    Parameters
+    ----------
+    interface : subclass of Interface
+    """
+    intf_ex = "\n\n*Examples*\n"
+    for example in interface._examples_:
+        intf_ex += build_example(example, api=False)
+    return intf_ex
+
+
 def dedent_docstring(text):
     """Remove uniform indentation from a multiline docstring"""
     # Problem is that first line might often have no offset, so might
@@ -358,6 +371,41 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     # assign the amended docs
     func.__doc__ = doc
     return func
+
+
+def build_example(example, api=True):
+    """Build a code example.
+
+    Take a dict from a classes _example_ specification (list of dicts) and
+    build a string with an api or cmd example (for use in cmd help or
+    docstring).
+
+    Parameters
+    ----------
+    api : bool
+        If True, build Python example for docstring. If False, build cmd
+        example.
+
+    Returns
+    -------
+    ex : str
+        Concatenated examples for the given class.
+    """
+    if api:
+        code_field='code_py'
+        indicator=''
+    else:
+        code_field='code_cmd'
+        indicator='% '
+    description = dedent_docstring(example.get('text'))
+    code = example.get(code_field)
+
+    ex = """{}::\n\n   {}{}\n\n""".format(description,
+                                        indicator,
+                                        code)
+    return ex
+
+
 
 
 def build_doc(cls, **kwargs):

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -187,7 +187,7 @@ def get_cmd_ex(interface):
     ----------
     interface : subclass of Interface
     """
-    intf_ex = "\n\n*Examples*\n"
+    intf_ex = "\n\n*Examples*\n\n"
     for example in interface._examples_:
         intf_ex += build_example(example, api=False)
     return intf_ex
@@ -407,8 +407,8 @@ def build_example(example, api=True):
     code = example.get(code_field)
 
     ex = """{}::\n\n   {}{}\n\n""".format(description,
-                                        indicator,
-                                        code)
+                                          indicator,
+                                          code)
     return ex
 
 
@@ -422,12 +422,13 @@ def update_docstring_with_examples(cls_doc, ex):
     ex: list
         list of dicts with examples
     """
+    from textwrap import indent
     if len(cls_doc):
         cls_doc += "\n"
-    cls_doc += "Examples\n--------\n"
+    cls_doc += "    Examples\n    --------\n"
     # loop though provided examples
     for example in ex:
-        cls_doc += build_example(example, api=True)
+        cls_doc += indent(build_example(example, api=True), ' '*4)
 
     return cls_doc
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -400,11 +400,16 @@ def build_example(example, api='python'):
     else:
         raise ValueError("unknown API selection: {}".format(api))
     description = dedent_docstring(example.get('text'))
-    code = example.get(code_field)
+    # this indent the code snippet to get it properly rendered as code
+    # we are not using textwrap.fill(), because it would not acknowledge
+    # any meaningful structure/formatting of code snippets. Instead, we
+    # maintain line content as is.
+    code = dedent_docstring(example.get(code_field))
+    code = textwrap.indent(code, '     ').lstrip()
 
-    ex = """{}::\n\n   {}{}\n\n""".format(description,
-                                          indicator,
-                                          code)
+    ex = """{}::\n\n   {} {}\n\n""".format(description,
+                                           indicator,
+                                           code)
     return ex
 
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -412,6 +412,24 @@ def build_example(example, api=True):
     return ex
 
 
+def update_docstring_with_examples(cls_doc, ex):
+    """Update a commands docstring with examples.
+
+    Take _examples_ of a command, build the Python examples, and append
+    them to the docstring.
+
+    cls_doc: docstring
+    ex: list
+        list of dicts with examples
+    """
+    if len(cls_doc):
+        cls_doc += "\n"
+    cls_doc += "Examples\n--------\n"
+    # loop though provided examples
+    for example in ex:
+        cls_doc += build_example(example, api=True)
+
+    return cls_doc
 
 
 def build_doc(cls, **kwargs):
@@ -446,7 +464,9 @@ def build_doc(cls, **kwargs):
     if hasattr(cls, '_docs_'):
         # expand docs
         cls_doc = cls_doc.format(**cls._docs_)
-
+    # get examples
+    ex = getattr(cls, '_examples_', [])
+    cls_doc = update_docstring_with_examples(cls_doc, ex)
     call_doc = None
     # suffix for update_docstring_with_parameters:
     if cls.__call__.__doc__:

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -189,7 +189,7 @@ def get_cmd_ex(interface):
     """
     intf_ex = "\n\n*Examples*\n\n"
     for example in interface._examples_:
-        intf_ex += build_example(example, api=False)
+        intf_ex += build_example(example, api='cmdline')
     return intf_ex
 
 
@@ -373,7 +373,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     return func
 
 
-def build_example(example, api=True):
+def build_example(example, api='python'):
     """Build a code example.
 
     Take a dict from a classes _example_ specification (list of dicts) and
@@ -382,21 +382,23 @@ def build_example(example, api=True):
 
     Parameters
     ----------
-    api : bool
-        If True, build Python example for docstring. If False, build cmd
-        example.
+    api : {'python', 'cmdline'}
+        If 'python', build Python example for docstring. If 'cmdline', build
+        cmd example.
 
     Returns
     -------
     ex : str
         Concatenated examples for the given class.
     """
-    if api:
+    if api == 'python' :
         code_field='code_py'
-        indicator=''
-    else:
+        indicator='>'
+    elif api == 'cmdline':
         code_field='code_cmd'
-        indicator='% '
+        indicator='%'
+    else:
+        raise ValueError("unknown API selection: {}".format(api))
     description = dedent_docstring(example.get('text'))
     code = example.get(code_field)
 
@@ -422,7 +424,7 @@ def update_docstring_with_examples(cls_doc, ex):
     cls_doc += "    Examples\n    --------\n"
     # loop though provided examples
     for example in ex:
-        cls_doc += indent(build_example(example, api=True), ' '*4)
+        cls_doc += indent(build_example(example, api='python'), ' '*4)
 
     return cls_doc
 

--- a/docs/source/designpatterns.rst
+++ b/docs/source/designpatterns.rst
@@ -59,3 +59,25 @@ All these methods take care of raising appropriate exceptions when expected
 conditions are not met. Whenever desired functionality can be achieved
 using simple custom calls to Git via these methods, their use is preferred
 over the implementation of additional, dedicated wrapper methods.
+
+Command examples
+================
+
+Examples of Python and commandline invocations of DataLad's user-oriented
+commands are defined in the class of the respective command as dictionaries
+within `_examples_`:
+
+.. code-block:: python
+
+   _examples_ = [
+    dict(text="""Create a dataset 'mydataset' in the current directory""",
+         code_py="create(path='mydataset')",
+         code_cmd="datalad create mydataset",
+    dict(text="""Apply the text2git procedure upon creation of a dataset""",
+         code_py="create(path='mydataset', cfg_proc='text2git')",
+         code_cmd="datalad create -c text2git mydataset")
+         ]
+
+The formatting of code lines is preserved. Changes to existing examples and
+new contributions should provide examples for Python and commandline API, as
+well as a consise description.


### PR DESCRIPTION
Following up on #3757, I'm drafting a standardized way to include examples into the docstrings or help messages of commands, and I would appreciate critical feedback.

My idea was to mimick the current way in which `_params_` within each command class holds the commands parameters and has custom functions to add them to the parser or the docstring.

I propose to have `_examples_` as a list of dictionaries, with each dictionary being one command example. The key `text` holds a description of the example, and `code_py` or `code_cmd` keys holds code snippets.
```python
    _examples_ = [
        dict(text="""Apply the text2git procedure upon creation of a dataset""",
             code_py="create(path='mydataset', cfg_proc='text2git')",
             code_cmd="datalad create -c text2git mydataset"),
```

Based on `_examples_`, additional functions in [`build_doc`](https://github.com/datalad/datalad/blob/3f1652d2da63d3e30f9c67db7a98528c1cf757a0/datalad/interface/base.py#L363) and [`setup_parser`](https://github.com/datalad/datalad/blob/3f1652d2da63d3e30f9c67db7a98528c1cf757a0/datalad/cmdline/main.py#L87) build the example and append it to the docstring or the help message. This is how it currently looks for me for 

<details><summary>cmd line help </summary>

```sh

datalad install --help
Usage: datalad install [-h] [-s SOURCE] [-d DATASET] [-g] [-D DESCRIPTION]
                       [-r] [-R LEVELS] [--nosave] [--reckless] [-J NJOBS]
                       [PATH [PATH ...]]

Install a dataset from a (remote) source.

This command creates a local sibling of an existing dataset from a
(remote) location identified via a URL or path. Optional recursion into
potential subdatasets, and download of all referenced data is supported.
The new dataset can be optionally registered in an existing
superdataset by identifying it via the DATASET argument (the new
dataset's path needs to be located within the superdataset for that).

It is recommended to provide a brief description to label the dataset's
nature *and* location, e.g. "Michael's music on black laptop". This helps
humans to identify data locations in distributed scenarios.  By default an
identifier comprised of user and machine name, plus path will be generated.

When only partial dataset content shall be obtained, it is recommended to
use this command without the GET-DATA flag, followed by a
`get` operation to obtain the desired data.

NOTE
  Power-user info: This command uses git clone, and
  git annex init to prepare the dataset. Registering to a
  superdataset is performed via a git submodule add operation
  in the discovered superdataset.

*Examples*
Install a dataset from Github into the current directory:

   % datalad install https://github.com/datalad-datasets/longnow-podcasts.git

Install a dataset as a subdataset into the current dataset:

   % datalad install -d . --source='https://github.com/datalad-datasets/longnow-podcasts.git'

Install a dataset, and get all contents right away:

   % datalad install --get-data --source https://github.com/datalad-datasets/longnow-podcasts.git

Install a dataset with all its subdatasets:

   % datalad install https://github.com/datalad-datasets/longnow-podcasts.git --recursive

*Arguments*
  PATH                  path/name of the installation target. If no PATH is
                        provided a destination path will be derived from a
                        source URL similar to git clone. [Default: None]

*Options*
  -h, --help, --help-np
                        show this help message. --help-np forcefully disables
                        the use of a pager for displaying the help message
  -s SOURCE, --source SOURCE
                        URL or local path of the installation source.
                        Constraints: value must be a string [Default: None]
  -d DATASET, --dataset DATASET
                        specify the dataset to perform the install operation
                        on. If no dataset is given, an attempt is made to
                        identify the dataset in a parent directory of the
                        current working directory and/or the PATH given.
                        Constraints: Value must be a Dataset or a valid
                        identifier of a Dataset (e.g. a path) [Default: None]
  -g, --get-data        if given, obtain all data content too. [Default:
                        False]
  -D DESCRIPTION, --description DESCRIPTION
                        short description to use for a dataset location. Its
                        primary purpose is to help humans to identify a
                        dataset copy (e.g., "mike's dataset on lab server").
                        Note that when a dataset is published, this
                        information becomes available on the remote side.
                        Constraints: value must be a string [Default: None]
  -r, --recursive       if set, recurse into potential subdataset. [Default:
                        False]
  -R LEVELS, --recursion-limit LEVELS
                        limit recursion into subdataset to the given number of
                        levels. Constraints: value must be convertible to type
                        'int' [Default: None]
  --nosave              by default all modifications to a dataset are
                        immediately saved. Giving this option will disable
                        this behavior. [Default: True]
  --reckless            Set up the dataset to be able to obtain content in the
                        cheapest/fastest possible way, even if this poses a
                        potential risk the data integrity (e.g. hardlink files
                        from a local clone of the dataset). Use with care, and
                        limit to "read-only" use cases. With this flag the
                        installed dataset will be marked as untrusted.
                        [Default: False]
  -J NJOBS, --jobs NJOBS
                        how many parallel jobs (where possible) to use.
                        Constraints: value must be convertible to type 'int',
                        or value must be one of ('auto',) [Default: 'auto']
```
</details>

and for a 
<details><summary>Python help</summary>

```python

Help on function __call__ in module datalad.core.local.create:

Signature:
create(
    path=None,
    initopts=None,
    force=False,
    description=None,
    dataset=None,
    no_annex=False,
    fake_dates=False,
    cfg_proc=None,
)
Docstring:
Create a new dataset from scratch.

This command initializes a new dataset at a given location, or the
current directory. The new dataset can optionally be registered in an
existing superdataset (the new dataset's path needs to be located
within the superdataset for that, and the superdataset needs to be given
explicitly via `dataset`). It is recommended
to provide a brief description to label the dataset's nature *and*
location, e.g. "Michael's music on black laptop". This helps humans to
identify data locations in distributed scenarios.  By default an identifier
comprised of user and machine name, plus path will be generated.

This command only creates a new dataset, it does not add existing content
to it, even if the target directory already contains additional files or
directories.

Plain Git repositories can be created via the `no_annex` flag.
However, the result will not be a full dataset, and, consequently,
not all features are supported (e.g. a description).

To create a local version of a remote dataset use the
:func:`~datalad.api.install` command instead.

.. note::
  Power-user info: This command uses :command:`git init` and
  :command:`git annex init` to prepare the new dataset. Registering to a
  superdataset is performed via a :command:`git submodule add` operation
  in the discovered superdataset.

Examples
--------
Create a dataset 'mydataset' in the current directory::

   create(path='mydataset')

Apply the text2git procedure upon creation of a dataset::

   create(path='mydataset', cfg_proc='text2git')

Create a subdataset in the root of an existing dataset::

   create(dataset='.', path='mysubdataset')

Create a dataset in an existing, non-empty directory::

   create(force=True, path='.')

Create a plain Git repository::

   create(path='mydataset', no_annex=True)


Parameters
----------
path : str or Dataset or None, optional
  path where the dataset shall be created, directories will be created
  as necessary. If no location is provided, a dataset will be created
  in the current working directory. Either way the command will error
  if the target directory is not empty. Use `force` to create a
  dataset in a non-empty directory. [Default: None]
initopts
  options to pass to :command:`git init`. Options can be given as a
  list of command line arguments or as a GitPython-style option
  dictionary. Note that not all options will lead to viable results.
  For example '--bare' will not yield a repository where DataLad can
  adjust files in its worktree. [Default: None]
force : bool, optional
  enforce creation of a dataset in a non-empty directory. [Default:
  False]
description : str or None, optional
  short description to use for a dataset location. Its primary purpose
  is to help humans to identify a dataset copy (e.g., "mike's dataset
  on lab server"). Note that when a dataset is published, this
  information becomes available on the remote side. [Default: None]
dataset : Dataset or None, optional
  specify the dataset to perform the create operation on. If a dataset
  is given, a new subdataset will be created in it. [Default: None]
no_annex : bool, optional
  if set, a plain Git repository will be created without any annex.
  [Default: False]
fake_dates : bool, optional
  Configure the repository to use fake dates. The date for a new
  commit will be set to one second later than the latest commit in the
  repository. This can be used to anonymize dates. [Default: False]
cfg_proc
  Run cfg_PROC procedure(s) (can be specified multiple times) on the
  created dataset. Use `run_procedure(discover=True)` to get a list of
  available procedures, such as cfg_text2git. [Default: None]
on_failure : {'ignore', 'continue', 'stop'}, optional
  behavior to perform on failure: 'ignore' any failure is reported,
  but does not cause an exception; 'continue' if any failure occurs an
  exception will be raised at the end, but processing other actions
  will continue for as long as possible; 'stop': processing will stop
  on first failure and an exception is raised. A failure is any result
  with status 'impossible' or 'error'. Raised exception is an
  IncompleteResultsError that carries the result dictionaries of the
  failures in its `failed` attribute. [Default: 'continue']
proc_post
  Like `proc_pre`, but procedures are executed after the main command
  has finished. [Default: None]
proc_pre
  DataLad procedure to run prior to the main command. The argument a
  list of lists with procedure names and optional arguments.
  Procedures are called in the order their are given in this list. It
  is important to provide the respective target dataset to run a
  procedure on as the `dataset` argument of the main command.
  [Default: None]
result_filter : callable or None, optional
  if given, each to-be-returned status dictionary is passed to this
  callable, and is only returned if the callable's return value does
  not evaluate to False or a ValueError exception is raised. If the
  given callable supports `**kwargs` it will additionally be passed
  the keyword arguments of the original API call. [Default: None]
result_renderer : {'default', 'json', 'json_pp', 'tailored'} or None, optional
  format of return value rendering on stdout. [Default: None]
result_xfm : {'datasets', 'successdatasets-or-none', 'paths', 'relpaths', 'metadata'} or callable or None, optional
  if given, each to-be-returned result status dictionary is passed to
  this callable, and its return value becomes the result instead. This
  is different from `result_filter`, as it can perform arbitrary
  transformation of the result value. This is mostly useful for top-
  level command invocations that need to provide the results in a
  particular format. Instead of a callable, a label for a pre-crafted
  result transformation can be given. [Default: None]
return_type : {'generator', 'list', 'item-or-list'}, optional
  return value behavior switch. If 'item-or-list' a single value is
  returned instead of a one-item return value list, or a list in case
  of multiple return values. `None` is return in case of an empty
  list. [Default: 'list']
File:      ~/repos/datalad/datalad/core/local/create.py
Type:      FunctionWrapper

```
</details>

Note that in the docstrings, examples use the simple ``::`` rst markup which I believe gets rendered by Sphinx into code markup

```
Create a subdataset in the root of an existing dataset::
    
   create(dataset='.', path='mysubdataset')
```

If you have any thoughts on this, please let me know. I will in any case draft examples for hopefully all commands.

### TODO

The dictionary data structure can be expanded with other keys, such as ``setup_py``/``setup_cmd`` and ``teardown_py``/``teardown_cmd``. These keys could hold the relevant code to run the command example and clean up afterwards, e.g.

```python
        dict(text="""Create a dataset 'mydataset' in the current directory""",
             code_py="create(path='mydataset')",
             code_cmd="datalad create mydataset",
             setup_py="python -c 'from datalad.api import create, remove'",
             setup_cmd="datalad create mydataset",
             teardown_py="remove(path='mydataset')",
             teardown_cmd="datalad remove mydataset"),
```

This would make it possible to write functions that build the examples, test whether they run, and tear down what an example executed.
