### PR TITLE
BF: lgr - use .setLevel() instead of .level =

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1290,7 +1290,8 @@ def swallow_logs(new_level=None, file_=None, name='datalad'):
         # TODO: if file_ and there was an exception -- most probably worth logging it?
         # although ideally it should be the next log outside added to that file_ ... oh well
     finally:
-        lgr.handlers, lgr.level = old_handlers, old_level
+        lgr.handlers = old_handlers
+        lgr.setLevel(old_level)
         adapter.cleanup()
 
 


### PR DESCRIPTION
Apparently .level is not even a property and I guess starting from
3.7 treatment has changed, or broke.  May be smth like (scheduled for 3.9
with backport requests for 3.8) https://github.com/python/cpython/pull/16325
was intended to fix it, I did not investigate deep enough -- just fixed
the issue we started to experience (Closes #3545)

After merged into 0.11.x, will send PR against master