### PR TITLE
ENH: download_url: Use trailing separator to signal directory target

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -379,6 +379,9 @@ class BaseDownloader(object, metaclass=ABCMeta):
 
         #### Specific to download
         if path:
+            download_dir = op.dirname(path)
+            if download_dir:
+                os.makedirs(download_dir, exist_ok=True)
             if isdir(path):
                 # provided path is a directory under which to save
                 filename = downloader_session.filename
@@ -406,9 +409,6 @@ class BaseDownloader(object, metaclass=ABCMeta):
                     "It will be overriden" % temp_filepath)
                 # TODO.  also logic below would clean it up atm
 
-            download_dir = op.dirname(temp_filepath)
-            if download_dir:
-                os.makedirs(download_dir, exist_ok=True)
             with open(temp_filepath, 'wb') as fp:
                 # TODO: url might be a bit too long for the beast.
                 # Consider to improve to make it animated as well, or shorten here

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -407,12 +407,8 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 # TODO.  also logic below would clean it up atm
 
             download_dir = op.dirname(temp_filepath)
-            if download_dir and not exists(download_dir):
-                # We use the "not exist then makedirs" pattern across our
-                # codebase. This is racy in a way that is unlikely to matter
-                # here, but when we drop Python 2, we might as well switch the
-                # code below to use exist_ok=True.
-                os.makedirs(download_dir)
+            if download_dir:
+                os.makedirs(download_dir, exist_ok=True)
             with open(temp_filepath, 'wb') as fp:
                 # TODO: url might be a bit too long for the beast.
                 # Consider to improve to make it animated as well, or shorten here

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -117,10 +117,15 @@ def test_HTTPDownloader_basic(toppath, topurl):
     download(furl, tfpath)
     ok_file_has_content(tfpath, 'abc')
 
-    # download() creates leading directories if needed.
+    # download() creates leading directories if needed for file targets...
     subdir_tfpath = opj(toppath, "l1", "l2", "file-downloaded.dat")
     download(furl, subdir_tfpath)
     ok_file_has_content(subdir_tfpath, 'abc')
