### PR TITLE
BF(workaround): mark test_clone.test_autoenabled_remote_msg as known to fail

### DIFF
--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -63,6 +63,7 @@ from datalad.tests.utils import (
     skip_if_no_network,
     skip_if,
     with_sameas_remote,
+    known_failure_windows,
 )
 from datalad.distribution.clone import _get_installationpath_from_url
 from datalad.distribution.dataset import Dataset
@@ -362,6 +363,9 @@ def test_clone_report_permission_issue(tdir):
         )
 
 
+# Started to hang on appveyor, only in the first run
+# (no DATALAD_REPO_VERSION=6 defined)
+@known_failure_windows  #FIXME - hangs
 @skip_if_no_network
 @with_tempfile
 def test_autoenabled_remote_msg(path):


### PR DESCRIPTION
Started to hang, someone needs to troubleshoot.
Sample job
   https://ci.appveyor.com/project/mih/datalad/builds/29552658

So that travis does not bother:
[ci skip]