### PR TITLE
MNT: Drop external mock dependency

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Install ${{ matrix.extension }} extension
       run: |
         pip install ${{ matrix.extension }}
+      if: matrix.extension != 'datalad_crawler'
+    - name: Install ${{ matrix.extension }} extension
+      run: |
+        pip install ${{ matrix.extension }}[devel]
+      if: matrix.extension == 'datalad_crawler'
     - name: Install Singularity
       run: sudo eatmydata apt-get install singularity-container
       if: matrix.extension == 'datalad_container'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ since we use it to provide backports of recent fixed external modules we depend 
 
 ```sh
 apt-get install -y -q git git-annex-standalone
-apt-get install -y -q patool python3-scrapy python3-{appdirs,argcomplete,git,humanize,keyring,lxml,msgpack,mock,progressbar,requests,setuptools}
+apt-get install -y -q patool python3-scrapy python3-{appdirs,argcomplete,git,humanize,keyring,lxml,msgpack,progressbar,requests,setuptools}
 ```
 
 and additionally, for development we suggest to use tox and new

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -11,7 +11,7 @@
 
 import sys
 # OPT delay import for expensive mock until used
-#from mock import patch
+#from unittest.mock import patch
 import builtins
 import lzma
 
@@ -95,7 +95,7 @@ class AutomagicIO(object):
         self._autoget = autoget
         self._in_open = False
         self._log_online = True
-        from mock import patch
+        from unittest.mock import patch
         self._patch = patch
         self._paths_cache = set() if check_once else None
         self._repos_cache = {} if check_once else None

--- a/datalad/cmdline/tests/test_helpers.py
+++ b/datalad/cmdline/tests/test_helpers.py
@@ -10,7 +10,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from mock import patch
+from unittest.mock import patch
 from nose.tools import assert_is_instance
 
 from os import mkdir

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -14,7 +14,7 @@ from datalad.tests.utils import on_windows
 import re
 import sys
 from io import StringIO
