### PR TITLE
OPT: is_with_annex - sample if there is .git/refs/heads/git-annex to avoid calling git

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1079,6 +1079,11 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     def is_with_annex(self):
         """Report if GitRepo (assumed) has (remotes with) a git-annex branch
         """
+        # OPT: To avoid "lengthy" invocation of git, first sample ref for
+        # `git-annex` branch
+        if op.exists(self.dot_git / "refs" / "heads" / "git-annex"):
+            return True
+        # It still could be present in the remote ones
         return any(
             b['refname:strip=2'] == 'git-annex' or b['refname:strip=2'].endswith('/git-annex')
             for b in self.for_each_ref_(fields='refname:strip=2', pattern=['refs/heads', 'refs/remotes'])

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1081,7 +1081,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         """
         # OPT: To avoid "lengthy" invocation of git, first sample ref for
         # `git-annex` branch
-        if op.exists(self.dot_git / "refs" / "heads" / "git-annex"):
+        if (self.dot_git / "refs" / "heads" / "git-annex").exists():
             return True
         # It still could be present in the remote ones
         return any(

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1081,6 +1081,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         """
         # OPT: To avoid "lengthy" invocation of git, first sample ref for
         # `git-annex` branch
+        if (self.pathobj / ".noannex").exists():
+            return False
         if (self.dot_git / "refs" / "heads" / "git-annex").exists():
             return True
         # It still could be present in the remote ones


### PR DESCRIPTION
Partially (only for git-annex repos) provides alternative solution to #4077, at least for already the repos with `git-annex` branch initialized.

I also mentally excercized an idea to establish some helper, which in this case would be

`@memoize_based_on_mtimes(paths=[`.git/refs`], recursive=True, dirs=True, files=False)` 

so it would quickly (I hope) check if any mtime was modified on any subdir under `.git/refs`, so if there is no changes from previous time, it means no new/updated references, and we could take previous value.  But yet to see if it would provide any benefit.