### PR TITLE
update: Support ff-only merges and merging parent revision

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -610,3 +610,150 @@ def test_merge_follow_parentds_subdataset_other_branch(path):
     ds_clone.update(merge=True, follow="parentds", recursive=True)
     if not on_adjusted:
         eq_(ds_clone.repo.get_hexsha(), ds_src.repo.get_hexsha())
+
+
+def _adjust(repo):
+    """Put `repo` into an adjusted branch, upgrading if needed.
+    """
+    # This can be removed once GIT_ANNEX_MIN_VERSION is at least
+    # 7.20190912.
+    if not repo.supports_unlocked_pointers:
+        repo.call_git(["annex", "upgrade"])
+        repo.config.reload(force=True)
+    repo.adjust()
+
+
+@with_tempfile(mkdir=True)
+def test_merge_follow_parentds_subdataset_adjusted_warning(path):
+    path = Path(path)
+
+    ds_src = Dataset(path / "source").create()
+    if ds_src.repo.is_managed_branch():
+        raise SkipTest(
+            "This test depends on the source repo being "
+            "an un-adjusted branch")
+
+    ds_src_subds = ds_src.create("subds")
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       recursive=True, result_xfm="datasets")
+    ds_clone_subds = Dataset(ds_clone.pathobj / "subds")
+    _adjust(ds_clone_subds.repo)
+    # Note: Were we to save ds_clone here, we would get a merge conflict in the
+    # top repo for the submodule (even if using 'git annex sync' rather than
+    # 'git merge').
+
+    ds_src_subds.repo.call_git(["checkout", "master^0"])
+    (ds_src_subds.pathobj / "foo").write_text("foo content")
+    ds_src.save(recursive=True)
+    assert_repo_status(ds_src.path)
+
+    assert_in_results(
+        ds_clone.update(merge=True, recursive=True, follow="parentds",
+                        on_failure="ignore"),
+        status="impossible",
+        path=ds_clone_subds.path,
+        action="update")
+    eq_(ds_clone.repo.get_hexsha(), ds_src.repo.get_hexsha())
+
+
+@with_tempfile(mkdir=True)
+def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
+    # Note: For the adjusted case, this is not much more than a smoke test that
+    # on an adjusted branch we fail sensibly. The resulting state is not easy
+    # to reason about nor desirable.
+    path = Path(path)
+    # $path/source/s0/s1
+    # The additional dataset level is to gain some confidence that this works
+    # for nested datasets.
+    ds_src = Dataset(path / "source").create()
+    if ds_src.repo.is_managed_branch():
+        if not on_adjusted:
+            raise SkipTest("System only supports adjusted branches. "
+                           "Skipping non-adjusted test")
+    ds_src_s0 = ds_src.create("s0")
+    ds_src_s1 = ds_src_s0.create("s1")
+    ds_src.save(recursive=True)
+    if on_adjusted:
+        # Note: We adjust after creating all the datasets above to avoid a bug
+        # fixed in git-annex 7.20191024, specifically bbdeb1a1a (sync: Fix
+        # crash when there are submodules and an adjusted branch is checked
+        # out, 2019-10-23).
+        for ds in [ds_src, ds_src_s0, ds_src_s1]:
+            _adjust(ds.repo)
+        ds_src.save(recursive=True)
+    assert_repo_status(ds_src.path)
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       recursive=True, result_xfm="datasets")
+    ds_clone_s1 = Dataset(ds_clone.pathobj / "s0" / "s1")
+
+    ds_src_s1.repo.checkout("master^0")
+    (ds_src_s1.pathobj / "foo").write_text("foo content")
+    ds_src.save(recursive=True)
+    assert_repo_status(ds_src.path)
+
+    res = ds_clone.update(merge=True, recursive=True, follow="parentds",
+                          on_failure="ignore")
+    if on_adjusted:
+        # The top-level update is okay because there is no parent revision to
+        # update to.
+        assert_in_results(
+            res,
+            status="ok",
+            path=ds_clone.path,
+            action="update")
+        # The subdataset, on the other hand, is impossible.
+        assert_in_results(
+            res,
+            status="impossible",
+            path=ds_clone_s1.path,
+            action="update")
+        return
+    assert_repo_status(ds_clone.path)
+
+    # We brought in the revision and got to the same state of the remote.
+    # Blind saving here without bringing in the current subdataset revision
+    # would have resulted in a new commit in ds_clone that reverting the
+    # last subdataset ID recorded in ds_src.
+    eq_(ds_clone.repo.get_hexsha(), ds_src.repo.get_hexsha())
+
+    # Record a revision in the parent and then move HEAD away from it so that
+    # the explicit revision fetch fails.
+    (ds_src_s1.pathobj / "bar").write_text("bar content")
+    ds_src.save(recursive=True)
+    ds_src_s1.repo.checkout(
+        ds_src_s1.repo.get_corresponding_branch("master"))
+    # This is the default, but just in case:
+    ds_src_s1.repo.config.set("uploadpack.allowAnySHA1InWant", "false",
+                              where="local")
+    res = ds_clone.update(merge=True, recursive=True, follow="parentds",
+                          on_failure="ignore")
+    # The fetch with the explicit ref fails because it isn't advertised.
+    assert_in_results(
+        res,
+        status="impossible",
+        path=ds_clone_s1.path,
+        action="update")
+
+    # Back to the detached head.
+    ds_src_s1.repo.checkout("HEAD@{1}")
+    # Set up a case where update() will not resolve the sibling.
+    ds_clone_s1.repo.call_git(["branch", "--unset-upstream"])
+    ds_clone_s1.config.reload(force=True)
+    ds_clone_s1.repo.call_git(["remote", "add", "other", ds_src_s1.path])
+    res = ds_clone.update(recursive=True, follow="parentds",
+                          on_failure="ignore")
+    # In this case, update() won't abort if we call with merge=False, but
+    # it does if the revision wasn't brought down in the `fetch(all_=True)`
+    # call.
+    assert_in_results(
+        res,
+        status="impossible",
+        path=ds_clone_s1.path,
+        action="update")
+
+
+def test_merge_follow_parentds_subdataset_detached():
+    yield check_merge_follow_parentds_subdataset_detached, True
+    yield check_merge_follow_parentds_subdataset_detached, False

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -103,8 +103,10 @@ class Update(Interface):
         merge=Parameter(
             args=("--merge",),
             action="store_true",
-            doc="""merge obtained changes from the given or the
-            default sibling""", ),
+            doc="""merge obtained changes from the sibling. If a sibling is not
+            explicitly given and there is only a single known sibling, that
+            sibling is used. Otherwise, an unspecified sibling defaults to the
+            configured remote for the current branch."""),
         follow=Parameter(
             args=("--follow",),
             constraints=EnsureChoice("sibling", "parentds"),

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -142,12 +142,14 @@ class Update(Interface):
                 res['status'] = 'notneeded'
                 yield res
                 continue
+            curr_branch = repo.get_active_branch()
             if not sibling and len(remotes) == 1:
                 # there is only one remote, must be this one
                 sibling_ = remotes[0]
             elif not sibling:
                 # nothing given, look for tracking branch
-                sibling_ = repo.get_tracking_branch(remote_only=True)[0]
+                sibling_ = repo.get_tracking_branch(
+                    branch=curr_branch, remote_only=True)[0]
             else:
                 sibling_ = sibling
             if sibling_ and sibling_ not in remotes:
@@ -180,7 +182,8 @@ class Update(Interface):
             if merge:
                 merge_fn = _choose_merge_fn(
                     repo,
-                    is_annex=is_annex)
+                    is_annex=is_annex,
+                    adjusted=is_annex and repo.is_managed_branch(curr_branch))
                 if is_annex and reobtain_data:
                     merge_fn = _reobtain(ds, merge_fn)
                 yield from merge_fn(repo, sibling_)
