### PR TITLE
ENH: Move git-annex-ria-remote to datalad core as git-annex-ora-remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=datalad
     - NOSE_OPTS=
+    # Note, that there's "turtle" as well, which is always excluded from
+    # running on Travis.
     - NOSE_SELECTION="integration or usecase or slow"
     - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
     # Special settings/helper for combined coverage from special remotes execution
@@ -248,7 +250,7 @@ script:
   - http_proxy=
     PATH=$PWD/../tools/coverage-bin:$PATH
     $NOSE_WRAPPER `which nosetests` $NOSE_OPTS
-      -A "$NOSE_SELECTION_OP($NOSE_SELECTION)"
+      -A "$NOSE_SELECTION_OP($NOSE_SELECTION) and not(turtle)"
       --with-doctest
       --with-cov --cover-package datalad
       --logging-level=INFO

--- a/.travis.yml
+++ b/.travis.yml
@@ -242,9 +242,6 @@ install:
 script:
   # Test installation system-wide
   - sudo pip install .
-  # install RIA special remote
-  # TODO: Remove whenever move of git-annex-ria-remote to datalad-core is finished
-  - sudo pip install git+https://github.com/bpoldrack/git-annex-ria-remote@transition-to-core
   - mkdir -p __testhome__
   - cd __testhome__
   # Run tests

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -533,7 +533,7 @@ def postclonecfg_ria(ds, props):
     # and was enabled (there could be RIA stores that actually only have repos)
     # make this function be a generator
     ria_remotes = [s for s in ds.siblings('query', result_renderer='disabled')
-                   if s.get('annex-externaltype', None) == 'ria'
+                   if s.get('annex-externaltype', None) == 'ora'
     ]
     if not ria_remotes:
         lgr.debug("Found no RIA special remote")

--- a/datalad/customremotes/ria_export_archive.py
+++ b/datalad/customremotes/ria_export_archive.py
@@ -90,8 +90,8 @@ class RIAExportArchive(Interface):
     @eval_results
     def __call__(
             target,
-            dataset=None,
-            opts=None):
+            opts=None,
+            dataset=None):
         # only non-bare repos have hashdirmixed, so require one
         ds = require_dataset(
             dataset, check_installed=True, purpose='RIA archive export')

--- a/datalad/customremotes/ria_export_archive.py
+++ b/datalad/customremotes/ria_export_archive.py
@@ -1,0 +1,194 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Export an archive of a local annex object store, suitable for RIA"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import os
+import os.path as op
+from hashlib import md5
+import subprocess
+from argparse import REMAINDER
+
+from datalad.utils import (
+    rmtree,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.results import (
+    get_status_dict,
+)
+from datalad.interface.utils import eval_results
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+    resolve_path,
+)
+from datalad.log import log_progress
+from datalad.dochelpers import (
+    exc_str,
+)
+
+lgr = logging.getLogger('datalad.customremotes.export_archive')
+
+
+@build_doc
+class RIAExportArchive(Interface):
+    """Export an archive of a local annex object store for the RIA remote.
+
+    Keys in the local annex object store are reorganized in a temporary
+    directory (using links to avoid storage duplication) to use the
+    'hashdirlower' setup used by git-annex for bare repositories and
+    the directory-type special remote. This alternative object store is
+    then moved into a 7zip archive that is suitable for use in a
+    RIA remote dataset store. Placing such an archive into::
+
+      <dataset location>/archives/archive.7z
+
+    Enables the RIA special remote to locate and retrieve all key contained
+    in the archive.
+    """
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to process.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        target=Parameter(
+            args=("target",),
+            metavar="TARGET",
+            doc="""if an existing directory, an 'archive.7z' is placed into
+            it, otherwise this is the path to the target archive""",
+            constraints=EnsureStr() | EnsureNone()),
+        opts=Parameter(
+            args=("opts",),
+            nargs=REMAINDER,
+            metavar="...",
+            doc="""list of options for 7z to replace the default '-mx0' to
+            generate an uncompressed archive"""),
+    )
+
+    @staticmethod
+    @datasetmethod(name='ria_export_archive')
+    @eval_results
+    def __call__(
+            target,
+            dataset=None,
+            opts=None):
+        # only non-bare repos have hashdirmixed, so require one
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='RIA archive export')
+        ds_repo = ds.repo
+
+        # TODO remove once datalad 0.12rc7 or later is released
+        if not hasattr(ds_repo, 'dot_git'):
+            from datalad.support.gitrepo import GitRepo
+            ds_repo.dot_git = ds_repo.pathobj / GitRepo.get_git_dir(ds_repo)
+
+        annex_objs = ds_repo.dot_git / 'annex' / 'objects'
+
+        archive = resolve_path(target, dataset)
+        if archive.is_dir():
+            archive = archive / 'archive.7z'
+        else:
+            archive.parent.mkdir(exist_ok=True, parents=True)
+
+        if not opts:
+            # uncompressed by default
+            opts = ['-mx0']
+
+        res_kwargs = dict(
+            action="export-ria-archive",
+            logger=lgr,
+        )
+
+        if not annex_objs.is_dir():
+            yield get_status_dict(
+                ds=ds,
+                status='notneeded',
+                message='no annex keys present',
+                **res_kwargs,
+            )
+            return
+
+        exportdir = ds_repo.dot_git / 'datalad' / 'tmp' / 'ria_archive'
+        if exportdir.exists():
+            yield get_status_dict(
+                ds=ds,
+                status='error',
+                message=(
+                    'export directory already exists, please remove first: %s',
+                    str(exportdir)),
+                **res_kwargs,
+            )
+            return
+
+        keypaths = [
+            k for k in annex_objs.glob(op.join('**', '*'))
+            if k.is_file()
+        ]
+
+        log_progress(
+            lgr.info,
+            'riaarchiveexport',
+            'Start RIA archive export %s', ds,
+            total=len(keypaths),
+            label='RIA archive export',
+            unit=' Keys',
+        )
+
+        for keypath in keypaths:
+            key = keypath.name
+            hashdir = op.join(keypath.parts[-4], keypath.parts[-3])
+            log_progress(
+                lgr.info,
+                'riaarchiveexport',
+                'Export key %s to %s', key, hashdir,
+                update=1,
+                increment=True)
+            keydir = exportdir / hashdir / key
+            keydir.mkdir(parents=True, exist_ok=True)
+            os.link(str(keypath), str(keydir / key))
+
+        log_progress(
+            lgr.info,
+            'riaarchiveexport',
+            'Finished RIA archive export from %s', ds
+        )
+        try:
+            subprocess.run(
+                ['7z', 'u', str(archive), '.'] + opts,
+                cwd=str(exportdir),
+            )
+            yield get_status_dict(
+                path=str(archive),
+                type='file',
+                status='ok',
+                **res_kwargs)
+        except Exception as e:
+            yield get_status_dict(
+                path=str(archive),
+                type='file',
+                status='error',
+                message=('7z failed: %s', exc_str(e)),
+                **res_kwargs)
+            return
+        finally:
+            rmtree(str(exportdir))

