### PR TITLE
BF: Implement workaround for file:// URL compatibility on Windows

### DIFF
--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -217,7 +217,8 @@ class Clone(Interface):
                 # this is where it was actually installed from
                 track_name, track_url = _get_tracking_source(destination_dataset)
                 if track_url in guessed_sources or \
-                        get_local_file_url(track_url) in guessed_sources:
+                        get_local_file_url(
+                            track_url, compatibility='git') in guessed_sources:
                     yield get_status_dict(
                         status='notneeded',
                         message=("dataset %s was already cloned from '%s'",

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -879,12 +879,18 @@ class GitRepo(RepoInterface, metaclass=Flyweight):
 
         # Massage URL
         url_ri = RI(url) if not isinstance(url, RI) else url
-        # try to get a local path from `url`:
-        try:
-            url = url_ri.localpath
-            url_ri = RI(url)
-        except ValueError:
-            pass
+        if not on_windows:
+            # if we are on windows, the local path of a URL
+            # would not end up being a proper local path and cloning
+            # would fail. Don't try to be smart and just pass the
+            # URL along unmodified
+
+            # try to get a local path from `url`:
+            try:
+                url = url_ri.localpath
+                url_ri = RI(url)
+            except ValueError:
+                pass
 
         if is_ssh(url_ri):
             ssh_manager.get_connection(url).open()

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -901,18 +901,26 @@ def is_ssh(ri):
         or (isinstance(_ri, URL) and _ri.scheme == 'ssh')
 
 
-def get_local_file_url(fname):
+def get_local_file_url(fname, compatibility='git-annex'):
     """Return OS specific URL pointing to a local file
 
     Parameters
     ----------
     fname : string
         Filename.  If not absolute, abspath is used
+    compatibility : {'git', 'git-annex'}, optional
+        On Windows, and only on that platform, file:// URLs may need to look
+        different depending on the use case or consuming application. This
+        switch selects different compatibility modes: 'git' for use with
+        Git commands (e.g. `clone` or `submodule add`); 'git-annex` for
+        Git-annex command input (e.g. `addurl`). On any other platform this
+        setting has no effect.
     """
     path = Path(fname).absolute()
     if on_windows:
         path = path.as_posix()
-        furl = 'file://{}'.format(
+        furl = 'file://{}{}'.format(
+            '/' if compatibility == 'git' else '',
             urlquote(
                 re.sub(r'([a-zA-Z]):', r'\1', path)
             ))

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1149,7 +1149,7 @@ def test_optimized_cloning(path):
     # now clone it in different ways and see what happens to the object storage
     from datalad.support.network import get_local_file_url
     clonepath = op.join(path, 'clone')
-    for src in (originpath, get_local_file_url(originpath)):
+    for src in (originpath, get_local_file_url(originpath, compatibility='git')):
         # deprecated
         assert_raises(DeprecatedError, GitRepo, url=src, path=clonepath)
         clone = GitRepo.clone(url=src, path=clonepath, create=True)

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -474,10 +474,14 @@ def test_get_local_file_url_compatibility(path):
     testfile.write_text('some')
 
     # compat with annex addurl
-    ds1.repo.add_url_to_file('test.txt', get_local_file_url(testfile))
+    ds1.repo.add_url_to_file(
+        'test.txt',
+        get_local_file_url(testfile, compatibility='git-annex'))
 
     # compat with git clone/submodule
-    assert_status('ok', ds1.clone(get_local_file_url(ds2.path)))
+    assert_status(
+        'ok',
+        ds1.clone(get_local_file_url(ds2.path, compatibility='git')))
 
 
 def test_is_ssh():

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -16,36 +16,49 @@ from os.path import (
 )
 from collections import OrderedDict
 
+from datalad.distribution.dataset import Dataset
+
 from datalad.utils import (
+    Path,
     PurePosixPath,
     on_windows,
 )
 
-from datalad.tests.utils import eq_, neq_, ok_, nok_, assert_raises
-from datalad.tests.utils import skip_if_on_windows
-from datalad.tests.utils import swallow_logs
-from datalad.tests.utils import assert_re_in
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import get_most_obscure_supported_name
-from datalad.tests.utils import SkipTest
-from datalad.tests.utils import known_failure_githubci_win
+from datalad.tests.utils import (
+    eq_,
+    neq_,
+    ok_,
+    nok_,
+    assert_raises,
+    skip_if_on_windows,
+    swallow_logs,
+    assert_in,
+    get_most_obscure_supported_name,
+    SkipTest,
+    known_failure_githubci_win,
+    with_tempfile,
+    assert_status,
+)
 
-from ..network import same_website, dlurljoin
-from ..network import get_tld
-from ..network import get_url_straight_filename
-from ..network import get_response_disposition_filename
-from ..network import parse_url_opts
-from ..network import RI
-from ..network import SSHRI
-from ..network import PathRI
-from ..network import DataLadRI
-from ..network import URL
-from ..network import _split_colon
-from ..network import is_url
-from ..network import is_datalad_compat_ri
-from ..network import get_local_file_url
-from ..network import is_ssh
-from ..network import iso8601_to_epoch
+from datalad.support.network import (
+    same_website,
+    dlurljoin,
+    get_tld,
+    get_url_straight_filename,
+    get_response_disposition_filename,
+    parse_url_opts,
+    RI,
+    SSHRI,
+    PathRI,
+    DataLadRI,
+    URL,
+    _split_colon,
+    is_url,
+    is_datalad_compat_ri,
+    get_local_file_url,
+    is_ssh,
+    iso8601_to_epoch,
+)
 
 
 def test_same_website():
@@ -448,6 +461,23 @@ def test_get_local_file_url():
                     get_local_file_url(os.getcwd()),
                     url))
             )
