### PR TITLE
NF: Command abstractions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,6 +98,8 @@ test_script:
   # remaining fails: test_addurls test_export_archive test_plugins"
   # additional tests need module `dateutil`!!
   - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates
+  # command abstraction tests:
+  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.support.operations.tests
   # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
   - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner
  

--- a/datalad/operations.py
+++ b/datalad/operations.py
@@ -1,0 +1,120 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+"""
+from datalad.utils import Path
+
+
+class OperationsBase(object):
+    """Abstract class with the desired API for operations.
+
+    Any path-like argument must be a pathlib object.
+
+    Method parameters must be verbose or generic enough to be translatable
+    to non-POSIX systems, such as Windows.
+    """
+    def __init__(self, cwd=None):
+        """
+        Parameters
+        ----------
+        cwd : Path or None
+          Current working directory to resolve any relative paths against.
+          If None, the process working directory (PWD) is used.
+        """
+        self._cwd = Path.cwd() if cwd is None else cwd
+
+    def make_directory(self, path, force=False):
+        """Create a new directory
+
+        Parameters
+        ----------
+        path : Path
+          Location at which to create a directory.
+        force : bool
+          Enforce creation of directory, even when it already exists,
+          or if parent directories are missing.
+        """
+        raise NotImplementedError
+
+    def exists(self, path):
+        """Test if something exists at the given path
+
+        Parameters
+        ----------
+        path : Path
+          Path to test.
+
+        Returns
+        -------
+        bool
+          True, if the path exists (even in case of a broken symlink), False
+          otherwise.
+        """
+        raise NotImplementedError
+
+    def remove(self, path, recursive=False):
+        """Remove the given path
+
+        Parameters
+        ----------
+        path : Path
+          Path to remove.
+        recursive : bool
+          If True, everything underneath `path` is also removed, If False,
+          `path` removal might fail with present content.
+        """
+        raise NotImplementedError
+
+    def change_permissions(self, path, mode, recursive=False):
+        """Change the permissions for a path
+
+        Parameters
+        ----------
+        path : Path
+          Path to change permissions of.
+        mode : str
+          Recognized label for a permission mode, such as 'user_readonly'.
+        recursive : bool
+          Apply change recursively to all content underneath the path, too.
+        """
+        raise NotImplementedError
+
+    def change_group(self, path, label, recursive=False):
+        """Change the group ownership for a path
+
+        Parameters
+        ----------
+        path : Path
+          Path to change ownership of.
+        label : str
+          Name of the group.
+        recursive : bool
+          Apply change recursively to all content underneath the path, too.
+        """
+        raise NotImplementedError
+
+
+class RemoteOperationsBase(OperationsBase):
+    """Abstract class with the desired API for remote operations.
+    """
+    def __init__(self, cwd=None, remote_cwd=None):
+        """
+        Parameters
+        ----------
+        cwd : Path or None
+          Local working directory to resolve any relative paths against.
+          If None, the process working directory (PWD) is used.
+        remote_cwd : Path or None
+          Remote working directory to resolve any remote relative paths
+          against. If None, the process working directory (PWD) of the
+          remote connection is used.
+        """
+        super(RemoteOperationsBase, self).__init__(cwd=cwd)
+
+        self._remote_cwd = remote_cwd

--- a/datalad/operations_local.py
+++ b/datalad/operations_local.py
@@ -1,0 +1,73 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+"""
+from datalad.operations import OperationsBase
+from datalad.cmd import Runner
+from datalad.utils import (
+    quote_cmdlinearg,
+    on_windows,
+)
+
+
+class PurePythonOperations(OperationsBase):
+    def make_directory(self, path, force=False):
+        path.mkdir(
+            parents=force,
+            exist_ok=force,
+        )
+
+    def exists(self, path):
+        return path.exists() or path.is_symlink()
+
+
+class PosixShellOperations(PurePythonOperations):
+    def __init__(self, cwd=None, env=None):
+        super(PosixShellOperations, self).__init__(cwd=cwd)
+
+        self._runner = Runner(
+            # pull from superclass, who knows what might have been
+            # done to it
+            cwd=self._cwd,
+            env=env,
+        )
+
+    def _run(self,
+             cmd,
+             log_stdout=True,
+             log_stderr=True,
+             log_online=False,
+             expect_stderr=False,
+             expect_fail=False,
+             stdin=None):
+        """Internal helper to execute command.
+
+        MUST NOT BE CALLED by non-(sub)class code.
+        """
+        return self._runner.run(
+            cmd,
+            log_stdout=log_stdout,
+            log_stderr=log_stderr,
+            log_online=log_online,
+            expect_stderr=expect_stderr,
+            expect_fail=expect_fail,
+            stdin=stdin,
+        )
+
+    def remove(self, path, recursive=False):
+        self._run('rm {} -f {}'.format(
+            '-r' if recursive else '',
+            quote_cmdlinearg))
+
+
+class WindowsShellOperations(PurePythonOperations):
+    pass
+
+
+LocalOperation = WindowsShellOperations if on_windows else PosixShellOperations

