### PR TITLE
OPT: tried to be "clever" AKA "smart" and reuse .repo (and .config)

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -608,7 +608,7 @@ class ConfigManager(object):
         if where == 'dataset':
             if not self._dataset_cfgfname:
                 raise ValueError(
-                    'ConfigManager cannot store to configuration to dataset, '
+                    'ConfigManager cannot store configuration to dataset, '
                     'none specified')
             # create an empty config file if none exists, `git config` will
             # fail otherwise

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -329,6 +329,10 @@ class Create(Interface):
         if initopts is not None and isinstance(initopts, list):
             initopts = {'_from_cmdline_': initopts}
 
+        # Note for the code below:
+        # OPT: be "smart" and avoid re-resolving .repo -- expensive in DataLad
+        # Re-use tbrepo instance, do not use tbds.repo
+
         # create and configure desired repository
         if no_annex:
             lgr.info("Creating a new git repo at %s", tbds.path)
@@ -365,7 +369,7 @@ class Create(Interface):
             tbrepo.set_default_backend(
                 cfg.obtain('datalad.repo.backend'),
                 persistent=True, commit=False)
-            add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
+            add_to_git[tbrepo.pathobj / '.gitattributes'] = {
                 'type': 'file',
                 'state': 'added'}
             # make sure that v6 annex repos never commit content under .datalad
@@ -375,7 +379,7 @@ class Create(Interface):
                 ('metadata/objects/**', 'annex.largefiles',
                  '({})'.format(cfg.obtain(
                      'datalad.metadata.create-aggregate-annex-limit'))))
-            attrs = tbds.repo.get_gitattributes(
+            attrs = tbrepo.get_gitattributes(
                 [op.join('.datalad', i[0]) for i in attrs_cfg])
             set_attrs = []
             for p, k, v in attrs_cfg:
@@ -383,20 +387,24 @@ class Create(Interface):
                         op.join('.datalad', p), {}).get(k, None) == v:
                     set_attrs.append((p, {k: v}))
             if set_attrs:
