### PR TITLE
clone: Store stderr so it is displayed on clone failure

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -684,8 +684,7 @@ def test_ria_http(lcl, storepath, url):
         with assert_raises(IncompleteResultsError) as cme:
             clone('ria+{}#{}@impossible'.format(url, ds.id),
                   lcl / 'clone_failed')
-    # ATM we have no meaningful error messages, see
-    # https://github.com/datalad/datalad/pull/4036#issue-364002705
+        assert_in("not found in upstream", str(cme.exception))
 
 
 @skip_if_no_network

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -680,16 +680,12 @@ def test_ria_http(lcl, storepath, url):
         neq_(riaclone2.repo.get_hexsha(), riaclone_orig.repo.get_hexsha())
 
     # attempt to clone a version that doesn't exist
-    res = clone(
-        'ria+{}#{}@impossible'.format(url, ds.id),
-        lcl / 'clone_failed',
-        on_failure='ignore',
-        result_xfm=None,
-        return_type='list',
-    )
+    with swallow_logs():
+        with assert_raises(IncompleteResultsError) as cme:
+            clone('ria+{}#{}@impossible'.format(url, ds.id),
+                  lcl / 'clone_failed')
     # ATM we have no meaningful error messages, see
     # https://github.com/datalad/datalad/pull/4036#issue-364002705
-    assert_status('error', res)
 
 
 @skip_if_no_network


### PR DESCRIPTION
When GitPython raises a GitCommandError, whether the exception's
stderr attribute actually contains the standard error depends on
whether progress reporting is enabled.  With progress enabled, the
standard error is stored in RemoteProgress.error_lines instead of the
exception [0].

As of 3ecc68a82 (2018-09-27), we assign RemoteProgress.error_lines to
our GitPythonProgressBar._last_error_lines.  In the case of clone(),
we consider _last_error_lines to some extent, but it's not included in
the errors messages that we show the clone call fails with all
candidates.  In the specific cases of an unknown version, this means
that we report that cloning failed without any indication that the
unknown version was the issue.

Make the standard error visible to the caller by replacing the
exception's stderr with _last_error_lines.

Fixes #4038.

[0]: https://github.com/gitpython-developers/GitPython/issues/599

---

As an example, this changes

```
$ datalad clone ria+http://127.0.0.1:36265/#eb94c485-3bbe-11ea-b262-28c63f920482@impossible a
[...]
install(error): /tmp/ga-KyJmTKq/a (dataset) [Failed to clone from all attempted sources: ['http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482', 'http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482/.git']]
```

into

```
$ datalad clone ria+http://127.0.0.1:36265/#eb94c485-3bbe-11ea-b262-28c63f920482@impossible a
[...]
install(error): /tmp/ga-KyJmTKq/a (dataset) [Failed to clone from any candidate source URL. Encountered errors per each url were:
- http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482
  Cmd('git') failed due to: exit code(128)
  cmdline: git clone --progress -v --branch=impossible http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482 /tmp/ga-KyJmTKq/a
  stderr: fatal: Remote branch impossible not found in upstream origin
- http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482/.git
  Cmd('git') failed due to: exit code(128)
  cmdline: git clone --progress -v --branch=impossible http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482/.git /tmp/ga-KyJmTKq/a
  stderr: fatal: repository 'http://127.0.0.1:36265/eb9/4c485-3bbe-11ea-b262-28c63f920482/.git/' not found]
```