### PR TITLE
7z-based (optional) replacement for patool

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -22,6 +22,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install ".[devel-docs]"
+        sudo apt-get install p7zip
     - name: Build docs
       run: |
         make -C docs html doctest;

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,6 +218,8 @@ before_install:
 install:
   # Install standalone build of git-annex for the recent enough version
   - travis_retry sudo eatmydata apt-get install zip pandoc p7zip-full
+  # needed for tests of patool compression fall-back solution
+  - travis_retry sudo eatmydata apt-get install xz-utils
   - travis_retry sudo eatmydata apt-get install shunit2
   # for metadata support
   - travis_retry sudo eatmydata apt-get install exempi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,8 +104,8 @@ test_script:
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates"
   # remaining fails: test_annexrepo test_digests test_locking test_repodates test_sshrun 
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_ datalad.support.tests.test_gitrepo"
-  # remaining fails: test__main__ test_archives test_cmd test_log  test_protocols test_test_utils test_auto
-  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos"
+  # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives"
 
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.ui"
   

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -57,7 +57,8 @@ def test_download_url_existing_dir_no_slash_exception(path):
         res = download_url('url', path="dir", save=False, on_failure='ignore')
         assert_result_count(res, 1, status='error')
         assert_message("Non-directory path given (no trailing separator) "
-                       "but a directory with that name exists",
+                       "but a directory with that name (after adding "
+                       "archive suffix) exists",
                        res)
 
 

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""patool based implementation for datalad.support.archives utilities"""
+"""7-zip based implementation for datalad.support.archives utilities"""
 
 
 # TODO Disabled for now due to https://github.com/datalad/datalad/issues/4047

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -8,6 +8,13 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """patool based implementation for datalad.support.archives utilities"""
 
+from .external_versions import external_versions
+external_versions.check(
+    "cmd:7z",
+    msg='The 7z binary (7-Zip) is required for archive handling, but is missing. '
+        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
+        "alternative implementation that may no need 7z.")
+
 from shlex import quote as quote_filename
 from datalad.utils import (
     Path,

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -86,7 +86,7 @@ def compress_files(files, archive, path=None, overwrite=True):
                     apath)
             )
     if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
-        cmd = '7z u .tar -so -- {} | 7z u -si {}'.format(
+        cmd = '7z u .tar -so -- {} | 7z u -si -- {}'.format(
             ' '.join(quote_filename(f) for f in files),
             quote_filename(str(apath)),
         )

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -9,13 +9,12 @@
 """7-zip based implementation for datalad.support.archives utilities"""
 
 
-# TODO Disabled for now due to https://github.com/datalad/datalad/issues/4047
-#from datalad.support.external_versions import external_versions
-#external_versions.check(
-#    "cmd:7z",
-#    msg='The 7z binary (7-Zip) is required for archive handling, but is missing. '
-#        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
-#        "alternative implementation that may no need 7z.")
+from datalad.support.external_versions import external_versions
+external_versions.check(
+    "cmd:7z",
+    msg='The 7z binary (7-Zip) is required for archive handling, but is missing. '
+        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
+        "alternative implementation that may no need 7z.")
 
 # TODO make common helper
 # https://github.com/datalad/datalad/issues/4048

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -1,0 +1,76 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""patool based implementation for datalad.support.archives utilities"""
+
+from shlex import quote as quote_filename
+from datalad.utils import (
+    Path,
+)
+
+import logging
+lgr = logging.getLogger('datalad.support.archive_utils_7z')
+
+from datalad.cmd import Runner
+
+
+def decompress_file(archive, dir_):
+    """Decompress `archive` into a directory `dir_`
+
+    This is an alternative implementation without patool, but directly calling 7z.
+
+    Parameters
+    ----------
+    archive: str
+    dir_: str
+    """
+    apath = Path(archive)
+    runner = Runner(cwd=dir_)
+    if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
+        # we have a compressed tar file that needs to be fed through the
+        # decompressor first
+        # hangs somehow, do via single string arg
+        #cmd = ['7z', 'x', archive, '-so', '|', '7z', 'x', '-si', '-ttar']
+        cmd = '7z x {} -so | 7z x -si -ttar'.format(quote_filename(archive))
+    else:
+        # fire and forget
+        cmd = ['7z', 'x', archive]
+    runner.run(cmd)
+
+
+def compress_files(files, archive, path=None, overwrite=True):
+    """Compress `files` into an `archive` file
+
+    Parameters
+    ----------
+    files : list of str
+    archive : str
+    path : str
+      Alternative directory under which compressor will be invoked, to e.g.
+      take into account relative paths of files and/or archive
+    overwrite : bool
+      Whether to allow overwriting the target archive file if one already exists
+    """
+    runner = Runner(cwd=path)
+    apath = Path(archive)
+    if apath.exists():
+        if overwrite:
+            apath.unlink()
+        else:
+            raise ValueError(
+                'Target archive {} already exists and overwrite is forbidden'.format(
+                    apath)
+            )
+    if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
+        cmd = '7z u .tar -so -- {} | 7z u -si {}'.format(
+            ' '.join(quote_filename(f) for f in files),
+            quote_filename(str(apath)),
+        )
+    else:
+        cmd = ['7z', 'u', quote_filename(str(apath))] + files
+    runner.run(cmd)

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -16,20 +16,9 @@ external_versions.check(
         "Setting the config flag 'datalad.runtime.use-patool' enabled an "
         "alternative implementation that may no need 7z.")
 
