### PR TITLE
datalad.core.distributed.push

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -565,7 +565,7 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
         # (e.g. fresh repo)
         # TODO is this possible? we just copied? Maybe check if anything
         # was actually copied?
-        if "fatal: couldn't find remote ref git-annex" not in e.stderr:
+        if "fatal: couldn't find remote ref git-annex" not in e.stderr.lower():
             raise
         lgr.debug('Remote does not have a git-annex branch: %s', e)
     # and push the annex branch to announce local availability info

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -198,8 +198,8 @@ class Push(Interface):
             since = _get_corresponding_remote_state(ds_repo, to)
             if not since:
                 lgr.info(
-                    "No tracked remote for active branch,
-                    detection of last pushed state not in effect.")
+                    "No tracked remote for active branch, "
+                    "detection of last pushed state not in effect.")
 
         # obtain a generator for information on the datasets to process
         # idea is to turn the `paths` argument into per-dataset

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -1,0 +1,724 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Interface for dataset (component) pushing
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from tempfile import TemporaryFile
+
+from datalad.cmd import WitlessRunner
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.common_opts import (
+    jobs_opt,
+    recursion_limit,
+    recursion_flag,
+)
+from datalad.interface.utils import (
+    eval_results,
+)
+from datalad.interface.results import annexjson2result
+from datalad.support.annexrepo import (
+    AnnexJsonProtocol,
+    AnnexRepo,
+)
+from datalad.support.gitrepo import GitRepo
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureNone,
+    EnsureChoice,
+)
+from datalad.support.exceptions import CommandError
+from datalad.utils import (
+    Path,
+    assure_list,
+)
+
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+    resolve_path,
+)
+from datalad.core.local.diff import diff_dataset
+
+
+lgr = logging.getLogger('datalad.core.distributed.push')
+
+
+@build_doc
+class Push(Interface):
+    """Push a dataset to a known :term:`sibling`.
+
+    This makes the last saved state of a dataset available to a sibling
+    or special remote data store of a dataset. Any target sibling must already
+    exist and be known to the dataset.
+
+    Optionally, it is possible to limit a push to change sets relative
+    to a particular point in the version history of a dataset (e.g. a release
+    tag). By default, the state of the local dataset is evaluated against the
+    last known state of the target sibling. An actual push is only attempted
+    if there was a change compared to the reference state, in order to speed up
+    processing of large collections of datasets. Evaluation with respect to
+    a particular "historic" state is only supported in conjunction with a
+    specified reference dataset. Change sets are also evaluated recursively, i.e.
+    only those subdatasets are pushed where a change was recorded that is
+    reflected in to current state of the top-level reference dataset.
+    See "since" option for more information.
+
+    Only a push of saved changes is supported.
+
+    .. note::
+      Power-user info: This command uses :command:`git push`, and :command:`git annex copy`
+      to push a dataset. Publication targets are either configured remote
+      Git repositories, or git-annex special remotes (if they support data
+      upload).
+    """
+
+    # TODO add examples
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc=""""specify the dataset to push""",
+            constraints=EnsureDataset() | EnsureNone()),
+        to=Parameter(
+            args=("--to",),
+            metavar='SIBLING',
+            doc="""name of the target sibling. If no name is given an attempt is
+            made to identify the target based on the dataset's configuration
+            (i.e. a configured tracking branch, or a single sibling that is
+            configured for push)""",
+            constraints=EnsureStr() | EnsureNone()),
+        since=Parameter(
+            args=("--since",),
+            constraints=EnsureStr() | EnsureNone(),
+            doc="""specifies commit (treeish, tag, etc.) from which to look for
+            changes to decide whether pushing is necessary.
+            If an empty string is given, the last state of the current branch
+            at the sibling is taken as a starting point."""),
+        path=Parameter(
+            args=("path",),
+            metavar='PATH',
+            doc="""path to contrain a push to. If given, only
+            data or changes for those paths are considered for a push.""",
+            nargs='*',
+            constraints=EnsureStr() | EnsureNone()),
+        force=Parameter(
+            # multi-mode option https://github.com/datalad/datalad/issues/3414
+            args=("-f", "--force",),
+            doc="""force particular operations, overruling automatic decision
+            making: ...""",
+            constraints=EnsureChoice(
+                'all', 'gitpush', 'no-datatransfer', 'datatransfer', None)),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+        jobs=jobs_opt,
+    )
+
+    # Desired features:
+    # - let Git do it's thing (push multiple configured refs without the need
+    #                          to specific anything on the command line
+    #   - compilication: we need publication dependencies (i.e. publish what
+    #     would be published by Git to a different remote first, hence we
+    #     cannot simply watch Git do it, and later act on it.)
+    #   - https://github.com/datalad/datalad/issues/1284
+    #   - https://github.com/datalad/datalad/issues/4006
+    # - make differences between remotes and various types of special remotes
+    #   opaque
+    #   - https://github.com/datalad/datalad/issues/3127
+    # - informative and comprehensive (error) reporting
+    #   - https://github.com/datalad/datalad/issues/2000
+    #   - https://github.com/datalad/datalad/issues/1682
+    #   - https://github.com/datalad/datalad/issues/2029
+    #   - https://github.com/datalad/datalad/issues/2855
+    #   - https://github.com/datalad/datalad/issues/3412
+    #   - https://github.com/datalad/datalad/issues/3424
+    # - ensure robust behavior in multi-lateral push scenarios (updating
+    #   a dataset that was updated by a 3rd-party after the last known
+    #   fetched change
+    #   - https://github.com/datalad/datalad/issues/2636
+    # - should NOT mimic `publish` and that it mixes `create-sibling` and
+    #   `push` into a single operation. This would fold the complexity
+    #   of all possible ways a local dataset hierarchy could possibly
+    #   connected to remote ends into this command. It would be lost battle
+    #   from the start.
+    #   - not tackle: https://github.com/datalad/datalad/issues/2186
+    # - maintain standard setup, and not reflect procedural aspects
+    #   onto the resulting outcomes
+    #   - https://github.com/datalad/datalad/issues/2001
+    # - do a straight push, nothing like 'sync'. If a remote has something that
+    #   needs merging first, fail and let users update. Any diff we are missing
+    #   locally can impact decision making via --since and friends.
+
+    @staticmethod
+    @datasetmethod(name='push')
+    @eval_results
+    def __call__(
+            path=None,
+            dataset=None,
+            to=None,
+            since=None,
+            force=None,
+            recursive=False,
+            recursion_limit=None,
+            jobs=None):
+        # we resolve here, because we need to perform inspection on what was given
+        # as an input argument further down
+        paths = [resolve_path(p, dataset) for p in assure_list(path)]
+
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='pushing')
+
+        if since:
+            # will blow with ValueError if unusable
+            ds.repo.get_hexsha(since)
+
+        if not since and since is not None:
+            # TODO figure out state of remote branch and set `since`
+            pass
+
+        # obtain a generator for information on the datasets to process
+        # idea is to turn the `paths` argument into per-dataset
+        # content listings that can be acted upon
+        if since:
+            ds_spec = _datasets_since_(
+                # important to pass unchanged dataset arg
+                dataset, since, paths, recursive, recursion_limit)
+        else:
+            ds_spec = _datasets_no_since_(
+                # important to pass unchanged dataset arg
+                dataset, paths, recursive, recursion_limit)
+
+        res_kwargs = dict(
+            action='publish',
+            refds=ds.path,
+            logger=lgr,
+        )
+        # instead of a loop, this could all be done in parallel
+        matched_anything = False
+        for dspath, dsrecords in ds_spec:
+            matched_anything = True
+            lgr.debug('Attempt push of Dataset at %s', dspath)
+            yield from _push(
+                dspath, dsrecords, to, force, jobs, res_kwargs.copy())
+        if not matched_anything:
+            yield dict(
+                res_kwargs,
+                status='notneeded',
+                message='Given constraints did not match any changes to publish',
+                type='dataset',
+                path=ds.path,
+            )
+
+
+def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
+    """Generator"""
+    # rely on diff() reporting sequentially across datasets
+    cur_ds = None
+    ds_res = None
+    for res in diff_dataset(
+            dataset=dataset,
+            fr=since,
+            # we never touch unsaved content
+            to='HEAD',
+            constant_refs=False,
+            path=paths,
+            # we need to know what is around locally to be able
+            # to report something that should have been pushed
+            # but could not, because we don't have a copy
+            annex='availability',
+            recursive=recursive,
+            recursion_limit=recursion_limit,
+            # make it as fast as possible
+            eval_file_type=False,
+            # we relay on all records of a dataset coming out
+            # in succession, with no interuption by records
+            # concerning subdataset content
+            reporting_order='breadth-first'):
+        if res.get('action', None) != 'diff':
+            # we don't care right now
+            continue
+        if res.get('status', None) != 'ok':
+            # we cannot handle this situation, report it in panic
+            raise RuntimeError(
+                'Cannot handle non-OK diff result: {}'.format(res))
+        parentds = res.get('parentds', None)
+        if not parentds:
+            raise RuntimeError(
+                'Cannot handle diff result without a parent dataset '
+                'property: {}'.format(res))
+        if res.get('type', None) == 'dataset':
+            # a subdataset record in another data
+            # this could be here, because
+            # - this dataset with explicitely requested by path
+            #   -> should get a dedicated dataset record -- even without recursion
+            # - a path within an existing subdataset was given
+            #   -> TODO verify that this causes a dedicated dataset record
+            # - a path within an non-existing subdataset was given
+            #   locally or not)
+            # -> it should be ignored, but should not cause the branch in the
+            #   superdataset not to be pushed, if this was the only change
+            p = Path(res['path'])
+            if any(arg == p for arg in paths) and \
+                    not GitRepo.is_valid_repo(res['path']):
+                raise ValueError(
+                    'Cannot publish subdataset, not present: {}'.format(res['path']))
+        if parentds != cur_ds:
+            if ds_res:
+                # we switch to another dataset, yield this one so outside
+                # code can start processing immediately
+                yield (cur_ds, ds_res)
+            # clean start
+            ds_res = []
+            cur_ds = parentds
+        ds_res.append({
+            k: v for k, v in res.items()
+            if k in (
+                # let's keep 'state' in for now, it would make it possible
+                # to implement a "sync"-type push downstream that actually
+                # pulls 'deleted' files
+                'state',
+                # 'file' to copy-to, and subdataset records to possibly
+                # act on
+                'type',
+                # essential
+                'path',
+                # maybe do a key-based copy-to?
+                'key',
+                # progress reporting?
+                'bytesize',
+                # 'impossible' result when we should have copy-to'ed, but
+                # could not, because content isn't present
+                'has_content')
+        })
+
+    # if we have something left to report, do it
+    # importantly do not test for ds_res, even if we had only seen subdataset
+    # records to be changes, we would still want to push the git branches
+    if cur_ds:
+        yield (cur_ds, ds_res)
+
+
+def _datasets_no_since_(dataset, paths, recursive, recursion_limit):
+    """Generator"""
+    # TODO can we do better an cheaper?
+    from datalad.consts import PRE_INIT_COMMIT_SHA
+    # use the diff "since before time"
+    return _datasets_since_(
+        dataset, PRE_INIT_COMMIT_SHA, paths, recursive, recursion_limit)
+
+
+def _push(dspath, content, target, force, jobs, res_kwargs,
+          done_fetch=None):
+    if not done_fetch:
+        done_fetch = set()
+    # nothing recursive in here, we only need a repo to work with
+    ds = Dataset(dspath)
+    repo = ds.repo
+
+    res_kwargs.update(type='dataset', path=dspath)
+
+    if not target:
+        try:
+            # let Git figure out what needs doing
+            wannabe_gitpush = repo.push(remote=None, git_options=['--dry-run'])
+            # we did not get an explicit push target, get it from Git
+            target = set(p.get('remote', None) for p in wannabe_gitpush)
+            # handle case where a pushinfo record did not have a 'remote'
+            # property -- should not happen, but be robust
+            target.discard(None)
+        except Exception as e:
+            lgr.debug(
+                'Dry-run push to determine default push target failed, '
+                'assume no configuration: %s', e)
+            target = set()
+        if not len(target):
+            yield dict(
+                res_kwargs,
+                status='error',
+                message='No push target given, and none could be '
+                        'auto-detected',
+            )
+            return
+        elif len(target) > 1:
+            # dunno if this can ever happen, but if it does, report
+            # nicely
+            yield dict(
+                res_kwargs,
+                status='error',
+                message=(
+                    'No push target given, '
+                    'multiple candidates auto-detected: %s',
+                    list(target),
+                )
+            )
+            return
+        else:
+            # can only be a single one at this point
+            target = target.pop()
+
+    if target not in repo.get_remotes():
+        yield dict(
+            res_kwargs,
+            status='error',
+            message=(
+                "Dataset %s does not know of a sibling '%s' to push to.",
+                ds, target))
+        return
+
+    lgr.debug("Attempt to push to '%s'", target)
+
+    # define config var name for potential publication dependencies
+    depvar = 'remote.{}.datalad-publish-depends'.format(target)
+    # list of remotes that are publication dependencies for the
+    # target remote
+    publish_depends = assure_list(ds.config.get(depvar, []))
+    if publish_depends:
+        lgr.debug("Discovered publication dependencies for '%s': %s'",
+                  target, publish_depends)
+
+    # anything that follows will not change the repo type, cache.
+    is_annex_repo = isinstance(ds.repo, AnnexRepo)
+
+    # TODO prevent this when `target` is a special remote
+    # (possibly redo) a push attempt to figure out what needs pushing
+    # do this on the main target only, and apply the result to all
+    # dependencies
+    try:
+        wannabe_gitpush = repo.push(
+            remote=target,
+            git_options=['--dry-run'])
+    except Exception as e:
+        lgr.debug(
+            'Dry-run push to check push configuration failed, '
+            'assume no configuration: %s', e)
+        wannabe_gitpush = []
+    refspecs2push = [
+        # if an upstream branch is set, go with it
+        p['from_ref']
+        if ds.config.get(
+            'branch.{}.remote'.format(p['from_ref'][len('refs/heads/'):]),
+            None) == target and ds.config.get(
+            'branch.{}.merge'.format(p['from_ref'][len('refs/heads/'):]),
+            None)
+        # if not, define target refspec explicitly to avoid having to
+        # set an upstream branch, which would happen implicitly from
+        # a users POV, and may also be hard to decide when publication
+        # dependencies are present
+        else '{}:{}'.format(p['from_ref'], p['to_ref'])
+        for p in wannabe_gitpush
+        # TODO: what if a publication dependency doesn't have it yet
+        # should we not attempt to push, because the main target has it?
+        if 'uptodate' not in p['operations'] and (
+            # cannot think of a scenario where we would want to push a
+            # managed branch directly, instead of the corresponding branch
+            'refs/heads/adjusted' not in p['from_ref'])
+    ]
+    if not refspecs2push:
+        lgr.debug(
+            'No refspecs configured for push, attempting to use active branch')
+        # nothing was set up for push, push the current branch at minimum
+        # TODO this is not right with managed branches
+        active_branch = repo.get_active_branch()
+        if not active_branch:
+            yield dict(
+                res_kwargs,
+                status='impossible',
+                message=
+                'There is no active branch, cannot determine remote '
+                'branch'
+            )
+            return
+        if is_annex_repo and repo.is_managed_branch(active_branch):
+            # a managed branch, in which case we need to determine
+            # the actual one and make sure it is sync'ed with the managed
+            # one, and push that one instead
+            active_branch = repo.get_corresponding_branch(active_branch)
+            _sync_annex(repo, target, active_branch)
+        refspecs2push.append(
+            # same dance as above
+            active_branch
+            if ds.config.get('branch.{}.merge'.format(active_branch), None)
+            else '{ab}:{ab}'.format(ab=active_branch)
+        )
+
+    # we know what to push and where, now dependency processing first
+    for r in publish_depends:
+        # simply make a call to this function again, all the same, but
+        # target is different, pass done_fetch to avoid duplicate
+        # and expensive calls to git-fetch
+        yield from _push(
+            dspath,
+            content,
+            # to this particular dependency
+            r,
+            force,
+            jobs,
+            res_kwargs.copy(),
+            done_fetch=None
+        )
+
+    # and lastly the primary push target
+    #
+    # push the main branches of interest first, but not yet (necessarily)
+    # the git-annex branch. We ant to push first in order to hit any conflicts
+    # or unknown history before we move data. Otherwise out decision making
+    # done above (--since ...) might have been inappropriate.
+    push_ok = True
+    for p in _push_refspecs(
+            repo,
+            target,
+            refspecs2push,
+            force,
+            res_kwargs.copy()):
+        if p['status'] not in ('ok', 'notneeded'):
+            push_ok = False
+        yield p
+    if not push_ok:
+        # error-type results have been yielded, the local status quo is
+        # outdated/invalid, stop to let user decide how to proceed.
+        # TODO final global error result for the dataset?!
+        return
+
+    # git-annex data move
+    #
+    if is_annex_repo:
+        if force == 'no-datatransfer':
+            lgr.debug("Data transfer to '%s' disabled by argument", target)
+        else:
+            yield from _push_data(
+                ds,
+                target,
+                content,
+                force,
+                jobs,
+                res_kwargs.copy(),
+            )
+            # after file transfer the remote might have different commits to
+            # the annex branch. They have to be merged locally, otherwise a
+            # push of it further down will fail
+            try:
+                # fetch remote, let annex sync them locally, so that the push
+                # later on works.
+                # We have to fetch via the push url (if there is any),
+                # not a pull url.
+                # The latter might be dumb and without the execution of a
+                # post-update hook we might not be able to retrieve the
+                # server-side git-annex branch updates (and git-annex does
+                # not trigger the hook on copy), but we know we have
+                # full access via the push url -- we have just used it to copy.
+                fetch_cmd = ['fetch', target, 'git-annex']
+                pushurl = repo.config.get(
+                    'remote.{}.pushurl'.format(target), None)
+                if pushurl:
+                    # for some reason overwriting remote.{target}.url
+                    # does not have any effect...
+                    fetch_cmd = [
+                        '-c',
+                        'url.{}.insteadof={}'.format(
+                            pushurl,
+                            repo.config.get(
+                                'remote.{}.url'.format(target), None)
+                        )
+                    ] + fetch_cmd
+                    lgr.debug(
+                        "Sync local annex branch from pushurl after remote "
+                        'availability update.')
+                repo.call_git(fetch_cmd)
+                _sync_annex(repo, target)
+            except CommandError as e:
+                # it is OK if the remote doesn't have a git-annex branch yet
+                # (e.g. fresh repo)
+                # TODO is this possible? we just copied? Maybe check if anything
+                # was actually copied?
+                if "fatal: couldn't find remote ref git-annex" not in e.stderr:
+                    raise
+                lgr.debug('Remote does not have a git-annex branch: %s', e)
+            # and push the annex branch to announce local availability info
+            # too
+            yield from _push_refspecs(
+                repo,
+                target,
+                ['git-annex'
+                 if ds.config.get('branch.git-annex.merge', None)
+                 else 'git-annex:git-annex'],
+                force,
+                res_kwargs.copy(),
+            )
+
+
+def _sync_annex(repo, target, corresponding_branch=None):
+    if not corresponding_branch:
+        corresponding_branch = repo.get_corresponding_branch()
+    synced_branch = 'synced/{}'.format(corresponding_branch)
+    had_synced_branch = synced_branch in repo.get_branches()
+    repo.call_git([
+        'annex', 'sync',
+        # there is no way to do this in a purely local fashion
+        # although this is what we want here, emulate...
+        target,
+        # disable any external interaction and other magic
+        '--no-push', '--no-pull', '--no-commit', '--no-resolvemerge',
+    ])
+    if not had_synced_branch:
+        # cleanup after sync, simply remove the sync branch and not
+        # use 'sync --cleanup' to further limit remote interaction
+        repo.call_git(['branch', '-D', synced_branch])
+
+
+def _push_refspecs(repo, target, refspecs, force, res_kwargs):
+    # TODO inefficient, but push only takes a single refspec at a time
+    # at the moment, enhance GitRepo.push() to do all at once
+    push_res = []
+    for refspec in refspecs:
+        push_res.extend(repo.push(
+            remote=target,
+            refspec=refspec,
+            git_options=['--force'] if force in ('all', 'gitpush') else None,
+        ))
+    # TODO maybe compress into a single message whenever everything is
+    # OK?
+    for pr in push_res:
+        ops = pr['operations']
+        status = (
+            'error'
+            if any(o in ops for o in (
+                'error', 'no-match', 'rejected', 'remote-rejected',
+                'remote-failure'))
+            else 'notneeded'
+            if 'uptodate' in pr['operations']
+            else 'ok'
+            if any(o in ops for o in (
+                'new-tag', 'new-branch', 'forced-update', 'fast-forward'))
+            # no really a good fit, but we have tested all relevant
+            # operations above, so in some sense this condition should be
+            # impossible to achieve
+            else 'impossible'
+        )
+        refspec = '{}:{}'.format(pr['from_ref'], pr['to_ref'])
+        yield dict(
+            res_kwargs,
+            status=status,
+            target=pr['remote'],
+            refspec=refspec,
+            operations=ops,
+            # seems like a good idea to pass on Git's native message
+            # TODO maybe implement a dedicated result renderer, instead
+            # of duplicating information only so that the default one
+            # can make sense at all
+            message='{}->{}:{} {}'.format(
+                pr['from_ref'],
+                pr['remote'],
+                pr['to_ref'],
+                pr['note']),
+        )
+
+
+def _push_data(ds, target, content, force, jobs, res_kwargs):
+    if ds.config.getbool('remote.{}'.format(target), 'annex-ignore', False):
+        lgr.debug(
+            "Target '%s' is set to annex-ignore, exclude from data-push.",
+            target,
+        )
+        return
+    if not ds.config.get('.'.join(('remote', target, 'annex-uuid')), None):
+        # this remote either isn't an annex,
+        # or hasn't been properly initialized
+        # rather than barfing tons of messages for each file, do one
+        # for the entire dataset
+        yield dict(
+            res_kwargs,
+            status='impossible'
+            if force in ('all', 'datatransfer')
+            else 'notneeded',
+            message=(
+                "Target '%s' does not appear to be an annex remote",
+                target)
+        )
+        return
+    # figure out which of the reported content (after evaluating
+    # `since` and `path` arguments needs transport
+    to_transfer = [
+        c
+        for c in content
+        # by force
+        if ((force in ('all', 'datatransfer') or
+             # or by modification report
+             c.get('state', None) not in ('clean', 'deleted'))
+            # only consider annex'ed files
+            and 'key' in c
+        )
+    ]
+    for c in [c for c in to_transfer if not c.get('has_content', False)]:
+        yield dict(
+            res_kwargs,
+            type=c['type'],
+            path=c['path'],
+            action='copy',
+            status='impossible',
+            message='Slated for transport, but no content present',
+        )
+
+    cmd = ['git', 'annex', 'copy', '--batch', '-z', '--to', target,
+           '--json', '--json-error-messages', '--json-progress']
+
+    if jobs:
+        cmd.extend(['--jobs', str(jobs)])
+
+    if not to_transfer and force not in ('all', 'datatransfer'):
+        lgr.debug("Invoking copy --auto")
+        cmd.append('--auto')
+
+    if force not in ('all', 'datatransfer'):
+        # if we force, we do not trust local knowledge and do the checks
+        cmd.append('--fast')
+
+    lgr.debug("Push data from %s to '%s'", ds, target)
+
+    # produce final path list. use knowledge that annex command will
+    # run in the root of the dataset and compact paths to be relative
+    # to this location
+    # XXX must not be a SpooledTemporaryFile -- dunno why, but doesn't work
+    # otherwise
+    with TemporaryFile() as file_list:
+        for c in to_transfer:
+            if not c.get('has_content', False):
+                # warned about above, now just skip
+                continue
+            file_list.write(
+                bytes(Path(c['path']).relative_to(ds.pathobj)))
+            file_list.write(b'\0')
+
+        # rewind stdin buffer
+        file_list.seek(0)
+        # and go
+        # TODO try-except and yield what was captured before the crash
+        res = WitlessRunner(
+            cwd=ds.path,
+            # TODO env
+        ).run(
+            cmd,
+            # TODO report how many in total, and give global progress too
+            protocol=AnnexJsonProtocol,
+            stdin=file_list)
+        for c in ('stdout', 'stderr'):
+            if res[c]:
+                lgr.debug('Received unexpected %s from `annex copy`: %s',
+                          c, res[c])
+        for j in res['stdout_json']:
+            yield annexjson2result(j, ds)
+    return

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -635,6 +635,7 @@ def _push_data(ds, target, content, force, jobs, res_kwargs):
             target,
         )
         return
