### PR TITLE
BF: Don't be silent in default renderer when everything is clean

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -473,3 +473,6 @@ class Status(Interface):
                         len(annexed),
                         single_or_plural('file', 'files', len(annexed)),
                         total_size))
+        if all(r.get('state', None) == 'clean' for r in results):
+            from datalad.ui import ui
+            ui.message("nothing to save, working tree clean")

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -473,6 +473,8 @@ class Status(Interface):
                         len(annexed),
                         single_or_plural('file', 'files', len(annexed)),
                         total_size))
-        if all(r.get('state', None) == 'clean' for r in results):
+        if all(r.get('action', None) == 'status'
+               and r.get('state', None) == 'clean'
+               for r in results):
             from datalad.ui import ui
             ui.message("nothing to save, working tree clean")


### PR DESCRIPTION
Follow up on a report by @dorianps considering no output confusing. `status`
now follows `git status` in wording.

Fixes gh-3916

```
(datalad3-dev) mih@meiner ~/hacking/datalad/git (git)-[bf-3916] % datalad status
nothing to save, working tree clean
```