### PR TITLE
TST: Relax get_open_files() test on Windows due to performance issues.

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -1190,6 +1190,16 @@ def test_get_open_files(p):
             os.getpid())
 
     assert not get_open_files(subd)
+
+    if on_windows:
+        # the remainder of the test assume a certain performance.
+        # however, on windows get_open_files() can be very slow
+        # (e.g. the first invocation in this test (above) can easily
+        # take 30-50s). It is not worth slowing the tests to
+        # accomodate this issue, given we have tested proper functioning
+        # in principle already above).
+        return
+
     # if we start a process within that directory, should get informed
     from subprocess import Popen, PIPE
     from time import time

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -446,6 +446,8 @@ def rmdir(path, *args, **kwargs):
 def get_open_files(path, log_open=False):
     """Get open files under a path
 
+    Note: This function is very slow on Windows.
+
     Parameters
     ----------
     path : str


### PR DESCRIPTION
Rational in the diff. We would need to budget ~1min per call to
get_open_files. This isn't worth it, given that this is only an
occasionally used test helper.

The test is now cut short on windows, only performing the timing
insensitive parts. It still runs for almost 3min...

Fixes gh-4233