### PR TITLE
BF: Prevent test cleanup breakage on Windows

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -522,6 +522,11 @@ def test_find_batch_equivalence(path):
     # If we give a subdirectory, we split that output.
     eq_(set(ar.find(["subdir"])["subdir"]), {"subdir/d", "subdir/e"})
     eq_(ar.find(["subdir"]), ar.find(["subdir"], batch=True))
+    # manually ensure that no annex batch processes are around anymore
+    # that make the test cleanup break on windows.
+    # story at https://github.com/datalad/datalad/issues/4190
+    # even an explicit `del ar` does not get it done
+    ar._batched.close()
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
`AnnexRepo` does not manage to cleanup pending `annex --batch` processes
in time for the test cleanup code to wipe out the respective repository.

This only happens in this one test, that explicitly starts a batched
`find`. Hence I decided to make the symptom go away, instead of figuring
out how `AnnexRepo` could always make sure this can never happen.
The code in `AnnexRepo.__del__` aiming to achieve that does not seem to
be sufficient (anymore).

Fixes gh-4190
