### PR TITLE
Enabled testrepo-based tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,7 +105,7 @@ test_script:
   # remaining fails: test_annexrepo test_digests test_locking test_repodates test_sshrun 
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_ datalad.support.tests.test_gitrepo"
   # remaining fails: test__main__ test_archives test_cmd test_log  test_protocols test_test_utils test_utils test_auto
-  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos"
 
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.ui"
   

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -253,8 +253,9 @@ def test_run_from_subds_gh3551(path):
         ok_(subds.repo.file_has_content("f"))
 
 
+#https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789009#step:8:644
+@known_failure_windows
 @slow  # ~10s
-# use of testrepos is broken on Windows and causes this test to be skipped there
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_run_explicit(path):
     ds = Dataset(path)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -54,6 +54,9 @@ from datalad.tests.utils import (
 )
 
 
+# https://ci.appveyor.com/project/mih/datalad/builds/29840270/job/oya0cs55nwtoga4p
+# # (The system cannot find the path specified.)
+@known_failure_appveyor
 @with_testrepos('.*git.*', flavors=['clone'])
 def test_save(path):
 

--- a/datalad/distribution/tests/test_clone.py
+++ b/datalad/distribution/tests/test_clone.py
@@ -64,6 +64,7 @@ from datalad.tests.utils import (
     skip_if,
     with_sameas_remote,
     known_failure_appveyor,
+    known_failure_windows,
 )
 from datalad.distribution.clone import _get_installationpath_from_url
 from datalad.distribution.dataset import Dataset
@@ -147,6 +148,8 @@ def test_clone_datasets_root(tdir):
         assert_status('error', res)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:258
+@known_failure_windows
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
 def test_clone_simple_local(src, path):
@@ -189,6 +192,8 @@ def test_clone_simple_local(src, path):
         eq_(uuid_before, ds.repo.uuid)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:216
+@known_failure_windows
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
 def test_clone_dataset_from_just_source(url, path):
@@ -222,6 +227,8 @@ def test_clone_dataladri(src, topurl, path):
     ok_file_has_content(op.join(path, 'test.txt'), 'some')
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:236
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -270,6 +277,8 @@ def test_clone_into_dataset(source, top_path):
     ok_clean_git(ds.path, untracked=['dummy.txt'])
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:278
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 def test_notclone_known_subdataset(src, path):

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -62,7 +62,8 @@ def test_EnsureDataset():
 
 # TODO: test remember/recall more extensive?
 
-
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:531
+@known_failure_windows
 @with_testrepos('submodule_annex')
 @with_tempfile(mkdir=True)
 def test_is_installed(src, path):

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -41,6 +41,7 @@ from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_message
 from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import slow
+from datalad.tests.utils import known_failure_windows
 from datalad.utils import with_pathsep
 from datalad.utils import chpwd
 from datalad.utils import assure_list
@@ -299,6 +300,8 @@ def test_get_recurse_dirs(o_path, c_path):
     ok_(ds.repo.file_has_content('file1.txt') is True)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:541
+@known_failure_windows
 @slow  # 15.1496s
 @with_testrepos('submodule_annex', flavors='local')
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -214,6 +214,8 @@ def test_install_datasets_root(tdir):
         assert_in("already exists and not empty", str(cme.exception))
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:360
+@known_failure_windows
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
 def test_install_simple_local(src, path):
@@ -253,6 +255,8 @@ def test_install_simple_local(src, path):
         eq_(uuid_before, ds.repo.uuid)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:298
+@known_failure_windows
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
 def test_install_dataset_from_just_source(url, path):
@@ -318,6 +322,8 @@ def test_install_dataladri(src, topurl, path):
     ok_file_has_content(opj(path, 'test.txt'), 'some')
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:338
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -398,6 +404,8 @@ def test_install_recursive_with_data(src, path):
             ok_(all(subds.repo.file_has_content(subds.repo.get_annexed_files())))
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:555
+@known_failure_windows
 @slow  # 88.0869s  because of going through multiple test repos, ~8sec each time
 @with_testrepos('.*annex.*', flavors=['local'])
 # 'local-url', 'network'
@@ -467,6 +475,8 @@ def test_failed_install_multiple(top_path):
         {'///nonexisting', _path_(top_path, 'ds2')})
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:318
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 def test_install_known_subdataset(src, path):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -102,6 +102,8 @@ def test_smth_about_not_supported(p1, p2):
         publish(to='target1', since='HEAD^')  # must not fail now
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:571
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -225,6 +227,8 @@ def test_publish_plain_git(origin, src_path, dst_path):
     eq_(res, [source])
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:380
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile
 @with_tempfile(mkdir=True)
@@ -394,6 +398,8 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     assert_status("notneeded", publish(since='', dataset=source.path))
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:452
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -43,6 +43,7 @@ from datalad.tests.utils import skip_if_no_network
 from datalad.tests.utils import use_cassette
 from datalad.tests.utils import usecase
 from datalad.tests.utils import known_failure_githubci_win
+from datalad.tests.utils import known_failure_windows
 from datalad.utils import chpwd
 from datalad.utils import _path_
 from datalad.support.external_versions import external_versions
@@ -126,6 +127,8 @@ def test_uninstall_invalid(path):
         assert_status('error', method(dataset=ds, path='../madeupnonexist', on_failure='ignore'))
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:489
+@known_failure_windows
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_uninstall_annex_file(path):
     ds = Dataset(path)
@@ -182,6 +185,8 @@ def test_uninstall_git_file(path):
     eq_(res, ['INFO.txt'])
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:509
+@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -40,6 +40,8 @@ from datalad.tests.utils import slow
 from datalad.tests.utils import known_failure_windows
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:622
+@known_failure_windows
 @slow
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
@@ -163,6 +165,8 @@ def test_update_git_smoke(src_path, dst_path):
     ok_file_has_content(opj(target.path, 'file.dat'), '123')
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:606
+@known_failure_windows
 @slow  # 20.6910s
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -40,6 +40,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     known_failure_githubci_win,
+    known_failure_windows,
 )
 
 
