### PR TITLE
BF: Store path URLs for remotes in POSIX (fixes gh-3972)

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -40,6 +40,7 @@ from datalad.support.exceptions import (
 )
 from datalad.support.network import (
     RI,
+    PathRI,
     URL,
 )
 from datalad.support.gitrepo import GitRepo
@@ -65,6 +66,7 @@ from datalad.distribution.update import Update
 from datalad.utils import (
     assure_list,
     slash_join,
+    Path,
 )
 from datalad.dochelpers import exc_str
 
@@ -367,6 +369,10 @@ def _add_remote(
             message=("sibling is already known: %s, use `configure` instead?", name),
             **res_kwargs)
         return
+    if isinstance(RI(url), PathRI):
+        # make sure any path URL is stored in POSIX conventions for consistency
+        # with git's behavior (e.g. origin configured by clone)
+        url = Path(url).as_posix()
     # this remote is fresh: make it known
     # just minimalistic name and URL, the rest is coming from `configure`
     ds.repo.add_remote(name, url)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -16,26 +16,32 @@ from datalad.support.path import (
     relpath,
 )
 
-from datalad.api import clone
-from datalad.api import create
-from datalad.api import Dataset
-from datalad.api import install
-from datalad.api import siblings
+from datalad.api import (
+    clone,
+    create,
+    Dataset,
+    install,
+    siblings,
+)
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 
-from datalad.tests.utils import chpwd
-from datalad.tests.utils import create_tree
-from datalad.tests.utils import with_tempfile, with_testrepos
-from datalad.tests.utils import assert_false
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import with_sameas_remote
+from datalad.tests.utils import (
+    chpwd,
+    create_tree,
+    with_tempfile, with_testrepos,
+    assert_false,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    assert_status,
+    assert_result_count,
+    with_sameas_remote,
+    eq_,
+    ok_,
+)
 
-from nose.tools import eq_, ok_
+from datalad.utils import Path
 
 
 # work on cloned repos to be safer
@@ -345,3 +351,24 @@ def test_sibling_inherit_no_super_remote(basedir):
     # doesn't have a remote `name`.
     ds_clone.siblings(action="add", name="donotexist", inherit=True,
                       url=ds_source.path, result_renderer=None)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_sibling_path_is_posix(basedir, otherpath):
+    ds_source = Dataset(opj(basedir, "source")).create()
+    # add remote with system native path
+    ds_source.siblings(
+        action="add",
+        name="donotexist",
+        url=otherpath,
+        result_renderer=None)
+    res = ds_source.siblings(
+        action="query",
+        name="donotexist",
+        result_renderer=None,
+        return_type='item-or-list')
+    # path URL should come out POSIX as if `git clone` had configured it for origin
+    # https://github.com/datalad/datalad/issues/3972
+    eq_(res['url'], Path(otherpath).as_posix())
+     


### PR DESCRIPTION
with a test.