### PR TITLE
GitRepo.fetch/pull/push() without GitPython

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -417,15 +417,7 @@ def clone_dataset(
                 create=True)
 
         except CommandError as e:
-            # Whenever progress reporting is enabled, as it is now,
-            # we end up without e.stderr since it is "processed" out by
-            # GitPython/our progress handler.
             e_stderr = e.stderr
-            from datalad.support.gitrepo import GitPythonProgressBar
-            if not e_stderr and GitPythonProgressBar._last_error_lines:
-                e_stderr = os.linesep.join(GitPythonProgressBar._last_error_lines)
-                # Mimic format set in GitCommandError.__init__().
-                e.stderr = "{}  stderr: {}".format(os.linesep, e_stderr)
 
             error_msgs[cand['giturl']] = e
             lgr.debug("Failed to clone from URL: %s (%s)",

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -61,11 +61,17 @@ def _push(ds, remote, things2push, force=False):
             ds.repo.push(remote=remote, force=force))
     if not push_res:
         return 'notneeded', 'Git reported nothing was pushed'
-    errors = ['{} -> {} {}'.format(
-        pi.local_ref,
-        pi.remote_ref,
-        pi.summary.strip()) for pi in push_res if (pi.flags & PI.ERROR) == PI.ERROR]
-    successes = [pi.summary.strip() for pi in push_res if (pi.flags & PI.ERROR) != PI.ERROR]
+    errors = [
+        '{} -> {} {}'.format(
+            pi['from_ref'],
+            pi['to_ref'],
+            pi['note'])
+        for pi in push_res
+        if 'error' in pi['operations']]
+    successes = [
+        pi['note']
+        for pi in push_res
+        if 'error' not in pi['operations']]
     if errors:
         return 'error', \
                ('failed to push to %s: %s;%s',

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -24,7 +24,7 @@ from datalad.dochelpers import exc_str
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import IncompleteResultsError
+from datalad.support.exceptions import CommandError
 from datalad.utils import chpwd
 
 from nose.tools import eq_, ok_, assert_is_instance
@@ -220,7 +220,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
     # amend and change commit msg in order to test for force push:
     source.repo.commit("amended", options=['--amend'])
     # push should be rejected (non-fast-forward):
-    assert_raises(IncompleteResultsError,
+    assert_raises(CommandError,
                   publish, dataset=source, to='target', result_xfm='datasets')
     # push with force=True works:
     res = publish(dataset=source, to='target', result_xfm='datasets', force=True)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -24,7 +24,7 @@ from datalad.dochelpers import exc_str
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import IncompleteResultsError
 from datalad.utils import chpwd
 
 from nose.tools import eq_, ok_, assert_is_instance
@@ -220,7 +220,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
     # amend and change commit msg in order to test for force push:
     source.repo.commit("amended", options=['--amend'])
     # push should be rejected (non-fast-forward):
-    assert_raises(CommandError,
+    assert_raises(IncompleteResultsError,
                   publish, dataset=source, to='target', result_xfm='datasets')
     # push with force=True works:
     res = publish(dataset=source, to='target', result_xfm='datasets', force=True)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -643,6 +643,13 @@ class StdOutCaptureWithGitProgress(GitProgress):
 class FetchInfo(dict):
     """
     dict that carries results of a fetch operation of a single head
+
+    Reduced variant of GitPython's RemoteProgress class
+
+    Original copyright:
+        Copyright (C) 2008, 2009 Michael Trier and contributors
+    Original license:
+        BSD 3-Clause "New" or "Revised" License
     """
 
     NEW_TAG, NEW_HEAD, HEAD_UPTODATE, TAG_UPDATE, REJECTED, FORCED_UPDATE, \
@@ -725,8 +732,15 @@ class FetchInfo(dict):
 
 
 class PushInfo(dict):
-    """dict that carries results of a push operation of a single head"""
+    """dict that carries results of a push operation of a single head
 
+    Reduced variant of GitPython's RemoteProgress class
+
+    Original copyright:
+        Copyright (C) 2008, 2009 Michael Trier and contributors
+    Original license:
+        BSD 3-Clause "New" or "Revised" License
+    """
     NEW_TAG, NEW_HEAD, NO_MATCH, REJECTED, REMOTE_REJECTED, REMOTE_FAILURE, DELETED, \
         FORCED_UPDATE, FAST_FORWARD, UP_TO_DATE, ERROR = [1 << x for x in range(11)]
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2375,7 +2375,20 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
     def fetch(self, remote=None, refspec=None, all_=False, git_options=None,
               **kwargs):
-        """
+        """Fetches changes from a remote (or all remotes).
+
+        Parameters
+        ----------
+        remote : str, optional
+          name of the remote to fetch from. If no remote is given and
+          `all_` is not set, the tracking branch is fetched.
+        refspec : str, optional
+          refspec to fetch.
+        all_ : bool, optional
+          fetch all remotes (and all of their branches).
+          Fails if `remote` was given.
+        git_options : list, optional
+          Additional command line options for git-push.
         kwargs :
           Deprecated. GitPython-style keyword argument for git-push.
           Will be appended to any git_options.
@@ -2394,21 +2407,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
     @guard_BadName
     def fetch_(self, remote=None, refspec=None, all_=False, git_options=None):
-        """Fetches changes from a remote (or all remotes).
-
-        Parameters
-        ----------
-        remote : str, optional
-          name of the remote to fetch from. If no remote is given and
-          `all_` is not set, the tracking branch is fetched.
-        refspec : str, optional
-          refspec to fetch.
-        all_ : bool, optional
-          fetch all remotes (and all of their branches).
-          Fails if `remote` was given.
-        git_options : list, optional
-          Additional command line options for git-push.
-        """
+        """Like `fetch`, but returns a generator"""
         yield from self._fetch_push_helper(
             base_cmd=['git', 'fetch', '--verbose', '--progress'],
             action='fetch',
@@ -2481,7 +2480,19 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
     def push(self, remote=None, refspec=None, all_remotes=False,
              all_=False, git_options=None, **kwargs):
-        """
+        """Push changes to a remote (or all remotes).
+
+        Parameters
+        ----------
+        remote : str, optional
+          name of the remote to push to. If no remote is given and
+          `all_` is not set, the tracking branch is pushed.
+        refspec : str, optional
+          refspec to push.
+        all_ : bool, optional
+          push to all remotes. Fails if `remote` was given.
+        git_options : list, optional
+          Additional command line options for git-push.
         kwargs :
           Deprecated. GitPython-style keyword argument for git-push.
           Will be appended to any git_options.
@@ -2502,20 +2513,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         )
 
     def push_(self, remote=None, refspec=None, all_=False, git_options=None):
-        """Push changes to a remote (or all remotes).
-
-        Parameters
-        ----------
-        remote : str, optional
-          name of the remote to push to. If no remote is given and
-          `all_` is not set, the tracking branch is pushed.
-        refspec : str, optional
-          refspec to push.
-        all_ : bool, optional
-          push to all remotes. Fails if `remote` was given.
-        git_options : list, optional
-          Additional command line options for git-push.
-        """
+        """Like `push`, but returns a generator"""
         yield from self._fetch_push_helper(
             base_cmd=['git', 'push', '--progress', '--porcelain'],
             action='push',

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -47,7 +47,6 @@ from functools import wraps
 from weakref import WeakValueDictionary
 
 import git as gitpy
-from git import RemoteProgress
 from gitdb.exc import BadName
 from git.exc import (
     GitCommandError,
@@ -64,6 +63,7 @@ from datalad.cmd import (
     GitRunner,
     BatchedCommand,
     run_gitcommand_on_file_list_chunks,
+    capture_output,
 )
 from datalad.config import (
     ConfigManager,
@@ -71,7 +71,6 @@ from datalad.config import (
 )
 
 from datalad.consts import (
-    GIT_SSH_COMMAND,
     ADJUSTED_BRANCH_EXPR,
 )
 from datalad.dochelpers import exc_str
@@ -638,99 +637,174 @@ class GitProgress(WitlessProtocol):
         return True
 
 
-class GitPythonProgressBar(RemoteProgress):
-    """A handler for Git commands interfaced by GitPython which report progress
+class FetchInfo(dict):
+    """
+    dict that carries results of a fetch operation of a single head
     """
 
-    # GitPython operates with op_codes which are a mask for actions.
-    _known_ops = {
-        RemoteProgress.COUNTING: "counting objects",
-        RemoteProgress.COMPRESSING: "compressing objects",
-        RemoteProgress.WRITING: "writing objects",
-        RemoteProgress.RECEIVING: "receiving objects",
-        RemoteProgress.RESOLVING: "resolving stuff",
-        RemoteProgress.FINDING_SOURCES: "finding sources",
-        RemoteProgress.CHECKING_OUT: "checking things out"
+    NEW_TAG, NEW_HEAD, HEAD_UPTODATE, TAG_UPDATE, REJECTED, FORCED_UPDATE, \
+        FAST_FORWARD, ERROR = [1 << x for x in range(8)]
+
+    _re_fetch_result = re.compile(r'^\s*(.) (\[?[\w\s\.$@]+\]?)\s+(.+) [-> ]+ ([^\s]+)(    \(.*\)?$)?')
+
+    _flag_map = {
+        '!': ERROR,
+        '+': FORCED_UPDATE,
+        '*': 0,
+        '=': HEAD_UPTODATE,
+        ' ': FAST_FORWARD,
+        '-': TAG_UPDATE,
+    }
+    _operation_map = {
+        NEW_TAG: 'new-tag',
+        NEW_HEAD: 'new-branch',
+        HEAD_UPTODATE: 'uptodate',
+        TAG_UPDATE: 'tag-update',
+        REJECTED: 'rejected',
+        FORCED_UPDATE: 'forced-update',
+        FAST_FORWARD: 'fast-forward',
+        ERROR: 'error',
     }
 
-    # To overcome the bug when GitPython (<=2.1.11), with tentative fix
-    # in https://github.com/gitpython-developers/GitPython/pull/798
-    # we will collect error_lines from the last progress bar used by GitPython
-    # To do that reliably this class should be used as a ContextManager,
-    # or .close() should be called explicitly before analysis of this
-    # attribute is done.
-    # TODO: remove the workaround whenever new GitPython version provides
-    # it natively and we boost versioned dependency on it
-    _last_error_lines = None
-
-    def __init__(self, action):
-        super(GitPythonProgressBar, self).__init__()
-        self._action = action
-        from datalad.ui import ui
-        self._ui = ui
-        self._pbar = None
-        self._op_code = None
-        GitPythonProgressBar._last_error_lines = None
-
-    def __del__(self):
-        self.close()
-
-    def close(self):
-        GitPythonProgressBar._last_error_lines = self.error_lines
-        self._close_pbar()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
-
-    def _close_pbar(self):
-        if self._pbar:
-            self._pbar.finish()
-        self._pbar = None
-
-    def _get_human_msg(self, op_code):
-        """Return human readable action message
+    @classmethod
+    def _from_line(cls, line):
+        """Parse information from the given line as returned by git-fetch -v
+        and return a new FetchInfo object representing this information.
         """
-        op_id = op_code & self.OP_MASK
-        op = self._known_ops.get(op_id, "doing other evil")
-        return "%s (%s)" % (self._action, op)
+        match = cls._re_fetch_result.match(line)
+        if match is None:
+            raise ValueError("Failed to parse line: %r" % line)
 
-    def update(self, op_code, cur_count, max_count=None, message=''):
-        # ATM we ignore message which typically includes bandwidth info etc
+        # parse lines
+        control_character, operation, local_remote_ref, remote_local_ref, note = \
+            match.groups()
+
+        # parse flags from control_character
+        flags = 0
         try:
-            if not max_count:
-                # spotted used by GitPython tests, so may be at times it is not
-                # known and assumed to be a 100%...? TODO
-                max_count = 100.0
-            if op_code:
-                # Apparently those are composite and we care only about the ones
-                # we know, so to avoid switching the progress bar for no good
-                # reason - first & with the mask
-                op_code = op_code & self.OP_MASK
-            if self._op_code is None or self._op_code != op_code:
-                # new type of operation
-                self._close_pbar()
+            flags |= cls._flag_map[control_character]
+        except KeyError:
+            raise ValueError(
+                "Control character %r unknown as parsed from line %r"
+                % (control_character, line))
+        # END control char exception handling
 
-                self._pbar = self._ui.get_progressbar(
-                    self._get_human_msg(op_code),
-                    total=max_count,
-                    unit=' objects'
-                )
-                self._op_code = op_code
-            if not self._pbar:
-                lgr.error("Ended up without progress bar... how?")
-                return
-            self._pbar.update(cur_count, increment=False)
-        except Exception as exc:
-            lgr.debug("GitPythonProgressBar errored with %s", exc_str(exc))
-            return
-        #import time; time.sleep(0.001)  # to see that things are actually "moving"
-        # without it we would get only a blink on initial 0 value, istead of
-        # a blink at some higher value.  Anyways git provides those
-        # without flooding so should be safe to force here.
-        self._pbar.refresh()
+        # parse operation string for more info - makes no sense for symbolic refs,
+        # but we parse it anyway
+        old_commit = None
+        if 'rejected' in operation:
+            flags |= cls.REJECTED
+        if 'new tag' in operation:
+            flags |= cls.NEW_TAG
+        if 'tag update' in operation:
+            flags |= cls.TAG_UPDATE
+        if 'new branch' in operation:
+            flags |= cls.NEW_HEAD
+        if '...' in operation or '..' in operation:
+            split_token = '...'
+            if control_character == ' ':
+                split_token = split_token[:-1]
+            old_commit = operation.split(split_token)[0]
+        # END handle refspec
+
+        return cls(
+            ref=remote_local_ref.strip(),
+            local_ref=local_remote_ref.strip(),
+            # convert flag int into a list of operation labels
+            operations=[
+                cls._operation_map[o]
+                for o in cls._operation_map.keys()
+                if flags & o
+            ],
+            note=note,
+            old_commit=old_commit,
+        )
+
+
+class PushInfo(dict):
+    """dict that carries results of a push operation of a single head"""
+
+    NEW_TAG, NEW_HEAD, NO_MATCH, REJECTED, REMOTE_REJECTED, REMOTE_FAILURE, DELETED, \
+        FORCED_UPDATE, FAST_FORWARD, UP_TO_DATE, ERROR = [1 << x for x in range(11)]
+
+    _flag_map = {'X': NO_MATCH,
+                 '-': DELETED,
+                 '*': 0,
+                 '+': FORCED_UPDATE,
+                 ' ': FAST_FORWARD,
+                 '=': UP_TO_DATE,
+                 '!': ERROR}
+
+    _operation_map = {
+        NEW_TAG: 'new-tag',
+        NEW_HEAD: 'new-branch',
+        NO_MATCH: 'no-match',
+        REJECTED: 'rejected',
+        REMOTE_REJECTED: 'remote-rejected',
+        REMOTE_FAILURE: 'remote-failure',
+        DELETED: 'deleted',
+        FORCED_UPDATE: 'forced-update',
+        FAST_FORWARD: 'fast-forward',
+        UP_TO_DATE: 'uptodate',
+        ERROR: 'error',
+    }
+
+    @classmethod
+    def _from_line(cls, line):
+        """Create a new PushInfo instance as parsed from line which is expected to be like
+            refs/heads/master:refs/heads/master 05d2687..1d0568e as bytes"""
+        control_character, from_to, summary = line.split('\t', 3)
+        flags = 0
+
+        # control character handling
+        try:
+            flags |= cls._flag_map[control_character]
+        except KeyError:
+            raise ValueError("Control character %r unknown as parsed from line %r" % (control_character, line))
+        # END handle control character
+
+        # from_to handling
+        from_ref_string, to_ref_string = from_to.split(':')
+
+        # commit handling, could be message or commit info
+        old_commit = None
+        if summary.startswith('['):
+            if "[rejected]" in summary:
+                flags |= cls.REJECTED
+            elif "[remote rejected]" in summary:
+                flags |= cls.REMOTE_REJECTED
+            elif "[remote failure]" in summary:
+                flags |= cls.REMOTE_FAILURE
+            elif "[no match]" in summary:
+                flags |= cls.ERROR
+            elif "[new tag]" in summary:
+                flags |= cls.NEW_TAG
+            elif "[new branch]" in summary:
+                flags |= cls.NEW_HEAD
+            # uptodate encoded in control character
+        else:
+            # fast-forward or forced update - was encoded in control character,
+            # but we parse the old and new commit
+            split_token = "..."
+            if control_character == " ":
+                split_token = ".."
+            old_sha, _new_sha = summary.split(' ')[0].split(split_token)
+            # have to use constructor here as the sha usually is abbreviated
+            old_commit = old_sha
+        # END message handling
+
+        return cls(
+            from_ref=from_ref_string.strip(),
+            to_ref=to_ref_string.strip(),
+            # convert flag int into a list of operation labels
+            operations=[
+                cls._operation_map[o]
+                for o in cls._operation_map.keys()
+                if flags & o
+            ],
+            note=summary.strip(),
+            old_commit=old_commit,
+        )
 
 
 # Compatibility kludge.  See GitRepo.get_submodules().
@@ -741,12 +815,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     """Representation of a git repository
 
     """
-    # We use our sshrun helper
-    # TODO remove this, when GitPython code is gone. It is a duplicate of
-    # GitRunner.get_git_environ_adjusted()
-    GIT_SSH_ENV = {'GIT_SSH_COMMAND': GIT_SSH_COMMAND,
-                   'GIT_SSH_VARIANT': 'ssh'}
-
     # We must check git config to have name and email set, but
     # should do it once
     _config_checked = False
@@ -2288,10 +2356,28 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             expect_stderr=True
         )
 
+    def fetch(self, remote=None, refspec=None, all_=False, git_options=None,
+              **kwargs):
+        """
+        kwargs :
+          Deprecated. GitPython-style keyword argument for git-push.
+          Will be appended to any git_options.
+        """
+        git_options = ensure_list(git_options)
+        if kwargs:
+            git_options.extend(to_options(**kwargs))
+        return list(
+            self.fetch_(
+                remote=remote,
+                refspec=refspec,
+                all_=all_,
+                git_options=git_options,
+            )
+        )
+
     # TODO: centralize all the c&p code in fetch, pull, push
-    # TODO: document **kwargs passed to gitpython
     @guard_BadName
-    def fetch(self, remote=None, refspec=None, all_=False, **kwargs):
+    def fetch_(self, remote=None, refspec=None, all_=False, git_options=None):
         """Fetches changes from a remote (or all remotes).
 
         Parameters
@@ -2304,211 +2390,281 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         all_ : bool, optional
           fetch all remotes (and all of their branches).
           Fails if `remote` was given.
-        kwargs :
-          passed to gitpython. TODO: Figure it out, make consistent use of it
-          and document it.
-
-        Returns
-        -------
-        list
-            FetchInfo objects of the items fetched from remote
+        git_options : list, optional
+          Additional command line options for git-push.
         """
-        # TODO: options=> **kwargs):
-        # Note: Apparently there is no explicit (fetch --all) in gitpython,
-        #       but fetch is always bound to a certain remote instead.
-        #       Therefore implement it on our own:
+        git_options = ensure_list(git_options)
+
+        cmd = ['git', 'fetch', '--verbose', '--progress'] + git_options
+
         if remote is None:
-            if refspec is not None:
+            if refspec:
                 # conflicts with using tracking branch or fetch all remotes
                 # For now: Just fail.
                 # TODO: May be check whether it fits to tracking branch
-                raise ValueError("refspec specified without a remote. (%s)" %
-                                 refspec)
+                raise ValueError(
+                    "refspec specified without a remote. ({})".format(refspec))
             if all_:
-                remotes_to_fetch = [
-                    self.repo.remote(r)
-                    for r in self.get_remotes(with_urls_only=True)
-                ]
+                # we cannot simply add '--all', because this flag will make
+                # git-fetch no longer report progress -- kinda makes sense,
+                # because there would be successive progress sections for all
+                # remotes
+                remotes_to_fetch = self.get_remotes(with_urls_only=True)
             else:
                 # No explicit remote to fetch.
                 # => get tracking branch:
                 tb_remote, refspec = self.get_tracking_branch()
                 if tb_remote is not None:
-                    remotes_to_fetch = [self.repo.remote(tb_remote)]
+                    remotes_to_fetch = [tb_remote]
                 else:
                     # No remote, no tracking branch
                     # => fail
                     raise ValueError("Neither a remote is specified to fetch "
                                      "from nor a tracking branch is set up.")
         else:
-            remotes_to_fetch = [self.repo.remote(remote)]
+            if all_:
+                raise ValueError(
+                    "Option 'all_' conflicts with specified remote "
+                    "'{}'.".format(remote))
+            remotes_to_fetch = [remote]
 
-        fi_list = []
-        for rm in remotes_to_fetch:
-            fetch_url = \
-                self.config.get('remote.%s.fetchurl' % rm.name,
-                                self.config.get('remote.%s.url' % rm.name,
-                                                None))
-            if fetch_url is None:
-                lgr.debug("Remote %s has no URL", rm)
-                return []
+        if refspec:
+            # prep for appending to cmd
+            refspec = ensure_list(refspec)
 
-            fi_list += self._call_gitpy_with_progress(
-                "Fetching %s" % rm.name,
-                rm.fetch,
-                rm.repo,
-                refspec,
-                fetch_url,
-                **kwargs
+        pbar_id = 'fetchremotes-{}'.format(id(self))
+        log_progress(
+            lgr.info,
+            pbar_id,
+            'Start fetching remotes for %s', self,
+            total=len(remotes_to_fetch),
+            label='Fetch',
+            unit=' Remotes',
+        )
+        try:
+            for remote in remotes_to_fetch:
+                r_cmd = cmd + [remote]
+                if refspec:
+                    r_cmd += refspec
+                log_progress(
+                    lgr.info,
+                    pbar_id,
+                    'Fetching remote %s', remote,
+                    update=1,
+                    increment=True,
+                )
+                # best effort to enable SSH connection caching
+                url = self.config.get('remote.{}.url'.format(remote), None)
+                if url and is_ssh(url):
+                    ssh_manager.get_connection(url).open()
+                with GitProgress() as progress:
+                    out = WitlessRunner(
+                        cwd=self.path,
+                        env=GitRunner.get_git_environ_adjusted()).run(
+                            r_cmd,
+                            proc_stderr=progress,
+                    )
+                stderr = out[1] or ''
+                for line in stderr.splitlines():
+                    try:
+                        yield FetchInfo._from_line(line)
+                    except Exception:
+                        # it is not progress and no fetch info
+                        # don't hide it completely
+                        lgr.debug('git-fetch reported stderr: %s', line)
+        finally:
+            log_progress(
+                lgr.info,
+                pbar_id,
+                'Finished fetching remotes for %s', self,
             )
 
-        # TODO: fetch returns a list of FetchInfo instances. Make use of it.
-        return fi_list
-
-    def _call_gitpy_with_progress(self, msg, callable, git_repo,
-                                  refspec, url, **kwargs):
-        """A helper to reduce code duplication
-
-        Wraps call to a GitPython method with all needed decoration for
-        workarounds of having aged git, or not providing full stderr
-        when monitoring progress of the operation
-        """
-        with GitPythonProgressBar(msg) as git_progress:
-            git_kwargs = dict(
-                refspec=refspec,
-                progress=git_progress,
-                **kwargs
-            )
-            if is_ssh(url):
-                ssh_manager.get_connection(url).open()
-                # TODO: with git <= 2.3 keep old mechanism:
-                #       with rm.repo.git.custom_environment(
-                # GIT_SSH="wrapper_script"):
-                with git_repo.git.custom_environment(**GitRepo.GIT_SSH_ENV):
-                    ret = callable(**git_kwargs)
-                    # TODO: +kwargs
-            else:
-                ret = callable(**git_kwargs)
-                # TODO: +kwargs
-        return ret
-
-    def pull(self, remote=None, refspec=None, **kwargs):
-        """See fetch
-        """
-
-        if remote is None:
-            if refspec is not None:
-                # conflicts with using tracking branch or fetch all remotes
-                # For now: Just fail.
-                # TODO: May be check whether it fits to tracking branch
-                raise ValueError("refspec specified without a remote. (%s)" %
-                                 refspec)
-            # No explicit remote to pull from.
-            # => get tracking branch:
-            tb_remote, refspec = self.get_tracking_branch()
-            if tb_remote is not None:
-                remote = self.repo.remote(tb_remote)
-            else:
-                # No remote, no tracking branch
-                # => fail
-                raise ValueError("No remote specified to pull from nor a "
-                                 "tracking branch is set up.")
-
-        else:
-            remote = self.repo.remote(remote)
-
-        fetch_url = \
-            remote.config_reader.get(
-                'fetchurl' if remote.config_reader.has_option('fetchurl')
-                else 'url')
-
-        return self._call_gitpy_with_progress(
-                "Pulling",
-                remote.pull,
-                remote.repo,
-                refspec,
-                fetch_url,
-                **kwargs
-            )
-
-    def push(self, remote=None, refspec=None, all_remotes=False,
-             **kwargs):
-        """Push to remote repository
+    def pull(self, remote=None, refspec=None, git_options=None, **kwargs):
+        """Pulls changes from a remote.
 
         Parameters
         ----------
-        remote: str
-          name of the remote to push to
-        refspec: str
-          specify what to push
-        all_remotes: bool
-          if set to True push to all remotes. Conflicts with `remote` not being
-          None.
-        kwargs: dict
-          options to pass to `git push`
-
-        Returns
-        -------
-        list
-            PushInfo objects of the items pushed to remote
+        remote : str, optional
+          name of the remote to pull from. If no remote is given,
+          the remote tracking branch is used.
+        refspec : str, optional
+          refspec to fetch.
+        git_options : list, optional
+          Additional command line options for git-pull.
+        kwargs :
+          Deprecated. GitPython-style keyword argument for git-pull.
+          Will be appended to any git_options.
         """
+        git_options = ensure_list(git_options)
+        if kwargs:
+            git_options.extend(to_options(**kwargs))
+
+        cmd = ['git', 'pull', '--progress'] + git_options
 
         if remote is None:
-            if refspec is not None:
+            if refspec:
                 # conflicts with using tracking branch or fetch all remotes
                 # For now: Just fail.
                 # TODO: May be check whether it fits to tracking branch
-                raise ValueError("refspec specified without a remote. (%s)" %
-                                 refspec)
-            if all_remotes:
-                remotes_to_push = self.repo.remotes
+                raise ValueError(
+                    "refspec specified without a remote. ({})".format(refspec))
+            # No explicit remote to fetch.
+            # => get tracking branch:
+            tb_remote, refspec = self.get_tracking_branch()
+            if tb_remote is not None:
+                remote = tb_remote
             else:
-                # Nothing explicitly specified. Just call `git push` and let git
-                # decide what to do would be an option. But:
-                # - without knowing the remote and its URL we cannot provide
-                #   shared SSH connection
-                # - we lose ability to use GitPython's progress info and return
-                #   values
-                #   (the latter would be solvable:
-                #    Provide a Repo.push() method for GitPython, copying
-                #    Remote.push() for similar return value and progress
-                #    (also: fetch, pull)
+                # No remote, no tracking branch
+                # => fail
+                raise ValueError("Neither a remote is specified to pull "
+                                 "from nor a tracking branch is set up.")
 
-                # Do what git would do:
-                # 1. branch.*.remote for current branch or 'origin' as default
-                #    if config is missing
-                # 2. remote.*.push or push.default
+        cmd.append(remote)
+        if refspec:
+            cmd += ensure_list(refspec)
 
-                # TODO: check out "same procedure" for fetch/pull
-
-                tb_remote, refspec = self.get_tracking_branch()
-                if tb_remote is None:
-                    tb_remote = 'origin'
-                remotes_to_push = [self.repo.remote(tb_remote)]
-                # use no refspec; let git find remote.*.push or push.default on
-                # its own
-
-        else:
-            if all_remotes:
-                lgr.warning("Option 'all_remotes' conflicts with specified "
-                            "remote '%s'. Option ignored.")
-            remotes_to_push = [self.repo.remote(remote)]
-
-        pi_list = []
-        for rm in remotes_to_push:
-            push_url = \
-                rm.config_reader.get('pushurl'
-                                     if rm.config_reader.has_option('pushurl')
-                                     else 'url')
-            pi_list += self._call_gitpy_with_progress(
-                "Pushing %s" % rm.name,
-                rm.push,
-                rm.repo,
-                refspec,
-                push_url,
-                **kwargs
+        # best effort to enable SSH connection caching
+        url = self.config.get('remote.{}.url'.format(remote), None)
+        if url and is_ssh(url):
+            ssh_manager.get_connection(url).open()
+        with GitProgress() as progress:
+            WitlessRunner(
+                cwd=self.path,
+                env=GitRunner.get_git_environ_adjusted()).run(
+                    cmd,
+                    proc_stderr=progress,
             )
-        return pi_list
+
+    def push(self, remote=None, refspec=None, all_remotes=False,
+             all_=False, git_options=None, **kwargs):
+        """
+        kwargs :
+          Deprecated. GitPython-style keyword argument for git-push.
+          Will be appended to any git_options.
+        """
+        git_options = ensure_list(git_options)
+        if kwargs:
+            git_options.extend(to_options(**kwargs))
+        if all_remotes:
+            # be nice to the elderly
+            all_ = True
+        return list(
+            self.push_(
+                remote=remote,
+                refspec=refspec,
+                all_=all_,
+                git_options=git_options,
+            )
+        )
+
+    def push_(self, remote=None, refspec=None, all_=False, git_options=None):
+        """Push changes to a remote (or all remotes).
+
+        Parameters
+        ----------
+        remote : str, optional
+          name of the remote to push to. If no remote is given and
+          `all_` is not set, the tracking branch is pushed.
+        refspec : str, optional
+          refspec to push.
+        all_ : bool, optional
+          push to all remotes. Fails if `remote` was given.
+        git_options : list, optional
+          Additional command line options for git-push.
+        """
+        git_options = ensure_list(git_options)
+
+        cmd = ['git', 'push', '--progress', '--porcelain'] + git_options
+
+        if remote is None:
+            if refspec:
+                # conflicts with using tracking branch or push all remotes
+                # For now: Just fail.
+                # TODO: May be check whether it fits to tracking branch
+                raise ValueError(
+                    "refspec specified without a remote. ({})".format(refspec))
+            if all_:
+                remotes_to_push = self.get_remotes(with_urls_only=True)
+            else:
+                # No explicit remote to fetch.
+                # => get tracking branch:
+                tb_remote, refspec = self.get_tracking_branch()
+                if tb_remote is not None:
+                    remotes_to_push = [tb_remote]
+                else:
+                    # No remote, no tracking branch
+                    # => fail
+                    raise ValueError("Neither a remote is specified to fetch "
+                                     "from nor a tracking branch is set up.")
+        else:
+            if all_:
+                raise ValueError(
+                    "Option 'all_' conflicts with specified remote "
+                    "'{}'.".format(remote))
+            remotes_to_push = [remote]
+
+        if refspec:
+            # prep for appending to cmd
+            refspec = ensure_list(refspec)
+
+        pbar_id = 'pushremotes-{}'.format(id(self))
+        log_progress(
+            lgr.info,
+            pbar_id,
+            'Start pushing remotes for %s', self,
+            total=len(remotes_to_push),
+            label='Push',
+            unit=' Remotes',
+        )
+        try:
+            for remote in remotes_to_push:
+                r_cmd = cmd + [remote]
+                if refspec:
+                    r_cmd += refspec
+                log_progress(
+                    lgr.info,
+                    pbar_id,
+                    'Pushing remote %s', remote,
+                    update=1,
+                    increment=True,
+                )
+                # best effort to enable SSH connection caching
+                url = self.config.get(
+                    # use pushurl, if available, and fall back on url
+                    'remote.{}.pushurl'.format(remote),
+                    self.config.get(
+                        'remote.{}.url'.format(remote),
+                        None)
+                )
+                if url and is_ssh(url):
+                    ssh_manager.get_connection(url).open()
+                with GitProgress() as progress:
+                    out = WitlessRunner(
+                        cwd=self.path,
+                        env=GitRunner.get_git_environ_adjusted()).run(
+                            r_cmd,
+                            proc_stdout=capture_output,
+                            proc_stderr=progress,
+                    )
+                stdout = out[0] or ''
+                for line in stdout.splitlines():
+                    try:
+                        # push info doesn't identify a remote
+                        # if one was given to push() we could easily add it
+                        # but if not (all=True) we need to perform
+                        # introspection -- delay that -- we don't know,
+                        # if it is needed
+                        yield PushInfo._from_line(line)
+                    except Exception:
+                        # it is not progress and no push info
+                        # don't hide it completely
+                        lgr.error('git-push reported stdout: %s', line)
+        finally:
+            log_progress(
+                lgr.info,
+                pbar_id,
+                'Finished pushing remotes for %s', self,
+            )
 
     def get_remote_url(self, name, push=False):
         """Get the url of a remote.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2475,7 +2475,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             cwd=self.path,
             env=GitRunner.get_git_environ_adjusted()).run(
                 cmd,
-                protocol=GitProgress,
+                protocol=StdOutCaptureWithGitProgress,
         )
 
     def push(self, remote=None, refspec=None, all_remotes=False,

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -39,7 +39,7 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_false
 from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_re_in
+from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import local_testrepo_flavors
@@ -648,7 +648,15 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     # amend to make it require "--force":
     repo.commit("amended", options=['--amend'])
     # push without --force should yield an error:
-    assert_raises(CommandError, repo.push, remote="ssh-remote", refspec="ssh-test")
+    res = repo.push(remote="ssh-remote", refspec="ssh-test")
+    assert_in_results(
+        res,
+        from_ref='refs/heads/ssh-test',
+        to_ref='refs/heads/ssh-test',
+        operations=['rejected', 'error'],
+        note='[rejected] (non-fast-forward)',
+        remote='ssh-remote',
+    )
     # now push using force:
     repo.push(remote="ssh-remote", refspec="ssh-test", force=True)
     # correct commit message in remote:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -507,7 +507,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     fetched = clone.fetch(remote='origin')
     # test FetchInfo list returned by fetch
     eq_([u'origin/' + clone.get_active_branch(), u'origin/new_branch'],
-        [commit.name for commit in fetched])
+        [commit['ref'] for commit in fetched])
 
     ok_clean_git(clone.path, annex=False)
     assert_in("origin/new_branch", clone.get_remote_branches())
@@ -519,9 +519,7 @@ def test_GitRepo_fetch(test_path, orig_path, clone_path):
     origin.config.unset('remote.not-available.url', where='local')
 
     # fetch without provided URL
-    fetched = origin.fetch('not-available')
-    # nothing was done, nothing returned:
-    eq_([], fetched)
+    assert_raises(CommandError, origin.fetch, 'not-available')
 
 
 def _path2localsshurl(path):
@@ -555,7 +553,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     eq_([], repo.get_remote_branches())
 
     fetched = repo.fetch(remote="ssh-remote")
-    assert_in('ssh-remote/master', [commit.name for commit in fetched])
+    assert_in('ssh-remote/master', [commit['ref'] for commit in fetched])
     ok_clean_git(repo)
 
     # the connection is known to the SSH manager, since fetch() requested it:
@@ -633,9 +631,10 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     assert_not_in("ssh_testfile.dat", remote_repo.get_indexed_files())
 
     # push changes:
-    pushed = repo.push(remote="ssh-remote", refspec="ssh-test")
-    # test PushInfo object for
-    assert_in("ssh-remote/ssh-test", [commit.remote_ref.name for commit in pushed])
+    pushed = list(repo.push(remote="ssh-remote", refspec="ssh-test"))
+    # test PushInfo
+    assert_in("refs/heads/ssh-test", [p['from_ref'] for p in pushed])
+    assert_in("refs/heads/ssh-test", [p['to_ref'] for p in pushed])
 
     # the connection is known to the SSH manager, since fetch() requested it:
     assert_in(socket_path, list(map(str, ssh_manager._connections)))
@@ -649,8 +648,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     # amend to make it require "--force":
     repo.commit("amended", options=['--amend'])
     # push without --force should yield an error:
-    pushed = repo.push(remote="ssh-remote", refspec="ssh-test")
-    assert_in("[rejected] (non-fast-forward)", pushed[0].summary)
+    assert_raises(CommandError, repo.push, remote="ssh-remote", refspec="ssh-test")
     # now push using force:
     repo.push(remote="ssh-remote", refspec="ssh-test", force=True)
     # correct commit message in remote:


### PR DESCRIPTION
Sit on top of #4080 to show that implementation can generalize, but is kept as a separate PR, because discussions might be needed.

Logic stays largely the same. Differences are:

- no longer returns "fetch_info" structures, which are internal to
  GitPython -- unclear of a replacement is actually needed. Will be done
  once it becomes necessary.
- additional progressbar wrapping the fetch of multiple remotes
- kwargs are ignored for the moment. Needs discussion on which ones are
  needed, or if all should be attempted

TODO

- [x] needs SSH connection sharing setup
- [x] deduplicate code between `fetch`, `pull`, and `push` (do at the end, when implementations are known to be complete), likely introduce a common helper method
- [x] add support for arbitrary kwargs for fetch, pull, and push
- [x] needs result reporting(GitPython *_info replacement) -- current code base only uses it for error reporting.
    - [x] for fetch
    - [x] for push