### PR TITLE
BF: Always report absolute location of discovered procedures

### DIFF
--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -481,10 +481,7 @@ class RunProcedure(Interface):
         if kwargs.get('discover', None):
             ui.message('{name} ({path}){msg}'.format(
                 name=ac.color_word(res['procedure_name'], ac.BOLD),
-                path=op.relpath(
-                    res['path'],
-                    res['refds'])
-                if res.get('refds', None) else res['path'],
+                path=res['path'],
                 msg=' [{}]'.format(
                     res['message'][0] % res['message'][1:]
                     if isinstance(res['message'], tuple) else res['message'])


### PR DESCRIPTION
Before it would report relpaths if operating on a dataset, leading to
the issue at hand.

I considered relpaths for dataset internal procedures, and abspaths for
others. However, when not invoked at the root of a dataset these would
again be somewhat confusing. So full abspath it is.

Fixes gh-3619
