### PR TITLE
ENH: Speed-up initial status() run in unlock()

### DIFF
--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -110,6 +110,7 @@ class Unlock(Interface):
                 dataset=dataset,
                 path=paths_lexist,
                 untracked="normal" if paths_nondir else "no",
+                report_filetype=False,
                 annex="availability",
                 recursive=recursive,
                 recursion_limit=recursion_limit,

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -145,9 +145,11 @@ class Unlock(Interface):
         # Do the actual unlocking.
         for ds_path, files in to_unlock.items():
             ds = Dataset(ds_path)
-            for r in ds.repo.unlock(files):
+            for r in ds.repo._run_annex_command_json(
+                    "unlock",
+                    files=files):
                 yield get_status_dict(
-                    path=op.join(ds.path, r),
-                    status='ok',
+                    path=op.join(ds.path, r['file']),
+                    status='ok' if r['success'] else 'error',
                     type='file',
                     **res_kwargs)


### PR DESCRIPTION
it should not be necessary determine the actual file type for unlock's internal need. So all those cycles can be saved.

Discovered in the context of https://github.com/datalad/datalad/issues/3869
