### PR TITLE
Refurbish eval_func()

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -176,29 +176,11 @@ def setup_parser(
         non-zero exit code; 'stop' halts on first failure and yields non-zero exit
         code. A failure is any result with status 'impossible' or 'error'.""")
     parser.add_argument(
-        '--proc-pre', dest='common_proc_pre',
-        nargs='+',
-        action='append',
-        metavar=('<PROCEDURE NAME>', 'ARGS'),
-        help="""Dataset procedure to run before the main command (see run-procedure
-        command for details). This option can be given more than once to run
-        multiple procedures in the order in which they were given.
-        It is important to specify the target dataset via the --dataset argument
-        of the main command."""),
-    parser.add_argument(
-        '--proc-post', dest='common_proc_post',
-        nargs='+',
-        action='append',
-        metavar=('<PROCEDURE NAME>', 'ARGS'),
-        help="""Like --proc-pre, but procedures are executed after the main command
-        has finished."""),
-    parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global
-        command line options before the subcommand label. Options like
-        --proc-pre can take an arbitrary number of arguments and may require
-        to be followed by a single --cmd in order to enable identification
-        of the subcommand.""")
+        command line options before the subcommand label. Options taking
+        an arbitrary number of arguments may require to be followed by a single
+        --cmd in order to enable identification of the subcommand.""")
 
     # yoh: atm we only dump to console.  Might adopt the same separation later on
     #      and for consistency will call it --verbose-level as well for now

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -386,24 +386,6 @@ def test_saving_prior(topdir):
 
 
 @with_tempfile(mkdir=True)
-def test_create_withprocedure(path):
-    # first without
-    ds = create(path)
-    assert(not op.lexists(op.join(ds.path, 'README.rst')))
-    ds.remove()
-    assert(not op.lexists(ds.path))
-    # now for reals...
-    ds = create(
-        # needs to identify the dataset, otherwise post-proc
-        # procedure doesn't know what to run on
-        dataset=path,
-        proc_post=[['cfg_metadatatypes', 'xmp', 'datacite']])
-    assert_repo_status(path)
-    ds.config.reload()
-    eq_(ds.config['datalad.metadata.nativetype'], ('xmp', 'datacite'))
-
-
-@with_tempfile(mkdir=True)
 def test_create_withcfg(path):
     ds = create(
         dataset=path,

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -41,8 +41,6 @@ def test_basics(src, dst):
     # on install to have 'bids' listed as a metadata type
     clone.config.set(
         'datalad.result-hook.alwaysbids.call-json',
-        # the spec is like --proc-post/pre, but has the dataset to run on as
-        # the first element
         # string substitutions based on the result record are supported
         'run_procedure {{"dataset":"{path}","spec":"cfg_metadatatypes bids"}}',
         where='local',

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -31,6 +31,8 @@ def test_basics(src, dst):
     (ds.pathobj / 'file1').write_text('some')
     ds.save()
     sub = ds.create('subds')
+    # second one for a result_xfm test below
+    ds.create('subds2')
     eq_(sub.config.get('datalad.metadata.nativetype'), None)
 
     # now clone the super
@@ -88,11 +90,14 @@ def test_basics(src, dst):
             '{"type":["in", ["file"]],"action":"get","status":"notneeded"}',
             where='local',
         )
-    # TODO resetting of detached HEAD seem to come after the install result
-    # and wipes out the change
+    # setup done, now see if it works
     clone.get('subds')
     clone_sub = Dataset(clone.pathobj / 'subds')
     eq_(clone_sub.config.get('datalad.metadata.nativetype'), 'bids')
+    # now the same thing with a result_xfm, should make no difference
+    clone.get('subds2')
+    clone_sub2 = Dataset(clone.pathobj / 'subds2')
+    eq_(clone_sub2.config.get('datalad.metadata.nativetype'), 'bids')
 
     # hook auto-unlocks the file
     if not on_windows:

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -681,7 +681,7 @@ class Interface(object):
             # XXX define or better get from elsewhere
             common_opts = ('change_path', 'common_debug', 'common_idebug', 'func',
                            'help', 'log_level', 'logger', 'pbs_runner',
-                           'result_renderer', 'proc_pre', 'proc_post', 'subparser')
+                           'result_renderer', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]
         kwargs = {k: getattr(args, k) for k in argnames if is_api_arg(k)}
@@ -712,8 +712,6 @@ class Interface(object):
                 # eval_results can't distinguish between --report-{status,type}
                 # not specified via the CLI and None passed via the Python API.
                 kwargs['result_filter'] = res_filter
-            kwargs['proc_pre'] = args.common_proc_pre
-            kwargs['proc_post'] = args.common_proc_post
         try:
             ret = cls.__call__(**kwargs)
             if inspect.isgenerator(ret):

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -308,15 +308,6 @@ eval_params = dict(
         that carries the result dictionaries of the failures in its `failed`
         attribute.""",
         constraints=EnsureChoice('ignore', 'continue', 'stop')),
