### PR TITLE
A few command documentation touch-ups

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -145,7 +145,7 @@ class Create(Interface):
             destination path of the repository will be passed to git-init
             as-is CMD]. Note that not all options will lead to viable results.
             For example '--bare' will not yield a repository where DataLad
-            can adjust files in its worktree."""),
+            can adjust files in its working tree."""),
         dataset=Parameter(
             args=("-d", "--dataset"),
             metavar='DATASET',

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -93,7 +93,7 @@ class Diff(Interface):
             metavar="REVISION",
             doc="""state to compare against the original state, as given by
             any identifier that Git understands. If none is specified,
-            the state of the worktree will be compared.""",
+            the state of the working tree will be compared.""",
             constraints=EnsureStr() | EnsureNone()),
     )
 

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -55,10 +55,10 @@ lgr = logging.getLogger('datalad.core.local.diff')
 class Diff(Interface):
     """Report differences between two states of a dataset (hierarchy)
 
-    The two to-be-compared states are given via to --from and --to options.
+    The two to-be-compared states are given via the --from and --to options.
     These state identifiers are evaluated in the context of the (specified
-    or detected) dataset. In case of a recursive report on a dataset
-    hierarchy corresponding state pairs for any subdataset are determined
+    or detected) dataset. In the case of a recursive report on a dataset
+    hierarchy, corresponding state pairs for any subdataset are determined
     from the subdataset record in the respective superdataset. Only changes
     recorded in a subdataset between these two states are reported, and so on.
 
@@ -93,7 +93,7 @@ class Diff(Interface):
             metavar="REVISION",
             doc="""state to compare against the original state, as given by
             any identifier that Git understands. If none is specified,
-            the state of the worktree will be used compared.""",
+            the state of the worktree will be compared.""",
             constraints=EnsureStr() | EnsureNone()),
     )
 

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -87,7 +87,7 @@ _common_diffstatus_params = dict(
         metavar='MODE',
         constraints=EnsureChoice('no', 'normal', 'all'),
         doc="""If and how untracked content is reported when comparing
-        a revision to the state of the work tree. 'no': no untracked
+        a revision to the state of the working tree. 'no': no untracked
         content is reported; 'normal': untracked files and entire
         untracked directories are reported as such; 'all': report
         individual files even in fully untracked directories."""),


### PR DESCRIPTION
- DOC: diff: Touch up grammar/typos in --help text
- DOC: Prefer "working tree" to "worktree" in --help text