### PR TITLE
BF: Reload datalad.cfg for test environment

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -130,6 +130,11 @@ def setup_package():
 """)
         _TEMP_PATHS_GENERATED.append(new_home)
 
+    # Re-load ConfigManager, since otherwise it won't consider global config
+    # from new $HOME (see gh-4153
+    global cfg
+    cfg.reload(force=True)
+
     # To overcome pybuild by default defining http{,s}_proxy we would need
     # to define them to e.g. empty value so it wouldn't bother touching them.
     # But then haskell libraries do not digest empty value nicely, so we just
@@ -222,6 +227,13 @@ def teardown_package():
 
     if _test_states['HOME'] is not None:
         os.environ['HOME'] = _test_states['HOME']
+
+    # Re-establish correct global config after changing $HOME.
+    # Might be superfluous, since after teardown datalad.cfg shouldn't be
+    # needed. However, maintaining a consistent state seems a good thing
+    # either way.
+    global cfg
+    cfg.reload(force=True)
 
     if _test_states['DATASETS_TOPURL_ENV']:
         os.environ['DATALAD_DATASETS_TOPURL'] = _test_states['DATASETS_TOPURL_ENV']

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -132,7 +132,6 @@ def setup_package():
 
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153
-    global cfg
     cfg.reload(force=True)
 
     # To overcome pybuild by default defining http{,s}_proxy we would need
@@ -232,7 +231,6 @@ def teardown_package():
     # Might be superfluous, since after teardown datalad.cfg shouldn't be
     # needed. However, maintaining a consistent state seems a good thing
     # either way.
-    global cfg
     cfg.reload(force=True)
 
     if _test_states['DATASETS_TOPURL_ENV']:

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -30,7 +30,10 @@ from datalad.tests.utils import (
     with_testsui,
     with_tree,
 )
-from datalad.utils import swallow_logs
+from datalad.utils import (
+    swallow_logs,
+    Path
+)
 
 from datalad.distribution.dataset import Dataset
 from datalad.api import create
@@ -491,3 +494,14 @@ def test_dataset_systemglobal_mode(path):
         assert_in('user.name', cfg)
         assert_not_in('datalad.dataset.id', cfg)
         assert_not_in('annex.version', cfg)
+
+
+def test_global_config():
+
+    # from within tests, global config should be read from faked $HOME (see
+    # setup_package)
+    from datalad import cfg
+    glb_cfg_file = Path(os.environ['HOME']) / '.gitconfig'
+    assert any(glb_cfg_file.samefile(Path(p)) for p in cfg._cfgfiles)
+    assert_equal(cfg.get("user.name"), "DataLad Tester")
+    assert_equal(cfg.get("user.email"), "test@example.com")


### PR DESCRIPTION
We change /home/ben from within setup_package, therefore we
need to consider the correct global git config file. This
used to be wrong, since datalad.cfg is instantiated on import
hence before setup_package is executed.
(Closes #4153)