### PR TITLE
BF: allow for fetch to fail due to HEAD not yet been available on a remote for annex

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -34,7 +34,6 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.sshconnector import sh_quote
 from datalad.support.exceptions import (
-    CommandError,
     InsufficientArgumentsError,
 )
 from datalad.support.network import URL, RI, SSHRI, is_ssh
@@ -262,6 +261,15 @@ def _check_and_update_remote_server_info(ds, remote):
     return False
 
 
+def _maybe_fetch(repo, remote):
+    if repo.config.get("remote.{}.fetch".format(remote)):
+        repo.fetch(remote=remote)
+    else:
+        # Fetching would lead to "Couldn't find remote ref HEAD" if no
+        # branch" error.  See gh-4199 for an example.
+        lgr.warning("Remote %s has no configured refspec", remote)
+
+
 def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False, jobs=None,
                      transfer_data='auto', **kwargs):
     remote_branch_name = _get_remote_branch(ds, refspec)
@@ -291,7 +299,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     for r in publish_depends + [remote]:
         if not ds.config.get('.'.join(('remote', remote, 'annex-uuid')), None):
             lgr.debug("Obtain remote annex info from '%s'", r)
-            ds.repo.fetch(remote=r)
+            _maybe_fetch(ds.repo, r)
             # in order to be able to use git's config to determine what to push,
             # we need to annex merge first. Otherwise a git push might be
             # rejected if involving all matching branches for example.
@@ -423,18 +431,8 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
         # even if we already fetched above we need to do it again
         if is_annex_repo:
             lgr.debug("Obtain remote annex info from '%s'", remote)
-            try:
-                ds.repo.fetch(remote=remote)
-                ds.repo.merge_annex(remote)
-            except CommandError as exc:
-                # We might be publishing for the first time to this
-                # possibly special (e.g. LFS) annex special remote,
-                # and no HEAD was known
-                if ("Couldn't find remote ref HEAD" in exc.stderr) and \
-                   ('%s/HEAD' % remote not in ds.repo.get_remote_branches()):
-                    pass
-                else:
-                    raise
+            _maybe_fetch(ds.repo, remote)
+            ds.repo.merge_annex(remote)
 
         # Note: git's push.default is 'matching', which doesn't work for first
         # time publication (a branch, that doesn't exist on remote yet)


### PR DESCRIPTION
This is an alternative solution to https://github.com/datalad/datalad/pull/4199
which is lfs specific.  In this solution which would probably behave "correctly" for any
special remote which has URL and for which we never managed to fetch HEAD.