### PR TITLE
BF: update -- do not save if no --merge, use save instead of Dataset(refds_path).add

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -104,6 +104,19 @@ def test_update_simple(origin, src_path, dst_path):
     dest.repo.get_file_key("update.txt")  # raises if unknown
     eq_([False], dest.repo.file_has_content(["update.txt"]))
 
+    # test that update doesn't crash if we specify only a single path (submod) to
+    # operate on
+    with chpwd(dest.path):
+        assert_result_count(
+            update(path=['subm 1'], recursive=True), 1,
+            status='ok', type='dataset')
+
+        # and with merge we would also try to save (but there would be no changes)
+        res_merge = update(path=['subm 1'], recursive=True, merge=True)
+        assert_result_count(res_merge, 2)
+        assert_in_results(res_merge, action='update', status='ok', type='dataset')
+        assert_in_results(res_merge, action='save', status='notneeded', type='dataset')
+
     # smoke-test if recursive update doesn't fail if submodule is removed
     # and that we can run it from within a dataset without providing it
     # explicitly

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -94,6 +94,7 @@ class Update(Interface):
             reobtain_data=False):
         """
         """
+        from datalad.api import save
         if fetch_all is not None:
             lgr.warning('update(fetch_all=...) called. Option has no effect, and will be removed')
 
@@ -186,15 +187,18 @@ class Update(Interface):
             res['status'] = 'ok'
             yield res
             save_paths.append(ap['path'])
-        if recursive:
+        # we need to save updated states only if merge was requested -- otherwise
+        # it was a pure fetch
+        if merge and recursive:
             save_paths = [p for p in save_paths if p != refds_path]
             if not save_paths:
                 return
             lgr.debug(
                 'Subdatasets where updated state may need to be '
                 'saved in the parent dataset: %s', save_paths)
-            for r in Dataset(refds_path).add(
+            for r in save(
                     path=save_paths,
+                    dataset=refds_path,
                     recursive=False,
                     message='[DATALAD] Save updated subdatasets'):
                 yield r


### PR DESCRIPTION
`refds_path` could be empty if dataset is not specified but path (to subdataset) is provided

Note that it would change existing behavior -- apparently we could have been saving some prior changes if there were some before running `update`.  I would consider that also to be a bug fix

Fixes #3097 
ref: https://github.com/templateflow/templateflow/issues/5

TODOs (after merge)
- merge/adjust for `master` way of things