### PR TITLE
BF+ENH+OPT: @memoize, correct config target for logging outputs

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -218,7 +218,7 @@ class Runner(object):
             adapter = self._LOG_OPTS_ADAPTERS.get(opt, None)
             self._log_opts[opt] = \
                 (cfg.getbool if not adapter else cfg.get_value)(
-                    'datalad.log.cmd', opt, default=default)
+                    'datalad.log', opt, default=default)
             if adapter:
                 self._log_opts[opt] = adapter(self._log_opts[opt])
             return self._log_opts[opt]

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -9,6 +9,7 @@
 """
 """
 
+from functools import lru_cache
 import datalad
 from datalad.consts import (
     DATASET_CONFIG_FILE,
@@ -54,6 +55,7 @@ _where_reload_doc = """
 
 # we cannot import external_versions here, as the cfg comes before anything
 # and we would have circular imports
+@lru_cache()
 def get_git_version(runner=None):
     """Return version of available git"""
     runner = runner or GitRunner()

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -54,8 +54,9 @@ _where_reload_doc = """
 
 # we cannot import external_versions here, as the cfg comes before anything
 # and we would have circular imports
-def get_git_version(runner):
+def get_git_version(runner=None):
     """Return version of available git"""
+    runner = runner or GitRunner()
     return runner.run('git version'.split())[0].split()[2]
 
 
@@ -241,7 +242,7 @@ class ConfigManager(object):
         self._runner = GitRunner(**run_kwargs)
         try:
             self._gitconfig_has_showorgin = \
-                LooseVersion(get_git_version(self._runner)) >= '2.8.0'
+                LooseVersion(get_git_version()) >= '2.8.0'
         except Exception:
             # no git something else broken, assume git is present anyway
             # to not delay this, but assume it is old

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -63,7 +63,7 @@ def _get_annex_version():
 
 def _get_git_version():
     """Return version of git we use (might be bundled)"""
-    return __get_git_version(_git_runner)
+    return __get_git_version()
 
 
 def _get_system_git_version():


### PR DESCRIPTION
Since CI is too busy, decided to just bundle in a single PR.  If needed -- could split into two or three if needed (ideally should have added a test for the `DATALAD_LOG_OUTPUTS` env var actually having an effect).

See individual commits for possibly more info ;-)