### PR TITLE
RF: Turn GitRepo non-method into standalone function

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -106,10 +106,10 @@ def run_gitcommand_on_file_list_chunks(func, cmd, files, *args, **kwargs):
     Parameters
     ----------
     func : callable
-      Typically a Runner.run variant. Assumed to return a 2-tuple with stdout,
+      Typically a Runner.run variant. Assumed to return a 2-tuple with stdout
       and stderr as strings.
     cmd : list
-      Base Git command argument list, to be ammended with '--', followed
+      Base Git command argument list, to be amended with '--', followed
       by a file list chunk.
     files : list
       List of files.

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -61,7 +61,8 @@ from datalad.support.json_py import loads as json_loads
 from datalad.cmd import (
     GitRunner,
     BatchedCommand,
-    SafeDelCloseMixin
+    SafeDelCloseMixin,
+    run_gitcommand_on_file_list_chunks,
 )
 
 # imports from same module:
@@ -957,7 +958,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         try:
             # TODO: RF to use --batch where possible instead of splitting
             # into multiple invocations
-            return self._run_command_files_split(
+            return run_gitcommand_on_file_list_chunks(
                 self.cmd_call_wrapper.run,
                 cmd_list,
                 files,


### PR DESCRIPTION
- rename to `run_gitcommand_on_file_list_chunks`
- move to `cmd.py` next to the runners it can work with
- avoid intermediate str concatenation
- add debug message
- more detailed docstring