### PR TITLE
RF+ENH: introduce WitlessRunner to AnnexRepo

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -253,11 +253,10 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
                 len(data), self.pid, fd_name, ':' if self._log_outputs else '')
         if self._log_outputs:
             log_data = assure_unicode(data)
-            if True: # for line in log_data.split(os.linesep):
-                # Level and way we log is to stay consistent with Runner.
-                # TODO: later we might just log in a single entry, without
-                # fd_name prefix
-                lgr.log(9, "%s| %s " % (fd_name, log_data))
+            # The way we log is to stay consistent with Runner.
+            # TODO: later we might just log in a single entry, without
+            # fd_name prefix
+            lgr.log(9, "%s| %s " % (fd_name, log_data))
 
     def connection_made(self, transport):
         self.transport = transport

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -1014,7 +1014,7 @@ class Runner(object):
 
 class GitRunnerBase(object):
     """
-    Mix-in class for *Runners to be used to run git and git annex commands
+    Mix-in class for Runners to be used to run git and git annex commands
 
     Overloads the runner class to check & update GIT_DIR and
     GIT_WORK_TREE environment variables set to the absolute path

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -256,7 +256,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
             # The way we log is to stay consistent with Runner.
             # TODO: later we might just log in a single entry, without
             # fd_name prefix
-            lgr.log(9, "%s| %s " % (fd_name, log_data))
+            lgr.log(5, "%s| %s " % (fd_name, log_data))
 
     def connection_made(self, transport):
         self.transport = transport
@@ -603,7 +603,7 @@ class Runner(object):
     def _log_err(self, line, expected=False):
         if line and self.log_outputs:
             self.log("stderr| " + line.rstrip('\n'),
-                     level={True: 9,
+                     level={True: 5,
                             False: 11}[expected])
 
     def _get_output_online(self, proc,
@@ -763,15 +763,15 @@ class Runner(object):
             Normally, having stderr output is a signal of a problem and thus it
             gets logged at level 11.  But some utilities, e.g. wget, use
             stderr for their progress output.  Whenever such output is expected,
-            set it to True and output will be logged at level 9 unless
+            set it to True and output will be logged at level 5 unless
             exit status is non-0 (in non-online mode only, in online -- would
-            log at 9)
+            log at 5)
 
         expect_fail: bool, optional
             Normally, if command exits with non-0 status, it is considered an
             error and logged at level 11 (above DEBUG). But if the call intended
             for checking routine, such messages are usually not needed, thus
-            it will be logged at level 9.
+            it will be logged at level 5.
 
         cwd : string, optional
             Directory under which run the command (passed to Popen)
@@ -899,7 +899,7 @@ class Runner(object):
                         stderr=out[1],
                         cwd=popen_cwd,
                     )
-                    lgr.log(9 if expect_fail else 11, str(exc))
+                    lgr.log(5 if expect_fail else 11, str(exc))
                     raise exc
                 else:
                     self.log("Finished running %r with status %s" % (cmd, status),
@@ -975,10 +975,10 @@ class Runner(object):
     def log(self, msg, *args, **kwargs):
         """log helper
 
-        Logs at level 9 by default and adds "Protocol:"-prefix in order to
+        Logs at level 5 by default and adds "Protocol:"-prefix in order to
         log the used protocol.
         """
-        level = kwargs.pop('level', 9)
+        level = kwargs.pop('level', 5)
         if isinstance(self.protocol, NullProtocol):
             lgr.log(level, msg, *args, **kwargs)
         else:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -991,7 +991,7 @@ class Runner(object):
 
 class GitRunnerBase(object):
     """
-    Runner to be used to run git and git annex commands
+    Mix-in class for *Runners to be used to run git and git annex commands
 
     Overloads the runner class to check & update GIT_DIR and
     GIT_WORK_TREE environment variables set to the absolute path
@@ -1062,12 +1062,15 @@ class GitRunnerBase(object):
 
 
 class GitRunner(Runner, GitRunnerBase):
