### PR TITLE
NF: Result hooks

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -448,6 +448,11 @@ class ConfigManager(object):
             self.add(var, '{}'.format(_value), where=where, reload=reload)
         return value
 
+    def __str__(self):
+        return "ConfigManager({}{})".format(
+            self._cfgfiles,
+            '+ overrides' if self.overrides else '',
+        )
     #
     # Compatibility with dict API
     #

--- a/datalad/core/local/resulthooks.py
+++ b/datalad/core/local/resulthooks.py
@@ -1,0 +1,102 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Interface utility functions
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+import json
+
+lgr = logging.getLogger('datalad.core.local.hooks')
+
+
+def get_hooks_from_config(cfg):
+    hooks = {}
+    for h in (k for k in cfg.keys()
+              if k.startswith('datalad.result-hook.')
+              and k.endswith('.match')):
+        proc = cfg.get('{}.proc'.format(h[:-6]), None)
+        if not proc:
+            lgr.warning(
+                'Incomplete result hook configuration %s in %s' % (
+                    h[:-6], cfg))
+            continue
+        sep = proc.index(' ')
+        hooks[h[20:-6]] = dict(
+            cmd=proc[:sep],
+            args=proc[sep + 1:],
+            match=json.loads(cfg.get(h)),
+        )
+    return hooks
+
+
+def match_hook2result(hook, res, match):
+    for k, v in match.items():
+        # do not test 'k not in res', because we could have a match that
+        # wants to make sure that a particular value is not present, and
+        # not having the key would be OK in that case
+
+        # in case the target value is an actual list, an explicit action 'eq'
+        # must be given
+        action, val = (v[0], v[1]) if isinstance(v, list) else ('eq', v)
+        if action == 'eq':
+            if k in res and res[k] == val:
+                continue
+        elif action == 'neq':
+            if k not in res or res[k] != val:
+                continue
+        elif action == 'in':
+            if k in res and res[k] in val:
+                continue
+        elif action == 'nin':
+            if k not in res or res[k] not in val:
+                continue
+        else:
+            lgr.warning(
+                'Unknown result comparison operation %s for hook %s, skipped',
+                action, hook)
+        # indentation level is intended!
+        return False
+    return True
+
+
+def run_hook(hook, spec, r, dataset_arg):
+    import datalad.api as dl
+    cmd_name = spec['cmd']
+    if not hasattr(dl, cmd_name):
+        # TODO maybe a proper error result?
+        lgr.warning(
+            'Hook %s requires unknown command %s, skipped',
+            hook, cmd_name)
+        return
+    cmd = getattr(dl, cmd_name)
+    # apply potential substitutions on the string form of the args
+    # for this particular result
+    # take care of proper JSON encoding for each value
+    enc = json.JSONEncoder().encode
+    # we have to ensure JSON encoding of all values (some might be Path instances),
+    # we are taking off the outer quoting, to enable flexible combination
+    # of individual items in supplied command and argument templates
+    args = spec['args'].format(
+        # we cannot use a dataset instance directly but must take the
+        # detour over the path location in order to have string substitution
+        # be possible
+        dsarg='' if dataset_arg is None else enc(dataset_arg.path).strip('"')
+        if isinstance(dataset_arg, dl.Dataset) else enc(dataset_arg).strip('"'),
+        # skip any present logger that we only carry for internal purposes
+        **{k: enc(str(v)).strip('"') for k, v in r.items() if k != 'logger'})
+    # now load
+    args = json.loads(args)
+    # only debug level, the hook can issue its own results and communicate
+    # through them
+    lgr.debug('Running hook %s: %s%s', hook, cmd_name, args)
+    for r in cmd(**args):
+        yield r

