### PR TITLE
BF/ENH: get_size_from_key to match specification

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -620,9 +620,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         # don't lookup the dict for the same things several times;
         # Is there a faster (and more compact) way of doing this? Note, that
         # locals() can't be updated.
-        s = parsed['s'] if 's' in parsed.keys() else None
-        S = parsed['S'] if 'S' in parsed.keys() else None
-        C = parsed['C'] if 'C' in parsed.keys() else None
+        s = parsed.get('s')
+        S = parsed.get('S')
+        C = parsed.get('C')
 
         if S is None and C is None:
             return s  # also okay if s is None as well -> no size to report

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -594,40 +594,48 @@ class AnnexRepo(GitRepo, RepoInterface):
 
     @staticmethod
     def get_size_from_key(key):
-        """A little helper to obtain size encoded in a key"""
+        """A little helper to obtain size encoded in a key
+
+        Returns
+        -------
+        int or None
+          size of the file or None if either no size is encoded in the key or
+          key was None itself
+
+        Raises
+        ------
+        ValueError
+          if key is considered invalid (at least its size-related part)
+        """
         if not key:
             return None
-
-        # TODO: this method can be more compact. we don't need particularly
-        #       elaborated error distinction
 
         # see: https://git-annex.branchable.com/internals/key_format/
         key_parts = key.split('--')
         key_fields = key_parts[0].split('-')
+        parsed = {field[0]: int(field[1:]) if field[1:].isdigit() else None
+                  for field in key_fields[1:]
+                  if field[0] in "sSC"}
 
-        s = S = C = None
+        # don't lookup the dict for the same things several times;
+        # Is there a faster (and more compact) way of doing this? Note, that
+        # locals() can't be updated.
+        s = parsed['s'] if 's' in parsed.keys() else None
+        S = parsed['S'] if 'S' in parsed.keys() else None
+        C = parsed['C'] if 'C' in parsed.keys() else None
 
-        for field in key_fields[1:]:  # first one has to be backend -> ignore
-            if field.startswith('s'):
-                # size of the annexed file content:
-                s = int(field[1:]) if field[1:].isdigit() else None
-            elif field.startswith('S'):
-                # we have a chunk and that's the chunksize:
-                S = int(field[1:]) if field[1:].isdigit() else None
-            elif field.startswith('C'):
-                # we have a chunk, this is it's number:
-                C = int(field[1:]) if field[1:].isdigit() else None
-
-        if s is None:
-            return None
-        elif S is None and C is None:
-            return s
+        if S is None and C is None:
+            return s  # also okay if s is None as well -> no size to report
+        elif s is None:
+            # s is None, while S and/or C are not.
+            raise ValueError("invalid key: {}".format(key))
         elif S and C:
             if C <= int(s / S):
                 return S
             else:
                 return s % S
         else:
+            # S or C are given with the respective other one missing
             raise ValueError("invalid key: {}".format(key))
 
     @normalize_path

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2356,3 +2356,26 @@ def test_annex_cmd_expect_fail(path):
         repo._run_annex_command_json('add', ['non-existing'], expect_fail=False)
         # message shows up at WARNING level
         assert_re_in(r".*\[WARNING\][^[]*git-annex: add: 1 failed", cml.out, flags=DOTALL)
+
+
+def test_get_size_from_key():
+
+    # see https://git-annex.branchable.com/internals/key_format/
+    # BACKEND[-sNNNN][-mNNNN][-SNNNN-CNNNN]--NAME
+
+    test_keys = {"ANYBACKEND--NAME": None,
+                 "ANYBACKEND-s123-m1234--NAME-WITH-DASHES.ext": 123,
+                 "MD5E-s100-S10-C1--somen.ame": 10,
+                 "SHA256-s99-S10-C10--name": 9,
+                 "SHA256E-sNaN--name": None,  # debatable: None or raise?
+                 }
+
+    invalid = ["ANYBACKEND-S10-C30--missing-total",
+               "s99-S10-C10--NOBACKEND",
+               "MD5-s100-S5--no-chunk-number"]
+
+    for key in invalid:
+        assert_raises(ValueError, AnnexRepo.get_size_from_key, key)
+
+    for key, value in test_keys.items():
+        eq_(AnnexRepo.get_size_from_key(key), value)


### PR DESCRIPTION
Suck in implementation from git-annex-ria-remote.
Former implementation couldn't correctly deal with chunks for example.
See https://git-annex.branchable.com/internals/key_format/ for specification.
