### PR TITLE
BF: cmdline: Don't capitalize first word of lines ending with ":"

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -104,13 +104,6 @@ class HelpAction(argparse.Action):
             pos_args_str = "*Arguments*"
         helpstr = re.sub(r'optional arguments:', opt_args_str, helpstr)
         helpstr = re.sub(r'positional arguments:', pos_args_str, helpstr)
-        # convert all headings to have the first character uppercase
-        headpat = re.compile(r'^([a-z])(.*):$',  re.MULTILINE)
-        helpstr = re.subn(
-            headpat,
-            lambda match: r'{0}{1}:'.format(match.group(1).upper(),
-                                            match.group(2)),
-            helpstr)[0]
         # usage is on the same line
         helpstr = re.sub(r'^usage:', 'Usage:', helpstr)
 


### PR DESCRIPTION
Our help text has lots of spots where the first word in a line is
incorrectly capitalized when the line ends with a colon.  The code
that does this has a comment that says this is to capitalize the first
word of all "headings", but it's not clear what those headings are.

Without this code, the help output of all of our current commands only
differs in cases of incorrect capitalization, so it looks like this
code is no longer serving its original purpose while causing issues
elsewhere.  Drop it.

Re: https://github.com/datalad/datalad/pull/4091#discussion_r371312477

---

Here is the difference in help output before and after this command:

<details>
<summary>diff</summary>

```python
from itertools import chain
import subprocess as sp
import sys

import datalad.interface.base as di

sp.run(["datalad", "--help"])

subcommands = map(di.get_cmdline_command_name,
                  chain(*(g[2] for g in di.get_interface_groups())))

for subcommand in sorted(subcommands):
    print(subcommand, file=sys.stderr)
    sp.run(["datalad", subcommand, "--help"])
```

