### PR TITLE
NF: create-sibling-ria command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -242,6 +242,9 @@ install:
 script:
   # Test installation system-wide
   - sudo pip install .
+  # install RIA special remote
+  # TODO: Remove whenever move of git-annex-ria-remote to datalad-core is finished
+  - sudo pip install git+https://github.com/datalad/git-annex-ria-remote
   - mkdir -p __testhome__
   - cd __testhome__
   # Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,7 +244,7 @@ script:
   - sudo pip install .
   # install RIA special remote
   # TODO: Remove whenever move of git-annex-ria-remote to datalad-core is finished
-  - sudo pip install git+https://github.com/datalad/git-annex-ria-remote@transition-to-core
+  - sudo pip install git+https://github.com/bpoldrack/git-annex-ria-remote@transition-to-core
   - mkdir -p __testhome__
   - cd __testhome__
   # Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,7 +244,7 @@ script:
   - sudo pip install .
   # install RIA special remote
   # TODO: Remove whenever move of git-annex-ria-remote to datalad-core is finished
-  - sudo pip install git+https://github.com/datalad/git-annex-ria-remote
+  - sudo pip install git+https://github.com/datalad/git-annex-ria-remote@transition-to-core
   - mkdir -p __testhome__
   - cd __testhome__
   # Run tests

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -450,11 +450,6 @@ def clone_dataset(
             # next candidate
             continue
 
-        # perform any post-processing that needs to know details of the clone
-        # source
-        if cand['type'] == 'ria':
-            yield from postclonecfg_ria(destds, cand)
-
         result_props['source'] = cand
         # do not bother with other sources if succeeded
         break
@@ -498,6 +493,11 @@ def clone_dataset(
         destds,
         reckless,
         description)
+
+    # perform any post-processing that needs to know details of the clone
+    # source
+    if result_props['source']['type'] == 'ria':
+        yield from postclonecfg_ria(destds, result_props['source'])
 
     # yield successful clone of the base dataset now, as any possible
     # subdataset clone down below will not alter the Git-state of the

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -835,6 +835,13 @@ def decode_source_spec(spec, cfg=None):
         source=spec,
         version=None,
     )
+
+    # Git never gets to see these URLs, so let's manually apply any
+    # rewrite configuration Git might know about.
+    # Note: We need to rewrite before parsing, otherwise parsing might go wrong.
+    # This is particularly true for insteadOf labels replacing even the URL
+    # scheme.
+    spec = cfg.rewrite_url(spec)
     # common starting point is a RI instance, support for accepting an RI
     # instance is kept for backward-compatibility reasons
     source_ri = RI(spec) if not isinstance(spec, RI) else spec
@@ -845,9 +852,6 @@ def decode_source_spec(spec, cfg=None):
         props['type'] = 'dataladri'
         props['giturl'] = source_ri.as_git_url()
     elif isinstance(source_ri, URL) and source_ri.scheme.startswith('ria+'):