--- a/datalad/support/operations/operations_abstract.py
+++ b/datalad/support/operations/operations_abstract.py
@@ -190,3 +190,25 @@ class RemoteOperationsBase(OperationsBase):
         if not path.is_absolute() and self._remote_cwd:
             path = self._remote_cwd / path
         return path
+
+    def get(self, source, destination, recursive=False, preserve_attrs=False):
+        # TODO: Doc. Not quite sure yet. For now signature is copied from
+        #       SSHConnection. Trying to use it delegating to SSHConnection from
+        #       within RemoteSSHShellOperations and differently from within
+        #       RemotePersistentSSHShellOperations. Let's see how that works.
+        #
+        #       Eventually we might even want get/put to be "copy" instead,
+        #       that can be performed locally as well. Would most consistent
+        #       with base idea about those command abstractions.
+        raise NotImplementedError
+
+    def put(self, source, destination, recursive=False, preserve_attrs=False):
+        # TODO: Doc. Not quite sure yet. For now signature is copied from
+        #       SSHConnection. Trying to use it delegating to SSHConnection from
+        #       within RemoteSSHShellOperations and differently from within
+        #       RemotePersistentSSHShellOperations. Let's see how that works.
+        #
+        #       Eventually we might even want get/put to be "copy" instead,
+        #       that can be performed locally as well. Would most consistent
+        #       with base idea about those command abstractions.
+        raise NotImplementedError

--- a/datalad/support/operations/operations_abstract.py
+++ b/datalad/support/operations/operations_abstract.py
@@ -32,7 +32,7 @@ class OperationsBase(object):
     def _ensure_absolute(self, path):
         """Internal helper to make a path absolute
 
-        If relative path is given, interprete it as relative to initialized CWD
+        If relative path is given, interpret it as relative to initialized CWD
         if any, to PWD otherwise.
 
         Parameters
@@ -117,6 +117,7 @@ class OperationsBase(object):
         # Need a unified behavior across subclasses
         raise NotImplementedError
 
+    # TODO: What do we want to do with symlinks? Follow? Make an option?
     def change_permissions(self, path, mode, recursive=False):
         """Change the permissions for a path
 
@@ -131,6 +132,7 @@ class OperationsBase(object):
         """
         raise NotImplementedError
 
+    # TODO: What do we want to do with symlinks? Follow? Make an option?
     def change_group(self, path, label, recursive=False):
         """Change the group ownership for a path
 
@@ -164,3 +166,27 @@ class RemoteOperationsBase(OperationsBase):
         super(RemoteOperationsBase, self).__init__(cwd=cwd)
 
         self._remote_cwd = remote_cwd
+
+    def _ensure_absolute_remote(self, path):
+        """Internal helper to make a path absolute
+
+        If relative path is given, interpret it as relative to initialized
+        REMOTE_CWD if any, pass into remote operation unchanged otherwise.
+
+        Parameters
+        ----------
+        path : Path
+
+        Returns
+        -------
+        Path
+        """
+
+        # Note, that this doesn't actually resolve the path. For now, this is
+        # intentional to not get completely confusing return values. This is
+        # only about interpreting as relative to the correct base.
+        # TODO: possibly turn this into a decorator, that allows to assign
+        #       arguments of the actual methods, that need to go through this.
+        if not path.is_absolute() and self._remote_cwd:
+            path = self._remote_cwd / path
+        return path

--- a/datalad/support/operations/operations_abstract.py
+++ b/datalad/support/operations/operations_abstract.py
@@ -85,8 +85,13 @@ class OperationsBase(object):
         """
         raise NotImplementedError
 
+    # TODO: force? How about permissions?
     def remove(self, path, recursive=False):
         """Remove the given path
+
+        Note, that this is supposed to not raise in case `path` doesn't exist
+        and `recursive` isn't required for an empty directory (as opposed to
+        plain shell "rm").
 
         Parameters
         ----------

--- a/datalad/support/operations/operations_abstract.py
+++ b/datalad/support/operations/operations_abstract.py
@@ -29,6 +29,33 @@ class OperationsBase(object):
         """
         self._cwd = Path.cwd() if cwd is None else cwd
 
+    def _ensure_absolute(self, path):
+        """Internal helper to make a path absolute
+
+        If relative path is given, interprete it as relative to initialized CWD
+        if any, to PWD otherwise.
+
+        Parameters
+        ----------
+        path : Path
+
+        Returns
+        -------
+        Path
+        """
+
+        # Note, that this doesn't actually resolve the path. For now, this is
+        # intentional to not get completely confusing return values. This is
+        # only about interpreting as relative to the correct base.
+        # TODO: possibly turn this into a decorator, that allows to assign
+        #       arguments of the actual methods, that need to go through this.
+        if not path.is_absolute():
+            if self._cwd:
+                path = self._cwd / path
+            else:
+                path = Path.cwd() / path
+        return path
+
     def make_directory(self, path, force=False):
         """Create a new directory
 
