### PR TITLE
ENH: Disable `siblings` output for freshly created sibling

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -339,7 +339,8 @@ def _create_dataset_sibling(
         annex_wanted=annex_wanted,
         annex_group=annex_group,
         annex_groupwanted=annex_groupwanted,
-        inherit=inherit
+        inherit=inherit,
+        result_renderer=None,
     )
 
     # check git version on remote end


### PR DESCRIPTION
Adds no information.

Fixes gh-4188