### PR TITLE
Bits to make bare repositories a more recognized use case

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -217,6 +217,14 @@ class Create(Interface):
                                  "description for annex repo and declaring "
                                  "no annex repo.")
 
+        if (isinstance(initopts, (list, tuple)) and '--bare' in initopts) or (
+                isinstance(initopts, dict) and 'bare' in initopts):
+            raise ValueError(
+                "Creation of bare repositories is not supported. Consider "
+                "one of the create-sibling commands, or use "
+                "Git to init a bare repository and push an existing dataset "
+                "into it.")
+
         if path:
             path = resolve_path(path, dataset)
 

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -41,6 +41,8 @@ from datalad.config import (
 from datalad.cmd import CommandError
 
 from datalad.support.external_versions import external_versions
+from datalad.support.gitrepo import GitRepo
+
 
 # XXX tabs are intentional (part of the format)!
 # XXX put back! confuses pep8
@@ -491,3 +493,19 @@ def test_dataset_systemglobal_mode(path):
         assert_in('user.name', cfg)
         assert_not_in('datalad.dataset.id', cfg)
         assert_not_in('annex.version', cfg)
+
+
+@with_tempfile()
+def test_bare(path):
+    # can we handle a bare repo?
+    gr = GitRepo(path, create=True, bare=True)
+    # any sensible (and also our CI) test environment(s) should have this
+    assert_in('user.name', gr.config)
+    # not set something that wasn't there
+    obscure_key = 'sec.reallyobscurename!@@.key'
+    assert_not_in(obscure_key, gr.config)
+    # to the local config, which is easily accessible
+    gr.config.set(obscure_key, 'myvalue', where='local')
+    assert_equal(gr.config.get(obscure_key), 'myvalue')
+    # now make sure the config is where we think it is
+    assert_in(obscure_key.split('.')[1], (gr.pathobj / 'config').read_text())


### PR DESCRIPTION
Bare-mode repositories frequently come up as a problem/use case:
- #4035
- #3855
- #2820
- #2819
- #2425

TODO:

- [x] Test for ConfigManager functionality in bare mode
- [x] Issue intelligible error message for `create --bare` (not supported, give pointers) Fixes #3855