### PR TITLE
BF: rerun --report: Restore diff value to original form

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -638,8 +638,13 @@ def diff_revision(dataset, revision="HEAD"):
         # No other commits are reachable from this revision.  Diff
         # with an empty tree instead.
         fr = PRE_INIT_COMMIT_SHA
+
+    def changed(res):
+        return res.get("action") == "diff" and res.get("state") != "clean"
+
     diff = dataset.diff(recursive=True,
                         fr=fr, to=revision,
+                        result_filter=changed,
                         return_type='generator', result_renderer=None)
     for r in diff:
         yield r

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -136,6 +136,15 @@ def test_rerun(path, nodspath):
     # We can get back a report of what would happen rather than actually
     # rerunning anything.
     report = ds.rerun(since="", report=True, return_type="list")
+    # The "diff" section of the report doesn't include the unchanged files that
+    # would come in "-f json diff" output.
+    for entry in report:
+        if entry["rerun_action"] == "run":
+            # None of the run commits touch .datalad/config or any other config
+            # file.
+            assert_false(any(r["path"].endswith("config")
+                             for r in entry["diff"]))
+
     # Nothing changed.
     eq_('xxxxxxxxxx\n', open(probe_path).read())
     assert_result_count(report, 1, rerun_action="skip-or-pick")


### PR DESCRIPTION
When we started storing the diff() results in 168c49e23 (NF: rerun:
Add --report, 2018-05-22), the results didn't include unchanged files.
However, the new diff() command---merged with 50beb3bca (RF: Aborb
rev-diff, 2019-04-30)---returns an entry for all files in the working
tree, with unchanged files having a state of "clean".

Filter these out to restore the original behavior and avoid dumping a
large amount of uninteresting information to `rerun --report` callers.