@@ -211,9 +214,16 @@ class Update(Interface):
 #  Merge functions
 
 
-def _choose_merge_fn(repo, is_annex=False):
-    if is_annex:
+def _choose_merge_fn(repo, is_annex=False, adjusted=False):
+    if adjusted and is_annex:
+        # For adjusted repos, blindly sync.
         merge_fn = _annex_sync
+    elif is_annex:
+        merge_fn = _annex_plain_merge
+    elif adjusted:
+        raise RuntimeError(
+            "bug: Upstream checks should make it impossible for "
+            "adjusted=True, is_annex=False")
     else:
         merge_fn = _pull
     return merge_fn
@@ -236,6 +246,14 @@ def _pull(repo, remote):
         else:
             # no marriage yet, be specific
             repo.pull(remote=remote, refspec=active_branch)
+    return []
+
+
+def _annex_plain_merge(repo, remote):
+    _pull(repo, remote)
+    # Note: Avoid repo.merge_annex() so we don't needlessly create synced/
+    # branches.
+    repo.call_git(["annex", "merge"])
     return []
 
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -143,13 +143,15 @@ class Update(Interface):
                 yield res
                 continue
             curr_branch = repo.get_active_branch()
+            tracking_remote = None
             if not sibling and len(remotes) == 1:
                 # there is only one remote, must be this one
                 sibling_ = remotes[0]
             elif not sibling:
                 # nothing given, look for tracking branch
