### PR TITLE
tests: Improve display of results in assertion messages

### DIFF
--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1358,7 +1358,7 @@ def assert_result_count(results, n, **kwargs):
                 n,
                 kwargs,
                 len(results),
-                dumps(results, indent=1, default=lambda x: str(x))))
+                dumps(results, indent=1, default=str)))
 
 
 def assert_in_results(results, **kwargs):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1372,7 +1372,10 @@ def assert_in_results(results, **kwargs):
     for r in assure_list(results):
         if all(k in r and r[k] == v for k, v in kwargs.items()):
             found = True
-    assert found, "Found no desired result (%s) among %s" % (repr(kwargs), repr(results))
+    if not found:
+        raise AssertionError(
+            "Desired result\n{}\nnot found among\n{}"
+            .format(_format_res(kwargs), _format_res(results)))
 
 
 def assert_not_in_results(results, **kwargs):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1360,10 +1360,10 @@ def assert_result_count(results, n, **kwargs):
             count += 1
     if not n == count:
         raise AssertionError(
-            'Got {} instead of {} expected results matching {}. Inspected {} record(s):\n{}'.format(
+            'Got {} instead of {} expected results matching\n{}\nInspected {} record(s):\n{}'.format(
                 count,
                 n,
-                kwargs,
+                _format_res(kwargs),
                 len(results),
                 _format_res(results)))
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -22,6 +22,7 @@ import multiprocessing
 import logging
 import random
 import socket
+import textwrap
 import warnings
 from fnmatch import fnmatch
 import time
@@ -1343,7 +1344,9 @@ def assert_message(message, results):
 
 
 def _format_res(x):
-    return dumps(x, indent=1, default=str)
+    return textwrap.indent(
+        dumps(x, indent=1, default=str),
+        prefix="  ")
 
 
 def assert_result_count(results, n, **kwargs):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1345,7 +1345,7 @@ def assert_message(message, results):
 
 def _format_res(x):
     return textwrap.indent(
-        dumps(x, indent=1, default=str),
+        dumps(x, indent=1, default=str, sort_keys=True),
         prefix="  ")
 
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1342,6 +1342,10 @@ def assert_message(message, results):
         assert_equal(m, message)
 
 
+def _format_res(x):
+    return dumps(x, indent=1, default=str)
+
+
 def assert_result_count(results, n, **kwargs):
     """Verify specific number of results (matching criteria, if any)"""
     count = 0
@@ -1358,7 +1362,7 @@ def assert_result_count(results, n, **kwargs):
                 n,
                 kwargs,
                 len(results),
-                dumps(results, indent=1, default=str)))
+                _format_res(results)))
 
 
 def assert_in_results(results, **kwargs):


### PR DESCRIPTION
When working with `assert_in_results` failures, I noticed that I often end up pasting them somewhere and reformatting them because I have a hard time digesting long lines like

```
AssertionError: Found no desired result ({'action': 'get', 'status': 'ok'}) among [{'action': 'get', 'path': '/tmp/datalad_temp_test_reobtain_datawmb8reri/load.dat', 'type': 'file', 'refds': '/tmp/datalad_temp_test_reobtain_datawmb8reri', 'status': 'notneeded', 'message': 'already present'}, {'action': 'update', 'path': '/tmp/datalad_temp_test_reobtain_datawmb8reri', 'type': 'dataset', 'refds': '/tmp/datalad_temp_test_reobtain_datawmb8reri', 'status': 'ok'}]
```

`assert_result_count`, on the other hand, formats the records with `json.dumps`, which I find much more helpful.

This series applies the same approach to `assert_in_results` and also makes a few additional tweaks to the formatting used in both `assert_result_count` and `assert_in_results`.

<details>
<summary>example of output change</summary>

```diff
-  File "/home/kyle/src/python/datalad/datalad/tests/utils.py", line 1371, in assert_in_results
-    assert found, "Found no desired result (%s) among %s" % (repr(kwargs), repr(results))
-AssertionError: Found no desired result ({'action': 'get', 'status': 'ok'}) among [{'action': 'get', 'path': '/tmp/datalad_temp_test_reobtain_datawmb8reri/load.dat', 'type': 'file', 'refds': '/tmp/datalad_temp_test_reobtain_datawmb8reri', 'status': 'notneeded', 'message': 'already present'}, {'action': 'update', 'path': '/tmp/datalad_temp_test_reobtain_datawmb8reri', 'type': 'dataset', 'refds': '/tmp/datalad_temp_test_reobtain_datawmb8reri', 'status': 'ok'}]
+  File "/home/kyle/src/python/datalad/datalad/tests/utils.py", line 1381, in assert_in_results
+    .format(_format_res(kwargs), _format_res(results)))
+AssertionError: Desired result
+  {
+   "action": "get",
+   "status": "ok"
+  }
+not found among
+  [
+   {
+    "action": "get",
+    "message": "already present",
+    "path": "/tmp/datalad_temp_test_reobtain_data6pin05pp/load.dat",
+    "refds": "/tmp/datalad_temp_test_reobtain_data6pin05pp",
+    "status": "notneeded",
+    "type": "file"
+   },
+   {
+    "action": "update",
+    "path": "/tmp/datalad_temp_test_reobtain_data6pin05pp",
+    "refds": "/tmp/datalad_temp_test_reobtain_data6pin05pp",
+    "status": "ok",
+    "type": "dataset"
+   }
+  ]


-  File "/home/kyle/src/python/datalad/datalad/tests/utils.py", line 1361, in assert_result_count
-    dumps(results, indent=1, default=lambda x: str(x))))
-AssertionError: Got 0 instead of 3 expected results matching {'status': 'error', 'type': 'dataset'}. Inspected 3 record(s):
-[
- {
-  "action": "update",
-  "path": "/tmp/datalad_temp_test_update_simplenlgj1vb9",
-  "type": "dataset",
-  "refds": "/tmp/datalad_temp_test_update_simplenlgj1vb9",
-  "status": "ok"
- },
- {
-  "action": "update",
-  "path": "/tmp/datalad_temp_test_update_simplenlgj1vb9/2",
-  "type": "dataset",
-  "refds": "/tmp/datalad_temp_test_update_simplenlgj1vb9",
-  "status": "ok"
- },
- {
-  "action": "update",
-  "path": "/tmp/datalad_temp_test_update_simplenlgj1vb9/subm 1",
-  "type": "dataset",
-  "refds": "/tmp/datalad_temp_test_update_simplenlgj1vb9",
-  "status": "ok"
- }
-]
+  File "/home/kyle/src/python/datalad/datalad/tests/utils.py", line 1368, in assert_result_count
+    _format_res(results)))
+AssertionError: Got 0 instead of 3 expected results matching
+  {
+   "status": "error",
+   "type": "dataset"
+  }
+Inspected 3 record(s):
+  [
+   {
+    "action": "update",
+    "path": "/tmp/datalad_temp_test_update_simple519zsud3",
+    "refds": "/tmp/datalad_temp_test_update_simple519zsud3",
+    "status": "ok",
+    "type": "dataset"
+   },
+   {
+    "action": "update",
+    "path": "/tmp/datalad_temp_test_update_simple519zsud3/2",
+    "refds": "/tmp/datalad_temp_test_update_simple519zsud3",
+    "status": "ok",
+    "type": "dataset"
+   },
+   {
+    "action": "update",
+    "path": "/tmp/datalad_temp_test_update_simple519zsud3/subm 1",
+    "refds": "/tmp/datalad_temp_test_update_simple519zsud3",
+    "status": "ok",
+    "type": "dataset"
+   }
+  ]
```

</details>
