### PR TITLE
Fix ConfigManager file tracking

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -172,19 +172,21 @@ class ConfigManager(object):
       Legacy option, do not use.
     overrides : dict, optional
       Variable overrides, see general class documentation for details.
-    source : {'any', 'local', 'dataset'}, optional
+    source : {'any', 'local', 'dataset', 'dataset-local'}, optional
       Which sources of configuration setting to consider. If 'dataset',
       configuration items are only read from a dataset's persistent
       configuration file, if any is present (the one in ``.datalad/config``, not
-      ``.git/config``); if 'local' any non-committed source is considered
-      (local and global configuration in Git config's terminology); if 'any'
+      ``.git/config``); if 'local', any non-committed source is considered
+      (local and global configuration in Git config's terminology);
+      if 'dataset-local', persistent dataset configuration and local, but
+      not global or system configuration are considered; if 'any'
       all possible sources of configuration are considered.
     """
 
     _checked_git_identity = False
 
     def __init__(self, dataset=None, dataset_only=False, overrides=None, source='any'):
-        if source not in ('any', 'local', 'dataset'):
+        if source not in ('any', 'local', 'dataset', 'dataset-local'):
             raise ValueError(
                 'Unkown ConfigManager(source=) setting: {}'.format(source))
             # legacy compat
@@ -295,6 +297,8 @@ class ConfigManager(object):
             self._store.update(self.overrides)
             return
 
+        if self._src_mode == 'dataset-local':
+            run_args.append('--local')
         stdout, stderr = self._run(run_args, log_stderr=True)
         self._store, self._cfgfiles = _parse_gitconfig_dump(
             stdout, self._store, self._cfgfiles, replace=True,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2516,7 +2516,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             '',
             ['git', 'config', '-z', '-l', '--file', '.gitmodules'])
         # abuse our config parser
-        db, _ = _parse_gitconfig_dump(out, {}, None, True)
+        db, _ = _parse_gitconfig_dump(out, {}, None, True, cwd=self.path)
         mods = {}
         for k, v in db.items():
             if not k.startswith('submodule.'):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -449,3 +449,19 @@ def test_no_leaks(path1, path2):
         # these are the right ones
         assert_in(opj(ds2.path, '.git', 'config'), ds2.config._cfgfiles)
         assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)
+
+
+@with_tempfile
+def test_dataset_local_mode(path):
+    ds = create(path)
+    # any sensible (and also our CI) test environment(s) should have this
+    assert_in('user.name', ds.config)
+    # from .datalad/config
+    assert_in('datalad.dataset.id', ds.config)
+    # from .git/config
+    assert_in('annex.version', ds.config)
+    # now check that dataset-local mode doesn't have the global piece
+    cfg = ConfigManager(ds, source='dataset-local')
+    assert_not_in('user.name', cfg)
+    assert_in('datalad.dataset.id', cfg)
+    assert_in('annex.version', cfg)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -446,3 +446,6 @@ def test_no_leaks(path1, path2):
         # and that we do not track the wrong files
         assert_not_in(opj(ds1.path, '.git', 'config'), ds2.config._cfgfiles)
         assert_not_in(opj(ds1.path, '.datalad', 'config'), ds2.config._cfgfiles)
+        # these are the right ones
+        assert_in(opj(ds2.path, '.git', 'config'), ds2.config._cfgfiles)
+        assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -465,3 +465,22 @@ def test_dataset_local_mode(path):
     assert_not_in('user.name', cfg)
     assert_in('datalad.dataset.id', cfg)
     assert_in('annex.version', cfg)
+
+
+# https://github.com/datalad/datalad/issues/4071
+@with_tempfile
+def test_dataset_systemglobal_mode(path):
+    ds = create(path)
+    # any sensible (and also our CI) test environment(s) should have this
+    assert_in('user.name', ds.config)
+    # from .datalad/config
+    assert_in('datalad.dataset.id', ds.config)
+    # from .git/config
+    assert_in('annex.version', ds.config)
+    with chpwd(path):
+        # now check that no config from a random dataset at PWD is picked up
+        # if not dataset instance was provided
+        cfg = ConfigManager(dataset=None, source='any')
+        assert_in('user.name', cfg)
+        assert_not_in('datalad.dataset.id', cfg)
+        assert_not_in('annex.version', cfg)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -433,7 +433,7 @@ def test_no_leaks(path1, path2):
     # now we move into this one repo, and create another
     # make sure that no config from ds1 leaks into ds2
     with chpwd(path1):
-        ds2 = Dataset(path2).create()
+        ds2 = Dataset(path2)
         assert_not_in('i.was.here', ds2.config.keys())
         ds2.config.reload()
         assert_not_in('i.was.here', ds2.config.keys())

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import (
     with_tree,
     with_tempfile,
     with_testsui,
+    chpwd,
 )
 from datalad.utils import swallow_logs
 
@@ -418,3 +419,30 @@ def test_rewrite_url():
             assert_equal(rewrite_url(cfg, input), output)
         if input.startswith('conflict'):
             assert_in("Ignoring URL rewrite", msg.out)
+
+
+# https://github.com/datalad/datalad/issues/4071
+@with_tempfile()
+@with_tempfile()
+def test_no_leaks(path1, path2):
+    ds1 = Dataset(path1).create()
+    ds1.config.set('i.was.here', 'today', where='local')
+    assert_in('i.was.here', ds1.config.keys())
+    ds1.config.reload()
+    assert_in('i.was.here', ds1.config.keys())
+    # now we move into this one repo, and create another
+    # make sure that no config from ds1 leaks into ds2
+    with chpwd(path1):
+        ds2 = Dataset(path2).create()
+        assert_not_in('i.was.here', ds2.config.keys())
+        ds2.config.reload()
+        assert_not_in('i.was.here', ds2.config.keys())
+
+        cfg = ConfigManager(ds2, source='local')
+        assert_not_in('i.was.here', cfg.keys())
+        cfg.reload()
+        assert_not_in('i.was.here', cfg.keys())
+
+        # and that we do not track the wrong files
+        assert_not_in(opj(ds1.path, '.git', 'config'), ds2.config._cfgfiles)
+        assert_not_in(opj(ds1.path, '.datalad', 'config'), ds2.config._cfgfiles)


### PR DESCRIPTION
This is a fix for #4071, in particular:

- [x] track `.git/config` from a given dataset, not something that just happens to be found in `PWD`
- [x] prevent invalid paramterization of `ConfigManager()`
- [x] enfore CWD for `git-config` calls to be a dataset's root dir, whenever it exists
- [x] prevent accidental interaction with a dataset at PWD, when a `ConfigManager` was parameterized with a dataset instance that has no equivalent on disk
- [x] quite a few additional tests