### PR TITLE
NF: clone: --reckless='ephemeral'

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -569,13 +569,6 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
         lgr.debug(
             "Instruct annex to hardlink content in %s from local "
             "sources, if possible (reckless)", ds.path)
-        # store the reckless setting in the dataset to make it
-        # known to later clones of subdatasets via get()
-        ds.config.set(
-            'datalad.clone.reckless', reckless,
-            where='local',
-            # delay reload until all config IO is done
-            reload=False)
         ds.config.set(
             'annex.hardlink', 'true', where='local', reload=True)
 
@@ -651,6 +644,16 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
             # TODO: What level? + note, that annex-dead is independ
             lgr.warning("reckless=ephemeral mode: Unable to create symlinks on "
                         "this file system.")
+
+    if reckless:
+        # we successfully dealt with reckless here.
+        # store the reckless setting in the dataset to make it
+        # known to later clones of subdatasets via get()
+        ds.config.set(
+            'datalad.clone.reckless', reckless,
+            where='local',
+            # delay reload until all config IO is done
+            reload=False)
 
     srs = {True: [], False: []}  # special remotes by "autoenable" key
     remote_uuids = None  # might be necessary to discover known UUIDs

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -652,8 +652,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
         ds.config.set(
             'datalad.clone.reckless', reckless,
             where='local',
-            # delay reload until all config IO is done
-            reload=False)
+            reload=True)
 
     srs = {True: [], False: []}  # special remotes by "autoenable" key
     remote_uuids = None  # might be necessary to discover known UUIDs

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -64,8 +64,8 @@ from datalad.distribution.dataset import (
 from datalad.distribution.utils import (
     _get_flexible_source_candidates,
 )
-from datalad.tests.utils import (
-    has_symlink_capability
+from datalad.utils import (
+    check_symlink_capability
 )
 
 __docformat__ = 'restructuredtext'
@@ -605,7 +605,8 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
 
         ds.repo._run_annex_command('dead', annex_options=['here'])
 
-        if has_symlink_capability():
+        if check_symlink_capability(ds.repo.dot_git / 'dl_link_test',
+                                    ds.repo.dot_git / 'dl_target_test'):
             # symlink the annex to avoid needless copies in an emphemeral clone
             annex_dir = ds.repo.dot_git / 'annex'
             origin_annex_url = ds.config.get("remote.origin.url", None)
@@ -613,7 +614,6 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
                 try:
                     # deal with file:// scheme URLs as well as plain paths
                     # if origin isn't local, we have nothing to do
-                    # TODO: Double-check it's always .git!
                     origin_git_path = Path(PathRI(origin_annex_url).localpath)
                     if origin_git_path.name != '.git':
                         origin_git_path /= '.git'

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -622,14 +622,17 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
             # symlink the annex to avoid needless copies in an emphemeral clone
             annex_dir = ds.repo.dot_git / 'annex'
             origin_annex_url = ds.config.get("remote.origin.url", None)
+            origin_git_path = None
             if origin_annex_url:
                 try:
                     # Deal with file:// scheme URLs as well as plain paths.
                     # If origin isn't local, we have nothing to do.
-                    origin_git_path = Path(PathRI(origin_annex_url).localpath)
+                    origin_git_path = Path(RI(origin_annex_url).localpath)
                     if origin_git_path.name != '.git':
                         origin_git_path /= '.git'
-                except Exception:
+                except ValueError:
+                    # Note, that accessing localpath on a non-local RI throws
+                    # ValueError rather than resulting in an AttributeError.
                     # TODO: Warning level okay or is info level sufficient?
                     # Note, that setting annex-dead is independent of
                     # symlinking .git/annex. It might still make sense to

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -615,7 +615,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
             'remote.origin.annex-ignore', 'true',
             where='local')
 
-        ds.repo._run_annex_command('dead', annex_options=['here'])
+        ds.repo.set_remote_dead('here')
 
         if check_symlink_capability(ds.repo.dot_git / 'dl_link_test',
                                     ds.repo.dot_git / 'dl_target_test'):

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -766,7 +766,7 @@ def test_ria_http_storedataladorg(path):
     eq_(ds.id, datalad_store_testds_id)
 
 
-@skip_if_on_windows  # see gh-
+@skip_if_on_windows  # see gh-4131
 @with_tree(tree={
     'ds': {
         'test.txt': 'some',

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -787,8 +787,10 @@ def test_ephemeral(origin_path, clone1_path, clone2_path):
         clone1_annex = (clone1.repo.dot_git / 'annex')
         ok_(clone1_annex.is_symlink())
         ok_(clone1_annex.resolve().samefile(origin.repo.dot_git / 'annex'))
-        ok_file_has_content(clone1.pathobj / file_test, content='some')
-        ok_file_has_content(clone1.pathobj / file_testsub, content='somemore')
+        if not clone1.repo.is_managed_branch():
+            # TODO: We can't properly handle adjusted branch yet
+            eq_((clone1.pathobj / file_test).read_text(), 'some')
+            eq_((clone1.pathobj / file_testsub).read_text(), 'somemore')
 
     # 2. clone via file-scheme URL
     clone2 = clone('file://' + Path(origin_path).as_posix(), clone2_path,
@@ -798,8 +800,10 @@ def test_ephemeral(origin_path, clone1_path, clone2_path):
         clone2_annex = (clone2.repo.dot_git / 'annex')
         ok_(clone2_annex.is_symlink())
         ok_(clone2_annex.resolve().samefile(origin.repo.dot_git / 'annex'))
-        ok_file_has_content(clone2.pathobj / file_test, content='some')
-        ok_file_has_content(clone2.pathobj / file_testsub, content='somemore')
+        if not clone2.repo.is_managed_branch():
+            # TODO: We can't properly handle adjusted branch yet
+            eq_((clone1.pathobj / file_test).read_text(), 'some')
+            eq_((clone1.pathobj / file_testsub).read_text(), 'somemore')
 
     # 3. add something to clone1 and push back to origin availability from
     # clone1 should not be propagated (we declared 'here' dead to that end)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -66,7 +66,8 @@ from datalad.tests.utils import (
     known_failure,
     known_failure_appveyor,
     patch_config,
-    has_symlink_capability
+    has_symlink_capability,
+    skip_if_on_windows
 )
 from datalad.core.distributed.clone import (
     decode_source_spec,
@@ -765,6 +766,7 @@ def test_ria_http_storedataladorg(path):
     eq_(ds.id, datalad_store_testds_id)
 
 
+@skip_if_on_windows  # see gh-
 @with_tree(tree={
     'ds': {
         'test.txt': 'some',

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -131,11 +131,13 @@ reckless_opt = Parameter(
     const='auto',
     nargs='?',
     # boolean types only for backward compatibility
-    constraints=EnsureChoice(None, True, False, 'auto'),
+    constraints=EnsureChoice(None, True, False, 'auto', 'ephemeral'),
     doc="""Set up the dataset to be able to obtain content in the
     cheapest/fastest possible way, even if this poses a potential
-    risk the data integrity (e.g. hardlink files from a local clone
-    of the dataset). Use with care, and limit to "read-only" use
+    risk the data integrity ('auto': hardlink files from a local clone
+    of the dataset, 'ephemeral': symlink annex to origin's annex and discard 
+    local availability info via git-annex-dead 'here'). Use with care, 
+    and limit to "read-only" use
     cases. With this flag the installed dataset will be marked as
     untrusted. The reckless mode is stored in a dataset's local
     configuration under 'datalad.clone.reckless', and will be inherited

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -136,12 +136,14 @@ reckless_opt = Parameter(
     cheapest/fastest possible way, even if this poses a potential
     risk the data integrity ('auto': hardlink files from a local clone
     of the dataset, 'ephemeral': symlink annex to origin's annex and discard 
-    local availability info via git-annex-dead 'here'). Use with care, 
-    and limit to "read-only" use
-    cases. With this flag the installed dataset will be marked as
-    untrusted. The reckless mode is stored in a dataset's local
-    configuration under 'datalad.clone.reckless', and will be inherited
-    to any of its subdatasets.""")
+    local availability info via git-annex-dead 'here'. Please note, that with a
+    symlinked annex you share the annex with origin w/o git-annex knowing
+    this. In case of a change in origin you need to update the clone before
+    you're able to save new content on your end.).
+    Use with care, and limit to "read-only" use cases. With this flag the
+    installed dataset will be marked as untrusted. The reckless mode is
+    stored in a dataset's local configuration under 'datalad.clone.reckless',
+    and will be inherited to any of its subdatasets.""")
 
 jobs_opt = Parameter(
     args=("-J", "--jobs"),

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1849,15 +1849,10 @@ def get_deeply_nested_structure(path):
 
 
 def has_symlink_capability():
-    try:
-        wdir = ut.Path(tempfile.mkdtemp())
-        (wdir / 'target').touch()
-        (wdir / 'link').symlink_to(wdir / 'target')
-        return True
-    except Exception:
-        return False
-    finally:
-        shutil.rmtree(str(wdir))
+
+    path = ut.Path(tempfile.mktemp())
+    target = ut.Path(tempfile.mktemp())
+    return utils.check_symlink_capability(path, target)
 
 
 def skip_wo_symlink_capability(func):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2421,5 +2421,7 @@ def check_symlink_capability(path, target):
     except Exception:
         return False
     finally:
-        path.unlink()
-        target.unlink()
+        if path.exists():
+            path.unlink()
+        if target.exists():
+            target.unlink()

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2392,3 +2392,34 @@ assure_dir = ensure_dir
 
 
 lgr.log(5, "Done importing datalad.utils")
+
+
+def check_symlink_capability(path, target):
+    """helper similar to datalad.tests.utils.has_symlink_capability
+
+    However, for use in a datalad command context, we shouldn't
+    assume to be able to write to tmpfile and also not import a whole lot from
+    datalad's test machinery. Finally, we want to know, whether we can create a
+    symlink at a specific location, not just somewhere. Therefore use
+    arbitrary path to test-build a symlink and delete afterwards. Suiteable
+    location can therefore be determined by high lever code.
+
+    Paremeter
+    ---------
+    path: Path
+    target: Path
+
+    Returns
+    -------
+    bool
+    """
+
+    try:
+        target.touch()
+        path.symlink_to(target)
+        return True
+    except Exception:
+        return False
+    finally:
+        path.unlink()
+        target.unlink()

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2404,8 +2404,8 @@ def check_symlink_capability(path, target):
     arbitrary path to test-build a symlink and delete afterwards. Suiteable
     location can therefore be determined by high lever code.
 
-    Paremeter
-    ---------
+    Parameters
+    ----------
     path: Path
     target: Path
 


### PR DESCRIPTION
Introduce reckless mode 'ephemeral' for throw-away clones, symlinking their .git/annex to origin's .git/annex.
In addition declare 'here' dead to not propagate availability info from it when publishing captured changes back.