+    """A Runner for git and git-annex commands.
+
+    See GitRunnerBase it mixes in for more details
+    """
 
     @borrowdoc(Runner)
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._check_git_path()
-
 
     def run(self, cmd, env=None, *args, **kwargs):
         out, err = super().run(
@@ -1080,6 +1083,10 @@ class GitRunner(Runner, GitRunnerBase):
 
 
 class GitWitlessRunner(WitlessRunner, GitRunnerBase):
+    """A WitlessRunner for git and git-annex commands.
+
+    See GitRunnerBase it mixes in for more details
+    """
 
     @borrowdoc(WitlessRunner)
     def __init__(self, *args, **kwargs):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1519,7 +1519,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 out, err = self._run_annex_command(
                     'lookupkey',
                     files=[files],
-                    expect_fail=True
+                    expect_fail=True,
+                    runner="gitwitless",
                 )
             except CommandError as e:
                 if e.code == 1:
@@ -1622,7 +1623,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         options = options[:] if options else []
 
         std_out, std_err = self._run_annex_command(
-            'unannex', annex_options=options, files=files
+            'unannex', annex_options=options, files=files, runner="gitwitless",
         )
         return [line.split()[1] for line in std_out.splitlines()
                 if line.split()[0] == 'unannex' and line.split()[-1] == 'ok']
@@ -1661,11 +1662,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             for f in files:
                 try:
-                    obj, er = self._run_annex_command(
+                    obj, _ = self._run_annex_command(
                         'find', files=[f],
                         annex_options=["--print0"],
                         expect_fail=True,
-                        merge_annex_branches=False
+                        merge_annex_branches=False,
+                        runner="gitwitless",
                     )
                     items = obj.rstrip("\0").split("\0")
                     objects[f] = items[0] if len(items) == 1 else items
@@ -2543,7 +2545,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             if with_content_only:
                 args.extend(['--in', '.'])
         out, err = self._run_annex_command(
-            'find', annex_options=args, merge_annex_branches=False
+            'find', annex_options=args, merge_annex_branches=False,
+            runner="gitwitless",
         )
         # TODO: JSON
         return out.splitlines()
@@ -2687,7 +2690,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             try:
                 out, err = self._run_annex_command('contentlocation',
                                                    annex_options=[key],
-                                                   expect_fail=True)
+                                                   expect_fail=True,
+                                                   runner="gitwitless")
                 return out.rstrip(linesep).splitlines()[0]
             except CommandError:
                 return ''
@@ -2730,7 +2734,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             try:
                 out, err = self._run_annex_command('checkpresentkey',
                                                    annex_options=list(annex_input),
-                                                   expect_fail=True)
+                                                   expect_fail=True,
+                                                   runner="gitwitless")
                 assert(not out)
                 return True
             except CommandError:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -47,22 +47,24 @@ from datalad.dochelpers import (
 from datalad.ui import ui
 import datalad.utils as ut
 from datalad.utils import (
-    linux_distribution_name,
-    auto_repr,
-    on_windows,
     assure_list,
+    auto_repr,
+    ensure_list,
+    linux_distribution_name,
     make_tempfile,
+    on_windows,
     partition,
-    unlink,
     quote_cmdlinearg,
     split_cmdline,
+    unlink,
 )
 from datalad.support.json_py import loads as json_loads
 from datalad.cmd import (
-    GitRunner,
     BatchedCommand,
-    SafeDelCloseMixin,
+    GitRunner,
+    GitWitlessRunner,
     run_gitcommand_on_file_list_chunks,
+    SafeDelCloseMixin,
 )
 
 # imports from same module:
@@ -1748,19 +1750,20 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._run_annex_command('initremote', annex_options=[name] + options)
         self.config.reload()
 
-    def enable_remote(self, name, env=None):
+    def enable_remote(self, name, options=None, env=None):
         """Enables use of an existing special remote
 
         Parameters
         ----------
         name: str
             name, the special remote was created with
+        options: list, optional
         """
 
         try:
             self._run_annex_command(
                 'enableremote',
-                annex_options=[name],
+                annex_options=[name] + ensure_list(options),
                 expect_fail=True,
                 log_stderr=True,
                 env=env)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -963,7 +963,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         runner: {None, "gitwitless"}, optional
             Use specified runner class instead of the bound Runner instance.
         **kwargs
-            these are passed as additional kwargs to the *Runner.run()
+            these are passed as additional kwargs to .run() of the runner
 
         Raises
         ------

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1151,8 +1151,11 @@ class AnnexRepo(GitRepo, RepoInterface):
                 cmd="git-annex indirect",
                 msg="Can't switch to indirect mode on that filesystem.")
 
