### PR TITLE
NF: ConfigManager.???(where='override')

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -627,7 +627,7 @@ class ConfigManager(object):
             val.append(value)
             self.overrides[var] = val[0] if len(val) == 1 else val
             if reload:
-                self.reload()
+                self.reload(force=True)
             return
 
         self._run(['--add', var, value], where=where, reload=reload, log_stderr=True)
@@ -654,7 +654,7 @@ class ConfigManager(object):
         if where == 'override':
             self.overrides[var] = value
             if reload:
-                self.reload()
+                self.reload(force=True)
             return
 
         from datalad.support.gitrepo import to_options
@@ -679,7 +679,7 @@ class ConfigManager(object):
                 for k, v in self.overrides.items()
             }
             if reload:
-                self.reload()
+                self.reload(force=True)
             return
 
         self._run(['--rename-section', old, new], where=where, reload=reload)
@@ -700,7 +700,7 @@ class ConfigManager(object):
                 if not k.startswith(sec + '.')
             }
             if reload:
-                self.reload()
+                self.reload(force=True)
             return
 
         self._run(['--remove-section', sec], where=where, reload=reload)
@@ -717,7 +717,7 @@ class ConfigManager(object):
         if where == 'override':
             self.overrides.pop(var, None)
             if reload:
-                self.reload()
+                self.reload(force=True)
             return
 
         # use unset all as it is simpler for now

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -357,6 +357,7 @@ def test_overrides():
     cfg.add('user.name', 'myother', where='override')
     assert_equal(cfg['user.name'], ['myoverride', 'myother'])
     # rename
+    assert_not_in('ups.name', cfg)
     cfg.rename_section('user', 'ups', where='override')
     # original variable still there
     assert_in('user.name', cfg)
@@ -364,4 +365,11 @@ def test_overrides():
     assert_equal(cfg['ups.name'], ['myoverride', 'myother'])
     # remove entirely by section
     cfg.remove_section('ups', where='override')
-    assert_not_in('ups.name', cfg)
+    from datalad.utils import Path
+    assert_not_in(
+        'ups.name', cfg,
+        (cfg._store,
+         cfg.overrides,
+         cfg._cfgfiles,
+         [Path(f).read_text() for f in cfg._cfgfiles if Path(f).exists()],
+    ))


### PR DESCRIPTION
This brings the same (and actually more) configuration override
flexibility to the Python API that the cmdline API offers via
`datalad -c key=val`.

This feature is a necessity for being able to rely on one-off
configuration (changes) to alter command behavior, whenever
a dedicated command option is not absolutely needed or shall be
avoided.

A dedicated test for overrides is also included.

Fixes gh-3970