### PR TITLE
ConfigManager can be limited to local config; prevent remote changes of hooks

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -159,23 +159,29 @@ class ConfigManager(object):
       If provided, all `git config` calls are executed in this dataset's
       directory. Moreover, any modifications are, by default, directed to
       this dataset's configuration file (which will be created on demand)
-    dataset_only : bool
-      If True, configuration items are only read from a datasets persistent
-      configuration file, if any present (the one in ``.datalad/config``, not
-      ``.git/config``).
+    source : {'any', 'local', 'dataset'}, optional
+      Which sources of configuration setting to consider. If 'dataset',
+      configuration items are only read from a dataset's persistent
+      configuration file, if any is present (the one in ``.datalad/config``, not
+      ``.git/config``); if 'local' any non-committed source is considered
+      (local and global configuration in Git config's terminology); if 'any'
+      all possible sources of configuration are considered.
     overrides : dict, optional
       Variable overrides, see general class documentation for details.
     """
 
     _checked_git_identity = False
 
-    def __init__(self, dataset=None, dataset_only=False, overrides=None):
+    def __init__(self, dataset=None, source='any', overrides=None):
         # store in a simple dict
         # no subclassing, because we want to be largely read-only, and implement
         # config writing separately
         self._store = {}
         self._cfgfiles = set()
         self._cfgmtimes = None
+        self._dataset_path = None
+        self._dataset_cfgfname = None
+        self._repo_cfgfname = None
         # public dict to store variables that always override any setting
         # read from a file
         # `hasattr()` is needed because `datalad.cfg` is generated upon first module
@@ -185,15 +191,18 @@ class ConfigManager(object):
         if overrides is not None:
             self.overrides.update(overrides)
         if dataset is None:
-            self._dataset_path = None
-            self._dataset_cfgfname = None
-            self._repo_cfgfname = None
+            if source == 'dataset':
+                raise ValueError(
+                    'ConfigManager configured to read dataset only, '
+                    'but no dataset given')
         else:
             self._dataset_path = dataset.path
-            self._dataset_cfgfname = opj(self._dataset_path, DATASET_CONFIG_FILE)
-            if not dataset_only:
+            if source != 'local':
+                self._dataset_cfgfname = opj(self._dataset_path,
+                                             DATASET_CONFIG_FILE)
+            if source != 'dataset':
                 self._repo_cfgfname = opj(self._dataset_path, '.git', 'config')
-        self._dataset_only = dataset_only
+        self._src_mode = source
         # Since configs could contain sensitive information, to prevent
         # any "facilitated" leakage -- just disable logging of outputs for
         # this runner
@@ -206,7 +215,7 @@ class ConfigManager(object):
         try:
             self._gitconfig_has_showorgin = \
                 LooseVersion(get_git_version(self._runner)) >= '2.8.0'
-        except:
+        except Exception:
             # no git something else broken, assume git is present anyway
             # to not delay this, but assume it is old
             self._gitconfig_has_showorgin = False
@@ -260,8 +269,8 @@ class ConfigManager(object):
                 self._store, self._cfgfiles = _parse_gitconfig_dump(
                     stdout, self._store, self._cfgfiles, replace=False)
 
-        if self._dataset_only:
-            # superimpose overrides
+        if self._src_mode == 'dataset':
+            # superimpose overrides, and stop early
             self._store.update(self.overrides)
             return
 

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -173,6 +173,9 @@ class ConfigManager(object):
     _checked_git_identity = False
 
     def __init__(self, dataset=None, source='any', overrides=None):
+        if source not in ('any', 'local', 'dataset'):
+            raise ValueError(
+                'Unkown ConfigManager(source=) setting: {}'.format(source))
         # store in a simple dict
         # no subclassing, because we want to be largely read-only, and implement
         # config writing separately

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -159,6 +159,10 @@ class ConfigManager(object):
       If provided, all `git config` calls are executed in this dataset's
       directory. Moreover, any modifications are, by default, directed to
       this dataset's configuration file (which will be created on demand)
+    dataset_only : bool
+      Legacy option, do not use.
+    overrides : dict, optional
+      Variable overrides, see general class documentation for details.
     source : {'any', 'local', 'dataset'}, optional
       Which sources of configuration setting to consider. If 'dataset',
       configuration items are only read from a dataset's persistent
@@ -166,16 +170,20 @@ class ConfigManager(object):
       ``.git/config``); if 'local' any non-committed source is considered
       (local and global configuration in Git config's terminology); if 'any'
       all possible sources of configuration are considered.
-    overrides : dict, optional
-      Variable overrides, see general class documentation for details.
     """
 
     _checked_git_identity = False
 
-    def __init__(self, dataset=None, source='any', overrides=None):
+    def __init__(self, dataset=None, dataset_only=False, overrides=None, source='any'):
         if source not in ('any', 'local', 'dataset'):
             raise ValueError(
                 'Unkown ConfigManager(source=) setting: {}'.format(source))
+            # legacy compat
+        if dataset_only:
+            if source != 'any':
+                raise ValueError('Refuse to combine legacy dataset_only flag, with '
+                                 'source setting')
+            source = 'dataset'
         # store in a simple dict
         # no subclassing, because we want to be largely read-only, and implement
         # config writing separately

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -99,12 +99,11 @@ def test_basics(path, super_path):
     ds.config.add(
         'datalad.clean.proc-pre',
         'datalad_test_proc',
-        where='dataset')
+        where='local')
     # run command that should trigger the demo procedure
     ds.clean()
     # look for traces
     ok_file_has_content(op.join(ds.path, 'fromproc.txt'), 'hello\n')
