### PR TITLE
WitlessRunner() to replace gitpy.Repo.clone_from() with plain `git-clone` call, but keep progress reporting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,7 +105,7 @@ test_script:
   # remaining fails: test_annexrepo test_digests test_locking test_repodates test_sshrun 
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.support.tests.test_cache datalad.support.tests.test_stats datalad.support.tests.test_status datalad.support.tests.test_versions datalad.support.tests.test_network datalad.support.tests.test_external_versions datalad.support.tests.test_sshconnector datalad.support.tests.test_json_py datalad.support.tests.test_vcr_ datalad.support.tests.test_gitrepo"
   # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
-  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives"
+  - "python -m nose -s -v --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner"
 
   - "python -m nose -s -v --with-cov --cover-package datalad datalad.ui"
   

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -99,10 +99,10 @@ def _cleanup_output(stream, std):
 
 
 class LeanRunner(object):
-    __slots__ = ['cwd', 'env', '_communicate_period']
+    __slots__ = ['cwd', 'env', '_poll_period']
 
-    def __init__(self, cwd=None, env=None, communicate_period=0.1):
-        self._communicate_period = communicate_period
+    def __init__(self, cwd=None, env=None, poll_period=0.1):
+        self._poll_period = poll_period
         self.env = env.copy() if env else None
         self.cwd = cwd
         if cwd and env is not None:
@@ -127,7 +127,7 @@ class LeanRunner(object):
                 stdin=stdin,
                 # intermediate reports are never decoded anyways
                 # from PY37 onwards
-                text=False,
+                #text=False,
                 universal_newlines=False,
             )
         except Exception as e:
@@ -145,7 +145,7 @@ class LeanRunner(object):
                     # get a chunk of output for the specific period
                     # of time
                     pout = process.communicate(
-                        timeout=self._communicate_period,
+                        timeout=self._poll_period,
                     )
                 except subprocess.TimeoutExpired as poll:
                     # this will always be the full report so far,

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -236,7 +236,11 @@ class WitlessRunner(object):
                 # get a chunk of output
                 pout = [
                     # read whatever is available, should not block
-                    o.read1(-1) if p else None
+                    # From P37 onwards we could say "I don't care how much you can give me"
+                    #o.read1(-1) if p else None
+                    # but instead we say, give me what you have, and if you have nothing,
+                    # make the shortest possible blocking read
+                    o.read1(1) if p else None
                     for o, p in zip(
                         (process.stdout, process.stderr),
                         proc_out)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -313,7 +313,7 @@ class WitlessRunner(object):
         return out
 
 
-class Runner(WitlessRunner):
+class Runner(object):
     """Provides a wrapper for calling functions and commands.
 
     An object of this class provides a methods that calls shell commands or
@@ -346,8 +346,9 @@ class Runner(WitlessRunner):
              Switch to instruct whether outputs should be logged or not.  If not
              set (default), config 'datalad.log.outputs' would be consulted
         """
-        super(Runner, self).__init__(cwd=cwd, env=env)
 
+        self.cwd = cwd
+        self.env = env
         if protocol is None:
             # TODO: config cmd.protocol = null
             protocol_str = os.environ.get('DATALAD_CMD_PROTOCOL', 'null')

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -98,6 +98,21 @@ def _cleanup_output(stream, std):
         std.close()
 
 
+def kill_output(output):
+    """Helper for WitlessRunner to swallow all output and neither
+    relay it to the parent process's stdout, not provide it as
+    return value of WitlessRunner.run().
+    """
+    return b'', 0
+
+
+def capture_output(output):
+    """Helper for WitlessRunner to capture all output and
+    provide it as return value of WitlessRunner.run().
+    """
+    return output, 0
+
+
 class WitlessRunner(object):
     """Minimal Runner with support for online command output processing
 
@@ -142,10 +157,15 @@ class WitlessRunner(object):
           that it is simply the name of the program, no complex shell
           commands are supported.
         proc_stdout : callable, optional
-          If given, all stdout is passed as byte-string to this callable,
-          in the chunks it was received by polling the processing. The
-          callable may transform it in any way, its output (byte-string)
-          is concatenated and provided as stdout return value.
+          By defaultno stdout is captured, but relayed to the parent
+          process's stdout. If given, all stdout is passed as byte-string
+          to this callable, in the chunks it was received by polling the
+          processing. The callable may transform it in any way, its output
+          (byte-string) is concatenated and provided as stdout return value.
+          The helper functions 'kill_output', and 'capture_output' are
+          provided to either swallow all output (and not relay it to the
+          parent), or to capture all output and provide it as return
+          value.
         proc_stderr : callable, optional
           Like proc_stdout, but for stderr.
         stdin : byte stream, optional

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -194,6 +194,8 @@ class WitlessRunner(object):
           raised which provides the command (cmd), stdout, stderr,
           exit code (status), and a message identifying the failed
           command, as properties.
+        FileNotFoundError
+          When a given executable does not exist.
         """
         proc_out = (proc_stdout, proc_stderr)
         try:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -155,10 +155,15 @@ class WitlessRunner(object):
           commands are supported.
         proc_stdout : callable, optional
           By default no stdout is captured, but relayed to the parent
-          process's stdout. If given, all stdout is passed as a byte-string
-          to this callable, in the chunks it was received by polling the
-          processing. The callable may transform it in any way, its output
-          (byte-string) is concatenated and provided as stdout return value.
+          process's stdout. If given, all stdout is sequentially passed
+          as a byte-string to this callable, in the chunks it was received
+          by polling the process (see `poll_latency`).
+          The callable may transform it in any way. It must
+          return a byte-string of the transformed output, and an integer
+          with the number of bytes at the end of the original output
+          that were left unprocessed (or 0, if the entire output was
+          considered). The returned byte-strings are concatenated and
+          provided as stdout return value.
           The helper functions 'kill_output' and 'capture_output' are
           provided to either swallow all output (and not relay it to the
           parent) or to capture all output and provide it as the return

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -120,9 +120,9 @@ class WitlessRunner(object):
     functionality. Derived classes should be used for additional
     specializations and convenience features.
     """
-    __slots__ = ['cwd', 'env', '_poll_period']
+    __slots__ = ['cwd', 'env']
 
-    def __init__(self, cwd=None, env=None, poll_period=0.1):
+    def __init__(self, cwd=None, env=None):
         """
         Parameters
         ----------
@@ -134,11 +134,7 @@ class WitlessRunner(object):
           was given, 'PWD' in the environment is set to its value.
           This must be a complete environment definition, no values
           from the current environment will be inherited.
-        poll_period : float, optional
-          Interval at which the running process is queried for
-          output.
         """
-        self._poll_period = poll_period
         self.env = env.copy() if env else None
         # stringify to support Path instances on PY35
         self.cwd = str(cwd) if cwd is not None else None
@@ -147,7 +143,8 @@ class WitlessRunner(object):
             # a potential PWD setting
             self.env['PWD'] = self.cwd
 
-    def run(self, cmd, proc_stdout=None, proc_stderr=None, stdin=None):
+    def run(self, cmd, proc_stdout=None, proc_stderr=None, stdin=None,
+            poll_period=0.1):
         """Execute a command and communicate with it.
 
         Parameters
@@ -171,6 +168,9 @@ class WitlessRunner(object):
         stdin : byte stream, optional
           File descriptor like, used as stdin for the process. Passed
           verbatim to subprocess.Popen().
+        poll_period : float, optional
+          Interval at which the running process is queried for
+          output (in seconds).
 
         Returns
         -------
@@ -225,7 +225,7 @@ class WitlessRunner(object):
                     # get a chunk of output for the specific period
                     # of time
                     pout = process.communicate(
-                        timeout=self._poll_period,
+                        timeout=poll_period,
                     )
                     # we know the process ended at this point
                     keep_going = False

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -142,10 +142,10 @@ class WitlessRunner(object):
         self.env = env.copy() if env else None
         # stringify to support Path instances on PY35
         self.cwd = str(cwd) if cwd is not None else None
-        if cwd and env is not None:
+        if self.cwd and env is not None:
             # if CWD was provided, we must not make it conflict with
             # a potential PWD setting
-            self.env['PWD'] = cwd
+            self.env['PWD'] = self.cwd
 
     def run(self, cmd, proc_stdout=None, proc_stderr=None, stdin=None):
         """Execute a command and communicate with it.

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -225,7 +225,7 @@ class WitlessRunner(object):
             keep_going = True
 
             def _handle_output(u, o, p):
-                processed, unprocessed_len = proc(u)
+                processed, unprocessed_len = p(u)
                 if processed:
                     o.append(processed)
                 return u[-(unprocessed_len):] if unprocessed_len else None

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -234,7 +234,7 @@ class LeanRunner(object):
             status = process.poll()
 
             # decode bytes to string
-            out = tuple(o.decode('utf-8') if o else '' for o in pout)
+            out = tuple(o.decode('utf-8') if o else '' for o in out)
 
             if status not in [0, None]:
                 msg = "Failed to run %r%s." % (

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -262,7 +262,7 @@ class LeanRunner(object):
                 # there are still possible (although unlikely) cases when
                 # we fail to interrupt but we
                 # should not crash if we fail to terminate the process
-                proc.terminate()
+                process.terminate()
             except BaseException as exc2:
                 lgr.warning("Failed to terminate process for %s: %s",
                             cmd, exc_str(exc2))

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -292,13 +292,6 @@ class WitlessRunner(object):
             else:
                 lgr.log(8, "Finished running %r with status %s", cmd, status)
 
-        except CommandError:
-            # do not bother with reacting to "regular" CommandError
-            # exceptions.  Somehow if we also terminate here for them
-            # some processes elsewhere might stall:
-            # see https://github.com/datalad/datalad/pull/3794
-            raise
-
         except BaseException as exc:
             exc_info = sys.exc_info()
             # KeyboardInterrupt is subclass of BaseException

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -100,7 +100,7 @@ def _cleanup_output(stream, std):
 
 def kill_output(output):
     """Helper for WitlessRunner to swallow all output and neither
-    relay it to the parent process's stdout, not provide it as
+    relay it to the parent process's stdout, nor provide it as the
     return value of WitlessRunner.run().
     """
     return b'', 0
@@ -108,7 +108,7 @@ def kill_output(output):
 
 def capture_output(output):
     """Helper for WitlessRunner to capture all output and
-    provide it as return value of WitlessRunner.run().
+    provide it as the return value of WitlessRunner.run().
     """
     return output, 0
 
@@ -130,7 +130,7 @@ class WitlessRunner(object):
           If given, commands are executed with this path as PWD,
           the PWD of the parent process is used otherwise.
         env : dict, optional
-          Environment to be pass to subprocess.Popen(). If `cwd`
+          Environment to be passed to subprocess.Popen(). If `cwd`
           was given, 'PWD' in the environment is set to its value.
           This must be a complete environment definition, no values
           from the current environment will be inherited.
@@ -157,14 +157,14 @@ class WitlessRunner(object):
           that it is simply the name of the program, no complex shell
           commands are supported.
         proc_stdout : callable, optional
-          By defaultno stdout is captured, but relayed to the parent
-          process's stdout. If given, all stdout is passed as byte-string
+          By default no stdout is captured, but relayed to the parent
+          process's stdout. If given, all stdout is passed as a byte-string
           to this callable, in the chunks it was received by polling the
           processing. The callable may transform it in any way, its output
           (byte-string) is concatenated and provided as stdout return value.
-          The helper functions 'kill_output', and 'capture_output' are
+          The helper functions 'kill_output' and 'capture_output' are
           provided to either swallow all output (and not relay it to the
-          parent), or to capture all output and provide it as return
+          parent) or to capture all output and provide it as the return
           value.
         proc_stderr : callable, optional
           Like proc_stdout, but for stderr.
@@ -181,7 +181,7 @@ class WitlessRunner(object):
         Raises
         ------
         CommandError
-          On executation failure (non-zero exit code) this exception is
+          On execution failure (non-zero exit code) this exception is
           raised which provides the command (cmd), stdout, stderr,
           exit code (status), and a message identifying the failed
           command, as properties.

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -210,8 +210,9 @@ class LeanRunner(object):
 
                 if proc_out is not None:
                     for i, (o, proc) in enumerate(zip(pout, proc_out)):
-                        if proc_out is None:
-                            out[i] += o
+                        if proc is None:
+                            if o is not None:
+                                out[i] += o
                             # no index update needed, can never change
                             continue
                         # current length of output

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -98,7 +98,7 @@ def _cleanup_output(stream, std):
         std.close()
 
 
-class LeanRunner(object):
+class WitlessRunner(object):
     """Minimal Runner with support for online command output processing
 
     It aims to be as simple as possible, providing only essential
@@ -276,7 +276,7 @@ class LeanRunner(object):
         return out
 
 
-class Runner(LeanRunner):
+class Runner(WitlessRunner):
     """Provides a wrapper for calling functions and commands.
 
     An object of this class provides a methods that calls shell commands or

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -196,7 +196,10 @@ class LeanRunner(object):
         try:
             out = [b'', b'']
             last_idx = [0, 0]
-            while process.poll() is None:
+            pout = None
+            # make sure to run this loop at least once, even if the
+            # process is already dead
+            while process.poll() is None or pout is None:
                 try:
                     # get a chunk of output for the specific period
                     # of time

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -219,13 +219,16 @@ class WitlessRunner(object):
             pout = None
             # make sure to run this loop at least once, even if the
             # process is already dead
-            while process.poll() is None or pout is None:
+            keep_going = True
+            while process.poll() is None or keep_going:
                 try:
                     # get a chunk of output for the specific period
                     # of time
                     pout = process.communicate(
                         timeout=self._poll_period,
                     )
+                    # we know the process ended at this point
+                    keep_going = False
                 except subprocess.TimeoutExpired as poll:
                     # this will always be the full report so far,
                     # not just an output increment

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -170,6 +170,7 @@ class LeanRunner(object):
         if all(p is None for p in proc_out):
             proc_out = None
         try:
+            lgr.log(8, "Start running %r", cmd)
             process = subprocess.Popen(
                 cmd,
                 # from PY37 onwards
@@ -244,7 +245,7 @@ class LeanRunner(object):
                     stderr=out[1],
                 )
             else:
-                lgr.log(8, "Finished running %r with status %s", (cmd, status))
+                lgr.log(8, "Finished running %r with status %s", cmd, status)
 
         except CommandError:
             # do not bother with reacting to "regular" CommandError

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -230,6 +230,12 @@ class WitlessRunner(object):
                     o.append(processed)
                 return u[-(unprocessed_len):] if unprocessed_len else None
 
+            def _read_stream(stream):
+                #if sys.version_info.major == 3 and sys.version_info.minor < 7:
+                nbytes_avail = len(stream.peek())
+                return stream.read(nbytes_avail) if nbytes_avail > 0 else None
+                # o.read1(-1)
+
             while process.poll() is None or keep_going:
                 # one last read?
                 keep_going = process.returncode is None
@@ -240,7 +246,7 @@ class WitlessRunner(object):
                     #o.read1(-1) if p else None
                     # but instead we say, give me what you have, and if you have nothing,
                     # make the shortest possible blocking read
-                    o.read1(1) if p else None
+                    _read_stream(o) if p else None
                     for o, p in zip(
                         (process.stdout, process.stderr),
                         proc_out)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -19,6 +19,7 @@ import os
 import atexit
 import functools
 import tempfile
+from locale import getpreferredencoding
 
 from collections import OrderedDict
 from .support import path as op
@@ -271,7 +272,10 @@ class WitlessRunner(object):
             status = process.poll()
 
             # decode bytes to string
-            out = tuple(b''.join(o).decode('utf-8') if o else '' for o in out)
+            out = tuple(
+                b''.join(o).decode(getpreferredencoding(do_setlocale=False))
+                if o else ''
+                for o in out)
 
             if status not in [0, None]:
                 msg = "Failed to run %r%s." % (

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -232,21 +232,19 @@ class WitlessRunner(object):
                 return u[-(unprocessed_len):] if unprocessed_len else None
 
             def _read_stream(stream):
-                #if sys.version_info.major == 3 and sys.version_info.minor < 7:
+                # read whatever is available, must not block,
+                # because if it blocks on, e.g., stdout, we will not get to
+                # read from stderr and vice versa. But if the other one
+                # receives large amounts of data in the meantime, we will
+                # get into issues and deadlock the process
                 nbytes_avail = len(stream.peek())
                 return stream.read(nbytes_avail) if nbytes_avail > 0 else None
-                # o.read1(-1)
 
             while process.poll() is None or keep_going:
                 # one last read?
                 keep_going = process.returncode is None
                 # get a chunk of output
                 pout = [
-                    # read whatever is available, should not block
-                    # From P37 onwards we could say "I don't care how much you can give me"
-                    #o.read1(-1) if p else None
-                    # but instead we say, give me what you have, and if you have nothing,
-                    # make the shortest possible blocking read
                     _read_stream(o) if p else None
                     for o, p in zip(
                         (process.stdout, process.stderr),

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -117,6 +117,8 @@ class LeanRunner(object):
         env : dict, optional
           Environment to be pass to subprocess.Popen(). If `cwd`
           was given, 'PWD' in the environment is set to its value.
+          This must be a complete environment definition, no values
+          from the current environment will be inherited.
         poll_period : float, optional
           Interval at which the running process is queried for
           output.

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -124,7 +124,7 @@ class LeanRunner(object):
         self._poll_period = poll_period
         self.env = env.copy() if env else None
         # stringify to support Path instances on PY35
-        self.cwd = str(cwd)
+        self.cwd = str(cwd) if cwd is not None else None
         if cwd and env is not None:
             # if CWD was provided, we must not make it conflict with
             # a potential PWD setting

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -27,7 +27,9 @@ from datalad.interface.common_opts import (
 from datalad.log import log_progress
 from datalad.support.gitrepo import (
     GitRepo,
-    GitCommandError,
+)
+from datalad.cmd import (
+    CommandError,
 )
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
@@ -410,7 +412,7 @@ def clone_dataset(
                 clone_options=clone_opts,
                 create=True)
 
-        except GitCommandError as e:
+        except CommandError as e:
             # Whenever progress reporting is enabled, as it is now,
             # we end up without e.stderr since it is "processed" out by
             # GitPython/our progress handler.
@@ -445,7 +447,8 @@ def clone_dataset(
                 )
                 yield get_status_dict(
                     status='error',
-                    message=re_match.group(1) if re_match else "stderr: " + e_stderr,
+                    message=re_match.group(1).strip()
+                    if re_match else "stderr: " + e_stderr,
                     **result_props)
                 return
             # next candidate

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -271,7 +271,9 @@ def log_progress(lgrcall, pid, *args, **kwargs):
     """
     d = dict(
         {'dlm_progress_{}'.format(n): v for n, v in kwargs.items()
-         if v},
+         # initial progress might be zero, but not sending it further
+         # would signal to destroy the progress bar, hence test for 'not None'
+         if v is not None},
         dlm_progress=pid)
     lgrcall(*args, extra=d)
 

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -13,7 +13,6 @@ import re
 from os import linesep
 
 
