### PR TITLE
BF: Fix clone relpath

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -487,7 +487,6 @@ def test_cfg_originorigin(path):
 
 
 # test fix for gh-2601/gh-3538
-@known_failure
 @with_tempfile()
 def test_relative_submodule_url(path):
     Dataset(op.join(path, 'origin')).create()

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -500,9 +500,27 @@ def test_relative_submodule_url(path):
     ds_cloned.repo.fetch()
 
     subinfo = ds.subdatasets(return_type='item-or-list')
+
+    from datalad.support.network import RI
     eq_(subinfo['gitmodule_url'],
         # must be a relative URL, not platform-specific relpath!
-        '../../origin')
+        '../../origin',
+        msg="XXXXXXXXXXX:\n"
+            "submodule pathobj: %s\n"
+            "submodule path: %s\n"
+            "super pathobj: %s\n"
+            "super path: %s\n"
+            "\n"
+            "original ds path: %s\n"
+            "RI(path).localpath: %s\n"
+            "realpath(path): %s\n" %
+            (str(Dataset(op.join(path, 'ds', 'sources')).repo.pathobj),
+             Dataset(op.join(path, 'ds', 'sources')).repo.path,
+             str(ds.repo.pathobj),
+             ds.repo.path,
+             op.join(path, 'origin'),
+             RI(op.join(path, 'origin')).localpath,
+             op.realpath(RI(op.join(path, 'origin')).localpath)))
 
 
 @with_tree(tree={"subdir": {}})

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -944,7 +944,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 # get git-created path
                 git_url = gr.config.get('remote.origin.url')
                 # Note: Not sure, whether there are circumstances where this is relative already
-                if op.isabs(git_url):
+                if posixpath.isabs(git_url):
                     # ... and make it a relative one
                     # Note: Using posixpath here, since pathlib's relative_to isn't what you'd expect
                     git_url_rel = posixpath.relpath(git_url, gr.pathobj.as_posix())

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -937,6 +937,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # make sure that Git doesn't mangle relative path specification into
         # mildly obscure absolute paths
         # https://github.com/datalad/datalad/issues/3538
+        # Note, that POSIX is required even on windows, since it's an URL!
         if isinstance(url_ri, PathRI):
             path = Path(url)
             if not path.is_absolute():
@@ -945,12 +946,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 # Note: Not sure, whether there are circumstances where this is relative already
                 if op.isabs(git_url):
                     # ... and make it a relative one
-                    # Note: Using os.path here, since pathlib's relative_to isn't what you'd expect
-                    git_url = op.relpath(git_url, gr.path)
-                path = Path(git_url)
-                # always in POSIX even on windows
-                path = path.as_posix()
-                gr.config.set('remote.origin.url', path,
+                    # Note: Using posixpath here, since pathlib's relative_to isn't what you'd expect
+                    git_url = posixpath.relpath(git_url, gr.pathobj.as_posix())
+                gr.config.set('remote.origin.url', git_url,
                               where='local', force=True)
         return gr
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -937,19 +937,19 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # make sure that Git doesn't mangle relative path specification into
         # mildly obscure absolute paths
         # https://github.com/datalad/datalad/issues/3538
-        # Note, that POSIX is required even on windows, since it's an URL!
+        # Note, that git reports POSIX paths even on windows. It's an URL after all. Don't mix in native paths.
         if isinstance(url_ri, PathRI):
-            path = Path(url)
-            if not path.is_absolute():
+            url_path = Path(url)
+            if not url_path.is_absolute():
                 # get git-created path
                 git_url = gr.config.get('remote.origin.url')
                 # Note: Not sure, whether there are circumstances where this is relative already
                 if op.isabs(git_url):
                     # ... and make it a relative one
                     # Note: Using posixpath here, since pathlib's relative_to isn't what you'd expect
-                    git_url = posixpath.relpath(git_url, gr.pathobj.as_posix())
-                gr.config.set('remote.origin.url', git_url,
-                              where='local', force=True)
+                    git_url_rel = posixpath.relpath(git_url, gr.pathobj.as_posix())
+                    lgr.debug("Remap origin url from %s to %s", git_url, git_url_rel)
+                    gr.config.set('remote.origin.url', git_url_rel, where='local', force=True)
         return gr
 
     def __del__(self):


### PR DESCRIPTION
Based on @kyleam 's #4025 (Couldn't push to your branch)

Don't actually revert, but (hopefully) fix the issue, by manipulating not the originally given URL, but the one git-clone created. Keeping the revert commit in for its added (and a fixed) test.
