### PR TITLE
BF: boost GitPython requirement to 3.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requires = {
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
-        'GitPython>=2.1.12',
+        'GitPython>=3.0.5',  # somewhere in 2.1.12 -- 3.0.5 pass additional options to git was fixed
         'iso8601',
         'humanize',
         'fasteners',


### PR DESCRIPTION
Otherwise, e.g. with 2.1.12 as available via Debian on buster we get

     cmdline: /usr/lib/git-annex.linux/git clone --multi-options=None --progress -v https://github.com/datalad-datasets/human-connectome-project-openaccess/.git /tmp/human-connectome-project-openaccess
     stderr: error: unknown option multi-options=None

I have not investigated on when exactly this was fixed in GitPython or either
we could addressed it without boosting dependency since Debian stable
doesn't have it  (yet at least -- looking into backporting).  But doing an upgrade

	$> pip install --upgrade GitPython
	Collecting GitPython
	  Downloading https://files.pythonhosted.org/packages/20/8c/4543981439d23c4ff65b2e62dddd767ebc84a8e664a9b67e840d1e2730d3/GitPython-3.0.5-py3-none-any.whl (455kB)
		 |████████████████████████████████| 460kB 1.3MB/s
	Requirement already satisfied, skipping upgrade: gitdb2>=2.0.0 in /usr/lib/python3/dist-packages (from GitPython) (2.0.5)
	Installing collected packages: GitPython
	  Found existing installation: GitPython 2.1.11
		Not uninstalling gitpython at /usr/lib/python3/dist-packages, outside environment /home/yoh/proj/datalad/datalad-master/venvs/dev3
		Can't uninstall 'GitPython'. No files were found to uninstall.
	Successfully installed GitPython-3.0.5
	WARNING: You are using pip version 19.2.2, however version 20.0.2 is available.
	You should consider upgrading via the 'pip install --upgrade pip' command.

did resolve the issue.  So I am suggesting it as the resolution
