### PR TITLE
Replace shlex.quote() with quote_cmdlinearg()

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -22,8 +22,6 @@ from os.path import normpath
 from os.path import relpath
 from tempfile import mkdtemp
 
-from shlex import quote as shlex_quote
-
 from datalad.core.local.save import Save
 from datalad.distribution.get import Get
 from datalad.distribution.install import Install
@@ -57,6 +55,7 @@ from datalad.utils import chpwd
 from datalad.utils import get_dataset_root
 from datalad.utils import getpwd
 from datalad.utils import SequenceFormatter
+from datalad.utils import quote_cmdlinearg
 
 lgr = logging.getLogger('datalad.core.local.run')
 
@@ -411,7 +410,7 @@ def normalize_command(command):
                 # Strip disambiguation marker. Note: "running from Python API"
                 # FIXME from below applies to this too.
                 command = command[1:]
-            command = " ".join(shlex_quote(c) for c in command)
+            command = " ".join(quote_cmdlinearg(c) for c in command)
     else:
         command = assure_unicode(command)
     return command
@@ -444,7 +443,7 @@ def format_command(dset, command, **kwds):
         io_val = kwds.pop(name, None)
         if not isinstance(io_val, GlobbedPaths):
             io_val = GlobbedPaths(io_val, pwd=kwds.get("pwd"))
-        kwds[name] = list(map(shlex_quote, io_val.expand(dot=False)))
+        kwds[name] = list(map(quote_cmdlinearg, io_val.expand(dot=False)))
     return sfmt.format(command, **kwds)
 
 

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -353,10 +353,12 @@ def test_inject(path):
 @with_tempfile(mkdir=True)
 def test_format_command_strip_leading_dashes(path):
     ds = Dataset(path).create()
-    eq_(format_command(ds, ["--", "cmd", "--opt"]), "cmd --opt")
+    eq_(format_command(ds, ["--", "cmd", "--opt"]),
+        '"cmd" "--opt"' if on_windows else "cmd --opt")
     eq_(format_command(ds, ["--"]), "")
     # Can repeat to escape.
-    eq_(format_command(ds, ["--", "--", "ok"]), "-- ok")
+    eq_(format_command(ds, ["--", "--", "ok"]),
+         '"--" "ok"' if on_windows else "-- ok")
     # String stays as is.
     eq_(format_command(ds, "--"), "--")
 
@@ -380,7 +382,8 @@ def test_run_cmdline_disambiguation(path):
             with assert_raises(SystemExit):
                 main(["datalad", "run", "--", "--message"])
             exec_cmd.assert_called_once_with(
-                "--message", path, expected_exit=None)
+                '"--message"' if on_windows else "--message",
+                path, expected_exit=None)
 
         # And a twist on above: Our parser mishandles --version (gh-3067),
         # treating 'datalad run CMD --version' as 'datalad --version'.
@@ -402,7 +405,8 @@ def test_run_cmdline_disambiguation(path):
             with assert_raises(SystemExit):
                 main(["datalad", "run", "--", "echo", "--version"])
             exec_cmd.assert_called_once_with(
-                "echo --version", path, expected_exit=None)
+                '"echo" "--version"' if on_windows else "echo --version",
+                path, expected_exit=None)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -34,7 +34,7 @@ from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetArgumentFound
-from datalad.utils import maybe_shlex_quote
+from datalad.utils import quote_cmdlinearg
 
 from datalad.utils import assure_list
 import datalad.support.ansi_colors as ac
@@ -181,7 +181,7 @@ def _guess_exec(script_file):
                 'template': u'bash {script} {ds} {args}',
                 'state': 'executable'}
     elif script_file.endswith('.py'):
-        ex = maybe_shlex_quote(sys.executable)
+        ex = quote_cmdlinearg(sys.executable)
         return {'type': u'python_script',
                 'template': u'%s {script} {ds} {args}' % ex,
                 'state': 'executable'}
@@ -362,6 +362,7 @@ class RunProcedure(Interface):
 
         if not isinstance(spec, (tuple, list)):
             # maybe coming from config
+            # TODO likely causing issues on Windows
             import shlex
             spec = shlex.split(spec)
         name = spec[0]
@@ -425,9 +426,9 @@ class RunProcedure(Interface):
                              "Missing 'execute' permissions?" % procedure_file)
 
         cmd = ex['template'].format(
-            script=maybe_shlex_quote(procedure_file),
-            ds=maybe_shlex_quote(ds.path) if ds else '',
-            args=(u' '.join(maybe_shlex_quote(a) for a in args) if args else ''))
+            script=quote_cmdlinearg(procedure_file),
+            ds=quote_cmdlinearg(ds.path) if ds else '',
+            args=(u' '.join(quote_cmdlinearg(a) for a in args) if args else ''))
         lgr.info(u"Running procedure %s", name)
         lgr.debug(u'Full procedure command: %r', cmd)
         for r in Run.__call__(

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -17,7 +17,7 @@ import sys
 
 from datalad.cmd import Runner
 from datalad.utils import chpwd
-from datalad.utils import maybe_shlex_quote
+from datalad.utils import quote_cmdlinearg
 from datalad.utils import swallow_outputs
 from datalad.tests.utils import eq_
 from datalad.tests.utils import ok_file_has_content
@@ -204,7 +204,7 @@ def test_configs(path):
     # for run:
     ds.config.add(
         'datalad.procedures.datalad_test_proc.call-format',
-        u'%s {script} {ds} {{mysub}} {args}' % maybe_shlex_quote(sys.executable),
+        u'%s {script} {ds} {{mysub}} {args}' % quote_cmdlinearg(sys.executable),
         where='dataset'
     )
     ds.config.add(
@@ -224,7 +224,7 @@ def test_configs(path):
     # config on dataset level:
     ds.config.add(
         'datalad.procedures.datalad_test_proc.call-format',
-        u'%s {script} {ds} local {args}' % maybe_shlex_quote(sys.executable),
+        u'%s {script} {ds} local {args}' % quote_cmdlinearg(sys.executable),
         where='local'
     )
     ds.unlock("fromproc.txt")

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -17,7 +17,6 @@ import logging
 import wrapt
 import sys
 import re
-import shlex
 from os import curdir
 from os import pardir
 from os import listdir

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -21,7 +21,8 @@ from subprocess import Popen
 import tempfile
 # importing the quote function here so it can always be imported from this
 # module
-from shlex import quote as sh_quote
+# this used to be shlex.quote(), but is now a cross-platform helper
+from datalad.utils import quote_cmdlinearg as sh_quote
 
 # !!! Do not import network here -- delay import, allows to shave off 50ms or so
 # on initial import datalad time

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2315,13 +2315,12 @@ def bytes2human(n, format='%(value).1f %(symbol)sB'):
     return format % dict(symbol=symbols[0], value=n)
 
 
-def maybe_shlex_quote(val):
-    """
-    shlex_quote() a value if the command is not run on a Windows
-    machine.
-    """
-
-    return val if on_windows else shlex_quote(val)
+def quote_cmdlinearg(arg):
+    """Perform platform-appropriate argument quoting"""
+    # https://stackoverflow.com/a/15262019
+    return '"{}"'.format(
+        arg.replace('"', '""')
+    ) if on_windows else shlex_quote(arg)
 
 
 def get_wrapped_class(wrapped):


### PR DESCRIPTION
This enables more appropriate command-line argument quoting on
windows, and will retain the previous behavior on any other platform.

This could potentially improve SSH support on Windows substantially,
because shlex.quote() was often inappropriately and unconditionally
used in associated code.

- [x] also replace `maybe_shlex_quote()`