### PR TITLE
Patched unicode issue for python2

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -800,7 +800,7 @@ class _EGrepCSSearch(_Search):
                     "Unknown value for stats. Know full and short")
 
             print(
-                '{k}\n in  {stat.ndatasets} datasets\n has {stat.uvals_str}'.format(
+                u'{k}\n in  {stat.ndatasets} datasets\n has {stat.uvals_str}'.format(
                 k=k, stat=stat
             ))
         # After #2156 datasets may not necessarily carry all


### PR DESCRIPTION
This fixes the following bug (too minor to open a github issue?)

$ cd ~/datalad/openneuro
$ datalad search -f json --show-keys short

...
bids.CogAtlasID
 in  17 datasets
 has 15 unique values: u' ', u'trm_4c8a84f20dde2', u'http://www.cognitiveatlas.org/task/id/trm_4c8a83 ....
[ERROR  ] 'ascii' codec can't encode character u'\u200b' in position 15: ordinal not in range(128) [search.py:show_keys:804] (UnicodeEncodeError)
