### PR TITLE
BF: gitrepo: Work around change in 'ls-files -o' output

### DIFF
--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import os
 import os.path as op
+from datalad.support.external_versions import external_versions
 from datalad.support.exceptions import (
     NoDatasetArgumentFound,
 )
@@ -341,8 +342,14 @@ def test_path_diff(_path, linkpath):
     # duplicate paths do not change things
     eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all'))
     # neither do nested paths
-    eq_(plain_recursive,
-        ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all'))
+    if external_versions["cmd:git"] < "2.24.0":
+        # TODO: The link below points to discussion of this behavioral change
+        # in Git. If the behavior is addressed in a future release, update the
+        # condition above with a ceiling. If it's not, think more about how to
+        # handle this change on our side.
+        # https://lore.kernel.org/git/87fti15agv.fsf@kyleam.com/T/#u
+        eq_(plain_recursive,
+            ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all'))
     # when invoked in a subdir of a dataset it still reports on the full thing
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):


### PR DESCRIPTION
```
save_() calls 'ls-files -o' on a list of untracked directories to
determine which directories correspond to untracked submodules.  If
the directories remain unexpanded in the 'ls-files -o' output, they
are taken as submodules.

This method of identifying untracked submodules breaks [0,1] with the
latest release of Git (v2.24.0) due to an unintentional change in the
'ls-files -o' output [2]: when given _multiple_ pathspecs, 'ls-files
-o' recurses into untracked submodules and lists the files from the
submodule (even the tracked ones).  save_() filters the output to
directories, so most of the additional entries are removed, but when
the submodule itself has submodules (untracked or tracked) these and
those from any deeper levels are included in the output.  save_()
passes these deeper repositories to add_submodule(), which as expected
leads to 'git submodule add' failing.

This behavior will hopefully be addressed in Git itself [2], but we
should still provide a workaround for the current version of Git.  Add
a helper that filters these deeper repositories from the list of
submodules that save_() feeds to add_submodule().  This approach takes
advantage of the fact that, even when 'ls-files -o' misbehaves and
traverses into the submodule, it still reports an unexpanded entry.
If it didn't, we wouldn't be able to distinguish a submodule from a
regular directory.

Note that the helper is conditionally defined at the module level; for
earlier versions of Git that don't need this kludge, this reduces the
cost per save_() call to a single call to an identity function.
```

0: https://github.com/datalad/datalad/issues/3890#issuecomment-561722194
1: https://github.com/datalad/datalad/pull/3902#issuecomment-562630681
2: https://lore.kernel.org/git/87fti15agv.fsf@kyleam.com/T/#u

---

Marking as "do not merge" because the tip commit should be dropped before merging.