### PR TITLE
More flexible clone URL generation for submodules

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -112,7 +112,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm_path, sm_url=None):
     # if we have a remote, let's check the location of that remote
     # for the presence of the desired submodule
     try:
-        last_commit = ds_repo.get_last_commit_hash(sm_path)
+        last_commit = ds_repo.get_last_commit_hexsha(sm_path)
         # ideally should also give preference to the remotes which have
         # the same branch checked out I guess
         candidate_remotes += list(_get_remotes_having_commit(ds_repo, last_commit))

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -105,7 +105,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm_path, sm_url=None):
 
     ds_repo = ds.repo
 
-    # should be our first candidate
+    # CANDIDATE: tracking remote of the current branch
     tracking_remote, tracking_branch = ds_repo.get_tracking_branch()
     candidate_remotes = [tracking_remote] if tracking_remote else []
 
@@ -113,6 +113,9 @@ def _get_flexible_source_candidates_for_submodule(ds, sm_path, sm_url=None):
     # for the presence of the desired submodule
     last_commit = ds_repo.get_last_commit_hexsha(sm_path)
     if last_commit:
+        # CANDIDATE: any remote that has the commit when the submodule was
+        # last modified
+
         # ideally should also give preference to the remotes which have
         # the same branch checked out I guess
         candidate_remotes += list(_get_remotes_having_commit(ds_repo, last_commit))
@@ -145,7 +148,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm_path, sm_url=None):
                     alternate_suffix=False
                 )
 
-    # Do based on the ds.path as the last resort
+    # CANDIDATE: relative to the local dataset path... more hope than plan
     if sm_url:
         clone_urls += _get_flexible_source_candidates(
             sm_url,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -111,14 +111,11 @@ def _get_flexible_source_candidates_for_submodule(ds, sm_path, sm_url=None):
 
     # if we have a remote, let's check the location of that remote
     # for the presence of the desired submodule
-    try:
-        last_commit = ds_repo.get_last_commit_hexsha(sm_path)
+    last_commit = ds_repo.get_last_commit_hexsha(sm_path)
+    if last_commit:
         # ideally should also give preference to the remotes which have
         # the same branch checked out I guess
         candidate_remotes += list(_get_remotes_having_commit(ds_repo, last_commit))
-    except StopIteration:
-        # no commit for it known yet, ... oh well
-        pass
 
     for remote in unique(candidate_remotes):
         remote_url = ds_repo.get_remote_url(remote, push=False)

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -210,14 +210,14 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     # CANDIDATE: the actual configured gitmodule URL
     if sm_url:
         clone_urls.extend(
-            ('origin', url)
+            ('local', url)
             for url in _get_flexible_source_candidates(
                 sm_url,
                 ds.path,
                 alternate_suffix=False)
         )
 
-    return unique(clone_urls)
+    return unique(clone_urls, lambda x: x[1])
 
 
 def _install_subds_from_flexible_source(ds, sm, **kwargs):

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -101,7 +101,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     Even if a URL for submodule is provided explicitly -- first tries urls under
     parent's module tracking branch remote.
 
-    Additional candidate URLs can be generate based on templates specified as
+    Additional candidate URLs can be generated based on templates specified as
     configuration variables with the pattern
 
       `datalad.get.subdataset-source-candidate-<name>`
@@ -109,9 +109,9 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     where `name` is an arbitrary identifier.
 
     A template string assigned to such a variable can utilize the Python format
-    mini language and may reference a number of properties that a inferred from
-    the parent dataset's knowledge about the target subdataset. Properties
-    include any submodule property specified in the respecive .gitmodules
+    mini language and may reference a number of properties that are inferred
+    from the parent dataset's knowledge about the target subdataset. Properties
+    include any submodule property specified in the respective .gitmodules
     record. For convenience, an existing `datalad-id` record is made available
     under the shortened name `id`.
 

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -78,15 +78,12 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     # first one could just know about itself or explicit url provided
     sshurl = 'ssh://e.c'
     httpurl = 'http://e.c'
-    # Expansion with '/.git' no longer done in this helper
-    #sm_httpurls = [httpurl, httpurl + '/.git']
-    sm_httpurls = [('origin', httpurl)]
     ds_subpath = str(ds.pathobj / 'sub')
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path)), [])
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path, gitmodule_url=sshurl)),
-        [('origin', sshurl)])
+        [('local', sshurl)])
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path, gitmodule_url=httpurl)),
-        sm_httpurls)
+        [('local', httpurl)])
 
     # but if we work on dsclone then it should also add urls deduced from its
     # own location default remote for current branch
