### PR TITLE
NF: Parametrized Protocols with non-stdout/err return values for WitlessRunner

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -256,7 +256,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         The result set for the `done` future must be a dict with keys
         that do not unintentionally conflict with the API of
         CommandError, as the result dict is passed to this exception
-        class as kwargs pon error. The Runner will overwrite 'cmd' and
+        class as kwargs on error. The Runner will overwrite 'cmd' and
         'cwd' on error, if they are present in the result.
         """
         return_code = self.transport.get_returncode()

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -17,7 +17,8 @@ class CommandError(RuntimeError):
     """Thrown if a command call fails.
     """
 
-    def __init__(self, cmd="", msg="", code=None, stdout="", stderr="", cwd=None):
+    def __init__(self, cmd="", msg="", code=None, stdout="", stderr="", cwd=None,
+                 **kwargs):
         RuntimeError.__init__(self, msg)
         self.cmd = cmd
         self.msg = msg
@@ -25,6 +26,7 @@ class CommandError(RuntimeError):
         self.stdout = stdout
         self.stderr = stderr
         self.cwd = cwd
+        self.kwargs = kwargs
 
     def to_str(self, include_output=True):
         from datalad.utils import (
@@ -54,6 +56,9 @@ class CommandError(RuntimeError):
             to_str += " [out: '{}']".format(ensure_unicode(self.stdout))
         if self.stderr:
             to_str += " [err: '{}']".format(ensure_unicode(self.stderr))
+        if self.kwargs:
+            to_str += " [info keys: {}]".format(
+                ', '.join(self.kwargs.keys()))
         return to_str
 
     def __str__(self):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2651,7 +2651,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 except CommandError as e:
                     # intercept some errors that we express as an error report
                     # in the info dicts
-                    if re.match('error: failed to (push|fetch) some refs', e.stderr):
+                    if re.match(
+                            '.*^error: failed to (push|fetch) some refs',
+                            e.stderr,
+                            re.DOTALL | re.MULTILINE):
                         output = {1: e.stderr, 0: e.stdout}[info_from]
                         if output is None:
                             output = ''

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -126,3 +126,24 @@ def test_runner_stdin(path):
         protocol=StdOutCapture,
     )
     assert_in(OBSCURE_FILENAME, out)
+
+
+def test_runner_parametrized_protocol():
+    runner = Runner()
+
+    # protocol returns a given value whatever it receives
+    class ProtocolInt(StdOutCapture):
+        def __init__(self, done_future, value):
+            self.value = value
+            super().__init__(done_future)
+
+        def pipe_data_received(self, fd, data):
+            super().pipe_data_received(fd, self.value)
+
+    out, err = runner.run(
+        py2cmd('print(1)'),
+        protocol=ProtocolInt,
+        # value passed to protocol constructor
+        value=b'5',
+    )
+    eq_(out, '5')

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -46,10 +46,10 @@ def test_runner(tempfile):
     runner = Runner()
     content = 'Testing äöü東 real run'
     cmd = ['sh', '-c', 'echo %s > %r' % (content, tempfile)]
-    out, err = runner.run(cmd)
+    res = runner.run(cmd)
     # no capture of any kind, by default
-    ok_(not out)
-    ok_(not err)
+    ok_(not res['stdout'])
+    ok_(not res['stderr'])
     ok_file_has_content(tempfile, content, strip=True)
     os.unlink(tempfile)
 
@@ -57,23 +57,23 @@ def test_runner(tempfile):
 def test_runner_stderr_capture():
     runner = Runner()
     test_msg = "stderr-Message"
-    out, err = runner.run(py2cmd(
+    res = runner.run(py2cmd(
         'import sys; print(%r, file=sys.stderr)' % test_msg),
         protocol=StdOutErrCapture,
     )
-    eq_(err.rstrip(), test_msg)
-    ok_(not out)
+    eq_(res['stderr'].rstrip(), test_msg)
+    ok_(not res['stdout'])
 
 
 def test_runner_stdout_capture():
     runner = Runner()
     test_msg = "stdout-Message"
-    out, err = runner.run(py2cmd(
+    res = runner.run(py2cmd(
         'import sys; print(%r, file=sys.stdout)' % test_msg),
         protocol=StdOutErrCapture,
     )
-    eq_(out.rstrip(), test_msg)
-    ok_(not err)
+    eq_(res['stdout'].rstrip(), test_msg)
+    ok_(not res['stderr'])
 
 
 @with_tempfile(mkdir=True)
@@ -91,11 +91,11 @@ def test_runner_fix_PWD(path):
     env = os.environ.copy()
     env['PWD'] = orig_cwd = os.getcwd()
     runner = Runner(cwd=path, env=env)
-    out, err = runner.run(
+    res = runner.run(
         py2cmd('import os; print(os.environ["PWD"])'),
         protocol=StdOutCapture,
     )
-    eq_(out.strip(), path)  # was fixed up to point to point to cwd's path
+    eq_(res['stdout'].strip(), path)  # was fixed up to point to point to cwd's path
     eq_(env['PWD'], orig_cwd)  # no side-effect
 
 
@@ -120,12 +120,12 @@ def test_runner_stdin(path):
     # go for diffcult content
     fakestdin.write_text(OBSCURE_FILENAME)
 
-    out, err = runner.run(
+    res = runner.run(
         py2cmd('import fileinput; print(fileinput.input().readline())'),
         stdin=fakestdin.open(),
         protocol=StdOutCapture,
     )
-    assert_in(OBSCURE_FILENAME, out)
+    assert_in(OBSCURE_FILENAME, res['stdout'])
 
 
 def test_runner_parametrized_protocol():
@@ -140,10 +140,10 @@ def test_runner_parametrized_protocol():
         def pipe_data_received(self, fd, data):
             super().pipe_data_received(fd, self.value)
 
-    out, err = runner.run(
+    res = runner.run(
         py2cmd('print(1)'),
         protocol=ProtocolInt,
         # value passed to protocol constructor
         value=b'5',
     )
-    eq_(out, '5')
+    eq_(res['stdout'], '5')


### PR DESCRIPTION
Changes:
- parameterized protocols are instrumental for passing handles to a protocol that can be used for specific communication via callbacks, or access to information that changes while the protocol is operating.
- move output stream decoding into Protocol class
- make WitlessRunner more ignorant of the actual nature of the Protocol return value, and allow for alternative implementations that are still compatible with WitlessRunner.

  The Protocol result is now always a dict that is expected to have keys 'code', 'stdout', 'stderr', matching the semantics of the CommandError exception.

- enhance CommandError to carry arbitrary additional results that may be reported by a protocol (e.g. stdout->parsed JSON), to avoid having to keep duplicates of the raw output strings

- taken together WitlessRunner can now drive Protocols that produce arbitrary additional results. Awareness of these additional results only needs to exist in "client-code", generic error handling needs no further customization.