### PR TITLE
BF: do not add [Default: ...] for --help if it is a flag (action="store_...")

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -574,7 +574,9 @@ class Interface(object):
                 # showing the Default: (likely boolean).
                 #   See https://github.com/datalad/datalad/issues/3203
                 if not parser_kwargs.get('action', '').startswith('store_'):
-                    help += " [Default: %r]" % (defaults[defaults_idx],)
+                    # [Default: None] also makes little sense for cmdline
+                    if defaults[defaults_idx] is not None:
+                        help += " [Default: %r]" % (defaults[defaults_idx],)
             # create the parameter, using the constraint instance for type
             # conversion
             parser.add_argument(*parser_args, help=help,

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -570,7 +570,11 @@ class Interface(object):
                     cdoc = cdoc[1:-1]
                 help += '  Constraints: %s' % cdoc
             if defaults_idx >= 0:
-                help += " [Default: %r]" % (defaults[defaults_idx],)
+                # if it is a flag, in commandline it makes little sense to show
+                # showing the Default: (likely boolean).
+                #   See https://github.com/datalad/datalad/issues/3203
+                if not parser_kwargs.get('action', '').startswith('store_'):
+                    help += " [Default: %r]" % (defaults[defaults_idx],)
             # create the parameter, using the constraint instance for type
             # conversion
             parser.add_argument(*parser_args, help=help,


### PR DESCRIPTION
Closes #3203 

Or there could be a flag without `action="store_..."`, or some `store_` wouldn't be a flag?

I  found no other conveniently available unittesting setup to test this change.  Any pointers or assistance would be appreciated