-                sibling_ = repo.get_tracking_branch(
+                tracking_remote = repo.get_tracking_branch(
                     branch=curr_branch, remote_only=True)[0]
+                sibling_ = tracking_remote
             else:
                 sibling_ = sibling
             if sibling_ and sibling_ not in remotes:
@@ -180,13 +182,24 @@ class Update(Interface):
             repo = ds.repo
 
             if merge:
+                merge_target = _choose_merge_target(
+                    repo, curr_branch,
+                    sibling_, tracking_remote)
+
                 merge_fn = _choose_merge_fn(
                     repo,
                     is_annex=is_annex,
                     adjusted=is_annex and repo.is_managed_branch(curr_branch))
+
+                if merge_target is None and merge_fn is not _annex_sync:
+                    yield dict(res,
+                               status="impossible",
+                               message="Could not determine merge target")
+                    continue
+
                 if is_annex and reobtain_data:
                     merge_fn = _reobtain(ds, merge_fn)
-                yield from merge_fn(repo, sibling_)
+                yield from merge_fn(repo, sibling_, merge_target)
 
             res['status'] = 'ok'
             yield res
@@ -211,6 +224,40 @@ class Update(Interface):
                 yield r
 
 
+def _choose_merge_target(repo, branch, remote, cfg_remote):
+    """Select a merge target for the update to `repo`.
+
+    Parameters
+    ----------
+    repo : Repo instance
+    branch : str
+        The current branch.
+    remote : str
+        The remote which updates are coming from.
+    cfg_remote : str
+        The configured upstream remote.
+
+    Returns
+    -------
+    str (the merge target) or None if a choice wasn't made.
+    """
+    merge_target = None
+    if cfg_remote and remote == cfg_remote:
+        # Use the configured cfg_remote branch as the merge target.
+        #
+        # In this scenario, it's tempting to use FETCH_HEAD as the merge
+        # target. That would be the equivalent of 'git pull REMOTE'. But doing
+        # so would be problematic when the GitRepo.fetch() call was passed
+        # all_=True. Given we can't use FETCH_HEAD, it's tempting to use the
+        # branch.*.merge value, but that assumes a value for remote.*.fetch.
+        merge_target = repo.call_git_oneline(
+            ["rev-parse", "--symbolic-full-name", "--abbrev-ref=strict",
+             "@{upstream}"])
+    elif branch:
+        merge_target = "{}/{}".format(remote, branch)
+    return merge_target
+
+
 #  Merge functions
 
 
@@ -225,39 +272,24 @@ def _choose_merge_fn(repo, is_annex=False, adjusted=False):
             "bug: Upstream checks should make it impossible for "
             "adjusted=True, is_annex=False")
     else:
-        merge_fn = _pull
+        merge_fn = _plain_merge
     return merge_fn
 
 
