### PR TITLE
BF: export-to-figshare - make default title include #id@version, ask for the title in UI

### DIFF
--- a/datalad/plugin/export_to_figshare.py
+++ b/datalad/plugin/export_to_figshare.py
@@ -148,10 +148,10 @@ def _get_default_title(dataset):
     from ..support.path import basename
     title = basename(dataset.path)
     if dataset.id:
-        title += f"#{dataset.id}"
+        title += "#{dataset.id}".format(**locals())
     version = dataset.repo.describe()
     if version:
-        title += f"@{version}"
+        title += "@{version}".format(**locals())
     # 3 is minimal length. Just in case there is no UUID or version and dir
     # is short
     if len(title) < 3:

--- a/datalad/plugin/tests/test_export_to_figshare.py
+++ b/datalad/plugin/tests/test_export_to_figshare.py
@@ -40,10 +40,10 @@ def test_get_default_title(path):
 
     # Initialize and get UUID
     ds.create(force=True)
-    eq_(_get_default_title(ds), f'{dirname}#{ds.id}')
+    eq_(_get_default_title(ds), '{dirname}#{ds.id}'.format(**locals()))
 
     # Tag and get @version
     # cannot use ds.save since our tags are not annotated,
     # see https://github.com/datalad/datalad/issues/4139
     ds.repo.tag("0.1", message="important version")
-    eq_(_get_default_title(ds), f'{dirname}#{ds.id}@0.1')
+    eq_(_get_default_title(ds), '{dirname}#{ds.id}@0.1'.format(**locals()))

--- a/datalad/plugin/tests/test_export_to_figshare.py
+++ b/datalad/plugin/tests/test_export_to_figshare.py
@@ -1,0 +1,49 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test export_to_figshare"""
+
+from datalad.api import export_archive
+from datalad.utils import chpwd
+from datalad.utils import md5sum
+from datalad.support import path as op
+
+from datalad.tests.utils import with_tree, eq_
+from datalad.tests.utils import ok_startswith
+from datalad.tests.utils import assert_true, assert_not_equal, assert_raises, \
+    assert_false, assert_equal
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_result_count
+
+from datalad.support.gitrepo import GitRepo
+from datalad.api import Dataset
+
+from ..export_to_figshare import (
+    _get_default_title,
+    _enter_title,
+)
+
+
+@with_tree({})
+def test_get_default_title(path):
+    repo = GitRepo(path)
+    ds = Dataset(path)
+    # There is no dataset initialized yet, so only path will be the title
+    dirname = op.basename(path)
+    eq_(_get_default_title(ds), dirname)
+
+    # Initialize and get UUID
+    ds.create(force=True)
+    eq_(_get_default_title(ds), f'{dirname}#{ds.id}')
+
+    # Tag and get @version
+    # cannot use ds.save since our tags are not annotated,
+    # see https://github.com/datalad/datalad/issues/4139
+    ds.repo.tag("0.1", message="important version")
+    eq_(_get_default_title(ds), f'{dirname}#{ds.id}@0.1')


### PR DESCRIPTION
Decided not to expose title specification in API since the whole experience is interactive, but I guess it could be added.

Closes #4138 