### PR TITLE
Exit right away with non-0 and a message when operating from a non-existing directory

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -54,7 +54,15 @@ from .log import lgr
 from datalad.utils import get_encoding_info, get_envvars_info, getpwd
 
 # To analyze/initiate our decision making on what current directory to return
-getpwd()
+if not getpwd(allow_non_existing_cwd=False):
+    import sys
+    from .ui import ui
+    ui.error(
+        "Running datalad from a non-existing directory is not supported. \n"
+        "Change current directory and try again."
+    )
+    sys.exit(1)
+
 
 lgr.log(5, "Instantiating ssh manager")
 from .support.sshconnector import SSHManager

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -22,7 +22,10 @@ import sys
 import textwrap
 import os
 
-from six import text_type
+from six import (
+    text_type,
+    PY3,
+)
 
 import datalad
 
@@ -432,6 +435,19 @@ def _fix_datalad_ri(s):
 
 
 def main(args=None):
+    cwd = None
+    try:
+        cwd = os.getcwd()
+    except (FileNotFoundError if PY3 else OSError):
+        cwd = None
+
+    if cwd is None:
+        from ..ui import ui
+        ui.error(
+            "Running datalad from a non-existing directory is not supported. \n"
+            "Change current directory and try again."
+        )
+        sys.exit(1)
     lgr.log(5, "Starting main(%r)", args)
     args = args or sys.argv
     if on_msys_tainted_paths:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -435,19 +435,6 @@ def _fix_datalad_ri(s):
 
 
 def main(args=None):
-    cwd = None
-    try:
-        cwd = os.getcwd()
-    except (FileNotFoundError if PY3 else OSError):
-        cwd = None
-
-    if cwd is None:
-        from ..ui import ui
-        ui.error(
-            "Running datalad from a non-existing directory is not supported. \n"
-            "Change current directory and try again."
-        )
-        sys.exit(1)
     lgr.log(5, "Starting main(%r)", args)
     args = args or sys.argv
     if on_msys_tainted_paths:

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -93,11 +93,16 @@ def test_version():
 @with_tempfile(mkdir=True)
 def test_nonexisting_dir(path):
     with chpwd(path):
+        runner = Runner()
         rmtree(path)
-        stdout, stderr = run_main(['--version'], exit_code=1, expect_stderr=True)
-        assert_not_in("FileNotFoundError", stderr)
-        # unfortunately run_main fails to capture it
-        # assert_in("not supported", stdout)
+        from datalad.cmd import CommandError
+        with assert_raises(CommandError) as cmr:
+            runner(['datalad', '--version'])
+        exc = cmr.exception
+        assert_not_in("FileNotFoundError", exc.stderr)
+        assert_in("not supported", exc.stdout)
+        # but we still show error
+        assert_in("getcwd() failed", exc.stderr)
 
 
 def test_help_np():

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -37,6 +37,7 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_re_in
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import slow
+from datalad.tests.utils import skip_if_on_windows
 
 
 def run_main(args, exit_code=0, expect_stderr=False):
@@ -88,6 +89,7 @@ def test_version():
     assert_not_in("Permission is hereby granted", out)
 
 
+@skip_if_on_windows  # cannot tolerate removing CWD
 @with_tempfile(mkdir=True)
 def test_nonexisting_dir(path):
     with chpwd(path):

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -27,7 +27,10 @@ from datalad import __version__
 from datalad.cmd import Runner
 from datalad.ui.utils import get_console_width
 from datalad.api import create
-from datalad.utils import chpwd
+from datalad.utils import (
+    chpwd,
+    rmtree,
+)
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_equal, assert_raises, in_, ok_startswith
 from datalad.tests.utils import assert_in
@@ -83,6 +86,16 @@ def test_version():
     # since https://github.com/datalad/datalad/pull/2733 no license in --version
     assert_not_in("Copyright", out)
     assert_not_in("Permission is hereby granted", out)
+
+
+@with_tempfile(mkdir=True)
+def test_nonexisting_dir(path):
+    with chpwd(path):
+        rmtree(path)
+        stdout, stderr = run_main(['--version'], exit_code=1, expect_stderr=True)
+        assert_not_in("FileNotFoundError", stderr)
+        # unfortunately run_main fails to capture it
+        # assert_in("not supported", stdout)
 
 
 def test_help_np():


### PR DESCRIPTION
Unfortunately AFAIK even --version cannot operate normally,
so better to exit with informative message right away if
CWD is cannot be determined

Closes #3874 