-def _pull(repo, remote):
-    active_branch = repo.get_active_branch()
-    if active_branch is None:
-        # I guess we need to fetch, and then let super-dataset to update
-        # into the state it points to for this submodule, but for now let's
-        # just blow I guess :-/
-        lgr.warning(
-            "No active branch in %s - we just fetched and not changing state",
-            repo
-        )
-    else:
-        if repo.config.get('branch.{}.remote'.format(active_branch)) == remote:
-            # the branch love this remote already, let git pull do its thing
-            repo.pull(remote=remote)
-        else:
-            # no marriage yet, be specific
-            repo.pull(remote=remote, refspec=active_branch)
+def _plain_merge(repo, _, target):
+    repo.merge(name=target)
     return []
 
 
-def _annex_plain_merge(repo, remote):
-    _pull(repo, remote)
+def _annex_plain_merge(repo, _, target):
+    _plain_merge(repo, _, target)
     # Note: Avoid repo.merge_annex() so we don't needlessly create synced/
     # branches.
     repo.call_git(["annex", "merge"])
     return []
 
 
-def _annex_sync(repo, remote):
+def _annex_sync(repo, remote, _target):
     repo.sync(remotes=remote, push=False, pull=True, commit=False)
     return []
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -129,12 +129,13 @@ class Update(Interface):
             if ds != refds:
                 saw_subds = True
             repo = ds.repo
+            is_annex = isinstance(repo, AnnexRepo)
             # prepare return value
             res = get_status_dict('update', ds=ds, logger=lgr, refds=refds.path)
             # get all remotes which have references (would exclude
             # special remotes)
             remotes = repo.get_remotes(
-                **({'exclude_special_remotes': True} if isinstance(repo, AnnexRepo) else {}))
+                **({'exclude_special_remotes': True} if is_annex else {}))
             if not remotes and not sibling:
                 res['message'] = ("No siblings known to dataset at %s\nSkipping",
                                   repo.path)
@@ -172,12 +173,18 @@ class Update(Interface):
                 recurse_submodules="no",
                 prune=True)  # prune to not accumulate a mess over time
             repo.fetch(**fetch_kwargs)
-            # NOTE if any further acces to `repo` is needed, reevaluate
-            # ds.repo again, as it might have be converted from an GitRepo
-            # to an AnnexRepo
+            # NOTE reevaluate ds.repo again, as it might have be converted from
+            # a GitRepo to an AnnexRepo
+            repo = ds.repo
+
             if merge:
-                for fr in _update_repo(ds, sibling_, reobtain_data):
-                    yield fr
+                merge_fn = _choose_merge_fn(
+                    repo,
+                    is_annex=is_annex)
+                if is_annex and reobtain_data:
+                    merge_fn = _reobtain(ds, merge_fn)
+                yield from merge_fn(repo, sibling_)
+
             res['status'] = 'ok'
             yield res
             save_paths.append(ds.path)
@@ -201,44 +208,63 @@ class Update(Interface):
                 yield r
 
 
-def _update_repo(ds, remote, reobtain_data):
-    repo = ds.repo
+#  Merge functions
 
-    lgr.info("Applying updates to %s", ds)
-    if isinstance(repo, AnnexRepo):
-        if reobtain_data:
-            # get all annexed files that have data present
-            lgr.info('Recording file content availability '
-                     'to re-obtain updated files later on')
-            ds_path = ds.path
-            present_files = [
-                opj(ds_path, p)
-                for p in repo.get_annexed_files(with_content_only=True)]
-        # this runs 'annex sync' and should deal with anything
-        repo.sync(remotes=remote, push=False, pull=True, commit=False)
-        if reobtain_data:
-            present_files = [p for p in present_files if lexists(p)]
-            if present_files:
-                lgr.info('Ensuring content availability for %i '
-                         'previously available files',
-                         len(present_files))
-                yield from ds.get(present_files, recursive=False,
-                                  return_type='generator')
+
+def _choose_merge_fn(repo, is_annex=False):
+    if is_annex:
+        merge_fn = _annex_sync
     else:
