### PR TITLE
Adjust special remote handling for sameas remotes

### DIFF
--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -157,14 +157,20 @@ def _handle_possible_annex_dataset(dataset, reckless, description=None):
     srs = {True: [], False: []}  # special remotes by "autoenable" key
     remote_uuids = None  # might be necessary to discover known UUIDs
 
+    # Note: The purpose of this function is to inform the user. So if something
+    # looks misconfigured, we'll warn and move on to the next item.
     for uuid, config in repo.get_special_remotes().items():
         sr_name = config.get('name', None)
+        if sr_name is None:
+            lgr.warning(
+                'Ignoring special remote %s because it does not have a name. '
+                'Known information: %s',
+                uuid, config)
+            continue
         sr_autoenable = config.get('autoenable', False)
         try:
             sr_autoenable = assure_bool(sr_autoenable)
         except ValueError:
-            # Be resilient against misconfiguration.  Here it is only about
-            # informing the user, so no harm would be done
             lgr.warning(
                 'Failed to process "autoenable" value %r for sibling %s in '
                 'dataset %s as bool.  You might need to enable it later '

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -172,7 +172,7 @@ def _handle_possible_annex_dataset(dataset, reckless, description=None):
                 sr_autoenable, sr_name, dataset.path)
             continue
 
-        # determine either there is a registered remote with matching UUID
+        # determine whether there is a registered remote with matching UUID
         if uuid:
             if remote_uuids is None:
                 remote_uuids = {

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -182,7 +182,12 @@ def _handle_possible_annex_dataset(dataset, reckless, description=None):
         if uuid:
             if remote_uuids is None:
                 remote_uuids = {
-                    repo.config.get('remote.%s.annex-uuid' % r)
+                    # Check annex-config-uuid first. For sameas annex remotes,
+                    # this will point to the UUID for the configuration (i.e.
+                    # the key returned by get_special_remotes) rather than the
+                    # shared UUID.
+                    (repo.config.get('remote.%s.annex-config-uuid' % r) or
+                     repo.config.get('remote.%s.annex-uuid' % r))
                     for r in repo.get_remotes()
                 }
             if uuid not in remote_uuids:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1053,11 +1053,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         Returns
         -------
         dict
-          Keys are special remote UUIDs, values are dicts with arguments
-          for `git-annex enableremote`. This includes at least the 'type'
-          and 'name' of a special remote. Each type of special remote
-          may require addition arguments that will be available in the
-          respective dictionary.
+          Keys are special remote UUIDs. Each value is a dictionary with
+          configuration information git-annex has for the remote. This should
+          include the 'type' and 'name' as well as any `initremote` parameters
+          that git-annex stores.
         """
         try:
             stdout, stderr = self._git_custom_command(

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -87,6 +87,7 @@ from datalad.tests.utils import skip_ssh
 from datalad.tests.utils import find_files
 from datalad.tests.utils import slow
 from datalad.tests.utils import set_annex_version
+from datalad.tests.utils import with_sameas_remote
 
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import CommandNotAvailableError
@@ -313,6 +314,18 @@ def test_AnnexRepo_get_remote_na(path):
     with assert_raises(RemoteNotAvailableError) as cme:
         ar.get('test-annex.dat', remote="NotExistingRemote")
     eq_(cme.exception.remote, "NotExistingRemote")
+
+
+@with_sameas_remote
+def test_annex_repo_sameas_special(repo):
+    remotes = repo.get_special_remotes()
+    eq_(len(remotes), 2)
+    rsync_info = [v for v in remotes.values()
+                  if v.get("sameas-name") == "r_rsync"]
+    eq_(len(rsync_info), 1)
+    # r_rsync is a sameas remote that points to r_dir. Its sameas-name value
+    # has been copied under "name".
+    eq_(rsync_info[0]["name"], rsync_info[0]["sameas-name"])
 
 
 # 1 is enough to test file_has_content


### PR DESCRIPTION
This series fixes gh-3816 (cloning of annex repos with special remotes that were set up with `--sameas`).

Some notes:

  * When merging to master, there will be a merge conflict because `_handle_possible_annex_dataset` was moved to clone.py in 8f9ae55fb (RF: Move clone-internal helper to clone.py, 2019-10-14).

  * This handles the clone case, but other places in DataLad (in particular `publish`) may need an update for git-annex's sameas functionality.

  * If the user is running a git-annex version that doesn't support sameas special remotes, we're informing them about a remote that they can't actually enable.  If others feel this is worth handling, I can rework the code to check the annex version.
