### PR TITLE
ENH(working Draft): with explicitly empty save message, invoke editor to provide one

### DIFF
--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -116,7 +116,9 @@ nosave_opt = Parameter(
 save_message_opt = Parameter(
     args=("-m", "--message",),
     metavar='MESSAGE',
-    doc="""a description of the state or the changes made to a dataset.""",
+    doc="""a description of the state or the changes made to a dataset. If empty 
+    value is explicitly specified, it would bring up an editor to enter the
+    message.""",
     constraints=EnsureStr() | EnsureNone())
 
 message_file_opt = Parameter(

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2319,4 +2319,15 @@ def maybe_shlex_quote(val):
     return val if on_windows else shlex_quote(val)
 
 
+def edit_text_in_file(path, content=None):
+    """TODO"""
+    if content:
+        with open(path, 'wb') as f:
+            f.write(content.encode())
+    from .ui import ui
+    ui.edit_file(path)
+    with open(path) as f:
+        return f.read()
+
+
 lgr.log(5, "Done importing datalad.utils")


### PR DESCRIPTION
Alternative to (closed without merge for now) #3101 to allow user to specify commit message.
 
In contrast to #3101, I do not think it is actually desired to try to make regular git
commit editor work, since we would not want it to pop up for every subdataset
we might be operating on in a recursive invocation.  It would also be inconsistent
with a single `-m` we provide for recursive `save` operation. With all the recursion
we better provide our own statistics and information about what is about
to happen.  In this initial commit I am not harvesting those stats, since
it would require further code RFing, and possibly some side-effect OPT to not
bother collecting and/or carrying around all the "clean" state information
about all the files in all datasets (but on a quick attempt it caused some tests expecting 'ok'
for even clean subdatasets)

To invoke editor upon save, just specify -m .  In the long run, we could
make it behave like git, i.e. upon not only an explicitly empty, but `None`
as well.

For now I have used `subprocess.call` directly without bothering with `Runner` to not inherit any possible complications. Moreover, interface to edit a file should be provided by UIs, so then some gui/web ui had a chance to provide needed interface.