### PR TITLE
BF: Reintroduce 'notneeded' results for existing datasets in get()

### DIFF
--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -333,8 +333,17 @@ def test_get_recurse_subdatasets(src, path):
     # MIH: Nope, we fulfill the dataset handle, but that doesn't
     #      imply fulfilling all file handles
     result = ds.get(rel_path_sub1, recursive=True)
-    # all good actions
-    assert_status('ok', result)
+    # the subdataset was already present
+    assert_in_results(
+        result,
+        type='dataset',
+        path=subds1.path,
+        status='notneeded')
+    # we got the file
+    assert_in_results(
+        result,
+        path=opj(ds.path, rel_path_sub1),
+        status='ok')
 
     assert_in_results(result, path=opj(ds.path, rel_path_sub1), status='ok')
     ok_(subds1.repo.file_has_content('test-annex.dat') is True)
@@ -367,8 +376,9 @@ def test_get_recurse_subdatasets(src, path):
     # now, the very same call, but without recursive:
     result = ds.get('.', recursive=False)
     assert_status('ok', result)
-    # one report is on the requested dir
-    eq_(len(result) - 1, 1)
+    # no duplicate reporting on subdataset install and annex-get of its
+    # directory
+    eq_(len(result), 1)
     assert_result_count(
         result, 1, path=opj(ds.path, 'test-annex.dat'), status='ok')
     ok_(ds.repo.file_has_content('test-annex.dat') is True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -368,6 +368,11 @@ def test_install_recursive(src, path_nr, path_r):
     for subsub in subds.subdatasets(recursive=True, result_xfm='datasets'):
         ok_(subsub.is_installed())
 
+    # check that we get subdataset instances manufactored from notneeded results
+    # to install existing subdatasets again
+    eq_(subds, ds.install('recursive-in-ds'))
+
+
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_install_recursive_with_data(src, path):
@@ -377,8 +382,8 @@ def test_install_recursive_with_data(src, path):
                   result_filter=None, result_xfm=None)
     assert_status('ok', res)
     # installed a dataset and two subdatasets, and one file with content in
-    # each, plus the report that we got all content in each dataset's root dir
-    eq_(len(res), 9)
+    # each
+    eq_(len(res), 6)
     assert_result_count(res, 3, type='dataset')
     # we recurse top down during installation, so toplevel should appear at
     # first position in returned list


### PR DESCRIPTION
However, instead of reverting to the behavior prior 0.12rc6 (blind duplicate reporting of dataset results for subdataset install and annex-get of its root directory, this patch compromises and actually inspects if there already was a report on a dataset, and only silences follow-up duplicate reports. This impacts the result composition of large-ish operations (recursive install of a dataset with data), but AFAICS it should have now actual impact on logic and actionability of the results.

This fixes gh-3836

Alternative to https://github.com/datalad/datalad/pull/3841 @bpoldrack 