### PR TITLE
NF: Clone of subdatasets uses reckless mode of superdataset (fixes gh-4030)

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -174,11 +174,6 @@ class Clone(Interface):
             dataset=None,
             description=None,
             reckless=None):
-        # legacy compatibility
-        if reckless is True:
-            # so that we can forget about how things used to be
-            reckless = 'auto'
-
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
         # Otherwise path will be resolved first.
@@ -186,6 +181,16 @@ class Clone(Interface):
             dataset, check_installed=True, purpose='cloning') \
             if dataset is not None else dataset
         refds_path = ds.path if ds else None
+
+        # legacy compatibility
+        if reckless is True:
+            # so that we can forget about how things used to be
+            reckless = 'auto'
+        if reckless is None and ds:
+            # if reckless is not explicitly given, but we operate on a
+            # superdataset, query whether it has been instructed to operate
+            # in a reckless mode, and inherit it for the coming clone
+            reckless = ds.config.get('datalad.clone.reckless', None)
 
         if isinstance(source, Dataset):
             source = source.path
@@ -535,7 +540,15 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
         lgr.debug(
             "Instruct annex to hardlink content in %s from local "
             "sources, if possible (reckless)", ds.path)
-        ds.config.add(
+        if reckless:
+            # store the reckless setting in the dataset to make it
+            # known to later clones of subdatasets via get()
+            ds.config.set(
+                'datalad.clone.reckless', reckless,
+                where='local',
+                # delay reload until all config IO is done
+                reload=False)
+        ds.config.set(
             'annex.hardlink', 'true', where='local', reload=True)
 
     # we have just cloned the repo, so it has 'origin', configure any

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -320,11 +320,18 @@ def test_failed_clone(dspath):
 
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
-def test_reckless(path, top_path):
-    ds = clone(path, top_path, reckless=True,
+def test_reckless(src, top_path):
+    ds = clone(src, top_path, reckless=True,
                result_xfm='datasets', return_type='item-or-list')
     eq_(ds.config.get('annex.hardlink', None), 'true')
+    # actual value is 'auto', because True is a legacy value and we map it
+    eq_(ds.config.get('datalad.clone.reckless', None), 'auto')
     eq_(ds.repo.repo_info()['untrusted repositories'][0]['here'], True)
+    # now, if we clone another repo into this one, it will inherit the setting
+    # without having to provide it explicitly
+    sub = ds.clone(src, 'sub', result_xfm='datasets', return_type='item-or-list')
+    eq_(sub.config.get('datalad.clone.reckless', None), 'auto')
+    eq_(sub.config.get('annex.hardlink', None), 'true')
 
 
 @with_tempfile

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -137,7 +137,9 @@ reckless_opt = Parameter(
     risk the data integrity (e.g. hardlink files from a local clone
     of the dataset). Use with care, and limit to "read-only" use
     cases. With this flag the installed dataset will be marked as
-    untrusted.""")
+    untrusted. The reckless mode is stored in a dataset's local
+    configuration under 'datalad.clone.reckless', and will be inherited
+    to any of its subdatasets.""")
 
 jobs_opt = Parameter(
     args=("-J", "--jobs"),


### PR DESCRIPTION
If `--reckless` is given, the label is stored verbatim under config
variable `datalad.clone.reckless`. `clone()` consults this variable
whenever `--reckless` is None.

As a consequence of this change, subdatasets will inherit any reckless
mode.

Obviously, this also makes it possible to provide global configuration
to force a particular reckless mode for any cloned dataset.