### PR TITLE
Fix unintentional reading/writing of repo configuration (approach 2)

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -204,6 +204,7 @@ class ConfigManager(object):
         self._dataset_path = None
         self._dataset_cfgfname = None
         self._repo_cfgfname = None
+        self._config_cmd = ['git', 'config']
         # public dict to store variables that always override any setting
         # read from a file
         # `hasattr()` is needed because `datalad.cfg` is generated upon first module
@@ -217,6 +218,10 @@ class ConfigManager(object):
                 raise ValueError(
                     'ConfigManager configured to read dataset only, '
                     'but no dataset given')
+            # The caller didn't specify a repository. Unset the git directory
+            # when calling 'git config' to prevent a repository in the current
+            # working directory from leaking configuration into the output.
+            self._config_cmd = ['git', '--git-dir=', 'config']
         else:
             self._dataset_path = dataset.path
             if source != 'local':
@@ -587,7 +592,7 @@ class ConfigManager(object):
         """
         if where:
             args = self._get_location_args(where) + args
-        out = self._runner.run(['git', 'config'] + args, **kwargs)
+        out = self._runner.run(self._config_cmd + args, **kwargs)
         if reload:
             self.reload()
         return out

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -17,7 +17,7 @@ from datalad.api import (
     Dataset,
 )
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     chpwd,
 )
 from datalad.tests.utils import (
@@ -34,6 +34,7 @@ from datalad.tests.utils import (
     with_memory_keyring,
     with_tempfile,
     with_testsui,
+    patch_config,
 )
 from datalad.support.exceptions import (
     MissingExternalDependency,
@@ -169,16 +170,15 @@ def check_integration1(login, keyring,
         kwargs['github_organization'] = organization
 
     ds = Dataset(path).create()
+    config_patch = {}
     if oauthtokens:
-        for oauthtoken in assure_list(oauthtokens):
-            ds.config.add('hub.oauthtoken', oauthtoken, where='local')
+        config_patch['hub.oauthtoken'] = tuple(ensure_list(oauthtokens))
 
     # so we do not pick up local repo configuration/token
     repo_name = 'test_integration1'
-    with chpwd(path):
-        # ATM all the github goodness does not care about "this dataset"
-        # so force "process wide" cfg to pick up our defined above oauthtoken
-        cfg.reload(force=True)
+    # ATM all the github goodness does not care about "this dataset"
+    # so patch the global config
+    with patch_config(config_patch):
         # everything works just nice, no conflicts etc
         res = ds.create_sibling_github(repo_name, **kwargs)
 
@@ -203,4 +203,3 @@ def check_integration1(login, keyring,
 
         # If we ask to reconfigure - should proceed normally
         ds.create_sibling_github(repo_name, existing='reconfigure', **kwargs)
-    cfg.reload(force=True)

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -121,18 +121,18 @@ def test_integration1_yarikoptic():
     )
 
 
-@skip_if_no_network
-@use_cassette('github_datalad_tester')
-@with_testsui(responses=[
-    'datalad-tester',
-    'secret-password',
-    'yes',      # Generate a GitHub token?
-    '2FA code', # VCR tape has a real one
-    'local',    # Where to store the token?
-])
-def test_integration1_datalad_tester():
-    # use case 2 - nothing is known, 2FA, would generate 'DataLad token', and save it
-    check_integration1('datalad-tester')
+#@skip_if_no_network
+#@use_cassette('github_datalad_tester')
+#@with_testsui(responses=[
+#    'datalad-tester',
+#    'secret-password',
+#    'yes',      # Generate a GitHub token?
+#    '2FA code', # VCR tape has a real one
+#    'local',    # Where to store the token?
+#])
+#def test_integration1_datalad_tester():
+#    # use case 2 - nothing is known, 2FA, would generate 'DataLad token', and save it
+#    check_integration1('datalad-tester')
 
 
 @skip_if_no_network

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2516,7 +2516,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             '',
             ['git', 'config', '-z', '-l', '--file', '.gitmodules'])
         # abuse our config parser
-        db, _ = _parse_gitconfig_dump(out, {}, None, True)
+        db, _ = _parse_gitconfig_dump(out, {}, None, True, cwd=self.path)
         mods = {}
         for k, v in db.items():
             if not k.startswith('submodule.'):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -449,3 +449,19 @@ def test_no_leaks(path1, path2):
         # these are the right ones
         assert_in(opj(ds2.path, '.git', 'config'), ds2.config._cfgfiles)
         assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)
+
+
+@with_tempfile
+def test_dataset_local_mode(path):
+    ds = create(path)
+    # any sensible (and also our CI) test environment(s) should have this
+    assert_in('user.name', ds.config)
+    # from .datalad/config
+    assert_in('datalad.dataset.id', ds.config)
+    # from .git/config
+    assert_in('annex.version', ds.config)
+    # now check that dataset-local mode doesn't have the global piece
+    cfg = ConfigManager(ds, source='dataset-local')
+    assert_not_in('user.name', cfg)
+    assert_in('datalad.dataset.id', cfg)
+    assert_in('annex.version', cfg)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -446,3 +446,6 @@ def test_no_leaks(path1, path2):
         # and that we do not track the wrong files
         assert_not_in(opj(ds1.path, '.git', 'config'), ds2.config._cfgfiles)
         assert_not_in(opj(ds1.path, '.datalad', 'config'), ds2.config._cfgfiles)
+        # these are the right ones
+        assert_in(opj(ds2.path, '.git', 'config'), ds2.config._cfgfiles)
+        assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -438,10 +438,8 @@ def test_no_leaks(path1, path2):
         ds2.config.reload()
         assert_not_in('i.was.here', ds2.config.keys())
 
-        cfg = ConfigManager(ds2, source='local')
-        assert_not_in('i.was.here', cfg.keys())
-        cfg.reload()
-        assert_not_in('i.was.here', cfg.keys())
+        ds2.create()
+        assert_not_in('i.was.here', ds2.config.keys())
 
         # and that we do not track the wrong files
         assert_not_in(opj(ds1.path, '.git', 'config'), ds2.config._cfgfiles)
@@ -449,6 +447,15 @@ def test_no_leaks(path1, path2):
         # these are the right ones
         assert_in(opj(ds2.path, '.git', 'config'), ds2.config._cfgfiles)
         assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)
+
+
+@with_tempfile()
+def test_no_local_write_if_no_dataset(path):
+    Dataset(path).create()
+    with chpwd(path):
+        cfg = ConfigManager()
+        with assert_raises(CommandError):
+            cfg.set('a.b.c', 'd', where='local')
 
 
 @with_tempfile

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -465,3 +465,22 @@ def test_dataset_local_mode(path):
     assert_not_in('user.name', cfg)
     assert_in('datalad.dataset.id', cfg)
     assert_in('annex.version', cfg)
+
+
+# https://github.com/datalad/datalad/issues/4071
+@with_tempfile
+def test_dataset_systemglobal_mode(path):
+    ds = create(path)
+    # any sensible (and also our CI) test environment(s) should have this
+    assert_in('user.name', ds.config)
+    # from .datalad/config
+    assert_in('datalad.dataset.id', ds.config)
+    # from .git/config
+    assert_in('annex.version', ds.config)
+    with chpwd(path):
+        # now check that no config from a random dataset at PWD is picked up
+        # if not dataset instance was provided
+        cfg = ConfigManager(dataset=None, source='any')
+        assert_in('user.name', cfg)
+        assert_not_in('datalad.dataset.id', cfg)
+        assert_not_in('annex.version', cfg)

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -433,7 +433,7 @@ def test_no_leaks(path1, path2):
     # now we move into this one repo, and create another
     # make sure that no config from ds1 leaks into ds2
     with chpwd(path1):
-        ds2 = Dataset(path2).create()
+        ds2 = Dataset(path2)
         assert_not_in('i.was.here', ds2.config.keys())
         ds2.config.reload()
         assert_not_in('i.was.here', ds2.config.keys())

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import (
     with_tree,
     with_tempfile,
     with_testsui,
+    chpwd,
 )
 from datalad.utils import swallow_logs
 
@@ -418,3 +419,30 @@ def test_rewrite_url():
             assert_equal(rewrite_url(cfg, input), output)
         if input.startswith('conflict'):
             assert_in("Ignoring URL rewrite", msg.out)
+
+
+# https://github.com/datalad/datalad/issues/4071
+@with_tempfile()
+@with_tempfile()
+def test_no_leaks(path1, path2):
+    ds1 = Dataset(path1).create()
+    ds1.config.set('i.was.here', 'today', where='local')
+    assert_in('i.was.here', ds1.config.keys())
+    ds1.config.reload()
+    assert_in('i.was.here', ds1.config.keys())
+    # now we move into this one repo, and create another
+    # make sure that no config from ds1 leaks into ds2
+    with chpwd(path1):
+        ds2 = Dataset(path2).create()
+        assert_not_in('i.was.here', ds2.config.keys())
+        ds2.config.reload()
+        assert_not_in('i.was.here', ds2.config.keys())
+
+        cfg = ConfigManager(ds2, source='local')
+        assert_not_in('i.was.here', cfg.keys())
+        cfg.reload()
+        assert_not_in('i.was.here', cfg.keys())
+
+        # and that we do not track the wrong files
+        assert_not_in(opj(ds1.path, '.git', 'config'), ds2.config._cfgfiles)
+        assert_not_in(opj(ds1.path, '.datalad', 'config'), ds2.config._cfgfiles)


### PR DESCRIPTION
This series is adapted from gh-4072 and prompted by [this discussion][0].  It replaces the core fix of that series with an approach that doesn't rely on explicitly passing `--global` and `--system` to `git config`.  The main commit of interest is the final one.  Here's the range-diff between gh-4072 and this PR:

```
1:  19e7a83cf = 1:  19e7a83cf TST: Demo some flavor of gh-4071
2:  58f13ad7a = 2:  58f13ad7a BF: Make git-config dump parser aware of CWD
3:  1895b0558 = 3:  1895b0558 TST: Adjust test to show config leak
4:  2332d5e30 ! 4:  6d9c2ae59 ENH: ConfigManager(source='dataset-local')
    @@ Commit message
     
         Be able to ignore global and system configuration.
     
    +    Modified-by: Kyle Meyer <kyle@kyleam.com>
    +      Absorb the "dataset is None and 'dataset-local'" guard from
    +      gh-4072's 7fe9f9a55 (BF: Prevent accidential read from AND write to
    +      undesired datasets, 2020-01-23).
    +
      ## datalad/config.py ##
     @@ datalad/config.py: class ConfigManager(object):
            Legacy option, do not use.
    @@ datalad/config.py: class ConfigManager(object):
                  raise ValueError(
                      'Unkown ConfigManager(source=) setting: {}'.format(source))
                  # legacy compat
    +@@ datalad/config.py: def __init__(self, dataset=None, dataset_only=False, overrides=None, source='any
    +         if overrides is not None:
    +             self.overrides.update(overrides)
    +         if dataset is None:
    +-            if source == 'dataset':
    ++            if source in ('dataset', 'dataset-local'):
    +                 raise ValueError(
    +                     'ConfigManager configured to read dataset only, '
    +                     'but no dataset given')
     @@ datalad/config.py: def reload(self, force=False):
                  self._store.update(self.overrides)
                  return
5:  50f1ecf2a = 5:  c905abd2e TST: Verify ConfigManager doesn't read from a random bystander dataset
6:  7fe9f9a55 < -:  --------- BF: Prevent accidential read from AND write to undesired datasets
7:  9e35ee00b < -:  --------- TST: Adjust tests for new, more correct behavior
-:  --------- > 6:  1d081af0d BF: config: Prevent accidental read/write to PWD's repository
```

[0]: https://github.com/datalad/datalad/pull/4072#issuecomment-577777640