--- a/datalad/customremotes/ria_remote.py
+++ b/datalad/customremotes/ria_remote.py
@@ -1,0 +1,923 @@
+from annexremote import SpecialRemote
+from annexremote import RemoteError
+
+from pathlib import (
+    Path,
+)
+import shutil
+from shlex import quote as sh_quote
+import subprocess
+import logging
+from functools import wraps
+from datalad.distributed.ria_utils import (
+    get_layout_locations,
+    verify_ria_url,
+)
+
+lgr = logging.getLogger('ria_remote')
+
+# TODO
+# - make archive check optional
+
+
+def _get_gitcfg(gitdir, key, cfgargs=None, regex=False):
+    cmd = [
+        'git',
+        '--git-dir', gitdir,
+        'config',
+    ]
+    if cfgargs:
+        cmd += cfgargs
+
+    cmd += ['--get-regexp'] if regex else ['--get']
+    cmd += [key]
+    try:
+        return subprocess.check_output(
+            cmd,
+            # yield text
+            universal_newlines=True).strip()
+    except Exception:
+        lgr.debug(
+            "Failed to obtain config '%s' at %s",
+            key, gitdir,
+        )
+        return None
+
+
+def _get_datalad_id(gitdir):
+    """Attempt to determine a DataLad dataset ID for a given repo
+
+    Returns
+    -------
+    str or None
+      None in case no ID was found
+    """
+    dsid = _get_gitcfg(
+        gitdir, 'datalad.dataset.id', ['--blob', ':.datalad/config']
+    )
+    if dsid is None:
+        lgr.debug(
+            "Cannot determine a DataLad ID for repository: %s",
+            gitdir,
+        )
+    else:
+        dsid = dsid.strip()
+    return dsid
+
+
+class RemoteCommandFailedError(Exception):
+    pass
+
+
+class RIARemoteError(RemoteError):
+
+    def __init__(self, msg):
+        super().__init__(msg.replace('\n', '\\n'))
+
+
+class IOBase(object):
+    """Abstract class with the desired API for local/remote operations"""
+    def mkdir(self, path):
+        raise NotImplementedError
+
+    def put(self, src, dst):
+        raise NotImplementedError
+
+    def get(self, src, dst):
+        raise NotImplementedError
+
+    def rename(self, src, dst):
+        raise NotImplementedError
+
+    def remove(self, path):
+        raise NotImplementedError
+
+    def exists(self, path):
+        raise NotImplementedError
+
+    def get_from_archive(self, archive, src, dst):
+        """Get a file from an archive
+
+        Parameters
+        ----------
+        archive_path : Path or str
+          Must be an absolute path and point to an existing supported archive
+        file_path : Path or str
+          Must be a relative Path (relative to the root
+          of the archive)
+        """
+        raise NotImplementedError
+
+    def in_archive(self, archive_path, file_path):
+        """Test whether a file is in an archive
+
+        Parameters
+        ----------
+        archive_path : Path or str
+          Must be an absolute path and point to an existing supported archive
+        file_path : Path or str
+          Must be a relative Path (relative to the root
+          of the archive)
+        """
+        raise NotImplementedError
+
+    def read_file(self, file_path):
+        """Read a remote file's content
+
+        Parameters
+        ----------
+        file_path : Path or str
+          Must be an absolute path
+
+        Returns
+        -------
+        string
+        """
+
+        raise NotImplementedError
+
+    def write_file(self, file_path, content, mode='w'):
+        """Write a remote file
+
+        Parameters
+        ----------
+        file_path : Path or str
+          Must be an absolute path
+        content : str
+        """
+
+        raise NotImplementedError
+
+
+class LocalIO(IOBase):
+    """IO operation if the object tree is local (e.g. NFS-mounted)"""
+    def mkdir(self, path):
+        path.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+
+    def put(self, src, dst):
+        shutil.copy(
+            str(src),
+            str(dst),
+        )
+
+    def get(self, src, dst):
+        shutil.copy(
+            str(src),
+            str(dst),
+        )
+
+    def get_from_archive(self, archive, src, dst):
+        # this requires python 3.5
+        with open(dst, 'wb') as target_file:
+            subprocess.run([
+                '7z', 'x', '-so',
+                str(archive), str(src)],
+                stdout=target_file,
+            )
+
+    def rename(self, src, dst):
+        src.rename(dst)
+
+    def remove(self, path):
+        path.unlink()
+
+    def remove_dir(self, path):
+        path.rmdir()
+
+    def exists(self, path):
+        return path.exists()
+
+    def in_archive(self, archive_path, file_path):
+        if not archive_path.exists():
+            # no archive, not file
+            return False
+        loc = str(file_path)
+        from datalad.cmd import Runner
+        runner = Runner()
+        # query 7z for the specific object location, keeps the output
+        # lean, even for big archives
+        out, err = runner(
+            ['7z', 'l', str(archive_path),
+             loc],
+            log_stdout=True,
+        )
+        return loc in out
+
+    def read_file(self, file_path):
+
+        with open(str(file_path), 'r') as f:
+            content = f.read()
+        return content
+
+    def write_file(self, file_path, content, mode='w'):
+
+        with open(str(file_path), mode) as f:
+            f.write(content)
+
+
+class SSHRemoteIO(IOBase):
+    """IO operation if the object tree is SSH-accessible
+
+    It doesn't even think about a windows server.
+    """
+
+    # output markers to detect possible command failure as well as end of output from a particular command:
+    REMOTE_CMD_FAIL = "ria-remote: end - fail"
+    REMOTE_CMD_OK = "ria-remote: end - ok"
+
+    def __init__(self, host):
+        """
+        Parameters
+        ----------
+        host : str
+          SSH-accessible host(name) to perform remote IO operations
+          on.
+        """
+
+        from datalad.support.sshconnector import SSHManager
+        # connection manager -- we don't have to keep it around, I think
+        self.sshmanager = SSHManager()
+        # the connection to the remote
+        # we don't open it yet, not yet clear if needed
+        self.ssh = self.sshmanager.get_connection(
+            host,
+            use_remote_annex_bundle=False,
+        )
+        self.ssh.open()
+        # open a remote shell
+        cmd = ['ssh'] + self.ssh._ssh_args + [self.ssh.sshri.as_str()]
+        self.shell = subprocess.Popen(cmd, stderr=subprocess.DEVNULL, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        # swallow login message(s):
+        self.shell.stdin.write(b"echo RIA-REMOTE-LOGIN-END\n")
+        self.shell.stdin.flush()
+        while True:
+            line = self.shell.stdout.readline()
+            if line == b"RIA-REMOTE-LOGIN-END\n":
+                break
+        # TODO: Same for stderr?
+
+    def close(self):
+        # try exiting shell clean first
+        self.shell.stdin.write(b"exit\n")
+        self.shell.stdin.flush()
+        exitcode = self.shell.wait(timeout=0.5)
+        # be more brutal if it doesn't work
+        if exitcode is None:  # timed out
+            # TODO: Theoretically terminate() can raise if not successful. How to deal with that?
+            self.shell.terminate()
+        self.sshmanager.close()
+
+    def _append_end_markers(self, cmd):
+        """Append end markers to remote command"""
+
+        return cmd + ' && echo "{}" || echo "{}"\n'.format(self.REMOTE_CMD_OK, self.REMOTE_CMD_FAIL)
+
+    def _get_download_size_from_key(self, key):
+        """Get the size of an annex object file from it's key
+
+        Note, that this is not necessarily the size of the annexed file, but possibly only a chunk of it.
+
+        Parameter
+        ---------
+        key: str
+          annex key of the file
+
+        Returns
+        -------
+        int
+          size in bytes
+        """
+        # TODO: datalad's AnnexRepo.get_size_from_key() is not correct/not fitting. Incorporate the wisdom there, too.
+        #       We prob. don't want to actually move this method there, since AnnexRepo would be quite an expensive
+        #       import. Startup time for special remote matters.
+        # TODO: this method can be more compact. we don't need particularly elaborated error distinction
+
+        # see: https://git-annex.branchable.com/internals/key_format/
+        key_parts = key.split('--')
+        key_fields = key_parts[0].split('-')
+
+        s = S = C = None
+
+        for field in key_fields[1:]:  # note: first one has to be backend -> ignore
+            if field.startswith('s'):
+                # size of the annexed file content:
+                s = int(field[1:]) if field[1:].isdigit() else None
+            elif field.startswith('S'):
+                # we have a chunk and that's the chunksize:
+                S = int(field[1:]) if field[1:].isdigit() else None
+            elif field.startswith('C'):
+                # we have a chunk, this is it's number:
+                C = int(field[1:]) if field[1:].isdigit() else None
+
+        if s is None:
+            return None
+        elif S is None and C is None:
+            return s
+        elif S and C:
+            if C <= int(s / S):
+                return S
+            else:
+                return s % S
+        else:
+            raise RIARemoteError("invalid key: {}".format(key))
+
+    def _run(self, cmd, no_output=True, check=False):
+
+        # TODO: we might want to redirect stderr to stdout here (or have additional end marker in stderr)
+        #       otherwise we can't empty stderr to be ready for next command. We also can't read stderr for better error
+        #       messages (RemoteError) without making sure there's something to read in any case (it's blocking!)
+        #       However, if we are sure stderr can only ever happen if we would raise RemoteError anyway, it might be
+        #       okay
+        call = self._append_end_markers(cmd)
+        self.shell.stdin.write(call.encode())
+        self.shell.stdin.flush()
+
+        lines = []
+        while True:
+            line = self.shell.stdout.readline().decode()
+            lines.append(line)
+            if line == self.REMOTE_CMD_OK + '\n':
+                # end reading
+                break
+            elif line == self.REMOTE_CMD_FAIL + '\n':
+                if check:
+                    raise RemoteCommandFailedError("{cmd} failed: {msg}".format(cmd=cmd,
+                                                                                msg="".join(lines[:-1]))
+                                                   )
+                else:
+                    break
+        if no_output and len(lines) > 1:
+            raise RIARemoteError("{}: {}".format(call, "".join(lines)))
+        return "".join(lines[:-1])
+
+    def mkdir(self, path):
+        self._run('mkdir -p {}'.format(sh_quote(str(path))))
+
+    def put(self, src, dst):
+        self.ssh.put(str(src), str(dst))
+
+    def get(self, src, dst):
+
+        # Note, that as we are in blocking mode, we can't easily fail on the actual get (that is 'cat').
+        # Therefore check beforehand.
+        if not self.exists(src):
+            raise RIARemoteError("annex object {src} does not exist.".format(src=src))
+
+        # TODO: see get_from_archive()
+
+        # TODO: Currently we will hang forever if the file isn't readable and it's supposed size is bigger than whatever
+        #       cat spits out on stdout. This is because we don't notice that cat has exited non-zero.
+        #       We could have end marker on stderr instead, but then we need to empty stderr beforehand to not act upon
+        #       output from earlier calls. This is a problem with blocking reading, since we need to make sure there's
+        #       actually something to read in any case.
+        cmd = 'cat {}'.format(str(src))
+        self.shell.stdin.write(cmd.encode())
+        self.shell.stdin.write(b"\n")
+        self.shell.stdin.flush()
+
+        from os.path import basename
+        key = basename(str(src))
+        try:
+            size = self._get_download_size_from_key(key)
+        except RemoteError as e:
+            raise RemoteError("src: {}".format(str(src)) + str(e))
+
+        if size is None:
+            # rely on SCP for now
+            self.ssh.get(str(src), str(dst))
+            return
+
+        with open(dst, 'wb') as target_file:
+            bytes_received = 0
+            while bytes_received < size:  # TODO: some additional abortion criteria? check stderr in addition?
+                c = self.shell.stdout.read1(1024)
+                # no idea yet, whether or not there's sth to gain by a sophisticated determination of how many bytes to
+                # read at once (like size - bytes_received)
+                if c:
+                    bytes_received += len(c)
+                    target_file.write(c)
+
+    def rename(self, src, dst):
+        self._run('mv {} {}'.format(sh_quote(str(src)), sh_quote(str(dst))))
+
+    def remove(self, path):
+        self._run('rm {}'.format(sh_quote(str(path))))
+
+    def remove_dir(self, path):
+        self._run('rmdir {}'.format(sh_quote(str(path))))
+
+    def exists(self, path):
+        try:
+            self._run('test -e {}'.format(sh_quote(str(path))), check=True)
+            return True
+        except RemoteCommandFailedError:
+            return False
+
+    def in_archive(self, archive_path, file_path):
+
+        if not self.exists(archive_path):
+            return False
+
+        loc = str(file_path)
+        # query 7z for the specific object location, keeps the output
+        # lean, even for big archives
+        cmd = '7z l {} {}'.format(str(archive_path), loc)
+
+        # Note: Currently relies on file_path not showing up in case of failure
+        # including non-existent archive. If need be could be more sophisticated
+        # and called with check=True + catch RemoteCommandFailedError
+        out = self._run(cmd, no_output=False, check=False)
+
+        return loc in out
+
+    def get_from_archive(self, archive, src, dst):
+
+        # Note, that as we are in blocking mode, we can't easily fail on the actual get (that is 'cat').
+        # Therefore check beforehand.
+        if not self.exists(archive):
+            raise RIARemoteError("archive {arc} does not exist.".format(arc=archive))
+
+        # TODO: We probably need to check exitcode on stderr (via marker). If archive or content is missing we will
+        #       otherwise hang forever waiting for stdout to fill `size`
+
+        cmd = '7z x -so {} {}\n'.format(str(archive), str(src))
+        self.shell.stdin.write(cmd.encode())
+        self.shell.stdin.flush()
+
+        # TODO: - size needs double-check and some robustness
+        #       - can we assume src to be a posixpath?
+        #       - RF: Apart from the executed command this should be pretty much identical to self.get(), so move that
+        #         code into a common function
+
+        from os.path import basename
+        size = self._get_download_size_from_key(basename(str(src)))
+
+        with open(dst, 'wb') as target_file:
+            bytes_received = 0
+            while bytes_received < size:
+                c = self.shell.stdout.read1(1024)
+                if c:
+                    bytes_received += len(c)
+                    target_file.write(c)
+
+    def read_file(self, file_path):
+
+        cmd = "cat  {}".format(str(file_path))
+        try:
+            out = self._run(cmd, no_output=False, check=True)
+        except RemoteCommandFailedError:
+            raise RIARemoteError("Could not read {}".format(str(file_path)))
+
+        return out
+
+    def write_file(self, file_path, content, mode='w'):
+
+        if mode == 'w':
+            mode = ">"
+        elif mode == 'a':
+            mode = ">>"
+        else:
+            raise ValueError("Unknown mode '{}'".format(mode))
+        if not content.endswith('\n'):
+            content += '\n'
+
+        cmd = "echo \"{}\" {} {}".format(content, mode, str(file_path))
+        try:
+            self._run(cmd, check=True)
+        except RemoteCommandFailedError:
+            raise RIARemoteError("Could not write to {}".format(str(file_path)))
+
+
+def handle_errors(func):
+    """Decorator to convert and log errors
+
+    Intended to use with every method of RiaRemote class, facing the outside world.
+    In particular, that is about everything, that may be called via annex' special remote protocol,
+    since a non-RemoteError will simply result in a broken pipe by default handling.
+    """
+
+    # TODO: configurable on remote end (flag within layout_version!)
+
+    @wraps(func)
+    def new_func(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except Exception as e:
+            if self.remote_log_enabled:
+                from datetime import datetime
+                from traceback import format_exc
+                exc_str = format_exc()
+                entry = "{time}: Error:\n{exc_str}\n".format(time=datetime.now(),
+                                                                exc_str=exc_str)
+                log_target = self.objtree_base_path / 'error_logs' / "{dsid}.{uuid}.log".format(dsid=self.archive_id,
+                                                                                                uuid=self.uuid)
+                self.io.write_file(log_target, entry, mode='a')
+            if not isinstance(e, RIARemoteError):
+                raise RIARemoteError(str(e))
+            else:
+                raise e
+
+    return new_func
+
+
+class RIARemote(SpecialRemote):
+    """This is the class of RIA remotes.
+    """
+
+    dataset_tree_version = '1'
+    object_tree_version = '2'
+    known_versions_objt = ['1', '2']
+    known_versions_dst = ['1']
+
+    @handle_errors
+    def __init__(self, annex):
+        super(RIARemote, self).__init__(annex)
+        # machine to SSH-log-in to access/store the data
+        # subclass must set this
+        self.storage_host = None
+        # must be absolute, and POSIX
+        # subclass must set this
+        self.objtree_base_path = None
+        # by default we can read and write
+        self.read_only = False
+        self.can_notify = None  # to be figured out later, since annex.protocol.extensions is not yet accessible
+        self.force_write = None
+        self.uuid = None
+        self.ignore_remote_config = None
+        self.remote_log_enabled = None
+        self.remote_dataset_tree_version = None
+        self.remote_object_tree_version = None
+
+        # for caching the remote's layout locations:
+        self.remote_git_dir = None
+        self.remote_archive_dir = None
+        self.remote_obj_dir = None
+
+    def _load_cfg(self, gitdir, name):
+        # for now still accept the configs, if no ria-URL is known:
+        if not self.ria_store_url:
+            self.storage_host = _get_gitcfg(
+                gitdir, 'annex.ria-remote.{}.ssh-host'.format(name))
+
+            objtree_base_path = _get_gitcfg(
+                gitdir, 'annex.ria-remote.{}.base-path'.format(name))
+            self.objtree_base_path = objtree_base_path.strip() \
+                if objtree_base_path else objtree_base_path
+        # Whether or not to force writing to the remote. Currently used to overrule write protection due to layout
+        # version mismatch.
+        self.force_write = _get_gitcfg(
+            gitdir, 'annex.ria-remote.{}.force-write'.format(name))
+
+        # whether to ignore config flags set at the remote end
+        self.ignore_remote_config = _get_gitcfg(gitdir, 'annex.ria-remote.{}.ignore-remote-config'.format(name))
+
+    def _verify_config(self, gitdir, fail_noid=True):
+        # try loading all needed info from (git) config
+        name = self.annex.getconfig('name')
+        # get store url:
+        self.ria_store_url = self.annex.getconfig('url')
+        if self.ria_store_url:
+            # support URL rewrite without talking to a DataLad ConfigManager
+            # Q is why? Why not use the config manager?
+            url_cfgs = dict()
+            url_cfgs_raw = _get_gitcfg(gitdir, "^url.*", regex=True)
+            if url_cfgs_raw:
+                for line in url_cfgs_raw.splitlines():
+                    k, v = line.split()
+                    url_cfgs[k] = v
+            self.storage_host, self.objtree_base_path = verify_ria_url(
+                self.ria_store_url,
+                url_cfgs,
+            )
+
+        # TODO duplicates call to `git-config` after RIA url rewrite
+        self._load_cfg(gitdir, name)
+
+        # for now still accept the configs, if no ria-URL is known:
+        if not self.ria_store_url:
+            if not self.objtree_base_path:
+                self.objtree_base_path = self.annex.getconfig('base-path')
+            if not self.objtree_base_path:
+                raise RIARemoteError(
+                    "No remote base path configured. "
+                    "Specify `base-path` setting.")
+
+        self.objtree_base_path = Path(self.objtree_base_path)
+        if not self.objtree_base_path.is_absolute():
+            raise RIARemoteError(
+                'Non-absolute object tree base path configuration')
+
+        # for now still accept the configs, if no ria-URL is known:
+        if not self.ria_store_url:
+            # Note: Special value '0' is replaced by None only after checking the repository's annex config.
+            # This is to uniformly handle '0' and None later on, but let a user's config '0' overrule what's
+            # stored by git-annex.
+            if not self.storage_host:
+                self.storage_host = self.annex.getconfig('ssh-host')
+            elif self.storage_host == '0':
+                self.storage_host = None
+
+        # go look for an ID
+        self.archive_id = self.annex.getconfig('archive-id')
+        if fail_noid and not self.archive_id:
+            raise RIARemoteError(
+                "No archive ID configured. This should not happen.")
+
+        # TODO: This should prob. not be done! Would only have an effect if force-write was committed
+        #       annex-special-remote-config and this is likely a bad idea.
+        if not self.force_write:
+            self.force_write = self.annex.getconfig('force-write')
+
+    def _get_version_config(self, path):
+        """ Get version and config flags from remote file
+        """
+
+        file_content = self.io.read_file(path).strip().split('|')
+        if not (1 <= len(file_content) <= 2):
+            self._info("invalid version file {}".format(path))
+            return None
+
+        remote_version = file_content[0]
+        remote_config_flags = file_content[1] if len(file_content) == 2 else None
+        if not self.ignore_remote_config and remote_config_flags:
+            # Note: 'or', since config flags can come from toplevel (dataset-tree-root) as well as
+            #       from dataset-level. toplevel is supposed flag the entire tree.
+            self.remote_log_enabled = self.remote_log_enabled or 'l' in remote_config_flags
+
+        return remote_version
+
+    @handle_errors
+    def initremote(self):
+        # which repo are we talking about
+        gitdir = self.annex.getgitdir()
+        self._verify_config(gitdir, fail_noid=False)
+        if not self.archive_id:
+            self.archive_id = _get_datalad_id(gitdir)
+            if not self.archive_id:
+                # fall back on the UUID for the annex remote
+                self.archive_id = self.annex.getuuid()
+        self.annex.setconfig('archive-id', self.archive_id)
+
+    def _local_io(self):
+        """Are we doing local operations?"""
+        # let's not make this decision dependent on the existance
+        # of a directory the matches the name of the configured
+        # object tree base dir. Such a match could be pure
+        # coincidence. Instead, let's do remote whenever there
+        # is a remote host configured
+        #return self.objtree_base_path.is_dir()
+        return not self.storage_host
+
+    def _info(self, msg):
+
+        if self.can_notify:
+            self.annex.info(msg)
+        # TODO: else: if we can't have an actual info message, at least have a debug message
+        #       This probably requires further refurbishment of datalad's capability to deal with such aspects of the
+        #       special remote protocol
+
+    def _set_read_only(self, msg):
+
+        if not self.force_write:
+            self.read_only = True
+            self._info(msg)
+        else:
+            self._info("Was instructed to force write")
+
+    def _check_layout_version(self):
+        """Check whether we can deal with the layout reported by the remote end
+
+        There are two aspects of layout versioning:
+        - the tree to put the datasets in (version recorded in base_path/ria-layout-version)
+        - the tree of the actual annex objects of a particular dataset (version recorded in
+          dataset_somewhere_beneath_base_path/ria-layout-version)
+
+        If the version found on the remote end isn't supported and `force-write` isn't configured,
+        this sets the remote to read-only operation.
+        """
+
+        dataset_tree_version_file = \
+            self.objtree_base_path / 'ria-layout-version'
+        object_tree_version_file = \
+            self.objtree_base_path / self.archive_id[:3] / self.archive_id[3:] / 'ria-layout-version'
+
+        read_only_msg = "Setting remote to read-only usage in order to prevent damage by putting things into an " \
+                        "unknown version of the target layout. You can overrule this by configuring " \
+                        "'annex.ria-remote.<name>.force-write'."
+
+        # 1. check dataset tree version
+        try:
+            self.remote_dataset_tree_version = self._get_version_config(dataset_tree_version_file)
+            if self.remote_dataset_tree_version not in self.known_versions_dst:
+                # Note: In later versions, condition might change in order to deal with older versions
+                self._info("Remote dataset tree reports version {}. Supported versions are: {}. Consider upgrading "
+                           "git-annex-ria-remote or fix the structure on the remote end."
+                           "".format(self.remote_dataset_tree_version, self.known_versions_dst))
+                self._set_read_only(read_only_msg)
+
+        except (RemoteError, FileNotFoundError):  # depends on whether self.io is local or ssh
+            # assume file doesn't exist
+            # TODO: Is there a possibility RemoteError has a different reason and should be handled differently?
+            #       Don't think so ATM
+            if not self.io.exists(dataset_tree_version_file.parent):
+                # we are first, just put our stamp on it
+                # ensure we have a store and simultaneously ensure the error log subdir
+                self.io.mkdir(dataset_tree_version_file.parent / 'error_logs')
+
+                self.io.write_file(dataset_tree_version_file, self.dataset_tree_version + '\n')
+            else:
+                # directory is there, but no version file. We don't know what that is. Treat the same way as if there
+                # was an unknown version on record
+                self._info("Remote doesn't report any dataset tree version. Consider upgrading git-annex-ria-remote or "
+                           "fix the structure on the remote end.")
+                self._set_read_only(read_only_msg)
+
+        # 2. check (annex) object tree version
+        try:
+            self.remote_object_tree_version = self._get_version_config(object_tree_version_file)
+            if self.remote_object_tree_version not in self.known_versions_objt:
+                self._info("Remote object tree reports version {}. Supported versions are {}. Consider upgrading "
+                           "git-annex-ria-remote.".format(self.remote_object_tree_version, self.known_versions_objt))
+                self._set_read_only(read_only_msg)
+        except (RemoteError, FileNotFoundError):
+            if not self.io.exists(object_tree_version_file.parent):
+                # we are first, just put our stamp on it
+                # ensure we have a ds dir and simultaneously ensure the archives subdir
+                self.io.mkdir(object_tree_version_file.parent / 'archives')
+                self.io.write_file(object_tree_version_file, self.object_tree_version + '\n')
+            else:
+                self._info("Remote doesn't report any object tree version. Consider upgrading git-annex-ria-remote or "
+                           "fix the structure on the remote end.")
+                self._set_read_only(read_only_msg)
+
+    @handle_errors
+    def prepare(self):
+
+        # can we use self.annex.info() for sending user output to annex?
+        self.can_notify = "INFO" in self.annex.protocol.extensions
+
+        gitdir = self.annex.getgitdir()
+        self.uuid = self.annex.getuuid()
+        self._verify_config(gitdir)
+
+        if self._local_io():
+            self.io = LocalIO()
+        elif self.storage_host:
+            self.io = SSHRemoteIO(self.storage_host)
+            from atexit import register
+            register(self.io.close)
+        else:
+            raise RIARemoteError(
+                "Local object tree base path does not exist, and no SSH host "
+                "configuration found.")
+
+        # report active special remote configuration
+        self.info = {
+            'objtree_base_path': str(self.objtree_base_path),
+            'storage_host': 'local'
+            if self._local_io() else self.storage_host,
+        }
+
+        self._check_layout_version()
+
+        # cache remote layout directories
+        self.remote_git_dir, self.remote_archive_dir, self.remote_obj_dir = \
+            self.get_layout_locations(self.objtree_base_path, self.archive_id)
+
+    @handle_errors
+    def transfer_store(self, key, filename):
+        if self.read_only:
+            raise RemoteError("Remote was set to read-only. "
+                              "Configure 'ria-remote.<name>.force-write' to overrule this.")
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        key_path = dsobj_dir / key_path
+
+        if self.io.exists(key_path):
+            # if the key is here, we trust that the content is in sync
+            # with the key
+            return
+
+        self.io.mkdir(key_path.parent)
+
+        # we need to copy to a temp location to let
+        # checkpresent fail while the transfer is still in progress
+        # and furthermore not interfere with administrative tasks in annex/objects
+        # In addition include uuid, to not interfere with parallel uploads from different remotes
+        transfer_dir = self.remote_git_dir / "ria-remote-{}".format(self.uuid) / "transfer"
+        self.io.mkdir(transfer_dir)
+        tmp_path = transfer_dir / key
+
+        if tmp_path.exists():
+            # Just in case - some parallel job could already be writing to it
+            # at least tell the conclusion, not just some obscure permission error
+            raise RIARemoteError('{}: upload already in progress'.format(filename))
+        try:
+            self.io.put(filename, tmp_path)
+            # copy done, atomic rename to actual target
+            self.io.rename(tmp_path, key_path)
+        except Exception as e:
+            # whatever went wrong, we don't want to leave the transfer location blocked
+            self.io.remove(tmp_path)
+            raise e
+
+    @handle_errors
+    def transfer_retrieve(self, key, filename):
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        abs_key_path = dsobj_dir / key_path
+        # sadly we have no idea what type of source gave checkpresent->true
+        # we can either repeat the checks, or just make two opportunistic
+        # attempts (at most)
+        try:
+            self.io.get(abs_key_path, filename)
+        except Exception as e1:
+            # catch anything and keep it around for a potential re-raise
+            try:
+                self.io.get_from_archive(archive_path, key_path, filename)
+            except Exception as e2:
+                raise RIARemoteError('Failed to key: {}'.format([str(e1), str(e2)]))
+
+    @handle_errors
+    def checkpresent(self, key):
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        abs_key_path = dsobj_dir / key_path
+        if self.io.exists(abs_key_path):
+            # we have an actual file for this key
+            return True
+        # do not make a careful check whether an archive exists, because at
+        # present this requires an additional SSH call for remote operations
+        # which may be rather slow. Instead just try to run 7z on it and let
+        # it fail if no archive is around
+        # TODO honor future 'archive-mode' flag
+        return self.io.in_archive(archive_path, key_path)
+
+    @handle_errors
+    def remove(self, key):
+        if self.read_only:
+            raise RIARemoteError("Remote was set to read-only. "
+                                 "Configure 'ria-remote.<name>.force-write' to overrule this.")
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        key_path = dsobj_dir / key_path
+        if self.io.exists(key_path):
+            self.io.remove(key_path)
+        key_dir = key_path
+        # remove at most two levels of empty directories
+        for level in range(2):
+            key_dir = key_dir.parent
+            try:
+                self.io.remove_dir(key_dir)
+            except Exception:
+                break
+
+    @handle_errors
+    def getcost(self):
+        # 100 is cheap, 200 is expensive (all relative to Config/Cost.hs)
+        # 100/200 are the defaults for local and remote operations in
+        # git-annex
+        # if we have the object tree locally, operations are cheap (100)
+        # otherwise expensive (200)
+        return '100' if self._local_io() else '200'
+
+    @handle_errors
+    def whereis(self, key):
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        return str(key_path) if self._local_io() \
+            else '{}: {}:{}'.format(
+                self.storage_host,
+                self.remote_git_dir,
+                sh_quote(str(key_path)),
+        )
+
+    @staticmethod
+    def get_layout_locations(base_path, dsid):
+        return get_layout_locations(1, base_path, dsid)
+
+    def _get_obj_location(self, key):
+        # Note: Changes to this method may require an update of RIARemote._layout_version
+        # Note2: archive_path is always the same ATM. However, it might depend on `key` in the future.
+        #        Therefore build the actual filename for the archive herein as opposed to `get_layout_locations`.
+
+        # If we didn't recognize the remote layout version, we set to read-only and promised to at least try and read
+        # according to our current version. So, treat that case as if remote version was our (client's) version.
+        if self.remote_object_tree_version == '1':
+            key_dir = self.annex.dirhash_lower(key)
+        else:
+            key_dir = self.annex.dirhash(key)
+        # double 'key' is not a mistake, but needed to achieve the exact same
+        # layout as the 'directory'-type special remote
+        key_path = Path(key_dir) / key / key
+        archive_path = self.remote_archive_dir / 'archive.7z'
+        return self.remote_obj_dir, archive_path, key_path
+
+
+def main():
+    """cmdline entry point"""
+    from annexremote import Master
+    master = Master()
+    remote = RIARemote(master)
+    master.LinkRemote(remote)
+    master.Listen()

--- a/datalad/customremotes/ria_remote.py
+++ b/datalad/customremotes/ria_remote.py
@@ -608,7 +608,8 @@ class RIARemote(SpecialRemote):
         self.objtree_base_path = Path(self.objtree_base_path)
         if not self.objtree_base_path.is_absolute():
             raise RIARemoteError(
-                'Non-absolute object tree base path configuration')
+                'Non-absolute object tree base path configuration: %s'
+                '' % str(self.objtree_base_path))
 
         # for now still accept the configs, if no ria-URL is known:
         if not self.ria_store_url:

--- a/datalad/customremotes/ria_remote.py
+++ b/datalad/customremotes/ria_remote.py
@@ -231,8 +231,8 @@ class SSHRemoteIO(IOBase):
     """
 
     # output markers to detect possible command failure as well as end of output from a particular command:
-    REMOTE_CMD_FAIL = "ria-remote: end - fail"
-    REMOTE_CMD_OK = "ria-remote: end - ok"
+    REMOTE_CMD_FAIL = "ora-remote: end - fail"
+    REMOTE_CMD_OK = "ora-remote: end - ok"
 
     def __init__(self, host):
         """
@@ -577,10 +577,10 @@ class RIARemote(SpecialRemote):
         # Whether or not to force writing to the remote. Currently used to overrule write protection due to layout
         # version mismatch.
         self.force_write = _get_gitcfg(
-            gitdir, 'annex.ria-remote.{}.force-write'.format(name))
+            gitdir, 'annex.ora-remote.{}.force-write'.format(name))
 
         # whether to ignore config flags set at the remote end