```diff
--- /tmp/dl-command-help.1	2020-01-27 15:49:04.383406891 -0500
+++ /tmp/dl-command-help.2	2020-01-27 15:49:17.715559872 -0500
@@ -388,7 +388,7 @@
 
 Enabling a metadata extractor for a dataset is done by adding its name to the
 'datalad.metadata.nativetype' configuration variable -- typically in the
-Dataset's configuration file (.datalad/config), e.g.::
+dataset's configuration file (.datalad/config), e.g.::
 
   [datalad "metadata"]
     nativetype = exif
@@ -1054,7 +1054,7 @@
 credential store. Lastly, an *oauth* token stored in the Git
 configuration under variable *hub.oauthtoken* will be used automatically.
 Such a token can be obtained, for example, using the commandline Github
-Interface (https://github.com/sociomantic/git-hub) by running:
+interface (https://github.com/sociomantic/git-hub) by running:
 git hub setup (if no 2FA is used).
 
 *Arguments*
@@ -1131,7 +1131,7 @@
 via python-gitlab, and all its features are supported. A particular GitLab
 site must be configured in a named section of a python-gitlab.cfg file
 (see https://python-gitlab.readthedocs.io/en/stable/cli.html#configuration
-For details), such as::
+for details), such as::
 
   [mygit]
   url = https://git.example.com
@@ -1143,7 +1143,7 @@
 
 (Recursive) sibling creation for all, or a selected subset of subdatasets
 is supported. Three different project layouts for nested datasets are
-Supported (see --layout):
+supported (see --layout):
 
 "hierarchy"
   Each dataset is placed into its own group, and the actual GitLab
@@ -1456,7 +1456,7 @@
    % datalad drop --dataset <path/to/dataset> --recursive
 
 Disable check to assure the configured minimum number of
-Remote sources for dropped data::
+remote sources for dropped data::
 
    % datalad drop <path/to/content> --nocheck
 
@@ -1998,7 +1998,7 @@
 When called with --report, this command reports information about what
 would be re-executed as a series of records. There will be a record
 for each revision in the specified revision range. Each of these will
-Have one of the following "rerun_action" values:
+have one of the following "rerun_action" values:
 
   - run: the revision has a recorded command that would be re-executed
   - skip-or-pick: the revision does not have a recorded command and would
@@ -2166,12 +2166,12 @@
 
 Run a command and specify a directory as a dependency
 for the run. The contents of the dependency will be retrieved
-Prior to running the script::
+prior to running the script::
 
    % datalad run -m 'run my script' --input 'data/*' 'code/script.sh'
 
 Run an executable script and specify output files of the
-Script to be unlocked prior to running the script::
+script to be unlocked prior to running the script::
 
    % datalad run -m 'run my script' --input 'data/*' --output 'output_dir/*' 'code/script.sh'
 
@@ -2290,7 +2290,7 @@
 dataset they shall operate on).
 
 For further customization there are two configuration settings per procedure
-Available:
+available:
 
 - 'datalad.procedures.<NAME>.call-format'
   fully customizable format string to determine how to execute procedure
@@ -2352,7 +2352,7 @@
 *Examples*
 
 Save any content underneath the current directory, without
-Altering any potential subdataset::
+altering any potential subdataset::
 
    % datalad save .
 
@@ -2365,13 +2365,13 @@
    % datalad save -m 'add file' myfile.txt
 
 Save any content underneath the current directory, and
-Recurse into any potential subdatasets::
+recurse into any potential subdatasets::
 
    % datalad save . --recursive
 
 Save any modification of known dataset content in the
 current directory, but leave untracked files (e.g. temporary files)
-Untouched::
+untouched::
 
    % datalad save -u -d .
 
@@ -2450,14 +2450,14 @@
 - autofield
 
 An alternative default mode can be configured by tuning the
-Configuration variable 'datalad.search.default-mode'::
+configuration variable 'datalad.search.default-mode'::
 
   [datalad "search"]
     default-mode = egrepcs
 
 Each search mode has its own default configuration for what kind of
 documents to query. The respective default can be changed via configuration
-Variables::
+variables::
 
   [datalad "search"]
     index-<mode_name>-documenttype = (all|datasets|files)
@@ -2539,7 +2539,7 @@
 of datasets. This mode uses its own query language (not regular expressions)
 that is similar to other search engines. It supports logical conjunctions
 and fuzzy search terms. More information on this is available from the Whoosh
-Project (search engine implementation):
+project (search engine implementation):
 
   - Description of the Whoosh query language:
     http://whoosh.readthedocs.io/en/latest/querylang.html)
@@ -2699,7 +2699,7 @@
 removal (or de-configuration) of a registered sibling.
 
 For each sibling (added, configured, or queried) all known sibling
-Properties are reported. This includes:
+properties are reported. This includes:
 
 "name"
     Name of the sibling
@@ -2715,7 +2715,7 @@
 a key that matches that in the Git configuration.
 
 By default, sibling information is rendered as one line per sibling
-Following this scheme::
+following this scheme::
 
   <dataset_path>: <sibling_name>(<+|->) [<access_specification]
 
@@ -2862,20 +2862,20 @@
 When it is necessary to address a subdataset record in a superdataset
 without causing a status query for the state _within_ the subdataset
 itself, this can be achieved by explicitly providing a reference dataset
-And the path to the root of the subdataset like so::
+and the path to the root of the subdataset like so::
 
   datalad status --dataset . subdspath
 
 In contrast, when the state of the subdataset within the superdataset is
 not relevant, a status query for the content of the subdataset can be
 obtained by adding a trailing path separator to the query path (rsync-like
-Syntax)::
+syntax)::
 
   datalad status --dataset . subdspath/
 
 When both aspects are relevant (the state of the subdataset content
 and the state of the subdataset within the superdataset), both queries
-Can be combined::
+can be combined::
 
   datalad status --dataset . subdspath subdspath/
 
@@ -2916,18 +2916,18 @@
 
 Address a subdataset record in a superdataset without
 causing a status query for the state _within_ the subdataset
-Itself::
+itself::
 
    % datalad status --dataset . mysubdataset
 
 Get a status query for the state within the subdataset
 without causing a status query for the superdataset (using trailing
-Path separator in the query path):::
+path separator in the query path):::
 
    % datalad status --dataset . mysubdataset/
 
 Report on the state of a subdataset in a superdataset and
-On the state within the subdataset::
+on the state within the subdataset::
 
    % datalad status --dataset . mysubdataset mysubdataset/
 
```

</details>