@@ -69,6 +96,20 @@ class OperationsBase(object):
           If True, everything underneath `path` is also removed, If False,
           `path` removal might fail with present content.
         """
+        raise NotImplementedError
+
+    def rename(self, src, dst):
+        """Rename path `src` to `dst`
+
+        Parameters
+        ----------
+        src : Path
+        dst : Path
+        """
+
+        # TODO; specify what happens if `dst` exists. Note, that pathlib would
+        # silently replace an existing file on Unix, if permissions allow it.
+        # Need a unified behavior across subclasses
         raise NotImplementedError
 
     def change_permissions(self, path, mode, recursive=False):

--- a/datalad/support/operations/operations_local.py
+++ b/datalad/support/operations/operations_local.py
@@ -36,7 +36,6 @@ class PurePythonOperations(OperationsBase):
         dst = self._ensure_absolute(dst)
         return src.rename(dst)
 
-    # TODO: force? How about permissions?
     def remove(self, path, recursive=False):
         path = self._ensure_absolute(path)
 
@@ -49,13 +48,15 @@ class PurePythonOperations(OperationsBase):
                 else:
                     p.unlink()
 
-        if path.is_dir():
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            # result oriented; don't raise
+            pass
+        except IsADirectoryError:
             if recursive:
                 _remove_dir_content(path)
-            else:
-                path.rmdir()
-        else:
-            path.unlink()
+            path.rmdir()
 
     def change_permissions(self, path, mode, recursive=False):
         # TODO: mode should prob. mapped from labels to whatever is needed

--- a/datalad/support/operations/operations_local.py
+++ b/datalad/support/operations/operations_local.py
@@ -53,7 +53,9 @@ class PurePythonOperations(OperationsBase):
         except FileNotFoundError:
             # result oriented; don't raise
             pass
-        except IsADirectoryError:
+        except (IsADirectoryError, PermissionError):
+            # Note, that on windows apparently PermissionError is raised
+            # instead of IsADirectoryError
             if recursive:
                 _remove_dir_content(path)
             path.rmdir()

--- a/datalad/support/operations/operations_local.py
+++ b/datalad/support/operations/operations_local.py
@@ -44,7 +44,7 @@ class PosixShellOperations(PurePythonOperations):
         self._runner = Runner(
             # pull from superclass, who knows what might have been
             # done to it
-            cwd=self._cwd,
+            cwd=quote_cmdlinearg(str(self._cwd)),
             env=env,
         )
 

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -128,6 +128,20 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
             quote_cmdlinearg(str(path))
         ))
 
+    def get(self, source, destination, recursive=False, preserve_attrs=False):
+        source = self._ensure_absolute_remote(source)
+        destination = self._ensure_absolute(destination)
+
+        self.con.get(source, destination, recursive=recursive,
+                     preserve_attrs=preserve_attrs)
+
+    def put(self, source, destination, recursive=False, preserve_attrs=False):
+        source = self._ensure_absolute(source)
+        destination = self._ensure_absolute_remote(destination)
+
+        self.con.put(source, destination, recursive=recursive,
+                     preserve_attrs=preserve_attrs)
+
 
 class RemotePersistentSSHShellOperations(RemoteOperationsBase):
 

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -46,17 +46,13 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
             use_remote_annex_bundle=use_remote_annex_bundle,
             force_ip=force_ip)
 
-        # TODO: Not sure yet about the following part. Might be better to
-        #   to deal with this per command
-        self.con.open()
-        if self._remote_cwd:
-            self.con("cd {}".format(quote_cmdlinearg(str(self._remote_cwd))))
-
     def make_directory(self, path, force=False):
+        path = self._ensure_absolute_remote(path)
         self.con("mkdir {} {}".format("-p" if force else "",
                                       quote_cmdlinearg(str(path))))
 
     def exists(self, path):
+        path = self._ensure_absolute_remote(path)
         try:
             self.con("test -e {}".format(quote_cmdlinearg(str(path))))
             return True
@@ -64,6 +60,7 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
             return False
 
     def remove(self, path, recursive=False):
+        path = self._ensure_absolute_remote(path)
         path = quote_cmdlinearg(str(path))
 
         # test for directory:
@@ -87,6 +84,8 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
         self.con(cmd)
 
     def rename(self, src, dst):
+        src = self._ensure_absolute_remote(src)
+        dst = self._ensure_absolute_remote(dst)
 
         self.con('mv {} {}'.format(quote_cmdlinearg(str(src)),
                                    quote_cmdlinearg(str(dst))))

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -73,7 +73,8 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
     def exists(self, path):
         path = self._ensure_absolute_remote(path)
         try:
-            self.con("test -e {}".format(quote_cmdlinearg(str(path))))
+            self.con("[ -h {p} -o -e {p} ]".format(
+                p=quote_cmdlinearg(str(path))))
             return True
         except CommandError:
             return False

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -9,27 +9,69 @@
 """
 """
 from datalad.support.operations.operations_abstract import RemoteOperationsBase
+from datalad.support.exceptions import CommandError
+from datalad.utils import (
+    Path,
+    PurePath
+)
 from datalad.cmd import Runner
 from datalad.utils import (
     quote_cmdlinearg,
     on_windows,
 )
 
+# TODO: We actually need to add/overwrite quote_cmdlinearg/on_windows funtions
+#       to sense what's going on at the remote end. However, this requires a
+#       test setup where local+remote are different indeed. Note, that this
+#       would include to not resolve Path objects locally (prob. allow for
+#       PurePath only when addressing remote locations?).
 
 # TODO: What about Windows Servers? Does SSH give a POSIX Shell? Might need a
 #       dedicated class
-# TODO: in operations_local we integrate decision on what to use in import of
-#       `LocalOperation`. What criterion would we use here to decide what
-#       class to use?
+
 
 class RemoteSSHShellOperations(RemoteOperationsBase):
 
-    def __init__(self, cwd=None, remote_cwd=None):
-        super().__init__(cwd, remote_cwd)
+    def __init__(self, url,
+                 cwd=None,
+                 remote_cwd=None,
+                 use_remote_annex_bundle=True,
+                 force_ip=False):
 
+        super().__init__(cwd, remote_cwd)
         from datalad import ssh_manager
 
-        # TODO: For now basically use existing ssh execution
+        self.con = ssh_manager.get_connection(
+            url=url,
+            use_remote_annex_bundle=use_remote_annex_bundle,
+            force_ip=force_ip)
+
+        # TODO: Not sure yet about the following part. Might be better to
+        #   to deal with this per command
+        self.con.open()
+        if self._remote_cwd:
+            self.con("cd {}".format(quote_cmdlinearg(str(self._remote_cwd))))
+
+    def make_directory(self, path, force=False):
+        self.con("mkdir {} {}".format("-p" if force else "",
+                                      quote_cmdlinearg(str(path))))
+
+    def exists(self, path):
+        try:
+            self.con("test -e {}".format(quote_cmdlinearg(str(path))))
+            return True
+        except CommandError:
+            return False
+
+    def remove(self, path, recursive=False):
+
+        self.con('rm {} -f {}'.format('-r' if recursive else '',
+                                      quote_cmdlinearg(str(path))))
+
+    def rename(self, src, dst):
+
+        self.con('mv {} {}'.format(quote_cmdlinearg(str(src)),
+                                   quote_cmdlinearg(str(dst))))
 
 
 class RemotePersistentSSHShellOperations(RemoteOperationsBase):
@@ -38,3 +80,11 @@ class RemotePersistentSSHShellOperations(RemoteOperationsBase):
     #  everything through a persistent remote shell
 
     pass
+
+
+# TODO: in operations_local we integrate decision on what to use in import of
+#       `LocalOperation`. What criterion would we use here to decide what
+#       class to use?
+#       -> decision may well be based on "URL-scheme" including ones like
+#       "ria+ssh"
+RemoteOperation = RemoteSSHShellOperations

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -30,6 +30,25 @@ from datalad.utils import (
 #       dedicated class
 
 
+#
+# TODO: From respective github-issue:
+#
+#     ATM create_sibling has custom code to perform a bunch of operations via
+#     SSH that are equivalents of:
+#
+#     exist()
+#     rmtree()
+#     chmod
+#     chgrp
+#     rm
+#     mkdir()
+#     git update-server-info
+#     git config
+#     enable post-update hook
+#     annex init
+#
+
+
 class RemoteSSHShellOperations(RemoteOperationsBase):
 
     def __init__(self, url,
@@ -89,6 +108,24 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
 
         self.con('mv {} {}'.format(quote_cmdlinearg(str(src)),
                                    quote_cmdlinearg(str(dst))))
+
+    def change_permissions(self, path, mode, recursive=False):
+        path = self._ensure_absolute_remote(path)
+
+        self.con("chmod {} {} {}".format(
+            mode,
+            "-R" if recursive else "",
+            quote_cmdlinearg(str(path))
+        ))
+
+    def change_group(self, path, label, recursive=False):
+        path = self._ensure_absolute_remote(path)
+
+        self.con("chgrp {} {} {}".format(
+            "-R" if recursive else "",
+            label,
+            quote_cmdlinearg(str(path))
+        ))
 
 
 class RemotePersistentSSHShellOperations(RemoteOperationsBase):

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -1,0 +1,40 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+"""
+from datalad.support.operations.operations_abstract import RemoteOperationsBase
+from datalad.cmd import Runner
+from datalad.utils import (
+    quote_cmdlinearg,
+    on_windows,
+)
+
+
+# TODO: What about Windows Servers? Does SSH give a POSIX Shell? Might need a
+#       dedicated class
+# TODO: in operations_local we integrate decision on what to use in import of
+#       `LocalOperation`. What criterion would we use here to decide what
+#       class to use?
+
+class RemoteSSHShellOperations(RemoteOperationsBase):
+
+    def __init__(self, cwd=None, remote_cwd=None):
+        super().__init__(cwd, remote_cwd)
+
+        from datalad import ssh_manager
+
+        # TODO: For now basically use existing ssh execution
+
+
+class RemotePersistentSSHShellOperations(RemoteOperationsBase):
+
+    # TODO: see RIA special remote. Instead of single shh execution stream
+    #  everything through a persistent remote shell
+
+    pass

