### PR TITLE
RF: siblings: Do not call update() with 'path' argument

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -445,8 +445,7 @@ def _configure_remote(
         if fetch:
             # fetch the remote so we are up to date
             for r in Update.__call__(
-                    dataset=res_kwargs['refds'],
-                    path=[dict(path=ds.path, type='dataset')],
+                    dataset=ds.path,
                     sibling=name,
                     merge=False,
                     recursive=False,


### PR DESCRIPTION
This patch prevents a spurious warning from an `update` call in `siblings`.  I noticed it when calling `create-sibling`:

    $ datalad create-sibling -r -s sm smaug:scratch/sib
    [INFO   ] Connecting ...
    [INFO   ] Considering to create a target dataset /tmp/dl-5RhTQQG at scratch/sib of smaug
    [WARNING] path constraints for subdataset updates ignored, because `recursive` option was not given
    [INFO   ] Fetching updates for <Dataset path=/tmp/dl-5RhTQQG>
    .: sm(+) [smaug:scratch/sib (git)]
    [INFO   ] Adjusting remote git configuration
    [INFO   ] Running post-update hooks in all created siblings
    create_sibling(ok): . (dataset)
