### PR TITLE
NF: WitlessProtocol for `annex ... --json` commands

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -292,7 +292,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         if self.buffer[fd - 1] is not None:
             self.buffer[fd - 1].extend(data)
 
-    def process_exited(self):
+    def _prepare_result(self):
         """Prepares the final result to be returned to the runner
 
         Note for derived classes overwriting this method:
@@ -315,8 +315,11 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
             for name, byt in zip(self.FD_NAMES[1:], self.buffer)
         }
         results['code'] = return_code
+        return results
+
+    def process_exited(self):
         # actually fulfill the future promise and let the execution finish
-        self.done.set_result(results)
+        self.done.set_result(self._prepare_result())
 
 
 class NoCapture(WitlessProtocol):


### PR DESCRIPTION
that returns parsed JSON. No attempt is made (yet) to replace `_run_annex_command_json()`

`--json-progress` type messages are acted upon immediately (like in GitProgress), and are subsequently excluded from the normal JSON record reporting.

Split from #4206 