### PR TITLE
Towards supporting access to RIA stores in clone()

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -734,20 +734,6 @@ def decode_source_spec(spec, cfg=None):
         props['giturl'] = source_ri.as_git_url()
     elif isinstance(source_ri, URL) and source_ri.scheme.startswith('ria+'):
         # parse a RIA URI
-        # check for store related configuration for SSH access
-        if source_ri.scheme == 'ria+ssh':
-            # we support the scenario were hostname is just a label for a config
-            # not an actual hostname
-            hostname = cfg.get(
-                'annex.ria-remote.{}.ssh-host'.format(source_ri.hostname),
-                source_ri.hostname)
-            basepath = cfg.get(
-                'annex.ria-remote.{}.base-path'.format(source_ri.hostname),
-                '')
-        else:
-            hostname = source_ri.hostname
-            basepath = ''
-
         dsid, version = source_ri.fragment.split('@', maxsplit=1) \
             if '@' in source_ri.fragment else (source_ri.fragment, None)
         uuid_regex = r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}'
@@ -760,11 +746,9 @@ def decode_source_spec(spec, cfg=None):
         # strip the custom protocol and go with standard one
         source_ri.scheme = source_ri.scheme[4:]
         # take any existing path, and add trace to dataset within the store
-        source_ri.path = '{urlpath}{urldelim}{basepath}{basedelim}{trace}'.format(
+        source_ri.path = '{urlpath}{urldelim}{trace}'.format(
             urlpath=source_ri.path if source_ri.path else '',
             urldelim='' if not source_ri.path or source_ri.path.endswith('/') else '/',
-            basepath=basepath,
-            basedelim='' if not basepath or basepath.endswith('/') else '/',
             trace='{}/{}'.format(dsid[:3], dsid[3:]),
         )
         props.update(

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -214,7 +214,7 @@ class Clone(Interface):
             action='install',
             logger=lgr,
             refds=refds_path,
-            source_url=source['giturl'])
+            source_url=source['source'])
 
         try:
             # this will implicitly cause pathlib to run a bunch of checks

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -675,6 +675,9 @@ def decode_source_spec(spec):
         # parse a RIA URI
         dsid, version = source_ri.fragment.split('@', maxsplit=1) \
             if '@' in source_ri.fragment else (source_ri.fragment, None)
+        uuid_regex = r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}'
+        if not re.match(uuid_regex, dsid):
+            raise ValueError('RIA URI does not contain a valid dataset ID: {}'.format(spec))
         props.update(
             type='ria',
             giturl='{}://{}{}{}/{}'.format(

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -759,12 +759,9 @@ def decode_source_spec(spec, cfg=None):
         )
     else:
         # let's assume that anything else is a URI that Git can handle
-        # TODO are there any advantages of going through a URL-reconversion
-        # by the RI instance, instead of using the original input right away?
-        # it feels like we could only accumulate bugs. Keeping how it was,
-        # for now...
         props['type'] = 'giturl'
-        props['giturl'] = str(source_ri)
+        # use original input verbatim
+        props['giturl'] = spec
 
     if 'default_destpath' not in props:
         # if we still have no good idea on where a dataset could be cloned to if no

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -84,16 +84,23 @@ class Clone(Interface):
 
     Primary differences over a direct `git clone` call are 1) the automatic
     initialization of a dataset annex (pure Git repositories are equally
-    supported); 2) automatic registration of the newly obtained dataset
-    as a subdataset (submodule), if a parent dataset is specified; and
-    3) support for datalad's resource identifiers and automatic configurable
-    generation of alternative access URL for common cases (such as appending
-    '.git' to the URL in case the accessing the base URL failed).
+    supported); 2) automatic registration of the newly obtained dataset as a
+    subdataset (submodule), if a parent dataset is specified; and 3) support
+    for additional resource identifiers (DataLad resource identifiers as used
+    on datasets.datalad.org, and RIA store URLs as used for store.datalad.org;
+    see examples); and 4) automatic configurable generation of alternative
+    access URL for common cases (such as appending '.git' to the URL in case
+    the accessing the base URL failed).
 
     || PYTHON >>By default, the command returns a single Dataset instance for
     an installed dataset, regardless of whether it was newly installed ('ok'
     result), or found already installed from the specified source ('notneeded'
     result).<< PYTHON ||
