### PR TITLE
TMP/NF: Draft a wrapper around rclone

### DIFF
--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -370,4 +370,20 @@ def test_sibling_path_is_posix(basedir, otherpath):
     # path URL should come out POSIX as if `git clone` had configured it for origin
     # https://github.com/datalad/datalad/issues/3972
     eq_(res['url'], Path(otherpath).as_posix())
-     
+
+
+@with_tempfile(mkdir=True)
+def test_sibling_special_remote(path):
+
+    ds = create(path)
+    # complain about missing name
+    assert_raises(
+        InsufficientArgumentsError,
+        ds.siblings,
+        'add',
+        remotetype='drive',
+    )
+    # TODO Adina: how to test something interactive? AFAIK it always requires
+    # authentication in webinterface, even if using OAuth tokens
+    # ds.siblings('add', name='gdrive', remotetype='drive') or similar always
+    # opens a browser...


### PR DESCRIPTION
ping @mih.
Here is what I came up with so far for #4149:

- I gave ``siblings`` a ``-t/--type`` argument. The default is ``git-remote``, but at the moment it also takes ``drive`` or ``any``
- If anything but ``git-remote`` is specified, an rclone-based special remote is configured.
    - If ``drive`` is given, a special remote to Google drive is configured (with no further arguments, the default configuration is used, but the optional arguments ``apikey`` and ``apisecret`` can be given to specify ``client_id`` and ``client_secret``. 
   - If ``--type any`` is given  or if ``-i/--interactive`` is specified, the interactive ``rclone configure`` command is started.
- After configuration, the special remote is initialized.
   - Without additional arguments, the following ``git annex init`` call is used: ``git annex init <remote-name> encryption=none externaltype='rclone' chunk=50MiB type=external prefix=datalad/<ds-ID> rclone_layout=lower target=<remote-name>``
   - Alternatively, ``encryption``, ``layout``, ``chunk``, ``prefix`` can also be given as arguments to the command line call

Currently, I can do something like this to configure a special remote called "mygdrive" as an rclone based Gdrive special remote with my Google API key:

```
datalad siblings add --type 'drive' -s mygdrive --apikey '774309559379-sapf1isni06pfnoahes23ldsm08jaa8qx.apps.googleusercontent.com' --apisecret '9l7iR5a2u2lHHocfNs862fPx'
```

It would be cool if you could check whether the general approach makes sense. I'm opening it as a draft because there is still a lot missing:

- I don't know how to write tests for an interactive process
- I don't know yet how to do result handling/reporting in the end. After successful command completion I would also like to provide an example command as help on how to configure the special remote as a publication dependency
- It's inconvenient that when started interactively, ``-s/--name`` given to the command and the name given in the interactive configuration need to match. Else, it fails with a not very helpful error
- This currently only does the configuration for the ``publishing`` part of sharing a dataset, but it doesn't take care of the "receiving end", i.e. configuration a special remote and enabling it for user who want to obtain the dataset contents from a clone
- Documentation
