### PR TITLE
RF: Use ConfigManager instead of GitPython config classes

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -198,11 +198,10 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
     eq_(src_is_annex, AnnexRepo.is_valid_repo(target_path))
     # And target one should be known to have a known UUID within the source if annex
     if src_is_annex:
-        annex = AnnexRepo(src_path)
-        local_target_cfg = annex.repo.remotes["local_target"].config_reader.get
+        lclcfg = AnnexRepo(src_path).config
         # basic config in place
-        eq_(local_target_cfg('annex-ignore'), 'false')
-        ok_(local_target_cfg('annex-uuid'))
+        eq_(lclcfg.get('remote.local_target.annex-ignore'), 'false')
+        ok_(lclcfg.get('remote.local_target.annex-uuid'))
 
     # do it again without force, but use a different name to avoid initial checks
     # for existing remotes:
@@ -251,12 +250,12 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         assert_false(exists(opj(target_path, 'random')))
 
         if src_is_annex:
-            annex = AnnexRepo(src_path)
-            local_target_cfg = annex.repo.remotes["local_target"].config_reader.get
-            eq_(local_target_cfg('annex-ignore'), 'false')
-            eq_(local_target_cfg('annex-uuid').count('-'), 4)  # valid uuid
+            lclcfg = AnnexRepo(src_path).config
+            eq_(lclcfg.get('remote.local_target.annex-ignore'), 'false')
+            # valid uuid
+            eq_(lclcfg.get('remote.local_target.annex-uuid').count('-'), 4)
             # should be added too, even if URL matches prior state
-            eq_(local_target_cfg('push'), 'master')
+            eq_(lclcfg.get('remote.local_target.push'), 'master')
 
         # again, by explicitly passing urls. Since we are on localhost, the
         # local path should work:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1059,11 +1059,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         -------
         True if in direct mode, False otherwise.
         """
-        # TEMP: Disable lazy loading and make sure to read from file every time
-        # instead, since we might have several instances pointing to the very
-        # same repo atm. TODO: We can remove that, right?
-        self.repo.config_reader()._is_initialized = False
-        self.repo.config_reader().read()
         self._direct_mode = None
 
         if self._direct_mode is None:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -168,17 +168,13 @@ def test_AnnexRepo_crippled_filesystem(src, dst):
     ar = AnnexRepo.clone(src, dst)
 
     # fake git-annex entries in .git/config:
-    writer = ar.repo.config_writer()
-    writer.set_value("annex", "crippledfilesystem", True)
-    writer.release()
+    ar.config.set("annex.crippledfilesystem", 'true')
     ok_(ar.is_crippled_fs())
-    writer.set_value("annex", "crippledfilesystem", False)
-    writer.release()
+    ar.config.set("annex.crippledfilesystem", 'false')
     assert_false(ar.is_crippled_fs())
     # since we can't remove the entry, just rename it to fake its absence:
-    writer.rename_section("annex", "removed")
-    writer.set_value("annex", "something", "value")
-    writer.release()
+    ar.config.rename_section("annex", "removed")
+    ar.config.set("annex.something", "value")
     assert_false(ar.is_crippled_fs())
 
 
@@ -1252,7 +1248,7 @@ def test_annex_remove(path1, path2):
 def test_repo_version(path1, path2, path3):
     annex = AnnexRepo(path1, create=True, version=6)
     ok_clean_git(path1, annex=True)
-    version = annex.repo.config_reader().get_value('annex', 'version')
+    version = int(annex.config.get('annex.version'))
     # Since git-annex 7.20181031, v6 repos upgrade to v7.
     supported_versions = AnnexRepo.check_repository_versions()["supported"]
     v6_lands_on = next(i for i in supported_versions if i >= 6)
@@ -1261,14 +1257,14 @@ def test_repo_version(path1, path2, path3):
     # default from config item (via env var):
     with patch.dict('os.environ', {'DATALAD_REPO_VERSION': '6'}):
         annex = AnnexRepo(path2, create=True)
-        version = annex.repo.config_reader().get_value('annex', 'version')
+        version = int(annex.config.get('annex.version'))
         eq_(version, v6_lands_on)
 
         # Assuming specified version is a supported version...
         if 5 in supported_versions:
             # ...parameter `version` still has priority over default config:
             annex = AnnexRepo(path3, create=True, version=5)
-            version = annex.repo.config_reader().get_value('annex', 'version')
+            version = int(annex.config.get('annex.version'))
             eq_(version, 5)
 
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -168,13 +168,19 @@ def test_AnnexRepo_crippled_filesystem(src, dst):
     ar = AnnexRepo.clone(src, dst)
 
     # fake git-annex entries in .git/config:
-    ar.config.set("annex.crippledfilesystem", 'true')
+    ar.config.set(
+        "annex.crippledfilesystem",
+        'true',
+        where='local')
     ok_(ar.is_crippled_fs())
-    ar.config.set("annex.crippledfilesystem", 'false')
+    ar.config.set(
+        "annex.crippledfilesystem",
+        'false',
+        where='local')
     assert_false(ar.is_crippled_fs())
     # since we can't remove the entry, just rename it to fake its absence:
-    ar.config.rename_section("annex", "removed")
-    ar.config.set("annex.something", "value")
+    ar.config.rename_section("annex", "removed", where='local')
+    ar.config.set("annex.something", "value", where='local')
     assert_false(ar.is_crippled_fs())
 
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -154,9 +154,7 @@ def test_GitRepo_instance_from_not_existing(path, path2):
 def test_GitRepo_init_options(path):
     # passing an option, not explicitly defined in GitRepo class:
     gr = GitRepo(path, create=True, bare=True)
-
-    cfg = gr.repo.config_reader()
-    ok_(cfg.get_value(section="core", option="bare"))
+    ok_(gr.config.getbool(section="core", option="bare"))
 
 
 @skip_if(external_versions['cmd:git'] < '2.14.0')

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -943,24 +943,6 @@ def _get_resolved_flavors(flavors):
         flavors_ = [x for x in flavors_ if not x.startswith('network')]
     return flavors_
 
-def _get_repo_url(path):
-    """Return ultimate URL for this repo"""
-
-    if path.startswith('http') or path.startswith('git'):
-        # We were given a URL, so let's just return it
-        return path
-
-    if not exists(opj(path, '.git')):
-        # do the dummiest check so we know it is not git.Repo's fault
-        raise AssertionError("Path %s does not point to a git repository "
-                             "-- missing .git" % path)
-    repo = git.Repo(path)
-    if len(repo.remotes) == 1:
-        remote = repo.remotes[0]
-    else:
-        remote = repo.remotes.origin
-    return remote.config_reader.get('url')
-
 
 def clone_url(url):
     # delay import of our code until needed for certain


### PR DESCRIPTION
Also strips an unused function with such code.