+
+    .. seealso::
+
+      http://handbook.datalad.org/en/latest/usecases/datastorage_for_institutions.html
+        More information on Remote Indexed Archive (RIA) stores
     """
     # by default ignore everything but install results
     # i.e. no "add to super dataset"
@@ -125,6 +132,12 @@ class Clone(Interface):
              "source='https://github.com/datalad-datasets/longnow-podcasts.git')",
              code_cmd="datalad clone -d . "
              "--source='https://github.com/datalad-datasets/longnow-podcasts.git'"),
+        dict(text="Install the main superdataset from datasets.datalad.org",
+             code_py="clone(source='///')",
+             code_cmd="datalad clone ///"),
+        dict(text="Install a dataset identified by its ID from store.datalad.org",
+             code_py="clone(source='ria+http://store.datalad.org#76b6ca66-36b1-11ea-a2e6-f0d5bf7b5561')",
+             code_cmd="datalad clone ria+http://store.datalad.org#76b6ca66-36b1-11ea-a2e6-f0d5bf7b5561"),
     ]
 
     _params_ = dict(

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -62,7 +62,6 @@ from datalad.distribution.dataset import (
     EnsureDataset,
 )
 from datalad.distribution.utils import (
-    _get_git_url_from_source,
     _get_flexible_source_candidates,
 )
 
@@ -636,3 +635,22 @@ def _get_installationpath_from_url(url):
     if path.endswith('.git'):
         path = path[:-4]
     return path
+
+
+def _get_git_url_from_source(source):
+    """Return URL for cloning associated with a source specification
+
+    For now just resolves DataLadRIs
+    """
+    # TODO: Probably RF this into RI.as_git_url(), that would be overridden
+    # by subclasses or sth. like that
+    if not isinstance(source, RI):
+        source_ri = RI(source)
+    else:
+        source_ri = source
+    if isinstance(source_ri, DataLadRI):
+        # we have got our DataLadRI as the source, so expand it
+        source = source_ri.as_git_url()
+    else:
+        source = str(source_ri)
+    return source

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -671,6 +671,20 @@ def decode_source_spec(spec):
         # we have got our DataLadRI as the source, so expand it
         props['type'] = 'dataladri'
         props['giturl'] = source_ri.as_git_url()
+    elif isinstance(source_ri, URL) and source_ri.scheme.startswith('ria+'):
+        # parse a RIA URI
+        dsid, version = source_ri.fragment.split('@', maxsplit=1) \
+            if '@' in source_ri.fragment else (source_ri.fragment, None)
+        props.update(
+            type='ria',
+            giturl='{}://{}{}{}/{}'.format(
+                source_ri.scheme[4:],
+                source_ri.hostname,
+                ':' if source_ri.scheme == 'ria+ssh' else '/',
+                dsid[:3],
+                dsid[3:]),
+            version=version
+        )
     else:
         # let's assume that anything else is a URI that Git can handle
         # TODO are there any advantages of going through a URL-reconversion

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -693,11 +693,12 @@ def decode_source_spec(spec):
             raise ValueError('RIA URI does not contain a valid dataset ID: {}'.format(spec))
         props.update(
             type='ria',
-            giturl='{proto}://{host}{delim}{basepath}{id1}/{id2}'.format(
+            giturl='{proto}://{host}{delim}{basepath}{pathdelim}{id1}/{id2}'.format(
                 proto=source_ri.scheme[4:],
                 host=hostname,
                 delim=':' if source_ri.scheme == 'ria+ssh' else '/',
                 basepath=basepath,
+                pathdelim='/' if basepath else '',
                 id1=dsid[:3],
                 id2=dsid[3:]),
             version=version,

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -550,3 +550,5 @@ def test_decode_source_spec():
                 version=version,
                 type='ria')
         )
+    # not a dataset UUID
+    assert_raises(ValueError, decode_source_spec, 'ria+http://example.com#123')

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -70,6 +70,9 @@ from datalad.core.distributed.clone import (
 )
 from datalad.distribution.dataset import Dataset
 
+# this is the dataset ID of our test dataset in the main datalad RIA store
+datalad_store_testds_id = '76b6ca66-36b1-11ea-a2e6-f0d5bf7b5561'
+
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -555,3 +558,12 @@ def test_decode_source_spec():
         )
     # not a dataset UUID
     assert_raises(ValueError, decode_source_spec, 'ria+http://example.com#123')
+
+
+@skip_if_no_network
+@with_tempfile()
+def test_ria_http(path):
+    # can we clone from the store w/o any dedicated config
+    ds = clone('ria+http://store.datalad.org#{}'.format(datalad_store_testds_id), path)
+    ok_(ds.is_installed())
+    eq_(ds.id, datalad_store_testds_id)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -509,7 +509,7 @@ def test_decode_source_spec():
     # resolves datalad RIs:
     eq_(decode_source_spec('///subds'),
         dict(source='///subds', giturl=consts.DATASETS_TOPURL + 'subds', version=None,
-             type='dataladri'))
+             type='dataladri', default_destpath='subds'))
     assert_raises(NotImplementedError, decode_source_spec,
                   '//custom/subds')
 
@@ -523,7 +523,9 @@ def test_decode_source_spec():
             'ssh://somewhe.re/else',
             'git://github.com/datalad/testrepo--basic--r1',
     ):
-        eq_(decode_source_spec(url), dict(source=url, version=None, giturl=url, type='giturl'))
+        props = decode_source_spec(url)
+        dest = props.pop('default_destpath')
+        eq_(props, dict(source=url, version=None, giturl=url, type='giturl'))
 
     # RIA URIs with and without version specification
     dsid = '6d69ca68-7e85-11e6-904c-002590f97d84'
@@ -548,6 +550,7 @@ def test_decode_source_spec():
                     dsid[:3],
                     dsid[3:]),
                 version=version,
+                default_destpath=dsid,
                 type='ria')
         )
     # not a dataset UUID

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -546,10 +546,9 @@ def test_decode_source_spec():
         eq_(decode_source_spec(spec),
             dict(
                 source=spec,
-                giturl='{}://{}{}{}/{}'.format(
+                giturl='{}://{}/{}/{}'.format(
                     proto,
                     loc,
-                    ':' if proto == 'ssh' else '/',
                     dsid[:3],
                     dsid[3:]),
                 version=version,

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -524,3 +524,29 @@ def test_decode_source_spec():
             'git://github.com/datalad/testrepo--basic--r1',
     ):
         eq_(decode_source_spec(url), dict(source=url, version=None, giturl=url, type='giturl'))
+
+    # RIA URIs with and without version specification
+    dsid = '6d69ca68-7e85-11e6-904c-002590f97d84'
+    for proto, loc, version in (
+            ('http', 'example.com', None),
+            ('http', 'example.com', 'v1.0'),
+            ('http', 'example.com', 'some_with@in_it'),
+            ('ssh', 'example.com', 'some_with@in_it'),
+    ):
+        spec = 'ria+{}://{}{}{}'.format(
+            proto,
+            loc,
+            '#{}'.format(dsid),
+            '@{}'.format(version) if version else '')
+        eq_(decode_source_spec(spec),
+            dict(
+                source=spec,
+                giturl='{}://{}{}{}/{}'.format(
+                    proto,
+                    loc,
+                    ':' if proto == 'ssh' else '/',
+                    dsid[:3],
+                    dsid[3:]),
+                version=version,
+                type='ria')
+        )

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -71,7 +71,7 @@ from datalad.utils import _path_
 from datalad.utils import rmtree
 
 from ..dataset import Dataset
-from ..utils import _get_git_url_from_source
+from datalad.core.distributed.clone import _get_git_url_from_source
 
 ###############
 # Test helpers:

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -26,7 +26,6 @@ from datalad.utils import getpwd
 from datalad.api import create
 from datalad.api import install
 from datalad.api import get
-from datalad import consts
 from datalad.utils import chpwd
 from datalad.utils import on_windows
 from datalad.support import path as op
@@ -71,33 +70,10 @@ from datalad.utils import _path_
 from datalad.utils import rmtree
 
 from ..dataset import Dataset
-from datalad.core.distributed.clone import _get_git_url_from_source
 
 ###############
 # Test helpers:
 ###############
-
-
-def test_get_git_url_from_source():
-
-    # resolves datalad RIs:
-    eq_(_get_git_url_from_source('///subds'), consts.DATASETS_TOPURL + 'subds')
-    assert_raises(NotImplementedError, _get_git_url_from_source,
-                  '//custom/subds')
-
-    # doesn't harm others:
-    eq_(_get_git_url_from_source('http://example.com'), 'http://example.com')
-    eq_(_get_git_url_from_source('/absolute/path'), '/absolute/path')
-    eq_(_get_git_url_from_source('file://localhost/some'),
-        'file://localhost/some')
-    eq_(_get_git_url_from_source('localhost/another/path'),
-        'localhost/another/path')
-    eq_(_get_git_url_from_source('user@someho.st/mydir'),
-        'user@someho.st/mydir')
-    eq_(_get_git_url_from_source('ssh://somewhe.re/else'),
-        'ssh://somewhe.re/else')
-    eq_(_get_git_url_from_source('git://github.com/datalad/testrepo--basic--r1'),
-        'git://github.com/datalad/testrepo--basic--r1')
 
 
 @with_tree(tree={'file.txt': '123'})

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -26,25 +26,6 @@ from datalad.support.network import PathRI
 lgr = logging.getLogger('datalad.distribution.utils')
 
 
-def _get_git_url_from_source(source):
-    """Return URL for cloning associated with a source specification
-
-    For now just resolves DataLadRIs
-    """
-    # TODO: Probably RF this into RI.as_git_url(), that would be overridden
-    # by subclasses or sth. like that
-    if not isinstance(source, RI):
-        source_ri = RI(source)
-    else:
-        source_ri = source
-    if isinstance(source_ri, DataLadRI):
-        # we have got our DataLadRI as the source, so expand it
-        source = source_ri.as_git_url()
-    else:
-        source = str(source_ri)
-    return source
-
-
 def _get_flexible_source_candidates(src, base_url=None, alternate_suffix=True):
     """Get candidates to try cloning from.
 


