### PR TITLE
DOC: Make explicit that create-sibling-git(hub|lab) are optional

### DIFF
--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -60,7 +60,7 @@ class CreateSiblingGitlab(Interface):
     interface can be configured as a sibling with the :command:`siblings`
     command. Alternativly, this command can create a GitLab project at any
     location/path a given user has appropriate permissions for. This is
-    particulary helpful for recursive sibling creation for subdatasets.  API
+    particulary helpful for recursive sibling creation for subdatasets. API
     access and authentication are implemented via python-gitlab, and all its
     features are supported. A particular GitLab site must be configured in a
     named section of a python-gitlab.cfg file (see

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -56,12 +56,16 @@ known_access_labels = ('http', 'ssh', 'ssh+http')
 class CreateSiblingGitlab(Interface):
     """Create dataset sibling at a GitLab site
 
-    A Git repository can be created at any location/path a given user has
-    appropriate permissions for. API access and authentication are implemented
-    via python-gitlab, and all its features are supported. A particular GitLab
-    site must be configured in a named section of a python-gitlab.cfg file
-    (see https://python-gitlab.readthedocs.io/en/stable/cli.html#configuration
-    for details), such as::
+    An existing GitLab project, or a project created via the GitLab web
+    interface can be configured as a sibling with the :command:`siblings`
+    command. Alternativly, this command can create a GitLab project at any
+    location/path a given user has appropriate permissions for. This is
+    particulary helpful for recursive sibling creation for subdatasets.  API
+    access and authentication are implemented via python-gitlab, and all its
+    features are supported. A particular GitLab site must be configured in a
+    named section of a python-gitlab.cfg file (see
+    https://python-gitlab.readthedocs.io/en/stable/cli.html#configuration for
+    details), such as::
 
       [mygit]
       url = https://git.example.com
@@ -72,8 +76,7 @@ class CreateSiblingGitlab(Interface):
     above).
 
     (Recursive) sibling creation for all, or a selected subset of subdatasets
-    is supported. Three different project layouts for nested datasets are
-    supported (see --layout):
+    is supported with three different project layouts (see --layout):
 
     "hierarchy"
       Each dataset is placed into its own group, and the actual GitLab

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -57,9 +57,9 @@ class CreateSiblingGithub(Interface):
     be configured as a sibling with the :command:`siblings` command.
     Alternatively, this command can create a repository under a user's Github
     account, or any organization a user is a member of (given appropriate
-    permissions).  This is particulary helpful for recursive sibling creation
+    permissions). This is particulary helpful for recursive sibling creation
     for subdatasets. In such a case, a dataset hierarchy is represented as a
-    flat list of Github repositories.
+    flat list of GitHub repositories.
 
     Github cannot host dataset content. However, in combination with
     other data sources (and siblings), publishing a dataset to Github can

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -53,11 +53,13 @@ template_fx = lambda x: re.sub(r'\s+', '_', re.sub(r'[/\\]+', '-', x))
 class CreateSiblingGithub(Interface):
     """Create dataset sibling on Github.
 
-    A repository can be created under a user's Github account, or any
-    organization a user is a member of (given appropriate permissions).
-
-    Recursive sibling creation for subdatasets is supported. A dataset
-    hierarchy is represented as a flat list of Github repositories.
+    An existing GitHub project, or a project created via the GitHub website can
+    be configured as a sibling with the :command:`siblings` command.
+    Alternatively, this command can create a repository under a user's Github
+    account, or any organization a user is a member of (given appropriate
+    permissions).  This is particulary helpful for recursive sibling creation
+    for subdatasets. In such a case, a dataset hierarchy is represented as a
+    flat list of Github repositories.
 
     Github cannot host dataset content. However, in combination with
     other data sources (and siblings), publishing a dataset to Github can


### PR DESCRIPTION
...but useful. This addresses some users' assumption that any such
linkage needs to be established through these commands, even if
there already is a corresponding project available.

Fixes gh-4120