@@ -85,6 +86,8 @@ def test_unlock_raises(path, path2, path3):
 
 # Note: As root there is no actual lock/unlock.
 #       Therefore don't know what to test for yet.
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789027#step:8:134
+@known_failure_windows
 @skip_if(cond=not on_windows and os.geteuid() == 0)  # uid not available on windows
 @with_testrepos('.*annex.*', flavors=['clone'])
 def test_unlock(path):

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -33,9 +33,12 @@ from datalad.tests.utils import (
     assert_in,
     assert_not_in,
     assert_status,
+    known_failure_windows,
 )
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:275
+@known_failure_windows
 @with_testrepos('.*nested_submodule.*', flavors=['clone'])
 def test_get_subdatasets(path):
     ds = Dataset(path)

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -900,8 +900,6 @@ def is_ssh(ri):
         or (isinstance(_ri, URL) and _ri.scheme == 'ssh')
 
 
-#### windows workaround ###
-# TODO: There should be a better way
 def get_local_file_url(fname):
     """Return OS specific URL pointing to a local file
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -39,6 +39,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import (
     on_windows,
     PurePath,
+    Path,
 )
 from datalad.utils import assure_dir, assure_bytes, assure_unicode, map_items
 from datalad import consts
@@ -908,14 +909,16 @@ def get_local_file_url(fname):
     fname : string
         Filename.  If not absolute, abspath is used
     """
-    fname = fname if isabs(fname) else abspath(fname)
+    path = Path(fname).absolute()
     if on_windows:
-        fname_rep = fname.replace('\\', '/')
-        furl = "file:///%s" % urlquote(fname_rep)
-        lgr.debug("Replaced '\\' in file\'s url: %s" % furl)
+        path = path.as_posix()
+        furl = 'file://{}'.format(
+            urlquote(
+                re.sub(r'([a-zA-Z]):', r'\1', path)
+            ))
     else:
         # TODO:  need to fix for all the encoding etc
-        furl = str(URL(scheme='file', path=fname))
+        furl = str(URL(scheme='file', path=str(path)))
     return furl
 
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -88,6 +88,7 @@ from datalad.tests.utils import slow
 from datalad.tests.utils import set_annex_version
 from datalad.tests.utils import known_failure_githubci_win
 from datalad.tests.utils import with_sameas_remote
+from datalad.tests.utils import known_failure_windows
 
 from datalad.support.exceptions import CommandError
 from datalad.support.exceptions import CommandNotAvailableError
@@ -204,6 +205,8 @@ def test_AnnexRepo_is_direct_mode_gitrepo(path):
         assert_false(dm)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:473
+@known_failure_windows
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
@@ -258,6 +261,8 @@ def test_AnnexRepo_get_outofspace(annex_path):
     assert_re_in(".*annex (find|get). needs 905.6 MB more", str(exc))
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:405
+@known_failure_windows
 @with_testrepos('basic_annex', flavors=['local'])
 def test_AnnexRepo_get_remote_na(path):
     ar = AnnexRepo(path)
@@ -733,6 +738,8 @@ def test_AnnexRepo_always_commit(path):
     eq_(num_commits, 4)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:445
+@known_failure_windows
 @with_testrepos('basic_annex', flavors=['local'])
 @with_tempfile
 def test_AnnexRepo_on_uninited_annex(origin, path):
@@ -778,6 +785,8 @@ def test_AnnexRepo_commit(path):
     assert_raises(FileNotInRepositoryError, ds.commit, files="not-existing")
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:295
+@known_failure_windows
 @with_testrepos('.*annex.*', flavors=['clone'])
 def test_AnnexRepo_add_to_annex(path):
 
@@ -925,6 +934,8 @@ def test_v7_detached_get(opath, path):
 #def init_remote(self, name, options):
 #def enable_remote(self, name):
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:348
+@known_failure_windows
 @with_testrepos('basic_annex$', flavors=['clone'])
 @with_tempfile
 def _test_AnnexRepo_get_contentlocation(batch, path, work_dir_outside):
@@ -1255,6 +1266,8 @@ def test_repo_version(path1, path2, path3):
             eq_(version, 5)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:330
+@known_failure_windows
 @with_testrepos('.*annex.*', flavors=['clone'])
 @with_tempfile(mkdir=True)
 def test_annex_copy_to(origin, clone):
@@ -1691,6 +1704,8 @@ def test_AnnexRepo_flyweight(path1, path2):
     assert_not_is_instance(repo4, AnnexRepo)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:417
+@known_failure_windows
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
 @with_tempfile
@@ -1968,6 +1983,8 @@ def test_AnnexRepo_get_tracking_branch(path):
     eq_(('origin', 'refs/heads/master'), ar.get_tracking_branch())
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:433
+@known_failure_windows
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_AnnexRepo_is_managed_branch(path):
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -47,7 +47,7 @@ from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import skip_if_on_windows
-from datalad.tests.utils import known_failure_githubci_win
+from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import integration
 from datalad.utils import rmtree
 from datalad.tests.utils_testrepos import BasicAnnexTestRepo
@@ -187,6 +187,8 @@ def test_GitRepo_equals(path1, path2):
     ok_(repo1 != repo2)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:515
+@known_failure_windows
 @assert_cwd_unchanged
 @with_testrepos('.*git.*', flavors=local_testrepo_flavors)
 @with_tempfile
@@ -443,6 +445,8 @@ def test_GitRepo_remote_remove(orig_path, path):
     assert_in('origin', out)
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:491
+@known_failure_windows
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile
 def test_GitRepo_get_remote_url(orig_path, path):
@@ -765,6 +769,8 @@ def test_GitRepo_get_files(url, path):
     eq_(set([filename]), branch_files.difference(local_files))
 
 
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:505
+@known_failure_windows
 @with_testrepos('.*git.*', flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
 @with_tempfile

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -436,7 +436,9 @@ def test_get_local_file_url():
                 ('/a', 'file:///a'),
                 ('/a/b/c', 'file:///a/b/c'),
                 ('/a~', 'file:///a~'),
-                ('/a b/', 'file:///a%20b/'),
+                # there are no files with trailing slashes in the name
+                #('/a b/', 'file:///a%20b/'),
+                ('/a b/name', 'file:///a%20b/name'),
             ):
         if isabs(path):
             eq_(get_local_file_url(path), url)

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -9,10 +9,17 @@
 
 import logging
 
