### PR TITLE
download-url: Fix archive path handling when in subdirectory

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -103,11 +103,8 @@ class DownloadURL(Interface):
         common_report = {"action": "download_url",
                          "ds": ds}
 
-        if isinstance(dataset, Dataset):
-            got_ds_instance = True
-            path = op.normpath(op.join(ds.path, path or op.curdir))
-        else:
-            got_ds_instance = False
+        got_ds_instance = isinstance(dataset, Dataset)
+        path = str(resolve_path(path or op.curdir, ds=dataset))
         urls = assure_list_from_str(urls)
 
         if len(urls) > 1 and path and not op.isdir(path):

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -24,7 +24,9 @@ from ..utils import assure_list_from_str
 from ..distribution.dataset import Dataset
 from ..distribution.dataset import datasetmethod
 from ..distribution.dataset import EnsureDataset
+from ..distribution.dataset import path_under_rev_dataset
 from ..distribution.dataset import require_dataset
+from ..distribution.dataset import resolve_path
 from ..dochelpers import exc_str
 from ..support.annexrepo import AnnexRepo, AnnexBatchCommandError
 from ..support.param import Parameter
@@ -102,8 +104,10 @@ class DownloadURL(Interface):
                          "ds": ds}
 
         if isinstance(dataset, Dataset):
+            got_ds_instance = True
             path = op.normpath(op.join(ds.path, path or op.curdir))
-
+        else:
+            got_ds_instance = False
         urls = assure_list_from_str(urls)
 
         if len(urls) > 1 and path and not op.isdir(path):
@@ -162,20 +166,38 @@ URLs:
                 yield r
 
             if isinstance(ds.repo, AnnexRepo):
+                if got_ds_instance:
+                    # Paths in `downloaded_paths` are already relative to the
+                    # dataset.
+                    rpaths = dict(zip(downloaded_paths, downloaded_paths))
+                else:
+                    # Paths in `downloaded_paths` are already relative to the
+                    # current working directory. Take these relative to the
+                    # dataset for use with the AnnexRepo method calls.
+                    rpaths = {}
+                    for orig_path, resolved in zip(
+                            downloaded_paths,
+                            resolve_path(downloaded_paths, ds=dataset)):
+                        rpath = path_under_rev_dataset(ds, resolved)
+                        if rpath:
+                            rpaths[str(rpath)] = orig_path
+                        else:
+                            lgr.warning("Path %s not under dataset %s",
+                                        orig_path, ds)
                 annex_paths = [p for p, annexed in
-                               zip(downloaded_paths,
-                                   ds.repo.is_under_annex(downloaded_paths))
+                               zip(rpaths,
+                                   ds.repo.is_under_annex(list(rpaths.keys())))
                                if annexed]
                 if annex_paths:
                     for path in annex_paths:
+                        url = path_urls[rpaths[path]]
                         try:
                             # The file is already present. This is just to
                             # register the URL.
-                            ds.repo.add_url_to_file(path, path_urls[path],
-                                                    batch=True)
+                            ds.repo.add_url_to_file(path, url, batch=True)
                         except AnnexBatchCommandError as exc:
                             lgr.warning("Registering %s with %s failed: %s",
-                                        path, path_urls[path], exc_str(exc))
+                                        path, url, exc_str(exc))
 
                     if archive:
                         from datalad.api import add_archive_content

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -162,3 +162,16 @@ def test_download_url_archive(toppath, topurl, path):
     ok_(ds.repo.file_has_content(opj("archive", "file1.txt")))
     assert_not_in(opj(ds.path, "archive.tar.gz"),
                   ds.repo.format_commit("%B"))
+
+
+@known_failure_githubci_win
+@with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})
+@serve_path_via_http
+@with_tempfile(mkdir=True)
+def test_download_url_archive_from_subdir(toppath, topurl, path):
+    ds = Dataset(path).create()
+    subdir_path = opj(ds.path, "subdir")
+    os.mkdir(subdir_path)
+    with chpwd(subdir_path):
+        download_url([topurl + "archive.tar.gz"], archive=True)
+    ok_(ds.repo.file_has_content(opj("subdir", "archive", "file1.txt")))


### PR DESCRIPTION
This patch fixes gh-3847.

```sh
#!/bin/sh

set -eu

cd $(mktemp -d --tmpdir dl-XXXXXXX)
datalad create
mkdir out
url=http://swcarpentry.github.io/python-novice-inflammation/data/python-novice-inflammation-data.zip

datalad -C out download-url --archive $url
tree --charset=asci out | head
```

```
[...]
action summary:
  add (ok: 1)
  download_url (ok: 1)
  save (ok: 1)
out
`-- data
    |-- inflammation-01.csv -> ../../.git/annex/objects/Kg/60/MD5E-s5365--d5a838342924a0806eeeea0e4adaba0a.csv/MD5E-s5365--d5a838342924a0806eeeea0e4adaba0a.csv
    |-- inflammation-02.csv -> ../../.git/annex/objects/zp/qF/MD5E-s5314--0551caa3e8a0ef3a53e99a4a01c27a65.csv/MD5E-s5314--0551caa3e8a0ef3a53e99a4a01c27a65.csv
    |-- inflammation-03.csv -> ../../.git/annex/objects/2Q/Fj/MD5E-s5127--671c1563d3bd76538dab97537c370623.csv/MD5E-s5127--671c1563d3bd76538dab97537c370623.csv
    |-- inflammation-04.csv -> ../../.git/annex/objects/FZ/Pf/MD5E-s5367--fc8d2c99778fb8f6d243de481c33e2e9.csv/MD5E-s5367--fc8d2c99778fb8f6d243de481c33e2e9.csv
    |-- inflammation-05.csv -> ../../.git/annex/objects/fv/Gg/MD5E-s5345--13bd5318271c66ace4de33a10dca9b72.csv/MD5E-s5345--13bd5318271c66ace4de33a10dca9b72.csv
    |-- inflammation-06.csv -> ../../.git/annex/objects/Q5/FF/MD5E-s5330--934b26dfc803cabd100b9267f44e08fc.csv/MD5E-s5330--934b26dfc803cabd100b9267f44e08fc.csv
    |-- inflammation-07.csv -> ../../.git/annex/objects/2f/m3/MD5E-s5342--e13ba83ccf44f33c97fa0e240962cc78.csv/MD5E-s5342--e13ba83ccf44f33c97fa0e240962cc78.csv
    |-- inflammation-08.csv -> ../../.git/annex/objects/2Q/Fj/MD5E-s5127--671c1563d3bd76538dab97537c370623.csv/MD5E-s5127--671c1563d3bd76538dab97537c370623.csv
```