-        self.ignore_remote_config = _get_gitcfg(gitdir, 'annex.ria-remote.{}.ignore-remote-config'.format(name))
+        self.ignore_remote_config = _get_gitcfg(gitdir, 'annex.ora-remote.{}.ignore-remote-config'.format(name))
 
     def _verify_config(self, gitdir, fail_noid=True):
         # try loading all needed info from (git) config
@@ -715,7 +715,7 @@ class RIARemote(SpecialRemote):
 
         read_only_msg = "Setting remote to read-only usage in order to prevent damage by putting things into an " \
                         "unknown version of the target layout. You can overrule this by configuring " \
-                        "'annex.ria-remote.<name>.force-write'."
+                        "'annex.ora-remote.<name>.force-write'."
 
         # 1. check dataset tree version
         try:
@@ -723,7 +723,7 @@ class RIARemote(SpecialRemote):
             if self.remote_dataset_tree_version not in self.known_versions_dst:
                 # Note: In later versions, condition might change in order to deal with older versions
                 self._info("Remote dataset tree reports version {}. Supported versions are: {}. Consider upgrading "
-                           "git-annex-ria-remote or fix the structure on the remote end."
+                           "datalad or fix the structure on the remote end."
                            "".format(self.remote_dataset_tree_version, self.known_versions_dst))
                 self._set_read_only(read_only_msg)
 