-    proc_pre=Parameter(
-        doc="""DataLad procedure to run prior to the main command. The argument
-        a list of lists with procedure names and optional arguments.
-        Procedures are called in the order their are given in this list.
-        It is important to provide the respective target dataset to run a procedure
-        on as the `dataset` argument of the main command."""),
-    proc_post=Parameter(
-        doc="""Like `proc_pre`, but procedures are executed after the main command
-        has finished."""),
 )
 
 eval_defaults = dict(
@@ -325,6 +316,4 @@ eval_defaults = dict(
     result_renderer=None,
     result_xfm=None,
     on_failure='continue',
-    proc_pre=None,
-    proc_post=None,
 )

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -275,26 +275,6 @@ class RunProcedure(Interface):
     - 'datalad.procedures.<NAME>.help'
       will be shown on `datalad run-procedure --help-proc NAME` to provide a
       description and/or usage info for procedure NAME
-
-    *Customize other commands with procedures*
-
-    On execution of any commands, DataLad inspects two additional
-    configuration settings:
-
-    - 'datalad.<name>.proc-pre'
-
-    - 'datalad.<name>.proc-post'
-
-    where '<name>' is the name of a DataLad command. Using this mechanism
-    DataLad can be instructed to run one or more procedures before or
-    after the execution of a given command. For example, configuring
-    a set of metadata types in any newly created dataset can be achieved
-    via:
-
-      % datalad -c 'datalad.create.proc-post=cfg_metadatatypes xmp image' create -d myds
-
-    As procedures run on datasets, it is necessary to explicitly identify
-    the target dataset via the -d (--dataset) option.
     """
     _params_ = dict(
         spec=Parameter(

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -43,8 +43,6 @@ def _new_args(**kwargs):
                 common_on_failure=None,  # ['ignore', 'continue', 'stop']
                 common_report_status=None,  # ['all', 'success', 'failure', 'ok', 'notneeded', 'impossible', 'error']
                 common_report_type=None,  # ['dataset', 'file']
-                common_proc_pre=None,
-                common_proc_post=None,
             ),
             kwargs
         )

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -398,12 +398,18 @@ def eval_results(func):
 
             # process main results
             for r in _process_results(
-                    # execute the wrapped function
+                    # execution
                     wrapped(*_args, **_kwargs),
-                    wrapped_class, action_summary,
-                    common_params['on_failure'], incomplete_results,
+                    wrapped_class,
+                    common_params['on_failure'],
+                    # bookkeeping
+                    action_summary,
+                    incomplete_results,
+                    # communication
                     result_renderer,
-                    result_log_level, **_kwargs):
+                    result_log_level,
+                    # let renderers get to see how a command was called
+                    allkwargs):
                 for hook, spec in hooks.items():
                     # run the hooks before we yield the result
                     # this ensures that they are executed before
@@ -508,10 +514,14 @@ def default_result_renderer(res):
 
 
 def _process_results(
-        results, cmd_class,
-        action_summary, on_failure, incomplete_results,
+        results,
+        cmd_class,
+        on_failure,
+        action_summary,
+        incomplete_results,
         result_renderer,
-        result_log_level, **kwargs):
+        result_log_level,
+        allkwargs):
     # private helper pf @eval_results
     # loop over results generated from some source and handle each
     # of them according to the requested behavior (logging, rendering, ...)
@@ -568,10 +578,10 @@ def _process_results(
                 default=lambda x: str(x)))
         elif result_renderer == 'tailored':
             if hasattr(cmd_class, 'custom_result_renderer'):
-                cmd_class.custom_result_renderer(res, **kwargs)
+                cmd_class.custom_result_renderer(res, **allkwargs)
         elif hasattr(result_renderer, '__call__'):
             try:
-                result_renderer(res, **kwargs)
+                result_renderer(res, **allkwargs)
             except Exception as e:
                 lgr.warning('Result rendering failed for: %s [%s]',
                             res, exc_str(e))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -333,7 +333,7 @@ def eval_results(func):
         kwargs = kwargs.copy()  # we will pop, which might cause side-effect
         common_params = {
             p_name: kwargs.pop(
-                # go way a any explicitly given default
+                # go with any explicitly given default
                 p_name,
                 # otherwise determine the command class and pull any
                 # default set in that class
@@ -429,7 +429,7 @@ def eval_results(func):
                             if not keep_result(hr, result_filter, **allkwargs):
                                 continue
                             hr = xfm_result(hr, result_xfm)
-                            # rational for conditional is a few lines down
+                            # rationale for conditional is a few lines down
                             if hr:
                                 yield hr
                 if not keep_result(r, result_filter, **allkwargs):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2320,6 +2320,15 @@ def maybe_shlex_quote(val):
     return val if on_windows else shlex_quote(val)
 
 
+def get_wrapped_class(wrapped):
+    """Determine the command class a wrapped __call__ belongs to"""
+    mod = sys.modules[wrapped.__module__]
+    command_class_name = wrapped.__qualname__.split('.')[-2]
+    _func_class = mod.__dict__[command_class_name]
+    lgr.debug("Determined class of decorated function: %s", _func_class)
+    return _func_class
+
+
 # TODO whenever we feel ready for English kill the compat block below
 assure_tuple_or_list = ensure_tuple_or_list
 assure_iter = ensure_iter


### PR DESCRIPTION
This became a little more elaborate than desired, but I think it is useful nevertheless.

- [x] Added a test that demos how `result_xfm` broke result hooks https://github.com/datalad/datalad/issues/3962
- [x] Ripped out proc-pre/post feature based on feedback in https://github.com/datalad/datalad/issues/3908 in order to get a clean fix for #3962 (which fixes #3908)
- [x] Actually fix #3962 
- [x] RF the decorator code, created helper functions (even if used just once) and removed duplicate variable to improve the subjective readability of the code
- [x] Result renderers now get to see all command args. Before it was dependent on how exactly a command was called: `cmd(path='this')` vs `cmd('this')` -- only the former case used to make it to the result renderer `kwargs`.