-
 class CommandError(RuntimeError):
     """Thrown if a command call fails.
     """
@@ -27,13 +26,17 @@ class CommandError(RuntimeError):
         self.stderr = stderr
 
     def __str__(self):
-        from datalad.utils import assure_unicode
+        from datalad.utils import ensure_unicode
         to_str = "%s: " % self.__class__.__name__
         if self.cmd:
             to_str += "command '%s'" % (self.cmd,)
         if self.code:
             to_str += " failed with exitcode %d" % self.code
-        to_str += "\n%s" % assure_unicode(self.msg)
+        to_str += "\n{}\nstdout={}\nstderr={}".format(
+            ensure_unicode(self.msg),
+            ensure_unicode(self.stdout),
+            ensure_unicode(self.stderr),
+        )
         return to_str
 
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -488,7 +488,6 @@ class GitProgress(object):
                 keep_lines.append(line)
         # the zero indicated that no data remained unprocessed at the
         # end of the input
-        # TODO reevaluate whether it is useful to keep this feature
         return b''. join(keep_lines), 0
 
     def _parse_progress_line(self, line):
@@ -1092,7 +1091,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             try:
                 lgr.debug("Git clone from {0} to {1}".format(url, path))
 
-                # TODO bring back progress reporting
                 with GitProgress() as progress:
                     WitlessRunner(env=env).run(
                         ['git', 'clone', '--progress', url, path] \

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -487,6 +487,13 @@ class GitProgress(object):
         keep_lines = []
         for line in byts.splitlines(keepends=True):
             if not self._parse_progress_line(line):
+                # anything that doesn't look like a progress report
+                # is retained and returned
+                # in case of partial progress lines, this can lead to
+                # leakage of progress info into the output, but
+                # it is better to enable better (maybe more expensive)
+                # subsequent filtering than hidding lines with
+                # unknown, potentially important info
                 lgr.debug('Non-progress Git output: %s', line)
                 keep_lines.append(line)
         # the zero indicated that no data remained unprocessed at the

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -554,9 +554,10 @@ class GitProgress(object):
             # Note: On windows it can happen that partial lines are sent
             # Hence we get something like "CompreReceiving objects", which is
             # a blend of "Compressing objects" and "Receiving objects".
-            # This can't really be prevented, so we drop the line verbosely
-            # to make sure we get informed in case the process spits out new
-            # commands at some point.
+            # This can't really be prevented.
+            lgr.debug(
+                'Output line matched a progress report of an unknown type: %s',
+                line)
             # TODO investigate if there is any chance that we might swallow
             # important info -- until them do not flag this line
             # as progress

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -420,6 +420,11 @@ def guard_BadName(func):
 
 class GitProgress(object):
     """Reduced variant of GitPython's RemoteProgress class
+
+    Original copyright:
+        Copyright (C) 2008, 2009 Michael Trier and contributors
+    Original license:
+        BSD 3-Clause "New" or "Revised" License
     """
     _num_op_codes = 10
     BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES, CHECKING_OUT, ENUMERATING = \

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1065,7 +1065,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             ssh_manager.get_connection(url).open()
             # TODO: with git <= 2.3 keep old mechanism:
             #       with rm.repo.git.custom_environment(GIT_SSH="wrapper_script"):
-            env = GitRepo.GIT_SSH_ENV
+            env = os.environ.copy()
+            env.update(GitRepo.GIT_SSH_ENV)
         else:
             if isinstance(url_ri, PathRI):
                 new_url = os.path.expanduser(url)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -76,14 +76,14 @@ import datalad.utils as ut
 from datalad.utils import (
     Path,
     PurePosixPath,
-    assure_list,
+    ensure_list,
     optional_args,
     on_windows,
     getpwd,
     posix_relpath,
-    assure_dir,
+    ensure_dir,
     generate_file_chunks,
-    assure_unicode,
+    ensure_unicode,
     split_cmdline,
 )
 
@@ -1358,7 +1358,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # there is no other way then to collect all files into a list
         # at this point, because we need to pass them at once to a single
         # `git add` call
-        files = [_normalize_path(self.path, f) for f in assure_list(files) if f]
+        files = [_normalize_path(self.path, f) for f in ensure_list(files) if f]
 
         if not (files or git_options or update):
             # wondering why just a warning? in cmdline this is also not an error
@@ -1372,7 +1372,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 # Set annex.largefiles to prevent storing files in annex when
                 # GitRepo() is instantiated with a v6+ annex repo.
                 ['git', '-c', 'annex.largefiles=nothing', 'add'] +
-                assure_list(git_options) +
+                ensure_list(git_options) +
                 to_options(update=update) + ['--verbose']
             )
             # get all the entries