--- a/datalad/core/local/resulthooks.py
+++ b/datalad/core/local/resulthooks.py
@@ -33,9 +33,9 @@ def get_jsonhooks_from_config(cfg):
       for a hook to be triggered.
     """
     hooks = {}
-    for h in (k for k in cfg.keys()
-              if k.startswith('datalad.result-hook.')
-              and k.endswith('.match-json')):
+    for h in cfg.keys():
+        if not (h.startswith('datalad.result-hook.') and h.endswith('.match-json')):
+            continue
         call = cfg.get('{}.call-json'.format(h[:-11]), None)
         if not call:
             lgr.warning(

--- a/datalad/core/local/resulthooks.py
+++ b/datalad/core/local/resulthooks.py
@@ -68,6 +68,9 @@ def match_hook2result(hook, res, match):
           "status": "notneeded"
         }
 
+    If a to be tested value is a list, an 'eq' operation needs to be specified
+    explicitly in order to disambiguate the definition.
+
     Parameters
     ----------
     hook : str

--- a/datalad/core/local/resulthooks.py
+++ b/datalad/core/local/resulthooks.py
@@ -28,7 +28,7 @@ def get_hooks_from_config(cfg):
       three keys: 'cmd' contains the name of the to-be-executed DataLad
       command; 'args' has a JSON-encoded string with a dict of keyword
       arguments for the command (format()-language based placeholders
-      can be present; 'match' hold a JSON-encoded string representing
+      can be present); 'match' holds a JSON-encoded string representing
       a dict with key/value pairs that need to match a result in order
       for a hook to be triggered.
     """
@@ -120,7 +120,7 @@ def run_hook(hook, spec, res, dsarg=None):
 
     A hook definition's 'proc' specification may contain placeholders that
     will be expanded using matching values in the given result record. In
-    addition to keys in the result an '{dsarg}' placeholder is supported.
+    addition to keys in the result a '{dsarg}' placeholder is supported.
     The characters '{' and '}' in the 'proc' specification that are not part
     of format() placeholders have to be escaped as '{{' and '}}'. Example
     'proc' specification to execute the DataLad ``unlock`` command::
@@ -134,7 +134,7 @@ def run_hook(hook, spec, res, dsarg=None):
     spec : dict
       Hook definition as returned by `get_hooks_from_config()`
     res : dict
-      Result records that was found to match the hook definition.
+      Result records that were found to match the hook definition.
     dsarg : Dataset or str or None, optional
       Value to substitute a {dsarg} placeholder in a hook 'proc' specification
       with. Non-string values are automatically converted.

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -54,7 +54,7 @@ def test_basics(src, dst):
     )
     # configure another one that will unlock any obtained file
     # {dsarg} is substituted by the dataset arg of the command that
-    # the eval_func() decorator belongs too
+    # the eval_func() decorator belongs to
     # but it may not have any, as this is not the outcome of a
     # require_dataset(), but rather the verbatim input
     # it could be more useful to use {refds}

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -29,7 +29,6 @@ from datalad.tests.utils import (
     known_failure_appveyor,
     known_failure_windows,
     swallow_outputs,
-    has_symlink_capability,
 )
 
 from datalad.distribution.dataset import Dataset
@@ -104,7 +103,7 @@ def test_basics(src, dst):
     eq_(clone_sub.config.get('datalad.metadata.nativetype'), 'bids')
 
     # hook auto-unlocks the file
-    if has_symlink_capability():
+    if not on_windows:
         ok_((clone.pathobj / 'file1').is_symlink())
     clone.get('file1')
     ok_(not (clone.pathobj / 'file1').is_symlink())

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -29,6 +29,7 @@ from datalad.tests.utils import (
     known_failure_appveyor,
     known_failure_windows,
     swallow_outputs,
+    has_symlink_capability,
 )
 
 from datalad.distribution.dataset import Dataset
@@ -103,7 +104,8 @@ def test_basics(src, dst):
     eq_(clone_sub.config.get('datalad.metadata.nativetype'), 'bids')
 
     # hook auto-unlocks the file
-    ok_((clone.pathobj / 'file1').is_symlink())
+    if has_symlink_capability():
+        ok_((clone.pathobj / 'file1').is_symlink())
     clone.get('file1')
     ok_(not (clone.pathobj / 'file1').is_symlink())
 

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -90,9 +90,11 @@ def test_basics(src, dst):
     # hook auto-unlocks the file
     if not on_windows:
         ok_((clone.pathobj / 'file1').is_symlink())
