### PR TITLE
DOC: Automatically add current year to copyright notice

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import shlex
+import datetime
 from os.path import join as opj, exists
 from os import pardir
 from glob import glob
@@ -95,8 +96,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
+current_year = datetime.datetime.now().year
 project = u'DataLad'
-copyright = u'2016-2019, DataLad team'
+copyright = (u'2016-{}, DataLad team').format(current_year)
 author = u'DataLad team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-import shlex
 import datetime
 from os.path import join as opj, exists
 from os import pardir


### PR DESCRIPTION
I noticed that the copyright notice on [docs.datalad.org](http://docs.datalad.org/en/latest/index.html) says 2016-2019. This change automatically adds the current year.

While I did this, I noticed an unused import (shlex), and removed it as well.