@@ -1414,7 +1414,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         modes when ran through proxy
         """
         return [{u'file': f, u'success': True}
-                for f in re.findall("'(.*)'[\n$]", assure_unicode(stdout))]
+                for f in re.findall("'(.*)'[\n$]", ensure_unicode(stdout))]
 
     @normalize_paths(match_return_type=False)
     def remove(self, files, recursive=False, **kwargs):
@@ -1515,7 +1515,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         """
         if not fields:
             raise ValueError('no `fields` provided, refuse to proceed')
-        fields = assure_list(fields)
+        fields = ensure_list(fields)
         cmd = [
             "git",
             "for-each-ref",
@@ -1528,10 +1528,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         if contains:
             cmd.append('--contains={}'.format(contains))
         if sort:
-            for k in assure_list(sort):
+            for k in ensure_list(sort):
                 cmd.append('--sort={}'.format(k))
         if pattern:
-            cmd += assure_list(pattern)
+            cmd += ensure_list(pattern)
         if count:
             cmd.append('--count={:d}'.format(count))
 
@@ -3212,7 +3212,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
           name and value items. Attribute values are either True or False,
           for set and unset attributes, or are the literal attribute value.
         """
-        path = assure_list(path)
+        path = ensure_list(path)
         cmd = ["git", "check-attr", "-z", "--all"]
         if index_only:
             cmd.append('--cached')
@@ -4110,7 +4110,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(
                 list(files.keys()),
-                ['git', 'add'] + assure_list(git_opts) + ['--verbose']
+                ['git', 'add'] + ensure_list(git_opts) + ['--verbose']
             )
             # get all the entries
             for r in self._process_git_get_output(*add_out):
@@ -4167,7 +4167,7 @@ def _fixup_submodule_dotgit_setup(ds, relativepath):
     src_dotgit = str(repo.dot_git)
     # move .git
     from os import rename, listdir, rmdir
-    assure_dir(subds_dotgit)
+    ensure_dir(subds_dotgit)
     for dot_git_entry in listdir(src_dotgit):
         rename(opj(src_dotgit, dot_git_entry),
                opj(subds_dotgit, dot_git_entry))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -421,8 +421,8 @@ def guard_BadName(func):
 class GitProgress(object):
     """Reduced variant of GitPython's RemoteProgress class
     """
-    _num_op_codes = 9
-    BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES, CHECKING_OUT = \
+    _num_op_codes = 10
+    BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES, CHECKING_OUT, ENUMERATING = \
         [1 << x for x in range(_num_op_codes)]
     STAGE_MASK = BEGIN | END
     OP_MASK = ~STAGE_MASK
@@ -432,6 +432,7 @@ class GitProgress(object):
 
     _known_ops = {
         COUNTING: ("Counting", "Objects"),
+        ENUMERATING: ("Enumerating", "Objects"),
         COMPRESSING: ("Compressing", "Objects"),
         WRITING: ("Writing", "Objects"),
         RECEIVING: ("Receiving", "Objects"),
@@ -547,6 +548,8 @@ class GitProgress(object):
             op_code |= self.FINDING_SOURCES
         elif op_name == 'Checking out files':
             op_code |= self.CHECKING_OUT
+        elif op_name == 'Enumerating objects':
+            op_code |= self.ENUMERATING
         else:
             # Note: On windows it can happen that partial lines are sent
             # Hence we get something like "CompreReceiving objects", which is

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -479,7 +479,7 @@ class GitProgress(object):
         Returns
         -------
         bytes
-          All input in its orignal form, excepted for lines that
+          All input in its original form, except for lines that
           were identified as recognized progress reports.
         """
         keep_lines = []

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -17,6 +17,7 @@ import time
 import os
 import os.path as op
 import warnings
+from locale import getpreferredencoding
 
 
 from itertools import chain
@@ -446,13 +447,14 @@ class GitProgress(object):
         CHECKING_OUT: ("Check out", "Things"),
     }
 
