### PR TITLE
BF: Complain if a nonexistent dataset is given to subdatasets()

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -388,6 +388,12 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                 # yield everything to let the caller decide how to deal with
                 # errors
                 yield res
+        if not subds.is_installed():
+            # an error result was emitted, and the external consumer can decide
+            # what to do with it, but there is no point in recursing into
+            # something that should be there, but isn't
+            lgr.debug('Subdataset %s could not be installed, skipped', subds)
+            continue
         # recurse
         # we can skip the start expression, we know we are within
         for res in _recursive_install_subds_underneath(

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -147,7 +147,7 @@ def test_subdatasets(path):
     # from scratch
     ds = Dataset(path)
     assert_false(ds.is_installed())
-    eq_(ds.subdatasets(), [])
+    assert_raises(ValueError, ds.subdatasets)
     ds = ds.create()
     assert_true(ds.is_installed())
     eq_(ds.subdatasets(), [])

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -225,16 +225,11 @@ class Subdatasets(Interface):
             if path else None
 
         ds = require_dataset(
-            dataset, check_installed=False, purpose='subdataset reporting/modification')
+            dataset, check_installed=True, purpose='subdataset reporting/modification')
         lgr.debug('Query subdatasets of %s', dataset)
         if paths is not None:
             lgr.debug('Query subdatasets underneath paths: %s', paths)
         refds_path = ds.path
-
-        # XXX this seems strange, but is tested to be the case -- I'd rather set
-        # `check_installed` to true above and fail
-        if not GitRepo.is_valid_repo(refds_path):
-            return
 
         # return as quickly as possible
         if isinstance(recursion_limit, int) and (recursion_limit <= 0):


### PR DESCRIPTION
or if there is no dataset to query. But retain the previous behavior when called as a bound method of a Dataset instance. The compromise is made to avoid gh-3938 while retaining internal assumptions about the behavior of the command.

Fixes gh-3938
