### PR TITLE
RF: GitRepo.clone clone_options -> options

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -407,7 +407,7 @@ def clone_dataset(
             GitRepo.clone(
                 path=str(dest_path),
                 url=cand['giturl'],
-                clone_options=clone_opts,
+                options=clone_opts,
                 create=True)
 
         except GitCommandError as e:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -803,7 +803,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         return self._repo
 
     @classmethod
-    def clone(cls, url, path, *args, clone_options=None, **kwargs):
+    def clone(cls, url, path, *args, options=None, **kwargs):
         """Clone url into path
 
         Provides workarounds for known issues (e.g.
@@ -813,7 +813,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ----------
         url : str
         path : str
-        clone_options : dict
+        options : dict
           Key/value pairs of arbitrary options that will be passed on to the
           underlying call to `git-clone`.
         expect_fail : bool
@@ -889,7 +889,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                         # tailored list of "multi options" to make a future
                         # non-GitPy based implementation easier. Do conversion
                         # here
-                        multi_options=to_options(**clone_options) if clone_options else None,
+                        multi_options=to_options(**options) if options else None,
                         odbt=default_git_odbt,
                         progress=git_progress
                     )


### PR DESCRIPTION
Many other methods in GitRepo have ability to pass options to git.
All of them, but add* (overloaded by git-annex, separate storry to
try/tell), seems to have "options" kwarg (some are on the 2nd line, not shown),
not command_options, since association to the command is obvious.

    $> git grep 'def .*options=' datalad/support/*repo.py
    datalad/support/annexrepo.py:    def get_toppath(cls, path, follow_up=True, git_options=None):
    datalad/support/annexrepo.py:    def add_remote(self, name, url, options=None):
    datalad/support/annexrepo.py:    def get(self, files, remote=None, options=None, jobs=None, key=False):
    datalad/support/annexrepo.py:    def add(self, files, git=None, backend=None, options=None, jobs=None,
    datalad/support/annexrepo.py:    def add_(self, files, git=None, backend=None, options=None, jobs=None,
    datalad/support/annexrepo.py:    def lock(self, files, options=None):
    datalad/support/annexrepo.py:    def unlock(self, files, options=None):
    datalad/support/annexrepo.py:    def adjust(self, options=None):
    datalad/support/annexrepo.py:    def unannex(self, files, options=None):
    datalad/support/annexrepo.py:    def add_url_to_file(self, file_, url, options=None, backend=None,
    datalad/support/annexrepo.py:    def add_urls(self, urls, options=None, backend=None, cwd=None,
    datalad/support/annexrepo.py:    def drop(self, files, options=None, key=False, jobs=None):
    datalad/support/annexrepo.py:    def drop_key(self, keys, options=None, batch=False):
    datalad/support/annexrepo.py:    def whereis(self, files, output='uuids', key=False, options=None, batch=False):
    datalad/support/annexrepo.py:    def commit(self, msg=None, options=None, _datalad_msg=False,
    datalad/support/annexrepo.py:    def copy_to(self, files, remote, options=None, jobs=None):
    datalad/support/annexrepo.py:    def __init__(self, batch_size=0, git_options=None):
    datalad/support/annexrepo.py:    def __init__(self, annex_cmd, git_options=None, annex_options=None, path=None,
    datalad/support/gitrepo.py:def kwargs_to_options(func, split_single_char_options=True,
    datalad/support/gitrepo.py:    def get_toppath(cls, path, follow_up=True, git_options=None):
    datalad/support/gitrepo.py:    def add(self, files, git=True, git_options=None, update=False):
    datalad/support/gitrepo.py:    def add_(self, files, git=True, git_options=None, update=False):
    datalad/support/gitrepo.py:    def commit(self, msg=None, options=None, _datalad_msg=False, careless=True,
    datalad/support/gitrepo.py:    def add_remote(self, name, url, options=None):
    datalad/support/gitrepo.py:    def checkout(self, name, options=None):
    datalad/support/gitrepo.py:    def merge(self, name, options=None, msg=None, allow_unrelated=False, **kwargs):
    datalad/support/gitrepo.py:    def ls_remote(self, remote, options=None):
    datalad/support/gitrepo.py:    def is_submodule_modified(self, name, options=[]):

I dont see why clone needs to be special.
