### PR TITLE
BF: LFS special remote has "url" in .git/config

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -829,7 +829,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             if remote not in self.get_remotes():
                 raise RemoteNotAvailableError(remote)
         opts = self.config.options('remote.{}'.format(remote))
-        if "url" in opts:
+        # for LFS git-annex records URL in the config
+        if "url" in opts and ('annex-git-lfs' not in opts):
             is_special = False
         elif any(o.startswith("annex-") for o in opts
                  if o not in ["annex-uuid", "annex-ignore"]):


### PR DESCRIPTION
Without this fix, initial publish would fail:

	/tmp > cd test-github-lfs2

	/tmp/test-github-lfs2 > git annex initremote github-lfs type=git-lfs url=https://github.com/yarikoptic/test-github-lfs2 encryption=none embedcreds=no
	initremote github-lfs ok
	(recording state in git...)

	/tmp/test-github-lfs2 > datalad create-sibling-github --publish-depends github-lfs test-github-lfs2
	[WARNING] Authentication failed using a token.
	[INFO   ] Configure additional publication dependency on "github-lfs"
	.: github(-) [https://github.com/yarikoptic/test-github-lfs2.git (git)]
	'https://github.com/yarikoptic/test-github-lfs2.git' configured as sibling 'github' for <Dataset path=/tmp/test-github-lfs2>

	/tmp/test-github-lfs2 > echo content > file.dat

	/tmp/test-github-lfs2 > datalad save -m content
	add(ok): file.dat (file)
	save(ok): . (dataset)
	action summary:
	  add (ok: 1)
	  save (ok: 1)

	/tmp/test-github-lfs2 > datalad publish --to=github
	CommandError: command '['git', 'fetch', '--verbose', '--progress', 'github-lfs']' failed with exitcode 128
	Failed to run ['git', 'fetch', '--verbose', '--progress', 'github-lfs'] at '/tmp/test-github-lfs2'.
	stdout=
	stderr=fatal: Couldn't find remote ref HEAD

	fatal: Couldn't find remote ref HEAD

Alternative/complimentary solution is coming in a subsequent PR.  I think this one is Ok, the other one might prove to be more robust but more ad-hoc