-# TODO make common helper
-# https://github.com/datalad/datalad/issues/4048
-from datalad.utils import on_windows
-if not on_windows:
-    from shlex import quote as quote_filename
-else:
-    def quote_filename(name):
-        # https://stackoverflow.com/a/15262019
-        return '"{}"'.format(
-            name.replace('"', '""')
-        )
-
 from datalad.utils import (
     Path,
+    quote_cmdlinearg,
 )
 
 import logging
@@ -55,7 +44,7 @@ def decompress_file(archive, dir_):
         # decompressor first
         # hangs somehow, do via single string arg
         #cmd = ['7z', 'x', archive, '-so', '|', '7z', 'x', '-si', '-ttar']
-        cmd = '7z x {} -so | 7z x -si -ttar'.format(quote_filename(archive))
+        cmd = '7z x {} -so | 7z x -si -ttar'.format(quote_cmdlinearg(archive))
     else:
         # fire and forget
         cmd = ['7z', 'x', archive]
@@ -87,8 +76,8 @@ def compress_files(files, archive, path=None, overwrite=True):
             )
     if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
         cmd = '7z u .tar -so -- {} | 7z u -si -- {}'.format(
-            ' '.join(quote_filename(f) for f in files),
-            quote_filename(str(apath)),
+            ' '.join(quote_cmdlinearg(f) for f in files),
+            quote_cmdlinearg(str(apath)),
         )
     else:
         cmd = ['7z', 'u', str(apath), '--'] + files

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -72,5 +72,5 @@ def compress_files(files, archive, path=None, overwrite=True):
             quote_filename(str(apath)),
         )
     else:
-        cmd = ['7z', 'u', quote_filename(str(apath))] + files
+        cmd = ['7z', 'u', str(apath), '--'] + files
     runner.run(cmd)

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -8,12 +8,14 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """patool based implementation for datalad.support.archives utilities"""
 