-    assert_repo_status(ds.path, modified=[op.join('.datalad', 'config')])
 
     # make a fresh dataset:
     super = Dataset(super_path).create()
@@ -112,7 +111,7 @@ def test_basics(path, super_path):
     super.config.add(
         'datalad.clean.proc-pre',
         'datalad_test_proc',
-        where='dataset')
+        where='local')
     # 'super' doesn't know any procedures but should get to know one by
     # installing the above as a subdataset
     super.install('sub', source=ds.path)
@@ -120,7 +119,6 @@ def test_basics(path, super_path):
     super.clean()
     # look for traces
     ok_file_has_content(op.join(super.path, 'fromproc.txt'), 'hello\n')
-    assert_repo_status(super.path, modified=[op.join('.datalad', 'config')])
 
 
 @skip_if(cond=on_windows and cfg.obtain("datalad.repo.version") < 6)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -53,6 +53,7 @@ from datalad.interface.base import get_allargs_as_kwargs
 from datalad.interface.common_opts import eval_params
 from datalad.interface.common_opts import eval_defaults
 from .results import known_result_xfms
+from datalad.config import ConfigManager
 
 
 lgr = logging.getLogger('datalad.interface.utils')
@@ -359,7 +360,17 @@ def eval_results(func):
                 # it only once. See https://github.com/datalad/datalad/issues/3575
                 from datalad.distribution.dataset import Dataset
                 ds = ds if isinstance(ds, Dataset) else Dataset(ds) if ds else None