@@ -740,7 +740,7 @@ class RIARemote(SpecialRemote):
             else:
                 # directory is there, but no version file. We don't know what that is. Treat the same way as if there
                 # was an unknown version on record
-                self._info("Remote doesn't report any dataset tree version. Consider upgrading git-annex-ria-remote or "
+                self._info("Remote doesn't report any dataset tree version. Consider upgrading datalad or "
                            "fix the structure on the remote end.")
                 self._set_read_only(read_only_msg)
 
@@ -749,7 +749,7 @@ class RIARemote(SpecialRemote):
             self.remote_object_tree_version = self._get_version_config(object_tree_version_file)
             if self.remote_object_tree_version not in self.known_versions_objt:
                 self._info("Remote object tree reports version {}. Supported versions are {}. Consider upgrading "
-                           "git-annex-ria-remote.".format(self.remote_object_tree_version, self.known_versions_objt))
+                           "datalad.".format(self.remote_object_tree_version, self.known_versions_objt))
                 self._set_read_only(read_only_msg)
         except (RemoteError, FileNotFoundError):
             if not self.io.exists(object_tree_version_file.parent):
@@ -758,7 +758,7 @@ class RIARemote(SpecialRemote):
                 self.io.mkdir(object_tree_version_file.parent / 'archives')
                 self.io.write_file(object_tree_version_file, self.object_tree_version + '\n')
             else:
-                self._info("Remote doesn't report any object tree version. Consider upgrading git-annex-ria-remote or "
+                self._info("Remote doesn't report any object tree version. Consider upgrading datalad or "
                            "fix the structure on the remote end.")
                 self._set_read_only(read_only_msg)
 
@@ -800,7 +800,7 @@ class RIARemote(SpecialRemote):
     def transfer_store(self, key, filename):
         if self.read_only:
             raise RemoteError("Remote was set to read-only. "
-                              "Configure 'ria-remote.<name>.force-write' to overrule this.")
+                              "Configure 'ora-remote.<name>.force-write' to overrule this.")
 
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         key_path = dsobj_dir / key_path
@@ -816,7 +816,7 @@ class RIARemote(SpecialRemote):
         # checkpresent fail while the transfer is still in progress
         # and furthermore not interfere with administrative tasks in annex/objects
         # In addition include uuid, to not interfere with parallel uploads from different remotes
-        transfer_dir = self.remote_git_dir / "ria-remote-{}".format(self.uuid) / "transfer"
+        transfer_dir = self.remote_git_dir / "ora-remote-{}".format(self.uuid) / "transfer"
         self.io.mkdir(transfer_dir)
         tmp_path = transfer_dir / key
 
@@ -868,7 +868,7 @@ class RIARemote(SpecialRemote):
     def remove(self, key):
         if self.read_only:
             raise RIARemoteError("Remote was set to read-only. "
-                                 "Configure 'ria-remote.<name>.force-write' to overrule this.")
+                                 "Configure 'ora-remote.<name>.force-write' to overrule this.")
 
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         key_path = dsobj_dir / key_path

--- a/datalad/customremotes/tests/ria_utils.py
+++ b/datalad/customremotes/tests/ria_utils.py
@@ -1,0 +1,100 @@
+import os
+import inspect
+from glob import glob
+from pathlib import Path
+from functools import wraps
+from six import iteritems
+
+from datalad.tests.utils import (
+    create_tree,
+)
+
+from nose import SkipTest
+from nose.plugins.attrib import attr
+
+example_payload = {
+    'one.txt': 'content1',
+    'subdir': {
+        'two': 'content2',
+    },
+}
+
+
+def get_all_files(path):
+    return sorted([
+        Path(p).relative_to(path)
+        for p in glob(str(Path(path) / '**'), recursive=True)
+        if not Path(p).is_dir()
+    ])
+
+
+# TODO think about migrating to AnnexRepo
+def initremote(repo, name, encryption=None, config=None):
+    cfg = dict(config) if config else {}
+    cfg['encryption'] = encryption if encryption else 'none'
+    args = [name]
+    args += ['{}={}'.format(k, v) for k, v in iteritems(cfg)]
+    repo._run_annex_command(
+        'initremote',
+        annex_options=args,
+    )
+
+
+def initexternalremote(repo, name, type, encryption=None, config=None):
+    config = dict(
+        config if config else {},
+        type='external',
+        externaltype=type,
+    )
+    return initremote(repo, name, encryption=encryption, config=config)
+
+
+def setup_archive_remote(repo, archive_path):
+    if 'RIA_TESTS_SSH' in os.environ:
+        cfg = {'url': 'ria+ssh://datalad-test{}'.format(archive_path)}
+    else:
+        cfg = {'url': 'ria+file://{}'.format(archive_path)}
+    initexternalremote(repo, 'archive', 'ria', config=cfg)
+
+
+def populate_dataset(ds):
+    create_tree(ds.path, example_payload)
+
+
+def check_not_generatorfunction(func):
+    """Internal helper to verify that we are not decorating generator tests"""
+    if inspect.isgeneratorfunction(func):
+        raise RuntimeError("{}: must not be decorated, is a generator test"
+                           .format(func.__name__))
+
+
+def skip_ssh(func):
+    """Skips SSH-based tests if environment variable RIA_TESTS_SSH was not set
+    """
+
+    check_not_generatorfunction(func)
+
+    @wraps(func)
+    @attr('skip_ssh')
+    def newfunc(*args, **kwargs):
+        if 'RIA_TESTS_SSH' not in os.environ:
+            raise SkipTest("Disabled, set RIA_TESTS_SSH to run")
+        return func(*args, **kwargs)
+    return newfunc
+
+
+def skip_non_ssh(func):
+    """Skips non-SSH-based tests if environment variable RIA_TESTS_SSH was set
+
+    This is for test alternatives in order to blow runtime of SSH testing with tests that ran in other test builds.
+    """
+
+    check_not_generatorfunction(func)
+
+    @wraps(func)
+    @attr('skip_ssh')
+    def newfunc(*args, **kwargs):
+        if 'RIA_TESTS_SSH' in os.environ:
+            raise SkipTest("Disabled, since RIA_TESTS_SSH is set")
+        return func(*args, **kwargs)
+    return newfunc

--- a/datalad/customremotes/tests/ria_utils.py
+++ b/datalad/customremotes/tests/ria_utils.py
@@ -50,6 +50,9 @@ def initexternalremote(repo, name, type, encryption=None, config=None):
 
 
 def setup_archive_remote(repo, archive_path):
+
+    # for integration in a URL, we need POSIX version of the path
+    archive_path = Path(archive_path).as_posix()
     if 'RIA_TESTS_SSH' in os.environ:
         cfg = {'url': 'ria+ssh://datalad-test{}'.format(archive_path)}
     else:

--- a/datalad/customremotes/tests/ria_utils.py
+++ b/datalad/customremotes/tests/ria_utils.py
@@ -1,10 +1,11 @@
 import os
 import inspect
 from glob import glob
-from pathlib import Path
 from functools import wraps
 from six import iteritems
 
+
+from datalad.utils import Path
 from datalad.tests.utils import (
     create_tree,
 )
@@ -52,11 +53,12 @@ def initexternalremote(repo, name, type, encryption=None, config=None):
 def setup_archive_remote(repo, archive_path):
 
     # for integration in a URL, we need POSIX version of the path
-    archive_path = Path(archive_path).as_posix()
+    archive_path = Path(archive_path)
+
     if 'RIA_TESTS_SSH' in os.environ:
-        cfg = {'url': 'ria+ssh://datalad-test{}'.format(archive_path)}
+        cfg = {'url': 'ria+ssh://datalad-test{}'.format(archive_path.as_posix())}
     else:
-        cfg = {'url': 'ria+file://{}'.format(archive_path)}
+        cfg = {'url': 'ria+{}'.format(archive_path.as_uri())}
     initexternalremote(repo, 'archive', 'ria', config=cfg)
 
 

--- a/datalad/customremotes/tests/ria_utils.py
+++ b/datalad/customremotes/tests/ria_utils.py
@@ -50,8 +50,9 @@ def setup_archive_remote(repo, archive_path):
     # for integration in a URL, we need POSIX version of the path
     archive_path = Path(archive_path)
 
-    if 'RIA_TESTS_SSH' in os.environ:
-        cfg = {'url': 'ria+ssh://datalad-test{}'.format(archive_path.as_posix())}
+    if 'DATALAD_TESTS_SSH' in os.environ:
+        cfg = {'url': 'ria+ssh://datalad-test{}'
+                      ''.format(archive_path.as_posix())}
     else:
         cfg = {'url': 'ria+{}'.format(archive_path.as_uri())}
     initexternalremote(repo, 'archive', 'ria', config=cfg)
@@ -68,25 +69,12 @@ def check_not_generatorfunction(func):
                            .format(func.__name__))
 
 
-def skip_ssh(func):
-    """Skips SSH-based tests if environment variable RIA_TESTS_SSH was not set
-    """
-
-    check_not_generatorfunction(func)
-
-    @wraps(func)
-    @attr('skip_ssh')
-    def newfunc(*args, **kwargs):
-        if 'RIA_TESTS_SSH' not in os.environ:
-            raise SkipTest("Disabled, set RIA_TESTS_SSH to run")
-        return func(*args, **kwargs)
-    return newfunc
-
-
 def skip_non_ssh(func):
-    """Skips non-SSH-based tests if environment variable RIA_TESTS_SSH was set
+    """Skips non-SSH-based tests if environment variable DATALAD_TESTS_SSH was
+    set
 