-from .external_versions import external_versions
-external_versions.check(
-    "cmd:7z",
-    msg='The 7z binary (7-Zip) is required for archive handling, but is missing. '
-        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
-        "alternative implementation that may no need 7z.")
+
+# TODO Disabled for now due to https://github.com/datalad/datalad/issues/4047
+#from datalad.support.external_versions import external_versions
+#external_versions.check(
+#    "cmd:7z",
+#    msg='The 7z binary (7-Zip) is required for archive handling, but is missing. '
+#        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
+#        "alternative implementation that may no need 7z.")
 
 from shlex import quote as quote_filename
 from datalad.utils import (

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -17,7 +17,18 @@
 #        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
 #        "alternative implementation that may no need 7z.")
 
-from shlex import quote as quote_filename
+# TODO make common helper
+# https://github.com/datalad/datalad/issues/4048
+from datalad.utils import on_windows
+if not on_windows:
+    from shlex import quote as quote_filename
+else:
+    def quote_filename(name):
+        # https://stackoverflow.com/a/15262019
+        return '"{}"'.format(
+            name.replace('"', '""')
+        )
+
 from datalad.utils import (
     Path,
 )

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -44,7 +44,9 @@ from datalad.utils import (
     get_tempfile_kwargs,
 )
 from datalad import cfg
-if cfg.get('datalad.runtime.use-patool', False):
+from datalad.config import anything2bool
+if cfg.obtain('datalad.runtime.use-patool', default=False,
+              valtype=anything2bool):
     from datalad.support.archive_utils_patool import (
         decompress_file as _decompress_file,
         # other code expects this to be here

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -43,11 +43,19 @@ from datalad.utils import (
     rmtree,
     get_tempfile_kwargs,
 )
-from datalad.support.archive_utils_patool import (
-    decompress_file as _decompress_file,
-    # other code expects this to be here
-    compress_files
-)
+from datalad import cfg
+if cfg.get('datalad.runtime.use-patool', False):
+    from datalad.support.archive_utils_patool import (
+        decompress_file as _decompress_file,
+        # other code expects this to be here
+        compress_files
+    )
+else:
+    from datalad.support.archive_utils_7z import (
+        decompress_file as _decompress_file,
+        # other code expects this to be here
+        compress_files
+    )
 
 lgr = logging.getLogger('datalad.support.archives')
 

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -32,6 +32,7 @@ from datalad.support.path import (
 )
 
 from datalad.support.locking import lock_if_check_fails
+from datalad.support.external_versions import external_versions
 from datalad.consts import ARCHIVES_TEMP_DIR
 from datalad.utils import (
     any_re_search,
@@ -42,11 +43,17 @@ from datalad.utils import (
     rmtemp,
     rmtree,
     get_tempfile_kwargs,
+    on_windows,
 )
 from datalad import cfg
 from datalad.config import anything2bool
-if cfg.obtain('datalad.runtime.use-patool', default=False,
-              valtype=anything2bool):
+
+# fall back on patool, if a functional implementation is available
+# (i.e. not on windows), it is requested, or 7z is not found
+if not on_windows and (
+        cfg.obtain(
+            'datalad.runtime.use-patool', default=False,
+            valtype=anything2bool) or not external_versions['cmd:7z']):
     from datalad.support.archive_utils_patool import (
         decompress_file as _decompress_file,
         # other code expects this to be here

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -11,42 +11,45 @@
 """
 
 import hashlib
-
 import os
 import tempfile
-from .path import (
+from urllib.parse import unquote as urlunquote
+import string
+import random
+import logging
+
+from datalad.support.path import (
     join as opj,
-    exists, abspath, isabs, normpath, relpath, pardir, isdir,
+    exists,
+    abspath,
+    isabs,
+    normpath,
+    relpath,
+    pardir,
+    isdir,
     realpath,
     sep as opsep,
 )
-from urllib.parse import unquote as urlunquote
 
-import string
-import random
-
-from .locking import lock_if_check_fails
-from ..utils import (
+from datalad.support.locking import lock_if_check_fails
+from datalad.consts import ARCHIVES_TEMP_DIR
+from datalad.utils import (
     any_re_search,
-    assure_bytes,
+    ensure_bytes,
+    ensure_unicode,
     unlink,
     rmdir,
+    rmtemp,
+    rmtree,
+    get_tempfile_kwargs,
 )
-
-import logging
-lgr = logging.getLogger('datalad.support.archives')
-
-from ..utils import rmtemp
-from ..consts import ARCHIVES_TEMP_DIR
-from ..utils import rmtree
-from ..utils import get_tempfile_kwargs
-from ..utils import assure_unicode
-
 from datalad.support.archive_utils_patool import (
     decompress_file as _decompress_file,
     # other code expects this to be here
     compress_files
 )
+
+lgr = logging.getLogger('datalad.support.archives')
 
 
 def decompress_file(archive, dir_, leading_directories='strip'):
@@ -89,7 +92,7 @@ def _get_cached_filename(archive):
     """
     #return "%s_%s" % (basename(archive), hashlib.md5(archive).hexdigest()[:5])
     # per se there is no reason to maintain any long original name here.
-    archive_cached = hashlib.md5(assure_bytes(realpath(archive))).hexdigest()[:10]
+    archive_cached = hashlib.md5(ensure_bytes(realpath(archive))).hexdigest()[:10]
     lgr.debug("Cached directory for archive %s is %s", archive, archive_cached)
     return archive_cached
 
@@ -132,7 +135,7 @@ class ArchivesCache(object):
             path = tempfile.mktemp(**get_tempfile_kwargs())
         self._path = path
         self.persistent = persistent
-        # TODO?  assure that it is absent or we should allow for it to persist a bit?
+        # TODO?  ensure that it is absent or we should allow for it to persist a bit?
         #if exists(path):
         #    self._clean_cache()
         self._archives = {}
@@ -144,9 +147,9 @@ class ArchivesCache(object):
                 self._made_path = True
                 os.makedirs(path)
                 lgr.debug("Cache initialized")
-            except:
+            except Exception as e:
                 lgr.error("Failed to initialize cached under %s" % path)
-                raise
+                raise e
         else:
             lgr.debug("Not initiating existing cache for the archives under %s" % self.path)
             self._made_path = False
@@ -307,7 +310,7 @@ class ExtractedArchive(object):
         assert (exists(path))
         # create a stamp
         with open(self.stamp_path, 'wb') as f:
-            f.write(assure_bytes(self._archive))
+            f.write(ensure_bytes(self._archive))
         # assert that stamp mtime is not older than archive's directory
         assert (self.is_extracted)
 
@@ -330,7 +333,7 @@ class ExtractedArchive(object):
         path_len = len(path) + (len(os.sep) if not path.endswith(os.sep) else 0)
         for root, dirs, files in os.walk(path):  # TEMP
             for name in files:
-                yield assure_unicode(opj(root, name)[path_len:])
+                yield ensure_unicode(opj(root, name)[path_len:])
 
     def get_leading_directory(self, depth=None, consider=None, exclude=None):
         """Return leading directory of the content within archive
@@ -396,5 +399,5 @@ class ExtractedArchive(object):
         try:
             if self._persistent:
                 self.clean()
-        except:  # MIH: IOError?
+        except Exception as e:  # MIH: IOError?
             pass

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -157,7 +157,7 @@ class ArchivesCache(object):
                 lgr.debug("Cache initialized")
             except Exception as e:
                 lgr.error("Failed to initialize cached under %s" % path)
-                raise e
+                raise
         else:
             lgr.debug("Not initiating existing cache for the archives under %s" % self.path)
             self._made_path = False

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -104,6 +104,27 @@ def _get_system_ssh_version():
         return None
 
 
+def _get_system_7z_version():
+    """Return version of 7-Zip"""
+    try:
+        out, err = _runner.run(
+            ['7z'], expect_fail=True, expect_stderr=True,
+        )
+        # reporting in variable order across platforms
+        # Linux: 7-Zip [64] 16.02
+        # Windows: 7-Zip 19.00 (x86)
+        pieces = out.strip().split(':', maxsplit=1)[0].strip().split()
+        for p in pieces:
+            # the one with the dot is the version
+            if '.' in p:
+                return p
+        lgr.debug("Could not determine version of 7z: %s", exc_str(exc))
+        return None
+    except CommandError as exc:
+        lgr.debug("Could not determine version of 7z: %s", exc_str(exc))
+        return None
+
+
 class ExternalVersions(object):
     """Helper to figure out/use versions of the externals (modules, cmdline tools, etc).
 
@@ -126,6 +147,7 @@ class ExternalVersions(object):
         'cmd:bundled-git': _get_bundled_git_version,
         'cmd:system-git': _get_system_git_version,
         'cmd:system-ssh': _get_system_ssh_version,
+        'cmd:7z': _get_system_7z_version,
     }
     INTERESTING = (
         'appdirs',
@@ -140,6 +162,7 @@ class ExternalVersions(object):
         'msgpack',
         'mutagen',
         'patool',
+        'cmd:7z',
         'requests',
         'scrapy',
         'wrapt',

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -8,35 +8,34 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import os
-from os.path import join as opj, exists
-
 from unittest.mock import patch
-from .utils import (
-    assert_true, assert_false, eq_,
-    with_tree, with_tempfile, swallow_outputs, on_windows,
+from datalad.tests.utils import (
+    assert_true,
+    assert_false,
+    assert_raises,
+    eq_,
+    with_tree,
+    with_tempfile,
+    swallow_outputs,
+    on_windows,
     ok_file_has_content,
+    ok_generator,
     known_failure_githubci_win,
+    OBSCURE_FILENAME,
+    SkipTest,
 )
-from .utils import assert_equal
 
-from ..dochelpers import exc_str
-from ..support.archives import (
+from datalad.dochelpers import exc_str
+from datalad.support.archives import (
     ArchivesCache,
     compress_files,
     decompress_file,
     ExtractedArchive,
 )
 from datalad.support.archive_utils_patool import unixify_path
-from ..support.exceptions import MissingExternalDependency
-from ..support import path as op
+from datalad.support.exceptions import MissingExternalDependency
+from datalad.support import path as op
 
-from .utils import (
-    assert_in,
-    assert_raises,
-    OBSCURE_FILENAME,
-    ok_generator,
-    SkipTest,
-)
 
 fn_in_archive_obscure = OBSCURE_FILENAME
 fn_archive_obscure = fn_in_archive_obscure.replace('a', 'b')
@@ -72,28 +71,28 @@ if on_windows:
 
 @with_tree(**tree_simplearchive)
 def check_decompress_file(leading_directories, path):
-    outdir = opj(path, 'simple-extracted')
+    outdir = op.join(path, 'simple-extracted')
 
     with swallow_outputs() as cmo:
-        decompress_file(opj(path, fn_archive_obscure_ext), outdir,
+        decompress_file(op.join(path, fn_archive_obscure_ext), outdir,
                         leading_directories=leading_directories)
         eq_(cmo.out, "")
         eq_(cmo.err, "")
 
-    path_archive_obscure = opj(outdir, fn_archive_obscure)
+    path_archive_obscure = op.join(outdir, fn_archive_obscure)
     if leading_directories == 'strip':
-        assert_false(exists(path_archive_obscure))
+        assert_false(op.exists(path_archive_obscure))
         testpath = outdir
     elif leading_directories is None:
-        assert_true(exists(path_archive_obscure))
+        assert_true(op.exists(path_archive_obscure))
         testpath = path_archive_obscure
     else:
         raise NotImplementedError("Dunno about this strategy: %s"
                                   % leading_directories)
 
-    assert_true(exists(opj(testpath, '3.txt')))
-    assert_true(exists(opj(testpath, fn_in_archive_obscure)))
-    with open(opj(testpath, '3.txt')) as f:
+    assert_true(op.exists(op.join(testpath, '3.txt')))
+    assert_true(op.exists(op.join(testpath, fn_in_archive_obscure)))
+    with open(op.join(testpath, '3.txt')) as f:
         eq_(f.read(), '3 load')
 
 
@@ -115,11 +114,11 @@ def check_compress_dir(ext, path, name):
     archive = name + ext
     compress_files([os.path.basename(path)], archive,
                    path=os.path.dirname(path))
-    assert_true(exists(archive))
+    assert_true(op.exists(archive))
     name_extracted = name + "_extracted"
     decompress_file(archive, name_extracted, leading_directories='strip')
-    assert_true(exists(opj(name_extracted, 'empty')))
-    assert_true(exists(opj(name_extracted, 'd1', 'd2', 'f1')))
+    assert_true(op.exists(op.join(name_extracted, 'empty')))
+    assert_true(op.exists(op.join(name_extracted, 'd1', 'd2', 'f1')))
 
 
 @known_failure_githubci_win
@@ -139,7 +138,7 @@ def check_compress_file(ext, annex, path, name):
     archive = name + ext
     compress_files([_filename], archive,
                    path=path)
-    assert_true(exists(archive))
+    assert_true(op.exists(archive))
     if annex:
         # It should work even when file is annexed and is a symlink to the
         # key
@@ -170,34 +169,34 @@ def test_compress_file():
 @known_failure_githubci_win
 @with_tree(**tree_simplearchive)
 def test_ExtractedArchive(path):
-    archive = opj(path, fn_archive_obscure_ext)
+    archive = op.join(path, fn_archive_obscure_ext)
     earchive = ExtractedArchive(archive)
-    assert_false(exists(earchive.path))
+    assert_false(op.exists(earchive.path))
     # no longer the case -- just using hash for now
     # assert_in(os.path.basename(archive), earchive.path)
 
-    fpath = opj(fn_archive_obscure,  # lead directory
-                fn_in_archive_obscure)
+    fpath = op.join(fn_archive_obscure,  # lead directory
+                    fn_in_archive_obscure)
     extracted = earchive.get_extracted_filename(fpath)
-    eq_(extracted, opj(earchive.path, fpath))
-    assert_false(exists(extracted))  # not yet
+    eq_(extracted, op.join(earchive.path, fpath))
+    assert_false(op.exists(extracted))  # not yet
 
     extracted_ = earchive.get_extracted_file(fpath)
     eq_(extracted, extracted_)
-    assert_true(exists(extracted))  # now it should
+    assert_true(op.exists(extracted))  # now it should
 
     extracted_files = earchive.get_extracted_files()
     ok_generator(extracted_files)
     eq_(sorted(extracted_files),
         sorted([
             # ['bbc/3.txt', 'bbc/abc']
-            opj(fn_archive_obscure, fn_in_archive_obscure),
-            opj(fn_archive_obscure, '3.txt')
+            op.join(fn_archive_obscure, fn_in_archive_obscure),
+            op.join(fn_archive_obscure, '3.txt')
         ]))
 
     earchive.clean()
     if not os.environ.get('DATALAD_TESTS_TEMP_KEEP'):
-        assert_false(exists(earchive.path))
+        assert_false(op.exists(earchive.path))
 
 #@with_tree(**tree_simplearchive)
 #@with_tree(**tree_simplearchive)
@@ -209,40 +208,40 @@ def test_ArchivesCache():
     assert_raises(ValueError, ArchivesCache, persistent=True)
     cache = ArchivesCache()  # by default -- non persistent
 
-    archive1_path = opj(path1, fn_archive_obscure_ext)
-    archive2_path = opj(path2, fn_archive_obscure_ext)
+    archive1_path = op.join(path1, fn_archive_obscure_ext)
+    archive2_path = op.join(path2, fn_archive_obscure_ext)
     cached_archive1_path = cache[archive1_path].path
     assert_false(cache[archive1_path].path == cache[archive2_path].path)
     assert_true(cache[archive1_path] is cache[archive1_path])
     cache.clean()
-    assert_false(exists(cached_archive1_path))
-    assert_false(exists(cache.path))
+    assert_false(op.exists(cached_archive1_path))
+    assert_false(op.exists(cache.path))
 
     # test del
     cache = ArchivesCache()  # by default -- non persistent
-    assert_true(exists(cache.path))
+    assert_true(op.exists(cache.path))
     cache_path = cache.path
     del cache
-    assert_false(exists(cache_path))
+    assert_false(op.exists(cache_path))
 
 
 def _test_get_leading_directory(ea, return_value, target_value, kwargs={}):
     with patch.object(ExtractedArchive, 'get_extracted_files', return_value=return_value):
-        assert_equal(ea.get_leading_directory(**kwargs), target_value)
+        eq_(ea.get_leading_directory(**kwargs), target_value)
 
 
 def test_get_leading_directory():
     ea = ExtractedArchive('/some/bogus', '/some/bogus')
     yield _test_get_leading_directory, ea, [], None
     yield _test_get_leading_directory, ea, ['file.txt'], None
-    yield _test_get_leading_directory, ea, ['file.txt', opj('d', 'f')], None
-    yield _test_get_leading_directory, ea, [opj('d', 'f'), opj('d', 'f2')], 'd'
-    yield _test_get_leading_directory, ea, [opj('d', 'f'), opj('d', 'f2')], 'd', {'consider': 'd'}
-    yield _test_get_leading_directory, ea, [opj('d', 'f'), opj('d', 'f2')], None, {'consider': 'dd'}
-    yield _test_get_leading_directory, ea, [opj('d', 'f'), opj('d2', 'f2')], None
-    yield _test_get_leading_directory, ea, [opj('d', 'd2', 'f'), opj('d', 'd2', 'f2')], opj('d', 'd2')
-    yield _test_get_leading_directory, ea, [opj('d', 'd2', 'f'), opj('d', 'd2', 'f2')], 'd', {'depth': 1}
+    yield _test_get_leading_directory, ea, ['file.txt', op.join('d', 'f')], None
+    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('d', 'f2')], 'd'
+    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('d', 'f2')], 'd', {'consider': 'd'}
+    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('d', 'f2')], None, {'consider': 'dd'}
+    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('d2', 'f2')], None
+    yield _test_get_leading_directory, ea, [op.join('d', 'd2', 'f'), op.join('d', 'd2', 'f2')], op.join('d', 'd2')
+    yield _test_get_leading_directory, ea, [op.join('d', 'd2', 'f'), op.join('d', 'd2', 'f2')], 'd', {'depth': 1}
     # with some parasitic files
-    yield _test_get_leading_directory, ea, [opj('d', 'f'), opj('._d')], 'd', {'exclude': ['\._.*']}
-    yield _test_get_leading_directory, ea, [opj('d', 'd1', 'f'), opj('d', '._d'), '._x'], opj('d', 'd1'), {'exclude': ['\._.*']}
+    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('._d')], 'd', {'exclude': ['\._.*']}
+    yield _test_get_leading_directory, ea, [op.join('d', 'd1', 'f'), op.join('d', '._d'), '._x'], op.join('d', 'd1'), {'exclude': ['\._.*']}
 


### PR DESCRIPTION
Sitting on top of #4039 

This is a complete draft implementation of a 7z-based file compression/decompression that should be as capable as the patool-based one.

TODO

- [x] confirm runs on windows (main objective here)
- [x] expand tests for additional archive formats and compressors (prev. tests were fairly minimal)
  - [x] support 7z archives
  - [x] support xz and tar.xz (required to pull in `xz-utils` on travis
  - [x] run entirety of `test_archives.py` on all platforms
- [x] implement fall-back to patool on non-windows platforms
  - [x] requestable via boolean `datalad.runtime.use-patool`config switch
  - [x] transparent fall-back when `7z` is not found/supported (as requested by @yarikoptic) although now we need close inspection of what was actually executed whenever something archive-related fails.
- [x] `wtf` reports `7z` version
- [x] RF if #4050 should land before this or vice versa


Further related TODOs (for subsequent PRs) surfaced by this PR:

- #4048 -> #4050
- add `p7zip` as dependency/recommends to Debian package