### PR TITLE
ENH: safe-guard --existing-replace for cases of populated directories

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -305,16 +305,21 @@ def _create_dataset_sibling(
 def _ls_remote_path(ssh, path):
     try:
         # yoh tried ls on mac
-        out, err = ssh("ls -a1 {}".format(sh_quote(path)))
+        out, err = ssh("ls -A1 {}".format(sh_quote(path)))
+        if err:
+            # we might even want to raise an exception, but since it was
+            # not raised, let's just log a warning
+            lgr.warning(
+                "There was some output to stderr while running ls on %s via ssh: %s",
+                path, err
+            )
     except CommandError as e:
         if "No such file or directory" in e.stderr and \
                 path in e.stderr:
             return None
         else:
             raise  # It's an unexpected failure here
-    return [
-        o for o in out.split(os.linesep) if o not in ('.', '..', '')
-    ]
+    return [l for l in out.split(os.linesep) if l]
 
 
 @build_doc

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -19,6 +19,9 @@ from os.path import join as opj, relpath, normpath, dirname, curdir
 
 import datalad
 from datalad import ssh_manager
+
+from datalad.ui import ui
+
 from datalad.cmd import CommandError
 from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
 from datalad.consts import TIMESTAMP_FMT
@@ -164,8 +167,6 @@ def _create_dataset_sibling(
                                  + " It is %sa git repository and has %d files/dirs." % (
                                      "" if has_git else "not ", len(path_children)
                                  )
-                    from datalad.ui import ui
-
                     if ui.is_interactive:
                         remove = ui.yesno(
                             "Do you really want to remove it?",

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -15,7 +15,13 @@ from distutils.version import LooseVersion
 from glob import glob
 import logging
 import os
-from os.path import join as opj, relpath, normpath, dirname, curdir
+from os.path import (
+    curdir,
+    dirname,
+    join as opj,
+    normpath,
+    relpath,
+)
 
 import datalad
 from datalad import ssh_manager
@@ -23,39 +29,62 @@ from datalad import ssh_manager
 from datalad.ui import ui
 
 from datalad.cmd import CommandError
-from datalad.consts import WEB_HTML_DIR, WEB_META_LOG
-from datalad.consts import TIMESTAMP_FMT
+from datalad.consts import (
+    TIMESTAMP_FMT,
+    WEB_HTML_DIR,
+    WEB_META_LOG
+)
 from datalad.dochelpers import exc_str
-from datalad.distribution.siblings import Siblings
-from datalad.distribution.siblings import _DelayedSuper
-from datalad.distribution.dataset import EnsureDataset, Dataset, \
-    datasetmethod, require_dataset
+from datalad.distribution.siblings import (
+    _DelayedSuper,
+    Siblings,
+)
+from datalad.distribution.dataset import (
+    Dataset,
+    datasetmethod,
+    EnsureDataset,
+    require_dataset,
+)
 from datalad.interface.annotate_paths import AnnotatePaths
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    Interface,
+)
 from datalad.interface.utils import eval_results
-from datalad.interface.common_opts import recursion_limit, recursion_flag
-from datalad.interface.common_opts import as_common_datasrc
-from datalad.interface.common_opts import publish_by_default
-from datalad.interface.common_opts import publish_depends
-from datalad.interface.common_opts import inherit_opt
-from datalad.interface.common_opts import annex_wanted_opt
-from datalad.interface.common_opts import annex_group_opt
-from datalad.interface.common_opts import annex_groupwanted_opt
+from datalad.interface.common_opts import (
+    annex_group_opt,
+    annex_groupwanted_opt,
+    annex_wanted_opt,
+    as_common_datasrc,
+    inherit_opt,
+    publish_by_default,
+    publish_depends,
+    recursion_flag,
+    recursion_limit,
+)
 from datalad.support.annexrepo import AnnexRepo
-from datalad.support.constraints import EnsureStr, EnsureNone, EnsureBool
-from datalad.support.constraints import EnsureChoice
-from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import MissingExternalDependency
-from datalad.support.network import RI
-from datalad.support.network import is_ssh
+from datalad.support.constraints import (
+    EnsureBool,
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import (
+    InsufficientArgumentsError,
+    MissingExternalDependency,
+)
+from datalad.support.network import (
+    is_ssh,
+    RI,
+)
 from datalad.support.sshconnector import sh_quote
 from datalad.support.param import Parameter
-from datalad.utils import make_tempfile
-from datalad.utils import _path_
-from datalad.utils import slash_join
-from datalad.utils import assure_list
-
+from datalad.utils import (
+    make_tempfile,
+    _path_,
+    slash_join,
+    assure_list,
+)
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -157,6 +157,7 @@ def _create_dataset_sibling(
                 lgr.info(_msg + " Skipping")
                 return
             elif existing == 'replace':
+                remove = False
                 if path_children:
                     has_git = '.git' in path_children
                     _msg_stats = _msg \
@@ -164,7 +165,7 @@ def _create_dataset_sibling(
                                      "" if has_git else "not ", len(path_children)
                                  )
                     from datalad.ui import ui
-                    remove = False
+
                     if ui.is_interactive:
                         remove = ui.yesno(
                             "Do you really want to remove it?",
@@ -174,6 +175,8 @@ def _create_dataset_sibling(
                     else:
                         remove = True
                         lgr.warning(_msg_stats)
+                if not remove:
+                    raise RuntimeError(_msg)
                 # Remote location might already contain a git repository or be
                 # just a directory.
                 lgr.info(_msg + " Replacing")

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -173,8 +173,10 @@ def _create_dataset_sibling(
                             default=False
                         )
                     else:
-                        remove = True
-                        lgr.warning(_msg_stats)
+                        raise RuntimeError(
+                            _msg_stats +
+                            " Remove it manually first or rerun datalad in "
+                            "interactive shell to confirm this action.")
                 if not remove:
                     raise RuntimeError(_msg)
                 # Remote location might already contain a git repository or be

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -171,11 +171,9 @@ def _create_dataset_sibling(
                             title=_msg_stats,
                             default=False
                         )
-                    if not remove:
-                        raise RuntimeError(
-                            _msg_stats +
-                            " Remove it manually first or rerun datalad in interactive shell"
-                        )
+                    else:
+                        remove = True
+                        lgr.warning(_msg_stats)
                 # Remote location might already contain a git repository or be
                 # just a directory.
                 lgr.info(_msg + " Replacing")
@@ -414,14 +412,20 @@ class CreateSibling(Interface):
         recursion_limit=recursion_limit,
         existing=Parameter(
             args=("--existing",),
-            constraints=EnsureChoice('skip', 'replace', 'error', 'reconfigure'),
+            constraints=EnsureChoice('skip', 'error', 'reconfigure', 'replace'),
             metavar='MODE',
             doc="""action to perform, if a sibling is already configured under the
-            given name and/or a target directory already exists.
-            In this case, a dataset can be skipped ('skip'), an existing target
-            directory be forcefully re-initialized, and the sibling (re-)configured
-            ('replace', implies 'reconfigure'), the sibling configuration be updated
-            only ('reconfigure'), or to error ('error').""",),
+            given name and/or a target (non-empty) directory already exists.
+            In this case, a dataset can be skipped ('skip'), the sibling
+            configuration be updated ('reconfigure'), or process interrupts with
+            error ('error'). DANGER ZONE: If 'replace' is used, an existing target
+            directory will be forcefully removed, re-initialized, and the
+            sibling (re-)configured (thus implies 'reconfigure').
+            `replace` could lead to data loss, so use with care.  To minimize
+            possibility of data loss, in interactive mode DataLad will ask for
+            confirmation, but it would just issue a warning and proceed in
+            non-interactive mode.
+            """,),
         inherit=inherit_opt,
         shared=Parameter(
             args=("--shared",),

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -17,48 +17,48 @@ from os.path import join as opj, exists, basename
 
 from ..dataset import Dataset
 from datalad.api import (
-    publish,
-    install,
     create_sibling,
+    install,
+    publish,
 )
 from datalad.cmd import Runner
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import urlquote
 from datalad.tests.utils import (
-    create_tree,
-    eq_,
+    assert_dict_equal,
     assert_false,
-    with_tempfile,
     assert_in,
-    with_testrepos,
-    ok_file_has_content,
-    ok_exists,
-    ok_clean_git,
-    ok_endswith,
+    assert_no_errors_logged,
+    assert_not_equal,
     assert_not_in,
     assert_raises,
-    skip_ssh,
-    assert_dict_equal,
     assert_result_count,
     assert_status,
-    assert_not_equal,
-    assert_no_errors_logged,
+    create_tree,
+    eq_,
     get_mtimes_and_digests,
-    swallow_logs,
     ok_,
+    ok_clean_git,
+    ok_endswith,
+    ok_exists,
+    ok_file_has_content,
     ok_file_under_git,
-    slow,
     skip_if_on_windows,
+    skip_ssh,
+    slow,
+    swallow_logs,
+    with_tempfile,
+    with_testrepos,
 )
 from datalad.support.exceptions import (
     CommandError,
     InsufficientArgumentsError,
 )
 from datalad.utils import (
+    _path_,
     chpwd,
     on_windows,
-    _path_,
 )
 
 import logging

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -212,7 +212,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             sshurl="ssh://localhost",
             target_dir=target_path)
     ok_(str(cm.exception).startswith(
-        "Target path %s already exists. And it fails to rmdir" % target_path))
+        "Target path %s already exists." % target_path))
     if src_is_annex:
         target_description = AnnexRepo(target_path, create=False).get_description()
         assert_not_equal(target_description, None)


### PR DESCRIPTION
A safe guard to Close #4145 

If remote directory contains some files/directories, we would ask user whenever session is interactive or just raise an exception if not interactive

edit 1: I have been thinking about it and I maintain the opinion that `--existing=replace` is already an explicit indication from the user of the intent to replace (remove, recreate) a possibly existing remote dataset.  Adding the interactive question or raising an exception (if not interactive) goes against the explicitly expressed desire to "replace".  So, what if we do that (question or exception) only if remote location does not already have `.git` and `.datalad/config`?  This way we would safe guard against some possible erroneous invocations, but would allow for automated (no interaction) and **explicitly** specified behavior. 

TODOs (if agreed that it is the way to go)
- [x] add tests
- ? add config option (or could be mode "force-replace"?) to be able to "proceed" instead of raising an exception in non-interactive mode or asking in interactive