-from os.path import join as opj
+import os
+from os.path import (
+    join as opj,
+    isabs,
+)
 from collections import OrderedDict
 
-from datalad.utils import PurePosixPath
+from datalad.utils import (
+    PurePosixPath,
+    on_windows,
+)
 
 from datalad.tests.utils import eq_, neq_, ok_, nok_, assert_raises
 from datalad.tests.utils import skip_if_on_windows
@@ -415,12 +422,30 @@ def test_is_datalad_compat_ri():
     nok_(is_datalad_compat_ri(123))
 
 
-@skip_if_on_windows
-def test_get_local_file_url_linux():
-    eq_(get_local_file_url('/a'), 'file:///a')
-    eq_(get_local_file_url('/a/b/c'), 'file:///a/b/c')
-    eq_(get_local_file_url('/a~'), 'file:///a~')
-    eq_(get_local_file_url('/a b/'), 'file:///a%20b/')
+def test_get_local_file_url():
+    for path, url in (
+                # relpaths are special-cased below
+                ('test.txt', 'test.txt'),
+                # static copy of "most_obscore_name"
+                (' "\';a&b&cΔЙקم๗あ `| ',
+                 # and translation by google chrome
+                 "%20%22%27%3Ba%26b%26c%CE%94%D0%99%D7%A7%D9%85%E0%B9%97%E3%81%82%20%60%7C%20"),
+            ) + (
+                ('C:\\Windows\\Notepad.exe', 'file://C/Windows/Notepad.exe'),
+            ) if on_windows else (
+                ('/a', 'file:///a'),
+                ('/a/b/c', 'file:///a/b/c'),
+                ('/a~', 'file:///a~'),
+                ('/a b/', 'file:///a%20b/'),
+            ):
+        if isabs(path):
+            eq_(get_local_file_url(path), url)
+        else:
+            eq_(get_local_file_url(path),
+                '/'.join((
+                    get_local_file_url(os.getcwd()),
+                    url))
+            )
 
 
 def test_is_ssh():

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -27,6 +27,7 @@ from ..support.annexrepo import AnnexRepo
 from .utils import with_tempfile
 from .utils import SkipTest
 from .utils import chpwd
+from .utils import known_failure_windows
 from datalad.support.json_py import LZMAFile
 
 try:
@@ -40,8 +41,11 @@ try:
 except ImportError:
     nib = None
 
+
 # somewhat superseeded by test_proxying_open_regular but still does
 # some additional testing, e.g. non-context manager style of invocation
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789030#step:8:398
+@known_failure_windows
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_proxying_open_testrepobased(repo):
     TEST_CONTENT = "content to be annex-addurl'd"

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -8,9 +8,9 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
-import git
 import os
 
+from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import integration
 from datalad.tests.utils import usecase
 from .utils import eq_, ok_, with_testrepos, with_tempfile
@@ -22,12 +22,12 @@ from .utils_testdatasets import make_studyforrest_mockup
 @with_testrepos('.*annex.*', flavors=['clone'])
 def test_having_annex(path):
     ok_(os.path.exists(os.path.join(path, '.git')))
-    repo = git.Repo(path)
+    repo = GitRepo(path)
     # might not necessarily be present upon initial submodule init
     #branches = [r.name for r in repo.branches]
     #ok_('git-annex' in branches, msg="Didn't find git-annex among %s" % branches)
     # look for it among remote refs
-    refs = [_.name for _ in repo.remote().refs]
+    refs = repo.get_remote_branches()
     ok_('origin/git-annex' in refs, msg="Didn't find git-annex among refs %s"
                                         % refs)
 

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -9,14 +9,18 @@
 """Tests for test repositories
 
 """
-from os.path import join as opj
-
-from .utils_testrepos import BasicAnnexTestRepo, BasicGitTestRepo
-from .utils import with_tempfile, assert_true, ok_clean_git, eq_, ok_
-from .utils import ok_file_under_git, ok_broken_symlink, ok_good_symlink
-from .utils import swallow_outputs
-from .utils import on_windows
-from .utils import SkipTest
+from datalad.tests.utils_testrepos import (
+    BasicAnnexTestRepo,
+    BasicGitTestRepo,
+)
+from datalad.tests.utils import (
+    with_tempfile,
+    ok_clean_git,
+    ok_,
+    ok_file_under_git,
+    swallow_outputs,
+    skip_if_on_windows,
+)
 
 
 def _test_BasicAnnexTestRepo(repodir):
@@ -34,6 +38,10 @@ def _test_BasicAnnexTestRepo(repodir):
 
 # Use of @with_tempfile() apparently is not friendly to test generators yet
 # so generating two tests manually
+# something is wrong with the implicit tempfile generation on windows
+# a bunch of tested assumptions aren't met, and which ones depends on the
+# windows version being tested
+@skip_if_on_windows
 def test_BasicAnnexTestRepo_random_location_generated():
     _test_BasicAnnexTestRepo(None)  # without explicit path -- must be generated
 

--- a/datalad/tests/test_utils_testrepos.py
+++ b/datalad/tests/test_utils_testrepos.py
@@ -18,10 +18,6 @@ from .utils import swallow_outputs
 from .utils import on_windows
 from .utils import SkipTest
 
-# TODO: still true?
-if on_windows:
-    raise SkipTest("experiencing issues on windows -- disabled for now")
-
 
 def _test_BasicAnnexTestRepo(repodir):
     trepo = BasicAnnexTestRepo(repodir)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -692,12 +692,11 @@ def _get_testrepos_uris(regex, flavors):
                       }
         # assure that now we do have those test repos created -- delayed
         # their creation until actually used
-        if not on_windows:
-            _basic_annex_test_repo.create()
-            _basic_git_test_repo.create()
-            _submodule_annex_test_repo.create()
-            _nested_submodule_annex_test_repo.create()
-            _inner_submodule_annex_test_repo.create()
+        _basic_annex_test_repo.create()
+        _basic_git_test_repo.create()
+        _submodule_annex_test_repo.create()
+        _nested_submodule_annex_test_repo.create()
+        _inner_submodule_annex_test_repo.create()
     uris = []
     for name, spec in _TESTREPOS.items():
         if not re.match(regex, name):
