### PR TITLE
update: Minor fixes and clean-ups extracted from gh-4118

### DIFF
--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -212,19 +212,19 @@ def _update_repo(ds, remote, reobtain_data):
             # get all annexed files that have data present
             lgr.info('Recording file content availability '
                      'to re-obtain updated files later on')
-            reobtain_data = [
+            present_files = [
                 opj(ds.path, p)
                 for p in repo.get_annexed_files(with_content_only=True)]
         # this runs 'annex sync' and should deal with anything
         repo.sync(remotes=remote, push=False, pull=True, commit=False)
         if reobtain_data:
-            reobtain_data = [p for p in reobtain_data if lexists(p)]
-        if reobtain_data:
-            lgr.info('Ensuring content availability for %i '
-                     'previously available files',
-                     len(reobtain_data))
-            yield from ds.get(reobtain_data, recursive=False,
-                              return_type='generator')
+            present_files = [p for p in present_files if lexists(p)]
+            if present_files:
+                lgr.info('Ensuring content availability for %i '
+                         'previously available files',
+                         len(present_files))
+                yield from ds.get(present_files, recursive=False,
+                                  return_type='generator')
     else:
         # handle merge in plain git
         active_branch = repo.get_active_branch()

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -148,7 +148,7 @@ class Update(Interface):
                 sibling_ = remotes[0]
             elif not sibling:
                 # nothing given, look for tracking branch
-                sibling_ = repo.get_tracking_branch()[0]
+                sibling_ = repo.get_tracking_branch(remote_only=True)[0]
             else:
                 sibling_ = sibling
             if sibling_ and sibling_ not in remotes:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -210,19 +210,21 @@ def _update_repo(ds, remote, reobtain_data):
     if isinstance(repo, AnnexRepo):
         if reobtain_data:
             # get all annexed files that have data present
-            lgr.info('Recording file content availability to re-obtain updated files later on')
-            reobtain_data = \
-                [opj(ds.path, p)
-                 for p in repo.get_annexed_files(with_content_only=True)]
+            lgr.info('Recording file content availability '
+                     'to re-obtain updated files later on')
+            reobtain_data = [
+                opj(ds.path, p)
+                for p in repo.get_annexed_files(with_content_only=True)]
         # this runs 'annex sync' and should deal with anything
         repo.sync(remotes=remote, push=False, pull=True, commit=False)
         if reobtain_data:
             reobtain_data = [p for p in reobtain_data if lexists(p)]
         if reobtain_data:
-            lgr.info('Ensure content availability for %i previously available files', len(reobtain_data))
-            for res in ds.get(
-                    reobtain_data, recursive=False, return_type='generator'):
-                yield res
+            lgr.info('Ensuring content availability for %i '
+                     'previously available files',
+                     len(reobtain_data))
+            yield from ds.get(reobtain_data, recursive=False,
+                              return_type='generator')
     else:
         # handle merge in plain git
         active_branch = repo.get_active_branch()

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -235,7 +235,7 @@ def _update_repo(ds, remote, reobtain_data):
                 repo
             )
         else:
-            if repo.config.get('branch.{}.remote'.format(remote), None) == remote:
+            if repo.config.get('branch.{}.remote'.format(active_branch)) == remote:
                 # the branch love this remote already, let git pull do its thing
                 repo.pull(remote=remote)
             else:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -107,8 +107,6 @@ class Update(Interface):
             recursion_limit=None,
             fetch_all=None,
             reobtain_data=False):
-        """
-        """
         if fetch_all is not None:
             lgr.warning('update(fetch_all=...) called. Option has no effect, and will be removed')
         if path and not recursive:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -212,8 +212,9 @@ def _update_repo(ds, remote, reobtain_data):
             # get all annexed files that have data present
             lgr.info('Recording file content availability '
                      'to re-obtain updated files later on')
+            ds_path = ds.path
             present_files = [
-                opj(ds.path, p)
+                opj(ds_path, p)
                 for p in repo.get_annexed_files(with_content_only=True)]
         # this runs 'annex sync' and should deal with anything
         repo.sync(remotes=remote, push=False, pull=True, commit=False)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -506,7 +506,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return branch
 
