### PR TITLE
Update for latest git-annex

### DIFF
--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -173,6 +173,11 @@ def test_py2_unicode_command(path):
 @with_tempfile(mkdir=True)
 def test_sidecar(path):
     ds = Dataset(path).create()
+    if ds.repo.is_managed_branch():
+        if not ds.repo._check_version_kludges("has-include-dotfiles"):
+            # FIXME(annex.dotfiles)
+            ds.repo.config.set("annex.dotfiles", "true",
+                               where="local", reload=True)
     # Simple sidecar message checks.
     ds.run("cd .> dummy0", message="sidecar arg", sidecar=True)
     assert_not_in('"cmd":', ds.repo.format_commit("%B"))

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -14,6 +14,7 @@ import os.path as op
 from datalad.utils import (
     on_windows,
     assure_list,
+    Path,
     rmtree,
 )
 from datalad.tests.utils import (
@@ -750,3 +751,40 @@ def test_save_obscure_name(path):
     # Just check that we don't fail with a unicode error.
     with swallow_outputs():
         ds.save(path=fname, result_renderer="default")
+
+
+@with_tree(tree={
+    ".dot": "ab", "nodot": "cd",
+    "nodot-subdir": {".dot": "ef", "nodot": "gh"},
+    ".dot-subdir": {".dot": "ij", "nodot": "kl"}})
+def check_save_dotfiles(to_git, save_path, path):
+    # Note: Take relpath to work with Travis "TMPDIR=/var/tmp/sym\ link" run.
+    paths = [Path(op.relpath(op.join(root, fname), path))
+             for root, _, fnames in os.walk(op.join(path, save_path or ""))
+             for fname in fnames]
+    ok_(paths)
+    ds = Dataset(path).create(force=True)
+    ds.save(save_path, to_git=to_git)
+    if save_path is None:
+        assert_repo_status(ds.path)
+    repo = ds.repo
+    annexinfo = repo.get_content_annexinfo()
+
+    def _check(fn, p):
+        fn("key", annexinfo[repo.pathobj / p], p)
+
+    if to_git:
+        def check(p):
+            _check(assert_not_in, p)
+    else:
+        def check(p):
+            _check(assert_in, p)
+
+    for path in paths:
+        check(path)
+
+
+def test_save_dotfiles():
+    for git in [True, False, None]:
+        for save_path in [None, "nodot-subdir"]:
+            yield check_save_dotfiles, git, save_path

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -764,6 +764,11 @@ def check_save_dotfiles(to_git, save_path, path):
              for fname in fnames]
     ok_(paths)
     ds = Dataset(path).create(force=True)
+    if not to_git and ds.repo.is_managed_branch():
+        if not ds.repo._check_version_kludges("has-include-dotfiles"):
+            # FIXME(annex.dotfiles)
+            ds.repo.config.set("annex.dotfiles", "true",
+                               where="local", reload=True)
     ds.save(save_path, to_git=to_git)
     if save_path is None:
         assert_repo_status(ds.path)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -49,6 +49,13 @@ from datalad.tests.utils import skip_if_on_windows
 from datalad.tests.utils import known_failure_windows
 
 
+def filter_fsck_error_msg(dicts):
+    # Filter keys that have expected differences when comparing target.fsck()
+    # to fsck(remote=target).
+    return [{k: v for k, v in d.items() if k not in ["note"]}
+            for d in dicts]
+
+
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_invalid_call(origin, tdir):
@@ -494,8 +501,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
     # data integrity check looks identical from all perspectives
     # minus "note" statements from git-annex
     eq_(source.repo.fsck(),
-        [{k: v for k, v in i.items() if k != 'note'}
-         for i in source.repo.fsck(remote='target')])
+        filter_fsck_error_msg(source.repo.fsck(remote='target')))
     eq_(target.fsck(), source.repo.fsck(remote='target'))
 
 

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -52,7 +52,7 @@ from datalad.tests.utils import known_failure_windows
 def filter_fsck_error_msg(dicts):
     # Filter keys that have expected differences when comparing target.fsck()
     # to fsck(remote=target).
-    return [{k: v for k, v in d.items() if k not in ["note"]}
+    return [{k: v for k, v in d.items() if k not in ["error-messages", "note"]}
             for d in dicts]
 
 
@@ -172,7 +172,8 @@ def test_publish_simple(origin, src_path, dst_path):
     ok_(set(source.repo.get_branch_commits("git-annex")).issubset(
         set(target.get_branch_commits("git-annex"))))
 
-    eq_(source.repo.fsck(), source.repo.fsck(remote='target'))
+    eq_(filter_fsck_error_msg(source.repo.fsck()),
+        filter_fsck_error_msg(source.repo.fsck(remote='target')))
 
 
 @with_testrepos('basic_git', flavors=['local'])
@@ -500,9 +501,10 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
 
     # data integrity check looks identical from all perspectives
     # minus "note" statements from git-annex
-    eq_(source.repo.fsck(),
+    eq_(filter_fsck_error_msg(source.repo.fsck()),
         filter_fsck_error_msg(source.repo.fsck(remote='target')))
-    eq_(target.fsck(), source.repo.fsck(remote='target'))
+    eq_(filter_fsck_error_msg(target.fsck()),
+        filter_fsck_error_msg(source.repo.fsck(remote='target')))
 
 
 @skip_if_on_windows  # create_sibling incompatible with win servers

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -265,6 +265,7 @@ def _get_referenced_objs(ds):
                 for f in ('content_info', 'dataset_info')])
 
 
