### PR TITLE
BF: clone: Account for relative paths when inheriting local origins

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -645,7 +645,7 @@ def configure_origins(cfgds, probeds, label=None):
         # given the clone source is a local dataset, we can have a
         # cheap look at it, and configure its own 'origin' as a remote
         # (if there is any), and benefit from additional annex availability
-        originorigin_ds = Dataset(origin_url)
+        originorigin_ds = Dataset(probeds.pathobj / origin_url)
         originorigin_url = originorigin_ds.config.get('remote.origin.url')
         if originorigin_url:
             yield from cfgds.siblings(

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -472,20 +472,20 @@ def test_cfg_originorigin(path):
     origin = Dataset(path / 'origin').create()
     (origin.pathobj / 'file1.txt').write_text('content')
     origin.save()
-    clone_direct = clone(origin, path / 'clone_direct')
-    clone_clone = clone(clone_direct, path / 'clone_clone')
+    clone_lev1 = clone(origin, path / 'clone_lev1')
+    clone_lev2 = clone(clone_lev1, path / 'clone_lev2')
     # the goal is to be able to get file content from origin without
     # the need to configure it manually
     assert_result_count(
-        clone_clone.get('file1.txt', on_failure='ignore'),
+        clone_lev2.get('file1.txt', on_failure='ignore'),
         1,
         action='get',
         status='ok',
-        path=str(clone_clone.pathobj / 'file1.txt'),
+        path=str(clone_lev2.pathobj / 'file1.txt'),
     )
-    eq_((clone_clone.pathobj / 'file1.txt').read_text(), 'content')
+    eq_((clone_lev2.pathobj / 'file1.txt').read_text(), 'content')
     eq_(
-        Path(clone_clone.siblings(
+        Path(clone_lev2.siblings(
             'query',
             name='origin-2',
             return_type='item-or-list')['url']),

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -492,6 +492,18 @@ def test_cfg_originorigin(path):
         origin.pathobj
     )
 
+    # Clone another level, this time with a relative path. Drop content from
+    # lev2 so that origin is the only place that the file is available from.
+    clone_lev2.drop("file1.txt")
+    with chpwd(path):
+        clone_lev3 = clone('clone_lev2', 'clone_lev3')
+    assert_result_count(
+        clone_lev3.get('file1.txt', on_failure='ignore'),
+        1,
+        action='get',
+        status='ok',
+        path=str(clone_lev3.pathobj / 'file1.txt'))
+
 
 # test fix for gh-2601/gh-3538
 @known_failure


### PR DESCRIPTION
As of 367454e0b (NF: Auto-configure local origin of local origin to
make annex available, 2019-12-29), we check whether origin's URL for a
newly cloned annex dataset points to a local dataset.  If it does, we
add _that_ dataset's origin (if any) to the newly cloned dataset.  And
as of d2a25d090 (ENH: Make configuration of local origin siblings work
recursively, 2020-01-05), we continue walking up the chain of local
origin's until we hit an origin that is not a local path.

However, we create the corresponding dataset instance with the wrong
path when origin is a _relative_ path: it should be relative to the
cloned repository, not the current working directory.  The incorrect
path means that there's no "origin of origin" to find, and an
"origin-N" remote isn't added.

Note that this bug isn't currently very accessible because `git clone`
converts relative paths to absolute ones, and the first attempt to
adjust these back to relative paths (02e2b4c46 and 0a80bb47e) was
reverted in e8c5d7069 (BF: clone: Revert incorrect relative path
adjustment to URLs, 2020-01-14).  But relative paths will be a common
case when the second attempt from gh-4026 lands.