-    def get_tracking_branch(self, branch=None, corresponding=True):
+    def get_tracking_branch(self, branch=None, remote_only=False,
+                            corresponding=True):
         """Get the tracking branch for `branch` if there is any.
 
         By default returns the tracking branch of the corresponding branch if
@@ -516,6 +517,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         ----------
         branch: str
           local branch to look up. If none is given, active branch is used.
+        remote_only : bool
+            Don't return a value if the upstream remote is set to "." (meaning
+            this repository).
         corresponding: bool
           If True actually look up the corresponding branch of `branch` (also if
           `branch` isn't explicitly given)
@@ -530,6 +534,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             branch = self.get_active_branch()
 
         return super(AnnexRepo, self).get_tracking_branch(
+                        remote_only=remote_only,
                         branch=self.get_corresponding_branch(branch)
                         if corresponding else branch)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3226,13 +3226,16 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         except:
             return None
 
-    def get_tracking_branch(self, branch=None):
+    def get_tracking_branch(self, branch=None, remote_only=False):
         """Get the tracking branch for `branch` if there is any.
 
         Parameters
         ----------
         branch: str
             local branch to look up. If none is given, active branch is used.
+        remote_only : bool
+            Don't return a value if the upstream remote is set to "." (meaning
+            this repository).
 
         Returns
         -------
@@ -3245,6 +3248,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 return None, None
 
         track_remote = self.config.get('branch.{0}.remote'.format(branch), None)
+        if remote_only and track_remote == ".":
+            return None, None
         track_branch = self.config.get('branch.{0}.merge'.format(branch), None)
         return track_remote, track_branch
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -945,6 +945,12 @@ def test_get_tracking_branch(o_path, c_path):
     eq_(('origin', 'refs/heads/' + master_branch),
         clone.get_tracking_branch(master_branch))
 
+    clone.checkout(master_branch, options=["--track", "-btopic"])
+    eq_(('.', 'refs/heads/' + master_branch),
+        clone.get_tracking_branch())
+    eq_((None, None),
+        clone.get_tracking_branch(remote_only=True))
+
 
 @with_testrepos('submodule_annex', flavors=['clone'])
 def test_submodule_deinit(path):


### PR DESCRIPTION
Based on discussion in gh-4148, I'm in the process of reworking the second half of the series in gh-4118.  The first half of that series consisted of miscellaneous fixes and clean-ups.  This PR splits those off, with an additional trivial clean-up on top.  Given that I think these are uncontroversial and that they were already proposed as part of gh-4118, I'll to merge this once the tests pass.

Here's the range-diff with gh-4118.

```
 1:  3485886ddb =  1:  12b1045125 ENH: repo: Teach get_tracking_branch() to optionally ignore "."
 2:  6ee5b663a3 =  2:  a231fbcce6 BF: update: Don't consider "." as an upstream remote
 3:  422b904806 =  3:  4a5cc193de BF: update: Query intended branch.*.remote variable
 4:  996cddb958 =  4:  351f65d24e RF: update: Cosmetic changes to _update_repo() helper
 5:  e33375f216 =  5:  3d5b5958d8 RF: update: Avoid overloading a variable for clarity
 6:  a08d8878d4 =  6:  694cbcddfe OPT: update: Avoid repeatedly accessing Dataset.path in a loop
 7:  d0698f56a0 <  -:  ---------- RF: update: Break apart _update_repo() helper
 8:  1d8dac50d8 <  -:  ---------- ENH: update: Use same merge approach for plain and annex repos
 9:  e7dc6d2948 <  -:  ---------- ENH: update: Avoid calling 'git pull' to merge changes
10:  0ea6cf46da <  -:  ---------- ENH: update: Don't set merge target to a guess that doesn't exist
11:  7c46d0fa94 <  -:  ---------- ENH: update: Try to fetch submodule commit explicitly if needed
12:  05adce76f6 <  -:  ---------- ENH: update: Prefer merge of submodule revision to a ref without it
 -:  ---------- >  7:  0647c7a5f7 CLN: update: Remove empty docstring
```

