### PR TITLE
RF: Refine what Get yields

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -592,14 +592,15 @@ def _yield_dataset_result(ds_record, result, in_paths):
     # we want to yield dataset results only once (not on every input path) and
     # in addition "notneeded" results are relevant only, if those paths were
     # actually requested:
-    if result['path'] not in ds_record and \
-            (result.get('status', None) != 'notneeded' or result.get('path', None) in in_paths):
+    result_tuple = (result['path'], result.get('status', None))
+    if result_tuple not in ds_record and \
+            (result.get('status', None) != 'notneeded' or result['path'] in in_paths):
         yield result
         # record that we have a dataset-type result for that path already
         # to avoid following up with an additional directory-type result
         # via annex-get or just another notneeded dataset-type result as
         # we deal with another input path
-        ds_record.append(result['path'])
+        ds_record.append(result_tuple)
 
 
 @build_doc
@@ -793,7 +794,7 @@ class Get(Interface):
                     jobs):
 
                 if res.get('status', None) == 'notneeded' and \
-                        res.get('path', None) in yielded_datasets:
+                        res['path'] in [p for p, s in yielded_datasets]:
                     # don't yield notneeded results about paths that we already reported on.
                     continue
                 yield res

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -672,10 +672,10 @@ class Get(Interface):
 
         path = assure_list(path)
         # resolve input paths against dataset in order to compare absolute paths in results
-        # to the given paths later on
-        # TODO: Not yet clear whether to use dataset or refds here. Why is dataset used in the call to Subdatasets?
+        # to the given paths later on:
         input_paths = [str(resolve_path(p, dataset)) for p in path]
         content_by_ds = {}
+        # keep a record of what datasets we reported on already:
         yielded_dataset_paths = []
         # use subdatasets() to discover any relevant content that is not
         # already present in the root dataset (refds)

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -363,6 +363,13 @@ class Install(Interface):
                     result_xfm=None,
                     **common_kwargs):
                 r['refds'] = refds_path
+
+                if r['type'] == 'dataset' and \
+                        r['path'] == destination_dataset.path:
+                    # we have a result for that dataset from above. It's pointless to yield
+                    # that Get also figured it out.
+                    continue
+
                 yield r
         # at this point no futher post-processing should be necessary,
         # `clone` and `get` must have done that (incl. parent handling)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -310,9 +310,12 @@ def test_get_recurse_subdatasets(src, path):
 
     # now, the very same call, but without recursive:
     result = ds.get('.', recursive=False)
-    assert_status('ok', result)
-    # one report is on the requested dir
-    eq_(len(result) - 1, 1)
+    # we get to "ok" results. the file itself and a directory-type result, since this is what we were asking to get.
+    assert_result_count(result, 2, status='ok')
+    # However, that directory also is a dataset (that we explicitly asked to get), therefore we get a notneeded result
+    # for the dataset:
+    assert_result_count(result, 1, status='notneeded')
+    assert_result_count(result, 3)
     assert_result_count(
         result, 1, path=opj(ds.path, 'test-annex.dat'), status='ok')
     ok_(ds.repo.file_has_content('test-annex.dat') is True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -632,13 +632,14 @@ def test_install_recursive_repeat(src, path):
     ok_(subsub.is_installed() is False)
 
     # install again, now with data and recursive, but recursion_limit 1:
-    result = get(path, dataset=path, recursive=True, recursion_limit=1,
-                 result_xfm='datasets')
-    # top-level dataset was not reobtained
-    assert_not_in(top_ds, result)
-    assert_in(sub1, result)
-    assert_in(sub2, result)
-    assert_not_in(subsub, result)
+    result = get(path, dataset=path, recursive=True, recursion_limit=1)
+    result_paths = [r['path'] for r in result]
+    assert_result_count(result, 3, type='dataset')
+    assert_result_count(result, 1, status='notneeded', type='dataset', path=path)
+    assert_result_count(result, 2, status='ok', type='dataset')
+    assert_in(sub1.path, result_paths)
+    assert_in(sub2.path, result_paths)
+    assert_not_in(subsub.path, result_paths)
     ok_(top_ds.repo.file_has_content('top_file.txt') is True)
     ok_(sub1.repo.file_has_content('sub1file.txt') is True)
     ok_(sub2.repo.file_has_content('sub2file.txt') is True)
@@ -706,7 +707,7 @@ def test_install_skip_failed_recursive(src, path):
             on_failure='ignore', result_xfm=None)
         # toplevel dataset was in the house already
         assert_result_count(
-            result, 0, path=ds.path, type='dataset')
+            result, 1, path=ds.path, type='dataset', status='notneeded')
         # subm 1 should fail to install. [1] since comes after '2' submodule
         assert_in_results(
             result, status='error', path=sub1.path, type='dataset',

--- a/datalad/interface/tests/test_annotate_paths.py
+++ b/datalad/interface/tests/test_annotate_paths.py
@@ -371,8 +371,9 @@ def test_recurseinto(dspath, dest):
     # explicitly -- must get it installed
     dest = install(source=ds.path, path=dest)
     res = dest.get(['.', opj('b', 'bb')], get_data=False, recursive=True)
-    assert_result_count(res, 7)
-    assert_result_count(res, 7, type='dataset')
+    assert_result_count(res, 8)
+    assert_result_count(res, 8, type='dataset')
+    assert_result_count(res, 1, type='dataset', status='notneeded', path=dest.path)
     assert_result_count(res, 1, type='dataset',
                         path=opj(dest.path, 'b', 'bb'))
     assert(Dataset(opj(dest.path, 'b', 'bb')).is_installed())


### PR DESCRIPTION
Closes #3836

Not entirely sure yet, what we really want.
Top-level dataset result can only ever be `notneeded` (since otherwise we couldn't have successfully called `get` in the first place) and therefore seems superfluous. But, if we explicitly say `get .` it's somewhat strange for the results to follow a different pattern, in that the explicitly passed dataset is not reported on at all. Plus: Not sure yet, how excluding the top-level dataset would work in the recursive case.
Additional aspect: While "top-level" is quite clear in case of (interactive) CLI usage, what would make sense becomes quickly vague in the context of the python API.
Finally, from within `install` perspective might change again. It makes a lot of sense to return the (top-level) dataset, including "notneeded".
So, do I correct the tests to not expect no result for the top-level dataset or do I try to differentiate more special cases on what to yield under what circumstances? What do you think, @datalad/developers ?