-        # Git never gets to see these URLs, so let's manually apply any
-        # rewrite configuration Git might know about
-        source_ri = RI(cfg.rewrite_url(spec))
         # parse a RIA URI
         dsid, version = source_ri.fragment.split('@', maxsplit=1) \
             if '@' in source_ri.fragment else (source_ri.fragment, None)

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -19,8 +19,8 @@ from datalad.interface.common_opts import (
     recursion_limit
 )
 from datalad.interface.base import (
-    Interface,
     build_doc,
+    Interface,
 )
 from datalad.interface.results import (
     get_status_dict,
@@ -28,14 +28,14 @@ from datalad.interface.results import (
 from datalad.interface.utils import eval_results
 from datalad.support.param import Parameter
 from datalad.support.constraints import (
+    EnsureBool,
+    EnsureChoice,
     EnsureNone,
     EnsureStr,
-    EnsureBool,
-    EnsureChoice
 )
 from datalad.distribution.dataset import (
-    EnsureDataset,
     datasetmethod,
+    EnsureDataset,
     require_dataset,
 )
 from datalad.utils import (

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -1,0 +1,599 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Create a sibling in a RIA store"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import subprocess
+
+from datalad.interface.common_opts import (
+    recursion_flag,
+    recursion_limit
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.results import (
+    get_status_dict,
+)
+from datalad.interface.utils import eval_results
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+    EnsureBool,
+    EnsureChoice
+)
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.utils import (
+    Path,
+    quote_cmdlinearg,
+    rmtree,
+)
+from datalad.support.exceptions import (
+    CommandError
+)
+from datalad.support.gitrepo import (
+    GitRepo
+)
+from datalad.core.distributed.clone import (
+    decode_source_spec
+)
+from datalad.log import log_progress
+from datalad.distributed.ria_utils import (
+    get_layout_locations,
+    verify_ria_url,
+)
+
+lgr = logging.getLogger('datalad.distributed.create_sibling_ria')
+
+
+@build_doc
+class CreateSiblingRia(Interface):
+    """Creates a sibling to a dataset in a RIA store
+
+    This creates a representation of a dataset in a ria-remote compliant
+    storage location. For access to it two siblings are configured for the
+    dataset by default. A "regular" one and a RIA remote (git-annex
+    special remote).  Furthermore, the former is configured to have a
+    publication dependency on the latter. If not given a default name for
+    the RIA remote is derived from the sibling's name by appending "-ria".
+
+    The store's base path currently is expected to either:
+
+      - not yet exist or
+      - be empty or
+      - have a valid `ria-layout-version` file and an `error_logs` directory.
+
+    In the first two cases, said file and directory are created by this
+    command. Alternatively you can manually create the third case, of course.
+    Please note, that `ria-layout-version` needs to contain a line stating the
+    version (currently '1') and optionally enable error logging (append '|l' in
+    that case). Currently, this line MUST end with a newline!
+
+    Error logging will create files in the `error_log` directory whenever the
+    RIA special remote (storage sibling) raises an exception, storing the
+    python traceback of it. The logfiles are named according to the scheme
+    <dataset id>.<annex uuid of the remote>.log showing 'who' ran into this
+    issue with what dataset. Since this logging can potentially leak personal
+    data (like local file paths for example) it can be disabled from the client
+    side via `annex.ria-remote.<RIAREMOTE>.ignore-remote-config`.
+
+    Todo
+    ----
+    Where to put the description of a RIA store (see below)?
+
+    The targeted layout of such a store is a tree of datasets, starting at the
+    configured base path. First level of subdirectories are named for the first
+    three characters of the datasets' id, second level is the remainder of
+    those ids. The thereby created dataset directories contain a bare git
+    repository.  Those bare repositories are slightly different from plain
+    git-annex bare repositories in that they use the standard dirhashmixed
+    layout beneath annex/objects as opposed to dirhashlower, which is
+    git-annex's default for bare repositories. Furthermore, there is an
+    additional directory 'archives' within the dataset directories, which may
+    or may not contain archives with annexed content.  Note, that this helps to
+    reduce the number of inodes consumed (no checkout + potential archive) as
+    well as it allows to resolve dependencies (that is (sub)datasets) merely by
+    their id.  Finally, there is a file `ria-layout-version` put beneath the
+    store's base path, determining the version of the dataset tree layout and a
+    file of the same name per each dataset directory determining object tree
+    layout version (we already switch from dirhashlower to dirhashmixed for
+    example) and an additional directory `error_logs` at the toplevel.  """
+
+    # TODO: description?
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to process.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        url=Parameter(
+            args=("url",),
+            metavar="ria+<ssh|file>://<host>[/path]",
+            doc="""URL identifying the target RIA store and access protocol.
+            """,
+            constraints=EnsureStr() | EnsureNone()),
+        name=Parameter(
+            args=('-s', '--name',),
+            metavar='NAME',
+            doc="""Name of the sibling.
+            With `recursive`, the same name will be used to label all
+            the subdatasets' siblings.""",
+            constraints=EnsureStr() | EnsureNone(),
+            required=True),
+        ria_remote_name=Parameter(
+            args=("--ria-remote-name",),
+            metavar="NAME",
+            doc="""Name of the RIA remote (a git-annex special remote).
+            Must not be identical to the sibling name. If not specified,
+            defaults to the sibling name plus a '-ria' suffix.""",
+            constraints=EnsureStr() | EnsureNone()),
+        post_update_hook=Parameter(
+            args=("--post-update-hook",),
+            doc="""Enable git's default post-update-hook for the created
+            sibling.""",
+            action="store_true"),
+        shared=Parameter(
+            args=("--shared",),
+            metavar='{false|true|umask|group|all|world|everybody|0xxx}',
+            doc="""If given, configures the permissions in the
+            RIA store for multi-users access.
+            Possible values for this option are identical to those of
+            `git init --shared` and are described in its documentation.""",
+            constraints=EnsureStr() | EnsureBool() | EnsureNone()),
+        group=Parameter(
+            args=("--group",),
+            metavar="GROUP",
+            doc="""Filesystem group for the repository. Specifying the group is
+            crucial when [CMD: --shared=group CMD][PY: shared="group" PY]""",
+            constraints=EnsureStr() | EnsureNone()),
+        ria_remote=Parameter(
+            args=("--no-ria-remote",),
+            dest='ria_remote',
+            doc="""Whether to establish remote indexed archive (RIA) capabilties
+            for the created sibling. If enabled, git-annex special remote access
+            will be configured to enable regular git-annex key storage, and
+            also retrieval of keys from (compressed) 7z archives that might be
+            provided by the dataset store. If disabled, git-annex is instructed
+            to ignore the sibling.""",
+            action="store_false"),
+        existing=Parameter(
+            args=("--existing",),
+            constraints=EnsureChoice(
+                'skip', 'replace', 'error', 'reconfigure'),
+            metavar='MODE',
+            doc="""Action to perform, if a sibling or ria-remote is already
+            configured under the given name and/or a target already exists.
+            In this case, a dataset can be skipped ('skip'), an existing target
+            directory be forcefully re-initialized, and the sibling
+            (re-)configured ('replace', implies 'reconfigure'), the sibling
+            configuration be updated only ('reconfigure'), or to error
+            ('error').""", ),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+    )
+
+    @staticmethod
+    @datasetmethod(name='create_sibling_ria')
+    @eval_results
+    def __call__(url,
+                 name,
+                 dataset=None,
+                 ria_remote_name=None,
+                 post_update_hook=False,
+                 shared=None,
+                 group=None,
+                 ria_remote=True,
+                 existing='error',
+                 recursive=False,
+                 recursion_limit=None
+                 ):
+
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='create sibling RIA')
+        res_kwargs = dict(
+            ds=ds,
+            action="create-sibling-ria",
+            logger=lgr,
+        )
+
+        if ds.repo.get_hexsha() is None or ds.id is None:
+            raise RuntimeError(
+                "Repository at {} is not a DataLad dataset, "
+                "run 'datalad create [--force]' first.".format(ds.path))
+
+        if not ria_remote and ria_remote_name:
+            lgr.warning(
+                "RIA remote setup disabled, but a ria-remote name was provided"
+            )
+
+        if ria_remote and not ria_remote_name:
+            ria_remote_name = "{}-ria".format(name)
+
+        if ria_remote and name == ria_remote_name:
+            # leads to unresolvable, circular dependency with publish-depends
+            raise ValueError("sibling names must not be equal")
+
+        if not isinstance(url, str):
+            raise TypeError("url is not a string, but %s" % type(url))
+
+        # Query existing siblings upfront in order to fail early on
+        # existing=='error', since misconfiguration (particularly of special
+        # remotes) only to fail in a subdataset later on with that config, can
+        # be quite painful.
+        # TODO: messages - this is "create-sibling". Don't confuse existence of
+        #       local remotes with existence of the actual remote sibling
+        #       in wording
+        if existing == 'error':
+            # in recursive mode this check could take a substantial amount of
+            # time: employ a progress bar (or rather a counter, because we dont
+            # know the total in advance
+            pbar_id = 'check-siblings-{}'.format(id(ds))
+            log_progress(
+                lgr.info, pbar_id,
+                'Start checking pre-existing sibling configuration %s', ds,
+                label='Query siblings',
+                unit=' Siblings',
+            )
+            # even if we have to fail, let's report all conflicting siblings
+            # in subdatasets
+            failed = False
+            for r in ds.siblings(result_renderer=None,
+                                 recursive=recursive,
+                                 recursion_limit=recursion_limit):
+                log_progress(
+                    lgr.info, pbar_id,
+                    'Discovered sibling %s in dataset at %s',
+                    r['name'], r['path'],
+                    update=1,
+                    increment=True)
+                if not r['type'] == 'sibling' or r['status'] != 'ok':
+                    # this is an internal status query that has not consequence
+                    # for the outside world. Be silent unless something useful
+                    # can be said
+                    #yield r
+                    continue
+                if r['name'] == name:
+                    res = get_status_dict(
+                        status='error',
+                        message="a sibling '{}' is already configured in "
+                        "dataset {}".format(name, r['path']),
+                        **res_kwargs,
+                    )
+                    failed = True
+                    yield res
+                    continue
+                if ria_remote_name and r['name'] == ria_remote_name:
+                    res = get_status_dict(
+                        status='error',
+                        message="a sibling '{}' is already configured in "
+                        "dataset {}".format(ria_remote_name, r['path']),
+                        **res_kwargs,
+                    )
+                    failed = True
+                    yield res
+                    continue
+            log_progress(
+                lgr.info, pbar_id,
+                'Finished checking pre-existing sibling configuration %s', ds,
+            )
+            if failed:
+                return
+
+        yield from _create_sibling_ria(
+            ds,
+            url,
+            name,
+            ria_remote,
+            ria_remote_name,
+            existing,
+            shared,
+            group,
+            post_update_hook,
+            res_kwargs)
+
+        if recursive:
+            # Note: subdatasets can be treated independently, so go full
+            # recursion when querying for them and _no_recursion with the
+            # actual call. Theoretically this can be parallelized.
+
+            for subds in ds.subdatasets(fulfilled=True,
+                                        recursive=True,
+                                        recursion_limit=recursion_limit,
+                                        result_xfm='datasets'):
+                yield from _create_sibling_ria(
+                    subds,
+                    url,
+                    name,
+                    ria_remote,
+                    ria_remote_name,
+                    existing,
+                    shared,
+                    group,
+                    post_update_hook,
+                    res_kwargs)
+
+
+def _create_sibling_ria(
+        ds,
+        url,
+        name,
+        ria_remote,
+        ria_remote_name,
+        existing,
+        shared,
+        group,
+        post_update_hook,
+        res_kwargs):
+    # be safe across datasets
+    res_kwargs = res_kwargs.copy()
+
+    # parse target URL
+    try:
+        ssh_host, base_path = verify_ria_url(url, ds.config)
+    except ValueError as e:
+        yield get_status_dict(
+            status='error',
+            message=str(e),
+            **res_kwargs
+        )
+        return
+
+    base_path = Path(base_path)
+
+    git_url = decode_source_spec(
+        # append dataset id to url and use magic from clone-helper:
+        url + '#{}'.format(ds.id),
+        cfg=ds.config
+    )['giturl']
+    # go for a v1 layout
+    repo_path, _, _ = get_layout_locations(1, base_path, ds.id)
+
+    ds_siblings = [r['name'] for r in ds.siblings(result_renderer=None)]
+    # Figure whether we are supposed to skip this very dataset
+    if existing == 'skip' and (
+            name in ds_siblings or (
+                ria_remote_name and ria_remote_name in ds_siblings)):
+        yield get_status_dict(
+            status='notneeded',
+            message="Skipped on existing sibling",
+            **res_kwargs
+        )
+        # if we skip here, nothing else can change that decision further
+        # down
+        return
+
+    # we might learn that some processing (remote repo creation is
+    # not desired)
+    skip = False
+
+    lgr.info("create sibling{} '{}'{} ...".format(
+        's' if ria_remote_name else '',
+        name,
+        " and '{}'".format(ria_remote_name) if ria_remote_name else '',
+    ))
+    if ssh_host:
+        from datalad import ssh_manager
+        ssh = ssh_manager.get_connection(
+            ssh_host,
+            use_remote_annex_bundle=False)
+        ssh.open()
+
+    # determine layout locations
+    if ria_remote:
+        lgr.debug('init special remote {}'.format(ria_remote_name))
+        ria_remote_options = ['type=external',
+                              'externaltype=ria',
+                              'encryption=none',
+                              'autoenable=true',
+                              'url={}'.format(url)]
+        try:
+            ds.repo.init_remote(
+                ria_remote_name,
+                options=ria_remote_options)
+        except CommandError as e:
+            if existing in ['replace', 'reconfigure'] \
+                    and 'git-annex: There is already a special remote' \
+                    in e.stderr:
+                # run enableremote instead
+                lgr.debug(
+                    "special remote '%s' already exists. "
+                    "Run enableremote instead.",
+                    ria_remote_name)
+                # TODO: Use AnnexRepo.enable_remote (which needs to get
+                #       `options` first)
+                cmd = [
+                    'git',
+                    'annex',
+                    'enableremote',
+                    ria_remote_name] + ria_remote_options
+                subprocess.run(cmd, cwd=quote_cmdlinearg(ds.repo.path))
+            else:
+                yield get_status_dict(
+                    status='error',
+                    message="initremote failed.\nstdout: %s\nstderr: %s"
+                    % (e.stdout, e.stderr),
+                    **res_kwargs
+                )
+                return
+
+        # 1. create remote object store:
+        # Note: All it actually takes is to trigger the special
+        # remote's `prepare` method once.
+        # ATM trying to achieve that by invoking a minimal fsck.
+        # TODO: - It's probably faster to actually talk to the special
+        #         remote (i.e. pretending to be annex and use
+        #         the protocol to send PREPARE)
+        #       - Alternatively we can create the remote directory and
+        #         ria version file directly, but this means
+        #         code duplication that then needs to be kept in sync
+        #         with ria-remote implementation.
+        #       - this leads to the third option: Have that creation
+        #         routine importable and callable from
+        #         ria-remote package without the need to actually
+        #         instantiate a RIARemote object
+        lgr.debug("initializing object store")
+        ds.repo.fsck(
+            remote=ria_remote_name,
+            fast=True,
+            annex_options=['--exclude=*/*'])
+    else:
+        # with no special remote we currently need to create the
+        # required directories
+        # TODO: This should be cleaner once we have access to the
+        #       special remote's RemoteIO classes without
+        #       talking via annex
+        if ssh_host:
+            try:
+                stdout, stderr = ssh(
+                    'test -e {repo}'.format(
+                        repo=quote_cmdlinearg(str(repo_path))))
+                exists = True
+            except CommandError as e:
+                exists = False
+            if exists:
+                if existing == 'skip':
+                    # 1. not rendered by default
+                    # 2. message doesn't show up in ultimate result
+                    #    record as shown by -f json_pp
+                    yield get_status_dict(
+                        status='notneeded',
+                        message="Skipped on existing remote "
+                        "directory {}".format(repo_path),
+                        **res_kwargs
+                    )
+                    skip = True
+                elif existing in ['error', 'reconfigure']:
+                    yield get_status_dict(
+                        status='error',
+                        message="remote directory {} already "
+                        "exists.".format(repo_path),
+                        **res_kwargs
+                    )
+                    return
+                elif existing == 'replace':
+                    ssh('chmod u+w -R {}'.format(
+                        quote_cmdlinearg(str(repo_path))))
+                    ssh('rm -rf {}'.format(
+                        quote_cmdlinearg(str(repo_path))))
+            if not skip:
+                ssh('mkdir -p {}'.format(
+                    quote_cmdlinearg(str(repo_path))))
+        else:
+            if repo_path.exists():
+                if existing == 'skip':
+                    skip = True
+                elif existing in ['error', 'reconfigure']:
+                    yield get_status_dict(
+                        status='error',
+                        message="remote directory {} already "
+                        "exists.".format(repo_path),
+                        **res_kwargs
+                    )
+                    return
+                elif existing == 'replace':
+                    rmtree(repo_path)
+            if not skip:
+                repo_path.mkdir(parents=True)
+
+    # Note, that this could have changed since last tested due to existing
+    # remote dir
+    if skip:
+        return
+
+    # 2. create a bare repository in-store:
+
+    lgr.debug("init bare repository")
+    # TODO: we should prob. check whether it's there already. How?
+    # Note: like the special remote itself, we assume local FS if no
+    # SSH host is specified
+    disabled_hook = repo_path / 'hooks' / 'post-update.sample'
+    enabled_hook = repo_path / 'hooks' / 'post-update'
+
+    if group:
+        chgrp_cmd = "chgrp -R {} {}".format(
+            quote_cmdlinearg(str(group)),
+            quote_cmdlinearg(str(repo_path)))
+
+    if ssh_host:
+        ssh('cd {rootdir} && git init --bare{shared}'.format(
+            rootdir=quote_cmdlinearg(str(repo_path)),
+            shared=" --shared='{}'".format(
+                quote_cmdlinearg(shared)) if shared else ''
+        ))
+        if post_update_hook:
+            ssh('mv {} {}'.format(quote_cmdlinearg(str(disabled_hook)),
+                                  quote_cmdlinearg(str(enabled_hook))))
+
+        if group:
+            # Either repository existed before or a new directory was
+            # created for it, set its group to a desired one if was
+            # provided with the same chgrp
+            ssh(chgrp_cmd)
+    else:
+        GitRepo(repo_path, create=True, bare=True,
+                shared=" --shared='{}'".format(
+                    quote_cmdlinearg(shared)) if shared else None)
+        if post_update_hook:
+            disabled_hook.rename(enabled_hook)
+        if group:
+            # TODO; do we need a cwd here?
+            subprocess.run(chgrp_cmd, cwd=quote_cmdlinearg(ds.path))
+
+    # add a git remote to the bare repository
+    # Note: needs annex-ignore! Otherwise we might push into default
+    # annex/object tree instead of directory type tree with dirhash
+    # lower. This in turn would be an issue, if we want to pack the
+    # entire thing into an archive. Special remote will then not be
+    # able to access content in the "wrong" place within the archive
+    lgr.debug("set up git remote")
+    # TODO:
+    # - This sibings call results in "[WARNING] Failed to determine
+    #   if datastore carries annex."
+    #   (see https://github.com/datalad/datalad/issues/4028)
+    #   => for now have annex-ignore configured before. Evtl. Allow
+    #      configure/add to include that option
+    #      - additionally there's
+    #        https://github.com/datalad/datalad/issues/3989,
+    #        where datalad-siblings might hang forever
+    if name in ds_siblings:
+        # otherwise we should have skipped or failed before
+        assert existing in ['replace', 'reconfigure']
+    ds.config.set(
+        "remote.{}.annex-ignore".format(name),
+        value="true",
+        where="local")
+    ds.siblings(
+        'configure',
+        name=name,
+        url=git_url
+        if ssh_host
+        else str(repo_path),
+        recursive=False,
+        # Note, that this should be None if ria_remote was not set
+        publish_depends=ria_remote_name,
+        result_renderer=None,
+        # Note, that otherwise a subsequent publish will report
+        # "notneeded".
+        fetch=True
+    )
+
+    yield get_status_dict(
+        status='ok',
+        **res_kwargs,
+    )

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -96,23 +96,25 @@ class CreateSiblingRia(Interface):
     ----
     Where to put the description of a RIA store (see below)?
 
-    The targeted layout of such a store is a tree of datasets, starting at the
-    configured base path. First level of subdirectories are named for the first
-    three characters of the datasets' id, second level is the remainder of
-    those ids. The thereby created dataset directories contain a bare git
-    repository. Those bare repositories are slightly different from plain
-    git-annex bare repositories in that they use the standard dirhashmixed
-    layout beneath annex/objects as opposed to dirhashlower, which is
-    git-annex's default for bare repositories. Furthermore, there is an
-    additional directory 'archives' within the dataset directories, which may
-    or may not contain archives with annexed content.  Note, that this helps to
-    reduce the number of inodes consumed (no checkout + potential archive) as
-    well as it allows to resolve dependencies (that is (sub)datasets) merely by
-    their id.  Finally, there is a file "ria-layout-version" put beneath the
-    store's base path, determining the version of the dataset tree layout and a
-    file of the same name per each dataset directory determining object tree
-    layout version (we already switch from dirhashlower to dirhashmixed for
-    example) and an additional directory "error_logs" at the toplevel.  """
+    The targeted layout of such a store is a tree of directories containing
+    datasets at the lowest level, starting at the configured base path.
+    First level of subdirectories are named for the first three characters of
+    the datasets' id, second level is the remainder of those ids.
+    The thereby created dataset directories contain a bare git repository.
+    Those bare repositories are slightly different from plain git-annex bare
+    repositories in that they use the standard dirhashmixed layout beneath
+    annex/objects as opposed to dirhashlower, which is git-annex's default for
+    bare repositories. Furthermore, there is an additional directory 'archives'
+    within the dataset directories, which may or may not contain archives with
+    annexed content.
+    Note, that this helps to reduce the number of inodes consumed (no checkout
+    + potential archive) as well as it allows to resolve dependencies (that is
+    (sub)datasets) merely by their id.  Finally, there is a file
+    "ria-layout-version" put beneath the store's base path, determining the
+    version of the dataset tree layout and a file of the same name per each
+    dataset directory determining object tree layout version (we already switch
+    from dirhashlower to dirhashmixed for example) and an additional directory
+    "error_logs" at the toplevel."""
 
     # TODO: description?
     _params_ = dict(
@@ -165,12 +167,12 @@ class CreateSiblingRia(Interface):
         ria_remote=Parameter(
             args=("--no-ria-remote",),
             dest='ria_remote',
-            doc="""Whether to establish remote indexed archive (RIA) capabilties
-            for the created sibling. If enabled, git-annex special remote access
-            will be configured to enable regular git-annex key storage, and
-            also retrieval of keys from (compressed) 7z archives that might be
-            provided by the dataset store. If disabled, git-annex is instructed
-            to ignore the sibling.""",
+            doc="""Flag to disable establishing remote indexed archive (RIA)
+            capabilities for the created sibling. If enabled, git-annex special
+            remote access will be configured to enable regular git-annex key
+            storage, and also retrieval of keys from (compressed) 7z archives
+            that might be provided by the dataset store. If disabled, git-annex
+            is instructed to ignore the sibling.""",
             action="store_false"),
         existing=Parameter(
             args=("--existing",),

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -68,7 +68,7 @@ class CreateSiblingRia(Interface):
     This creates a representation of a dataset in a ria-remote compliant
     storage location. For access to it two siblings are configured for the
     dataset by default. A "regular" one and a RIA remote (git-annex
-    special remote).  Furthermore, the former is configured to have a
+    special remote). Furthermore, the former is configured to have a
     publication dependency on the latter. If not given a default name for
     the RIA remote is derived from the sibling's name by appending "-ria".
 
@@ -76,21 +76,21 @@ class CreateSiblingRia(Interface):
 
       - not yet exist or
       - be empty or
-      - have a valid `ria-layout-version` file and an `error_logs` directory.
+      - have a valid "ria-layout-version" file and an "error_logs" directory.
 
     In the first two cases, said file and directory are created by this
     command. Alternatively you can manually create the third case, of course.
-    Please note, that `ria-layout-version` needs to contain a line stating the
-    version (currently '1') and optionally enable error logging (append '|l' in
-    that case). Currently, this line MUST end with a newline!
+    Please note, that "ria-layout-version" needs to contain a line stating the
+    version (currently "1") and optionally enable error logging (append a pipe
+    symbol and an "l"  in that case). Currently, this line MUST end with a newline!
 
-    Error logging will create files in the `error_log` directory whenever the
+    Error logging will create files in the "error_log" directory whenever the
     RIA special remote (storage sibling) raises an exception, storing the
     python traceback of it. The logfiles are named according to the scheme
     <dataset id>.<annex uuid of the remote>.log showing 'who' ran into this
     issue with what dataset. Since this logging can potentially leak personal
     data (like local file paths for example) it can be disabled from the client
-    side via `annex.ria-remote.<RIAREMOTE>.ignore-remote-config`.
+    side via "annex.ria-remote.<RIAREMOTE>.ignore-remote-config".
 
     Todo
     ----
@@ -100,7 +100,7 @@ class CreateSiblingRia(Interface):
     configured base path. First level of subdirectories are named for the first
     three characters of the datasets' id, second level is the remainder of
     those ids. The thereby created dataset directories contain a bare git
-    repository.  Those bare repositories are slightly different from plain
+    repository. Those bare repositories are slightly different from plain
     git-annex bare repositories in that they use the standard dirhashmixed
     layout beneath annex/objects as opposed to dirhashlower, which is
     git-annex's default for bare repositories. Furthermore, there is an
@@ -108,11 +108,11 @@ class CreateSiblingRia(Interface):
     or may not contain archives with annexed content.  Note, that this helps to
     reduce the number of inodes consumed (no checkout + potential archive) as
     well as it allows to resolve dependencies (that is (sub)datasets) merely by
-    their id.  Finally, there is a file `ria-layout-version` put beneath the
+    their id.  Finally, there is a file "ria-layout-version" put beneath the
     store's base path, determining the version of the dataset tree layout and a
     file of the same name per each dataset directory determining object tree
     layout version (we already switch from dirhashlower to dirhashmixed for
-    example) and an additional directory `error_logs` at the toplevel.  """
+    example) and an additional directory "error_logs" at the toplevel.  """
 
     # TODO: description?
     _params_ = dict(

--- a/datalad/distributed/ria_utils.py
+++ b/datalad/distributed/ria_utils.py
@@ -1,0 +1,72 @@
+def get_layout_locations(version, base_path, dsid):
+    """Return dataset-related path in a RIA store
+
+    Parameters
+    ----------
+    version : int
+      Layout version of the store.
+    base_path : Path
+      Base path of the store.
+    dsid : str
+      Dataset ID
+
+    Returns
+    -------
+    Path, Path, Path
+      The location of the bare dataset repository in the store,
+      the directory with archive files for the dataset, and the
+      annex object directory are return in that order.
+    """
+    if version == 1:
+        dsgit_dir = base_path / dsid[:3] / dsid[3:]
+        archive_dir = dsgit_dir / 'archives'
+        dsobj_dir = dsgit_dir / 'annex' / 'objects'
+        return dsgit_dir, archive_dir, dsobj_dir
+    else:
+        raise ValueError("Unknown layout version: {}".format(version))
+
+
+def verify_ria_url(url, cfg):
+    """Verify and decode ria url
+
+    Expects a ria-URL pointing to a RIA store, applies rewrites and tries to
+    decode potential host and base path for the store from it. Additionally
+    raises if `url` is considered invalid.
+
+    ria+ssh://somehost:/path/to/store
+    ria+file:///path/to/store
+
+    Parameters
+    ----------
+    url : str
+      URL to verify an decode.
+    cfg : dict-like
+      Configuration settings for rewrite_url()
+
+    Raises
+    ------
+    ValueError
+
+    Returns
+    -------
+    tuple
+      (host, base-path)
+    """
+    from datalad.config import rewrite_url
+    from datalad.support.network import URL
+
+    if not url:
+        raise ValueError("Got no URL")
+
+    url = rewrite_url(cfg, url)
+    url_ri = URL(url)
+    if not url_ri.scheme.startswith('ria+'):
+        raise ValueError("Missing ria+ prefix in final URL: %s" % url)
+    if url_ri.fragment:
+        raise ValueError(
+            "Unexpected fragment in RIA-store URL: %s" % url_ri.fragment)
+    protocol = url_ri.scheme[4:]
+    if protocol not in ['ssh', 'file']:
+        raise ValueError("Unsupported protocol: %s" % protocol)
+
+    return url_ri.hostname if protocol == 'ssh' else None, url_ri.path

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -15,6 +15,7 @@ from datalad.tests.utils import (
     assert_raises,
     chpwd,
     skip_ssh,
+    skip_if_on_windows
 )
 from functools import wraps
 from nose.plugins.attrib import attr
@@ -57,6 +58,7 @@ def test_invalid_calls(path):
                   name='some', ria_remote_name='some')
 
 
+@skip_if_on_windows  # running into short path issues; same as gh-4131
 @with_tempfile
 @with_store_insteadof
 @with_tree({'ds': {'file1.txt': 'some'},

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -15,7 +15,8 @@ from datalad.tests.utils import (
     assert_raises,
     chpwd,
     skip_ssh,
-    skip_if_on_windows
+    skip_if_on_windows,
+    skip_if_no_module
 )
 from functools import wraps
 from nose.plugins.attrib import attr
@@ -65,6 +66,7 @@ def test_invalid_calls(path):
             'sub': {'other.txt': 'other'}})
 @with_tempfile(mkdir=True)
 def _test_create_store(host, base_path, ds_path, clone_path):
+    skip_if_no_module("ria_remote")  # special remote needs to be installed
 
     ds = Dataset(ds_path).create(force=True)
 

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -1,0 +1,123 @@
+import os.path as op
+
+from datalad import cfg
+from datalad.api import (
+    Dataset,
+    clone
+)
+from datalad.tests.utils import (
+    with_tempfile,
+    with_tree,
+    assert_repo_status,
+    assert_in,
+    assert_result_count,
+    eq_,
+    assert_raises,
+    chpwd,
+    skip_ssh,
+)
+
+
+@with_tempfile
+def test_invalid_calls(path):
+
+    ds = Dataset(path).create()
+
+    # no argument:
+    assert_raises(TypeError, ds.create_sibling_ria)
+
+    # same name for git- and special remote:
+    assert_raises(ValueError, ds.create_sibling_ria, 'ria+file:///some/where',
+                  name='some', ria_remote_name='some')
+
+
+@with_tree({'ds': {'file1.txt': 'some'},
+            'sub': {'other.txt': 'other'}})
+@with_tempfile
+@with_tempfile(mkdir=True)
+def _test_create_store(host, ds_path, base_path, clone_path):
+
+    # TODO: This is an issue. We are writing to ~/.gitconfig here. Override
+    #       doesn't work, since RIARemote itself (actually git-annex!) doesn't
+    #       have access to it, so initremote will still fail.
+    #       => at least move cfg.set/unset into a decorator, so it doesn't
+    #       remain when a test is failing.
+    # TODO this should be wrapped in a decorator that performs the set/unset
+    # in a try-finally configuration
+    cfg.set('url.ria+{prot}://{host}{path}.insteadOf'
+            ''.format(prot='ssh' if host else 'file',
+                      host=host if host else '',
+                      path=base_path),
+            'ria+ssh://test-store:', where='global')
+
+    ds = Dataset(ds_path).create(force=True)
+    subds = ds.create('sub', force=True)
+    ds.save(recursive=True)
+    assert_repo_status(ds.path)
+
+    # don't specify special remote. By default should be git-remote + "-ria"
+    res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore")
+    assert_result_count(res, 1, status='ok', action='create-sibling-ria')
+    eq_(len(res), 1)
+
+    # remotes exist, but only in super
+    siblings = ds.siblings(result_renderer=None)
+    eq_({'datastore', 'datastore-ria', 'here'}, {s['name'] for s in siblings})
+    sub_siblings = subds.siblings(result_renderer=None)
+    eq_({'here'}, {s['name'] for s in sub_siblings})
+
+    # TODO: post-update hook was enabled
+
+    # implicit test of success by ria-installing from store:
+    ds.publish(to="datastore", transfer_data='all')
+    with chpwd(clone_path):
+        if host:
+            # note, we are not using the "test-store"-label here
+            clone('ria+ssh://{}{}#{}'.format(host, base_path, ds.id),
+                  path='test_install')
+        else:
+            # TODO: Whenever ria+file supports special remote config (label),
+            # change here:
+            clone('ria+file://{}#{}'.format(base_path, ds.id),
+                  path='test_install')
+        installed_ds = Dataset(op.join(clone_path, 'test_install'))
+        assert installed_ds.is_installed()
+        assert_repo_status(installed_ds.repo)
+        eq_(installed_ds.id, ds.id)
+        assert_in(op.join('ds', 'file1.txt'),
+                  installed_ds.repo.get_annexed_files())
+        assert_result_count(installed_ds.get(op.join('ds', 'file1.txt')),
+                            1,
+                            status='ok',
+                            action='get',
+                            path=op.join(installed_ds.path, 'ds', 'file1.txt'))
+
+    # now, again but recursive.
+    res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore",
+                                recursive=True, existing='replace')
+    eq_(len(res), 2)
+    assert_result_count(res, 2, status='ok', action="create-sibling-ria")
+
+    # remotes now exist in super and sub
+    siblings = ds.siblings(result_renderer=None)
+    eq_({'datastore', 'datastore-ria', 'here'}, {s['name'] for s in siblings})
+    sub_siblings = subds.siblings(result_renderer=None)
+    eq_({'datastore', 'datastore-ria', 'here'},
+        {s['name'] for s in sub_siblings})
+
+    cfg.unset('url.ria+{prot}://{host}{path}.insteadOf'
+              ''.format(prot='ssh' if host else 'file',
+                        host=host if host else '',
+                        path=base_path),
+              where='global', reload=True)
+
+
+def test_create_simple():
+
+    yield _test_create_store, None
+    yield skip_ssh(_test_create_store), 'datalad-test'
+
+
+# TODO: explicit naming of special remote
+# TODO: Don't publish git history via --no-publish
+# TODO: --no-server switch

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -121,6 +121,17 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     eq_({'datastore', 'datastore-ria', 'here'},
         {s['name'] for s in sub_siblings})
 
+    # for testing trust_level parameter, redo for each label:
+    for trust in ['trust', 'semitrust', 'untrust']:
+        ds.create_sibling_ria("ria+ssh://test-store:",
+                              "datastore",
+                              existing='replace',
+                              trust_level=trust)
+        res = ds.repo.repo_info()
+        assert_in('[datastore-ria]',
+                  [r['description']
+                   for r in res['{}ed repositories'.format(trust)]])
+
 
 def test_create_simple():
 

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -2,21 +2,21 @@ import os.path as op
 
 from datalad import cfg
 from datalad.api import (
-    Dataset,
-    clone
+    clone,
+    Dataset
 )
 from datalad.tests.utils import (
+    assert_in,
+    assert_raises,
+    assert_repo_status,
+    assert_result_count,
+    chpwd,
+    eq_,
+    skip_if_no_module,
+    skip_if_on_windows,
+    skip_ssh,
     with_tempfile,
     with_tree,
-    assert_repo_status,
-    assert_in,
-    assert_result_count,
-    eq_,
-    assert_raises,
-    chpwd,
-    skip_ssh,
-    skip_if_on_windows,
-    skip_if_no_module
 )
 from functools import wraps
 from nose.plugins.attrib import attr

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -110,7 +110,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
 
     # now, again but recursive.
     res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore",
-                                recursive=True, existing='replace')
+                                recursive=True, existing='reconfigure')
     eq_(len(res), 2)
     assert_result_count(res, 2, status='ok', action="create-sibling-ria")
 
