### PR TITLE
Fixes and tweaks to command example handling

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -121,15 +121,16 @@ class Clone(Interface):
              code_cmd="datalad clone "
              "https://github.com/datalad-datasets/longnow-podcasts.git"),
         dict(text="Install a dataset into a specific directory",
-             code_py="clone("
-             "source='https://github.com/datalad-datasets/longnow"
-             "-podcasts.git', path='myfavpodcasts')",
-             code_cmd="datalad clone "
-             "https://github.com/datalad-datasets/longnow-podcasts.git "
-             "myfavpodcasts"),
+             code_py="""\
+             clone(source='https://github.com/datalad-datasets/longnow-podcasts.git',
+                   path='myfavpodcasts')""",
+             code_cmd="""\
+             datalad clone https://github.com/datalad-datasets/longnow-podcasts.git \\
+             myfavpodcasts"""),
         dict(text="Install a dataset as a subdataset into the current dataset",
-             code_py="clone(dataset='.', "
-             "source='https://github.com/datalad-datasets/longnow-podcasts.git')",
+             code_py="""\
+             clone(dataset='.',
+                   source='https://github.com/datalad-datasets/longnow-podcasts.git')""",
              code_cmd="datalad clone -d . "
              "https://github.com/datalad-datasets/longnow-podcasts.git"),
         dict(text="Install the main superdataset from datasets.datalad.org",

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -116,11 +116,11 @@ class Create(Interface):
              code_py="create(dataset='.', path='mysubdataset')",
              code_cmd="datalad create -d . mysubdataset"),
         dict(text="Create a dataset in an existing, non-empty directory",
-             code_py="create(force=True, path='.')",
+             code_py="create(force=True)",
              code_cmd="datalad create --force"),
         dict(text="Create a plain Git repository",
              code_py="create(path='mydataset', no_annex=True)",
-             code_cmd="datalad create --no-annex"),
+             code_cmd="datalad create --no-annex mydataset"),
     ]
 
     _params_ = dict(

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -128,7 +128,7 @@ class Run(Interface):
     """
     _examples_ = [
         dict(text="Run an executable script and record the impact on a dataset",
-             code_py="ds.run(message='run my script', cmd='code/script.sh')",
+             code_py="run(message='run my script', cmd='code/script.sh')",
              code_cmd="datalad run -m 'run my script' 'code/script.sh'"),
         dict(text="Run a command and specify a directory as a dependency "
                   "for the run. The contents of the dependency will be retrieved "
@@ -136,22 +136,22 @@ class Run(Interface):
              code_cmd="datalad run -m 'run my script' --input 'data/*' "
              "'code/script.sh'",
              code_py="""\
-             ds.run(cmd='code/script.sh', message='run my script',
-                    inputs=['data/*'])"""),
+             run(cmd='code/script.sh', message='run my script',
+                 inputs=['data/*'])"""),
         dict(text="Run an executable script and specify output files of the "
                   "script to be unlocked prior to running the script",
              code_py="""\
-             ds.run(cmd='code/script.sh', message='run my script',
-                    inputs=['data/*'], outputs=['output_dir'])""",
+             run(cmd='code/script.sh', message='run my script',
+                 inputs=['data/*'], outputs=['output_dir'])""",
              code_cmd="""\
              datalad run -m 'run my script' --input 'data/*' \\
              --output 'output_dir/*' 'code/script.sh'"""),
         dict(text="Specify multiple inputs and outputs",
              code_py="""\
-             ds.run(cmd='code/script.sh',
-                    message='run my script',
-                    inputs=['data/*', 'datafile.txt'],
-                    outputs=['output_dir', 'outfile.txt'])""",
+             run(cmd='code/script.sh',
+                 message='run my script',
+                 inputs=['data/*', 'datafile.txt'],
+                 outputs=['output_dir', 'outfile.txt'])""",
              code_cmd="""\
              datalad run -m 'run my script' --input 'data/*' \\
              --input 'datafile.txt' --output 'output_dir/*' --output \\

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -136,11 +136,11 @@ class Run(Interface):
              code_cmd="datalad run -m 'run my script' --input 'data/*' "
              "'code/script.sh'",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs='data/*')"),
+             "inputs=['data/*'])"),
         dict(text="Run an executable script and specify output files of the "
                   "script to be unlocked prior to running the script",
              code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs='data/*', outputs='output_dir')",
+             "inputs=['data/*'], outputs=['output_dir'])",
              code_cmd="datalad run -m 'run my script' --input 'data/*' "
              "--output 'output_dir/*' 'code/script.sh'"),
         dict(text="Specify multiple inputs and outputs",

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -150,9 +150,9 @@ class Run(Interface):
                     inputs=['data/*', 'datafile.txt'],
                     outputs=['output_dir', 'outfile.txt'])""",
              code_cmd="""\
-             datalad run -m 'run my script' --input 'data/*'
-               --input 'datafile.txt' --output 'output_dir/*' --output
-               'outfile.txt' 'code/script.sh'""")
+             datalad run -m 'run my script' --input 'data/*' \\
+             --input 'datafile.txt' --output 'output_dir/*' --output \\
+             'outfile.txt' 'code/script.sh'""")
     ]
 
     _params_ = dict(

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -135,14 +135,17 @@ class Run(Interface):
                   "prior to running the script",
              code_cmd="datalad run -m 'run my script' --input 'data/*' "
              "'code/script.sh'",
-             code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs=['data/*'])"),
+             code_py="""\
+             ds.run(cmd='code/script.sh', message='run my script',
+                    inputs=['data/*'])"""),
         dict(text="Run an executable script and specify output files of the "
                   "script to be unlocked prior to running the script",
-             code_py="ds.run(cmd='code/script.sh', message='run my script', "
-             "inputs=['data/*'], outputs=['output_dir'])",
-             code_cmd="datalad run -m 'run my script' --input 'data/*' "
-             "--output 'output_dir/*' 'code/script.sh'"),
+             code_py="""\
+             ds.run(cmd='code/script.sh', message='run my script',
+                    inputs=['data/*'], outputs=['output_dir'])""",
+             code_cmd="""\
+             datalad run -m 'run my script' --input 'data/*' \\
+             --output 'output_dir/*' 'code/script.sh'"""),
         dict(text="Specify multiple inputs and outputs",
              code_py="""\
              ds.run(cmd='code/script.sh',

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -80,7 +80,7 @@ class Save(Interface):
              code_py="save(path='myfile.txt')",
              code_cmd="datalad save myfile.txt"),
         dict(text="""Attach a commit message to save""",
-             code_py="save(path='myfile.txt', message='add a file')",
+             code_py="save(path='myfile.txt', message='add file')",
              code_cmd="datalad save -m 'add file' myfile.txt"),
         dict(text="""Save any content underneath the current directory, and
              recurse into any potential subdatasets""",
@@ -93,7 +93,7 @@ class Save(Interface):
              code_cmd="""datalad save -u ."""),
         dict(text="Tag the most recent saved state of a dataset",
              code_py="save(version_tag='bestyet')",
-             code_cmd="datalad save -d . --version-tag 'bestyet'"),
+             code_cmd="datalad save --version-tag 'bestyet'"),
     ]
 
     _params_ = dict(

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -74,7 +74,7 @@ class Save(Interface):
     _examples_ = [
         dict(text="""Save any content underneath the current directory, without
              altering any potential subdataset""",
-             code_py="save()",
+             code_py="save(path='.')",
              code_cmd="datalad save ."),
         dict(text="""Save specific content in the dataset""",
              code_py="save(path='myfile.txt')",
@@ -84,13 +84,13 @@ class Save(Interface):
              code_cmd="datalad save -m 'add file' myfile.txt"),
         dict(text="""Save any content underneath the current directory, and
              recurse into any potential subdatasets""",
-             code_py="save(recursive=True)",
+             code_py="save(path='.', recursive=True)",
              code_cmd="datalad save . --recursive"),
         dict(text="Save any modification of known dataset content in the "
                   "current directory, but leave untracked files (e.g. temporary files) "
                   "untouched",
-             code_py="""save(updated=True)""",
-             code_cmd="""datalad save -u -d ."""),
+             code_py="""save(path='.', updated=True)""",
+             code_cmd="""datalad save -u ."""),
         dict(text="Tag the most recent saved state of a dataset",
              code_py="save(version_tag='bestyet')",
              code_cmd="datalad save -d . --version-tag 'bestyet'"),

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -74,25 +74,25 @@ class Save(Interface):
     _examples_ = [
         dict(text="""Save any content underneath the current directory, without
              altering any potential subdataset""",
-             code_py="ds.save()",
+             code_py="save()",
              code_cmd="datalad save ."),
         dict(text="""Save specific content in the dataset""",
-             code_py="ds.save(path='myfile.txt')",
+             code_py="save(path='myfile.txt')",
              code_cmd="datalad save myfile.txt"),
         dict(text="""Attach a commit message to save""",
-             code_py="ds.save(path='myfile.txt', message='add a file')",
+             code_py="save(path='myfile.txt', message='add a file')",
              code_cmd="datalad save -m 'add file' myfile.txt"),
         dict(text="""Save any content underneath the current directory, and
              recurse into any potential subdatasets""",
-             code_py="ds.save(recursive=True)",
+             code_py="save(recursive=True)",
              code_cmd="datalad save . --recursive"),
         dict(text="Save any modification of known dataset content in the "
                   "current directory, but leave untracked files (e.g. temporary files) "
                   "untouched",
-             code_py="""ds.save(updated=True)""",
+             code_py="""save(updated=True)""",
              code_cmd="""datalad save -u -d ."""),
         dict(text="Tag the most recent saved state of a dataset",
-             code_py="ds.save(version_tag='bestyet')",
+             code_py="save(version_tag='bestyet')",
              code_cmd="datalad save -d . --version-tag 'bestyet'"),
     ]
 

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -227,27 +227,27 @@ class Status(Interface):
     result_renderer = 'tailored'
     _examples_ = [
         dict(text="Report on the state of a dataset",
-             code_py="ds.status()",
+             code_py="status()",
              code_cmd="datalad status"),
         dict(text="Report on the state of a dataset and all subdatasets",
-             code_py="ds.status(recursive=True)",
+             code_py="status(recursive=True)",
              code_cmd="datalad status --recursive"),
         dict(text="Address a subdataset record in a superdataset without "
                   "causing a status query for the state _within_ the subdataset "
                   "itself",
-             code_py="ds.status(path='mysubdataset')",
+             code_py="status(dataset='.', path='mysubdataset')",
              code_cmd="datalad status --dataset . mysubdataset"),
         dict(text="Get a status query for the state within the subdataset "
                   "without causing a status query for the superdataset (using trailing "
                   "path separator in the query path):",
-             code_py="ds.status(path='mysubdataset/')",
+             code_py="status(dataset='.', path='mysubdataset/')",
              code_cmd="datalad status --dataset . mysubdataset/"),
         dict(text="Report on the state of a subdataset in a superdataset and "
                   "on the state within the subdataset",
-             code_py="ds.status(path=['mysubdataset', 'mysubdataset/'])",
+             code_py="status(dataset='.', path=['mysubdataset', 'mysubdataset/'])",
              code_cmd="datalad status --dataset . mysubdataset mysubdataset/"),
         dict(text="Report the file size of annexed content in a dataset",
-             code_py="ds.status(annex=True)",
+             code_py="status(annex=True)",
              code_cmd="datalad status --annex")
     ]
 

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -111,7 +111,7 @@ class Install(Interface):
         dict(text="Install a dataset, and get all content right away",
              code_py="install(source="
              "'https://github.com/datalad-datasets/longnow-podcasts.git', "
-             "get_data=True')",
+             "get_data=True)",
              code_cmd="datalad install --get-data "
              "--source https://github.com/datalad-datasets/longnow-podcasts.git"),
         dict(text="Install a dataset with all its subdatasets",

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -104,23 +104,26 @@ class Install(Interface):
              code_cmd="datalad install "
              "https://github.com/datalad-datasets/longnow-podcasts.git"),
         dict(text="Install a dataset as a subdataset into the current dataset",
-             code_py="install(dataset='.', "
-             "source='https://github.com/datalad-datasets/longnow-podcasts.git')",
-             code_cmd="datalad install -d . "
-             "--source='https://github.com/datalad-datasets/longnow-podcasts.git'"),
+             code_py="""\
+             install(dataset='.',
+                     source='https://github.com/datalad-datasets/longnow-podcasts.git')""",
+             code_cmd="""\
+             datalad install -d . \\
+             --source='https://github.com/datalad-datasets/longnow-podcasts.git'"""),
         dict(text="Install a dataset, and get all content right away",
-             code_py="install(source="
-             "'https://github.com/datalad-datasets/longnow-podcasts.git', "
-             "get_data=True)",
-             code_cmd="datalad install --get-data "
-             "--source https://github.com/datalad-datasets/longnow-podcasts.git"),
+             code_py="""\
+             install(source='https://github.com/datalad-datasets/longnow-podcasts.git',
+                     get_data=True)""",
+             code_cmd="""\
+             datalad install --get-data \\
+             --source https://github.com/datalad-datasets/longnow-podcasts.git"""),
         dict(text="Install a dataset with all its subdatasets",
-             code_py="install("
-             "source='https://github.com/datalad-datasets/longnow-podcasts.git', "
-             "recursive=True)",
-             code_cmd="datalad install "
-             "https://github.com/datalad-datasets/longnow-podcasts.git "
-             "--recursive"),
+             code_py="""\
+             install(source='https://github.com/datalad-datasets/longnow-podcasts.git',
+                     recursive=True)""",
+             code_cmd="""\
+             datalad install --recursive \\
+             https://github.com/datalad-datasets/longnow-podcasts.git"""),
     ]
 
     _params_ = dict(

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -408,7 +408,8 @@ def build_example(example, api='python'):
     # any meaningful structure/formatting of code snippets. Instead, we
     # maintain line content as is.
     code = dedent_docstring(example.get(code_field))
-    code = textwrap.indent(code, '     ').lstrip()
+    needs_indicator = not code.startswith(indicator)
+    code = textwrap.indent(code, ' ' * (5 if needs_indicator else 3)).lstrip()
 
     ex = """{}::\n\n   {}{}\n\n""".format(
         description,
@@ -416,9 +417,9 @@ def build_example(example, api='python'):
         # this enables providing more complex examples without having
         # to infer its inner structure
         '{} '.format(indicator)
-        if not code.startswith(indicator)
+        if needs_indicator
         # maintain spacing to avoid undesired relative indentation
-        else '  ',
+        else '',
         code)
 
     return ex

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -479,7 +479,9 @@ def build_doc(cls, **kwargs):
         cls_doc = cls_doc.format(**cls._docs_)
     # get examples
     ex = getattr(cls, '_examples_', [])
-    cls_doc = update_docstring_with_examples(cls_doc, ex)
+    if ex:
+        cls_doc = update_docstring_with_examples(cls_doc, ex)
+
     call_doc = None
     # suffix for update_docstring_with_parameters:
     if cls.__call__.__doc__:

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -46,10 +46,6 @@ class DownloadURL(Interface):
     It allows for a uniform download interface to various supported URL
     schemes, re-using or asking for authentication details maintained by
     datalad.
-
-    Examples:
-
-      $ datalad download-url http://example.com/file.dat s3://bucket/file2.dat
     """
 
     _params_ = dict(


### PR DESCRIPTION
This series follows up on the recent improvements that Adina brought in with gh-4091.  Patches 1-5 are more or less clear-cut fixes.  Patches 6-9 are more subjective, and I'd be fine with dropping any of those if there are objections.

    [1/9] DOC: interface: Don't write empty example section to docstrings
    [2/9] DOC: run: Don't use string for inputs/outputs in Python examples
    [3/9] DOC: download-url: Drop repeated example
    [4/9] DOC: install: Drop stray quote from example
    [5/9] DOC: interface: Use same indentation for pre-crafted examples
    [6/9] DOC: examples: Format multi-line command-line snippets consistently
    [7/9] DOC: examples: Break more snippets across multiple lines
    [8/9] DOC: examples: Consistently use unbound Python commands
    [9/9] DOC: examples: Resolve some command-line/python discrepancies
