### PR TITLE
create-sibling: Add support for local paths (v2)

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -615,7 +615,7 @@ class CreateSibling(Interface):
         if not name:
             # use the hostname as default remote name
             if not ssh_sibling:
-                name = "localhost"
+                name = "local"
             else:
                 name = sibling_ri.hostname
                 lgr.debug(

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -28,7 +28,10 @@ from datalad import ssh_manager
 
 from datalad.ui import ui
 
-from datalad.cmd import CommandError
+from datalad.cmd import (
+    CommandError,
+    Runner,
+)
 from datalad.consts import (
     TIMESTAMP_FMT,
     WEB_HTML_DIR,
@@ -73,8 +76,10 @@ from datalad.support.exceptions import (
     InsufficientArgumentsError,
     MissingExternalDependency,
 )
+from datalad.support.external_versions import external_versions
 from datalad.support.network import (
     is_ssh,
+    PathRI,
     RI,
 )
 from datalad.support.sshconnector import sh_quote
@@ -89,13 +94,32 @@ from datalad.utils import (
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 
 
+class _RunnerAdapter(Runner):
+    """An adapter to use interchanegably with SSH connection"""
+
+    def get_git_version(self):
+        return external_versions['cmd:git']
+
+    def get_annex_version(self):
+        return external_versions['cmd:git-annex']
+
+    def copy(self, source, destination, recursive=False,
+             preserve_attrs=False):
+        import shutil
+        if not recursive:
+            (shutil.copy2 if preserve_attrs else shutil.copy)(source, destination)
+        else:
+            if not preserve_attrs:
+                lgr.debug("recursive copy always preserves attributes in local copying")
+            shutil.copytree(source, destination)
+
 def _create_dataset_sibling(
         name,
         ds,
         hierarchy_basepath,
-        ssh,
+        shell,
         replicate_local_structure,
-        ssh_url,
+        ri,
         target_dir,
         target_url,
         target_pushurl,
@@ -132,20 +156,21 @@ def _create_dataset_sibling(
         remoteds_path = normpath(opj(target_dir, ds_name))
 
     # construct a would-be ssh url based on the current dataset's path
-    ssh_url.path = remoteds_path
-    ds_sshurl = ssh_url.as_str()
+    ri.path = remoteds_path
+    ds_url = ri.as_str()
     # configure dataset's git-access urls
     ds_target_url = target_url.replace('%RELNAME', ds_name) \
-        if target_url else ds_sshurl
+        if target_url else ds_url
     # push, configure only if needed
     ds_target_pushurl = None
-    if ds_target_url != ds_sshurl:
+    if ds_target_url != ds_url:
         # not guaranteed that we can push via the primary URL
         ds_target_pushurl = target_pushurl.replace('%RELNAME', ds_name) \
-            if target_pushurl else ds_sshurl
+            if target_pushurl else ds_url
 
     lgr.info("Considering to create a target dataset {0} at {1} of {2}".format(
-        localds_path, remoteds_path, ssh_url.hostname))
+        localds_path, remoteds_path,
+        "localhost" if isinstance(ri, PathRI) else ri.hostname))
     # Must be set to True only if exists and existing='reconfigure'
     # otherwise we might skip actions if we say existing='reconfigure'
     # but it did not even exist before
@@ -153,7 +178,7 @@ def _create_dataset_sibling(
     if remoteds_path != '.':
         # check if target exists
         # TODO: Is this condition valid for != '.' only?
-        path_children = _ls_remote_path(ssh, remoteds_path)
+        path_children = _ls_remote_path(shell, remoteds_path)
         path_exists = path_children is not None
 
         if path_exists:
@@ -166,7 +191,7 @@ def _create_dataset_sibling(
                     remoteds_path
                 )
                 # should be safe since should not remove anything unless an empty dir
-                ssh("rmdir {}".format(sh_quote(remoteds_path)))
+                shell("rmdir {}".format(sh_quote(remoteds_path)))
                 path_exists = False
             except CommandError as e:
                 # If fails to rmdir -- either contains stuff no permissions
@@ -213,9 +238,9 @@ def _create_dataset_sibling(
                 # just a directory.
                 lgr.info(_msg + " Replacing")
                 # enable write permissions to allow removing dir
-                ssh("chmod +r+w -R {}".format(sh_quote(remoteds_path)))
+                shell("chmod +r+w -R {}".format(sh_quote(remoteds_path)))
                 # remove target at path
-                ssh("rm -rf {}".format(sh_quote(remoteds_path)))
+                shell("rm -rf {}".format(sh_quote(remoteds_path)))
                 # if we succeeded in removing it
                 path_exists = False
                 # Since it is gone now, git-annex also should forget about it
@@ -241,7 +266,7 @@ def _create_dataset_sibling(
                         repr(existing)))
 
         if not path_exists:
-            ssh("mkdir -p {}".format(sh_quote(remoteds_path)))
+            shell("mkdir -p {}".format(sh_quote(remoteds_path)))
 
     delayed_super = _DelayedSuper(ds)
     if inherit and delayed_super.super:
@@ -249,35 +274,35 @@ def _create_dataset_sibling(
             # here we must analyze current_ds's super, not the super_ds
             # inherit from the setting on remote end
             shared = CreateSibling._get_ds_remote_shared_setting(
-                delayed_super, name, ssh)
+                delayed_super, name, shell)
 
         if not install_postupdate_hook:
             # Even though directive from above was False due to no UI explicitly
             # requested, we were asked to inherit the setup, so we might need
             # to install the hook, if super has it on remote
             install_postupdate_hook = CreateSibling._has_active_postupdate(
-                delayed_super, name, ssh)
+                delayed_super, name, shell)
 
 
 
     if group:
         # Either repository existed before or a new directory was created for it,
         # set its group to a desired one if was provided with the same chgrp
-        ssh("chgrp -R {} {}".format(
+        shell("chgrp -R {} {}".format(
             sh_quote(str(group)),
             sh_quote(remoteds_path)))
     # don't (re-)initialize dataset if existing == reconfigure
     if not only_reconfigure:
         # init git and possibly annex repo
         if not CreateSibling.init_remote_repo(
-                remoteds_path, ssh, shared, ds,
+                remoteds_path, shell, shared, ds,
                 description=target_url):
             return
 
         if target_url and not is_ssh(target_url):
             # we are not coming in via SSH, hence cannot assume proper
             # setup for webserver access -> fix
-            ssh('git -C {} update-server-info'.format(sh_quote(remoteds_path)))
+            shell('git -C {} update-server-info'.format(sh_quote(remoteds_path)))
     else:
         # TODO -- we might still want to reconfigure 'shared' setting!
         pass
@@ -305,10 +330,10 @@ def _create_dataset_sibling(
 
     # check git version on remote end
     lgr.info("Adjusting remote git configuration")
-    if ssh.get_git_version() and ssh.get_git_version() >= LooseVersion("2.4"):
+    if shell.get_git_version() and shell.get_git_version() >= LooseVersion("2.4"):
         # allow for pushing to checked out branch
         try:
-            ssh("git -C {} config receive.denyCurrentBranch updateInstead".format(
+            shell("git -C {} config receive.denyCurrentBranch updateInstead".format(
                 sh_quote(remoteds_path)))
         except CommandError as e:
             lgr.error("git config failed at remote location %s.\n"
@@ -320,14 +345,14 @@ def _create_dataset_sibling(
                   " of receive.denyCurrentBranch - you will not be able to"
                   " publish updates to this repository. Upgrade your git"
                   " and run with --existing=reconfigure",
-                  ssh.get_git_version())
+                  shell.get_git_version())
 
     if install_postupdate_hook:
         # enable metadata refresh on dataset updates to publication server
         lgr.info("Enabling git post-update hook ...")
         try:
             CreateSibling.create_postupdate_hook(
-                remoteds_path, ssh, ds)
+                remoteds_path, shell, ds)
         except CommandError as e:
             lgr.error("Failed to add json creation command to post update "
                       "hook.\nError: %s" % exc_str(e))
@@ -357,11 +382,11 @@ def _ls_remote_path(ssh, path):
 
 @build_doc
 class CreateSibling(Interface):
-    """Create a dataset sibling on a UNIX-like SSH-accessible machine
+    """Create a dataset sibling on a UNIX-like Shell (local or SSH)-accessible machine
 
-    Given a local dataset, and SSH login information this command creates
-    a remote dataset repository and configures it as a dataset sibling to
-    be used as a publication target (see `publish` command).
+    Given a local dataset, and a path or SSH login information this command
+    creates a remote dataset repository and configures it as a dataset sibling
+    to be used as a publication target (see `publish` command).
 
     Various properties of the remote sibling can be configured (e.g. name
     location on the server, read and write access URLs, and access
@@ -393,7 +418,8 @@ class CreateSibling(Interface):
             metavar='SSHURL',
             nargs='?',
             doc="""Login information for the target server. This can be given
-                as a URL (ssh://host/path) or SSH-style (user@host:path).
+                as a URL (ssh://host/path), SSH-style (user@host:path) or just
+                a local path.
                 Unless overridden, this also serves the future dataset's access
                 URL and path on the server.""",
             constraints=EnsureStr()),
@@ -566,18 +592,22 @@ class CreateSibling(Interface):
             sshurl = slash_join(super_url, relpath(ds.path, super_ds.path))
 
         # check the login URL
-        sshri = RI(sshurl)
-        if not is_ssh(sshri):
+        sibling_ri = RI(sshurl)
+        ssh_sibling = is_ssh(sibling_ri)
+        if not (ssh_sibling or isinstance(sibling_ri, PathRI)):
             raise ValueError(
-                "Unsupported SSH URL: '{0}', "
-                "use ssh://host/path or host:path syntax".format(sshurl))
+                "Unsupported SSH URL or path: '{0}', "
+                "use ssh://host/path, host:path or path syntax".format(sshurl))
 
         if not name:
             # use the hostname as default remote name
-            name = sshri.hostname
-            lgr.debug(
-                "No sibling name given, use URL hostname '%s' as sibling name",
-                name)
+            if not ssh_sibling:
+                name = "localhost"
+            else:
+                name = sibling_ri.hostname
+                lgr.debug(
+                    "No sibling name given, use URL hostname '%s' as sibling name",
+                    name)
 
         if since == '':
             # consider creating siblings only since the point of
@@ -646,22 +676,25 @@ class CreateSibling(Interface):
             return
 
         if target_dir is None:
-            if sshri.path:
-                target_dir = sshri.path
+            if sibling_ri.path:
+                target_dir = sibling_ri.path
             else:
                 target_dir = '.'
 
         # TODO: centralize and generalize template symbol handling
         replicate_local_structure = "%RELNAME" not in target_dir
 
-        # request ssh connection:
-        lgr.info("Connecting ...")
-        assert(sshurl is not None)  # delayed anal verification
-        ssh = ssh_manager.get_connection(sshurl)
-        if not ssh.get_annex_version():
-            raise MissingExternalDependency(
-                'git-annex',
-                msg='on the remote system')
+        if ssh_sibling:
+            # request ssh connection:
+            lgr.info("Connecting ...")
+            assert(sshurl is not None)  # delayed anal verification
+            shell = ssh_manager.get_connection(sshurl)
+            if not shell.get_annex_version():
+                raise MissingExternalDependency(
+                    'git-annex',
+                    msg='on the remote system')
+        else:
+            shell = _RunnerAdapter()  # cwd=sibling_ri.path)
 
         #
         # all checks done and we have a connection, now do something
@@ -681,9 +714,9 @@ class CreateSibling(Interface):
                 name,
                 current_ds,
                 ds.path,
-                ssh,
+                shell,
                 replicate_local_structure,
-                sshri,
+                sibling_ri,
                 target_dir,
                 target_url,
                 target_pushurl,
@@ -713,7 +746,7 @@ class CreateSibling(Interface):
             if current_ds.path == ds.path and ui:
                 lgr.info("Uploading web interface to %s" % path)
                 try:
-                    CreateSibling.upload_web_interface(path, ssh, shared, ui)
+                    CreateSibling.upload_web_interface(path, shell, shared, ui)
                 except CommandError as e:
                     currentds_ap['status'] = 'error'
                     currentds_ap['message'] = (
@@ -730,9 +763,9 @@ class CreateSibling(Interface):
             # Trigger the hook
             lgr.debug("Running hook for %s (if exists and executable)", path)
             try:
-                ssh("cd {} "
-                    "&& ( [ -x hooks/post-update ] && hooks/post-update || : )"
-                    "".format(sh_quote(_path_(path, ".git"))))
+                shell("cd {} "
+                      "&& ( [ -x hooks/post-update ] && hooks/post-update || : )"
+                      "".format(sh_quote(_path_(path, ".git"))))
             except CommandError as e:
                 currentds_ap['status'] = 'error'
                 currentds_ap['message'] = (

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -684,6 +684,13 @@ class CreateSibling(Interface):
                      "or --since if this is unexpected")
             return
 
+        if ssh_sibling:
+            # request ssh connection:
+            lgr.info("Connecting ...")
+            shell = ssh_manager.get_connection(sshurl)
+        else:
+            shell = _RunnerAdapter()
+
         if target_dir is None:
             if sibling_ri.path:
                 target_dir = sibling_ri.path
@@ -692,13 +699,6 @@ class CreateSibling(Interface):
 
         # TODO: centralize and generalize template symbol handling
         replicate_local_structure = "%RELNAME" not in target_dir
-
-        if ssh_sibling:
-            # request ssh connection:
-            lgr.info("Connecting ...")
-            shell = ssh_manager.get_connection(sshurl)
-        else:
-            shell = _RunnerAdapter()
 
         if not shell.get_annex_version():
             raise MissingExternalDependency(

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -103,8 +103,8 @@ class _RunnerAdapter(Runner):
     def get_annex_version(self):
         return external_versions['cmd:git-annex']
 
-    def copy(self, source, destination, recursive=False,
-             preserve_attrs=False):
+    def put(self, source, destination, recursive=False,
+            preserve_attrs=False):
         import shutil
         if not recursive:
             (shutil.copy2 if preserve_attrs else shutil.copy)(source, destination)

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -106,12 +106,12 @@ class _RunnerAdapter(Runner):
     def put(self, source, destination, recursive=False,
             preserve_attrs=False):
         import shutil
+        copy_fn = shutil.copy2 if preserve_attrs else shutil.copy
         if not recursive:
-            (shutil.copy2 if preserve_attrs else shutil.copy)(source, destination)
+            copy_fn(source, destination)
         else:
-            if not preserve_attrs:
-                lgr.debug("recursive copy always preserves attributes in local copying")
-            shutil.copytree(source, destination)
+            shutil.copytree(source, destination, copy_function=copy_fn)
+
 
 def _create_dataset_sibling(
         name,

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -101,7 +101,7 @@ class _RunnerAdapter(Runner):
         return external_versions['cmd:git']
 
     def get_annex_version(self):
-        return external_versions['cmd:git-annex']
+        return external_versions['cmd:annex']
 
     def put(self, source, destination, recursive=False,
             preserve_attrs=False):

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -689,12 +689,14 @@ class CreateSibling(Interface):
             lgr.info("Connecting ...")
             assert(sshurl is not None)  # delayed anal verification
             shell = ssh_manager.get_connection(sshurl)
-            if not shell.get_annex_version():
-                raise MissingExternalDependency(
-                    'git-annex',
-                    msg="It's required on the remote machine to create a sibling")
         else:
             shell = _RunnerAdapter()  # cwd=sibling_ri.path)
+
+        if not shell.get_annex_version():
+            raise MissingExternalDependency(
+                'git-annex',
+                msg="It's required on the {} machine to create a sibling"
+                    .format('remote' if ssh_sibling else 'local'))
 
         #
         # all checks done and we have a connection, now do something

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -692,7 +692,7 @@ class CreateSibling(Interface):
             if not shell.get_annex_version():
                 raise MissingExternalDependency(
                     'git-annex',
-                    msg='on the remote system')
+                    msg="It's required on the remote machine to create a sibling")
         else:
             shell = _RunnerAdapter()  # cwd=sibling_ri.path)
 

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -696,7 +696,6 @@ class CreateSibling(Interface):
         if ssh_sibling:
             # request ssh connection:
             lgr.info("Connecting ...")
-            assert(sshurl is not None)  # delayed anal verification
             shell = ssh_manager.get_connection(sshurl)
         else:
             shell = _RunnerAdapter()  # cwd=sibling_ri.path)

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -107,10 +107,10 @@ class _RunnerAdapter(Runner):
             preserve_attrs=False):
         import shutil
         copy_fn = shutil.copy2 if preserve_attrs else shutil.copy
-        if not recursive:
-            copy_fn(source, destination)
-        else:
+        if recursive:
             shutil.copytree(source, destination, copy_function=copy_fn)
+        else:
+            copy_fn(source, destination)
 
 
 def _create_dataset_sibling(

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -613,15 +613,11 @@ class CreateSibling(Interface):
                 "use ssh://host/path, host:path or path syntax".format(sshurl))
 
         if not name:
-            # use the hostname as default remote name
-            if not ssh_sibling:
-                name = "local"
-            else:
-                name = sibling_ri.hostname
-                lgr.debug(
-                    "No sibling name given. Using URL hostname '%s' as sibling name",
-                    name)
-
+            name = sibling_ri.hostname if ssh_sibling else "local"
+            lgr.debug(
+                "No sibling name given. Using %s'%s' as sibling name",
+                "URL hostname " if ssh_sibling else "",
+                name)
         if since == '':
             # consider creating siblings only since the point of
             # the last update

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -698,7 +698,7 @@ class CreateSibling(Interface):
             lgr.info("Connecting ...")
             shell = ssh_manager.get_connection(sshurl)
         else:
-            shell = _RunnerAdapter()  # cwd=sibling_ri.path)
+            shell = _RunnerAdapter()
 
         if not shell.get_annex_version():
             raise MissingExternalDependency(

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -46,6 +46,7 @@ from datalad.distribution.dataset import (
     Dataset,
     datasetmethod,
     EnsureDataset,
+    resolve_path,
     require_dataset,
 )
 from datalad.interface.annotate_paths import AnnotatePaths
@@ -690,6 +691,7 @@ class CreateSibling(Interface):
             shell = ssh_manager.get_connection(sshurl)
         else:
             shell = _RunnerAdapter()
+            sibling_ri.path = str(resolve_path(sibling_ri.path, dataset))
 
         if target_dir is None:
             if sibling_ri.path:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -450,10 +450,12 @@ class CreateSibling(Interface):
             args=('--target-dir',),
             metavar='PATH',
             doc="""path to the directory *on the server* where the dataset
-                shall be created. By default the SSH access URL is used to
-                identify this directory. If a relative path is provided here,
-                it is interpreted as being relative to the user's home
-                directory on the server.\n
+                shall be created. By default this is set to the URL (or local
+                path) specified via [PY: `sshurl` PY][CMD: SSHURL CMD]. If a
+                relative path is provided here, it is interpreted as being
+                relative to the user's home directory on the server (or
+                relative to [PY: `sshurl` PY][CMD: SSHURL CMD], when that is a
+                local path).
                 Additional features are relevant for recursive processing of
                 datasets with subdatasets. By default, the local
                 dataset structure is replicated on the server. However, it is
@@ -692,6 +694,8 @@ class CreateSibling(Interface):
         else:
             shell = _RunnerAdapter()
             sibling_ri.path = str(resolve_path(sibling_ri.path, dataset))
+            if target_dir:
+                target_dir = opj(sibling_ri.path, target_dir)
 
         if target_dir is None:
             if sibling_ri.path:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -619,7 +619,7 @@ class CreateSibling(Interface):
             else:
                 name = sibling_ri.hostname
                 lgr.debug(
-                    "No sibling name given, use URL hostname '%s' as sibling name",
+                    "No sibling name given. Using URL hostname '%s' as sibling name",
                     name)
 
         if since == '':

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -707,3 +707,41 @@ def test_local_relpath(path):
             name="relpath-unbound-dsnone", recursive=True,
             sshurl=os.path.relpath(str(path / "c"), ds_main.path))
     ok_((path / "c" / "subds").exists())
+
+
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+def test_local_path_target_dir(path):
+    path = Path(path)
+    ds_main = Dataset(path / "main").create()
+
+    ds_main.create_sibling(
+        name="abspath-targetdir",
+        sshurl=str(path / "a"), target_dir="tdir")
+    ok_((path / "a" / "tdir").exists())
+
+    ds_main.create_sibling(
+        name="relpath-bound-targetdir",
+        sshurl=os.path.relpath(str(path / "b"), ds_main.path),
+        target_dir="tdir")
+    ok_((path / "b" / "tdir").exists())
+
+    with chpwd(path):
+        create_sibling(
+            dataset=ds_main.path,
+            name="relpath-unbound-targetdir",
+            sshurl="c", target_dir="tdir")
+    ok_((path / "c" / "tdir").exists())
+
+    ds_main.create("subds")
+
+    ds_main.create_sibling(
+        name="rec-plain-targetdir", recursive=True,
+        sshurl=str(path / "d"), target_dir="tdir")
+    ok_((path / "d" / "tdir" / "subds").exists())
+
+    ds_main.create_sibling(
+        name="rec-template-targetdir", recursive=True,
+        sshurl=str(path / "e"), target_dir="d%RELNAME")
+    ok_((path / "e" / "d").exists())
+    ok_((path / "e" / "d-subds").exists())


### PR DESCRIPTION
This PR resurrects @yarikoptic's patch from gh-2615 that added local path support to `create_sibling`.  The (rebased) commit from that PR sits as the first commit of this series.  The final patch extends the existing `create_sibling` tests to go through the local path case.  The patches in between are various tweaks and fixes.

When this was initially proposed in gh-2615, the main objection, raised by @mih, was that `create_sibling` should be reworked to not assume a local or remote shell.  That is, put some abstraction layer over the calls to `{SSHConnection,_RunnerAdapter}.__call__`.  On top of that, there was the idea that such an abstraction could lead to dissolving `create_sibling_github`.

The command abstractions being worked on in gh-4068 are bringing us closer to the first part (relying solely on methods rather than explicit shell commands).  But in the meantime, this PR isn't making things any worse or more difficult going forward.  The core logic added to `CreateSibling` boils down to a single condition about local vs remote, the one that decides whether to use `SSHConnection` or the local-path-based `_RunnerAdapter`.

As for the second point, with the addition of `create_sibling_gitlab` and `create_sibling_ria`, I think it's safe to conclude that the idea of unifying these variants should not prevent moving forward with the local path support in `create_sibling`.  Assuming that such a union of `create_sibling*` variants is desirable, it isn't going to happen in the near future, and teaching `create_sibling` to handle local paths certainly isn't making the situation any worse than the recent `create_sibling_*` additions did.

Closes #1680.