### PR TITLE
RF: Attribute -> Value Error + provide an informative message for the exception

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -120,7 +120,8 @@ class Dataset(object):
             raise TypeError("__init__() requires argument `path`")
 
         if path is None:
-            raise AttributeError
+            lgr.debug("path is None. args: %s, kwargs: %s", args, kwargs)
+            raise ValueError("path must not be None")
 
         # Custom handling for few special abbreviations
         path_ = path

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -128,7 +128,7 @@ def test_is_installed(src, path):
 def test_dataset_contructor(path):
     # dataset needs a path
     assert_raises(TypeError, Dataset)
-    assert_raises(AttributeError, Dataset, None)
+    assert_raises(ValueError, Dataset, None)
     dsabs = Dataset(path)
     # always abspath
     ok_(os.path.isabs(dsabs.path))


### PR DESCRIPTION
See https://github.com/datalad/datalad/issues/3973 .   I am not really sure why it was
intended to be an AttributeError, but I feel that ValueError is a better fit here.
lgr.debug message might be of help in some cases to identify the reason which lead
to crash, but because args and kwargs are modified by the code above, not sure really
if it would be very informative.  but I do not think that it would somehow negatively
effect the performance so I added it

Looking at the code I see that we have duplicated functionality across `_flyweight_id_from_args` implementations.  I will look into unifying it in a separate PR (on top)