-    This is for test alternatives in order to blow runtime of SSH testing with tests that ran in other test builds.
+    This is for test alternatives in order to blow runtime of SSH testing with
+    tests that ran in other test builds.
     """
 
     check_not_generatorfunction(func)
@@ -94,7 +82,7 @@ def skip_non_ssh(func):
     @wraps(func)
     @attr('skip_ssh')
     def newfunc(*args, **kwargs):
-        if 'RIA_TESTS_SSH' in os.environ:
-            raise SkipTest("Disabled, since RIA_TESTS_SSH is set")
+        if 'DATALAD_TESTS_SSH' in os.environ:
+            raise SkipTest("Disabled, since DATALAD_TESTS_SSH is set")
         return func(*args, **kwargs)
     return newfunc

--- a/datalad/customremotes/tests/ria_utils.py
+++ b/datalad/customremotes/tests/ria_utils.py
@@ -29,16 +29,11 @@ def get_all_files(path):
     ])
 
 
-# TODO think about migrating to AnnexRepo
 def initremote(repo, name, encryption=None, config=None):
     cfg = dict(config) if config else {}
     cfg['encryption'] = encryption if encryption else 'none'
-    args = [name]
-    args += ['{}={}'.format(k, v) for k, v in iteritems(cfg)]
-    repo._run_annex_command(
-        'initremote',
-        annex_options=args,
-    )
+    args = ['{}={}'.format(k, v) for k, v in iteritems(cfg)]
+    repo.init_remote(name, args)
 
 
 def initexternalremote(repo, name, type, encryption=None, config=None):

--- a/datalad/customremotes/tests/ria_utils.py
+++ b/datalad/customremotes/tests/ria_utils.py
@@ -55,7 +55,7 @@ def setup_archive_remote(repo, archive_path):
                       ''.format(archive_path.as_posix())}
     else:
         cfg = {'url': 'ria+{}'.format(archive_path.as_uri())}
-    initexternalremote(repo, 'archive', 'ria', config=cfg)
+    initexternalremote(repo, 'archive', 'ora', config=cfg)
 
 
 def populate_dataset(ds):

--- a/datalad/customremotes/tests/test_ria_basics.py
+++ b/datalad/customremotes/tests/test_ria_basics.py
@@ -1,0 +1,186 @@
+from pathlib import Path
+import shutil
+import subprocess
+import logging
+from datalad.interface.results import annexjson2result
+from datalad.api import (
+    create,
+)
+
+from datalad.utils import (
+    swallow_logs
+)
+from datalad.tests.utils import (
+    assert_raises,
+    assert_repo_status,
+    assert_status,
+    eq_,
+    with_tempfile,
+)
+
+from datalad.support.exceptions import (
+    IncompleteResultsError
+)
+
+from datalad.customremotes.tests.ria_utils import (
+    get_all_files,
+    initremote,
+    initexternalremote,
+    populate_dataset,
+    setup_archive_remote,
+)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+def test_archive_layout(path, objtree, archivremote):
+    ds = create(path)
+    setup_archive_remote(ds.repo, objtree)
+    populate_dataset(ds)
+    ds.save()
+    assert_repo_status(ds.path)
+
+    # copy files into the RIA archive
+    ds.repo.copy_to('.', 'archive')
+
+    # we should see the exact same annex object tree
+    arxiv_files = get_all_files(objtree)
+    # anything went there at all?
+    assert len(arxiv_files) > 1
+    # minus the two layers for the archive path the content is identically
+    # structured, except for the two additional version files at the root of the entire tree and at the dataset level
+    assert len([p for p in arxiv_files if p.name == 'ria-layout-version']) == 2
+
+    eq_(
+        sorted([p.parts[-4:] for p in arxiv_files if p.name != 'ria-layout-version']),
+        # Note: datalad-master has ds.repo.dot_git Path object. Not in 0.12.0rc6 though. This would
+        # also resolve .git-files, which pathlib obv. can't. If we test more sophisticated structures, we'd need to
+        # account for that
+        sorted([p.parts for p in get_all_files(ds.pathobj / '.git' / 'annex' / 'objects')])
+    )
+
+    # we can simply pack up the content of the directory remote into a
+    # 7z archive and place it in the right location to get a functional
+    # special remote
+    whereis = ds.repo.whereis('one.txt')
+    targetpath = Path(archivremote) / ds.id[:3] / ds.id[3:] / 'archives'
+    ds.ria_export_archive(targetpath / 'archive.7z')
+    initexternalremote(ds.repo, '7z', 'ria', config={'base-path': archivremote})
+    # now fsck the new remote to get the new special remote indexed
+    ds.repo.fsck(remote='7z', fast=True)
+    eq_(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+def test_backup_archive(path, objtree, archivremote):
+    """Similar to test_archive_layout(), but not focused on
+    compatibility with the directory-type special remote. Instead,
+    it tests build a second RIA remote from an existing one, e.g.
+    for backup purposes.
+    """
+    ds = create(path)
+    setup_archive_remote(ds.repo, objtree)
+    populate_dataset(ds)
+    ds.save()
+    assert_repo_status(ds.path)
+
+    # copy files into the RIA archive
+    ds.repo.copy_to('.', 'archive')
+
+    targetpath = Path(archivremote) / ds.id[:3] / ds.id[3:] / 'archives'
+    targetpath.mkdir(parents=True)
+    subprocess.run(
+        ['7z', 'u', str(targetpath / 'archive.7z'), '.'],
+        cwd=str(Path(objtree) / ds.id[:3] / ds.id[3:] / 'annex' / 'objects'),
+    )
+    initexternalremote(ds.repo, '7z', 'ria', config={'base-path': archivremote})
+    # wipe out the initial RIA remote (just for testing if the upcoming
+    # one can fully take over)
+    shutil.rmtree(objtree)
+    # fsck to make git-annex aware of the loss
+    assert_status(
+        'error',
+        [annexjson2result(r, ds)
+         for r in ds.repo.fsck(remote='archive', fast=True)])
+    # now only available "here"
+    eq_(len(ds.repo.whereis('one.txt')), 1)
+
+    # make the backup archive known
+    initexternalremote(
+        ds.repo, 'backup', 'ria', config={'base-path': archivremote})
+    # now fsck the new remote to get the new special remote indexed
+    assert_status(
+        'ok',
+        [annexjson2result(r, ds)
+         for r in ds.repo.fsck(remote='backup', fast=True)])
+    eq_(len(ds.repo.whereis('one.txt')), 2)
+
+    # now we can drop all content locally, reobtain it, and survive an
+    # fsck
+    ds.drop('.')
+    ds.get('.')
+    assert_status('ok', [annexjson2result(r, ds) for r in ds.repo.fsck()])
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_version_check(path, objtree):
+
+    ds = create(path)
+    setup_archive_remote(ds.repo, objtree)
+    populate_dataset(ds)
+    ds.save()
+    assert_repo_status(ds.path)
+
+    remote_ds_tree_version_file = Path(objtree) / 'ria-layout-version'
+    remote_obj_tree_version_file = Path(objtree) / ds.id[:3] / ds.id[3:] / 'ria-layout-version'
+
+    # Those files are not yet there
+    assert not remote_ds_tree_version_file.exists()
+    assert not remote_obj_tree_version_file.exists()
+
+    # Now copy everything to remote. This should create the structure including those version files
+    ds.repo.copy_to('.', 'archive')
+    assert remote_ds_tree_version_file.exists()
+    assert remote_obj_tree_version_file.exists()
+
+    # Currently the content of booth should be "2"
+    with open(str(remote_ds_tree_version_file), 'r') as f:
+        eq_(f.read().strip(), '1')
+    with open(str(remote_obj_tree_version_file), 'r') as f:
+        eq_(f.read().strip(), '2')
+
+    # Accessing the remote should not yield any output regarding versioning, since it's the "correct" version
+    # Note that "fsck" is an arbitrary choice. We need just something to talk to the special remote
+    with swallow_logs(new_level=logging.INFO) as cml:
+        ds.repo.fsck(remote='archive', fast=True)
+        assert not cml.out  # TODO: For some reason didn't get cml.assert_logged to assert "nothing was logged"
+
+    # Now fake-change the version
+    with open(str(remote_obj_tree_version_file), 'w') as f:
+        f.write('X\n')
+
+    # Now we should see a message about it
+    with swallow_logs(new_level=logging.INFO) as cml:
+        ds.repo.fsck(remote='archive', fast=True)
+        cml.assert_logged(level="INFO", msg="Remote object tree reports version X", regex=False)
+        cml.assert_logged(level="INFO", msg="Setting remote to read-only usage", regex=False)
+
+    # reading still works:
+    ds.drop('.')
+    assert_status('ok', ds.get('.'))
+
+    # but writing doesn't:
+    with open(str(Path(ds.path) / 'new_file'), 'w') as f:
+        f.write("arbitrary addition")
+    ds.save(message="Add a new_file")
+
+    # TODO: use self.annex.error and see whether we get an actual error result
+    assert_raises(IncompleteResultsError, ds.repo.copy_to, 'new_file', 'archive')
+
+    # However, we can force it by configuration
+    ds.config.add("annex.ria-remote.archive.force-write", "true", where='local')
+    ds.repo.copy_to('new_file', 'archive')

--- a/datalad/customremotes/tests/test_ria_basics.py
+++ b/datalad/customremotes/tests/test_ria_basics.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import shutil
 import subprocess
 import logging
@@ -8,6 +7,7 @@ from datalad.api import (
 )
 
 from datalad.utils import (
+    Path,
     swallow_logs
 )
 from datalad.tests.utils import (

--- a/datalad/customremotes/tests/test_ria_basics.py
+++ b/datalad/customremotes/tests/test_ria_basics.py
@@ -15,6 +15,7 @@ from datalad.tests.utils import (
     assert_repo_status,
     assert_status,
     eq_,
+    skip_if_on_windows,
     with_tempfile,
 )
 
@@ -31,6 +32,7 @@ from datalad.customremotes.tests.ria_utils import (
 )
 
 
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
@@ -72,6 +74,7 @@ def test_archive_layout(path, objtree, archivremote):
     eq_(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
 
 
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
@@ -125,6 +128,7 @@ def test_backup_archive(path, objtree, archivremote):
     assert_status('ok', [annexjson2result(r, ds) for r in ds.repo.fsck()])
 
 
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile()
 def test_version_check(path, objtree):

--- a/datalad/customremotes/tests/test_ria_basics.py
+++ b/datalad/customremotes/tests/test_ria_basics.py
@@ -68,7 +68,7 @@ def test_archive_layout(path, objtree, archivremote):
     whereis = ds.repo.whereis('one.txt')
     targetpath = Path(archivremote) / ds.id[:3] / ds.id[3:] / 'archives'
     ds.ria_export_archive(targetpath / 'archive.7z')
-    initexternalremote(ds.repo, '7z', 'ria', config={'base-path': archivremote})
+    initexternalremote(ds.repo, '7z', 'ora', config={'base-path': archivremote})
     # now fsck the new remote to get the new special remote indexed
     ds.repo.fsck(remote='7z', fast=True)
     eq_(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
@@ -99,7 +99,7 @@ def test_backup_archive(path, objtree, archivremote):
         ['7z', 'u', str(targetpath / 'archive.7z'), '.'],
         cwd=str(Path(objtree) / ds.id[:3] / ds.id[3:] / 'annex' / 'objects'),
     )
-    initexternalremote(ds.repo, '7z', 'ria', config={'base-path': archivremote})
+    initexternalremote(ds.repo, '7z', 'ora', config={'base-path': archivremote})
     # wipe out the initial RIA remote (just for testing if the upcoming
     # one can fully take over)
     shutil.rmtree(objtree)
@@ -113,7 +113,7 @@ def test_backup_archive(path, objtree, archivremote):
 
     # make the backup archive known
     initexternalremote(
-        ds.repo, 'backup', 'ria', config={'base-path': archivremote})
+        ds.repo, 'backup', 'ora', config={'base-path': archivremote})
     # now fsck the new remote to get the new special remote indexed
     assert_status(
         'ok',
@@ -186,5 +186,5 @@ def test_version_check(path, objtree):
     assert_raises(IncompleteResultsError, ds.repo.copy_to, 'new_file', 'archive')
 
     # However, we can force it by configuration
-    ds.config.add("annex.ria-remote.archive.force-write", "true", where='local')
+    ds.config.add("annex.ora-remote.archive.force-write", "true", where='local')
     ds.repo.copy_to('new_file', 'archive')

--- a/datalad/customremotes/tests/test_ria_config.py
+++ b/datalad/customremotes/tests/test_ria_config.py
@@ -5,6 +5,7 @@ import shutil
 from datalad.tests.utils import (
     assert_raises,
     assert_status,
+    skip_if_on_windows,
     with_tempfile,
 )
 from datalad.support.exceptions import CommandError
@@ -15,7 +16,10 @@ from datalad.customremotes.tests.ria_utils import (
     populate_dataset,
 )
 
+from datalad.utils import Path
 
+
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
@@ -55,6 +59,7 @@ def test_site_archive_location_config(path, objtree, objtree_alt):
     assert_status('ok', ds.get('.'))
 
 
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 @with_tempfile()
 @with_tempfile()
@@ -69,7 +74,8 @@ def test_site_archive_url_config(path, objtree, objtree_alt):
         config=None,
     )
     # specify archive location via URL + configured label (url...insteadOf) for reconfiguration
-    ds.config.set('url.ria+file://{}.insteadOf'.format(objtree), 'localstore:', where='local')
+    ds.config.set('url.ria+{}.insteadOf'.format(Path(objtree).as_uri()),
+                  'localstore:', where='local')
     initexternalremote(
         ds.repo, 'archive', 'ria', config={'url': 'localstore:'}
     )
@@ -88,7 +94,7 @@ def test_site_archive_url_config(path, objtree, objtree_alt):
     # relocate the archive on the system
     shutil.move(objtree, objtree_alt)
     # adjust the config -- doesn't touch committed content
-    ds.config.unset('url.ria+file://{}.insteadOf'.format(objtree), where='local')
-    ds.config.set('url.ria+file://{}.insteadOf'.format(objtree_alt), 'localstore:', where='local')
+    ds.config.unset('url.ria+{}.insteadOf'.format(Path(objtree).as_uri()), where='local')
+    ds.config.set('url.ria+{}.insteadOf'.format(Path(objtree_alt).as_uri()), 'localstore:', where='local')
     # remote continues to function normally after system reconfiguration
     assert_status('ok', ds.get('.'))

--- a/datalad/customremotes/tests/test_ria_config.py
+++ b/datalad/customremotes/tests/test_ria_config.py
@@ -1,0 +1,94 @@
+from datalad.api import (
+    create,
+)
+import shutil
+from datalad.tests.utils import (
+    assert_raises,
+    assert_status,
+    with_tempfile,
+)
+from datalad.support.exceptions import CommandError
+
+from datalad.customremotes.tests.ria_utils import (
+    get_all_files,
+    initexternalremote,
+    populate_dataset,
+)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+def test_site_archive_location_config(path, objtree, objtree_alt):
+    ds = create(path)
+    # needs base-path under all circumstances
+    assert_raises(
+        CommandError,
+        initexternalremote,
+        ds.repo, 'archive', 'ria',
+        config=None,
+    )
+    # specify archive location via config (could also be system-wide
+    # config setting, done locally here for a simple test setup)
+    ds.config.set('annex.ria-remote.archive.base-path', objtree, where='local')
+    initexternalremote(
+        ds.repo, 'archive', 'ria',
+    )
+    # put some stuff in and check if it flies
+    populate_dataset(ds)
+    ds.save()
+    ds.repo.copy_to('.', 'archive')
+    arxiv_files = get_all_files(objtree)
+    assert len(arxiv_files) > 1
+
+    # now simulate a site-wide reconfiguration (here done to the
+    # local git-repos config, but nothing that is committed or
+    # invokes 'enableremote'
+    # drop everything locally
+    assert_status('ok', ds.drop('.'))
+    # relocate the archive on the system
+    shutil.move(objtree, objtree_alt)
+    # adjust the config -- doesn't touch committed content
+    ds.config.set(
+        'annex.ria-remote.archive.base-path', objtree_alt, where='local')
+    # remote continues to function normally after system reconfiguration
+    assert_status('ok', ds.get('.'))
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+def test_site_archive_url_config(path, objtree, objtree_alt):
+    # same as test_site_archive_location_config but using an URL for configuration
+    ds = create(path)
+    # needs base-path under all circumstances
+    assert_raises(
+        CommandError,
+        initexternalremote,
+        ds.repo, 'archive', 'ria',
+        config=None,
+    )
+    # specify archive location via URL + configured label (url...insteadOf) for reconfiguration
+    ds.config.set('url.ria+file://{}.insteadOf'.format(objtree), 'localstore:', where='local')
+    initexternalremote(
+        ds.repo, 'archive', 'ria', config={'url': 'localstore:'}
+    )
+    # put some stuff in and check if it flies
+    populate_dataset(ds)
+    ds.save()
+    ds.repo.copy_to('.', 'archive')
+    arxiv_files = get_all_files(objtree)
+    assert len(arxiv_files) > 1
+
+    # now simulate a site-wide reconfiguration (here done to the
+    # local git-repos config, but nothing that is committed or
+    # invokes 'enableremote'
+    # drop everything locally
+    assert_status('ok', ds.drop('.'))
+    # relocate the archive on the system
+    shutil.move(objtree, objtree_alt)
+    # adjust the config -- doesn't touch committed content
+    ds.config.unset('url.ria+file://{}.insteadOf'.format(objtree), where='local')
+    ds.config.set('url.ria+file://{}.insteadOf'.format(objtree_alt), 'localstore:', where='local')
+    # remote continues to function normally after system reconfiguration
+    assert_status('ok', ds.get('.'))

--- a/datalad/customremotes/tests/test_ria_config.py
+++ b/datalad/customremotes/tests/test_ria_config.py
@@ -32,14 +32,14 @@ def test_site_archive_location_config(path, objtree, objtree_alt):
     assert_raises(
         CommandError,
         initexternalremote,
-        ds.repo, 'archive', 'ria',
+        ds.repo, 'archive', 'ora',
         config=None,
     )
     # specify archive location via config (could also be system-wide
     # config setting, done locally here for a simple test setup)
     ds.config.set('annex.ria-remote.archive.base-path', objtree, where='local')
     initexternalremote(
-        ds.repo, 'archive', 'ria',
+        ds.repo, 'archive', 'ora',
     )
     # put some stuff in and check if it flies
     populate_dataset(ds)
@@ -60,14 +60,14 @@ def test_site_archive_url_config(path, objtree, objtree_alt):
     assert_raises(
         CommandError,
         initexternalremote,
-        ds.repo, 'archive', 'ria',
+        ds.repo, 'archive', 'ora',
         config=None,
     )
     # specify archive location via URL + configured label (url...insteadOf) for reconfiguration
     ds.config.set('url.ria+{}.insteadOf'.format(Path(objtree).as_uri()),
                   'localstore:', where='local')
     initexternalremote(
-        ds.repo, 'archive', 'ria', config={'url': 'localstore:'}
+        ds.repo, 'archive', 'ora', config={'url': 'localstore:'}
     )
     # put some stuff in and check if it flies
     populate_dataset(ds)

--- a/datalad/customremotes/tests/test_ria_data_transfer.py
+++ b/datalad/customremotes/tests/test_ria_data_transfer.py
@@ -1,0 +1,62 @@
+from datalad.api import (
+    clone,
+)
+from datalad.utils import (
+    Path,
+)
+from datalad.tests.utils import (
+    skip_if_on_windows,
+    skip_ssh,
+    with_tempfile,
+)
+
+from datalad.customremotes.tests.ria_utils import (
+    skip_non_ssh,
+)
+
+
+@skip_non_ssh
+@skip_if_on_windows
+@with_tempfile
+@with_tempfile
+def test_binary_data_local(dspath, store):
+    # make sure, special remote deals with binary data and doesn't
+    # accidentally involve any decode/encode etc.
+
+    url = "https://github.com/psychoinformatics-de/studyforrest-data-phase2"
+    file = Path("sub-01/ses-movie/func/sub-01_ses-movie_task-movie_run-1_bold"
+                ".nii.gz")
+
+    ds = clone(url, dspath)
+    ds.get(file)
+
+    ds.create_sibling_ria("ria+{}".format(Path(store).as_uri()),
+                          "datastore")
+
+    ds.publish(to="datastore", transfer_data="all")
+    ds.drop(file)
+    ds.get(file, source="datastore-ria")
+
+
+@skip_ssh
+@skip_if_on_windows
+@with_tempfile
+@with_tempfile
+def test_binary_data_ssh(dspath, store):
+    # make sure, special remote deals with binary data and doesn't
+    # accidentally involve any decode/encode etc.
+
+    url = "https://github.com/psychoinformatics-de/studyforrest-data-phase2"
+    file = Path("sub-01/ses-movie/func/sub-01_ses-movie_task-movie_run-1_bold"
+                ".nii.gz")
+
+    ds = clone(url, dspath)
+    ds.get(file)
+
+    ds.create_sibling_ria("ria+ssh://localhost{}"
+                          "".format(Path(store).as_posix()),
+                          "datastore")
+
+    ds.publish(to="datastore", transfer_data="all")
+    ds.drop(file)
+    ds.get(file, source="datastore-ria")

--- a/datalad/customremotes/tests/test_ria_data_transfer.py
+++ b/datalad/customremotes/tests/test_ria_data_transfer.py
@@ -51,12 +51,12 @@ def test_binary_data_ssh(dspath, store):
                 ".nii.gz")
 
     ds = clone(url, dspath)
-    ds.get(file)
+    ds.get(str(file))
 
     ds.create_sibling_ria("ria+ssh://localhost{}"
                           "".format(Path(store).as_posix()),
                           "datastore")
 
     ds.publish(to="datastore", transfer_data="all")
-    ds.drop(file)
+    ds.drop(str(file))
     ds.get(file, source="datastore-ria")

--- a/datalad/customremotes/tests/test_ria_git_remote.py
+++ b/datalad/customremotes/tests/test_ria_git_remote.py
@@ -1,0 +1,209 @@
+from pathlib import Path
+import os.path as op
+import subprocess
+from datalad.interface.results import annexjson2result
+from datalad.api import (
+    create,
+)
+from datalad.tests.utils import (
+    assert_repo_status,
+    assert_result_count,
+    assert_status,
+    eq_,
+    serve_path_via_http,
+    SkipTest,
+    with_tempfile,
+)
+from datalad.customremotes.tests.ria_utils import (
+    initexternalremote,
+    populate_dataset,
+    skip_non_ssh
+)
+
+
+@skip_non_ssh  # superfluous in an SSH-run and annex-testremote is slow
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_bare_git(origin, remote_base_path):
+
+    remote_base_path = Path(remote_base_path)
+
+    # This test should take a dataset and create a bare repository at the remote end from it.
+    # Given, that it is placed correctly within a tree of dataset, that remote thing should then be usable as a
+    # ria-remote as well as as a git-type remote
+
+    ds = create(origin)
+    populate_dataset(ds)
+    ds.save()
+    assert_repo_status(ds.path)
+
+    # Use git to make sure the remote end is what git thinks a bare clone of it should look like
+    bare_repo_path = remote_base_path / ds.id[:3] / ds.id[3:]
+    subprocess.run(['git', 'clone', '--bare', origin, str(bare_repo_path)])
+
+    # Now, let's have the bare repo as a git remote and use it with annex
+    eq_(subprocess.run(['git', 'remote', 'add', 'bare-git', str(bare_repo_path)], cwd=origin).returncode,
+        0)
+    eq_(subprocess.run(['git', 'annex', 'enableremote', 'bare-git'], cwd=origin).returncode,
+        0)
+    eq_(subprocess.run(['git', 'annex', 'testremote', 'bare-git'], cwd=origin).returncode,
+        0)
+    # copy files to the remote
+    ds.repo.copy_to('.', 'bare-git')
+    eq_(len(ds.repo.whereis('one.txt')), 2)
+
+    # now we can drop all content locally, reobtain it, and survive an
+    # fsck
+    ds.drop('.')
+    ds.get('.')
+    assert_status('ok', [annexjson2result(r, ds) for r in ds.repo.fsck()])
+
+    # Since we created the remote this particular way instead of letting ria-remote create it, we need to put
+    # ria-layout-version files into it. Then we should be able to also add it as a ria-remote.
+    with open(str(remote_base_path / 'ria-layout-version'), 'w') as f:
+        f.write('1')
+    with open(str(bare_repo_path / 'ria-layout-version'), 'w') as f:
+        f.write('1')
+
+    # Now, add the ria remote:
+    initexternalremote(ds.repo, 'riaremote', 'ria', config={'base-path': str(remote_base_path)})
+    # fsck to make availability known
+    assert_status(
+        'ok',
+        [annexjson2result(r, ds)
+         for r in ds.repo.fsck(remote='riaremote', fast=True)])
+    eq_(len(ds.repo.whereis('one.txt')), 3)
+
+    # Now move content from git-remote to local and see it not being available via bare-git anymore
+    eq_(subprocess.run(['git', 'annex', 'move', '--all', '--from=bare-git'], cwd=origin).returncode,
+        0)
+    # ria-remote doesn't know yet:
+    eq_(len(ds.repo.whereis('one.txt')), 2)
+
+    # But after fsck it does:
+    fsck_res = [annexjson2result(r, ds) for r in ds.repo.fsck(remote='riaremote', fast=True)]
+    assert_result_count(fsck_res,
+                        1,
+                        status='error',
+                        message='** Based on the location log, one.txt\n** was expected to be present, '
+                                'but its content is missing.')
+    assert_result_count(fsck_res,
+                        1,
+                        status='error',
+                        message='** Based on the location log, subdir/two\n** was expected to be present, '
+                                'but its content is missing.')
+
+    eq_(len(ds.repo.whereis('one.txt')), 1)
+
+
+@with_tempfile
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+@with_tempfile
+@with_tempfile
+@with_tempfile(mkdir=True)
+def test_create_as_bare(origin, remote_base_path, remote_base_url, public, consumer, tmp_location):
+
+    # Note/TODO: Do we need things like:
+    #    git config receive.denyCurrentBranch updateInstead
+    #    mv .hooks/post-update.sample hooks/post-update
+    #    git update-server-info
+
+    # Test how we build a riaremote from an existing dataset, that is a bare git repo and can be accessed as a git type
+    # remote as well. This should basically outline how to publish to that kind of structure as a data store, that is
+    # autoenabled, so we can publish to github/gitlab and make that storage known.
+
+    remote_base_path = Path(remote_base_path)
+
+    ds = create(origin)
+    populate_dataset(ds)
+    ds.save()
+    assert_repo_status(ds.path)
+
+    # add the ria remote:
+    # Note: For serve_path_via_http to work (which we need later), the directory needs to already exist.
+    #       But by default RIARemote will reject to create the remote structure in an already existing directory,
+    #       that wasn't created by itself (lacks as ria-layout-version file).
+    #       So, we can either configure force-write here or put a version file in it beforehand.
+    #       However, this is specific to the test environment!
+    with open(str(remote_base_path / 'ria-layout-version'), 'w') as f:
+        f.write('1')
+    initexternalremote(ds.repo, 'riaremote', 'ria', config={'base-path': str(remote_base_path)})
+    # pretty much any annex command that talks to that remote should now trigger the actual creation on the remote end:
+    assert_status(
+        'ok',
+        [annexjson2result(r, ds)
+         for r in ds.repo.fsck(remote='riaremote', fast=True)])
+
+    remote_dataset_path = remote_base_path / ds.id[:3] / ds.id[3:]
+
+    assert remote_base_path.exists()
+    assert remote_dataset_path.exists()
+    ds.repo.copy_to('.', 'riaremote')
+
+    # Now, let's make the remote end a valid, bare git repository
+    eq_(subprocess.run(['git', 'init', '--bare'], cwd=str(remote_dataset_path)).returncode,
+        0)
+
+    #subprocess.run(['mv', 'hooks/post-update.sample', 'hooks/post-update'], cwd=remote_dataset_path)
+    #subprocess.run(['git', 'update-server-info'], cwd=remote_dataset_path)
+
+    # TODO: we might need "mv .hooks/post-update.sample hooks/post-update", "git update-server-info" as well
+    # add as git remote and push everything
+    eq_(subprocess.run(['git', 'remote', 'add', 'bare-git', str(remote_dataset_path)], cwd=origin).returncode,
+        0)
+    # Note: "--mirror" does the job for this test, while it might not be a good default some kind of
+    # datalad-create-sibling. However those things need to be configurable for actual publish/creation routine anyway
+    eq_(subprocess.run(['git', 'push', '--mirror', 'bare-git'], cwd=origin).returncode,
+        0)
+
+    # annex doesn't know the bare-git remote yet:
+    eq_(len(ds.repo.whereis('one.txt')), 2)
+    # But after enableremote and a fsck it does:
+    eq_(subprocess.run(['git', 'annex', 'enableremote', 'bare-git'], cwd=origin).returncode,
+        0)
+    assert_status(
+        'ok',
+        [annexjson2result(r, ds)
+         for r in ds.repo.fsck(remote='bare-git', fast=True)])
+    eq_(len(ds.repo.whereis('one.txt')), 3)
+
+    # we can drop and get again via 'bare-git' remote:
+    ds.drop('.')
+    eq_(len(ds.repo.whereis('one.txt')), 2)
+    eq_(subprocess.run(['git', 'annex', 'get', 'one.txt', '--from', 'bare-git'], cwd=origin).returncode,
+        0)
+    eq_(len(ds.repo.whereis('one.txt')), 3)
+    # let's get the other one from riaremote
+    eq_(len(ds.repo.whereis(op.join('subdir', 'two'))), 2)
+    eq_(subprocess.run(['git', 'annex', 'get', op.join('subdir', 'two'), '--from', 'riaremote'], cwd=origin).returncode,
+        0)
+    eq_(len(ds.repo.whereis(op.join('subdir', 'two'))), 3)
+
+    raise SkipTest("NOT YET DONE")
+    # TODO: Part below still doesn't work. "'storage' is not available" when trying to copy to it. May be the HTTP
+    # Server is not available from within the context of the git-type special remote? Either way, still smells like an
+    # issue with the f****** test setup.
+
+
+
+    # Now, let's try make it a data store for datasets available from elsewhere (like github or gitlab):
+    # For this test, we need a second git remote pointing to remote_dataset_path, but via HTTP.
+    # This is because annex-initremote for a git-type special remote requires a git remote pointing to the same location
+    # and it fails to match local paths. Also doesn't work with file:// scheme.
+    #
+    # TODO: Figure it out in detail. That issue is either a bug or not "real".
+    #
+    # ds.repo._allow_local_urls()
+    # dataset_url = remote_base_url + ds.id[:3] + '/' + ds.id[3:] + '/'
+    # eq_(subprocess.run(['git', 'remote', 'add', 'datasrc', dataset_url],
+    #                    cwd=origin).returncode,
+    #     0)
+    # eq_(subprocess.run(['git', 'annex', 'initremote', 'storage',  'type=git',
+    #                     'location={}'.format(dataset_url), 'autoenable=true'],
+    #                    cwd=origin).returncode,
+    #     0)
+    # assert_status(
+    #     'ok',
+    #     [annexjson2result(r, ds)
+    #      for r in fsck(ds.repo, remote='storage', fast=True)])

--- a/datalad/customremotes/tests/test_ria_git_remote.py
+++ b/datalad/customremotes/tests/test_ria_git_remote.py
@@ -11,6 +11,7 @@ from datalad.tests.utils import (
     assert_status,
     eq_,
     serve_path_via_http,
+    skip_if_on_windows,
     SkipTest,
     with_tempfile,
 )
@@ -21,6 +22,7 @@ from datalad.customremotes.tests.ria_utils import (
 )
 
 
+@skip_if_on_windows
 @skip_non_ssh  # superfluous in an SSH-run and annex-testremote is slow
 @with_tempfile(mkdir=True)
 @with_tempfile()
@@ -96,6 +98,7 @@ def test_bare_git(origin, remote_base_path):
     eq_(len(ds.repo.whereis('one.txt')), 1)
 
 
+@skip_if_on_windows
 @with_tempfile
 @with_tempfile(mkdir=True)
 @serve_path_via_http

--- a/datalad/customremotes/tests/test_ria_git_remote.py
+++ b/datalad/customremotes/tests/test_ria_git_remote.py
@@ -68,7 +68,7 @@ def test_bare_git(origin, remote_base_path):
         f.write('1')
 
     # Now, add the ria remote:
-    initexternalremote(ds.repo, 'riaremote', 'ria', config={'base-path': str(remote_base_path)})
+    initexternalremote(ds.repo, 'riaremote', 'ora', config={'base-path': str(remote_base_path)})
     # fsck to make availability known
     assert_status(
         'ok',
@@ -131,7 +131,7 @@ def test_create_as_bare(origin, remote_base_path, remote_base_url, public, consu
     #       However, this is specific to the test environment!
     with open(str(remote_base_path / 'ria-layout-version'), 'w') as f:
         f.write('1')
-    initexternalremote(ds.repo, 'riaremote', 'ria', config={'base-path': str(remote_base_path)})
+    initexternalremote(ds.repo, 'riaremote', 'ora', config={'base-path': str(remote_base_path)})
     # pretty much any annex command that talks to that remote should now trigger the actual creation on the remote end:
     assert_status(
         'ok',

--- a/datalad/customremotes/tests/test_ria_gitannex.py
+++ b/datalad/customremotes/tests/test_ria_gitannex.py
@@ -4,10 +4,12 @@ from datalad.api import (
 from datalad.tests.utils import with_tempfile
 
 from datalad.utils import Path
-from datalad.tests.utils import skip_if_on_windows
+from datalad.tests.utils import (
+    skip_if_on_windows,
+    skip_ssh,
+)
 from datalad.customremotes.tests.ria_utils import (
     initexternalremote,
-    skip_ssh,
     skip_non_ssh,
 )
 

--- a/datalad/customremotes/tests/test_ria_gitannex.py
+++ b/datalad/customremotes/tests/test_ria_gitannex.py
@@ -1,0 +1,40 @@
+from datalad.api import (
+    create,
+)
+from datalad.tests.utils import with_tempfile
+
+from datalad.customremotes.tests.ria_utils import (
+    initexternalremote,
+    skip_ssh,
+    skip_non_ssh,
+)
+
+
+@skip_non_ssh  # superfluous in an SSH-run and annex-testremote is slow
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_gitannex_localio_url(path, objtree):
+    ds = create(path)
+    initexternalremote(
+        ds.repo, 'ria-local', 'ria',
+        config={'url': "ria+file://{}".format(objtree)})
+    ds.repo._run_annex_command(
+        'testremote',
+        annex_options=['ria-local'],
+        log_stdout=False,
+    )
+
+
+@skip_ssh
+@with_tempfile(mkdir=True)
+@with_tempfile()
+def test_gitannex_remoteio_url(path, objtree):
+    ds = create(path)
+    initexternalremote(
+        ds.repo, 'ria-remote', 'ria',
+        config={'url': "ria+ssh://datalad-test:{}".format(objtree)})
+    ds.repo._run_annex_command(
+        'testremote',
+        annex_options=['ria-remote'],
+        log_stdout=False,
+    )

--- a/datalad/customremotes/tests/test_ria_gitannex.py
+++ b/datalad/customremotes/tests/test_ria_gitannex.py
@@ -7,7 +7,7 @@ from datalad.utils import Path
 from datalad.tests.utils import (
     skip_if_on_windows,
     skip_ssh,
-    slow
+    turtle
 )
 from datalad.customremotes.tests.ria_utils import (
     initexternalremote,
@@ -31,7 +31,7 @@ def test_gitannex_localio_url(path, objtree):
     )
 
 
-@slow
+@turtle
 @skip_if_on_windows
 @skip_ssh
 @with_tempfile(mkdir=True)

--- a/datalad/customremotes/tests/test_ria_gitannex.py
+++ b/datalad/customremotes/tests/test_ria_gitannex.py
@@ -7,6 +7,7 @@ from datalad.utils import Path
 from datalad.tests.utils import (
     skip_if_on_windows,
     skip_ssh,
+    slow
 )
 from datalad.customremotes.tests.ria_utils import (
     initexternalremote,
@@ -30,6 +31,7 @@ def test_gitannex_localio_url(path, objtree):
     )
 
 
+@slow
 @skip_if_on_windows
 @skip_ssh
 @with_tempfile(mkdir=True)

--- a/datalad/customremotes/tests/test_ria_gitannex.py
+++ b/datalad/customremotes/tests/test_ria_gitannex.py
@@ -3,6 +3,8 @@ from datalad.api import (
 )
 from datalad.tests.utils import with_tempfile
 
+from datalad.utils import Path
+from datalad.tests.utils import skip_if_on_windows
 from datalad.customremotes.tests.ria_utils import (
     initexternalremote,
     skip_ssh,
@@ -10,6 +12,7 @@ from datalad.customremotes.tests.ria_utils import (
 )
 
 
+@skip_if_on_windows
 @skip_non_ssh  # superfluous in an SSH-run and annex-testremote is slow
 @with_tempfile(mkdir=True)
 @with_tempfile()
@@ -17,7 +20,7 @@ def test_gitannex_localio_url(path, objtree):
     ds = create(path)
     initexternalremote(
         ds.repo, 'ria-local', 'ria',
-        config={'url': "ria+file://{}".format(objtree)})
+        config={'url': "ria+{}".format(Path(objtree).as_uri())})
     ds.repo._run_annex_command(
         'testremote',
         annex_options=['ria-local'],
@@ -25,6 +28,7 @@ def test_gitannex_localio_url(path, objtree):
     )
 
 
+@skip_if_on_windows
 @skip_ssh
 @with_tempfile(mkdir=True)
 @with_tempfile()

--- a/datalad/customremotes/tests/test_ria_gitannex.py
+++ b/datalad/customremotes/tests/test_ria_gitannex.py
@@ -22,7 +22,7 @@ from datalad.customremotes.tests.ria_utils import (
 def test_gitannex_localio_url(path, objtree):
     ds = create(path)
     initexternalremote(
-        ds.repo, 'ria-local', 'ria',
+        ds.repo, 'ria-local', 'ora',
         config={'url': "ria+{}".format(Path(objtree).as_uri())})
     ds.repo._run_annex_command(
         'testremote',
@@ -39,7 +39,7 @@ def test_gitannex_localio_url(path, objtree):
 def test_gitannex_remoteio_url(path, objtree):
     ds = create(path)
     initexternalremote(
-        ds.repo, 'ria-remote', 'ria',
+        ds.repo, 'ria-remote', 'ora',
         config={'url': "ria+ssh://datalad-test:{}".format(objtree)})
     ds.repo._run_annex_command(
         'testremote',

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -359,7 +359,7 @@ def _create_sibling_ria(
 
     # parse target URL
     try:
-        ssh_host, base_path = verify_ria_url(url, ds.config)
+        ssh_host, base_path, rewritten_url = verify_ria_url(url, ds.config)
     except ValueError as e:
         yield get_status_dict(
             status='error',

--- a/datalad/distributed/ria_utils.py
+++ b/datalad/distributed/ria_utils.py
@@ -69,4 +69,4 @@ def verify_ria_url(url, cfg):
     if protocol not in ['ssh', 'file']:
         raise ValueError("Unsupported protocol: %s" % protocol)
 
-    return url_ri.hostname if protocol == 'ssh' else None, url_ri.path
+    return url_ri.hostname if protocol == 'ssh' else None, url_ri.path, url

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -18,6 +18,7 @@ from datalad.tests.utils import (
     with_tempfile,
     with_tree,
 )
+from datalad.utils import Path
 from functools import wraps
 from nose.plugins.attrib import attr
 
@@ -85,6 +86,14 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     eq_({'here'}, {s['name'] for s in sub_siblings})
 
     # TODO: post-update hook was enabled
+
+    # check bare repo:
+    git_config = Path(base_path) / ds.id[:3] / ds.id[3:] / 'config'
+    assert git_config.exists()
+    content = git_config.read_text()
+    assert_in("[datalad \"ria-remote\"]", content)
+    super_uuid = ds.config.get("remote.{}.annex-uuid".format('datastore-ria'))
+    assert_in("uuid = {}".format(super_uuid), content)
 
     # implicit test of success by ria-installing from store:
     ds.publish(to="datastore", transfer_data='all')

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -66,7 +66,6 @@ def test_invalid_calls(path):
             'sub': {'other.txt': 'other'}})
 @with_tempfile(mkdir=True)
 def _test_create_store(host, base_path, ds_path, clone_path):
-    skip_if_no_module("ria_remote")  # special remote needs to be installed
 
     ds = Dataset(ds_path).create(force=True)
 

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -57,7 +57,7 @@ def test_invalid_calls(path):
 
     # same name for git- and special remote:
     assert_raises(ValueError, ds.create_sibling_ria, 'ria+file:///some/where',
-                  name='some', ria_remote_name='some')
+                  name='some', ora_remote_name='some')
 
 
 @skip_if_on_windows  # running into short path issues; same as gh-4131
@@ -91,7 +91,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     git_config = Path(base_path) / ds.id[:3] / ds.id[3:] / 'config'
     assert git_config.exists()
     content = git_config.read_text()
-    assert_in("[datalad \"ria-remote\"]", content)
+    assert_in("[datalad \"ora-remote\"]", content)
     super_uuid = ds.config.get("remote.{}.annex-uuid".format('datastore-ria'))
     assert_in("uuid = {}".format(super_uuid), content)
 

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -74,6 +74,8 @@ _group_misc = (
         ('datalad.core.local.run', 'Run', 'run'),
         ('datalad.interface.rerun', 'Rerun', 'rerun'),
         ('datalad.interface.run_procedure', 'RunProcedure', 'run-procedure'),
+        ('datalad.customremotes.ria_export_archive', 'RIAExportArchive',
+         'ria-export-archive')
     ])
 
 _group_plumbing = (

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1977,6 +1977,12 @@ def slow(f):
     return attr('slow')(f)
 
 
+def turtle(f):
+    """Mark test as very slow, meaning to not run it on Travis due to its
+    time limit"""
+    return attr('turtle')(f)
+
+
 def usecase(f):
     """Mark test as a usecase user ran into and which (typically) caused bug report
     to be filed/troubleshooted

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -68,6 +68,7 @@ Miscellaneous commands
    generated/man/datalad-download-url
    generated/man/datalad-ls
    generated/man/datalad-test
