### PR TITLE
TST: create-sibling: Loosen check's assumption about Git's behavior

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -322,7 +322,6 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             # files which hook would manage to generate
             _path_('.git/info/refs'), '.git/objects/info/packs'
         }
-        # on elderly git we don't change receive setting
         ok_modified_files.add(_path_('.git/config'))
         ok_modified_files.update({f for f in digests if f.startswith(_path_('.git/datalad/web'))})
         # it seems that with some recent git behavior has changed a bit

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -319,8 +319,6 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         # collect which files were expected to be modified without incurring any changes
         ok_modified_files = {
             _path_('.git/hooks/post-update'), 'index.html',
-            # files which hook would manage to generate
-            _path_('.git/info/refs'), '.git/objects/info/packs'
         }
         ok_modified_files.add(_path_('.git/config'))
         ok_modified_files.update({f for f in digests if f.startswith(_path_('.git/datalad/web'))})
@@ -328,7 +326,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         # and index might get touched
         if _path_('.git/index') in modified_files:
             ok_modified_files.add(_path_('.git/index'))
-        assert_set_equal(modified_files, ok_modified_files)
+        ok_(modified_files.issuperset(ok_modified_files))
 
 
 @skip_if_on_windows  # create_sibling incompatible with win servers


### PR DESCRIPTION
This addresses one of the failures from gh-3890.

---

```
A check in test_target_ssh_simple assumes that executing the
post-update hook will change the modification times of .git/info/refs
and .git/objects/info/packs.  In test runs with more recent Git
versions, this check has started to fail because the modification
times of the files are not updated [0].  This change in behavior is
likely due to Git's f4f476b6a1 (update-server-info: avoid needless
overwrites, 2019-05-13), which was part of the v2.23.0 release.

We could condition the check on the Git version, but, as the now
failing check demonstrates, this check is much too concerned with
internal implementation details of git.  To avoid the test starting to
fail due to another change within .git/ that we do not control, let's
instead update the check to not assume that it knows the strict set of
files that's modified.
```

\[0]: Re: https://github.com/datalad/datalad/issues/3890#issuecomment-565587037
