### PR TITLE
A few touch-ups for the recent 7z additions

### DIFF
--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -13,8 +13,8 @@ from datalad.support.external_versions import external_versions
 external_versions.check(
     "cmd:7z",
     msg='The 7z binary (7-Zip) is required for archive handling, but is missing. '
-        "Setting the config flag 'datalad.runtime.use-patool' enabled an "
-        "alternative implementation that may no need 7z.")
+        "Setting the config flag 'datalad.runtime.use-patool' enables an "
+        "alternative implementation that may not need 7z.")
 
 from datalad.utils import (
     Path,

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -118,7 +118,8 @@ def _get_system_7z_version():
             # the one with the dot is the version
             if '.' in p:
                 return p
-        lgr.debug("Could not determine version of 7z: %s", exc_str(exc))
+        lgr.debug("Could not determine version of 7z from stdout. "
+                  "stdout: %s, stderr: %s", out, err)
         return None
     except CommandError as exc:
         lgr.debug("Could not determine version of 7z: %s", exc_str(exc))

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -91,39 +91,30 @@ def _get_system_ssh_version():
     Annex prior 20170302 was using bundled version, but now would use system one
     if installed
     """
-    try:
-        out, err = _runner.run('ssh -V'.split(),
-                               expect_fail=True, expect_stderr=True)
-        # apparently spits out to err but I wouldn't trust it blindly
-        if err.startswith('OpenSSH'):
-            out = err
-        assert out.startswith('OpenSSH')  # that is the only one we care about atm
-        return out.split(' ', 1)[0].rstrip(',.').split('_')[1]
-    except CommandError as exc:
-        lgr.debug("Could not determine version of ssh available: %s", exc_str(exc))
-        return None
+    out, err = _runner.run('ssh -V'.split(),
+                           expect_fail=True, expect_stderr=True)
+    # apparently spits out to err but I wouldn't trust it blindly
+    if err.startswith('OpenSSH'):
+        out = err
+    assert out.startswith('OpenSSH')  # that is the only one we care about atm
+    return out.split(' ', 1)[0].rstrip(',.').split('_')[1]
 
 
 def _get_system_7z_version():
     """Return version of 7-Zip"""
-    try:
-        out, err = _runner.run(
-            ['7z'], expect_fail=True, expect_stderr=True,
-        )
-        # reporting in variable order across platforms
-        # Linux: 7-Zip [64] 16.02
-        # Windows: 7-Zip 19.00 (x86)
-        pieces = out.strip().split(':', maxsplit=1)[0].strip().split()
-        for p in pieces:
-            # the one with the dot is the version
-            if '.' in p:
-                return p
-        lgr.debug("Could not determine version of 7z from stdout. "
-                  "stdout: %s, stderr: %s", out, err)
-        return None
-    except CommandError as exc:
-        lgr.debug("Could not determine version of 7z: %s", exc_str(exc))
-        return None
+    out, err = _runner.run(
+        ['7z'], expect_fail=True, expect_stderr=True,
+    )
+    # reporting in variable order across platforms
+    # Linux: 7-Zip [64] 16.02
+    # Windows: 7-Zip 19.00 (x86)
+    pieces = out.strip().split(':', maxsplit=1)[0].strip().split()
+    for p in pieces:
+        # the one with the dot is the version
+        if '.' in p:
+            return p
+    lgr.debug("Could not determine version of 7z from stdout. "
+              "stdout: %s, stderr: %s", out, err)
 
 
 class ExternalVersions(object):


### PR DESCRIPTION
* Fix use of undefined variable from 7fb806abd.
* Simplify newly added `_get_system_7z_version`, as well as the nearby `_get_system_ssh_version`.
* Fix message for `external_versions.check` call from d674922b8.