--- a/datalad/support/operations/operations_remote.py
+++ b/datalad/support/operations/operations_remote.py
@@ -64,9 +64,27 @@ class RemoteSSHShellOperations(RemoteOperationsBase):
             return False
 
     def remove(self, path, recursive=False):
+        path = quote_cmdlinearg(str(path))
 
-        self.con('rm {} -f {}'.format('-r' if recursive else '',
-                                      quote_cmdlinearg(str(path))))
+        # test for directory:
+        isdir = True
+        try:
+            self.con('[ -d {} ]'.format(path))
+        except CommandError as e:
+            if e.code != 0:
+                isdir = False
+
+        # build actual command
+        if isdir:
+            if recursive:
+                cmd = "rm -r -f {}".format(path)
+            else:
+                cmd = "rmdir {}".format(path)
+
+        else:
+            cmd = "rm -f {}".format(path)
+
+        self.con(cmd)
 
     def rename(self, src, dst):
 

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -352,6 +352,7 @@ def test_rename_remote(cwd, remote_cwd):
         assert_false(ops.exists(link_path))
 
 
+@skip_if_on_windows  # not yet implemented on windows
 @with_tempfile
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -46,7 +46,8 @@ from datalad.tests.utils import (
     OBSCURE_FILENAME,
     SkipTest,
     has_symlink_capability,
-    skip_ssh
+    skip_ssh,
+    skip_if_on_windows
 )
 
 