### PR DESCRIPTION
- [x] generalize existing URL normalization function to a helper to decode more it less arbitrary specifications to git-compatible clone url plus any number of additional properties
- [x] add support for `ria+<protocol>://` URIs
- [x] populated `store.datalad.org` with a test dataset using https://github.com/datalad/git-annex-ria-remote/pull/38. Requires the client-side setup described below and then:
   - `datalad create test`
   - `datalad -d test create-sibling-ria storedataladorg`

   Result now sitting at `http://store.datalad.org/76b/6ca66-36b1-11ea-a2e6-f0d5bf7b5561`
- [x] make `datalad clone ria+http://store.datalad.org#76b6ca66-36b1-11ea-a2e6-f0d5bf7b5561` work
   - for now I had to manually run `git update-server-info` on the server, would a smart http setup on the server help @yarikoptic ?
- [x] make `datalad clone ria+ssh://store.datalad.org#76b6ca66-36b1-11ea-a2e6-f0d5bf7b5561` work
  - only works with additional client-side configuration (see below), because the actual location on the server cannot be inferred from the identifier. This is not a problem, because only people with write access will need to have this, and they already need that for `ria-remote`.
- [x] add tests against `store.datalad.org`
   - [x] clone from http
   - [x] verify required post-clone configuration is in place
- [x] enhance the clone source specification decoding to also suggest a destination path.Often more clever names will be possible then just the basename derived from the final git-clone url
- [x] describe `ria+http|ssh://` URIs in docs
- [x] check that `ria+http` logic can deal with URLs were the store needs a path in addition to the hostname, .e.g. `example.com/mystore#dsid`