-        self._run_annex_command('direct' if enable_direct_mode else 'indirect',
-                                expect_stderr=True)
+        self._run_annex_command(
+            'direct' if enable_direct_mode else 'indirect',
+            expect_stderr=True,
+            runner="gitwitless"
+        )
         self.config.reload()
 
         # For paranoid we will just re-request
@@ -1595,7 +1598,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                      'version that supports unlocked pointers'))
 
         options = options[:] if options else to_options(unlock=True)
-        self._run_annex_command('adjust', annex_options=options)
+        self._run_annex_command('adjust', annex_options=options, runner="gitwitless")
 
     @normalize_paths
     def unannex(self, files, options=None):
@@ -1782,7 +1785,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         # TODO: figure out consistent way for passing options + document
 
-        self._run_annex_command('initremote', annex_options=[name] + options)
+        self._run_annex_command(
+            'initremote',
+            annex_options=[name] + options,
+            runner="gitwitless",
+        )
         self.config.reload()
 
     def enable_remote(self, name, options=None, env=None):
@@ -1867,7 +1874,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                                all=all,
                                fast=fast))
         args.extend(assure_list(remotes))
-        self._run_annex_command('sync', annex_options=args)
+        self._run_annex_command('sync', annex_options=args, runner="gitwitless")
 
     @normalize_path
     def add_url_to_file(self, file_, url, options=None, backend=None,
@@ -2019,7 +2026,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         url: str
         """
 
-        self._run_annex_command('rmurl', files=[file_, url])
+        self._run_annex_command('rmurl', files=[file_, url], runner="gitwitless")
 
     @normalize_path
     def get_urls(self, file_, key=False, batch=False):
@@ -2809,7 +2816,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 "Command 'migrate' is not available in direct mode.")
         self._run_annex_command('migrate',
                                 annex_options=files,
-                                backend=backend)
+                                backend=backend,
+                                runner="gitwitless")
 
     @classmethod
     def get_key_backend(cls, key):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -57,7 +57,7 @@ from datalad.support.due import due, Doi
 
 from datalad import ssh_manager
 from datalad.cmd import (
-    WitlessRunner,
+    GitWitlessRunner,
     WitlessProtocol,
     GitRunner,
     BatchedCommand,
@@ -1215,8 +1215,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             try:
                 lgr.debug("Git clone from {0} to {1}".format(url, path))
 
-                res = WitlessRunner(
-                    env=GitRunner.get_git_environ_adjusted()).run(
+                res = GitWitlessRunner().run(
                         ['git', 'clone', '--progress', url, path] \
                         + (to_options(**clone_options)
                            if clone_options else []),
@@ -2500,11 +2499,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         url = self.config.get('remote.{}.url'.format(remote), None)
         if url and is_ssh(url):
             ssh_manager.get_connection(url).open()
-        WitlessRunner(
-            cwd=self.path,
-            env=GitRunner.get_git_environ_adjusted()).run(
-                cmd,
-                protocol=StdOutCaptureWithGitProgress,
+        GitWitlessRunner(cwd=self.path).run(
+            cmd,
+            protocol=StdOutCaptureWithGitProgress,
         )
 
     def push(self, remote=None, refspec=None, all_remotes=False,
@@ -2641,11 +2638,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 if url and is_ssh(url):
                     ssh_manager.get_connection(url).open()
                 try:
-                    out = WitlessRunner(
-                        cwd=self.path,
-                        env=GitRunner.get_git_environ_adjusted()).run(
-                            r_cmd,
-                            protocol=protocol,
+                    out = GitWitlessRunner(cwd=self.path).run(
+                        r_cmd,
+                        protocol=protocol,
                     )
                     output = out[info_from] or ''
                 except CommandError as e:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1793,7 +1793,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         file_chunks = generate_file_chunks(files, cmd) if files else [[]]
 
-        runner = WitlessRunner(cwd=self.path, env=env)
+        runner = GitWitlessRunner(cwd=self.path, env=env)
 
         try:
             for i, chunk in enumerate(file_chunks):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2048,8 +2048,7 @@ def test_is_special(path):
                                             check_if_known=False))
     # FIXME: ar.enable_remote() doesn't support specifying options, but we need
     # to specify directory= here.
-    ar._run_annex_command("enableremote",
-                          annex_options=["imspecial", dir_arg])
+    ar.enable_remote("imspecial", options=[dir_arg])
     ok_(ar.is_special_annex_remote("imspecial"))
 
     # With a mis-configured remote, give warning and return false.

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2046,8 +2046,6 @@ def test_is_special(path):
 
     assert_false(ar.is_special_annex_remote("imspecial",
                                             check_if_known=False))
-    # FIXME: ar.enable_remote() doesn't support specifying options, but we need
-    # to specify directory= here.
     ar.enable_remote("imspecial", options=[dir_arg])
     ok_(ar.is_special_annex_remote("imspecial"))
 

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -57,7 +57,7 @@ def test_runner_dry(tempfile):
 
     # test dry command call
     cmd = 'echo Testing äöü東 dry run > %s' % tempfile
-    with swallow_logs(new_level=9) as cml:
+    with swallow_logs(new_level=5) as cml:
         ret = runner.run(cmd)
         cml.assert_logged("{DryRunProtocol} Running: %s" % cmd, regex=False)
     assert_equal(("DRY", "DRY"), ret,
@@ -158,9 +158,9 @@ def test_runner_log_stderr():
     runner = Runner(log_outputs=True)
     cmd = 'echo stderr-Message should be logged >&2'
     with swallow_outputs() as cmo:
-        with swallow_logs(new_level=9) as cml:
+        with swallow_logs(new_level=5) as cml:
             ret = runner.run(cmd, log_stderr=True, expect_stderr=True)
-            cml.assert_logged("Running: %s" % cmd, level='Level 9', regex=False)
+            cml.assert_logged("Running: %s" % cmd, level='Level 5', regex=False)
             if not on_windows:
                 # we can just count on sanity
                 cml.assert_logged("stderr| stderr-"
@@ -171,7 +171,7 @@ def test_runner_log_stderr():
 
     cmd = 'echo stderr-Message should not be logged >&2'
     with swallow_outputs() as cmo:
-        with swallow_logs(new_level=9) as cml:
+        with swallow_logs(new_level=5) as cml:
             ret = runner.run(cmd, log_stderr=False)
             eq_(cmo.err.rstrip(), "stderr-Message should not be logged")
             assert_raises(AssertionError, cml.assert_logged,
@@ -191,9 +191,9 @@ def test_runner_log_stdout():
         # on Windows it can't find echo if ran outside the shell
         if on_windows and isinstance(cmd, list):
             kw['shell'] = True
-        with swallow_logs(9) as cm:
+        with swallow_logs(5) as cm:
             ret = runner.run(cmd, log_stdout=True, **kw)
-            cm.assert_logged("Running: %s" % cmd, level='Level 9', regex=False)
+            cm.assert_logged("Running: %s" % cmd, level='Level 5', regex=False)
             if not on_windows:
                 # we can just count on sanity
                 cm.assert_logged("stdout| stdout-"


### PR DESCRIPTION
Inspired by the attempt to mitigate stalling git-annex in https://github.com/datalad/datalad/pull/4116 . Unfortunately it did not help, but it could be a beginning to RFing AnnexRepo to use new async'ed WitlessRunner.

Also it relates to #4194 which fixes `Runner` to actually use `datalad.log.outputs` config variable (instead of `datalad.log.cmd.outputs`)

TODOs:
- [x] migrate a few more of annex commands (e.g., `initremote`) to use GitWitlessRunner, and see what needs to be done to match behavior described with previous `log_*` settings with WitlessRunner protocols