@@ -399,6 +400,7 @@ def test_change_permissions_local(file_path, dir_path, cwd):
     eq_(stat.S_IMODE((cwd / "relative").stat().st_mode), 0o777)
 
 
+@skip_if_on_windows  # not yet implemented on windows
 @skip_ssh
 @with_tempfile
 @with_tempfile(mkdir=True)

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -200,11 +200,17 @@ def test_remove_local(dir_path, link_path, cwd):
     ops.remove(dir_path)
     ops.make_directory(dir_path)
     ok_(ops.exists(dir_path))
-    # directory, but w/o recursive
-    assert_raises(CommandError, ops.remove, dir_path)
+    # empty directory
+    ops.remove(dir_path)
+    assert_false(ops.exists(dir_path))
+    # recreate for a tree
+    ops.make_directory(dir_path)
     ok_(ops.exists(dir_path))
     underneath = (dir_path / 'some')
     underneath.write_text('content')
+    # non-empty dir w/o recursive
+    assert_raises(OSError, ops.remove(dir_path))
+    ok_(ops.exists(dir_path))
     # non-empty dir w/ recursive
     ops.remove(dir_path, recursive=True)
     assert_false(ops.exists(dir_path))
@@ -244,11 +250,17 @@ def test_remove_remote(dir_path, link_path, cwd, remote_cwd):
     ops.remove(dir_path)
     ops.make_directory(dir_path)
     ok_(ops.exists(dir_path))
-    # directory, but w/o recursive
-    assert_raises(CommandError, ops.remove, dir_path)
+    # empty directory
+    ops.remove(dir_path)
+    assert_false(ops.exists(dir_path))
+    # recreate for a tree
+    ops.make_directory(dir_path)
     ok_(ops.exists(dir_path))
     underneath = (dir_path / 'some')
     underneath.write_text('content')
+    # non-empty dir w/o recursive
+    assert_raises(CommandError, ops.remove(dir_path))
+    ok_(ops.exists(dir_path))
     # non-empty dir w/ recursive
     ops.remove(dir_path, recursive=True)
     assert_false(ops.exists(dir_path))

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -9,7 +9,9 @@
 """
 """
 
