### PR TITLE
TST: annexrepo: Ignore racy "is clean?" failure

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1864,7 +1864,15 @@ def test_AnnexRepo_dirty(path):
         ok_(repo.dirty)
         # commit
         repo.commit("file2.txt annexed")
-    ok_(not repo.dirty)
+
+    try:
+        ok_(not repo.dirty)
+    except AssertionError:
+        if "7.20191024" <= external_versions['cmd:annex'] < "7.20191230":
+            raise SkipTest(
+                "Test known to trigger git-to-annex content conversion "
+                "with this git-annex version (see gh-3890)")
+        raise
 
     # TODO: unlock/modify
 


### PR DESCRIPTION
```
As of git-annex 7.20191024, test_AnnexRepo_dirty has started to
intermittently fail [0] due to the repository being in an unexpectedly
dirty state, with content that was previously tracked by git converted
to annexed content.  The failure happens due to the combination of two
things:

 1) Calling `git -c annex.largefiles=anything annex add -- FILES` can
    in some cases result in git running git-annex's clean filter on
    files that are _not_ part of FILES.  Importantly the clean filter
    runs within the `-c annex.largefiles=anything` context.

 2) As of 7.20191024, git-annex's clean filter remembers the inode for
    annexed content, leading git-annex to conclude that the regular
    git file in the working tree (file1.txt in this test) should be
    annexed, because the content was tagged as such in 1.

See the associated git-annex bug report [1] for a more complete
description.

git-annex 7.20191230, specifically commit ea3cb7d27, works around this
edge case.  For git-annex versions before this fix but after
7.20191024, skip the test if the "is clean" assertion fails.
```

\[0]: https://github.com/datalad/datalad/issues/3890#issuecomment-565027169
\[1]: https://git-annex.branchable.com/bugs/A_case_where_file_tracked_by_git_unexpectedly_becomes_annex_pointer_file/
