### PR TITLE
siblings: Check for remote before inheriting annex settings

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -468,7 +468,8 @@ def _configure_remote(
             # makes sense only if current AND super are annexes, so it is
             # kinda a boomer, since then forbids having a super a pure git
             if isinstance(ds.repo, AnnexRepo) and \
-                    isinstance(delayed_super.repo, AnnexRepo):
+                    isinstance(delayed_super.repo, AnnexRepo) and \
+                    name in delayed_super.repo.get_remotes():
                 if annex_wanted is None:
                     annex_wanted = _inherit_annex_var(
                         delayed_super, name, 'wanted')

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -294,3 +294,15 @@ def test_sibling_inherit(basedir):
     res = ds_clone.siblings(action="query", name="source",
                             result_renderer=None)
     eq_(res[0]["annex-group"], "grp")
+
+
+@with_tempfile(mkdir=True)
+def test_sibling_inherit_no_super_remote(basedir):
+    ds_source = Dataset(opj(basedir, "source")).create()
+    ds_super = Dataset(opj(basedir, "super")).create()
+    ds_clone = ds_super.clone(
+        source=ds_source.path, path="clone", result_xfm="datasets")[0]
+    # Adding a sibling with inherit=True doesn't crash when the superdataset
+    # doesn't have a remote `name`.
+    ds_clone.siblings(action="add", name="donotexist", inherit=True,
+                      url=ds_source.path, result_renderer=None)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -274,3 +274,23 @@ def test_sibling_enable_sameas(repo, clone_path):
     assert_status("ok", res)
     ds_cloned.get(path=["f0"])
     ok_(ds_cloned.repo.file_has_content("f0"))
+
+
+@with_tempfile(mkdir=True)
+def test_sibling_inherit(basedir):
+    ds_source = Dataset(opj(basedir, "source")).create()
+
+    # In superdataset, set up remote "source" that has git-annex group "grp".
+    ds_super = Dataset(opj(basedir, "super")).create()
+    ds_super.siblings(action="add", name="source", url=ds_source.path,
+                      annex_group="grp", result_renderer=None)
+
+    ds_clone = ds_super.clone(
+        source=ds_source.path, path="clone", result_xfm="datasets")[0]
+    # In a subdataset, adding a "source" sibling with inherit=True pulls in
+    # that configuration.
+    ds_clone.siblings(action="add", name="source", url=ds_source.path,
+                      inherit=True, result_renderer=None)
+    res = ds_clone.siblings(action="query", name="source",
+                            result_renderer=None)
+    eq_(res[0]["annex-group"], "grp")


### PR DESCRIPTION
The first patch adds a basic test for `siblings(..., inherit=True)`.  The second prevents `siblings(..., inherit=True)` from crashing when the parent dataset doesn't include a remote of the same name (reported by @dorianps in gh-3950).