@@ -94,7 +91,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     eq_(f(clone, dict(path=ds_subpath, parentds=t, gitmodule_url=sshurl)),
         [('origin', ds_subpath), ('origin', sshurl)])
     eq_(f(clone, dict(path=ds_subpath, parentds=t, gitmodule_url=httpurl)),
-        [('origin', ds_subpath)] + sm_httpurls)
+        [('origin', ds_subpath), ('origin', httpurl)])
 
     # make sure it does meaningful things in an actual clone with an actual
     # record of a subdataset
@@ -102,7 +99,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
             ('origin', ds_subpath),
-            ('origin', clone_subpath),
+            ('local', clone_subpath),
     ])
 
     # check that a configured remote WITHOUT the desired submodule commit
@@ -112,7 +109,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
             ('origin', ds_subpath),
-            ('origin', clone_subpath),
+            ('local', clone_subpath),
     ])
     # inject a source URL config, should alter the result accordingly
     with patch.dict(
@@ -122,7 +119,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             [
                 ('origin', ds_subpath),
                 ('bang', 'youredead'),
-                ('origin', clone_subpath),
+                ('local', clone_subpath),
         ])
     # verify template instantiation works
     with patch.dict(
@@ -132,7 +129,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             [
                 ('origin', ds_subpath),
                 ('bang', 'pre-{}-post'.format(sub.id)),
-                ('origin', clone_subpath),
+                ('local', clone_subpath),
         ])
     # now again, but have an additional remote besides origin that
     # actually has the relevant commit
@@ -147,7 +144,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
         [
             ('origin', clone_subpath),
             ('myremote', ds_subpath),
-            ('origin', str(clone3.pathobj / 'sub')),
+            ('local', str(clone3.pathobj / 'sub')),
     ])
 
     # TODO: check that http:// urls for the dataset itself get resolved

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -78,20 +78,18 @@ def test_get_flexible_source_candidates_for_submodule(t, t2):
     # Expansion with '/.git' no longer done in this helper
     #sm_httpurls = [httpurl, httpurl + '/.git']
     sm_httpurls = [httpurl]
-    eq_(f(ds, 'sub'), [])
-    eq_(f(ds, 'sub', sshurl), [sshurl])
-    eq_(f(ds, 'sub', httpurl), sm_httpurls)
-    eq_(f(ds, 'sub', None), [])  # otherwise really we have no clue were to get from
+    subpath = str(ds.pathobj / 'sub')
+    eq_(f(ds, dict(path=subpath, parentds=ds.path)), [])
+    eq_(f(ds, dict(path=subpath, parentds=ds.path, gitmodule_url=sshurl)), [sshurl])
+    eq_(f(ds, dict(path=subpath, parentds=ds.path, gitmodule_url=httpurl)), sm_httpurls)
 
     # but if we work on dsclone then it should also add urls deduced from its
     # own location default remote for current branch
     subpath = op.sep.join((t, 'sub'))
