### PR TITLE
ENH/RF: change how we map credentials to env variables

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -42,10 +42,16 @@ class Keyring(object):
     def _get_service_name(cls, name):
         return "datalad-%s" % str(name)
 
+    @staticmethod
+    def _get_envvar_name(name, field):
+        """Return env variable which would be checked first for a credential"""
+        return ('DATALAD_KEYRING_%s__%s' % (name, field))\
+            .replace('-', '_').replace(':', '_')
+
     # proxy few methods of interest explicitly, to be rebound to the module's
     def get(self, name, field):
         # consult environment, might be provided there and should take precedence
-        env_var = ('DATALAD_%s_%s' % (name, field)).replace('-', '_')
+        env_var = self._get_envvar_name(name, field)
         if env_var in os.environ:
             return os.environ[env_var]
         return self._keyring.get_password(self._get_service_name(name), field)


### PR DESCRIPTION
This changes might break somebody"s workflow who somehow discovered this feature.
We might want to consult old version too

With this change we could also request parts for the composite credential,
such as loris token, where they have index like :1, which we would sanitize now.

Here is how the one for loris test would look like: DATALAD_KEYRING_loris_demo_1__token

TODO:
- [ ] add basic documentation about credentials (in the docs) and how they could be specified via env vars 
- [ ] add a test if we don't have any (if nothing breaks ATM)
- [ ] check interaction with config and `wtf` to make sure we don't leak those