### PR TITLE
update: Try harder to fetch and merge subdataset revision

### DIFF
--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -232,7 +232,7 @@ class Update(Interface):
                 else:
                     merge_target = _choose_merge_target(
                         repo, curr_branch,
-                        sibling_, tracking_remote)
+                        sibling_, revision, tracking_remote)
 
                 if merge_target is None:
                     lgr.warning("No merge target determined for %s update. "
@@ -278,7 +278,7 @@ class Update(Interface):
                 yield r
 
 
-def _choose_merge_target(repo, branch, remote, cfg_remote):
+def _choose_merge_target(repo, branch, remote, revision, cfg_remote):
     """Select a merge target for the update to `repo`.
 
     Parameters
@@ -288,6 +288,9 @@ def _choose_merge_target(repo, branch, remote, cfg_remote):
         The current branch.
     remote : str
         The remote which updates are coming from.
+    revision : str
+        The specific revision from `remote` that should come in with the
+        update.
     cfg_remote : str
         The configured upstream remote.
 
@@ -311,6 +314,13 @@ def _choose_merge_target(repo, branch, remote, cfg_remote):
         remote_branch = "{}/{}".format(remote, branch)
         if repo.commit_exists(remote_branch):
             merge_target = remote_branch
+
+    if revision and merge_target:
+        if not repo.is_ancestor(revision, merge_target):
+            lgr.debug("Revision %s in subdataset %s is not contained "
+                      "in merge target %s. Using revision as target.",
+                      revision, repo, merge_target)
+            merge_target = revision
     return merge_target
 
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -212,19 +212,19 @@ def _update_repo(ds, remote, reobtain_data):
             # get all annexed files that have data present
             lgr.info('Recording file content availability '
                      'to re-obtain updated files later on')
-            reobtain_data = [
+            present_files = [
                 opj(ds.path, p)
                 for p in repo.get_annexed_files(with_content_only=True)]
         # this runs 'annex sync' and should deal with anything
         repo.sync(remotes=remote, push=False, pull=True, commit=False)
         if reobtain_data:
-            reobtain_data = [p for p in reobtain_data if lexists(p)]
-        if reobtain_data:
-            lgr.info('Ensuring content availability for %i '
-                     'previously available files',
-                     len(reobtain_data))
-            yield from ds.get(reobtain_data, recursive=False,
-                              return_type='generator')
+            present_files = [p for p in present_files if lexists(p)]
+            if present_files:
+                lgr.info('Ensuring content availability for %i '
+                         'previously available files',
+                         len(present_files))
+                yield from ds.get(present_files, recursive=False,
+                                  return_type='generator')
     else:
         # handle merge in plain git
         active_branch = repo.get_active_branch()

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -148,7 +148,7 @@ class Update(Interface):
                 sibling_ = remotes[0]
             elif not sibling:
                 # nothing given, look for tracking branch
-                sibling_ = repo.get_tracking_branch()[0]
+                sibling_ = repo.get_tracking_branch(remote_only=True)[0]
             else:
                 sibling_ = sibling
             if sibling_ and sibling_ not in remotes:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -255,7 +255,9 @@ def _choose_merge_target(repo, branch, remote, cfg_remote):
             ["rev-parse", "--symbolic-full-name", "--abbrev-ref=strict",
              "@{upstream}"])
     elif branch:
-        merge_target = "{}/{}".format(remote, branch)
+        remote_branch = "{}/{}".format(remote, branch)
+        if repo.commit_exists(remote_branch):
+            merge_target = remote_branch
     return merge_target
 
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -210,19 +210,21 @@ def _update_repo(ds, remote, reobtain_data):
     if isinstance(repo, AnnexRepo):
         if reobtain_data:
             # get all annexed files that have data present
-            lgr.info('Recording file content availability to re-obtain updated files later on')
-            reobtain_data = \
-                [opj(ds.path, p)
-                 for p in repo.get_annexed_files(with_content_only=True)]
+            lgr.info('Recording file content availability '
+                     'to re-obtain updated files later on')
+            reobtain_data = [
+                opj(ds.path, p)
+                for p in repo.get_annexed_files(with_content_only=True)]
         # this runs 'annex sync' and should deal with anything
         repo.sync(remotes=remote, push=False, pull=True, commit=False)
         if reobtain_data:
             reobtain_data = [p for p in reobtain_data if lexists(p)]
         if reobtain_data:
-            lgr.info('Ensure content availability for %i previously available files', len(reobtain_data))
-            for res in ds.get(
-                    reobtain_data, recursive=False, return_type='generator'):
-                yield res
+            lgr.info('Ensuring content availability for %i '
+                     'previously available files',
+                     len(reobtain_data))
+            yield from ds.get(reobtain_data, recursive=False,
+                              return_type='generator')
     else:
         # handle merge in plain git
         active_branch = repo.get_active_branch()

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -235,7 +235,7 @@ def _update_repo(ds, remote, reobtain_data):
                 repo
             )
         else:
-            if repo.config.get('branch.{}.remote'.format(remote), None) == remote:
+            if repo.config.get('branch.{}.remote'.format(active_branch)) == remote:
                 # the branch love this remote already, let git pull do its thing
                 repo.pull(remote=remote)
             else:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -212,8 +212,9 @@ def _update_repo(ds, remote, reobtain_data):
             # get all annexed files that have data present
             lgr.info('Recording file content availability '
                      'to re-obtain updated files later on')
+            ds_path = ds.path
             present_files = [
-                opj(ds.path, p)
+                opj(ds_path, p)
                 for p in repo.get_annexed_files(with_content_only=True)]
         # this runs 'annex sync' and should deal with anything
         repo.sync(remotes=remote, push=False, pull=True, commit=False)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -506,7 +506,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return branch
 
-    def get_tracking_branch(self, branch=None, corresponding=True):
+    def get_tracking_branch(self, branch=None, remote_only=False,
+                            corresponding=True):
         """Get the tracking branch for `branch` if there is any.
 
         By default returns the tracking branch of the corresponding branch if
@@ -516,6 +517,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         ----------
         branch: str
           local branch to look up. If none is given, active branch is used.
+        remote_only : bool
+            Don't return a value if the upstream remote is set to "." (meaning
+            this repository).
         corresponding: bool
           If True actually look up the corresponding branch of `branch` (also if
           `branch` isn't explicitly given)
@@ -530,6 +534,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             branch = self.get_active_branch()
 
         return super(AnnexRepo, self).get_tracking_branch(
+                        remote_only=remote_only,
                         branch=self.get_corresponding_branch(branch)
                         if corresponding else branch)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3226,13 +3226,16 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         except:
             return None
 
-    def get_tracking_branch(self, branch=None):
+    def get_tracking_branch(self, branch=None, remote_only=False):
         """Get the tracking branch for `branch` if there is any.
 
         Parameters
         ----------
         branch: str
             local branch to look up. If none is given, active branch is used.
+        remote_only : bool
+            Don't return a value if the upstream remote is set to "." (meaning
+            this repository).
 
         Returns
         -------
@@ -3245,6 +3248,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 return None, None
 
         track_remote = self.config.get('branch.{0}.remote'.format(branch), None)
+        if remote_only and track_remote == ".":
+            return None, None
         track_branch = self.config.get('branch.{0}.merge'.format(branch), None)
         return track_remote, track_branch
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -945,6 +945,12 @@ def test_get_tracking_branch(o_path, c_path):
     eq_(('origin', 'refs/heads/' + master_branch),
         clone.get_tracking_branch(master_branch))
 
+    clone.checkout(master_branch, options=["--track", "-btopic"])
+    eq_(('.', 'refs/heads/' + master_branch),
+        clone.get_tracking_branch())
+    eq_((None, None),
+        clone.get_tracking_branch(remote_only=True))
+
 
 @with_testrepos('submodule_annex', flavors=['clone'])
 def test_submodule_deinit(path):


### PR DESCRIPTION
The motivation for this series stemmed from a scenario where, on the remote end, the submodule revision is the commit pointed to by another branch, say "other".  `update(..., merge=True)` called while on master in the local repo may choose to merge in something different, most likely origin/master, which let's say hasn't diverged from the local master (though either way it's problematic).  Then it saves that state as the submodule revision in the parent, bringing the submodule revision back to where it was before the remote update.

<details>
<summary>In code</summary>

```sh
cd "$(mktemp -d --tmpdir dl-XXXXXXX)"

datalad create rem
datalad create rem/sub
datalad -C rem save -r

datalad install -r -s rem ds

(
    cd rem/sub
    git checkout -b other
    echo foo >foo
)
datalad -C rem save -r

datalad -C ds update -r --merge
```

</details>

A very similar case can happen when the remote submodule has a detached head, a common occurrence when working with `git submodule` directly.  In this case, an additional issue is that the submodule revision might not even be fetched from the remote if the revision isn't contained in a ref that is pulled down on the fetch.

---

```
  [ 1/12] ENH: repo: Teach get_tracking_branch() to optionally ignore "."
  [ 2/12] BF: update: Don't consider "." as an upstream remote
  [ 3/12] BF: update: Query intended branch.*.remote variable
  [ 4/12] RF: update: Cosmetic changes to _update_repo() helper
  [ 5/12] RF: update: Avoid overloading a variable for clarity
  [ 6/12] OPT: update: Avoid repeatedly accessing Dataset.path in a loop
  [ 7/12] RF: update: Break apart _update_repo() helper
  [ 8/12] ENH: update: Use same merge approach for plain and annex repos
  [ 9/12] ENH: update: Avoid calling 'git pull' to merge changes
  [10/12] ENH: update: Don't set merge target to a guess that doesn't exist
  [11/12] ENH: update: Try to fetch submodule commit explicitly if needed
  [12/12] ENH: update: Prefer merge of submodule revision to a ref without it
```

Patch 1-3 are unrelated bugs that I noticed in the code I was touching for the fix.  These (or something like them) should be split off into a separate PR if the more substantial changes in this PR don't make the cut.

Patch 4-7 are cleanup/prep patches, with no intended change in behavior.

Patch 8-12 are the proposed fix, moving to a more targeted `git merge` to bring in changes rather using `git pull <remote> [<configured upstream or guess>]` in git repos or using `git annex sync <remote>`  in annex repos.  Note that, when we're on an adjusted branch, we keep using `git annex sync <remote>` as we did before.  It's not that this is correct or leads to good behavior; it's just that I don't see an alternative because using submodules and adjusted branches together is fundamentally problematic, and this PR isn't trying to address that.
