### PR TITLE
[WIP] Looking into windows failure

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -1182,6 +1182,9 @@ def test_get_open_files(p):
     eq_(get_open_files(p), {})
     f1 = opj(p, '1')
     subd = opj(p, 'd')
+
+    # THIS TEST FAILS FOR WINDOWS SHORT PATHS 
+
     with open(f1) as f:
         # since lsof does not care about PWD env var etc, paths
         # will not contain symlinks, we better realpath them


### PR DESCRIPTION
Debugging seemingly unrelated windows failure in PR #4124 

```
File "C:\hostedtoolcache\windows\Python\3.7.6\x64\lib\site-packages\datalad\tests\test_utils.py", line 1206, in test_get_open_files
eq_(get_open_files(subd)[op.realpath(subd)].pid, proc.pid)
KeyError: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\datalad_temp_tree_vyg7mweq\\d'
```
Somewhat remarkable that it doesn't fail a line before.