-from mock import patch
+from unittest.mock import patch
 
 import datalad
 from ..main import (

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -23,7 +23,7 @@ from os import (
 )
 import sys
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.utils import (
     assure_unicode,

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for customremotes archives providing dl+archive URLs handling"""
 
-from mock import patch
+from unittest.mock import patch
 import os
 import os.path as op
 import sys

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -303,7 +303,7 @@ class _CreateFailureGitLab(_FakeGitLab):
 
 @with_tempfile
 def test_fake_gitlab(path):
-    from mock import patch
+    from unittest.mock import patch
     import datalad.distributed.create_sibling_gitlab
     ds = Dataset(path).create()
     with patch("datalad.distributed.create_sibling_gitlab.GitLabSite", _NewProjectGitLab):

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -24,7 +24,7 @@ from os import (
 )
 import os.path as op
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.api import (
     create,

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -15,7 +15,7 @@ from os import curdir
 import os.path as op
 from os.path import join as opj, basename
 from glob import glob
-from mock import patch
+from unittest.mock import patch
 
 from datalad.api import create
 from datalad.api import get

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -19,7 +19,7 @@ from os.path import realpath
 from os.path import basename
 from os.path import dirname
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.utils import getpwd
 

--- a/datalad/downloaders/tests/test_credentials.py
+++ b/datalad/downloaders/tests/test_credentials.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for credentials"""
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.tests.utils import with_testsui
 from datalad.tests.utils import assert_equal

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -48,7 +48,7 @@ except (ImportError, AttributeError):
        activate = lambda s, t: t
     httpretty = NoHTTPPretty()
 
-from mock import patch
+from unittest.mock import patch
 from ...tests.utils import SkipTest
 from ...tests.utils import assert_in
 from ...tests.utils import assert_not_in

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -12,7 +12,7 @@ import os.path as op
 
 import logging
 
-from mock import patch
+from unittest.mock import patch
 
 from ..providers import Provider
 from ..providers import Providers

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -9,7 +9,7 @@
 """Tests for S3 downloader"""
 
 import os
-from mock import patch
+from unittest.mock import patch
 
 from ..s3 import S3Authenticator
 from ..s3 import S3Downloader

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -10,7 +10,7 @@
 
 """
 
-import mock
+import unittest.mock as mock
 from datalad.tests.utils import *
 from datalad.utils import updated
 from ..base import (

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -16,7 +16,7 @@ import sys
 
 from glob import glob
 from collections import Counter
-from mock import patch
+from unittest.mock import patch
 
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -21,7 +21,7 @@ from os import (
 )
 
 from io import StringIO
-from mock import patch
+from unittest.mock import patch
 
 from datalad.utils import (
     chpwd,

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -11,7 +11,7 @@
 
 import logging
 from shutil import copy
-from mock import patch
+from unittest.mock import patch
 from os import makedirs
 from os.path import join as opj
 from os.path import dirname

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -546,7 +546,7 @@ def add_urls(rows, ifexists=None, options=None):
 def add_meta(rows):
     """Call `git annex metadata --set` using information in `rows`.
     """
-    from mock import patch
+    from unittest.mock import patch
 
     for row in rows:
         ds, filename = row["ds"], row["ds_filename"]

--- a/datalad/plugin/export_archive.py
+++ b/datalad/plugin/export_archive.py
@@ -75,7 +75,7 @@ class ExportArchive(Interface):
         import os
         import tarfile
         import zipfile
-        from mock import patch
+        from unittest.mock import patch
         from os.path import join as opj, dirname, normpath, isabs
         import os.path as op
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -16,7 +16,7 @@ import os.path as op
 import shutil
 import tempfile
 
-from mock import patch
+from unittest.mock import patch
 
 from io import StringIO
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -33,7 +33,7 @@ from urllib.parse import urlsplit
 
 import git
 from git import GitCommandError
-from mock import patch
+from unittest.mock import patch
 import gc
 
 from datalad.cmd import Runner

--- a/datalad/support/tests/test_ansi_colors.py
+++ b/datalad/support/tests/test_ansi_colors.py
@@ -9,7 +9,7 @@
 """Test ANSI color tools """
 
 import os
-from mock import patch
+from unittest.mock import patch
 from datalad.tests.utils import assert_equal
 from datalad.tests.utils import patch_config
 

--- a/datalad/support/tests/test_due_utils.py
+++ b/datalad/support/tests/test_due_utils.py
@@ -22,7 +22,7 @@ from ...tests.utils import (
     with_tempfile,
 )
 import logging
-from mock import patch
+from unittest.mock import patch
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -25,7 +25,7 @@ from ...tests.utils import (
     swallow_logs,
 )
 
-from mock import patch
+from unittest.mock import patch
 from nose.tools import (
     assert_true, assert_false,
     assert_equal, assert_greater_equal, assert_greater,

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -9,7 +9,7 @@
 """Tests for github helpers"""
 
 import logging
-import mock
+import unittest.mock as mock
 
 import github as gh
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1328,7 +1328,7 @@ def test_get_hexsha_tag(path):
 
 @with_tempfile(mkdir=True)
 def test_get_tags(path):
-    from mock import patch
+    from unittest.mock import patch
 
     gr = GitRepo(path, create=True)
     eq_(gr.get_tags(), [])

--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -12,7 +12,7 @@
 __docformat__ = 'restructuredtext'
 
 import logging
-from mock import patch
+from unittest.mock import patch
 import os.path as op
 
 from datalad.support.globbedpaths import GlobbedPaths

--- a/datalad/support/tests/test_repodates.py
+++ b/datalad/support/tests/test_repodates.py
@@ -7,7 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -13,7 +13,7 @@ import logging
 import os
 import os.path as op
 from os.path import exists, isdir, getmtime, join as opj
-from mock import patch
+from unittest.mock import patch
 
 from nose import SkipTest
 

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -11,7 +11,7 @@ import sys
 from io import StringIO
 from nose.tools import assert_raises, assert_equal
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.api import sshrun
 from datalad.cmd import Runner

--- a/datalad/support/vcr_.py
+++ b/datalad/support/vcr_.py
@@ -99,7 +99,7 @@ def externals_use_cassette(name):
     For instance whenever we are testing custom special remotes invoked by the annex
     but want to minimize their network traffic by using vcr.py
     """
-    from mock import patch
+    from unittest.mock import patch
     cassette_path = realpath(_get_cassette_path(name))  # realpath OK
     with patch.dict('os.environ', {'DATALAD_TESTS_USECASSETTE': cassette_path}):
         yield

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -9,7 +9,7 @@
 
 import sys
 
-from mock import patch
+from unittest.mock import patch
 from io import StringIO
 from tempfile import NamedTemporaryFile
 from nose.tools import assert_raises, assert_equal

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -10,7 +10,7 @@
 import os
 from os.path import join as opj, exists
 
-from mock import patch
+from unittest.mock import patch
 from .utils import (
     assert_true, assert_false, eq_,
     with_tree, with_tempfile, swallow_outputs, on_windows,

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -13,7 +13,7 @@ import io
 import os
 from os.path import join as opj, dirname
 
-from mock import patch
+from unittest.mock import patch
 
 from io import StringIO
 from .utils import with_testrepos

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -23,7 +23,7 @@ from .utils import (
     SkipTest,
 )
 
-from mock import patch
+from unittest.mock import patch
 
 
 # verify that any target platform can deal with forward slashes

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -14,7 +14,7 @@ import os
 from os.path import exists
 from os.path import join as opj
 
-from mock import patch
+from unittest.mock import patch
 from nose.tools import assert_false, assert_true, assert_equal
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_in, assert_not_in

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -20,7 +20,7 @@ import datalad.api
 from datalad import cfg
 
 from nose.tools import ok_
-from mock import patch
+from unittest.mock import patch
 
 from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import swallow_logs

--- a/datalad/tests/test_dochelpers.py
+++ b/datalad/tests/test_dochelpers.py
@@ -10,7 +10,7 @@
 """
 
 import os
-from mock import patch
+from unittest.mock import patch
 
 from ..dochelpers import single_or_plural, borrowdoc, borrowkwargs
 from ..dochelpers import exc_str

--- a/datalad/tests/test_installed.py
+++ b/datalad/tests/test_installed.py
@@ -9,7 +9,7 @@
 """Test invocation of datalad utilities "as is installed"
 """
 
-from mock import patch
+from unittest.mock import patch
 from .utils import ok_startswith, eq_, assert_cwd_unchanged
 
 from datalad.cmd import Runner

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -17,7 +17,7 @@ from logging import makeLogRecord
 from nose.tools import assert_raises, assert_is_instance, assert_true
 from git.exc import GitCommandError
 
-from mock import patch
+from unittest.mock import patch
 
 from datalad.log import LoggerHelper
 from datalad.log import TraceBack

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -24,7 +24,7 @@ from os.path import exists, join as opj, basename
 
 from urllib.request import urlopen
 
-from mock import patch
+from unittest.mock import patch
 from nose.tools import assert_in, assert_not_in, assert_true
 from nose import SkipTest
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -15,7 +15,7 @@ import os, os.path as op
 import shutil
 import sys
 import logging
-from mock import patch
+from unittest.mock import patch
 import builtins
 
 from operator import itemgetter

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -27,7 +27,7 @@ from fnmatch import fnmatch
 import time
 from difflib import unified_diff
 from contextlib import contextmanager
-from mock import patch
+from unittest.mock import patch
 
 from http.server import SimpleHTTPRequestHandler
 from http.server import HTTPServer

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -24,7 +24,7 @@ import time
 import getpass
 
 #!!! OPT adds >100ms to import time!!!
-# from mock import patch
+# from unittest.mock import patch
 from collections import deque
 from copy import copy
 
@@ -144,7 +144,7 @@ def getpass_echo(prompt='Password', stream=None):
         #     if out == '\n':
         #         return
         #     stream.write(out)
-        from mock import patch
+        from unittest.mock import patch
         with patch('termios.ECHO', 255 ** 2):
             #patch.object(stream, 'write', _no_emptyline_write(stream)):
             return getpass.getpass(prompt=prompt, stream=stream)

--- a/datalad/ui/tests/test_base.py
+++ b/datalad/ui/tests/test_base.py
@@ -24,7 +24,7 @@ from ...tests.utils import (
     with_testsui,
 )
 
-from mock import patch
+from unittest.mock import patch
 
 
 def test_ui_switcher():

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -13,7 +13,7 @@ __docformat__ = 'restructuredtext'
 from io import StringIO
 import builtins
 
-from mock import (
+from unittest.mock import (
     call,
     patch,
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ requires = {
         'iso8601',
         'humanize',
         'fasteners',
-        'mock>=1.0.1',  # mock is also used for auto.py, not only for testing
         'patool>=1.7',
         'tqdm',
         'wrapt',
@@ -59,7 +58,6 @@ requires = {
     'tests': [
         'BeautifulSoup4',  # VERY weak requirement, still used in one of the tests
         'httpretty>=0.8.14',
-        'mock',
         'nose>=1.3.4',
         'vcrpy',
     ],


### PR DESCRIPTION
We've dropped Python 2 support, and since Python 3.3 mock is included
in the standard library.