### PR TITLE
MNT: Drop "Choose a base" item from PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,6 @@ Please go through the following checklist before submitting the PR:
 
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
 
-- [ ] Choose a base branch for your PR's topic branch.
-
-  The two branches that are likely candidates are `master` and the maintenance branch `0.11.x`.  Bug fixes that apply to `0.11.x` should usually go there, while everything else can go on top of `master`.
-
-  To choose a base, (1) branch off of that point in your local repository and (2) choose the base branch in the drop-down list when creating the PR on GitHub.
-
 - [ ] **Delete these instructions**. :-)
 
 Thanks for contributing!


### PR DESCRIPTION
The instructions for choosing a PR base are stale.  The 0.12.* series
has been released, and we do not plan to continue to extend the 0.11.*
series.  At this point, there's not a maintenance branch for 0.12.*,
so drop the item entirely rather than updating it.