-    eq_(f(clone, 'sub'), [subpath])
-    eq_(f(clone, 'sub', sshurl), [subpath, sshurl])
-    eq_(f(clone, 'sub', httpurl), [subpath] + sm_httpurls)
-    eq_(f(clone, 'sub'), [subpath])  # otherwise really we have no clue were to get from
+    eq_(f(clone, dict(path=subpath, parentds=t)), [subpath])
+    eq_(f(clone, dict(path=subpath, parentds=t, gitmodule_url=sshurl)), [subpath, sshurl])
+    eq_(f(clone, dict(path=subpath, parentds=t, gitmodule_url=httpurl)), [subpath] + sm_httpurls)
     # TODO: check that http:// urls for the dataset itself get resolved
-
     # TODO: many more!!
 
 

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -77,18 +77,22 @@ def test_get_flexible_source_candidates_for_submodule(t, t2):
     httpurl = 'http://e.c'
     # Expansion with '/.git' no longer done in this helper
     #sm_httpurls = [httpurl, httpurl + '/.git']
-    sm_httpurls = [httpurl]
+    sm_httpurls = [('origin', httpurl)]
     subpath = str(ds.pathobj / 'sub')
     eq_(f(ds, dict(path=subpath, parentds=ds.path)), [])
-    eq_(f(ds, dict(path=subpath, parentds=ds.path, gitmodule_url=sshurl)), [sshurl])
-    eq_(f(ds, dict(path=subpath, parentds=ds.path, gitmodule_url=httpurl)), sm_httpurls)
+    eq_(f(ds, dict(path=subpath, parentds=ds.path, gitmodule_url=sshurl)),
+        [('origin', sshurl)])
+    eq_(f(ds, dict(path=subpath, parentds=ds.path, gitmodule_url=httpurl)),
+        sm_httpurls)
 
     # but if we work on dsclone then it should also add urls deduced from its
     # own location default remote for current branch
     subpath = op.sep.join((t, 'sub'))
-    eq_(f(clone, dict(path=subpath, parentds=t)), [subpath])
-    eq_(f(clone, dict(path=subpath, parentds=t, gitmodule_url=sshurl)), [subpath, sshurl])
-    eq_(f(clone, dict(path=subpath, parentds=t, gitmodule_url=httpurl)), [subpath] + sm_httpurls)
+    eq_(f(clone, dict(path=subpath, parentds=t)), [('origin', subpath)])
+    eq_(f(clone, dict(path=subpath, parentds=t, gitmodule_url=sshurl)),
+        [('origin', subpath), ('origin', sshurl)])
+    eq_(f(clone, dict(path=subpath, parentds=t, gitmodule_url=httpurl)),
+        [('origin', subpath)] + sm_httpurls)
     # TODO: check that http:// urls for the dataset itself get resolved
     # TODO: many more!!
 

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -95,10 +95,4 @@ def _get_flexible_source_candidates(src, base_url=None, alternate_suffix=True):
                 candidates.append(
                     '{0}/.git'.format(src.rstrip('/')))
 
-    # TODO:
-    # We need to provide some error msg with InstallFailedError, since now
-    # it just swallows everything.
-    # yoh: not sure if this comment applies here, but could be still applicable
-    # outisde
-
     return candidates

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -569,7 +569,7 @@ def _get_latest_refcommit(ds, subds_relpaths):
     if not relevant_paths:
         return None
 
-    return ds.repo.get_last_commit_hash(relevant_paths)
+    return ds.repo.get_last_commit_hexsha(relevant_paths)
 
 
 def _get_obj_location(hash_str, ref_type, dumper):

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -320,7 +320,7 @@ class _WhooshSearch(_Search):
         from .metadata import get_ds_aggregate_db_locations
         dbloc, db_base_path = get_ds_aggregate_db_locations(self.ds)
         # what is the lastest state of aggregated metadata
-        metadata_state = self.ds.repo.get_last_commit_hash(relpath(dbloc, start=self.ds.path))
+        metadata_state = self.ds.repo.get_last_commit_hexsha(relpath(dbloc, start=self.ds.path))
         # use location common to all index types, they would all invalidate
         # simultaneously
         stamp_fname = opj(self.index_dir, 'datalad_metadata_state')

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1830,23 +1830,6 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
                 paths=None, ref=branch, untracked='no', eval_file_type=False)
             ]
 