@@ -708,7 +707,9 @@ def _get_testrepos_uris(regex, flavors):
         if 'clone' in flavors and 'clone' not in spec:
             uris.append(clone_url(spec['local']))
 
-        if 'network-clone' in flavors and 'network-clone' not in spec:
+        if 'network-clone' in flavors \
+                and 'network' in spec \
+                and 'network-clone' not in spec:
             uris.append(clone_url(spec['network']))
 
     return uris
@@ -750,8 +751,8 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
     @wraps(t)
     @attr('with_testrepos')
     def newfunc(*arg, **kw):
-        if on_windows:
-            raise SkipTest("Testrepo setup is broken on Windows")
+        #if on_windows:
+        #    raise SkipTest("Testrepo setup is broken on Windows")
 
         # TODO: would need to either avoid this "decorator" approach for
         # parametric tests or again aggregate failures like sweepargs does

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -109,6 +109,131 @@ def skip_if_url_is_not_available(url, regex=None):
         raise SkipTest("%s failed to download" % url)
 
 
+def check_not_generatorfunction(func):
+    """Internal helper to verify that we are not decorating generator tests"""
+    if inspect.isgeneratorfunction(func):
+        raise RuntimeError("{}: must not be decorated, is a generator test"
+                           .format(func.__name__))
+
+
+def skip_if_no_network(func=None):
+    """Skip test completely in NONETWORK settings
+
+    If not used as a decorator, and just a function, could be used at the module level
+    """
+    check_not_generatorfunction(func)
+
+    def check_and_raise():
+        if os.environ.get('DATALAD_TESTS_NONETWORK'):
+            raise SkipTest("Skipping since no network settings")
+
+    if func:
+        @wraps(func)
+        @attr('network')
+        @attr('skip_if_no_network')
+        def newfunc(*args, **kwargs):
+            check_and_raise()
+            return func(*args, **kwargs)
+        return newfunc
+    else:
+        check_and_raise()
+
+
+def skip_if_on_windows(func=None):
+    """Skip test completely under Windows
+    """
+    check_not_generatorfunction(func)
+
+    def check_and_raise():
+        if on_windows:
+            raise SkipTest("Skipping on Windows")
+
+    if func:
+        @wraps(func)
+        @attr('skip_if_on_windows')
+        def newfunc(*args, **kwargs):
+            check_and_raise()
+            return func(*args, **kwargs)
+        return newfunc
+    else:
+        check_and_raise()
+
+
+@optional_args
+def skip_if(func, cond=True, msg=None, method='raise'):
+    """Skip test for specific condition
+
+    Parameters
+    ----------
+    cond: bool
+      condition on which to skip
+    msg: str
+      message to print if skipping
+    method: str
+      either 'raise' or 'pass'. Whether to skip by raising `SkipTest` or by
+      just proceeding and simply not calling the decorated function.
+      This is particularly meant to be used, when decorating single assertions
+      in a test with method='pass' in order to not skip the entire test, but
+      just that assertion.
+    """
+
+    check_not_generatorfunction(func)
+
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        if cond:
+            if method == 'raise':
+                raise SkipTest(msg if msg else "condition was True")
+            elif method == 'pass':
+                print(msg if msg else "condition was True")
+                return
+        return func(*args, **kwargs)
+    return newfunc
+
+
+def skip_ssh(func):
+    """Skips SSH tests if on windows or if environment variable
+    DATALAD_TESTS_SSH was not set
+    """
+
+    check_not_generatorfunction(func)
+
+    @wraps(func)
+    @attr('skip_ssh')
+    def newfunc(*args, **kwargs):
+        from datalad import cfg
+        test_ssh = cfg.get("datalad.tests.ssh", '')
+        if not test_ssh or test_ssh in ('0', 'false', 'no'):
+            raise SkipTest("Run this test by setting DATALAD_TESTS_SSH")
+        return func(*args, **kwargs)
+    return newfunc
+
+
+@optional_args
+def skip_v6_or_later(func, method='raise'):
+    """Skip tests if v6 or later will be used as the default repo version.
+
+    The default repository version is controlled by the configured value of
+    DATALAD_REPO_VERSION and whether v5 repositories are supported by the
+    installed git-annex.
+    """
+
+    from datalad import cfg
+    from datalad.support.annexrepo import AnnexRepo
+
+    version = cfg.obtain("datalad.repo.version")
+    info = AnnexRepo.check_repository_versions()
+
+    @skip_if(version >= 6 or 5 not in info["supported"],
+             msg="Skip test in v6+ test run", method=method)
+    @wraps(func)
+    @attr('skip_v6_or_later')
+    @attr('v6_or_later')
+    def newfunc(*args, **kwargs):
+        return func(*args, **kwargs)
+    return newfunc
+
+
 #
 # Addition "checkers"
 #
@@ -604,354 +729,6 @@ def with_tempfile(t, **tkwargs):
     return newfunc
 
 