+    res_kwargs['target'] = target
     if not ds.config.get('.'.join(('remote', target, 'annex-uuid')), None):
         # this remote either isn't an annex,
         # or hasn't been properly initialized
@@ -690,6 +691,9 @@ def _push_data(ds, target, content, force, jobs, res_kwargs):
 
     lgr.debug("Push data from %s to '%s'", ds, target)
 
+    # input has type=dataset, but now it is about files
+    res_kwargs.pop('type', None)
+
     # produce final path list. use knowledge that annex command will
     # run in the root of the dataset and compact paths to be relative
     # to this location
@@ -721,7 +725,7 @@ def _push_data(ds, target, content, force, jobs, res_kwargs):
                 lgr.debug('Received unexpected %s from `annex copy`: %s',
                           c, res[c])
         for j in res['stdout_json']:
-            yield annexjson2result(j, ds, type='file')
+            yield annexjson2result(j, ds, type='file', **res_kwargs)
     return
 
 

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -94,7 +94,7 @@ class Push(Interface):
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc=""""specify the dataset to push""",
+            doc="""specify the dataset to push""",
             constraints=EnsureDataset() | EnsureNone()),
         to=Parameter(
             args=("--to",),
@@ -123,9 +123,9 @@ class Push(Interface):
             args=("-f", "--force",),
             doc="""force particular operations, overruling automatic decision
             making: use --force with git-push ('gitpush'); do not use --fast
-            with git-annex copy (datatransfer); do not attempt to copy annex'ed
-            file content (no-datatransfer); combine force modes 'gitpush' and
-            'datatransfer' (all).""",
+            with git-annex copy ('datatransfer'); do not attempt to copy
+            annex'ed file content ('no-datatransfer'); combine force modes
+            'gitpush' and 'datatransfer' ('all').""",
             constraints=EnsureChoice(
                 'all', 'gitpush', 'no-datatransfer', 'datatransfer', None)),
         recursive=recursion_flag,

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -351,9 +351,9 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
         if not len(target):
             yield dict(
                 res_kwargs,
-                status='error',
+                status='impossible',
                 message='No push target given, and none could be '
-                        'auto-detected',
+                        'auto-detected, please specific via --to',
             )
             return
         elif len(target) > 1:
@@ -378,8 +378,7 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
             res_kwargs,
             status='error',
             message=(
-                "Dataset %s does not know of a sibling '%s' to push to.",
-                ds, target))
+                "Unknown target sibling '%s'.", target))
         return
 
     lgr.debug("Attempt to push to '%s'", target)

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -267,16 +267,17 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
             # - this dataset with explicitely requested by path
             #   -> should get a dedicated dataset record -- even without recursion
             # - a path within an existing subdataset was given
-            #   -> TODO verify that this causes a dedicated dataset record
             # - a path within an non-existing subdataset was given
             #   locally or not)
-            # -> it should be ignored, but should not cause the branch in the
+            #   -> it should be ignored, but should not cause the branch in the
             #   superdataset not to be pushed, if this was the only change
             p = Path(res['path'])
+            # was given as an explicit path argument
             if any(arg == p for arg in paths) and \
                     not GitRepo.is_valid_repo(res['path']):
                 raise ValueError(
                     'Cannot publish subdataset, not present: {}'.format(res['path']))
+
         if parentds != cur_ds:
             if ds_res:
                 # we switch to another dataset, yield this one so outside
@@ -642,6 +643,7 @@ def _push_data(ds, target, content, force, jobs, res_kwargs):
         # for the entire dataset
         yield dict(
             res_kwargs,
+            action='copy',
             status='impossible'
             if force in ('all', 'datatransfer')
             else 'notneeded',
@@ -720,5 +722,5 @@ def _push_data(ds, target, content, force, jobs, res_kwargs):
                 lgr.debug('Received unexpected %s from `annex copy`: %s',
                           c, res[c])
         for j in res['stdout_json']:
-            yield annexjson2result(j, ds)
+            yield annexjson2result(j, ds, type='file')
     return

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -452,7 +452,8 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
             # managed one, and push that one instead. following methods can
             # be called unconditionally
             repo.localsync(managed_only=True)
-            active_branch = repo.get_corresponding_branch(active_branch)
+            active_branch = repo.get_corresponding_branch(
+                active_branch) or active_branch
         refspecs2push.append(
             # same dance as above
             active_branch

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -477,26 +477,31 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
         )
 
     # and lastly the primary push target
-    #
-    # push the main branches of interest first, but not yet (necessarily)
-    # the git-annex branch. We ant to push first in order to hit any conflicts
-    # or unknown history before we move data. Otherwise out decision making
-    # done above (--since ...) might have been inappropriate.
-    push_ok = True
-    for p in _push_refspecs(
-            repo,
-            target,
-            refspecs2push,
-            force,
-            res_kwargs.copy()):
-        if p['status'] not in ('ok', 'notneeded'):
-            push_ok = False
-        yield p
-    if not push_ok:
-        # error-type results have been yielded, the local status quo is
-        # outdated/invalid, stop to let user decide how to proceed.
-        # TODO final global error result for the dataset?!
-        return
+    target_is_git_remote = repo.config.get(
+        'remote.{}.url'.format(target), None) is not None
+    # only attempt, if Git knows about a URL, otherwise this is
+    # a pure special remote that doesn't deal with the git repo
+    if target_is_git_remote:
+        # push the main branches of interest first, but not yet (necessarily)
+        # the git-annex branch. We ant to push first in order to hit any
+        # conflicts or unknown history before we move data. Otherwise out
+        # decision making done above (--since ...) might have been
+        # inappropriate.
+        push_ok = True
+        for p in _push_refspecs(
+                repo,
+                target,
+                refspecs2push,
+                force,
+                res_kwargs.copy()):
+            if p['status'] not in ('ok', 'notneeded'):
+                push_ok = False
+            yield p
+        if not push_ok:
+            # error-type results have been yielded, the local status quo is
+            # outdated/invalid, stop to let user decide how to proceed.
+            # TODO final global error result for the dataset?!
+            return
 
     # git-annex data move
     #
@@ -515,6 +520,12 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
         jobs,
         res_kwargs.copy(),
     )
+
+    if not target_is_git_remote:
+        # there is nothing that we need to push or sync with on the git-side
+        # of things with this remote
+        return
+
     # after file transfer the remote might have different commits to
     # the annex branch. They have to be merged locally, otherwise a
     # push of it further down will fail

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -452,8 +452,8 @@ def _push(dspath, content, target, force, jobs, res_kwargs,
             # determine the actual one and make sure it is sync'ed with the
             # managed one, and push that one instead. following methods can
             # be called unconditionally
+            repo.localsync(managed_only=True)
             active_branch = repo.get_corresponding_branch(active_branch)
-            repo.localsync(target)
         refspecs2push.append(
             # same dance as above
             active_branch

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -19,6 +19,7 @@ from datalad.support.exceptions import (
 from datalad.tests.utils import (
     assert_in,
     assert_in_results,
+    assert_not_in,
     assert_not_in_results,
     assert_raises,
     assert_repo_status,
@@ -111,6 +112,7 @@ def check_push(annex, src_path, dst_path):
     src_repo = src.repo
     # push should not add branches to the local dataset
     orig_branches = src_repo.get_branches()
+    assert_not_in('synced/master', orig_branches)
 
     res = src.push(on_failure='ignore')
     assert_result_count(res, 1)
@@ -118,10 +120,13 @@ def check_push(annex, src_path, dst_path):
         res, status='impossible',
         message='No push target given, and none could be auto-detected, '
         'please specific via --to')
+    eq_(orig_branches, src_repo.get_branches())
     # target sibling
     target = mk_push_target(src, 'target', dst_path, annex=annex)
+    eq_(orig_branches, src_repo.get_branches())
 
     res = src.push(to="target")
+    eq_(orig_branches, src_repo.get_branches())
     assert_result_count(res, 2 if annex else 1)
     assert_in_results(
         res,
@@ -140,6 +145,7 @@ def check_push(annex, src_path, dst_path):
     # don't fail when doing it again, no explicit target specification
     # needed anymore
     res = src.push()
+    eq_(orig_branches, src_repo.get_branches())
     # and nothing is pushed
     assert_status('notneeded', res)
 

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -1,0 +1,507 @@
+
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test push
+
+"""
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.exceptions import (
+    IncompleteResultsError,
+    InsufficientArgumentsError,
+)
+from datalad.tests.utils import (
+    assert_in,
+    assert_in_results,
+    assert_not_in_results,
+    assert_raises,
+    assert_repo_status,
+    assert_result_count,
+    assert_status,
+    eq_,
+    neq_,
+    ok_,
+    ok_file_has_content,
+    serve_path_via_http,
+    skip_if_on_windows,
+    skip_ssh,
+    with_tempfile,
+    with_tree,
+    SkipTest,
+)
+from datalad.utils import (
+    chpwd,
+    Path,
+)
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
+from datalad.core.distributed.clone import Clone
+from datalad.core.distributed.push import Push
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_invalid_call(origin, tdir):
+    ds = Dataset(origin).create()
+    # no target
+    assert_status('error', ds.push(on_failure='ignore'))
+    # no dataset
+    with chpwd(tdir):
+        assert_raises(InsufficientArgumentsError, Push.__call__)
+    # dataset, but outside path
+    assert_raises(IncompleteResultsError, ds.push, path=tdir)
+    # given a path constraint that doesn't match anything, will cause
+    # nothing to be done
+    assert_status('notneeded', ds.push(path=ds.pathobj / 'nothere'))
+
+    # unavailable subdataset
+    dummy_sub = ds.create('sub')
+    dummy_sub.uninstall()
+    assert_in('sub', ds.subdatasets(fulfilled=False, result_xfm='relpaths'))
+    # now an explicit call to publish the unavailable subdataset
+    assert_raises(ValueError, ds.push, 'sub')
+
+    target = mk_push_target(ds, 'target', tdir, annex=True)
+    # revision that doesn't exist
+    assert_raises(
+        ValueError,
+        ds.push, to='target', since='09320957509720437523')
+
+
+def mk_push_target(ds, name, path, annex=True, bare=True):
+    # life could be simple, but nothing is simple on windows
+    #src.create_sibling(dst_path, name='target')
+    if annex:
+        if bare:
+            target = GitRepo(path=path, bare=True, create=True)
+            target.call_git(['annex', 'init'])
+        else:
+            target = AnnexRepo(path, init=True, create=True)
+            if not target.is_managed_branch():
+                # for managed branches we need more fireworks->below
+                target.config.set(
+                    'receive.denyCurrentBranch', 'updateInstead',
+                    where='local')
+    else:
+        target = GitRepo(path=path, bare=bare, create=True)
+    ds.siblings('add', name=name, url=path, result_renderer=None)
+    if annex and not bare and target.is_managed_branch():
+        # maximum complication
+        # the target repo already has a commit that is unrelated
+        # to the source repo, because it has built a reference
+        # commit for the managed branch.
+        # the only sane approach is to let git-annex establish a shared
+        # history
+        ds.repo.call_git(['annex', 'sync'])
+        ds.repo.call_git(['annex', 'sync', '--cleanup'])
+    return target
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def check_push(annex, src_path, dst_path):
+    # prepare src
+    src = Dataset(src_path).create(no_annex=not annex)
+    src_repo = src.repo
+    # push should not add branches to the local dataset
+    orig_branches = src_repo.get_branches()
+
+    res = src.push(on_failure='ignore')
+    assert_result_count(res, 1)
+    assert_in_results(
+        res, status='error',
+        message='No push target given, and none could be auto-detected')
+    # target sibling
+    target = mk_push_target(src, 'target', dst_path, annex=annex)
+
+    res = src.push(to="target")
+    assert_result_count(res, 2 if annex else 1)
+    assert_in_results(
+        res,
+        action='publish', status='ok', target='target',
+        refspec='refs/heads/master:refs/heads/master',
+        operations=['new-branch'])
+
+    assert_repo_status(src_repo, annex=annex)
+    eq_(list(target.get_branch_commits_("master")),
+        list(src_repo.get_branch_commits_("master")))
+
+    # configure a default merge/upstream target
+    src.config.set('branch.master.remote', 'target', where='local')
+    src.config.set('branch.master.merge', 'master', where='local')
+
+    # don't fail when doing it again, no explicit target specification
+    # needed anymore
+    res = src.push()
+    # and nothing is pushed
+    assert_status('notneeded', res)
+
+    assert_repo_status(src_repo, annex=annex)
+    eq_(list(target.get_branch_commits_("master")),
+        list(src_repo.get_branch_commits_("master")))
+
+    # some modification:
+    (src.pathobj / 'test_mod_file').write_text("Some additional stuff.")
+    src.save(to_git=True, message="Modified.")
+    (src.pathobj / 'test_mod_annex_file').write_text("Heavy stuff.")
+    src.save(to_git=not annex, message="Modified again.")
+    assert_repo_status(src_repo, annex=annex)
+
+    res = src.push(to='target', since="HEAD~2", jobs=2)
+    assert_in_results(
+        res,
+        action='publish', status='ok', target='target',
+        refspec='refs/heads/master:refs/heads/master',
+        # we get to see what happened
+        operations=['fast-forward'])
+    if annex:
+        # we got to see the copy result for the annexed files
+        assert_in_results(
+            res,
+            action='copy',
+            status='ok',
+            path=str(src.pathobj / 'test_mod_annex_file'))
+        # we published, so we can drop and reobtain
+        ok_(src_repo.file_has_content('test_mod_annex_file'))
+        src_repo.drop('test_mod_annex_file')
+        ok_(not src_repo.file_has_content('test_mod_annex_file'))
+        src_repo.get('test_mod_annex_file')
+        ok_(src_repo.file_has_content('test_mod_annex_file'))
+        ok_file_has_content(
+            src_repo.pathobj / 'test_mod_annex_file',
+            'Heavy stuff.')
+
+    eq_(list(target.get_branch_commits_("master")),
+        list(src_repo.get_branch_commits_("master")))
+    if not (annex and src_repo.is_managed_branch()):
+        # the following doesn't make sense in managed branches, because
+        # a commit that could be amended is no longer the last commit
+        # of a branch after a sync has happened (which did happen
+        # during the last push above
+
+        # amend and change commit msg in order to test for force push:
+        src_repo.commit("amended", options=['--amend'])
+        # push should be rejected (non-fast-forward):
+        res = src.push(to='target', since='HEAD~2', on_failure='ignore')
+        # fails before even touching the annex branch
+        assert_result_count(res, 1)
+        assert_in_results(
+            res,
+            action='publish', status='error', target='target',
+            refspec='refs/heads/master:refs/heads/master',
+            operations=['rejected', 'error'])
+        # push with force=True works:
+        res = src.push(to='target', since='HEAD~2', force='gitpush')
+        assert_in_results(
+            res,
+            action='publish', status='ok', target='target',
+            refspec='refs/heads/master:refs/heads/master',
+            operations=['forced-update'])
+        eq_(list(target.get_branch_commits_("master")),
+            list(src_repo.get_branch_commits_("master")))
+
+    # we do not have more branches than we had in the beginning
+    # in particular no 'synced/master'
+    eq_(orig_branches, src_repo.get_branches())
+
+
+def test_push():
+    yield check_push, False
+    yield check_push, True
+
+
+@with_tempfile
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_push_recursive(
+        origin_path, src_path, dst_top, dst_sub, dst_subnoannex, dst_subsub):
+    # dataset with two submodules and one subsubmodule
+    origin = Dataset(origin_path).create()
+    origin_subm1 = origin.create('sub m')
+    origin_subm1.create('subsub m')
+    origin.create('subm noannex', no_annex=True)
+    origin.save()
+    assert_repo_status(origin.path)
+    # prepare src as a fresh clone with all subdatasets checkout out recursively
+    # running on a clone should make the test scenario more different than
+    # test_push(), even for the pieces that should be identical
+    top = Clone.__call__(source=origin.path, path=src_path)
+    sub, subsub, subnoannex = top.get(
+        '.', recursive=True, get_data=False, result_xfm='datasets')
+
+    target_top = mk_push_target(top, 'target', dst_top, annex=True)
+    # subdatasets have no remote yet, so recursive publishing should fail:
+    res = top.push(to="target", recursive=True, on_failure='ignore')
+    assert_in_results(
+        res, path=top.path, type='dataset',
+        refspec='refs/heads/master:refs/heads/master',
+        operations=['new-branch'], action='publish', status='ok',
+        target='target')
+    for d in (sub, subsub, subnoannex):
+        assert_in_results(
+            res, status='error', type='dataset', path=d.path,
+            message=("Dataset %s does not know of a sibling '%s' to push to.",
+                     d, 'target'))
+    # now fix that and set up targets for the submodules
+    target_sub = mk_push_target(sub, 'target', dst_sub, annex=True)
+    target_subnoannex = mk_push_target(
+        subnoannex, 'target', dst_subnoannex, annex=False)
+    target_subsub = mk_push_target(subsub, 'target', dst_subsub, annex=True)
+
+    # and same push call as above
+    res = top.push(to="target", recursive=True)
+    # topds skipped
+    assert_in_results(
+        res, path=top.path, type='dataset',
+        action='publish', status='notneeded', target='target')
+    # the rest pushed
+    for d in (sub, subsub, subnoannex):
+        assert_in_results(
+            res, status='ok', type='dataset', path=d.path,
+            refspec='refs/heads/master:refs/heads/master')
+    # all correspondig branches match across all datasets
+    for s, d in zip((top, sub, subnoannex, subsub),
+                    (target_top, target_sub, target_subnoannex,
+                     target_subsub)):
+        eq_(list(s.repo.get_branch_commits_("master")),
+            list(d.get_branch_commits_("master")))
+        if s != subnoannex:
+            eq_(list(s.repo.get_branch_commits_("git-annex")),
+                list(d.get_branch_commits_("git-annex")))
+
+    # rerun should not result in further pushes of master
+    res = top.push(to="target", recursive=True)
+    assert_not_in_results(
+        res, status='ok', refspec="refs/heads/master:refs/heads/master")
+    assert_in_results(
+        res, status='notneeded', refspec="refs/heads/master:refs/heads/master")
+
+    if top.repo.is_managed_branch():
+        raise SkipTest(
+            'Save/status of subdataset with managed branches is an still '
+            'unresolved issue')
+
+    # now annex a file in subsub
+    test_copy_file = subsub.pathobj / 'test_mod_annex_file'
+    test_copy_file.write_text("Heavy stuff.")
+    # save all the way up
+    assert_status(
+        ('ok', 'notneeded'),
+        top.save(message='subsub got something', recursive=True))
+    assert_repo_status(top.path)
+    # publish straight up, should be smart by default
+    res = top.push(to="target", recursive=True)
+    # we see 3 out of 4 datasets pushed (sub noannex was left unchanged)
+    for d in (top, sub, subsub):
+        assert_in_results(
+            res, status='ok', type='dataset', path=d.path,
+            refspec='refs/heads/master:refs/heads/master')
+    # file content copied too
+    assert_in_results(
+        res,
+        action='copy',
+        status='ok',
+        path=str(test_copy_file))
+    # verify it is accessible, drop and bring back
+    assert_status('ok', top.drop(str(test_copy_file)))
+    ok_(not subsub.repo.file_has_content('test_mod_annex_file'))
+    top.get(test_copy_file)
+    ok_file_has_content(test_copy_file, 'Heavy stuff.')
+
+    # make two modification
+    (sub.pathobj / 'test_mod_annex_file').write_text('annex')
+    (subnoannex.pathobj / 'test_mod_file').write_text('git')
+    # save separately
+    top.save(sub.pathobj, message='annexadd', recursive=True)
+    top.save(subnoannex.pathobj, message='gitadd', recursive=True)
+    # now only publish the latter one
+    res = top.push(to="target", since='HEAD~1', recursive=True)
+    # nothing copied, no reports on the other modification
+    assert_not_in_results(res, action='copy')
+    assert_not_in_results(res, path=sub.path)
+    for d in (top, subnoannex):
+        assert_in_results(
+            res, status='ok', type='dataset', path=d.path,
+            refspec='refs/heads/master:refs/heads/master')
+    # an unconditional push should now pick up the remaining changes
+    res = top.push(to="target", recursive=True)
+    assert_in_results(
+        res,
+        action='copy',
+        status='ok',
+        path=str(sub.pathobj / 'test_mod_annex_file'))
+    assert_in_results(
+        res, status='ok', type='dataset', path=sub.path,
+        refspec='refs/heads/master:refs/heads/master')
+    for d in (top, subnoannex, subsub):
+        assert_in_results(
+            res, status='notneeded', type='dataset', path=d.path,
+            refspec='refs/heads/master:refs/heads/master')
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_force_datatransfer(srcpath, dstpath):
+    src = Dataset(srcpath).create()
+    target = mk_push_target(src, 'target', dstpath, annex=True, bare=True)
+    (src.pathobj / 'test_mod_annex_file').write_text("Heavy stuff.")
+    src.save(to_git=False, message="New annex file")
+    assert_repo_status(src.path, annex=True)
+    whereis_prior = src.repo.whereis(files=['test_mod_annex_file'])[0]
+
+    res = src.push(to='target', force='no-datatransfer')
+    # nothing reported to be copied
+    assert_not_in_results(res, action='copy')
+    # we got the git-push nevertheless
+    eq_(src.repo.get_hexsha('master'), target.get_hexsha('master'))
+    # nothing moved
+    eq_(whereis_prior, src.repo.whereis(files=['test_mod_annex_file'])[0])
+
+    # now a push without forced no-transfer
+    # we do not give since, so the non-transfered file is picked up
+    # and transferred
+    res = src.push(to='target', force=None)
+    # no branch change, done before
+    assert_in_results(res, action='publish', status='notneeded',
+                      refspec='refs/heads/master:refs/heads/master')
+    # but availability update
+    assert_in_results(res, action='publish', status='ok',
+                      refspec='refs/heads/git-annex:refs/heads/git-annex')
+    assert_in_results(res, status='ok',
+                      path=str(src.pathobj / 'test_mod_annex_file'),
+                      action='copy')
+    # whereis info reflects the change
+    ok_(len(whereis_prior) < len(
+        src.repo.whereis(files=['test_mod_annex_file'])[0]))
+
+    # do it yet again will do nothing, because all is uptodate
+    assert_status('notneeded', src.push(to='target', force=None))
+    # an explicit reference point doesn't change that
+    assert_status('notneeded',
+                  src.push(to='target', force=None, since='HEAD~1'))
+
+    # now force data transfer
+    res = src.push(to='target', force='datatransfer')
+    # no branch change, done before
+    assert_in_results(res, action='publish', status='notneeded',
+                      refspec='refs/heads/master:refs/heads/master')
+    # no availability update
+    assert_in_results(res, action='publish', status='notneeded',
+                      refspec='refs/heads/git-annex:refs/heads/git-annex')
+    # but data transfer
+    assert_in_results(res, status='ok',
+                      path=str(src.pathobj / 'test_mod_annex_file'),
+                      action='copy')
+
+    # force data transfer, but data isn't available
+    src.repo.drop('test_mod_annex_file')
+    res = src.push(to='target', force='datatransfer', on_failure='ignore')
+    assert_in_results(res, status='impossible',
+                      path=str(src.pathobj / 'test_mod_annex_file'),
+                      action='copy',
+                      message='Slated for transport, but no content present')
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_gh1426(origin_path, target_path):
+    # set up a pair of repos, one the published copy of the other
+    origin = Dataset(origin_path).create()
+    target = mk_push_target(
+        origin, 'target', target_path, annex=True, bare=False)
+    origin.push(to='target')
+    assert_repo_status(origin.path)
+    assert_repo_status(target.path)
+    eq_(origin.repo.get_hexsha('master'), target.get_hexsha('master'))
+
+    # gist of #1426 is that a newly added subdataset does not cause the
+    # superdataset to get published
+    origin.create('sub')
+    assert_repo_status(origin.path)
+    neq_(origin.repo.get_hexsha('master'), target.get_hexsha('master'))
+    # now push
+    res = origin.push(to='target')
+    assert_result_count(
+        res, 1, status='ok', type='dataset', path=origin.path,
+        action='publish', target='target', operations=['fast-forward'])
+    eq_(origin.repo.get_hexsha('master'), target.get_hexsha('master'))
+
+
+@skip_if_on_windows  # create_sibling incompatible with win servers
+@skip_ssh
+@with_tree(tree={'1': '123'})
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+def test_publish_target_url(src, desttop, desturl):
+    # https://github.com/datalad/datalad/issues/1762
+    ds = Dataset(src).create(force=True)
+    if ds.repo.is_managed_branch():
+        raise SkipTest(
+            'Skipped due to https://github.com/datalad/datalad/issues/4075')
+    ds.save('1')
+    ds.create_sibling('ssh://localhost:%s/subdir' % desttop,
+                      name='target',
+                      target_url=desturl + 'subdir/.git')
+    results = ds.push(to='target')
+    assert results
+    ok_file_has_content(Path(desttop, 'subdir', '1'), '123')
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+def test_gh1763(src, target1, target2):
+    # this test is very similar to test_publish_depends, but more
+    # comprehensible, and directly tests issue 1763
+    src = Dataset(src).create(force=True)
+    target1 = mk_push_target(src, 'target1', target1, bare=False)
+    target2 = mk_push_target(src, 'target2', target2, bare=False)
+    src.siblings('configure', name='target2', publish_depends='target1',
+                 result_renderer=None)
+    # a file to annex
+    (src.pathobj / 'probe1').write_text('probe1')
+    src.save('probe1', to_git=False)
+    # make sure the probe is annexed, not straight in Git
+    assert_in('probe1', src.repo.get_annexed_files(with_content_only=True))
+    # publish to target2, must handle dependency
+    src.push(to='target2')
+    for target in (target1, target2):
+        # with a managed branch we are pushing into the corresponding branch
+        # and do not see a change in the worktree
+        if not target.is_managed_branch():
+            # direct test for what is in the checkout
+            assert_in(
+                'probe1',
+                target.get_annexed_files(with_content_only=True))
+        # ensure git-annex knows this target has the file
+        assert_in(target.config.get('annex.uuid'), src.repo.whereis(['probe1'])[0])
+
+
+@with_tempfile()
+@with_tempfile()
+def test_gh1811(srcpath, clonepath):
+    orig = Dataset(srcpath).create()
+    (orig.pathobj / 'some').write_text('some')
+    orig.save()
+    clone = Clone.__call__(source=orig.path, path=clonepath)
+    (clone.pathobj / 'somemore').write_text('somemore')
+    clone.save()
+    clone.repo.call_git(['checkout', 'HEAD~1'])
+    res = clone.push(to='origin', on_failure='ignore')
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1,
+        path=clone.path, type='dataset', action='publish',
+        status='impossible',
+        message='There is no active branch, cannot determine remote '
+                'branch',
+    )

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -451,6 +451,7 @@ def test_force_datatransfer(srcpath, dstpath):
                       message='Slated for transport, but no content present')
 
 
