### PR TITLE
Use annex-add's --force-{large,small} when available

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -603,7 +603,6 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         Return the kludge under `key`.
         """
-        assert key in {"has-include-dotfiles"}
         kludges = cls._version_kludges
         if kludges:
             return kludges[key]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -611,6 +611,11 @@ class AnnexRepo(GitRepo, RepoInterface):
             cls._check_git_annex_version()
 
         ver = cls.git_annex_version
+        if ver >= "7.20200202.7":
+            kludges["force-large"] = ["--force-large"]
+        else:
+            kludges["force-large"] = ["-c", "annex.largefiles=anything"]
+
         kludges["has-include-dotfiles"] = ver < "8"
         cls._version_kludges = kludges
         return kludges[key]
@@ -1478,7 +1483,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # if None -- leave it to annex to decide
         if git is False:
-            options.extend(['-c', 'annex.largefiles=anything'])
+            options.extend(self._check_version_kludges("force-large"))
 
         if git:
             # explicitly use git-add with --update instead of git-annex-add
@@ -3398,7 +3403,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             options.append('--include-dotfiles')
         # if None -- leave it to annex to decide
         if git is False:
-            options.extend(['-c', 'annex.largefiles=anything'])
+            options.extend(self._check_version_kludges("force-large"))
         if on_windows:
             # git-annex ignores symlinks on windows
             # https://github.com/datalad/datalad/issues/2955

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1478,16 +1478,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         }
 
         # if None -- leave it to annex to decide
-        if git is not None:
-            options += [
-                '-c',
-                'annex.largefiles=%s' % (('anything', 'nothing')[int(git)])
-            ]
-            if git and self._check_version_kludges("has-include-dotfiles"):
-                # to maintain behaviour similar to git
-                options += ['--include-dotfiles']
+        if git is False:
+            options.extend(['-c', 'annex.largefiles=anything'])
 
-        if git and update:
+        if git:
             # explicitly use git-add with --update instead of git-annex-add
             # TODO: This might still need some work, when --update AND files
             # are specified!

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1364,8 +1364,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(
                 files,
-                # Set annex.largefiles to prevent storing files in annex when
-                # GitRepo() is instantiated with a v6+ annex repo.
+                # Set annex.largefiles to prevent storing files in
+                # annex with a v6+ annex repo.
                 ['git', '-c', 'annex.largefiles=nothing', 'add'] +
                 ensure_list(git_options) +
                 to_options(update=update) + ['--verbose']

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -4026,7 +4026,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._git_custom_command(
                 list(files.keys()),
-                ['git', 'add'] + ensure_list(git_opts) + ['--verbose']
+                # Set annex.largefiles to prevent storing files in
+                # annex with a v6+ annex repo.
+                ['git', '-c', 'annex.largefiles=nothing', 'add'] +
+                ensure_list(git_opts) + ['--verbose']
             )
             # get all the entries
             for r in self._process_git_get_output(*add_out):


### PR DESCRIPTION
Switch over to using `--force-{large,small}` instead `-c annex.largefiles={anything,nothing}`.  The last commit gives background on why we should avoid one-off `annex.largefiles` overrides.

---

This may help with the intermittent failures mentioned in gh-4218.