-    __slots__ = ('_seen_ops', '_pbars')
+    __slots__ = ('_seen_ops', '_pbars', '_encoding')
 
     re_op_absolute = re.compile(r"(remote: )?([\w\s]+):\s+()(\d+)()(.*)")
     re_op_relative = re.compile(r"(remote: )?([\w\s]+):\s+(\d+)% \((\d+)/(\d+)\)(.*)")
 
     def __init__(self):
         self.__enter__()
+        self._encoding = getpreferredencoding(do_setlocale=False)
 
     def __enter__(self):
         self._seen_ops = []
@@ -508,7 +510,7 @@ class GitProgress(object):
         # Compressing objects:  50% (1/2)
         # Compressing objects: 100% (2/2)
         # Compressing objects: 100% (2/2), done.
-        line = line.decode('utf-8') if isinstance(line, bytes) else line
+        line = line.decode(self._encoding) if isinstance(line, bytes) else line
         if line.startswith(('warning:', 'error:', 'fatal:')):
             return False
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -58,7 +58,7 @@ from datalad.support.due import due, Doi
 
 from datalad import ssh_manager
 from datalad.cmd import (
-    LeanRunner,
+    WitlessRunner,
     GitRunner,
     BatchedCommand
 )
@@ -469,7 +469,7 @@ class GitProgress(object):
             )
 
     def __call__(self, byts):
