### PR TITLE
BF: use mimeencoding not mimetype for text2git

### DIFF
--- a/datalad/distribution/create.py
+++ b/datalad/distribution/create.py
@@ -343,9 +343,9 @@ class Create(Interface):
                 attrs = tbrepo.get_gitattributes('.')
                 # some basic protection against useless duplication
                 # on rerun with --force
-                if not attrs.get('.', {}).get('annex.largefiles', None) == '(not(mimetype=text/*)and(largerthan=0))':
+                if not attrs.get('.', {}).get('annex.largefiles', None) == '((mimeencoding=binary)and(largerthan=0))':
                     tbrepo.set_gitattributes([
-                        ('*', {'annex.largefiles': '(not(mimetype=text/*)and(largerthan=0))'})])
+                        ('*', {'annex.largefiles': '((mimeencoding=binary)and(largerthan=0))'})])
                     add_to_git.append('.gitattributes')
 
         if native_metadata_type is not None:

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -383,7 +383,7 @@ def test_add_subdataset(path, other):
     'file.txt': 'some text',
     'empty': '',
     'file2.txt': 'some text to go to annex',
-    '.gitattributes': '* annex.largefiles=(not(mimetype=text/*))'}
+    '.gitattributes': '* annex.largefiles=((mimeencoding=binary))'}
 )
 @known_failure_direct_mode  #FIXME
 def test_add_mimetypes(path):

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -334,7 +334,7 @@ def test_create_text_no_annex(path):
     import re
     ok_file_has_content(
         _path_(path, '.gitattributes'),
-        content='\* annex\.largefiles=\(not\(mimetype=text/\*\)and\(largerthan=0\)\)',
+        content='\* annex\.largefiles=\(\(mimeencoding=binary\)and\(largerthan=0\)\)',
         re_=True,
         match=False,
         flags=re.MULTILINE

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -10,7 +10,7 @@ ds = require_dataset(
     check_installed=True,
     purpose='configuration')
 
-annex_largefiles = '(not(mimetype=text/*)and(largerthan=0))'
+annex_largefiles = '((mimeencoding=binary)and(largerthan=0))'
 attrs = ds.repo.get_gitattributes('*')
 if not attrs.get('*', {}).get(
         'annex.largefiles', None) == annex_largefiles:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -118,7 +118,8 @@ class AnnexRepo(GitRepo, RepoInterface):
     # 6.20170220 -- annex status provides --ignore-submodules
     # 6.20180416 -- annex handles unicode filenames more uniformly
     # 6.20180913 -- annex fixes all known to us issues for v6
-    GIT_ANNEX_MIN_VERSION = '6.20180913'
+    # 7.20190503 -- annex introduced mimeencoding support needed for our text2git
+    GIT_ANNEX_MIN_VERSION = '7.20190503'
     git_annex_version = None
     supports_direct_mode = None
     repository_versions = None


### PR DESCRIPTION
Also extends the test to test some structured text files to guarantee that there would be no change in behavior (from git-annex or libmagic changes).

I was a bit not sure if it is worth introducing in 0.11.x since it would demand minimal git annex boost.  But since I use ATM both versions interchangeably and older annex would not support (crash) mimeencoding - I have decided that it is worth adding it to 0.11.x first.

I also was not sure if we shouldn't detect "old" line in `.gitattributes` and warn the user and may be even suggest (in interactive sessions) to adjust that gory statement.  But if we do so, we would need to mark somewhere to not pester user about it again in that dataset if they say "nah"... so - pain. I guess we are just doomed to look forward.

Closes #3361 