@@ -125,7 +125,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     for trust in ['trust', 'semitrust', 'untrust']:
         ds.create_sibling_ria("ria+ssh://test-store:",
                               "datastore",
-                              existing='replace',
+                              existing='reconfigure',
                               trust_level=trust)
         res = ds.repo.repo_info()
         assert_in('[datastore-ria]',
@@ -140,5 +140,3 @@ def test_create_simple():
 
 
 # TODO: explicit naming of special remote
-# TODO: Don't publish git history via --no-publish
-# TODO: --no-server switch

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -34,7 +34,7 @@ def with_store_insteadof(func):
                     ''.format(prot='ssh' if host else 'file',
                               host=host if host else '',
                               path=base_path),
-                    'ria+ssh://test-store:', where='global')
+                    'ria+ssh://test-store:', where='global', reload=True)
             return func(*args, **kwargs)
         finally:
             cfg.unset('url.ria+{prot}://{host}{path}.insteadOf'
@@ -67,6 +67,7 @@ def test_invalid_calls(path):
 def _test_create_store(host, base_path, ds_path, clone_path):
 
     ds = Dataset(ds_path).create(force=True)
+
     subds = ds.create('sub', force=True)
     ds.save(recursive=True)
     assert_repo_status(ds.path)

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -292,7 +292,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     # make sure we are up-to-date on this topic on all affected remotes, before
     # we start making decisions
     for r in publish_depends + [remote]:
-        if not ds.config.get('.'.join(('remote', remote, 'annex-uuid')), None):
+        if not ds.config.get('.'.join(('remote', r, 'annex-uuid')), None):
             lgr.debug("Obtain remote annex info from '%s'", r)
             ds.repo.fetch(remote=r)
             # in order to be able to use git's config to determine what to push,

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -42,6 +42,9 @@ _group_dataset = (
         ('datalad.distributed.create_sibling_gitlab',
          'CreateSiblingGitlab',
          'create-sibling-gitlab'),
+        ('datalad.distributed.create_sibling_ria',
+         'CreateSiblingRia',
+         'create-sibling-ria'),
         ('datalad.interface.unlock', 'Unlock', 'unlock'),
         ('datalad.core.local.save', 'Save', 'save'),
     ])

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -26,6 +26,7 @@ Dataset operations
    generated/man/datalad-create-sibling
    generated/man/datalad-create-sibling-github
    generated/man/datalad-create-sibling-gitlab
