### PR TITLE
NF: Support cloning of specific repository versions (fixes gh-2109)

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -385,16 +385,25 @@ def clone_dataset(
     )
     error_msgs = OrderedDict()  # accumulate all error messages formatted per each url
     for cand in candidate_sources:
+        log_progress(
+            lgr.info,
+            'cloneds',
+            'Attempting to clone from %s to %s', cand['giturl'], dest_path,
+            update=1,
+            increment=True)
+
+        clone_opts = {}
+
+        if cand.get('version', None):
+            clone_opts['branch'] = cand['version']
         try:
-            log_progress(
-                lgr.info,
-                'cloneds',
-                'Attempting to clone from %s to %s', cand['giturl'], dest_path,
-                update=1,
-                increment=True)
             # TODO for now GitRepo.clone() cannot handle Path instances, and PY35
             # doesn't make it happen seemlessly
-            GitRepo.clone(path=str(dest_path), url=cand['giturl'], create=True)
+            GitRepo.clone(
+                path=str(dest_path),
+                url=cand['giturl'],
+                clone_options=clone_opts,
+                create=True)
 
         except GitCommandError as e:
             error_msgs[cand['giturl']] = e

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -660,6 +660,18 @@ def test_ria_http(lcl, storepath, url):
         eq_(riaclone2.repo.get_hexsha(), ds.repo.get_hexsha())
         neq_(riaclone2.repo.get_hexsha(), riaclone_orig.repo.get_hexsha())
 
+    # attempt to clone a version that doesn't exist
+    res = clone(
+        'ria+{}#{}@impossible'.format(url, ds.id),
+        lcl / 'clone_failed',
+        on_failure='ignore',
+        result_xfm=None,
+        return_type='list',
+    )
+    # ATM we have no meaningful error messages, see
+    # https://github.com/datalad/datalad/pull/4036#issue-364002705
+    assert_status('error', res)
+
 
 @skip_if_no_network
 @with_tempfile()

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -629,7 +629,9 @@ def test_ria_http(lcl, storepath, url):
     # fashion
     for origds, cloneds in ((ds, riaclone), (subds, riaclonesub)):
         eq_(origds.id, cloneds.id)
-        eq_(origds.repo.get_hexsha(), cloneds.repo.get_hexsha())
+        if not ds.repo.is_managed_branch():
+            # test logic cannot handle adjusted branches
+            eq_(origds.repo.get_hexsha(), cloneds.repo.get_hexsha())
         ok_(cloneds.config.get('remote.origin.url').startswith(url))
         eq_(cloneds.config.get('remote.origin.annex-ignore'), 'true')
         eq_(cloneds.config.get('datalad.get.subdataset-source-candidate-origin'),
@@ -650,11 +652,13 @@ def test_ria_http(lcl, storepath, url):
         'ria+{}#{}@{}'.format(url, ds.id, 'original'),
         lcl / 'clone_orig',
     )
-    # we got the precise version we wanted
-    eq_(riaclone.repo.get_hexsha(), riaclone_orig.repo.get_hexsha())
-    # and not the latest
-    eq_(riaclone2.repo.get_hexsha(), ds.repo.get_hexsha())
-    neq_(riaclone2.repo.get_hexsha(), riaclone_orig.repo.get_hexsha())
+    if not ds.repo.is_managed_branch():
+        # test logic cannot handle adjusted branches
+        # we got the precise version we wanted
+        eq_(riaclone.repo.get_hexsha(), riaclone_orig.repo.get_hexsha())
+        # and not the latest
+        eq_(riaclone2.repo.get_hexsha(), ds.repo.get_hexsha())
+        neq_(riaclone2.repo.get_hexsha(), riaclone_orig.repo.get_hexsha())
 
 
 @skip_if_no_network

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -890,7 +890,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                         # tailored list of "multi options" to make a future
                         # non-GitPy based implementation easier. Do conversion
                         # here
-                        multi_options=to_options(**clone_options),
+                        multi_options=to_options(**clone_options) if clone_options else None,
                         odbt=default_git_odbt,
                         progress=git_progress
                     )

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -804,7 +804,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         return self._repo
 
     @classmethod
-    def clone(cls, url, path, *args, **kwargs):
+    def clone(cls, url, path, *args, clone_options=None, **kwargs):
         """Clone url into path
 
         Provides workarounds for known issues (e.g.
@@ -814,6 +814,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ----------
         url : str
         path : str
+        clone_options : dict
+          Key/value pairs of arbitrary options that will be passed on to the
+          underlying call to `git-clone`.
         expect_fail : bool
           Whether expect that command might fail, so error should be logged then
           at DEBUG level instead of ERROR
@@ -883,6 +886,11 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                     repo = gitpy.Repo.clone_from(
                         url, path,
                         env=env,
+                        # we accept a plain dict with options, and not a gitpy
+                        # tailored list of "multi options" to make a future
+                        # non-GitPy based implementation easier. Do conversion
+                        # here
+                        multi_options=to_options(**clone_options),
                         odbt=default_git_odbt,
                         progress=git_progress
                     )


### PR DESCRIPTION
`GitRepo.clone()` is enhanced to accept arbitrary additional options
that are passed on to `git-clone`. We use the `--branch` option
(that, despite its name, can handle any relevant version identifier)
to let `git-clone` do all the work.

`datalad-clone` is now set up to acknowledge a request for a particular
version, for any kind of source URL where `decode_source_spec()`
yields a non-None `version` property.

At the moment this is only the case for `ria+http|ssh://` URL, but
future additions only need to alter/enhance `decode_source_spec()`
to extend this functionality for other types.

This change also sets the stage for gh-4035

The user experience of this new feature is negatively impacted by #4038.