### PR TITLE
ENH: wtf() reports dataset ID

### DIFF
--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -234,6 +234,7 @@ def _describe_dataset(ds, sensitive):
         infos = {
             'path': ds.path,
             'repo': ds.repo.__class__.__name__ if ds.repo else None,
+            'id': ds.id,
         }
         if not sensitive:
             infos['metadata'] = _HIDDEN


### PR DESCRIPTION
Dunno why we didn't have this since the start. But being able to
identify a dataset without having to fall back to Git (hoping that we
never move that file):

  git config --file .datalad/config datalad.dataset.id

seems like a good thing:

  datalad -f '{infos[dataset][id]}' wtf -S dataset