+@skip_if_on_windows  # https://github.com/datalad/datalad/issues/4278
 @with_tempfile(mkdir=True)
 @with_tree(tree={'ria-layout-version': '1\n'})
 def test_ria_push(srcpath, dstpath):

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -50,7 +50,7 @@ from datalad.core.distributed.push import Push
 def test_invalid_call(origin, tdir):
     ds = Dataset(origin).create()
     # no target
-    assert_status('error', ds.push(on_failure='ignore'))
+    assert_status('impossible', ds.push(on_failure='ignore'))
     # no dataset
     with chpwd(tdir):
         assert_raises(InsufficientArgumentsError, Push.__call__)
@@ -115,8 +115,9 @@ def check_push(annex, src_path, dst_path):
     res = src.push(on_failure='ignore')
     assert_result_count(res, 1)
     assert_in_results(
-        res, status='error',
-        message='No push target given, and none could be auto-detected')
+        res, status='impossible',
+        message='No push target given, and none could be auto-detected, '
+        'please specific via --to')
     # target sibling
     target = mk_push_target(src, 'target', dst_path, annex=annex)
 
@@ -249,8 +250,8 @@ def test_push_recursive(
     for d in (sub, subsub, subnoannex):
         assert_in_results(
             res, status='error', type='dataset', path=d.path,
-            message=("Dataset %s does not know of a sibling '%s' to push to.",
-                     d, 'target'))
+            message=("Unknown target sibling '%s'.",
+                     'target'))
     # now fix that and set up targets for the submodules
     target_sub = mk_push_target(sub, 'target', dst_sub, annex=True)
     target_subnoannex = mk_push_target(

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -26,6 +26,7 @@ _group_dataset = (
         ('datalad.distribution.install', 'Install'),
         ('datalad.distribution.get', 'Get'),
         ('datalad.distribution.publish', 'Publish'),
+        ('datalad.core.distributed.push', 'Push', 'push'),
         ('datalad.distribution.uninstall', 'Uninstall', 'uninstall', 'uninstall'),
         ('datalad.distribution.drop', 'Drop', 'drop', 'drop'),
         ('datalad.distribution.remove', 'Remove', 'remove', 'remove'),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3500,7 +3500,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             ", and corresponding '{}' branch".format(corresponding_branch)
             if corresponding_branch else '')
 
-        synced_branch = 'synced/{}'.format(corresponding_branch)
+        synced_branch = 'synced/{}'.format(branch)
         had_synced_branch = synced_branch in self.get_branches()
         cmd = ['annex', 'sync']
         if remote:

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -95,6 +95,7 @@ Plumbing commands
    generated/man/datalad-clone
    generated/man/datalad-create-test-dataset
    generated/man/datalad-diff
+   generated/man/datalad-push
    generated/man/datalad-sshrun
    generated/man/datalad-siblings
    generated/man/datalad-status

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -77,6 +77,7 @@ Plumbing commands
    api.diff
    api.download_url
    api.ls
+   api.push
    api.sshrun
    api.siblings
    api.subdatasets


### PR DESCRIPTION
Approach is similar as before:

- do not attempt to build a 1:1 replacement of `publish`
- see what makes sense for the scope of a "plumbing" command
- focus on correct operation, not feature-wealth
- keep parallelization in mind
- hide as little as shallow as possible

Note that the tests here are affected (probabilisticly) by #4279 

Status quo:

- [X] basic functionality working across all platforms
- [x] support for managed branches
- [x] investigate speed-impact of `diff` not having `--report-filetype raw` capabilities ATM. If this is an issue, RF `_diff_cmd()` into a proper public function that we can use. it already exposes this parameter.
- [x] support for recursive operation
- [x] >90% test coverage
- [x] path handling uniform with `status` and `diff`. Fixes gh-1726 and fixes gh-4098
- [x] dedciated `action=publish` result for each pushed branch. Fixes gh-2000
- [x] dedicated error result when remote branch name cannot be determined. Fixes gh-2855
- [x] sync with remote annex branch after data transfer and before a push of the local git-annex branch to the remote. Fixes gh-2636
- [x] always publish the main branch first, and the git-annex branch last. Fixes gh-2001
- [x] no longer use `AnnexRepo.copy_to()`, but a dedicated async call with a protocol class implementing
annex JSON comminucation. Results are directly reported after normalization without intermediate inspection and decision making. Fixes gh-3412
- [x] if no branches are configured for push, the active branch (or rather its corresponding branch) is pushed by default. Fixes gh-1275
- [x] if branches are configured to be pushed by default, such configuration is honored. Fixes gh-4006
- [x] passes `--jobs` on to `git annex copy`. Fixes gh-3732
- [x] can push to an empty repository, regardless of without it is just a GitRepo, a (non-bare) AnnexRepo, or even a pseudo-empty AnnexRepo in adjusted-unlock mode (were initially an unrelated commit exists to mark the state prior to the created (empty) adjusted branch). Fixes gh-4074
- [x] recognized and supports non-annex datasets. Fixes gh-4082
- [x] reports an `impossible` result when content should be transferred, but isn't present locally. Fixes gh-3424
- [x] supports 'force' modes `datatransfer` and `nodatatransfer` (among other) that replace the clunky `--transfer-data` parameter of `publish`. Fixes gh-3414
- [x] rebase should #4228 be altered
- [x] rebase when #4229 is merged
- [x] PR cleanup