### PR TITLE
ENH: Expose diff_dataset() and add reporting_order parameter.

### DIFF
--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -277,7 +277,7 @@ def diff_dataset(
             origpaths=None if not path else OrderedDict(path),
             untracked=untracked,
             annexinfo=annex,
-            eval_file_type=True,
+            eval_file_type=eval_file_type,
             cache=content_info_cache,
             order=reporting_order):
         res.update(

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -289,7 +289,7 @@ def diff_dataset(
 
 
 def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
-             annexinfo, eval_file_type, cache, order):
+             annexinfo, eval_file_type, cache, order='depth-first'):
     if not ds.is_installed():
         # asked to query a subdataset that is not available
         lgr.debug("Skip diff of unavailable subdataset: %s", ds)


### PR DESCRIPTION
This make a faster diff with `eval_file_type=True` accessible to
internal users (like `push()`).

`reporting_order` enables more flexible applications. While the past and
current default `depth-first` is most suitable for human-readable
reporting, the alternative `breadth-first` enables straightforward
consolidation of all diff reports for a dataset (incl. all submodule
records) into an uninterrupted series of results. This simplies client
code that needs to investigate a complete changes set of a dataset, and
aims to yield its conclusions immediately, in order to kick of further
processing (generator-style) -- useful for effective parallelization.

Split from #4206 

TODO:

- [ ] add compatibility kludge for metalad