+   generated/man/datalad-create-sibling-ria
    generated/man/datalad-drop
    generated/man/datalad-get
    generated/man/datalad-install


### PR DESCRIPTION
This is the code that was used to push the HCP datasets to store.datalad.org -- written by @bpoldrack (see https://github.com/datalad/git-annex-ria-remote/pull/38). It is one of the last pieces of RIA functionality to move into -core (the actual special remote implementation being the very last one). It is being proposed as a separate PR, because it can function without it (HCP doesn't use the ria-special remote), and to keep the complexity of the PR more manageable.

Feedback is very much welcome! Thanks!

Related:

- #4068 consolidation on common operations with `create_sibling`
- UX issues:
  - https://github.com/datalad/git-annex-ria-remote/issues/44
  - https://github.com/datalad/git-annex-ria-remote/issues/45

Update by @bpoldrack :

From my point of view, this is ready. Above mentioned UX issues are addressed and test failures fixed (includes a fix for #4151). A long the way I doscovered #4152 and #4153. However, those are neither fixed herein nor are fixes for that actually required for this PR.

Tests currently depend on installing `https://github.com/datalad/git-annex-ria-remote@transition-to-core`, which removes the conflicting implementation of `create-sibling-ria` therein. While this seems somewhat ugly, it should be a quite short lived approach. Rational: We are moving the special remote to core. I'm currently working on PR #4068 to integrate execution via a persistent remote shell. When this is done, git-annex-ria-remote can go into core completely. If we had an actual dependency on the `ria_remote` package via `setup.py`, this would lead to people installing it, when shortly afterwards it will become at least unnecessary, if not conflicting to have it installed, which is why I consider this approach superior.

Edit by @bpoldrack :

Plans changed. Since there's some time pressure and a new idea re special remote configuration ( https://github.com/datalad/datalad/pull/4124#issuecomment-587487164 ), updated plan for ria-remote's move to core:
  - move ria-remote as is with remote execution factored out for easier RF later on.
  - once it's merged:
      - this PR (`create-sibling-ria`) can remove Travis dependency it properly reference/import within core and be merged
      - then special remote's `initremote` can be adapted to store the annex UUID in the bare repo's config
      - and `clone` then needs to be aware to make use of it

Note, that integration with #4068 is thereby postponed.

So, 3 PRs:
  - the main move to core
  - this very PR with adaptions
  - change `RIARemote.initremote()` and datalad-clone
 