-        """Callable interface compatible with LeanRunner()
+        """Callable interface compatible with WitlessRunner()
 
         Parameters
         ----------
@@ -1094,7 +1094,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
                 # TODO bring back progress reporting
                 with GitProgress() as progress:
-                    LeanRunner(env=env).run(
+                    WitlessRunner(env=env).run(
                         ['git', 'clone', '--progress', url, path] \
                         + (to_options(**clone_options) if clone_options else []),
                         proc_stderr=progress,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -485,6 +485,7 @@ class GitProgress(object):
         keep_lines = []
         for line in byts.splitlines(keepends=True):
             if not self._parse_progress_line(line):
+                lgr.debug('Non-progress Git output: %s', line)
                 keep_lines.append(line)
         # the zero indicated that no data remained unprocessed at the
         # end of the input
@@ -508,7 +509,7 @@ class GitProgress(object):
         # Compressing objects: 100% (2/2)
         # Compressing objects: 100% (2/2), done.
         line = line.decode('utf-8') if isinstance(line, bytes) else line
-        if line.startswith(('error:', 'fatal:')):
+        if line.startswith(('warning:', 'error:', 'fatal:')):
             return False
 
         # find escape characters and cut them away - regex will not work with

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1069,10 +1069,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             env.update(GitRepo.GIT_SSH_ENV)
         else:
             if isinstance(url_ri, PathRI):
+                # expand user, because execution not going through a shell
+                # doesn't work well otherwise
                 new_url = os.path.expanduser(url)
                 if url != new_url:
-                    # TODO: remove whenever GitPython is fixed:
-                    # https://github.com/gitpython-developers/GitPython/issues/731
                     lgr.info("Expanded source path to %s from %s", new_url, url)
                     url = new_url
             env = None

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -16,6 +16,7 @@ import logging
 from functools import partial
 from glob import glob
 import os
+import re
 from os import mkdir
 from os.path import join as opj
 from os.path import basename
@@ -258,7 +259,7 @@ def test_AnnexRepo_get_outofspace(annex_path):
         ar.get("file")
     exc = cme.exception
     eq_(exc.sizemore_msg, '905.6 MB')
-    assert_re_in(".*annex (find|get). needs 905.6 MB more", str(exc))
+    assert_re_in(".*annex (find|get).*needs 905.6 MB more", str(exc), re.DOTALL)
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:405

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -169,7 +169,7 @@ def test_runner_incomplete_capture():
             # report that to the runner
             proc_stdout=outproc,
             # make sure the runner polls faster than the output is coming
-            poll_period=0.1)
+            poll_latency=0.1)
     # we must not loose any output, except for the very last three bytes
     # even though we poll at a higher frequency
     eq_(out, '123456789abcd')
