### PR TITLE
Fix download-url breakage reported in #2849

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -220,7 +220,9 @@ URLs:
                                 url,
                                 # avoid batch mode for single files
                                 # https://github.com/datalad/datalad/issues/2849
-                                batch=len(annex_paths) > 1)
+                                batch=len(annex_paths) > 1,
+                                # bypass URL size check, we already have the file
+                                options=['--relaxed'])
                         except AnnexBatchCommandError as exc:
                             lgr.warning("Registering %s with %s failed: %s",
                                         path, url, exc_str(exc))

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -215,7 +215,12 @@ URLs:
                         try:
                             # The file is already present. This is just to
                             # register the URL.
-                            ds.repo.add_url_to_file(path, url, batch=True)
+                            ds.repo.add_url_to_file(
+                                path,
+                                url,
+                                # avoid batch mode for single files
+                                # https://github.com/datalad/datalad/issues/2849
+                                batch=len(annex_paths) > 1)
                         except AnnexBatchCommandError as exc:
                             lgr.warning("Registering %s with %s failed: %s",
                                         path, url, exc_str(exc))


### PR DESCRIPTION
This is the least-cost path that made it work for me. Here is the compact use case:

```
datalad remove -d bf2849 --nocheck ; datalad create bf2849; datalad -C bf2849 download-url https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css
```

The dataset deletion is critical for the demo, as otherwise git-annex seems to use prior knowledge about the key and doesn't fail on second attempt, even with a `git reset --hard HEAD~1`.

Fixes gh-2849