-def _get_resolved_flavors(flavors):
-    #flavors_ = (['local', 'clone'] + (['local-url'] if not on_windows else [])) \
-    #           if flavors == 'auto' else flavors
-    flavors_ = (['local', 'clone', 'local-url', 'network'] if not on_windows
-                else ['network', 'network-clone']) \
-               if flavors == 'auto' else flavors
-
-    if not isinstance(flavors_, list):
-        flavors_ = [flavors_]
-
-    if os.environ.get('DATALAD_TESTS_NONETWORK'):
-        flavors_ = [x for x in flavors_ if not x.startswith('network')]
-    return flavors_
-
-def _get_repo_url(path):
-    """Return ultimate URL for this repo"""
-
-    if path.startswith('http') or path.startswith('git'):
-        # We were given a URL, so let's just return it
-        return path
-
-    if not exists(opj(path, '.git')):
-        # do the dummiest check so we know it is not git.Repo's fault
-        raise AssertionError("Path %s does not point to a git repository "
-                             "-- missing .git" % path)
-    repo = git.Repo(path)
-    if len(repo.remotes) == 1:
-        remote = repo.remotes[0]
-    else:
-        remote = repo.remotes.origin
-    return remote.config_reader.get('url')
-
-
-def clone_url(url):
-    # delay import of our code until needed for certain
-    from ..cmd import Runner
-    runner = Runner()
-    tdir = tempfile.mkdtemp(**get_tempfile_kwargs({}, prefix='clone_url'))
-    _ = runner(["git", "clone", url, tdir], expect_stderr=True)
-    if GitRepo(tdir).is_with_annex():
-        AnnexRepo(tdir, init=True)
-    _TEMP_PATHS_CLONES.add(tdir)
-    return tdir
-
-
-if not on_windows:
-    local_testrepo_flavors = ['local'] # 'local-url'
-else:
-    local_testrepo_flavors = ['network-clone']
-
-_TESTREPOS = None
-
-def _get_testrepos_uris(regex, flavors):
-    global _TESTREPOS
-    # we should instantiate those whenever test repos actually asked for
-    # TODO: just absorb all this lazy construction within some class
-    if not _TESTREPOS:
-        from .utils_testrepos import BasicAnnexTestRepo, BasicGitTestRepo, \
-            SubmoduleDataset, NestedDataset, InnerSubmodule
-
-        _basic_annex_test_repo = BasicAnnexTestRepo()
-        _basic_git_test_repo = BasicGitTestRepo()
-        _submodule_annex_test_repo = SubmoduleDataset()
-        _nested_submodule_annex_test_repo = NestedDataset()
-        _inner_submodule_annex_test_repo = InnerSubmodule()
-        _TESTREPOS = {'basic_annex':
-                        {'network': 'git://github.com/datalad/testrepo--basic--r1',
-                         'local': _basic_annex_test_repo.path,
-                         'local-url': _basic_annex_test_repo.url},
-                      'basic_git':
-                        {'local': _basic_git_test_repo.path,
-                         'local-url': _basic_git_test_repo.url},
-                      'submodule_annex':
-                        {'local': _submodule_annex_test_repo.path,
-                         'local-url': _submodule_annex_test_repo.url},
-                      'nested_submodule_annex':
-                        {'local': _nested_submodule_annex_test_repo.path,
-                         'local-url': _nested_submodule_annex_test_repo.url},
-                      # TODO: append 'annex' to the name:
-                      # Currently doesn't work with some annex tests, despite
-                      # working manually. So, figure out how the tests' setup
-                      # messes things up with this one.
-                      'inner_submodule':
-                        {'local': _inner_submodule_annex_test_repo.path,
-                         'local-url': _inner_submodule_annex_test_repo.url}
-                      }
-        # assure that now we do have those test repos created -- delayed
-        # their creation until actually used
-        _basic_annex_test_repo.create()
-        _basic_git_test_repo.create()
-        _submodule_annex_test_repo.create()
-        _nested_submodule_annex_test_repo.create()
-        _inner_submodule_annex_test_repo.create()
-    uris = []
-    for name, spec in _TESTREPOS.items():
-        if not re.match(regex, name):
-            continue
-        uris += [spec[x] for x in set(spec.keys()).intersection(flavors)]
-
-        # additional flavors which might have not been
-        if 'clone' in flavors and 'clone' not in spec:
-            uris.append(clone_url(spec['local']))
-
-        if 'network-clone' in flavors \
-                and 'network' in spec \
-                and 'network-clone' not in spec:
-            uris.append(clone_url(spec['network']))
-
-    return uris
-
-
-@optional_args
-def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
-    """Decorator to provide a local/remote test repository
-
-    All tests under datalad/tests/testrepos are stored in two-level hierarchy,
-    where top-level name describes nature/identifier of the test repository,
-    and there could be multiple instances (e.g. generated differently) of the
-    same "content"
-
-    Parameters
-    ----------
-    regex : string, optional
-      Regex to select which test repos to use
-    flavors : {'auto', 'local', 'local-url', 'clone', 'network', 'network-clone'} or list of thereof, optional
-      What URIs to provide.  E.g. 'local' would just provide path to the
-      repository, while 'network' would provide url of the remote location
-      available on Internet containing the test repository.  'clone' would
-      clone repository first to a temporary location. 'network-clone' would
-      first clone from the network location. 'auto' would include the list of
-      appropriate ones (e.g., no 'network*' flavors if network tests are
-      "forbidden").
-    count: int, optional
-      If specified, only up to that number of repositories to test with
-
-    Examples
-    --------
-
-    >>> from datalad.tests.utils import with_testrepos
-    >>> @with_testrepos('basic_annex')
-    ... def test_write(repo):
-    ...    assert(os.path.exists(os.path.join(repo, '.git', 'annex')))
-
-    """
-    @wraps(t)
-    @attr('with_testrepos')
-    def newfunc(*arg, **kw):
-        #if on_windows:
-        #    raise SkipTest("Testrepo setup is broken on Windows")
-
-        # TODO: would need to either avoid this "decorator" approach for
-        # parametric tests or again aggregate failures like sweepargs does
-        flavors_ = _get_resolved_flavors(flavors)
-
-        testrepos_uris = _get_testrepos_uris(regex, flavors_)
-        # we should always have at least one repo to test on, unless explicitly only
-        # network was requested by we are running without networked tests
-        if not (os.environ.get('DATALAD_TESTS_NONETWORK') and flavors == ['network']):
-            assert(testrepos_uris)
-        else:
-            if not testrepos_uris:
-                raise SkipTest("No non-networked repos to test on")
-
-        fake_dates = os.environ.get("DATALAD_FAKE__DATES")
-        ntested = 0
-        for uri in testrepos_uris:
-            if count and ntested >= count:
-                break
-            ntested += 1
-            if __debug__:
-                lgr.debug('Running %s on %s' % (t.__name__, uri))
-            try:
-                t(*(arg + (uri,)), **kw)
-            finally:
-                # The is_explicit_path check is needed because it may be a URL,
-                # but check_dates needs a local path or GitRepo object.
-                if fake_dates and is_explicit_path(uri):
-                    from ..support.repodates import check_dates
-                    assert_false(
-                        check_dates(uri, annex="tree")["objects"])
-                if uri in _TEMP_PATHS_CLONES:
-                    _TEMP_PATHS_CLONES.discard(uri)
-                    rmtemp(uri)
-                pass  # might need to provide additional handling so, handle
-    return newfunc
-with_testrepos.__test__ = False
-
-
-@optional_args
-def with_sameas_remote(func, autoenabled=False):
-    """Provide a repository with a git-annex sameas remote configured.
-
-    The repository will have two special remotes: r_dir (type=directory) and
-    r_rsync (type=rsync). The rsync remote will be configured with
-    --sameas=r_dir, and autoenabled if `autoenabled` is true.
-    """
-    from datalad.support.annexrepo import AnnexRepo
-    from datalad.support.exceptions import CommandError
-
-    @wraps(func)
-    @attr('with_sameas_remotes')
-    @skip_if_on_windows
-    @skip_ssh
-    @with_tempfile(mkdir=True)
-    @with_tempfile(mkdir=True)
-    def newfunc(*args, **kwargs):
-        sr_path, repo_path = args[-2:]
-        fn_args = args[:-2]
-        repo = AnnexRepo(repo_path)
-        repo.init_remote("r_dir",
-                         options=["type=directory",
-                                  "encryption=none",
-                                  "directory=" + sr_path])
-        options = ["type=rsync",
-                   "rsyncurl=datalad-test:" + sr_path]
-        if autoenabled:
-            options.append("autoenable=true")
-        options.append("--sameas=r_dir")
-
-        try:
-            repo.init_remote("r_rsync", options=options)
-        except CommandError:
-            if repo.git_annex_version < "7.20191017":
-                raise SkipTest("git-annex lacks --sameas support")
-            # This should have --sameas support.
-            raise
-        return func(*(fn_args + (repo,)), **kwargs)
-    return newfunc
-
-
-@optional_args
-def with_fake_cookies_db(func, cookies={}):
-    """mock original cookies db with a fake one for the duration of the test
-    """
-    from ..support.cookies import cookies_db
-
-    @wraps(func)
-    @attr('with_fake_cookies_db')
-    def newfunc(*args, **kwargs):
-        try:
-            orig_cookies_db = cookies_db._cookies_db
-            cookies_db._cookies_db = cookies.copy()
-            return func(*args, **kwargs)
-        finally:
-            cookies_db._cookies_db = orig_cookies_db
-    return newfunc
-
-
-def check_not_generatorfunction(func):
-    """Internal helper to verify that we are not decorating generator tests"""
-    if inspect.isgeneratorfunction(func):
-        raise RuntimeError("{}: must not be decorated, is a generator test"
-                           .format(func.__name__))
-
-
-def skip_if_no_network(func=None):
-    """Skip test completely in NONETWORK settings
-
-    If not used as a decorator, and just a function, could be used at the module level
-    """
-    check_not_generatorfunction(func)
-
-    def check_and_raise():
-        if os.environ.get('DATALAD_TESTS_NONETWORK'):
-            raise SkipTest("Skipping since no network settings")
-
-    if func:
-        @wraps(func)
-        @attr('network')
-        @attr('skip_if_no_network')
-        def newfunc(*args, **kwargs):
-            check_and_raise()
-            return func(*args, **kwargs)
-        return newfunc
-    else:
-        check_and_raise()
-
-
-def skip_if_on_windows(func=None):
-    """Skip test completely under Windows
-    """
-    check_not_generatorfunction(func)
-
-    def check_and_raise():
-        if on_windows:
-            raise SkipTest("Skipping on Windows")
-
-    if func:
-        @wraps(func)
-        @attr('skip_if_on_windows')
-        def newfunc(*args, **kwargs):
-            check_and_raise()
-            return func(*args, **kwargs)
-        return newfunc
-    else:
-        check_and_raise()
-
-
-@optional_args
-def skip_if(func, cond=True, msg=None, method='raise'):
-    """Skip test for specific condition
-
-    Parameters
-    ----------
-    cond: bool
-      condition on which to skip
-    msg: str
-      message to print if skipping
-    method: str
-      either 'raise' or 'pass'. Whether to skip by raising `SkipTest` or by
-      just proceeding and simply not calling the decorated function.
-      This is particularly meant to be used, when decorating single assertions
-      in a test with method='pass' in order to not skip the entire test, but
-      just that assertion.
-    """
-
-    check_not_generatorfunction(func)
-
-    @wraps(func)
-    def newfunc(*args, **kwargs):
-        if cond:
-            if method == 'raise':
-                raise SkipTest(msg if msg else "condition was True")
-            elif method == 'pass':
-                print(msg if msg else "condition was True")
-                return
-        return func(*args, **kwargs)
-    return newfunc
-
-
-def skip_ssh(func):
-    """Skips SSH tests if on windows or if environment variable
-    DATALAD_TESTS_SSH was not set
-    """
-
-    check_not_generatorfunction(func)
-
-    @wraps(func)
-    @attr('skip_ssh')
-    def newfunc(*args, **kwargs):
-        from datalad import cfg
-        test_ssh = cfg.get("datalad.tests.ssh", '')
-        if not test_ssh or test_ssh in ('0', 'false', 'no'):
-            raise SkipTest("Run this test by setting DATALAD_TESTS_SSH")
-        return func(*args, **kwargs)
-    return newfunc
-
-
 # ### ###
 # START known failure decorators
 # ### ###
