### PR TITLE
BF: Make sure source candidate configs for submodules are inherited

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -456,6 +456,7 @@ def clone_dataset(
         if cand['type'] == 'ria':
             yield from postclonecfg_ria(destds, cand)
 
+        result_props['source'] = cand
         # do not bother with other sources if succeeded
         break
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -198,7 +198,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                         alternate_suffix=False)
                 )
 
-        for name, tmpl in [(c[40:], ds_repo.config[c])
+        for name, tmpl in [(c[12:], ds_repo.config[c])
                            for c in ds_repo.config.keys()
                            if c.startswith(
                                'datalad.get.subdataset-source-candidate-')]:

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -119,7 +119,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
                 ('origin', ds_subpath),
-                ('bang', 'youredead'),
+                ('subdataset-source-candidate-bang', 'youredead'),
                 ('local', clone_subpath),
         ])
     # verify template instantiation works
@@ -129,7 +129,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
                 ('origin', ds_subpath),
-                ('bang', 'pre-{}-post'.format(sub.id)),
+                ('subdataset-source-candidate-bang', 'pre-{}-post'.format(sub.id)),
                 ('local', clone_subpath),
         ])
     # now again, but have an additional remote besides origin that


### PR DESCRIPTION
[ this is sitting on top of #4072 and hence inherits its issues]

This makes it possible to have large collections of datasets put in
some dataset store, without any of them carrying knowledge about their
hosting location, even if they have super-sub-dataset relationships
among themselves. The only requirement to make any of these datasets
accessible, is a single top-level superdataset with a source candidate
configuration that is point to the store. Everything else will be
handle with on-clone configuration in `.git/config` of each subdataset.