### PR TITLE
NF: Helper to support Git-style URL rewriting

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -749,21 +749,32 @@ def rewrite_url(cfg, url):
         for k, v in cfg.items()
         if k.startswith('url.') and k.endswith('.insteadof')
     }
+
     # all config that applies
     matches = {
-        key: len(v)
+        key: v
         for key, val in insteadof.items()
         for v in (val if isinstance(val, tuple) else (val,))
         if url.startswith(v)
     }
     # find longest match, like Git does
     if matches:
-        rewrite_base, match_len = sorted(
+        rewrite_base, match = sorted(
             matches.items(),
-            key=lambda x: x[1],
+            key=lambda x: len(x[1]),
             reverse=True,
         )[0]
-        url = '{}{}'.format(rewrite_base, url[match_len:])
+        if sum(match == v for v in matches.values()) > 1:
+            lgr.warning(
+                "Ignoring URL rewrite configuration for '%s', "
+                "multiple conflicting definitions exists: %s",
+                match,
+                ['url.{}.insteadof'.format(k)
+                 for k, v in matches.items()
+                 if v == match]
+            )
+        else:
+            url = '{}{}'.format(rewrite_base, url[len(match):])
     return url
 
 

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -750,8 +750,12 @@ def rewrite_url(cfg, url):
         if k.startswith('url.') and k.endswith('.insteadof')
     }
     # all config that applies
-    matches = {k: len(v) for k, v in insteadof.items()
-               if url.startswith(v)}
+    matches = {
+        key: len(v)
+        for key, val in insteadof.items()
+        for v in (val if isinstance(val, tuple) else (val,))
+        if url.startswith(v)
+    }
     # find longest match, like Git does
     if matches:
         rewrite_base, match_len = sorted(

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -749,20 +749,17 @@ def rewrite_url(cfg, url):
         for k, v in cfg.items()
         if k.startswith('url.') and k.endswith('.insteadof')
     }
-    prev_url = None
-    while url != prev_url:
-        prev_url = url
-        # all config that applies
-        matches = {k: len(v) for k, v in insteadof.items()
-                   if url.startswith(v)}
-        # find longest match, like Git does
-        if matches:
-            rewrite_base, match_len = sorted(
-                matches.items(),
-                key=lambda x: x[1],
-                reverse=True,
-            )[0]
-            url = '{}{}'.format(rewrite_base, url[match_len:])
+    # all config that applies
+    matches = {k: len(v) for k, v in insteadof.items()
+               if url.startswith(v)}
+    # find longest match, like Git does
+    if matches:
+        rewrite_base, match_len = sorted(
+            matches.items(),
+            key=lambda x: x[1],
+            reverse=True,
+        )[0]
+        url = '{}{}'.format(rewrite_base, url[match_len:])
     return url
 
 

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -771,6 +771,9 @@ def decode_source_spec(spec, cfg=None):
         props['type'] = 'dataladri'
         props['giturl'] = source_ri.as_git_url()
     elif isinstance(source_ri, URL) and source_ri.scheme.startswith('ria+'):
+        # Git never gets to see these URLs, so let's manually apply any
+        # rewrite configuration Git might know about
+        source_ri = RI(cfg.rewrite_url(spec))
         # parse a RIA URI
         dsid, version = source_ri.fragment.split('@', maxsplit=1) \
             if '@' in source_ri.fragment else (source_ri.fragment, None)


### PR DESCRIPTION
With this helper (and its use in the relevant places), we can make
DataLad acknowledge URL rewrite instructions by supporting Git's own
mechanism: `url.<base>.insteadof`

With this move we should be able to avoid custom configuration for
the purpose of mapping locations (like needed for the RIA support
code). The included test contains the desired mappings.

As suggested by @kyleam this should set us up better for eventually
supporting custom protocols like `ria+ssh://` in a proper Git remote
helper.