### PR TITLE
BF: Make all known_failure GitRepo tests run on windows

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -16,7 +16,6 @@ import subprocess
 import sys
 import logging
 import os
-import shlex
 import atexit
 import functools
 import tempfile
@@ -38,6 +37,7 @@ from .utils import (
     assure_bytes,
     unlink,
     auto_repr,
+    split_cmdline,
 )
 from .dochelpers import borrowdoc
 
@@ -383,7 +383,7 @@ class Runner(object):
         system's stdout or stderr respectively.
 
         Note: Using a string as `cmd` and shell=True allows for piping,
-              multiple commands, etc., but that implies shlex.split() is not
+              multiple commands, etc., but that implies split_cmdline() is not
               used. This is considered to be a security hazard.
               So be careful with input.
 
@@ -487,7 +487,7 @@ class Runner(object):
             if self.protocol.records_ext_commands:
                 prot_exc = None
                 prot_id = self.protocol.start_section(
-                    shlex.split(cmd, posix=not on_windows)
+                    split_cmdline(cmd)
                     if isinstance(cmd, str)
                     else cmd)
             try:
@@ -576,8 +576,7 @@ class Runner(object):
 
         else:
             if self.protocol.records_ext_commands:
-                self.protocol.add_section(shlex.split(cmd,
-                                                      posix=not on_windows)
+                self.protocol.add_section(split_cmdline(cmd)
                                           if isinstance(cmd, str)
                                           else cmd, None)
             out = ("DRY", "DRY")

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -16,7 +16,6 @@ __docformat__ = 'restructuredtext'
 
 import re
 import os
-import shlex
 import tempfile
 
 from os.path import join as opj, realpath, curdir, exists, lexists, relpath, basename
@@ -42,6 +41,7 @@ from ..utils import getpwd, rmtree, file_basename
 from ..utils import md5sum
 from ..utils import assure_tuple_or_list
 from ..utils import get_dataset_root
+from ..utils import split_cmdline
 
 from datalad.customremotes.base import init_datalad_remote
 
@@ -314,7 +314,7 @@ class AddArchiveContent(Interface):
 
             if annex_options:
                 if isinstance(annex_options, str):
-                    annex_options = shlex.split(annex_options)
+                    annex_options = split_cmdline(annex_options)
 
             leading_dir = earchive.get_leading_directory(
                 depth=leading_dirs_depth, exclude=exclude, consider=leading_dirs_consider) \

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -34,7 +34,10 @@ from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetArgumentFound
-from datalad.utils import quote_cmdlinearg
+from datalad.utils import (
+    quote_cmdlinearg,
+    split_cmdline,
+)
 
 from datalad.utils import assure_list
 import datalad.support.ansi_colors as ac
@@ -362,9 +365,7 @@ class RunProcedure(Interface):
 
         if not isinstance(spec, (tuple, list)):
             # maybe coming from config
-            # TODO likely causing issues on Windows
-            import shlex
-            spec = shlex.split(spec)
+            spec = split_cmdline(spec)
         name = spec[0]
         args = spec[1:]
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -18,7 +18,6 @@ import logging
 import math
 import os
 import re
-import shlex
 
 from itertools import chain
 from os import linesep
@@ -54,7 +53,9 @@ from datalad.utils import (
     assure_list,
     make_tempfile,
     partition,
-    unlink
+    unlink,
+    quote_cmdlinearg,
+    split_cmdline,
 )
 from datalad.support.json_py import loads as json_loads
 from datalad.cmd import (
@@ -2776,7 +2777,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         -------
         stdout, stderr
         """
-        cmd = shlex.split(cmd_str + " " + " ".join(files), posix=not on_windows) \
+        cmd = split_cmdline(
+            cmd_str + " " + " ".join(quote_cmdlinearg(f) for f in files)) \
             if isinstance(cmd_str, str) \
             else cmd_str + files
 
@@ -2965,7 +2967,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         annex_options = ['--to=%s' % remote]
         if options:
-            annex_options.extend(shlex.split(options))
+            annex_options.extend(split_cmdline(options))
 
         # TODO: provide more meaningful message (possibly aggregating 'note'
         #  from annex failed ones

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -13,7 +13,6 @@ For further information on GitPython see http://gitpython.readthedocs.org/
 """
 
 import re
-import shlex
 import time
 import os
 import os.path as op
@@ -82,7 +81,8 @@ from datalad.utils import (
     posix_relpath,
     assure_dir,
     generate_file_chunks,
-    assure_unicode
+    assure_unicode,
+    split_cmdline,
 )
 
 # imports from same module:
@@ -1866,7 +1866,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         # ensure cmd_str becomes a well-formed list:
         if isinstance(cmd_str, str):
-            cmd = shlex.split(cmd_str, posix=not on_windows)
+            cmd = split_cmdline(cmd_str)
         else:
             cmd = cmd_str[:]  # we will modify in-place
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1111,6 +1111,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 log_stdout=True, log_stderr=True,
                 expect_fail=True, expect_stderr=True)
             toppath = toppath.rstrip('\n\r')
+            if on_windows:
+                # normalize POSIX-like path reported by Git
+                # back to platform conventions
+                toppath = str(Path(toppath))
         except CommandError:
             return None
         except OSError:

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -23,6 +23,7 @@ import tempfile
 from datalad.support.param import Parameter
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
+from datalad.utils import split_cmdline
 
 from datalad import ssh_manager
 
@@ -88,16 +89,15 @@ class SSHRun(Interface):
         if cmd.startswith("'") and cmd.endswith("'"):
             lgr.debug(
                 "Detected additional level of quotations in %r so performing "
-                "shlex split", cmd
+                "command line splitting", cmd
             )
             # there is an additional layer of quotes
-            # Let's strip them off using shlex
-            import shlex
-            cmd_ = shlex.split(cmd)
+            # Let's strip them off by splitting the command
+            cmd_ = split_cmdline(cmd)
             if len(cmd_) != 1:
                 raise RuntimeError(
-                    "Obtained more or less than a single argument upon shlex "
-                    "split: %s" % repr(cmd_))
+                    "Obtained more or less than a single argument after "
+                    "command line splitting: %s" % repr(cmd_))
             cmd = cmd_[0]
         sshurl = 'ssh://{}{}'.format(
             login,

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -24,7 +24,10 @@ import sys
 from datalad import get_encoding_info
 from datalad.cmd import Runner
 
-from datalad.utils import unlink
+from datalad.utils import (
+    unlink,
+    Path,
+)
 from datalad.tests.utils import ok_
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import eq_
@@ -47,7 +50,6 @@ from datalad.tests.utils import get_most_obscure_supported_name
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import skip_if
 from datalad.tests.utils import skip_if_on_windows
-from datalad.tests.utils import known_failure_windows
 from datalad.tests.utils import integration
 from datalad.utils import rmtree
 from datalad.tests.utils_testrepos import BasicAnnexTestRepo
@@ -187,14 +189,12 @@ def test_GitRepo_equals(path1, path2):
     ok_(repo1 != repo2)
 
 
-# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:515
-@known_failure_windows
 @assert_cwd_unchanged
-@with_testrepos('.*git.*', flavors=local_testrepo_flavors)
+@with_tempfile
 @with_tempfile
 def test_GitRepo_add(src, path):
 
-    gr = GitRepo.clone(src, path)
+    gr = GitRepo(path, create=True)
     filename = get_most_obscure_supported_name()
     with open(op.join(path, filename), 'w') as f:
         f.write("File to add to git")
@@ -445,15 +445,13 @@ def test_GitRepo_remote_remove(orig_path, path):
     assert_in('origin', out)
 
 
-# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:491
-@known_failure_windows
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile
 def test_GitRepo_get_remote_url(orig_path, path):
 
     gr = GitRepo.clone(orig_path, path)
     gr.add_remote('github', 'git://github.com/datalad/testrepo--basic--r1')
-    eq_(gr.get_remote_url('origin'), orig_path)
+    eq_(gr.get_remote_url('origin'), Path(orig_path).as_posix())
     eq_(gr.get_remote_url('github'),
                  'git://github.com/datalad/testrepo--basic--r1')
 
@@ -769,12 +767,11 @@ def test_GitRepo_get_files(url, path):
     eq_(set([filename]), branch_files.difference(local_files))
 
 
-# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:505
-@known_failure_windows
-@with_testrepos('.*git.*', flavors=local_testrepo_flavors)
+@with_tempfile
 @with_tempfile(mkdir=True)
 @with_tempfile
 def test_GitRepo_get_toppath(repo, tempdir, repo2):
+    GitRepo(repo, create=True)
     reporeal = op.realpath(repo)
     eq_(GitRepo.get_toppath(repo, follow_up=False), reporeal)
     eq_(GitRepo.get_toppath(repo), repo)

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -13,7 +13,6 @@ import os
 import os.path as op
 import sys
 import logging
-import shlex
 
 from .utils import (
     ok_,
@@ -46,6 +45,7 @@ from ..cmd import (
 )
 from ..support.exceptions import CommandError
 from ..support.protocol import DryRunProtocol
+from ..utils import split_cmdline
 
 
 @known_failure_githubci_win
@@ -63,7 +63,7 @@ def test_runner_dry(tempfile):
         cml.assert_logged("{DryRunProtocol} Running: %s" % cmd, regex=False)
     assert_equal(("DRY", "DRY"), ret,
                  "Output of dry run (%s): %s" % (cmd, ret))
-    assert_equal(shlex.split(cmd, posix=not on_windows), dry[0]['command'])
+    assert_equal(split_cmdline(cmd), dry[0]['command'])
     assert_false(os.path.exists(tempfile))
 
     # test dry python function call
@@ -102,7 +102,7 @@ def test_runner(tempfile):
     #   the shell itself.
     # which is what it ruins it for us!  So, for now we are not testing/using
     # this form
-    # ret = runner.run(shlex.split(cmd, posix=not on_windows), shell=True)
+    # ret = runner.run(split_cmdline(cmd), shell=True)
     # # ?! for some reason there is an empty line in stdout
     # # TODO: figure out.  It shouldn't though be of critical effect
     # ret = (ret[0].rstrip(), ret[1])


### PR DESCRIPTION
This includes a fix to GitRepo.get_toppath() which used POSIX-convention
paths on windows, but was tested to produce native paths. It now
yields native paths.

This PR sits on top of #4053 