-                tbds.repo.set_gitattributes(
+                tbrepo.set_gitattributes(
                     set_attrs,
                     attrfile=op.join('.datalad', '.gitattributes'))
 
             # prevent git annex from ever annexing .git* stuff (gh-1597)
-            attrs = tbds.repo.get_gitattributes('.git')
+            attrs = tbrepo.get_gitattributes('.git')
             if not attrs.get('.git', {}).get(
                     'annex.largefiles', None) == 'nothing':
-                tbds.repo.set_gitattributes([
+                tbrepo.set_gitattributes([
                     ('**/.git*', {'annex.largefiles': 'nothing'})])
                 # must use the repo.pathobj as this will have resolved symlinks
-                add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
+                add_to_git[tbrepo.pathobj / '.gitattributes'] = {
                     'type': 'file',
                     'state': 'untracked'}
+
+        # OPT: be "smart" and avoid re-resolving .repo -- expensive in DataLad
+        # Note, must not happen earlier (before if) since "smart" it would not be
+        tbds_config = tbds.config
 
         # record an ID for this repo for the afterlife
         # to be able to track siblings and children
@@ -404,10 +412,10 @@ class Create(Interface):
         # Note, that Dataset property `id` will change when we unset the
         # respective config. Therefore store it before:
         tbds_id = tbds.id
-        if id_var in tbds.config:
+        if id_var in tbds_config:
             # make sure we reset this variable completely, in case of a
             # re-create
-            tbds.config.unset(id_var, where='dataset')
+            tbds_config.unset(id_var, where='dataset')
 
         if _seed is None:
             # just the standard way
@@ -415,7 +423,7 @@ class Create(Interface):
         else:
             # Let's generate preseeded ones
             uuid_id = str(uuid.UUID(int=random.getrandbits(128)))
-        tbds.config.add(
+        tbds_config.add(
             id_var,
             tbds_id if tbds_id is not None else uuid_id,
             where='dataset',
@@ -427,21 +435,21 @@ class Create(Interface):
         # a dedicated argument, because it is sufficient for the cmdline
         # and unnecessary for the Python API (there could simply be a
         # subsequence ds.config.add() call)
-        for k, v in tbds.config.overrides.items():
-            tbds.config.add(k, v, where='local', reload=False)
+        for k, v in tbds_config.overrides.items():
+            tbds_config.add(k, v, where='local', reload=False)
 
         # all config manipulation is done -> fll reload
-        tbds.config.reload()
+        tbds_config.reload()
 
         # must use the repo.pathobj as this will have resolved symlinks
-        add_to_git[tbds.repo.pathobj / '.datalad'] = {
+        add_to_git[tbrepo.pathobj / '.datalad'] = {
             'type': 'directory',
             'state': 'untracked'}
 
         # save everything, we need to do this now and cannot merge with the
         # call below, because we may need to add this subdataset to a parent
         # but cannot until we have a first commit
-        tbds.repo.save(
+        tbrepo.save(
             message='[DATALAD] new dataset',
             git=True,
             # we have to supply our own custom status, as the repo does

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -337,8 +337,9 @@ class Dataset(object, metaclass=PathBasedFlyweight):
         -------
         ConfigManager
         """
-
-        if self.repo is None:
+        # OPT: be "smart" and avoid re-resolving .repo -- expensive in DataLad
+        repo = self.repo
+        if repo is None:
             # if there's no repo (yet or anymore), we can't read/write config at
             # dataset level, but only at user/system level
             # However, if this was the case before as well, we don't want a new
@@ -348,7 +349,7 @@ class Dataset(object, metaclass=PathBasedFlyweight):
                 self._cfg_bound = False
 
         else:
-            self._cfg = self.repo.config
+            self._cfg = repo.config
             self._cfg_bound = True
 
         return self._cfg


### PR DESCRIPTION
surprisingly, benchmarking locally it only shows that things got slower:
```
(git)lena:~datalad/datalad-master[opt-smart]git
$> asv compare -m hopa master HEAD | grep -v failed

All benchmarks:

       before           after         ratio
     [c741a5b1]       [9db20858]
     <master>         <opt-smart>
        1.20±0.2s        1.35±0.1s    ~1.12  api.supers.time_createadd [hopa/virtualenv-py3.7]
        1.49±0.2s        1.67±0.1s    ~1.12  api.supers.time_createadd_to_dataset [hopa/virtualenv-py3.7]
       4.66±0.04s       5.59±0.01s    ~1.20  api.supers.time_installr [hopa/virtualenv-py3.7]
          118±2ms         126±10ms     1.06  api.supers.time_ls [hopa/virtualenv-py3.7]
        1.51±0.2s        1.69±0.4s    ~1.12  api.supers.time_ls_recursive [hopa/virtualenv-py3.7]
        1.84±0.2s        1.99±0.2s     1.08  api.supers.time_ls_recursive_long_all [hopa/virtualenv-py3.7]
         487±20ms         548±80ms    ~1.13  api.supers.time_status [hopa/virtualenv-py3.7]
        1.00±0.2s        1.04±0.1s     1.03  api.supers.time_status_recursive [hopa/virtualenv-py3.7]
         60.8±2ms        61.1±10ms     1.01  api.supers.time_subdatasets [hopa/virtualenv-py3.7]
        396±100ms         307±50ms    ~0.77  api.supers.time_subdatasets_recursive [hopa/virtualenv-py3.7]
         65.4±5ms         60.5±2ms     0.93  api.supers.time_subdatasets_recursive_first [hopa/virtualenv-py3.7]
        3.69±0.4s       3.55±0.06s     0.96  api.supers.time_uninstall [hopa/virtualenv-py3.7]
         451±50ms         449±50ms     1.00  api.testds.time_create_test_dataset1 [hopa/virtualenv-py3.7]
        3.47±0.5s        3.56±0.2s     1.03  api.testds.time_create_test_dataset2x2 [hopa/virtualenv-py3.7]
         52.5±5ns         46.7±1ns    ~0.89  check_asv.Benchmarks.time_upper [hopa/virtualenv-py3.7]
         49.3±7ns         47.1±1ns     0.96  check_asv.Suite1.time_upper [hopa/virtualenv-py3.7]
         49.2±6ns         49.8±2ns     1.01  check_asv.Suite2.time_upper [hopa/virtualenv-py3.7]
        894±200μs         891±30μs     1.00  core.runner.time_echo [hopa/virtualenv-py3.7]
       1.94±0.3ms       1.22±0.1ms    ~0.63  core.runner.time_echo_gitrunner [hopa/virtualenv-py3.7]
-            4.55             2.43     0.53  core.runner.track_overhead_100ms [hopa/virtualenv-py3.7]
-          221.65           194.26     0.88  core.runner.track_overhead_echo [hopa/virtualenv-py3.7]
-           21.24           -16.78    -0.79  core.runner.track_overhead_heavyout [hopa/virtualenv-py3.7]
+            4.55             8.12     1.78  core.runner.track_overhead_heavyout_online_process [hopa/virtualenv-py3.7]
-           27.36            24.22     0.89  core.runner.track_overhead_heavyout_online_through [hopa/virtualenv-py3.7]
          326±7ms         319±10ms     0.98  core.startup.time_help_np [hopa/virtualenv-py3.7]
         71.1±1ms         68.3±2ms     0.96  core.startup.time_import [hopa/virtualenv-py3.7]
          287±6ms         269±10ms     0.94  core.startup.time_import_api [hopa/virtualenv-py3.7]
       8.91±0.1ms      8.65±0.09ms     0.97  repo.gitrepo.time_get_content_info [hopa/virtualenv-py3.7]
       4.14±0.1ms      3.98±0.05ms     0.96  support.path.get_parent_paths.time_allsubmods_toplevel [hopa/virtualenv-py3.7]
       3.91±0.2ms      3.71±0.07ms     0.95  support.path.get_parent_paths.time_allsubmods_toplevel_only [hopa/virtualenv-py3.7]
          189±2ns          183±1ns     0.97  support.path.get_parent_paths.time_no_submods [hopa/virtualenv-py3.7]
      3.12±0.05ms       3.23±0.1ms     1.04  support.path.get_parent_paths.time_one_submod_subdir [hopa/virtualenv-py3.7]
      3.05±0.02ms      3.02±0.09ms     0.99  support.path.get_parent_paths.time_one_submod_toplevel [hopa/virtualenv-py3.7]
        36.7±0.3s          35.3±1s     0.96  usecases.study_forrest.time_make_studyforrest_mockup [hopa/virtualenv-py3.7]
```
let's see what travis says