### PR TITLE
BF: Sort keys in wtf() result renderer (fixes gh-3915)

### DIFF
--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -121,7 +121,9 @@ def test_wtf(topdir):
                     '## %s' % s.lower(), cmo.out.lower()
                 )
             # order should match our desired one, not alphabetical
-            assert cmo.out.index('## git-annex') < cmo.out.index('## configuration')
+            # but because of https://github.com/datalad/datalad/issues/3915
+            # alphanum is now desired
+            assert cmo.out.index('## git-annex') > cmo.out.index('## configuration')
 
     # not achievable from cmdline is to pass an empty list of sections.
     with chpwd(path):

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -411,7 +411,7 @@ def _render_report(res):
 
     def _unwind(text, val, top):
         if isinstance(val, dict):
-            for k in val:
+            for k in sorted(val):
                 text += u'\n{}{} {}{} '.format(
                     '##' if not top else top,
                     '-' if top else '',


### PR DESCRIPTION
This fix conflicts with a prior test condition (now flipped). Please check.

I consider a defined top-level (non-alphanum) sorting a needless complication.