### PR TITLE
RF: bring common (?) functionality under PathBasedFlyweight

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -39,6 +39,7 @@ from datalad.support.gitrepo import NoSuchPathError
 from datalad.support.repo import PathBasedFlyweight
 from datalad.support.network import RI
 from datalad.support.exceptions import InvalidAnnexRepositoryError
+from datalad.support import path as op
 
 from datalad.utils import assure_unicode
 from datalad.utils import getpwd
@@ -118,6 +119,15 @@ class Dataset(object):
         if path != path_:
             lgr.debug("Resolved dataset alias %r to path %r", path, path_)
         return path_
+
+    @classmethod
+    def _flyweight_postproc_path(cls, path):
+        # we want an absolute path, but no resolved symlinks
+        if not op.isabs(path):
+            path = op.join(op.getpwd(), path)
+
+        # use canonical paths only:
+        return op.normpath(path)
     # End Flyweight
 
     def __init__(self, path):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -120,7 +120,8 @@ class Dataset(object):
             raise TypeError("__init__() requires argument `path`")
 
         if path is None:
-            raise AttributeError
+            lgr.debug("path is None. args: %s, kwargs: %s", args, kwargs)
+            raise ValueError("path must not be None")
 
         # Custom handling for few special abbreviations
         path_ = path

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -128,7 +128,7 @@ def test_is_installed(src, path):
 def test_dataset_contructor(path):
     # dataset needs a path
     assert_raises(TypeError, Dataset)
-    assert_raises(AttributeError, Dataset, None)
+    assert_raises(ValueError, Dataset, None)
     dsabs = Dataset(path)
     # always abspath
     ok_(os.path.isabs(dsabs.path))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -77,7 +77,7 @@ from .exceptions import OutdatedExternalDependencyWarning
 from .exceptions import PathKnownToRepositoryError
 from .network import RI, PathRI
 from .network import is_ssh
-from .repo import Flyweight
+from .repo import PathBasedFlyweight
 from .repo import RepoInterface
 
 # shortcuts
@@ -547,7 +547,7 @@ class GitPythonProgressBar(RemoteProgress):
         self._pbar.refresh()
 
 
-@add_metaclass(Flyweight)
+@add_metaclass(PathBasedFlyweight)
 class GitRepo(RepoInterface):
     """Representation of a git repository
 
@@ -564,35 +564,6 @@ class GitRepo(RepoInterface):
     # Begin Flyweight:
 
     _unique_instances = WeakValueDictionary()
-
-    @classmethod
-    def _flyweight_id_from_args(cls, *args, **kwargs):
-
-        if args:
-            # to a certain degree we need to simulate an actual call to __init__
-            # and make sure, passed arguments are fitting:
-            # TODO: Figure out, whether there is a cleaner way to do this in a
-            # generic fashion
-            assert('path' not in kwargs)
-            path = args[0]
-            args = args[1:]
-        elif 'path' in kwargs:
-            path = kwargs.pop('path')
-        else:
-            raise TypeError("__init__() requires argument `path`")
-
-        if path is None:
-            raise AttributeError
-
-        # Sanity check for argument `path`:
-        # raise if we cannot deal with `path` at all or
-        # if it is not a local thing:
-        path = RI(path).localpath
-        # resolve symlinks to make sure we have exactly one instance per
-        # physical repository at a time
-        path = realpath(path)
-        kwargs['path'] = path
-        return path, args, kwargs
 
     @classmethod
     def _flyweight_invalid(cls, id_):

--- a/datalad/support/repo.py
+++ b/datalad/support/repo.py
@@ -88,7 +88,7 @@ class Flyweight(type):
         hashable, args, kwargs
           id, optionally manipulated args and kwargs to be passed to __init__
         """
-        pass
+        raise NotImplementedError
 
     def _flyweight_invalid(cls, id):
         """determines whether or not an instance with `id` became invalid and

--- a/datalad/support/repo.py
+++ b/datalad/support/repo.py
@@ -168,7 +168,6 @@ class Flyweight(type):
 
 class PathBasedFlyweight(Flyweight):
 
-    @classmethod
     def _flyweight_preproc_path(cls, path):
         """perform any desired path preprocessing (e.g., aliases)
 
@@ -176,7 +175,6 @@ class PathBasedFlyweight(Flyweight):
         """
         return path
 
-    @classmethod
     def _flyweight_postproc_path(cls, path):
         """perform any desired path post-processing (e.g., dereferencing etc)
 
@@ -188,7 +186,6 @@ class PathBasedFlyweight(Flyweight):
         # physical repository at a time
         return op.realpath(path)
 
-    @classmethod
     def _flyweight_id_from_args(cls, *args, **kwargs):
 
         if args:


### PR DESCRIPTION
We had to almost identical copies of the code for `_flyweight_id_from_args`.
That can breed bugs having fixes in one copy but not another.  I have decided
to go superclass subclassing path so we could also "modularize" the logic for
handling aliases (ATM only for the datasets).
    
I have taken implementation from  Dataset, which did not explicitly
"realpath" the path.  Not sure yet if such difference in behavior (Dataset vs *Repo)
was intended/desired, tests might show

- [x] make sure no notable hit on benchmarks
- [x] decide on that `realpath` handling
- Sits on top of #3986 
- TODO: For the merge in master, conflict resolution should add handling of yet another piece of seems duplicate path handling/conversion:
```diff
+        # mirror what is happening in __init__
+        if isinstance(path, ut.PurePath):
+            path = str(path)
```