### PR TITLE
ENH: add "DataLad extension" to terms glossary

### DIFF
--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -178,7 +178,7 @@ The following keys should exists if possible:
 Extension packages
 ^^^^^^^^^^^^^^^^^^
 
-As the name suggests, an extension package is a proper Python package.
+As the name suggests, a :term:`DataLad extension` package is a proper Python package.
 Consequently, there is a significant amount of boilerplate code involved in the
 creation of a new Datalad extension. However, this overhead enables a number of
 useful features for extension developers:
@@ -197,7 +197,7 @@ useful features for extension developers:
 Using an extension
 ==================
 
-A DataLad extension is a standard Python package. Beyond installation of the package there is
+A :term:`DataLad extension` is a standard Python package. Beyond installation of the package there is
 no additional setup required.
 
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,5 +44,13 @@ them to the corresponding Git_/git-annex_ concepts.
     operations significantly and impair handling of such repositories in
     general).
 
+  DataLad extension
+    A Python package, developed outside of the core DataLad codebase, which
+    (when installed) typically either provides additional top level `datalad`
+    commands and/or additional metadata extractors.  Visit
+    `Handbook, Ch.2. DataLad’s extensions <http://handbook.datalad.org/en/latest/basics/101-144-intro_extensions.html>`_
+    for a representative list of extensions and instructions on how to install
+    them.
+
 .. _Git: https://git-scm.com
 .. _Git-annex: http://git-annex.branchable.com


### PR DESCRIPTION
a user complaint was that it was not clear what to do even if you discover the command in the docs which comes from an extension.  So probably all extensions should refer to the ```:term:`DataLad extension` ```, where they would be instructed to proceed to user-facing documentation (handbook) which hints on installing them.  Still a wild chase, but imho better than no term ;)