-    def _get_remotes_having_commit(self, commit_hexsha, with_urls_only=True):
-        """Traverse all branches of the remote and check if commit in any of their ancestry
-
-        It is a generator yielding names of the remotes
-        """
-        remote_branches = [
-            b['refname:strip=2']
-            for b in self.for_each_ref_(
-                fields='refname:strip=2',
-                pattern='refs/remotes',
-                contains=commit_hexsha)]
-        return [
-            remote
-            for remote in self.get_remotes(with_urls_only=with_urls_only)
-            if any(rb.startswith(remote + '/') for rb in remote_branches)
-        ]
-
     @normalize_paths(match_return_type=False)
     def _git_custom_command(self, files, cmd_str,
                             log_stdout=True, log_stderr=True, log_online=False,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1310,8 +1310,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         count : int, optional
           Stop iteration after the given number of matches.
         contains : str, optional
-          Only list refs which contain the specified commit (HEAD if not
-          specified).
+          Only list refs which contain the specified commit.
 
         Yields
         ------

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1582,12 +1582,8 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             assert(len(stdout) == 1)
             return stdout[0]
 
-    # TODO should likely be
-    #   get_last_commit_hexsha()
-    # or even
-    #   get_last_commit()
     @normalize_paths(match_return_type=False)
-    def get_last_commit_hash(self, files):
+    def get_last_commit_hexsha(self, files):
         """Return the hash of the last commit the modified any of the given
         paths"""
         try:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1582,19 +1582,23 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             assert(len(stdout) == 1)
             return stdout[0]
 
+    # TODO should likely be
+    #   get_last_commit_hexsha()
+    # or even
+    #   get_last_commit()
     @normalize_paths(match_return_type=False)
     def get_last_commit_hash(self, files):
         """Return the hash of the last commit the modified any of the given
         paths"""
         try:
-            stdout, stderr = self._git_custom_command(
-                files,
-                ['git', 'log', '-n', '1', '--pretty=format:%H'],
-                expect_fail=True)
-            commit = stdout.strip()
-            return commit
+            commit = self.call_git(
+                ['rev-list', '-n1', 'HEAD'],
+                files=files,
+            )
+            commit = commit.strip()
+            return commit if commit else None
         except CommandError as e:
-            if 'does not have any commits' in e.stderr:
+            if 'unknown revision or path not in the working tree' in e.stderr:
                 return None
             raise
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1590,11 +1590,13 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
             commit = self.call_git(
                 ['rev-list', '-n1', 'HEAD'],
                 files=files,
+                expect_fail=True,
             )
             commit = commit.strip()
             return commit if commit else None
-        except CommandError as e:
-            if 'unknown revision or path not in the working tree' in e.stderr:
+        except CommandError:
+            if self.get_hexsha() is None:
+                # unborn branch, don't freak out
                 return None
             raise
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -470,15 +470,16 @@ def test_GitRepo_pull(test_path, orig_path, clone_path):
     ok_(op.exists(op.join(clone_path, filename)))
 
     # While at it, let's test _get_remotes_having_commit a bit
+    from datalad.distribution.get import _get_remotes_having_commit
     clone.add_remote("very_origin", test_path)
     clone.fetch("very_origin")
     eq_(
-        clone._get_remotes_having_commit(clone.get_hexsha()),
+        _get_remotes_having_commit(clone, clone.get_hexsha()),
         ['origin']
     )
     prev_commit = clone.get_hexsha('HEAD^')
     eq_(
-        set(clone._get_remotes_having_commit(prev_commit)),
+        set(_get_remotes_having_commit(clone, prev_commit)),
         {'origin', 'very_origin'}
     )
 


### PR DESCRIPTION
This fixes gh-3827, while also tweaking a little bit on the sides -- this is rather old code.

This is technically ready. Once agreed on, there will be a use case description in the handbook on feature.