### PR TITLE
RF: Discontinue use of GitCommandError

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -73,7 +73,6 @@ from .gitrepo import (
     _normalize_path,
     normalize_path,
     normalize_paths,
-    GitCommandError,
     to_options
 )
 from . import ansi_colors

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -49,7 +49,6 @@ from weakref import WeakValueDictionary
 import git as gitpy
 from gitdb.exc import BadName
 from git.exc import (
-    GitCommandError,
     NoSuchPathError,
     InvalidGitRepositoryError
 )
@@ -1172,13 +1171,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # fail early on non-empty target:
         from os import listdir
         if exists(path) and listdir(path):
-            # simulate actual GitCommandError:
-            lgr.warning("destination path '%s' already exists and is not an "
-                        "empty directory." % path)
-            raise GitCommandError(
-                ['git', 'clone', '-v', url, path],
-                128,
-                "fatal: destination path '%s' already exists and is not an "
+            raise ValueError(
+                "destination path '%s' already exists and is not an "
                 "empty directory." % path)
         else:
             # protect against cloning into existing and obviously dangling

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -35,7 +35,6 @@ from urllib.parse import urljoin
 from urllib.parse import urlsplit
 
 import git
-from git import GitCommandError
 from unittest.mock import patch
 import gc
 
@@ -131,12 +130,10 @@ def test_AnnexRepo_instance_from_clone(src, dst):
     assert_is_instance(ar, AnnexRepo, "AnnexRepo was not created.")
     ok_(os.path.exists(os.path.join(dst, '.git', 'annex')))
 
-    # do it again should raise GitCommandError since git will notice
+    # do it again should raise ValueError since git will notice
     # there's already a git-repo at that path and therefore can't clone to `dst`
     with swallow_logs(new_level=logging.WARN) as cm:
-        assert_raises(GitCommandError, AnnexRepo.clone, src, dst)
-        if git.__version__ != "1.0.2" and git.__version__ != "2.0.5":
-            assert("already exists" in cm.out)
+        assert_raises(ValueError, AnnexRepo.clone, src, dst)
 
 
 @assert_cwd_unchanged
@@ -1237,7 +1234,7 @@ def test_annex_remove(path1, path2):
     if repo.is_direct_mode():
         assert_raises(CommandError, repo.remove, "rm-test.dat")
     else:
-        assert_raises(GitCommandError, repo.remove, "rm-test.dat")
+        assert_raises(ValueError, repo.remove, "rm-test.dat")
     assert_in("rm-test.dat", repo.get_annexed_files())
 
     # now force:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1160,6 +1160,7 @@ def test_optimized_cloning(path):
 @with_tempfile
 @with_tempfile
 def test_GitRepo_gitpy_injection(path, path2):
+    from git import GitCommandError
 
     gr = GitRepo(path, create=True)
     gr._GIT_COMMON_OPTIONS.extend(['test-option'])

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -65,7 +65,6 @@ from datalad.support.sshconnector import get_connection_hash
 
 from datalad.support.gitrepo import (
     _normalize_path,
-    GitCommandError,
     gitpy,
     GitRepo,
     guard_BadName,
@@ -105,13 +104,13 @@ def test_GitRepo_instance_from_clone(src, dst):
                        "Failed to instantiate GitPython Repo object.")
     ok_(op.exists(op.join(dst, '.git')))
 
-    # do it again should raise GitCommandError since git will notice there's
+    # do it again should raise ValueError since git will notice there's
     # already a git-repo at that path and therefore can't clone to `dst`
     # Note: Since GitRepo is now a WeakSingletonRepo, this is prevented from
     # happening atm. Disabling for now:
 #    raise SkipTest("Disabled for RF: WeakSingletonRepo")
     with swallow_logs() as logs:
-        assert_raises(GitCommandError, GitRepo.clone, src, dst)
+        assert_raises(ValueError, GitRepo.clone, src, dst)
 
 
 @assert_cwd_unchanged


### PR DESCRIPTION
Was only ever used to fake a GitPython error, but was nowhere acted
upon, specifically. It is now replaced with ValueError, as it is done
in other places when inappropriate arguments are given (here a non-empty
directory).

Also discontinue the practice of logging a warning about a situation
that will unconditionally raise an exception on the next line. If that
exception is caught anywhere, it is the responsibility of the caller to
decide if and how to log this event.