-from datalad.support.operations.operations_local import LocalOperation
+from datalad.support.operations.operations_local import (
+    LocalOperation,
+)
 from datalad.support.operations.operations_remote import RemoteOperation
 from datalad.support.exceptions import CommandError
 from datalad.utils import (

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -1,0 +1,171 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+
+
+from datalad.support.operations.operations_local import LocalOperation
+from datalad.support.exceptions import CommandError
+from datalad.utils import Path
+from datalad.tests.utils import (
+    assert_raises,
+    assert_false,
+    assert_repo_status,
+    with_tempfile,
+    with_tree,
+    ok_,
+    ok_exists,
+    ok_file_has_content,
+    create_tree,
+    eq_,
+    neq_,
+    assert_status,
+    assert_result_count,
+    assert_in,
+    assert_in_results,
+    assert_not_in,
+    swallow_logs,
+    swallow_outputs,
+    known_failure_githubci_win,
+    known_failure_appveyor,
+    known_failure_windows,
+    slow,
+    with_testrepos,
+    OBSCURE_FILENAME,
+    SkipTest,
+    has_symlink_capability
+)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_make_directory_local(cwd, path):
+    cwd = Path(cwd)
+    path = Path(path)
+    deep = path / 'deeper' / OBSCURE_FILENAME
+
+    ops = LocalOperation(cwd=cwd)
+
+    # raise on non-existing parents:
+    assert_raises(FileNotFoundError, ops.make_directory, deep)
+    # doesn't raise:
+    ops.make_directory(path)
+    assert path.is_dir()
+    # raise on existing target:
+    assert_raises(FileExistsError, ops.make_directory, path)
+    # doesn't raise:
+    ops.make_directory(deep, force=True)
+    assert deep.is_dir()
+    # relative resolves based on cwd:
+    rel_path = Path('another')
+    ops.make_directory(rel_path)
+    assert (cwd / rel_path).is_dir()
+
+
+@with_tempfile
+@with_tempfile
+@with_tempfile
+@with_tempfile(mkdir=True)
+def test_exists_local(file_path, dir_path, link_path, cwd):
+    file_path = Path(file_path)
+    dir_path = Path(dir_path)
+    link_path = Path(link_path)
+    cwd = Path(cwd)
+    ops = LocalOperation(cwd=cwd)
+
+    # regular file:
+    assert_false(ops.exists(file_path))
+    file_path.write_text('some')
+    ok_(ops.exists(file_path))
+
+    # symlink
+    if has_symlink_capability():
+        assert_false(ops.exists(link_path))
+        link_path.symlink_to('broken')
+        ok_(ops.exists(link_path))
+        ops.remove(link_path)
+        link_path.symlink_to(file_path)
+        ok_(ops.exists(link_path))
+
+    # directory
+    assert_false(ops.exists(dir_path))
+    ops.make_directory(dir_path)
+    ok_(ops.exists(dir_path))
+
+    # relative
+    assert_false(ops.exists(Path('relative')))
+    (cwd / 'relative').write_text('content')
+    ok_(ops.exists(Path('relative')))
+
+
+@with_tempfile
+@with_tempfile
+@with_tempfile(mkdir=True)
+def test_remove_local(dir_path, link_path, cwd):
+
+    dir_path = Path(dir_path)
+    link_path = Path(link_path)
+    cwd = Path(cwd)
+    ops = LocalOperation(cwd=cwd)
+
+    # non-existent doesn't raise:
+    ops.remove(dir_path)
+    ops.make_directory(dir_path)
+    ok_(ops.exists(dir_path))
+    # directory, but w/o recursive
+    assert_raises(CommandError, ops.remove, dir_path)
+    ok_(ops.exists(dir_path))
+    underneath = (dir_path / 'some')
+    underneath.write_text('content')
+    # non-empty dir w/ recursive
+    ops.remove(dir_path, recursive=True)
+    assert_false(ops.exists(dir_path))
+
+    if has_symlink_capability():
+        # remove a link
+        link_path.symlink_to('broken')
+        ops.remove(link_path)
+
+    # relative to correct base:
+    relative = (cwd / OBSCURE_FILENAME)
+    relative.write_text("doesn't matter")
+    ok_(ops.exists(relative))
+    ops.remove(Path(OBSCURE_FILENAME))
+    assert_false(ops.exists(relative))
+
+
+@with_tempfile(mkdir=True)
+def test_rename_local(cwd):
+    cwd = Path(cwd)
+    ops = LocalOperation(cwd=cwd)
+
+    # rename regular file
+    file_path = cwd / "first"
+    file_path.write_text("first")
+    ops.rename(Path("first"), Path("second"))
+    ok_(ops.exists(Path("second")))
+    assert_false(ops.exists(Path("first")))
+    eq_("first", (cwd / "second").read_text())
+
+    # rename dir
+    dir_path = cwd / "dir"
+    ops.make_directory(dir_path)
+    dir_path.is_dir()
+    ops.rename(Path("dir"), Path(OBSCURE_FILENAME))
+    ok_(ops.exists(Path(OBSCURE_FILENAME)))
+    (cwd / OBSCURE_FILENAME).is_dir()
+    assert_false(ops.exists(dir_path))
+
+    if has_symlink_capability():
+        # rename symlink
+        link_path = cwd / "somelink"
+        link_path.symlink_to('broken')
+        ok_(ops.exists(link_path))
+        ops.rename(link_path, Path("newlink"))
+        ok_(ops.exists(Path("newlink")))
+        assert_false(ops.exists(link_path))

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -6,12 +6,16 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-
-
+"""
+"""
 
 from datalad.support.operations.operations_local import LocalOperation
+from datalad.support.operations.operations_remote import RemoteOperation
 from datalad.support.exceptions import CommandError
-from datalad.utils import Path
+from datalad.utils import (
+    Path,
+    PurePath
+)
 from datalad.tests.utils import (
     assert_raises,
     assert_false,
@@ -38,7 +42,8 @@ from datalad.tests.utils import (
     with_testrepos,
     OBSCURE_FILENAME,
     SkipTest,
-    has_symlink_capability
+    has_symlink_capability,
+    skip_ssh
 )
 
 
@@ -65,6 +70,39 @@ def test_make_directory_local(cwd, path):
     rel_path = Path('another')
     ops.make_directory(rel_path)
     assert (cwd / rel_path).is_dir()
+
+
+@skip_ssh
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_make_directory_remote(cwd, remote_cwd, path):
+    cwd = Path(cwd)
+    remote_cwd = Path(remote_cwd)
+    path = Path(path)
+    deep = path / 'deeper' / OBSCURE_FILENAME
+
+    # NOTE, that "datalad-test" is supposed to be localhost. So, absolute paths
+    # match on "local" and "remote" end.
+    ops = RemoteOperation("ssh://datalad-test:",
+                          cwd=cwd,
+                          remote_cwd=remote_cwd)
+
+    # raise on non-existing parents:
+    assert_raises(CommandError, ops.make_directory, deep)
+    # doesn't raise:
+    ops.make_directory(path)
+    ok_(path.is_dir())
+    # raise on existing target:
+    assert_raises(CommandError, ops.make_directory, path)
+    # doesn't raise:
+    ops.make_directory(deep, force=True)
+    ok_(deep.is_dir())
+    # relative resolves based on cwd:
+    rel_path = Path('another')
+    ops.make_directory(rel_path)
+    ok_((remote_cwd / rel_path).is_dir())
+    assert_false((cwd / rel_path).is_dir())
 
 
 @with_tempfile
@@ -103,6 +141,49 @@ def test_exists_local(file_path, dir_path, link_path, cwd):
     ok_(ops.exists(Path('relative')))
 
 
+@skip_ssh
+@with_tempfile
+@with_tempfile
+@with_tempfile
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_exists_remote(file_path, dir_path, link_path, cwd, remote_cwd):
+    file_path = Path(file_path)
+    dir_path = Path(dir_path)
+    link_path = Path(link_path)
+    cwd = Path(cwd)
+    remote_cwd = Path(remote_cwd)
+    # NOTE, that "datalad-test" is supposed to be localhost. So, absolute paths
+    # match on "local" and "remote" end.
+    ops = RemoteOperation("ssh://datalad-test:",
+                          cwd=cwd,
+                          remote_cwd=remote_cwd)
+
+    # regular file:
+    assert_false(ops.exists(file_path))
+    file_path.write_text('some')
+    ok_(ops.exists(file_path))
+
+    # symlink
+    if has_symlink_capability():
+        assert_false(ops.exists(link_path))
+        link_path.symlink_to('broken')
+        ok_(ops.exists(link_path))
+        ops.remove(link_path)
+        link_path.symlink_to(file_path)
+        ok_(ops.exists(link_path))
+
+    # directory
+    assert_false(ops.exists(dir_path))
+    ops.make_directory(dir_path)
+    ok_(ops.exists(dir_path))
+
+    # relative
+    assert_false(ops.exists(Path('relative')))
+    (remote_cwd / 'relative').write_text('content')
+    ok_(ops.exists(Path('relative')))
+
+
 @with_tempfile
 @with_tempfile
 @with_tempfile(mkdir=True)
@@ -132,7 +213,51 @@ def test_remove_local(dir_path, link_path, cwd):
         ops.remove(link_path)
 
     # relative to correct base:
-    relative = (cwd / OBSCURE_FILENAME)
+    relative = cwd / OBSCURE_FILENAME
+    relative.write_text("doesn't matter")
+    ok_(ops.exists(relative))
+    ops.remove(Path(OBSCURE_FILENAME))
+    assert_false(ops.exists(relative))
+
+
+@skip_ssh
+@with_tempfile
+@with_tempfile
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_remove_remote(dir_path, link_path, cwd, remote_cwd):
+
+    dir_path = Path(dir_path)
+    link_path = Path(link_path)
+    cwd = Path(cwd)
+    remote_cwd = Path(remote_cwd)
+
+    # NOTE, that "datalad-test" is supposed to be localhost. So, absolute paths
+    # match on "local" and "remote" end.
+    ops = RemoteOperation("ssh://datalad-test:",
+                          cwd=cwd,
+                          remote_cwd=remote_cwd)
+
+    # non-existent doesn't raise:
+    ops.remove(dir_path)
+    ops.make_directory(dir_path)
+    ok_(ops.exists(dir_path))
+    # directory, but w/o recursive
+    assert_raises(CommandError, ops.remove, dir_path)
+    ok_(ops.exists(dir_path))
+    underneath = (dir_path / 'some')
+    underneath.write_text('content')
+    # non-empty dir w/ recursive
+    ops.remove(dir_path, recursive=True)
+    assert_false(ops.exists(dir_path))
+
+    if has_symlink_capability():
+        # remove a link
+        link_path.symlink_to('broken')
+        ops.remove(link_path)
+
+    # relative to correct base:
+    relative = remote_cwd / OBSCURE_FILENAME
     relative.write_text("doesn't matter")
     ok_(ops.exists(relative))
     ops.remove(Path(OBSCURE_FILENAME))
@@ -164,6 +289,46 @@ def test_rename_local(cwd):
     if has_symlink_capability():
         # rename symlink
         link_path = cwd / "somelink"
+        link_path.symlink_to('broken')
+        ok_(ops.exists(link_path))
+        ops.rename(link_path, Path("newlink"))
+        ok_(ops.exists(Path("newlink")))
+        assert_false(ops.exists(link_path))
+
+
+@skip_ssh
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_rename_remote(cwd, remote_cwd):
+    cwd = Path(cwd)
+    remote_cwd = Path(remote_cwd)
+
+    # NOTE, that "datalad-test" is supposed to be localhost. So, absolute paths
+    # match on "local" and "remote" end.
+    ops = RemoteOperation("ssh://datalad-test:",
+                          cwd=cwd,
+                          remote_cwd=remote_cwd)
+
+    # rename regular file
+    file_path = remote_cwd / "first"
+    file_path.write_text("first")
+    ops.rename(Path("first"), Path("second"))
+    ok_(ops.exists(Path("second")))
+    assert_false(ops.exists(Path("first")))
+    eq_("first", (remote_cwd / "second").read_text())
+
+    # rename dir
+    dir_path = remote_cwd / "dir"
+    ops.make_directory(dir_path)
+    dir_path.is_dir()
+    ops.rename(Path("dir"), Path(OBSCURE_FILENAME))
+    ok_(ops.exists(Path(OBSCURE_FILENAME)))
+    (remote_cwd / OBSCURE_FILENAME).is_dir()
+    assert_false(ops.exists(dir_path))
+
+    if has_symlink_capability():
+        # rename symlink
+        link_path = remote_cwd / "somelink"
         link_path.symlink_to('broken')
         ok_(ops.exists(link_path))
         ops.rename(link_path, Path("newlink"))

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -465,3 +465,11 @@ def test_change_group_local():
 
 def test_change_group_remote():
     raise SkipTest("TODO")
+
+
+def test_get():
+    raise SkipTest("TODO")
+
+
+def test_put():
+    raise SkipTest("TODO")

--- a/datalad/support/operations/tests/test_basic_operations.py
+++ b/datalad/support/operations/tests/test_basic_operations.py
@@ -211,7 +211,7 @@ def test_remove_local(dir_path, link_path, cwd):
     underneath = (dir_path / 'some')
     underneath.write_text('content')
     # non-empty dir w/o recursive
-    assert_raises(OSError, ops.remove(dir_path))
+    assert_raises(OSError, ops.remove, dir_path)
     ok_(ops.exists(dir_path))
     # non-empty dir w/ recursive
     ops.remove(dir_path, recursive=True)
@@ -261,7 +261,7 @@ def test_remove_remote(dir_path, link_path, cwd, remote_cwd):
     underneath = (dir_path / 'some')
     underneath.write_text('content')
     # non-empty dir w/o recursive
-    assert_raises(CommandError, ops.remove(dir_path))
+    assert_raises(CommandError, ops.remove, dir_path)
     ok_(ops.exists(dir_path))
     # non-empty dir w/ recursive
     ops.remove(dir_path, recursive=True)
@@ -419,7 +419,7 @@ def test_change_permissions_remote(file_path, dir_path, cwd, remote_cwd):
                           remote_cwd=remote_cwd)
 
     # non-existing path:
-    assert_raises(FileNotFoundError, ops.change_permissions, file_path, 0o777)
+    assert_raises(CommandError, ops.change_permissions, file_path, 0o777)
     # existing file:
     file_path.write_text("some")
     neq_(stat.S_IMODE(file_path.stat().st_mode), 0o777)


### PR DESCRIPTION
ATM This is more thinking out loud than a concrete implementation. The idea
is this:

Let's collect basic operation into classes that can take care of doing
the right thing under different conditions in order to achieve this.
At the moment, we have the Runner to help with that, but the actual
nature of the operations done are scattered throughout the code.

This limits us, and, for example, is something that contributes to the
fact that something like `create_sibling()` can only work with
POSIX-like system, via SSH connections. Moving the local and remote
operation it performs into helper classes that can be specialized for any
target scenario, would help simplify the implementation of that command,
while simultaneously make it more flexible, e.g. it could discover
that the target sibling is at a local path, and internally pick a local
operations helper and achieve the desired result without having to go
through SSH. #4066

Likewise, any, now hardcoded, command execution could be centrally
switched to a variant that is optimized for the local platform
(look for `LocalOperations` in the diff).

Another angle for mid-term improvements would be that less code talks
directly to a Runner. Having specialized methods for particular
operations would enable us to optimize the execution to meet our needs
better.

I envision no limit to the scope of supported operations. For example,
something like `enable_post_update_hook(path)` would be perfectly
in-scope. But even `edit_textfile_interactively(path)` is easily within
the range of possibilities. It would be important, though, that the
classes remain cheap to instantiate.

It is also fine, if not all operations are implemented for all potential
target scenarios immediately. However, the API of an operation would
need to be carefully crafted to avoid overfitting any particular
environment or use case.

We should also consider a similar approach for interfacing with Git
commands, in particular those that report paths -- which are reported in
POSIX conventions, but were/are inappropriately treated as native paths,
leading to failure on Windows. However, it is less clear to me how to
consolidate this with our current approach (ie.  GitRepo.call_git...()).

In conclusion, I'd argue that having such an abstraction layer would
benefit old code by making it more flexible with little effect, and aid
the design of new code that could be written with the fact in mind that
low-level operations are taken care off in a platform-appropriate
fashion, but also that they have to be implemented in a
platform-appropriate fashion, and where this can be done.

[skip ci]