-                proc_cfg = ds.config if ds and ds.is_installed() else dlcfg
+                # do not reuse a dataset's existing config manager here
+                # they are configured to read the committed dataset configuration
+                # too. That means a datalad update can silently bring in new
+                # procedure definitions from the outside, and in some sense enable
+                # remote code execution by a 3rd-party
+                # To avoid that, create a new config manager that only reads local
+                # config (system and .git/config), plus any overrides given to this
+                # datalad session
+                proc_cfg = ConfigManager(
+                    ds, source='local', overrides=dlcfg.overrides
+                ) if ds and ds.is_installed() else dlcfg
 
             spec = proc_cfg.get(cfg_key, None)
             if spec is None:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1090,7 +1090,7 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
         """
         if self._cfg is None:
             # associate with this dataset and read the entire config hierarchy
-            self._cfg = ConfigManager(dataset=self, dataset_only=False)
+            self._cfg = ConfigManager(dataset=self, source='any')
         return self._cfg
 
     def is_with_annex(self):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -205,6 +205,15 @@ def test_something(path, new_home):
 def test_crazy_cfg(path):
     cfg = ConfigManager(Dataset(opj(path, 'ds')), source='dataset')
     assert_in('crazy.padry', cfg)
+    # make sure crazy config is not read when in local mode
+    cfg = ConfigManager(Dataset(opj(path, 'ds')), source='local')
+    assert_not_in('crazy.padry', cfg)
+    # it will make it in in 'any' mode though
+    cfg = ConfigManager(Dataset(opj(path, 'ds')), source='any')
+    assert_in('crazy.padry', cfg)
+    # typos in the source mode arg will not have silent side-effects
+    assert_raises(
+        ValueError, ConfigManager, Dataset(opj(path, 'ds')), source='locale')
 
 
 @with_tempfile

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -52,11 +52,10 @@ _dataset_config_template = {
 @with_tree(tree=_dataset_config_template)
 @with_tempfile(mkdir=True)
 def test_something(path, new_home):
-    # read nothing, has nothing
-    cfg = ConfigManager(dataset_only=True)
-    assert_false(len(cfg))
+    # will refuse to work on dataset without a dataset
+    assert_raises(ValueError, ConfigManager, source='dataset')
     # now read the example config
-    cfg = ConfigManager(Dataset(opj(path, 'ds')), dataset_only=True)
+    cfg = ConfigManager(Dataset(opj(path, 'ds')), source='dataset')
     assert_equal(len(cfg), 3)
     assert_in('something.user', cfg)
     # multi-value
@@ -154,7 +153,7 @@ def test_something(path, new_home):
                     {'HOME': new_home, 'DATALAD_SNEAKY_ADDITION': 'ignore'}):
         global_gitconfig = opj(new_home, '.gitconfig')
         assert(not exists(global_gitconfig))
-        globalcfg = ConfigManager(dataset_only=False)
+        globalcfg = ConfigManager()
         assert_not_in('datalad.unittest.youcan', globalcfg)
         assert_in('datalad.sneaky.addition', globalcfg)
         cfg.add('datalad.unittest.youcan', 'removeme', where='global')
@@ -184,7 +183,7 @@ def test_something(path, new_home):
 
     cfg = ConfigManager(
         Dataset(opj(path, 'ds')),
-        dataset_only=True,
+        source='dataset',
         overrides={'datalad.godgiven': True})
     assert_equal(cfg.get('datalad.godgiven'), True)
     # setter has no effect
@@ -204,7 +203,7 @@ def test_something(path, new_home):
     padry = !git paremotes | tr ' ' '\\n' | xargs -r -l1 git push --dry-run
 """}}})
 def test_crazy_cfg(path):
-    cfg = ConfigManager(Dataset(opj(path, 'ds')), dataset_only=True)
+    cfg = ConfigManager(Dataset(opj(path, 'ds')), source='dataset')
     assert_in('crazy.padry', cfg)
 
 
@@ -309,7 +308,7 @@ def test_from_env():
     assert_in('datalad.crazy.cfg', cfg)
     assert_equal(cfg['datalad.crazy.cfg'], 'impossibletoguess')
     # not in dataset-only mode
-    cfg = ConfigManager(Dataset('nowhere'), dataset_only=True)
+    cfg = ConfigManager(Dataset('nowhere'), source='dataset')
     assert_not_in('datalad.crazy.cfg', cfg)
     # check env trumps override
     cfg = ConfigManager()


### PR DESCRIPTION
The issue was raised in https://github.com/datalad/datalad/pull/3903#issuecomment-562979754 but is in fact a long-standing issue in DataLad. Hence this comes as a separate PR, and https://github.com/datalad/datalad/pull/3903 will need to be adjusted, once this is merged.

We may want to have an override that re-enables this feature -- but I think we should wait if an actual use case materializes. Otherwise not supporting it seems like the better way.