@@ -1120,28 +897,251 @@ def known_failure_githubci_win(func):
 # ### ###
 
 
+def _get_resolved_flavors(flavors):
+    #flavors_ = (['local', 'clone'] + (['local-url'] if not on_windows else [])) \
+    #           if flavors == 'auto' else flavors
+    flavors_ = (['local', 'clone', 'local-url', 'network'] if not on_windows
+                else ['network', 'network-clone']) \
+               if flavors == 'auto' else flavors
+
+    if not isinstance(flavors_, list):
+        flavors_ = [flavors_]
+
+    if os.environ.get('DATALAD_TESTS_NONETWORK'):
+        flavors_ = [x for x in flavors_ if not x.startswith('network')]
+    return flavors_
+
+def _get_repo_url(path):
+    """Return ultimate URL for this repo"""
+
+    if path.startswith('http') or path.startswith('git'):
+        # We were given a URL, so let's just return it
+        return path
+
+    if not exists(opj(path, '.git')):
+        # do the dummiest check so we know it is not git.Repo's fault
+        raise AssertionError("Path %s does not point to a git repository "
+                             "-- missing .git" % path)
+    repo = git.Repo(path)
+    if len(repo.remotes) == 1:
+        remote = repo.remotes[0]
+    else:
+        remote = repo.remotes.origin
+    return remote.config_reader.get('url')
+
+
+def clone_url(url):
+    # delay import of our code until needed for certain
+    from ..cmd import Runner
+    runner = Runner()
+    tdir = tempfile.mkdtemp(**get_tempfile_kwargs({}, prefix='clone_url'))
+    _ = runner(["git", "clone", url, tdir], expect_stderr=True)
+    if GitRepo(tdir).is_with_annex():
+        AnnexRepo(tdir, init=True)
+    _TEMP_PATHS_CLONES.add(tdir)
+    return tdir
+
+
+if not on_windows:
+    local_testrepo_flavors = ['local'] # 'local-url'
+else:
+    local_testrepo_flavors = ['network-clone']
+
+_TESTREPOS = None
+
+def _get_testrepos_uris(regex, flavors):
+    global _TESTREPOS
+    # we should instantiate those whenever test repos actually asked for
+    # TODO: just absorb all this lazy construction within some class
+    if not _TESTREPOS:
+        from .utils_testrepos import BasicAnnexTestRepo, BasicGitTestRepo, \
+            SubmoduleDataset, NestedDataset, InnerSubmodule
+
+        _basic_annex_test_repo = BasicAnnexTestRepo()
+        _basic_git_test_repo = BasicGitTestRepo()
+        _submodule_annex_test_repo = SubmoduleDataset()
+        _nested_submodule_annex_test_repo = NestedDataset()
+        _inner_submodule_annex_test_repo = InnerSubmodule()
+        _TESTREPOS = {'basic_annex':
+                        {'network': 'git://github.com/datalad/testrepo--basic--r1',
+                         'local': _basic_annex_test_repo.path,
+                         'local-url': _basic_annex_test_repo.url},
+                      'basic_git':
+                        {'local': _basic_git_test_repo.path,
+                         'local-url': _basic_git_test_repo.url},
+                      'submodule_annex':
+                        {'local': _submodule_annex_test_repo.path,
+                         'local-url': _submodule_annex_test_repo.url},
+                      'nested_submodule_annex':
+                        {'local': _nested_submodule_annex_test_repo.path,
+                         'local-url': _nested_submodule_annex_test_repo.url},
+                      # TODO: append 'annex' to the name:
+                      # Currently doesn't work with some annex tests, despite
+                      # working manually. So, figure out how the tests' setup
+                      # messes things up with this one.
+                      'inner_submodule':
+                        {'local': _inner_submodule_annex_test_repo.path,
+                         'local-url': _inner_submodule_annex_test_repo.url}
+                      }
+        # assure that now we do have those test repos created -- delayed
+        # their creation until actually used
+        _basic_annex_test_repo.create()
+        _basic_git_test_repo.create()
+        _submodule_annex_test_repo.create()
+        _nested_submodule_annex_test_repo.create()
+        _inner_submodule_annex_test_repo.create()
+    uris = []
+    for name, spec in _TESTREPOS.items():
+        if not re.match(regex, name):
+            continue
+        uris += [spec[x] for x in set(spec.keys()).intersection(flavors)]
+
+        # additional flavors which might have not been
+        if 'clone' in flavors and 'clone' not in spec:
+            uris.append(clone_url(spec['local']))
+
+        if 'network-clone' in flavors \
+                and 'network' in spec \
+                and 'network-clone' not in spec:
+            uris.append(clone_url(spec['network']))
+
+    return uris
+
+
+# addurls with our generated file:// URLs doesn't work on appveyor
+# https://ci.appveyor.com/project/mih/datalad/builds/29841505/job/330rwn2a3cvtrakj
+@known_failure_appveyor
 @optional_args
