### PR TITLE
DOC: examples for more commands

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -106,13 +106,13 @@ class Create(Interface):
         EnsureKeyChoice('status', ('ok', 'notneeded'))
 
     _examples_ = [
-        dict(text="""Create a dataset 'mydataset' in the current directory""",
+        dict(text="Create a dataset 'mydataset' in the current directory",
              code_py="create(path='mydataset')",
              code_cmd="datalad create mydataset"),
-        dict(text="""Apply the text2git procedure upon creation of a dataset""",
+        dict(text="Apply the text2git procedure upon creation of a dataset",
              code_py="create(path='mydataset', cfg_proc='text2git')",
              code_cmd="datalad create -c text2git mydataset"),
-        dict(text="""Create a subdataset in the root of an existing dataset""",
+        dict(text="Create a subdataset in the root of an existing dataset",
              code_py="create(dataset='.', path='mysubdataset')",
              code_cmd="datalad create -d . mysubdataset"),
         dict(text="Create a dataset in an existing, non-empty directory",

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -98,18 +98,18 @@ class Diff(Interface):
     )
 
     _examples_ = [
-        dict(text="Show unsaved changes in the current dataset",
-             code_py="diff(dataset='.')",
+        dict(text="Show unsaved changes in a dataset",
+             code_py="diff()",
              code_cmd="datalad diff"),
         dict(text="Compare a previous dataset state identified by shasum "
                   "against current worktree",
-             code_py="diff(dataset='.', fr='SHASUM')",
+             code_py="diff(fr='SHASUM')",
              code_cmd="datalad diff --from <SHASUM>"),
         dict(text="Compare two branches against each other",
              code_py="diff(fr='branch1', to='branch2')",
              code_cmd="datalad diff --from branch1 --to branch2"),
         dict(text="Show unsaved changes in the dataset and potential subdatasets",
-             code_py="diff(recursive=True, dataset='.')",
+             code_py="diff(recursive=True)",
              code_cmd="datalad diff --recursive"),
         dict(text="Show unsaved changes made to a particular file",
              code_py="diff(path='path/to/file')",

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -98,14 +98,14 @@ class Diff(Interface):
     )
 
     _examples_ = [
-        dict(text="""Show unsaved changes in the current dataset""",
+        dict(text="Show unsaved changes in the current dataset",
              code_py="diff(dataset='.')",
              code_cmd="datalad diff"),
-        dict(text="""Compare a previous dataset state identified by shasum
-                     against current worktree""",
+        dict(text="Compare a previous dataset state identified by shasum "
+                  "against current worktree",
              code_py="diff(dataset='.', fr='SHASUM')",
              code_cmd="datalad diff --from <SHASUM>"),
-        dict(text="""Compare two branches against each other""",
+        dict(text="Compare two branches against each other",
              code_py="diff(fr='branch1', to='branch2')",
              code_cmd="datalad diff --from branch1 --to branch2"),
         dict(text="Show unsaved changes in the dataset and potential subdatasets",

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -97,6 +97,25 @@ class Diff(Interface):
             constraints=EnsureStr() | EnsureNone()),
     )
 
+    _examples_ = [
+        dict(text="""Show unsaved changes in the current dataset""",
+             code_py="diff(dataset='.')",
+             code_cmd="datalad diff"),
+        dict(text="""Compare a previous dataset state identified by shasum
+                     against current worktree""",
+             code_py="diff(dataset='.', fr='SHASUM')",
+             code_cmd="datalad diff --from <SHASUM>"),
+        dict(text="""Compare two branches against each other""",
+             code_py="diff(fr='branch1', to='branch2')",
+             code_cmd="datalad diff --from branch1 --to branch2"),
+        dict(text="Show unsaved changes in the dataset and potential subdatasets",
+             code_py="diff(recursive=True, dataset='.')",
+             code_cmd="datalad diff --recursive"),
+        dict(text="Show unsaved changes made to a particular file",
+             code_py="diff(path='path/to/file')",
+             code_cmd="datalad diff <path/to/file>"),
+    ]
+
     @staticmethod
     @datasetmethod(name='diff')
     @eval_results

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -130,15 +130,15 @@ class Run(Interface):
         dict(text="Run an executable script and record the impact on a dataset",
              code_py="ds.run(message='run my script', cmd='code/script.sh')",
              code_cmd="datalad run -m 'run my script' 'code/script.sh'"),
-        dict(text="""Run a command and specify a directory as a dependency
-             for the run. The contents of the dependency will be retrieved
-             prior to running the script""",
+        dict(text="Run a command and specify a directory as a dependency "
+                  "for the run. The contents of the dependency will be retrieved "
+                  "prior to running the script",
              code_cmd="datalad run -m 'run my script' --input 'data/*' "
              "'code/script.sh'",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
              "inputs='data/*')"),
-        dict(text="""Run an executable script and specify output files of the
-             script to be unlocked prior to running the script""",
+        dict(text="Run an executable script and specify output files of the "
+                  "script to be unlocked prior to running the script",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
              "inputs='data/*', outputs='output_dir')",
              code_cmd="datalad run -m 'run my script' --input 'data/*' "

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -89,7 +89,7 @@ class Save(Interface):
         dict(text="Save any modification of known dataset content in the "
                   "current directory, but leave untracked files (e.g. temporary files) "
                   "untouched",
-             code_py="""ds.save(updated=True, path='.')""",
+             code_py="""ds.save(updated=True, dataset='.')""",
              code_cmd="""datalad save -u -d ."""),
         dict(text="Tag the most recent saved state of a dataset",
              code_py="ds.save(version_tag='bestyet')",

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -89,7 +89,7 @@ class Save(Interface):
         dict(text="Save any modification of known dataset content in the "
                   "current directory, but leave untracked files (e.g. temporary files) "
                   "untouched",
-             code_py="""ds.save(updated=True, dataset='.')""",
+             code_py="""ds.save(updated=True)""",
              code_cmd="""datalad save -u -d ."""),
         dict(text="Tag the most recent saved state of a dataset",
              code_py="ds.save(version_tag='bestyet')",

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -86,9 +86,9 @@ class Save(Interface):
              recurse into any potential subdatasets""",
              code_py="ds.save(recursive=True)",
              code_cmd="datalad save . --recursive"),
-        dict(text="""Save any modification of known dataset content in the
-             current directory, but leave untracked files (e.g. temporary files)
-             untouched""",
+        dict(text="Save any modification of known dataset content in the "
+                  "current directory, but leave untracked files (e.g. temporary files) "
+                  "untouched",
              code_py="""ds.save(updated=True, path='.')""",
              code_cmd="""datalad save -u -d ."""),
         dict(text="Tag the most recent saved state of a dataset",

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -240,11 +240,11 @@ class Status(Interface):
         dict(text="Get a status query for the state within the subdataset "
                   "without causing a status query for the superdataset (using trailing "
                   "path separator in the query path):",
-             code_py="ds.status(path='mysubdataset')",
+             code_py="ds.status(dataset='.', path='mysubdataset/')",
              code_cmd="datalad status --dataset . mysubdataset/"),
         dict(text="Report on the state of a subdataset in a superdataset and "
                   "on the state within the subdataset",
-             code_py="ds.status(path=['mysubdataset', 'mysubdataset/'])",
+             code_py="ds.status(dataset='.', path=['mysubdataset', 'mysubdataset/'])",
              code_cmd="datalad status --dataset . mysubdataset mysubdataset/"),
         dict(text="Report the file size of annexed content in a dataset",
              code_py="ds.status(annex=True)",

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -240,11 +240,11 @@ class Status(Interface):
         dict(text="Get a status query for the state within the subdataset "
                   "without causing a status query for the superdataset (using trailing "
                   "path separator in the query path):",
-             code_py="ds.status(dataset='.', path='mysubdataset/')",
+             code_py="ds.status(path='mysubdataset/')",
              code_cmd="datalad status --dataset . mysubdataset/"),
         dict(text="Report on the state of a subdataset in a superdataset and "
                   "on the state within the subdataset",
-             code_py="ds.status(dataset='.', path=['mysubdataset', 'mysubdataset/'])",
+             code_py="ds.status(path=['mysubdataset', 'mysubdataset/'])",
              code_cmd="datalad status --dataset . mysubdataset mysubdataset/"),
         dict(text="Report the file size of annexed content in a dataset",
              code_py="ds.status(annex=True)",

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -226,27 +226,27 @@ class Status(Interface):
     # does not yield meaningful output for this command
     result_renderer = 'tailored'
     _examples_ = [
-        dict(text="""Report on the state of a dataset""",
+        dict(text="Report on the state of a dataset",
              code_py="ds.status()",
              code_cmd="datalad status"),
-        dict(text="""Report on the state of a dataset and all subdatasets""",
+        dict(text="Report on the state of a dataset and all subdatasets",
              code_py="ds.status(recursive=True)",
              code_cmd="datalad status --recursive"),
-        dict(text="""Address a subdataset record in a superdataset without
-             causing a status query for the state _within_ the subdataset
-             itself""",
+        dict(text="ddress a subdataset record in a superdataset without "
+                  "causing a status query for the state _within_ the subdataset "
+                  "itself",
              code_py="ds.status(path='mysubdataset')",
              code_cmd="datalad status --dataset . mysubdataset"),
-        dict(text="""Get a status query for the state within the subdataset
-             without causing a status query for the superdataset (using trailing
-             path separator in the query path):""",
+        dict(text="Get a status query for the state within the subdataset "
+                  "without causing a status query for the superdataset (using trailing "
+                  "path separator in the query path):",
              code_py="ds.status(path='mysubdataset')",
              code_cmd="datalad status --dataset . mysubdataset/"),
-        dict(text="""Report on the state of a subdataset in a superdataset and
-             on the state within the subdataset""",
+        dict(text="Report on the state of a subdataset in a superdataset and "
+                  "on the state within the subdataset",
              code_py="ds.status(path=['mysubdataset', 'mysubdataset/'])",
              code_cmd="datalad status --dataset . mysubdataset mysubdataset/"),
-        dict(text="""Report the file size of annexed content in a dataset""",
+        dict(text="Report the file size of annexed content in a dataset",
              code_py="ds.status(annex=True)",
              code_cmd="datalad status --annex")
     ]

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -232,7 +232,7 @@ class Status(Interface):
         dict(text="Report on the state of a dataset and all subdatasets",
              code_py="ds.status(recursive=True)",
              code_cmd="datalad status --recursive"),
-        dict(text="ddress a subdataset record in a superdataset without "
+        dict(text="Address a subdataset record in a superdataset without "
                   "causing a status query for the state _within_ the subdataset "
                   "itself",
              code_py="ds.status(path='mysubdataset')",

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -140,8 +140,8 @@ class Drop(Interface):
         dict(text="Drop all file content in a dataset and all its subdatasets",
              code_py="drop(dataset='.', recursive=True)",
              code_cmd="datalad drop --dataset <path/to/dataset> --recursive"),
-        dict(text="""Disable check to assure the configured minimum number of
-             remote sources for dropped data""",
+        dict(text="Disable check to ensure the configured minimum number of "
+                  "remote sources for dropped data",
              code_py="drop(path='path/to/content', check=False)",
              code_cmd="datalad drop <path/to/content> --nocheck"),
     ]

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -129,16 +129,6 @@ class Drop(Interface):
     file content is dropped. As these checks could lead to slow operation
     (network latencies, etc), they can be disabled.
 
-    Examples:
-
-      Drop all file content in a dataset::
-
-        ~/some/dataset$ datalad drop
-
-      Drop all file content in a dataset and all its subdatasets::
-
-        ~/some/dataset$ datalad drop --recursive
-
     """
     _examples_ = [
         dict(text="Drop single file content",
@@ -155,6 +145,7 @@ class Drop(Interface):
              code_py="drop(path='path/to/content', check=False)",
              code_cmd="datalad drop <path/to/content> --nocheck"),
     ]
+
     _action = 'drop'
 
     _params_ = dict(

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -596,6 +596,9 @@ class Get(Interface):
         dict(text="Get all contents of the current dataset and its subdatasets",
              code_py="get(dataset='.', recursive=True)",
              code_cmd="datalad get . --recursive"),
+        dict(text="Get (clone) a registered subdataset, but don't retrieve data",
+             code_py="get('path/to/subds', get_data=False)",
+             code_cmd="datalad get -n <path/to/subds>"),
     ]
 
     _params_ = dict(

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -62,12 +62,6 @@ class Remove(Interface):
     file content is dropped. As these checks could lead to slow operation
     (network latencies, etc), they can be disabled.
 
-    Examples:
-
-      Permanently remove a subdataset from a dataset and wipe out the subdataset
-      association too::
-
-        ~/some/dataset$ datalad remove somesubdataset1
     """
     _action = 'remove'
 
@@ -85,6 +79,21 @@ class Remove(Interface):
         message=save_message_opt,
         if_dirty=if_dirty_opt,
     )
+
+    _examples_ = [
+        dict(text="""Permanently remove a subdataset from a dataset and wipe out
+                     the subdataset association too""",
+             code_py="remove(path='path/to/subds')",
+             code_cmd="datalad remove <path/to/subds>"),
+        dict(text="Permanently remove a dataset and all subdatasets",
+             code_py="remove('path/to/dataset/', recursive=True)",
+             code_cmd="datalad remove -d <path/to/dataset/> --recursive"),
+        dict(text="""Permanently remove a dataset and all subdatasets even if there
+                  are less than the configured minimum amount of (remote) sources
+                  for data""",
+             code_py="remove('path/to/dataset', recursive=True, check=False)",
+             code_cmd="datalad remove -d <path/to/dataset/> --recursive --nocheck"),
+    ]
 
     @staticmethod
     @datasetmethod(name=_action)

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -83,15 +83,15 @@ class Remove(Interface):
     _examples_ = [
         dict(text="Permanently remove a subdataset from a dataset and wipe out "
                   "the subdataset association too",
-             code_py="remove(path='path/to/subds')",
-             code_cmd="datalad remove <path/to/subds>"),
+             code_py="remove(dataset='path/to/dataset', path='path/to/subds')",
+             code_cmd="datalad remove -d <path/to/dataset> <path/to/subds>"),
         dict(text="Permanently remove a dataset and all subdatasets",
-             code_py="remove('path/to/dataset/', recursive=True)",
+             code_py="remove(dataset='path/to/dataset', recursive=True)",
              code_cmd="datalad remove -d <path/to/dataset/> --recursive"),
         dict(text="Permanently remove a dataset and all subdatasets even if there "
                   "are fewer than the configured minimum number of (remote) sources "
                   "for data",
-             code_py="remove('path/to/dataset', recursive=True, check=False)",
+             code_py="remove(dataset='path/to/dataset', recursive=True, check=False)",
              code_cmd="datalad remove -d <path/to/dataset/> --recursive --nocheck"),
     ]
 

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -89,7 +89,7 @@ class Remove(Interface):
              code_py="remove('path/to/dataset/', recursive=True)",
              code_cmd="datalad remove -d <path/to/dataset/> --recursive"),
         dict(text="Permanently remove a dataset and all subdatasets even if there "
-                  "are less than the configured minimum amount of (remote) sources "
+                  "are fewer than the configured minimum number of (remote) sources "
                   "for data",
              code_py="remove('path/to/dataset', recursive=True, check=False)",
              code_cmd="datalad remove -d <path/to/dataset/> --recursive --nocheck"),

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -81,16 +81,16 @@ class Remove(Interface):
     )
 
     _examples_ = [
-        dict(text="""Permanently remove a subdataset from a dataset and wipe out
-                     the subdataset association too""",
+        dict(text="Permanently remove a subdataset from a dataset and wipe out "
+                  "the subdataset association too",
              code_py="remove(path='path/to/subds')",
              code_cmd="datalad remove <path/to/subds>"),
         dict(text="Permanently remove a dataset and all subdatasets",
              code_py="remove('path/to/dataset/', recursive=True)",
              code_cmd="datalad remove -d <path/to/dataset/> --recursive"),
-        dict(text="""Permanently remove a dataset and all subdatasets even if there
-                  are less than the configured minimum amount of (remote) sources
-                  for data""",
+        dict(text="Permanently remove a dataset and all subdatasets even if there "
+                  "are less than the configured minimum amount of (remote) sources "
+                  "for data",
              code_py="remove('path/to/dataset', recursive=True, check=False)",
              code_cmd="datalad remove -d <path/to/dataset/> --recursive --nocheck"),
     ]

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -144,10 +144,10 @@ class Uninstall(Interface):
         dict(text="Uninstall a subdataset (undo installation)",
              code_py="uninstall(path='path/to/subds')",
              code_cmd="datalad uninstall <path/to/subds>"),
-        dict(text="Uninstall a subdataset and all potential further subdatasets",
+        dict(text="Uninstall a subdataset and all potential subdatasets",
              code_py="uninstall(path='path/to/subds', recursive=True)",
              code_cmd="datalad uninstall -r <path/to/subds>"),
-        dict(text="Skip checks that assure a minimal number of (remote) sources",
+        dict(text="Skip checks that ensure a minimal number of (remote) sources",
              code_py="uninstall(path='path/to/subds', check=False)",
              code_cmd="datalad uninstall <path/to/subds> --nocheck"),
     ]

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -124,11 +124,6 @@ class Uninstall(Interface):
     subdirectories within a dataset is done automatically. An optional
     recursion limit is applied relative to each given input path.
 
-    Examples:
-
-      Uninstall a subdataset (undo installation)::
-
-        ~/some/dataset$ datalad uninstall somesubdataset1
     """
     _action = 'uninstall'
 
@@ -144,6 +139,18 @@ class Uninstall(Interface):
         check=check_argument,
         if_dirty=if_dirty_opt,
     )
+
+    _examples_ = [
+        dict(text="Uninstall a subdataset (undo installation)",
+             code_py="uninstall(path='path/to/subds')",
+             code_cmd="datalad uninstall <path/to/subds>"),
+        dict(text="Uninstall a subdataset and all potential further subdatasets",
+             code_py="uninstall(path='path/to/subds', recursive=True)",
+             code_cmd="datalad uninstall -r <path/to/subds>"),
+        dict(text="Skip checks that assure a minimal number of (remote) sources",
+             code_py="uninstall(path='path/to/subds', check=False)",
+             code_cmd="datalad uninstall <path/to/subds> --nocheck"),
+    ]
 
     @staticmethod
     @datasetmethod(name=_action)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -49,6 +49,15 @@ class Update(Interface):
     # TODO: adjust docs to say:
     # - update from just one sibling at a time
 
+    _examples_ = [
+        dict(text="Update from a particular sibling",
+             code_py="update(sibling='siblingname')",
+             code_cmd="datalad update -s <siblingname>"),
+        dict(text="Update from a particular sibling and merge the obtained changes",
+             code_py="update(sibling='siblingname', merge=True)",
+             code_cmd="datalad update --merge -s <siblingname>"),
+    ]
+
     _params_ = dict(
         path=Parameter(
             args=("path",),

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -407,9 +407,11 @@ def build_example(example, api='python'):
     code = dedent_docstring(example.get(code_field))
     code = textwrap.indent(code, '     ').lstrip()
 
+    # only show an example if it exist for the API
     ex = """{}::\n\n   {} {}\n\n""".format(description,
                                            indicator,
-                                           code)
+                                           code) if code else ""
+
     return ex
 
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -399,6 +399,9 @@ def build_example(example, api='python'):
         indicator='%'
     else:
         raise ValueError("unknown API selection: {}".format(api))
+    if code_field not in example:
+        # only show an example if it exist for the API
+        return ''
     description = dedent_docstring(example.get('text'))
     # this indent the code snippet to get it properly rendered as code
     # we are not using textwrap.fill(), because it would not acknowledge
@@ -407,10 +410,9 @@ def build_example(example, api='python'):
     code = dedent_docstring(example.get(code_field))
     code = textwrap.indent(code, '     ').lstrip()
 
-    # only show an example if it exist for the API
     ex = """{}::\n\n   {} {}\n\n""".format(description,
                                            indicator,
-                                           code) if code else ""
+                                           code)
 
     return ex
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -410,9 +410,16 @@ def build_example(example, api='python'):
     code = dedent_docstring(example.get(code_field))
     code = textwrap.indent(code, '     ').lstrip()
 
-    ex = """{}::\n\n   {} {}\n\n""".format(description,
-                                           indicator,
-                                           code)
+    ex = """{}::\n\n   {}{}\n\n""".format(
+        description,
+        # disable automatic prefixing, if the example already has one
+        # this enables providing more complex examples without having
+        # to infer its inner structure
+        '{} '.format(indicator)
+        if not code.startswith(indicator)
+        # maintain spacing to avoid undesired relative indentation
+        else '  ',
+        code)
 
     return ex
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -402,7 +402,7 @@ def build_example(example, api='python'):
     if code_field not in example:
         # only show an example if it exist for the API
         return ''
-    description = dedent_docstring(example.get('text'))
+    description = textwrap.fill(example.get('text'))
     # this indent the code snippet to get it properly rendered as code
     # we are not using textwrap.fill(), because it would not acknowledge
     # any meaningful structure/formatting of code snippets. Instead, we

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -95,7 +95,7 @@ class DownloadURL(Interface):
         dict(text="Download files from an http and S3 URL",
              code_py="download_url(urls=['http://example.com/file.dat', 's3://bucket/file2.dat'])",
              code_cmd="datalad download-url http://example.com/file.dat s3://bucket/file2.dat"),
-        dict(text="Downlaod a file to a path and provide a commit message",
+        dict(text="Download a file to a path and provide a commit message",
              code_py="download_url(urls='s3://bucket/file2.dat', message='added a file', path='myfile.dat')",
              code_cmd="""datalad download-url -m 'added a file' -O myfile.dat \\
                          s3://bucket/file2.dat"""),

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -91,6 +91,16 @@ class DownloadURL(Interface):
         message=save_message_opt
     )
 
+    _examples_ = [
+        dict(text="Download files from an http and S3 URL",
+             code_py="download_url(urls=['http://example.com/file.dat', 's3://bucket/file2.dat'])",
+             code_cmd="datalad download-url http://example.com/file.dat s3://bucket/file2.dat"),
+        dict(text="Downlaod a file to a path and provide a commit message",
+             code_py="download_url(urls='s3://bucket/file2.dat', message='added a file', path='myfile.dat')",
+             code_cmd="""datalad download-url -m 'added a file' -O myfile.dat \\
+                         s3://bucket/file2.dat"""),
+    ]
+
     @staticmethod
     @datasetmethod(name="download_url")
     @eval_results

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -167,7 +167,6 @@ class Rerun(Interface):
              code_cmd="datalad rerun --onto= --since=HEAD~5"),
         dict(text="""Re-execute all previous commands and compare the old and
                      new results""",
-             code_py=" ",
              code_cmd="""# on master branch
                       % datalad rerun --branch=verify --since=
                       % # now on verify branch

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -73,30 +73,6 @@ class Rerun(Interface):
     information about the revision the would be checked out before rerunning
     any commands.
 
-    Examples:
-
-      Re-execute the command from the previous commit::
-
-        % datalad rerun
-
-      Re-execute any commands in the last five commits::
-
-        % datalad rerun --since=HEAD~5
-
-      Do the same as above, but re-execute the commands on top of
-      HEAD~5 in a detached state::
-
-        % datalad rerun --onto= --since=HEAD~5
-
-      Re-execute all previous commands and compare the old and new
-      results::
-
-        % # on master branch
-        % datalad rerun --branch=verify --since=
-        % # now on verify branch
-        % datalad diff --revision=master..
-        % git log --oneline --left-right --cherry-pick master...
-
     .. note::
       Currently the "onto" feature only sets the working tree of the current
       dataset to a previous state. The working trees of any subdatasets remain
@@ -177,6 +153,28 @@ class Rerun(Interface):
             CMD][PY: `onto` PY] because checking out a new HEAD can easily fail
             when the working tree has modifications."""),
     )
+
+    _examples_ = [
+        dict(text="Re-execute the command from the previous commit",
+             code_py="rerun()",
+             code_cmd="datalad rerun"),
+        dict(text="Re-execute any commands in the last five commits",
+             code_py="rerun(since='HEAD~5')",
+             code_cmd="datalad rerun --since=HEAD~5"),
+        dict(text="""Do the same as above, but re-execute the commands on top of
+                     HEAD~5 in a detached state""",
+             code_py="rerun(onto='', since='HEAD~5')",
+             code_cmd="datalad rerun --onto= --since=HEAD~5"),
+        dict(text="""Re-execute all previous commands and compare the old and
+                     new results""",
+             code_py=" ",
+             code_cmd="""# on master branch
+                      % datalad rerun --branch=verify --since=
+                      % # now on verify branch
+                      % datalad diff --revision=master..
+                      % git log --oneline --left-right --cherry-pick master..."""),
+    ]
+
 
     @staticmethod
     @datasetmethod(name='rerun')

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -161,12 +161,12 @@ class Rerun(Interface):
         dict(text="Re-execute any commands in the last five commits",
              code_py="rerun(since='HEAD~5')",
              code_cmd="datalad rerun --since=HEAD~5"),
-        dict(text="""Do the same as above, but re-execute the commands on top of
-                     HEAD~5 in a detached state""",
+        dict(text="Do the same as above, but re-execute the commands on top of "
+                  "HEAD~5 in a detached state",
              code_py="rerun(onto='', since='HEAD~5')",
              code_cmd="datalad rerun --onto= --since=HEAD~5"),
-        dict(text="""Re-execute all previous commands and compare the old and
-                     new results""",
+        dict(text="Re-execute all previous commands and compare the old and "
+                  "new results",
              code_cmd="""% # on master branch
                 % datalad rerun --branch=verify --since=
                 % # now on verify branch

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -167,11 +167,11 @@ class Rerun(Interface):
              code_cmd="datalad rerun --onto= --since=HEAD~5"),
         dict(text="""Re-execute all previous commands and compare the old and
                      new results""",
-             code_cmd="""# on master branch
-                      % datalad rerun --branch=verify --since=
-                      % # now on verify branch
-                      % datalad diff --revision=master..
-                      % git log --oneline --left-right --cherry-pick master..."""),
+             code_cmd="""% # on master branch
+                % datalad rerun --branch=verify --since=
+                % # now on verify branch
+                % datalad diff --revision=master..
+                % git log --oneline --left-right --cherry-pick master..."""),
     ]
 
 

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -302,7 +302,7 @@ class RunProcedure(Interface):
     )
 
     _examples_ = [
-        dict(text="""Find out which procedures are available on the current system""",
+        dict(text="Find out which procedures are available on the current system",
              code_py="run_procedure(discover=True)",
              code_cmd="datalad run-procedure --discover"),
         dict(text="Run the 'yoda' procedure in the current dataset",

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -301,6 +301,15 @@ class RunProcedure(Interface):
         )
     )
 
+    _examples_ = [
+        dict(text="""Find out which procedures are available on the current system""",
+             code_py="run_procedure(discover=True)",
+             code_cmd="datalad run-procedure --discover"),
+        dict(text="Run the 'yoda' procedure in the current dataset",
+             code_py="run_procedure(spec='cfg_yoda', recursive=True)",
+             code_cmd="datalad run-procedure cfg_yoda"),
+    ]
+
     result_renderer = 'tailored'
 
     @staticmethod

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -64,7 +64,7 @@ class Unlock(Interface):
     )
 
     _examples_ = [
-        dict(text="""Unlock a single file""",
+        dict(text="Unlock a single file",
              code_py="unlock(path='path/to/file')",
              code_cmd="datalad unlock <path/to/file>"),
         dict(text="Unlock all contents in the dataset",

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -63,6 +63,16 @@ class Unlock(Interface):
         recursion_limit=recursion_limit,
     )
 
+    _examples_ = [
+        dict(text="""Unlock a single file""",
+             code_py="unlock(path='path/to/file')",
+             code_cmd="datalad unlock <path/to/file>"),
+        dict(text="Unlock all contents in the dataset",
+             code_py="unlock('.')",
+             code_cmd="datalad unlock ."),
+    ]
+
+
     @staticmethod
     @datasetmethod(name='unlock')
     @eval_results


### PR DESCRIPTION
- I've added a few examples to `update`, `uninstall`, `remove`, `download-url`, `diff`, and `run-procedure`. 
- For `drop`, I removed duplicate examples that were still present in the docstring. 
- For `rerun`, I transferred examples from the docstring into the `_examples_` list and added Python translations when possible. 

I deemed one of the examples of `rerun` as not very suitable for the Python API help:
```
Re-execute all previous commands and compare the old and new results:
% # on master branch
% datalad rerun --branch=verify --since=
% # now on verify branch
% datalad diff --revision=master..
% git log --oneline --left-right --cherry-pick master...
```
Therefore, I modified `build_example` to only include an example in the help text of an API if a code snippet exists for this API, and did not translate it to a Python example.