+@known_failure_githubci_win  # fails since upgrade to 8.20200226-g2d3ef2c07
 @with_tree(tree=_dataset_hierarchy_template)
 def test_aggregate_removal(path):
     base = Dataset(opj(path, 'origin')).create(force=True)
@@ -358,6 +359,7 @@ def test_update_strategy(path):
     eq_(target_meta, base.metadata(return_type='list'))
 
 
+@known_failure_githubci_win  # fails since upgrade to 8.20200226-g2d3ef2c07
 @with_tree({
     'this': 'that',
     'sub1': {'here': 'there'},

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -203,6 +203,7 @@ _ds_template = {
 '''}
 
 
+@known_failure_githubci_win  # fails since upgrade to 8.20200226-g2d3ef2c07
 @with_tree(_ds_template)
 def test_add_readme(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -135,6 +135,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     git_annex_version = None
     supports_direct_mode = None
     repository_versions = None
+    _version_kludges = {}
 
     # Class wide setting to allow insecure URLs. Used during testing, since
     # git annex 6.20180626 those will by default be not allowed for security
@@ -226,7 +227,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # initialize
         self._uuid = None
-        self._annex_common_options = []
+        self._annex_common_options = ["-c", "annex.dotfiles=true"]
 
         if annex_opts or annex_init_opts:
             lgr.warning("TODO: options passed to git-annex and/or "
@@ -591,6 +592,25 @@ class AnnexRepo(GitRepo, RepoInterface):
                 key_remap[k]: list(map(int, v.strip().split()))
                 for k, v in kvs if k in key_remap}
         return cls.repository_versions
+
+    @classmethod
+    def _check_version_kludges(cls, key):
+        """Cache some annex-version-specific kludges in one go.
+
+        Return the kludge under `key`.
+        """
+        assert key in {"has-include-dotfiles"}
+        kludges = cls._version_kludges
+        if kludges:
+            return kludges[key]
+
+        if cls.git_annex_version is None:
+            cls._check_git_annex_version()
+
+        ver = cls.git_annex_version
+        kludges["has-include-dotfiles"] = ver <= "7.20200226"
+        cls._version_kludges = kludges
+        return kludges[key]
 
     @staticmethod
     def get_size_from_key(key):
@@ -1374,7 +1394,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 '-c',
                 'annex.largefiles=%s' % (('anything', 'nothing')[int(git)])
             ]
-            if git:
+            if git and self._check_version_kludges("has-include-dotfiles"):
                 # to maintain behaviour similar to git
                 options += ['--include-dotfiles']
 
@@ -3388,7 +3408,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         # there is a standard mechanism that is uniform between Git
         # Annex repos to decide on the behavior on a case-by-case
         # basis
-        options = ['--include-dotfiles']
+        options = []
+        if self._check_version_kludges("has-include-dotfiles"):
+            options.append('--include-dotfiles')
         # if None -- leave it to annex to decide
         if git is not None:
             options += [

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3388,7 +3388,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         # there is a standard mechanism that is uniform between Git
         # Annex repos to decide on the behavior on a case-by-case
         # basis
-        # TODO have a dedicated test for this
         options = ['--include-dotfiles']
         # if None -- leave it to annex to decide
         if git is not None:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1508,9 +1508,12 @@ def test_annex_add_no_dotfiles(path):
     with open(opj(ar.path, '.datalad', 'somefile'), 'w') as f:
         f.write('some content')
     # make sure the repo is considered dirty now
-    assert_true(ar.dirty)  # TODO: has been more detailed assertion (untracked file)
-    # no file is being added, as dotfiles/directories are ignored by default
-    ar.add('.', git=False)
+    if ar._check_version_kludges("has-include-dotfiles"):
+        assert_true(ar.dirty)  # TODO: has been more detailed assertion (untracked file)
+        # no file is being added, as dotfiles/directories are ignored by default
+        ar.add('.', git=False)
+        # ^ Note: No longer true as of 8.20200226, which does _not_ skip
+        # dotfiles.
     # double check, still dirty
     assert_true(ar.dirty)  # TODO: has been more detailed assertion (untracked file)
     # now add to git, and it should work


### PR DESCRIPTION
This series includes a few git-annex-related updates.  Most importantly, it deals with the removal of `--include-dotfiles` in git-annex 8.20200226 ~and switches to using `add --force-{small,large}` when available (7.20200202.7 and later)~ (update: should do, but put off for now).