-def skip_v6_or_later(func, method='raise'):
-    """Skip tests if v6 or later will be used as the default repo version.
+def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
+    """Decorator to provide a local/remote test repository
 
-    The default repository version is controlled by the configured value of
-    DATALAD_REPO_VERSION and whether v5 repositories are supported by the
-    installed git-annex.
+    All tests under datalad/tests/testrepos are stored in two-level hierarchy,
+    where top-level name describes nature/identifier of the test repository,
+    and there could be multiple instances (e.g. generated differently) of the
+    same "content"
+
+    Parameters
+    ----------
+    regex : string, optional
+      Regex to select which test repos to use
+    flavors : {'auto', 'local', 'local-url', 'clone', 'network', 'network-clone'} or list of thereof, optional
+      What URIs to provide.  E.g. 'local' would just provide path to the
+      repository, while 'network' would provide url of the remote location
+      available on Internet containing the test repository.  'clone' would
+      clone repository first to a temporary location. 'network-clone' would
+      first clone from the network location. 'auto' would include the list of
+      appropriate ones (e.g., no 'network*' flavors if network tests are
+      "forbidden").
+    count: int, optional
+      If specified, only up to that number of repositories to test with
+
+    Examples
+    --------
+
+    >>> from datalad.tests.utils import with_testrepos
+    >>> @with_testrepos('basic_annex')
+    ... def test_write(repo):
+    ...    assert(os.path.exists(os.path.join(repo, '.git', 'annex')))
+
     """
+    @wraps(t)
+    @attr('with_testrepos')
+    def newfunc(*arg, **kw):
+        # TODO: would need to either avoid this "decorator" approach for
+        # parametric tests or again aggregate failures like sweepargs does
+        flavors_ = _get_resolved_flavors(flavors)
 
-    from datalad import cfg
+        testrepos_uris = _get_testrepos_uris(regex, flavors_)
+        # we should always have at least one repo to test on, unless explicitly only
+        # network was requested by we are running without networked tests
+        if not (os.environ.get('DATALAD_TESTS_NONETWORK') and flavors == ['network']):
+            assert(testrepos_uris)
+        else:
+            if not testrepos_uris:
+                raise SkipTest("No non-networked repos to test on")
+
+        fake_dates = os.environ.get("DATALAD_FAKE__DATES")
+        ntested = 0
+        for uri in testrepos_uris:
+            if count and ntested >= count:
+                break
+            ntested += 1
+            if __debug__:
+                lgr.debug('Running %s on %s' % (t.__name__, uri))
+            try:
+                t(*(arg + (uri,)), **kw)
+            finally:
+                # The is_explicit_path check is needed because it may be a URL,
+                # but check_dates needs a local path or GitRepo object.
+                if fake_dates and is_explicit_path(uri):
+                    from ..support.repodates import check_dates
+                    assert_false(
+                        check_dates(uri, annex="tree")["objects"])
+                if uri in _TEMP_PATHS_CLONES:
+                    _TEMP_PATHS_CLONES.discard(uri)
+                    rmtemp(uri)
+                pass  # might need to provide additional handling so, handle
+    return newfunc
+with_testrepos.__test__ = False
+
+
+@optional_args
+def with_sameas_remote(func, autoenabled=False):
+    """Provide a repository with a git-annex sameas remote configured.
+
+    The repository will have two special remotes: r_dir (type=directory) and
+    r_rsync (type=rsync). The rsync remote will be configured with
+    --sameas=r_dir, and autoenabled if `autoenabled` is true.
+    """
     from datalad.support.annexrepo import AnnexRepo
+    from datalad.support.exceptions import CommandError
 
-    version = cfg.obtain("datalad.repo.version")
-    info = AnnexRepo.check_repository_versions()
-
-    @skip_if(version >= 6 or 5 not in info["supported"],
-             msg="Skip test in v6+ test run", method=method)
     @wraps(func)
-    @attr('skip_v6_or_later')
-    @attr('v6_or_later')
+    @attr('with_sameas_remotes')
+    @skip_if_on_windows
+    @skip_ssh
+    @with_tempfile(mkdir=True)
+    @with_tempfile(mkdir=True)
     def newfunc(*args, **kwargs):
-        return func(*args, **kwargs)
+        sr_path, repo_path = args[-2:]
+        fn_args = args[:-2]
+        repo = AnnexRepo(repo_path)
+        repo.init_remote("r_dir",
+                         options=["type=directory",
+                                  "encryption=none",
+                                  "directory=" + sr_path])
+        options = ["type=rsync",
+                   "rsyncurl=datalad-test:" + sr_path]
+        if autoenabled:
+            options.append("autoenable=true")
+        options.append("--sameas=r_dir")
+
+        try:
+            repo.init_remote("r_rsync", options=options)
+        except CommandError:
+            if repo.git_annex_version < "7.20191017":
+                raise SkipTest("git-annex lacks --sameas support")
+            # This should have --sameas support.
+            raise
+        return func(*(fn_args + (repo,)), **kwargs)
+    return newfunc
+
+
+@optional_args
+def with_fake_cookies_db(func, cookies={}):
+    """mock original cookies db with a fake one for the duration of the test
+    """
+    from ..support.cookies import cookies_db
+
+    @wraps(func)
+    @attr('with_fake_cookies_db')
+    def newfunc(*args, **kwargs):
+        try:
+            orig_cookies_db = cookies_db._cookies_db
+            cookies_db._cookies_db = cookies.copy()
+            return func(*args, **kwargs)
+        finally:
+            cookies_db._cookies_db = orig_cookies_db
     return newfunc
 
 

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -19,6 +19,7 @@ from ..support.network import get_local_file_url
 from ..support.external_versions import external_versions
 from ..utils import swallow_outputs
 from ..utils import swallow_logs
+from ..utils import on_windows
 
 from ..version import __version__
 from . import _TEMP_PATHS_GENERATED
@@ -159,9 +160,9 @@ class SubmoduleDataset(BasicAnnexTestRepo):
         annex.create()
         kw = dict(cwd=self.path, expect_stderr=True)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', annex.url, 'subm 1'], **kw)
+            '', ['git', 'submodule', 'add', annex.path if on_windows else annex.url, 'subm 1'], **kw)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', annex.url, '2'], **kw)
+            '', ['git', 'submodule', 'add', annex.path if on_windows else annex.url, '2'], **kw)
         self.repo.commit('Added subm 1 and 2.')
         self.repo._git_custom_command(
             '', ['git', 'submodule', 'update', '--init', '--recursive'], **kw)
@@ -178,10 +179,10 @@ class NestedDataset(BasicAnnexTestRepo):
         ds.create()
         kw = dict(expect_stderr=True)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', ds.url, 'sub dataset1'],
+            '', ['git', 'submodule', 'add', ds.path if on_windows else ds.url, 'sub dataset1'],
             cwd=self.path, **kw)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', ds.url, 'sub sub dataset1'],
+            '', ['git', 'submodule', 'add', ds.path if on_windows else ds.url, 'sub sub dataset1'],
             cwd=opj(self.path, 'sub dataset1'), **kw)
         GitRepo(opj(self.path, 'sub dataset1')).commit('Added sub dataset.')
         self.repo.commit('Added subdatasets.', options=["-a"])

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -11,11 +11,10 @@ import os
 import tempfile
 
 from abc import ABCMeta, abstractmethod
-from os.path import dirname, join as opj, exists, pardir
+from os.path import join as opj, exists
 
 from ..support.gitrepo import GitRepo
 from ..support.annexrepo import AnnexRepo
-from ..cmd import Runner
 from ..support.network import get_local_file_url
 from ..support.external_versions import external_versions
 from ..utils import swallow_outputs
@@ -105,7 +104,6 @@ class BasicAnnexTestRepo(TestRepo):
         self.create_file('test.dat', '123\n', annex=False)
         self.repo.commit("Adding a basic INFO file and rudimentary load file for annex testing")
         # even this doesn't work on bloody Windows
-        from .utils import on_windows
         fileurl = get_local_file_url(remote_file_path)
         # Note:
         # The line above used to be conditional:


### PR DESCRIPTION
...as much as feels feasible right now. In any case, this is a huge step forward in terms of critical test coverage on windows. We are now in the position to investigate individual tests, instead of facing global failure.

- [x] cross-platform implementation of get_local_file_url()
- [x] basic testrepo setup is running on windows
- [x] all new test failures due to testrepos being enabled on windows are marked "known" and annotated with a traceback log link
- [x] addurl is not working on appveyor, fix or disable testrepos on appveyor (leaning towards the latter)

There is still an open issue with `get_local_file_ur l()` https://github.com/datalad/datalad/issues/3977, but given that this is needed for #3966 it will have to come in a separate PR.