+   generated/man/datalad-ria-export-archive
 
 
 Plugin commands

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requires = {
         'patool>=1.7',
         'tqdm',
         'wrapt',
+        'annexremote',
     ],
     'downloaders': [
         'boto',
@@ -130,6 +131,7 @@ setup_kwargs = setup_entry_points(
         'datalad': 'datalad.cmdline.main',
         'git-annex-remote-datalad-archives': 'datalad.customremotes.archives',
         'git-annex-remote-datalad': 'datalad.customremotes.datalad',
+        'git-annex-remote-ria': 'datalad.customremotes.ria_remote',
     })
 
 # normal entrypoints for the rest

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup_kwargs = setup_entry_points(
         'datalad': 'datalad.cmdline.main',
         'git-annex-remote-datalad-archives': 'datalad.customremotes.archives',
         'git-annex-remote-datalad': 'datalad.customremotes.datalad',
-        'git-annex-remote-ria': 'datalad.customremotes.ria_remote',
+        'git-annex-remote-ora': 'datalad.customremotes.ria_remote',
     })
 
 # normal entrypoints for the rest


### PR DESCRIPTION
Integrate RIA special remote and `ria-export-archive` command in datalad core.

- [x] move entire code base of https://github.com/datalad/git-annex-ria-remote to datalad core
- [ ] adapt some tests/utils to make use of what we have already
- [x] add test for binary data
- [x] change special remote config to be based on bare repo's config rather than actual user configs (idea appeared in context of PR #4124); this will need additional adapting `clone`, but in another PR.
- [ ] have a progressbar for transfer via special remote (done for get over SSH - note, that it's not actually implementing a progress *bar*, but reporting progress to annex, of course. It's a special remote.) More of that will have to wait until we're done with more essential parts.


Edit/Update:

New Plan. We need the special remote in master urgently on our side. As long as we don't break anything in core, a merge will only lead to make it easier to deal with RIA. Some of the things I still need to do require proper RF'ing first. So, strongly vote for merge - I'll open follow-up PRs instantly, that can be used for review etc. There need to be at least the following things to address in next PRs:

- RF to move the creation of the remote end (may include a separation of store creation from dataset creation)
- Find a spot for docs and update them (last step of moving into core - git-annex-ria-remote repo can be archived/deleted/ignored after that)
- Rework tests. Partially outdated and otherwise not nicely structured ATM.
- Move remote execution to the command abstraction classes
