### PR TITLE
MNT: Set upper bound on `ls-files -o` workarounds

### DIFF
--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -365,12 +365,9 @@ def test_path_diff(_path, linkpath):
     # duplicate paths do not change things
     eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all'))
     # neither do nested paths
-    if external_versions["cmd:git"] < "2.24.0":
-        # TODO: The link below points to discussion of this behavioral change
-        # in Git. If the behavior is addressed in a future release, update the
-        # condition above with a ceiling. If it's not, think more about how to
-        # handle this change on our side.
-        # https://lore.kernel.org/git/87fti15agv.fsf@kyleam.com/T/#u
+    if not ("2.24.0" <= external_versions["cmd:git"] < "2.25.0"):
+        # Release 2.24.0 contained a regression that was fixed with 072a231016
+        # (2019-12-10).
         eq_(plain_recursive,
             ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all'))
     # when invoked in a subdir of a dataset it still reports on the full thing

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -361,14 +361,13 @@ def _remove_empty_items(list_):
     return [file_ for file_ in list_ if file_]
 
 
-if external_versions["cmd:git"] >= "2.24.0":
+if "2.24.0" <= external_versions["cmd:git"] < "2.25.0":
     # An unintentional change in Git 2.24.0 led to `ls-files -o` traversing
     # into untracked submodules when multiple pathspecs are given, returning
     # repositories that are deeper than the first level. This helper filters
     # these deeper levels out so that save_() doesn't fail trying to add them.
     #
-    # TODO: Once an upstream release includes a fix, either set a ceiling on
-    # the Git version above or remove _prune_deeper_repos() entirely.
+    # This regression fixed with upstream's 072a231016 (2019-12-10).
     def _prune_deeper_repos(repos):
         firstlevel_repos = []
         prev = None


### PR DESCRIPTION
ca234631a (BF: gitrepo: Work around change in 'ls-files -o' output,
2019-12-06) and a4a6e2955 (TST: diff: Skip an assertion that fails
with Git v2.24.0, 2019-12-07) worked around a `git ls-files -o` bug.
The upstream fix is part of the Git v2.25.0 release.