+
+    # ... and for directory targets.
+    subdir_dirtarget = opj(toppath, "d1", "d2", "")
+    download(furl, subdir_dirtarget)
+    ok_file_has_content(opj(subdir_dirtarget, "file.dat"), "abc")
 
     # see if fetch works correctly
     assert_equal(downloader.fetch(furl), 'abc')

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -61,8 +61,8 @@ class DownloadURL(Interface):
             metavar='PATH',
             doc="""specify the dataset to add files to. If no dataset is given,
             an attempt is made to identify the dataset based on the current
-            working directory and/or the `path` given. Use [CMD: --nosave
-            CMD][PY: save=False PY] to prevent adding files to the dataset.""",
+            working directory. Use [CMD: --nosave CMD][PY: save=False PY] to
+            prevent adding files to the dataset.""",
             constraints=EnsureDataset() | EnsureNone()),
         overwrite=Parameter(
             args=("-o", "--overwrite"),

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -103,11 +103,8 @@ class DownloadURL(Interface):
         common_report = {"action": "download_url",
                          "ds": ds}
 
-        if isinstance(dataset, Dataset):
-            got_ds_instance = True
-            path = op.normpath(op.join(ds.path, path or op.curdir))
-        else:
-            got_ds_instance = False
+        got_ds_instance = isinstance(dataset, Dataset)
+        path = str(resolve_path(path or op.curdir, ds=dataset))
         urls = assure_list_from_str(urls)
 
         if len(urls) > 1 and path and not op.isdir(path):

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -24,7 +24,9 @@ from ..utils import assure_list_from_str
 from ..distribution.dataset import Dataset
 from ..distribution.dataset import datasetmethod
 from ..distribution.dataset import EnsureDataset
+from ..distribution.dataset import path_under_rev_dataset
 from ..distribution.dataset import require_dataset
+from ..distribution.dataset import resolve_path
 from ..dochelpers import exc_str
 from ..support.annexrepo import AnnexRepo, AnnexBatchCommandError
 from ..support.param import Parameter
@@ -102,8 +104,10 @@ class DownloadURL(Interface):
                          "ds": ds}
 
         if isinstance(dataset, Dataset):
+            got_ds_instance = True
             path = op.normpath(op.join(ds.path, path or op.curdir))
-
+        else:
+            got_ds_instance = False
         urls = assure_list_from_str(urls)
 
         if len(urls) > 1 and path and not op.isdir(path):
@@ -162,20 +166,38 @@ URLs:
                 yield r
 
             if isinstance(ds.repo, AnnexRepo):
+                if got_ds_instance:
+                    # Paths in `downloaded_paths` are already relative to the
+                    # dataset.
+                    rpaths = dict(zip(downloaded_paths, downloaded_paths))
+                else:
+                    # Paths in `downloaded_paths` are already relative to the
+                    # current working directory. Take these relative to the
+                    # dataset for use with the AnnexRepo method calls.
+                    rpaths = {}
+                    for orig_path, resolved in zip(
+                            downloaded_paths,
+                            resolve_path(downloaded_paths, ds=dataset)):
+                        rpath = path_under_rev_dataset(ds, resolved)
+                        if rpath:
+                            rpaths[str(rpath)] = orig_path
+                        else:
+                            lgr.warning("Path %s not under dataset %s",
+                                        orig_path, ds)
                 annex_paths = [p for p, annexed in
-                               zip(downloaded_paths,
-                                   ds.repo.is_under_annex(downloaded_paths))
+                               zip(rpaths,
+                                   ds.repo.is_under_annex(list(rpaths.keys())))
                                if annexed]
                 if annex_paths:
                     for path in annex_paths:
+                        url = path_urls[rpaths[path]]
                         try:
                             # The file is already present. This is just to
                             # register the URL.
-                            ds.repo.add_url_to_file(path, path_urls[path],
-                                                    batch=True)
+                            ds.repo.add_url_to_file(path, url, batch=True)
                         except AnnexBatchCommandError as exc:
                             lgr.warning("Registering %s with %s failed: %s",
-                                        path, path_urls[path], exc_str(exc))
+                                        path, url, exc_str(exc))
 
                     if archive:
                         from datalad.api import add_archive_content

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -162,3 +162,16 @@ def test_download_url_archive(toppath, topurl, path):
     ok_(ds.repo.file_has_content(opj("archive", "file1.txt")))
     assert_not_in(opj(ds.path, "archive.tar.gz"),
                   ds.repo.format_commit("%B"))
+
+
+@known_failure_githubci_win
+@with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})
+@serve_path_via_http
+@with_tempfile(mkdir=True)
+def test_download_url_archive_from_subdir(toppath, topurl, path):
+    ds = Dataset(path).create()
+    subdir_path = opj(ds.path, "subdir")
+    os.mkdir(subdir_path)
+    with chpwd(subdir_path):
+        download_url([topurl + "archive.tar.gz"], archive=True)
+    ok_(ds.repo.file_has_content(opj("subdir", "archive", "file1.txt")))

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -31,8 +31,8 @@ def test_download_url_exceptions():
     res0 = download_url(['url1', 'url2'], path=__file__,
                         save=False, on_failure='ignore')
     assert_result_count(res0, 1, status='error')
-    assert_message('When specifying multiple urls, --path should point to '
-                   'an existing directory. Got %r',
+    assert_message("When specifying multiple urls, --path should point to "
+                   "a directory target (with a trailing separator). Got %r",
                    res0)
 
     res1 = download_url('http://example.com/bogus',
@@ -51,6 +51,16 @@ def test_download_url_exceptions():
         assert_in('http://example.com/bogus', msg)
 
 
+@with_tree(tree={"dir": {}})
+def test_download_url_existing_dir_no_slash_exception(path):
+    with chpwd(path):
+        res = download_url('url', path="dir", save=False, on_failure='ignore')
+        assert_result_count(res, 1, status='error')
+        assert_message("Non-directory path given (no trailing separator) "
+                       "but a directory with that name exists",
+                       res)
+
+
 @known_failure_githubci_win
 @assert_cwd_unchanged
 @with_tree(tree=[
@@ -60,6 +70,8 @@ def test_download_url_exceptions():
 @serve_path_via_http
 @with_tempfile(mkdir=True)
 def test_download_url_return(toppath, topurl, outdir):
+    # Ensure that out directory has trailing slash.
+    outdir = opj(outdir, "")
     files = ['file1.txt', 'file2.txt']
     urls = [topurl + f for f in files]
     outfiles = [opj(outdir, f) for f in files]
@@ -124,7 +136,7 @@ def test_download_url_dataset(toppath, topurl, path):
     ds.download_url([opj(topurl, "file1.txt")], path=subdir_target)
     ok_(ds.repo.file_has_content(subdir_target))
 
-    subdir_path = opj(ds.path, "subdir")
+    subdir_path = opj(ds.path, "subdir", "")
     os.mkdir(subdir_path)
     with chpwd(subdir_path):
         download_url(topurl + "file4.txt")
@@ -170,8 +182,28 @@ def test_download_url_archive(toppath, topurl, path):
 @with_tempfile(mkdir=True)
 def test_download_url_archive_from_subdir(toppath, topurl, path):
     ds = Dataset(path).create()
-    subdir_path = opj(ds.path, "subdir")
+    subdir_path = opj(ds.path, "subdir", "")
     os.mkdir(subdir_path)
     with chpwd(subdir_path):
         download_url([topurl + "archive.tar.gz"], archive=True)
     ok_(ds.repo.file_has_content(opj("subdir", "archive", "file1.txt")))
+
+
+@known_failure_githubci_win
+@with_tree(tree={"a0.tar.gz": {'f0.txt': 'abc'},
+                 "a1.tar.gz": {'f1.txt': 'def'}})
+@serve_path_via_http
+@with_tempfile(mkdir=True)
+def test_download_url_archive_trailing_separator(toppath, topurl, path):
+    ds = Dataset(path).create()
+    # Archives will be extracted in the specified subdirectory, which doesn't
+    # need to exist.
+    ds.download_url([topurl + "a0.tar.gz"], path=opj("with-slash", ""),
+                    archive=True)
+    ok_(ds.repo.file_has_content(opj("with-slash", "a0", "f0.txt")))
+    # But if the path doesn't have a trailing separator, it will not be
+    # considered a directory. The archive will be downloaded to that path and
+    # then extracted in the top-level of the dataset.
+    ds.download_url([topurl + "a1.tar.gz"], path="no-slash",
+                    archive=True)
+    ok_(ds.repo.file_has_content(opj("a1", "f1.txt")))


### PR DESCRIPTION
This implements the [trailing slash solution][0] to gh-3848.  It sits on top of the unmerged gh-3850.  I'm marking it as a draft because more extensive testing should be added to test_download_url.py.

[0]: https://github.com/datalad/datalad/issues/3848#issuecomment-548436256