### PR TITLE
BF: clone: Revert incorrect relative path adjustment to URLs

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -934,18 +934,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 gr.fsck()
             else:
                 lgr.warning("Experienced issues while cloning: %s", exc_str(fix_annex))
-        # make sure that Git doesn't mangle relative path specification into
-        # mildly obscure absolute paths
-        # https://github.com/datalad/datalad/issues/3538
-        if isinstance(url_ri, PathRI):
-            path = Path(url)
-            if not path.is_absolute():
-                # always in POSIX even on windows
-                path = path.as_posix()
-                if not path.startswith(op.pardir + '/'):
-                    path = posixpath.join(op.curdir, path)
-                gr.config.set('remote.origin.url', path,
-                              where='local', force=True)
         return gr
 
     def __del__(self):


### PR DESCRIPTION
When git clone is called with a local relative path as the URL, it
will prepend the current working directory to the URL to get an
absolute path.  "../" components are retained.  In common DataLad
scenarios (see gh-3538), installing a subdataset using a local path
source can lead to .git/config URLs such as

    url = /tmp/super/../source

A downside of these absolute paths is that they become invalid for
URLs that point within a dataset hierarchy (e.g., "../../source") if
the hierarchy is moved to a different location.  With relative URLs,
the URLs would remain valid as long the relative relationships are
retained.  (On the other hand, absolute paths provide a better
stability when moving datasets if the URLs point outside of the
hierarchy.)

Two recent commits from gh-3966, 02e2b4c46 (BF: Avoid relpath mangling
for submodule url configuration, 2020-01-10) followed up by 0a80bb47e
(BF: submodule relpath must start with ./ or ../, 2020-01-10), tried
to avoid these absolute URLs.  The combined result says "if the URL
given is a local path and is relative, overwrite the configured URL
with that path (prepending ./ if the path doesn't start with ../)".

However, this logic points the URL to the wrong location.  Here are
some examples (similar to the cases the added test):

  * For `git clone a b`, the correct location from _within_ repo b
    would "../a", not "./a".

  * Similarly, for `git clone ../a b`, the correct location would be
    "../../a", not "../a"

  * Calling `git clone a ../b` from $DIR, the correct location would
    "$DIR/a", not "./a".

An alternative approach is needed, but it seems unlikely to have a
quick and obviously correct fix, so let's revert the changes from
02e2b4c46 and 0a80bb47e to avoid these invalid URLs.

Re-opens gh-3538.