@@ -192,7 +192,7 @@ def test_runner_incomplete_capture():
             # we don't process the last three in the output, but we
             # report that to the runner
             proc_stdout=outproc,
-            poll_period=0.1)
+            poll_latency=0.1)
     # we miss three bytes at the end of each batch
     if len(outproc.received) > 1:
         eq_(out, '123456abcd')

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -156,19 +156,20 @@ import sys
 print("123456789", end="", file=sys.stdout, flush=True)
 import time
 time.sleep(1.5)
-print("abcdefg", end="", file=sys.stdout)
+print("abcdefg", end="", file=sys.stdout, flush=True)
 """
 
 
 def test_runner_incomplete_capture():
-    # make sure the runner polls faster than the output is coming
-    runner = Runner(poll_period=0.1)
+    runner = Runner()
     with TweakOutput(rtruncate_nbytes=3) as outproc:
         out, err = runner.run(
             py2cmd(py_9bytes_plus_6bytes),
             # we don't process the last three in the output, but we
             # report that to the runner
-            proc_stdout=outproc)
+            proc_stdout=outproc,
+            # make sure the runner polls faster than the output is coming
+            poll_period=0.1)
     # we must not loose any output, except for the very last three bytes
     # even though we poll at a higher frequency
     eq_(out, '123456789abcd')
@@ -190,7 +191,8 @@ def test_runner_incomplete_capture():
             py2cmd(py_9bytes_plus_6bytes),
             # we don't process the last three in the output, but we
             # report that to the runner
-            proc_stdout=outproc)
+            proc_stdout=outproc,
+            poll_period=0.1)
     # we miss three bytes at the end of each batch
     if len(outproc.received) > 1:
         eq_(out, '123456abcd')

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -1,0 +1,149 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test WitlessRunner
+"""
+
+import os
+import sys
+
+from .utils import (
+    ok_,
+    eq_,
+    assert_raises,
+    assert_in,
+    with_tempfile,
+    assert_cwd_unchanged,
+    ok_file_has_content,
+    OBSCURE_FILENAME,
+)
+from datalad.cmd import (
+    WitlessRunner as Runner,
+    capture_output,
+)
+from datalad.utils import Path
+from datalad.support.exceptions import CommandError
+
+
+class SwallowOutput(object):
+    """Test helper to collect output from WitlessRunner"""
+    def __init__(self):
+        self.__enter__()
+
+    def __enter__(self):
+        self.swallowed = b''
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    def __call__(self, byts):
+        self.swallowed += byts
+        return b'', 0
+
+    def as_utf8(self):
+        return self.swallowed.decode('utf-8')
+
+
+def py2cmd(code):
+    """Helper to invoke some Python code through a cmdline invokation of
+    the Python interpreter.
+
+    This should be more portable in some cases.
+    """
+    return [sys.executable, '-c', code]
+
+
+@assert_cwd_unchanged
+@with_tempfile
+def test_runner(tempfile):
+    runner = Runner()
+    content = 'Testing äöü東 real run'
+    cmd = ['sh', '-c', 'echo %s > %r' % (content, tempfile)]
+    out, err = runner.run(cmd)
+    # no capture of any kind, by default
+    ok_(not out)
+    ok_(not err)
+    ok_file_has_content(tempfile, content, strip=True)
+    os.unlink(tempfile)
+
+
+def test_runner_stderr_capture():
+    runner = Runner()
+    test_msg = "stderr-Message"
+    out, err = runner.run(py2cmd(
+        'import sys; print(%r, file=sys.stderr)' % test_msg),
+        proc_stdout=capture_output,
+        proc_stderr=capture_output,
+    )
+    eq_(err.rstrip(), test_msg)
+    ok_(not out)
+
+
+def test_runner_stdout_capture():
+    runner = Runner()
+    test_msg = "stdout-Message"
+    out, err = runner.run(py2cmd(
+        'import sys; print(%r, file=sys.stdout)' % test_msg),
+        proc_stdout=capture_output,
+        proc_stderr=capture_output,
+    )
+    eq_(out.rstrip(), test_msg)
+    ok_(not err)
+
+
+@with_tempfile(mkdir=True)
+def test_runner_failure(dir_):
+    runner = Runner()
+    with assert_raises(CommandError) as cme:
+        runner.run(
+            py2cmd('import sys; sys.exit(53)')
+        )
+    eq_(53, cme.exception.code)
+
+
+@with_tempfile(mkdir=True)
+def test_runner_fix_PWD(path):
+    env = os.environ.copy()
+    env['PWD'] = orig_cwd = os.getcwd()
+    runner = Runner(cwd=path, env=env)
+    out, err = runner.run(
+        py2cmd('import os; print(os.environ["PWD"])'),
+        proc_stdout=capture_output,
+    )
+    eq_(out.strip(), path)  # was fixed up to point to point to cwd's path
+    eq_(env['PWD'], orig_cwd)  # no side-effect
+
+
+@with_tempfile(mkdir=True)
+def test_runner_cwd_encoding(path):
+    env = os.environ.copy()
+    # Add PWD to env so that runner will temporarily adjust it to point to cwd.
+    env['PWD'] = os.getcwd()
+    cwd = Path(path) / OBSCURE_FILENAME
+    cwd.mkdir()
+    # Running doesn't fail if cwd or env has unicode value.
+    Runner(cwd=cwd, env=env).run(
+        py2cmd(
+            'from pathlib import Path; (Path.cwd() / "foo").write_text("t")'))
+    (cwd / 'foo').exists()
+
+
+@with_tempfile(mkdir=True)
+def test_runner_stdin(path):
+    runner = Runner()
+    fakestdin = Path(path) / 'io'
+    # go for diffcult content
+    fakestdin.write_text(OBSCURE_FILENAME)
+
+    out, err = runner.run(
+        py2cmd('import fileinput; print(fileinput.input().readline())'),
+        stdin=fakestdin.open(),
+        proc_stdout=capture_output,
+    )
+    assert_in(OBSCURE_FILENAME, out)


### PR DESCRIPTION
- [x] actually replace GitPython in `clone()`
- [x] implement a leaner runner that is capable of pulling out progress info from a `git clone` run
- [x] implement a progress info extractor for `git-clone` based on GitPython's approach, but simplified
- [x] bring back progress reporting for `GitRepo.clone()
- [x] document `WitlessRunner`
- [x] find answer to test WTF
- [x] show that this is sufficient for fetch/pull/push #4087 (concrete usage needs more work, but no structural limitation were identified, which was the aim within the context of this PR)
- [x] basic tests
- [x] decide whether to capture or kill all process output, instead of relaying it to the parent by default -- decided: better to relay then to hide by default.
- [x] works just as well on windows