-    # we get to see the results from the hook too!
-    assert_result_count(
-        clone.get('file1'), 1, action='unlock', path=str(clone.pathobj / 'file1'))
+    res = clone.get('file1')
+    if not on_windows:
+        # we get to see the results from the hook too!
+        assert_result_count(
+            res, 1, action='unlock', path=str(clone.pathobj / 'file1'))
     ok_(not (clone.pathobj / 'file1').is_symlink())
 
     if not on_windows:

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -12,26 +12,10 @@ from datalad.utils import (
     on_windows,
 )
 from datalad.tests.utils import (
-    assert_status,
-    assert_repo_status,
-    assert_result_count,
-    assert_in,
-    assert_in_results,
-    assert_not_in,
-    assert_raises,
-    create_tree,
     with_tempfile,
-    with_tree,
-    with_testrepos,
     eq_,
     ok_,
-    chpwd,
-    known_failure_appveyor,
-    known_failure_windows,
-    swallow_outputs,
 )
-
-from datalad.distribution.dataset import Dataset
 from datalad.api import (
     Dataset,
     install,

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test result hooks"""
+
+from datalad.utils import (
+    on_windows,
+)
+from datalad.tests.utils import (
+    assert_status,
+    assert_repo_status,
+    assert_result_count,
+    assert_in,
+    assert_in_results,
+    assert_not_in,
+    assert_raises,
+    create_tree,
+    with_tempfile,
+    with_tree,
+    with_testrepos,
+    eq_,
+    ok_,
+    chpwd,
+    known_failure_appveyor,
+    known_failure_windows,
+    swallow_outputs,
+)
+
+from datalad.distribution.dataset import Dataset
+from datalad.api import (
+    Dataset,
+    install,
+)
+
+
+@with_tempfile()
+@with_tempfile()
+def test_basics(src, dst):
+    # dataset with subdataset, not specific configuration
+    ds = Dataset(src).create()
+    (ds.pathobj / 'file1').write_text('some')
+    ds.save()
+    sub = ds.create('subds')
+    eq_(sub.config.get('datalad.metadata.nativetype'), None)
+
+    # now clone the super
+    clone = install(source=src, path=dst)
+    # and configure it, such that it modifies each obtained subdataset
+    # on install to have 'bids' listed as a metadata type
+    clone.config.set(
+        'datalad.result-hook.alwaysbids.proc',
+        # the spec is like --proc-post/pre, but has the dataset to run on as
+        # the first element
+        # string substitutions based on the result record are supported
+        'run_procedure {{"dataset":"{path}","spec":"cfg_metadatatypes bids"}}',
+        where='local',
+    )
+    # config on which kind of results this hook should operate
+    clone.config.set(
+        'datalad.result-hook.alwaysbids.match',
+        # any successfully installed dataset
+        '{"type":"dataset","action":"install","status":["eq", "ok"]}',
+        where='local',
+    )
+    # configure another one that will unlock any obtained file
+    # {dsarg} is substituted by the dataset arg of the command that
+    # the eval_func() decorator belongs too
+    # but it may not have any, as this is not the outcome of a
+    # require_dataset(), but rather the verbatim input
+    # it could be more useful to use {refds}
+    clone.config.set(
+        'datalad.result-hook.unlockfiles.proc',
+        'unlock {{"dataset":"{dsarg}","path":"{path}"}}',
+        where='local',
+    )
+    clone.config.set(
+        'datalad.result-hook.unlockfiles.match',
+        '{"type":"file","action":"get","status":"ok"}',
+        where='local',
+    )
+    if not on_windows:
+        # and one that runs a shell command on any notneeded file-get
+        clone.config.set(
+            'datalad.result-hook.annoy.proc',
+            'run {{"cmd":"touch {path}_annoyed",'
+            '"dataset":"{dsarg}","explicit":true}}',
+            where='local',
+        )
+        clone.config.set(
+            'datalad.result-hook.annoy.match',
+            '{"type":["in", ["file"]],"action":"get","status":"notneeded"}',
+            where='local',
+        )
+    # TODO resetting of detached HEAD seem to come after the install result
+    # and wipes out the change
+    clone.get('subds')
+    clone_sub = Dataset(clone.pathobj / 'subds')
+    eq_(clone_sub.config.get('datalad.metadata.nativetype'), 'bids')
+
+    # hook auto-unlocks the file
+    ok_((clone.pathobj / 'file1').is_symlink())
+    clone.get('file1')
+    ok_(not (clone.pathobj / 'file1').is_symlink())
+
+    if not on_windows:
+        # different hook places annoying file next to a file that was already present
+        annoyed_file = clone.pathobj / 'file1_annoyed'
+        ok_(not annoyed_file.exists())
+        clone.get('file1')
+        ok_(annoyed_file.exists())

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -15,6 +15,7 @@ from datalad.tests.utils import (
     with_tempfile,
     eq_,
     ok_,
+    assert_result_count,
 )
 from datalad.api import (
     Dataset,
@@ -89,7 +90,9 @@ def test_basics(src, dst):
     # hook auto-unlocks the file
     if not on_windows:
         ok_((clone.pathobj / 'file1').is_symlink())
-    clone.get('file1')
+    # we get to see the results from the hook too!
+    assert_result_count(
+        clone.get('file1'), 1, action='unlock', path=str(clone.pathobj / 'file1'))
     ok_(not (clone.pathobj / 'file1').is_symlink())
 
     if not on_windows:

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -38,7 +38,7 @@ def test_basics(src, dst):
     # and configure it, such that it modifies each obtained subdataset
     # on install to have 'bids' listed as a metadata type
     clone.config.set(
-        'datalad.result-hook.alwaysbids.proc',
+        'datalad.result-hook.alwaysbids.call-json',
         # the spec is like --proc-post/pre, but has the dataset to run on as
         # the first element
         # string substitutions based on the result record are supported
@@ -47,7 +47,7 @@ def test_basics(src, dst):
     )
     # config on which kind of results this hook should operate
     clone.config.set(
-        'datalad.result-hook.alwaysbids.match',
+        'datalad.result-hook.alwaysbids.match-json',
         # any successfully installed dataset
         '{"type":"dataset","action":"install","status":["eq", "ok"]}',
         where='local',
@@ -59,25 +59,25 @@ def test_basics(src, dst):
     # require_dataset(), but rather the verbatim input
     # it could be more useful to use {refds}
     clone.config.set(
-        'datalad.result-hook.unlockfiles.proc',
+        'datalad.result-hook.unlockfiles.call-json',
         'unlock {{"dataset":"{dsarg}","path":"{path}"}}',
         where='local',
     )
     clone.config.set(
-        'datalad.result-hook.unlockfiles.match',
+        'datalad.result-hook.unlockfiles.match-json',
         '{"type":"file","action":"get","status":"ok"}',
         where='local',
     )
     if not on_windows:
         # and one that runs a shell command on any notneeded file-get
         clone.config.set(
-            'datalad.result-hook.annoy.proc',
+            'datalad.result-hook.annoy.call-json',
             'run {{"cmd":"touch {path}_annoyed",'
             '"dataset":"{dsarg}","explicit":true}}',
             where='local',
         )
         clone.config.set(
-            'datalad.result-hook.annoy.match',
+            'datalad.result-hook.annoy.match-json',
             '{"type":["in", ["file"]],"action":"get","status":"notneeded"}',
             where='local',
         )

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -52,6 +52,13 @@ def test_basics(src, dst):
         '{"type":"dataset","action":"install","status":["eq", "ok"]}',
         where='local',
     )
+    # a smoke test to see if a hook definition without any call args works too
+    clone.config.set('datalad.result-hook.wtf.call-json', 'wtf', where='local')
+    clone.config.set(
+        'datalad.result-hook.wtf.match-json',
+        '{"type":"dataset","action":"install","status":["eq", "ok"]}',
+        where='local',
+    )
     # configure another one that will unlock any obtained file
     # {dsarg} is substituted by the dataset arg of the command that
     # the eval_func() decorator belongs to

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -55,9 +55,9 @@ from datalad.interface.common_opts import eval_defaults
 from .results import known_result_xfms
 from datalad.config import ConfigManager
 from datalad.core.local.resulthooks import (
-    get_hooks_from_config,
-    match_hook2result,
-    run_hook,
+    get_jsonhooks_from_config,
+    match_jsonhook2result,
+    run_jsonhook,
 )
 
 
@@ -400,7 +400,7 @@ def eval_results(func):
             proc_cfg=proc_cfg)
 
         # look for hooks
-        hooks = get_hooks_from_config(proc_cfg)
+        hooks = get_jsonhooks_from_config(proc_cfg)
 
         # this internal helper function actually drives the command
         # generator-style, it may generate an exception if desired,
@@ -445,14 +445,14 @@ def eval_results(func):
                     # this ensures that they are executed before
                     # a potentially wrapper command gets to act
                     # on them
-                    if match_hook2result(hook, r, spec['match']):
+                    if match_jsonhook2result(hook, r, spec['match']):
                         lgr.debug('Result %s matches hook %s', r, hook)
                         # a hook is also a command that yields results
                         # so yield them outside too
                         # users need to pay attention to void infinite
                         # loops, i.e. when a hook yields a result that
                         # triggers that same hook again
-                        for hr in run_hook(hook, spec, r, dataset_arg):
+                        for hr in run_jsonhook(hook, spec, r, dataset_arg):
                             yield hr
                 yield r
                 # collect if summary is desired


### PR DESCRIPTION
This is aims to be a more flexible alternative to --proc-pre/post and its proposed successor of command hooks (#3264).

The key idea is that we have DataLad's results that all pass through the main event loop, and we can define ad-hoc hooks that run custom actions whenever a matching result is observed.

Key differences to what we already have:

- can act more than once per command execution
- no "pre" action anymore
- informed by the actual result itself
- runs dataset procedures, but also any proper datalad command

To define a hook, two config variables need to be set:

- `datalad.result-hook.<name>.match`
- `datalad.result-hook.<name>.proc`

where `<name>` is any Git config compatible identifier.

`match` contains a JSON-encoded dict that is used to match a result against in order to test whether the respective hook should run. It can contain any number of keys. For each key it is tested, if the value matches the one in the result, if all match the hook is executed. In addition to `==` tests, `in`, `not in`, and `!=` tests are supported. The operation can be given by wrapping the test value into a list, the first item is the operation label 'eq', 'neq', 'in', 'nin' -- the second value is the test value (set). Example:

```
{"type": ["in", ["file", "directory"]], "action": "get", "status": "notneeded"}
```

`proc` is the specification of what the hook execution comprises. Any datalad command is suitable (which includes `run_procedure`). The value is a string, where the first word is the name of the datalad command to run (in Python notation). The remainder of the string is a JSON-encoded dict with keyword arguments for the command execution. Unlike `match` string substitution is supported. Any key from a matching result can be used to trigger a substitution with the respective value in the result dict. In addition a `dsarg` key is supported that is expanded with the `dataset` argument that was giving to the command that the `eval_func` decorator belongs to and is processing the results.
Because of the string substitution using Python's `format()`, curly braces have to be protected. Hence an example setting could look like:

```
unlock {{"dataset": "{dsarg}", "path": "{path}"}}
```

or

```
run {{"cmd": "touch {path}_annoyed", "dataset": "{dsarg}", "explicit": true}}
```

Hook evaluation obviously slows processing, especially given the location in the code path (`eval_func`). The code is trying to minimize this impact. However, the lookup of potential hooks in the config represents an unconditional additional cost.

However, I consider this an extremely powerful mechanism that can be used to achieve custom setups without having to add features to the implementation of particular commands. So in summary I think this is worth the cost. 

For more info, please see the test inside.

### Benchmarks:

Our standard benchmarks show no impact (not a surprise, not much happening in them). So I ran tests that generate a lot of results (saving a dataset with 10k tiny files):

```
# setup
for i in $(seq 10000); do s=$(uuid | tr '-' '/'); mkdir -p ${s:5:19} && echo $s > ${s:5}; done;

# no hooks defined, this PR
datalad save  27.97s user 11.27s system 101% cpu 38.800 total

# no hooks defined, master 6031944e8a7770ec59389b6d7ec02d122cfbcbc3
datalad save  28.72s user 11.56s system 84% cpu 47.818 total
```

Looking forward to your feedback @datalad/developers 

TODO:

- [x] string substitution with windows paths leads to invalid JSON. No idea how to deal with that yet
- [x] investigate and potentially adjust timing of installation success results for datasets. It seems as if further processing is being perform on the dataset (content) after it is yielded (see disabled test inside). Now addressed in https://github.com/datalad/datalad/pull/3906 (merged into this PR too)