+
+
+@with_tempfile(mkdir=True)
+def test_get_local_file_url_compatibility(path):
+    # smoke test for file:// URL compatibility with other datalad/git/annex
+    # pieces
+    path = Path(path)
+    ds1 = Dataset(path / 'ds1').create()
+    ds2 = Dataset(path / 'ds2').create()
+    testfile = path / 'testfile.txt'
+    testfile.write_text('some')
+
+    # compat with annex addurl
+    ds1.repo.add_url_to_file('test.txt', get_local_file_url(testfile))
+
+    # compat with git clone/submodule
+    assert_status('ok', ds1.clone(get_local_file_url(ds2.path)))
 
 
 def test_is_ssh():

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -67,7 +67,7 @@ class TestRepo(object, metaclass=ABCMeta):
 
     @property
     def url(self):
-        return get_local_file_url(self.path)
+        return get_local_file_url(self.path, compatibility='git')
 
     def create_file(self, name, content, add=True, annex=False):
         filename = opj(self.path, name)
@@ -105,7 +105,7 @@ class BasicAnnexTestRepo(TestRepo):
         self.create_file('test.dat', '123\n', annex=False)
         self.repo.commit("Adding a basic INFO file and rudimentary load file for annex testing")
         # even this doesn't work on bloody Windows
-        fileurl = get_local_file_url(remote_file_path)
+        fileurl = get_local_file_url(remote_file_path, compatibility='git-annex')
         # Note:
         # The line above used to be conditional:
         # if not on_windows \
@@ -160,9 +160,9 @@ class SubmoduleDataset(BasicAnnexTestRepo):
         annex.create()
         kw = dict(cwd=self.path, expect_stderr=True)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', annex.path if on_windows else annex.url, 'subm 1'], **kw)
+            '', ['git', 'submodule', 'add', annex.url, 'subm 1'], **kw)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', annex.path if on_windows else annex.url, '2'], **kw)
+            '', ['git', 'submodule', 'add', annex.url, '2'], **kw)
         self.repo.commit('Added subm 1 and 2.')
         self.repo._git_custom_command(
             '', ['git', 'submodule', 'update', '--init', '--recursive'], **kw)
@@ -179,10 +179,10 @@ class NestedDataset(BasicAnnexTestRepo):
         ds.create()
         kw = dict(expect_stderr=True)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', ds.path if on_windows else ds.url, 'sub dataset1'],
+            '', ['git', 'submodule', 'add', ds.url, 'sub dataset1'],
             cwd=self.path, **kw)
         self.repo._git_custom_command(
-            '', ['git', 'submodule', 'add', ds.path if on_windows else ds.url, 'sub sub dataset1'],
+            '', ['git', 'submodule', 'add', ds.url, 'sub sub dataset1'],
             cwd=opj(self.path, 'sub dataset1'), **kw)
         GitRepo(opj(self.path, 'sub dataset1')).commit('Added sub dataset.')
         self.repo.commit('Added subdatasets.', options=["-a"])
@@ -205,7 +205,7 @@ class InnerSubmodule(object):
 
     @property
     def url(self):
-        return get_local_file_url(self.path)
+        return get_local_file_url(self.path, compatibility='git')
 
     def create(self):
         self._ds.create()


### PR DESCRIPTION
The new 'compatibility' argument of get_local_file_url() is relatively
painless and the workaround implementation can be removed (and the
argument rendered into a no-op) if there should be a compatibility
fix at the git-annex end.

Fixes gh-3639