-        # handle merge in plain git
-        active_branch = repo.get_active_branch()
-        if active_branch is None:
-            # I guess we need to fetch, and then let super-dataset to update
-            # into the state it points to for this submodule, but for now let's
-            # just blow I guess :-/
-            lgr.warning(
-                "No active branch in %s - we just fetched and not changing state",
-                repo
-            )
+        merge_fn = _pull
+    return merge_fn
+
+
+def _pull(repo, remote):
+    active_branch = repo.get_active_branch()
+    if active_branch is None:
+        # I guess we need to fetch, and then let super-dataset to update
+        # into the state it points to for this submodule, but for now let's
+        # just blow I guess :-/
+        lgr.warning(
+            "No active branch in %s - we just fetched and not changing state",
+            repo
+        )
+    else:
+        if repo.config.get('branch.{}.remote'.format(active_branch)) == remote:
+            # the branch love this remote already, let git pull do its thing
+            repo.pull(remote=remote)
         else:
-            if repo.config.get('branch.{}.remote'.format(active_branch)) == remote:
-                # the branch love this remote already, let git pull do its thing
-                repo.pull(remote=remote)
-            else:
-                # no marriage yet, be specific
-                repo.pull(remote=remote, refspec=active_branch)
+            # no marriage yet, be specific
+            repo.pull(remote=remote, refspec=active_branch)
+    return []
+
+
+def _annex_sync(repo, remote):
+    repo.sync(remotes=remote, push=False, pull=True, commit=False)
+    return []
+
+
+def _reobtain(ds, merge_fn):
+    def wrapped(*args, **kwargs):
+        repo = ds.repo
+
+        lgr.info("Applying updates to %s", ds)
+        # get all annexed files that have data present
+        lgr.info('Recording file content availability '
+                 'to re-obtain updated files later on')
+        ds_path = ds.path
+        present_files = [
+            opj(ds_path, p)
+            for p in repo.get_annexed_files(with_content_only=True)]
+
+        # No merge functions yield results yet...
+        yield from merge_fn(*args, **kwargs)
+
+        present_files = [p for p in present_files if lexists(p)]
+        if present_files:
+            lgr.info('Ensuring content availability for %i '
+                     'previously available files',
+                     len(present_files))
+            yield from ds.get(present_files, recursive=False,
+                              return_type='generator')
+    return wrapped

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -254,7 +254,9 @@ def _choose_merge_target(repo, branch, remote, cfg_remote):
             ["rev-parse", "--symbolic-full-name", "--abbrev-ref=strict",
              "@{upstream}"])
     elif branch:
-        merge_target = "{}/{}".format(remote, branch)
+        remote_branch = "{}/{}".format(remote, branch)
+        if repo.commit_exists(remote_branch):
+            merge_target = remote_branch
     return merge_target
 
 


### PR DESCRIPTION
This series is based on the discussion in gh-4148.  On top of the existing "merge in the chosen branch from the sibling" mode, it adds a "follow parent" mode for merging in the registered revision for updated subdatasets. It replaces the approach proposed in gh-4118, which was a hybrid approach that merged in the subdataset revision directly only if the to-be-merged sibling branch didn't contain the registered revision.  It think the approach here is simpler and will make it easier for the caller to anticipate the result.

Also, `--merge` is expanded so that `--merge=ff-only` limits the allowed merges to fast-forwards, while `--merge` retains the same behavior (and is now a shorthand for `--merge=any`).

Patch 1-4 follow patches from gh-4118 pretty closely.

```
  [ 1/10] RF: update: Break apart _update_repo() helper
  [ 2/10] ENH: update: Use same merge approach for plain and annex repos
  [ 3/10] ENH: update: Avoid calling 'git pull' to merge changes
  [ 4/10] ENH: update: Don't set merge target to a guess that doesn't exist
  [ 5/10] TST: update: Make more specific assertions about result counts
  [ 6/10] ENH: update: Yield result for merge event
  [ 7/10] NF: update: Add option to merge in recorded commit
  [ 8/10] ENH: update: Try to fetch submodule commit explicitly if needed
  [ 9/10] DOC: update: Explain how sibling is chosen for merge
  [10/10] NF: update: Support restricting merges to fast-forwards
```
