### PR TITLE
ENH: list datalad-container extension provided commands

### DIFF
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -93,6 +93,7 @@ _group_plumbing = (
 
 # Some known extensions and their commands to suggest whenever lookup fails
 _known_extension_commands = {
+    'datalad-container': ('containers-list', 'containers-remove', 'containers-add', 'containers-run'),
     'datalad-crawler': ('crawl', 'crawl-init'),
     'datalad-neuroimaging': ('bids2scidata',)
 }


### PR DESCRIPTION
So a user would get a hint when he uses the command without datalad-container
extension being installed:

```
$> datalad containers-list
datalad: Unknown command 'containers-list'.  See 'datalad --help'.

Hint: Command containers-list is provided by (not installed) extension datalad-container.
```
