### PR TITLE
Resolve conflicts to bring gh-3835 into master

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -58,7 +58,8 @@ from datalad.utils import (
 from datalad.support.json_py import loads as json_loads
 from datalad.cmd import (
     GitRunner,
-    BatchedCommand
+    BatchedCommand,
+    SafeDelCloseMixin
 )
 
 # imports from same module:
@@ -3424,7 +3425,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
 # TODO: Why was this commented out?
 # @auto_repr
-class BatchedAnnexes(dict):
+class BatchedAnnexes(SafeDelCloseMixin, dict):
     """Class to contain the registry of active batch'ed instances of annex for
     a repository
     """
@@ -3473,9 +3474,6 @@ class BatchedAnnexes(dict):
         """
         for p in self.values():
             p.close()
-
-    def __del__(self):
-        self.close()
 
 
 def readlines_until_ok_or_failed(stdout, maxlines=100):


### PR DESCRIPTION
@yarikoptic This resolves master's conflict with gh-3835 by relocating your recently added `SafeDelCloseMixin` to cmd.py.  Is that OK with you?

I'm marking this as "do not merge" because a merge via github would result in a needless merge commit.

```
0.11.x's c031806c6 (ENH: swallow exceptions in __del__ if lgr or
os.fdopen already unbound, gh-3851) defined a SafeDelCloseMixin class
in annexrepo.py and used it as a base class for BatchedAnnex and
BatchedAnnexes.  On master, 9d714f520 (2019-04-08) relocated much of
the core functionality for BatchedAnnex to cmd.py as BatchedCommand.

SafeDelCloseMixin is relevant for BatchedCommand (which is used in a
spot other than annexrepo.py), so move SafeDelCloseMixin to cmd.py and
drop BatchedCommand's __del__() method.

Conflicts:
    datalad/support/annexrepo.py
```

