### PR TITLE
RF: Dedicated method to perform a local annex sync

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -313,7 +313,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
             # each fetch could give evidence that there is an annex
             # somewhere and replace the repo class...
             if isinstance(ds.repo, AnnexRepo):
-                ds.repo.merge_annex(r)
+                ds.repo.localsync(r)
     ds.config.reload()
 
     # anything that follows will not change the repo type anymore, cache
@@ -438,7 +438,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
         if is_annex_repo:
             lgr.debug("Obtain remote annex info from '%s'", remote)
             _maybe_fetch(ds.repo, remote)
-            ds.repo.merge_annex(remote)
+            ds.repo.localsync(remote)
 
         # Note: git's push.default is 'matching', which doesn't work for first
         # time publication (a branch, that doesn't exist on remote yet)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3503,13 +3503,14 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         branch = self.get_active_branch()
         corresponding_branch = self.get_corresponding_branch(branch)
-        if branch == corresponding_branch:
-            # nothing to sync
-            return
+
+        have_corresponding_branch = branch != corresponding_branch
 
         lgr.debug(
-            "Git-annex adjusted branch detected, sync'ing %s",
-            corresponding_branch)
+            "Sync local 'git-annex' branch%s%s%s.",
+            ", and corresponding '" if have_corresponding_branch else '',
+            corresponding_branch if have_corresponding_branch else '',
+            "' branch")
 
         synced_branch = 'synced/{}'.format(branch)
         had_synced_branch = synced_branch in self.get_branches()

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1843,19 +1843,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 raise e
         self.config.reload()
 
-    def merge_annex(self, remote=None):
-        """Merge git-annex branch
-
-        Merely calls `sync` with the appropriate arguments.
-
-        Parameters
-        ----------
-        remote: str, optional
-          Name of a remote to be "merged".
-        """
-        self.sync(
-            remotes=remote, push=False, pull=False, commit=False, content=False,
-            all=False)
+    def merge_annex(self, remote=None):  # do not use anymore, use localsync()
+        self.localsync(remote)
 
     def sync(self, remotes=None, push=True, pull=True, commit=True,
              content=False, all=False, fast=False):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3466,9 +3466,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         super(AnnexRepo, self)._save_post(
             message, status, partial_commit)
         # then sync potential managed branches
-        self.localsync()
+        self.localsync(managed_only=True)
 
-    def localsync(self, remote=None):
+    def localsync(self, remote=None, managed_only=False):
         """Consolidate the local git-annex branch and/or managed branches.
 
         This method calls `git annex sync` to perform purely local operations
@@ -3489,11 +3489,18 @@ class AnnexRepo(GitRepo, RepoInterface):
         remote : str or list, optional
           If given, specifies the name of one or more remotes to sync against.
           If not given, all remotes are considered.
+        managed_only : bool, optional
+          Only perform a sync if a managed branch with a corresponding branch
+          is detected. By default, a sync is always performed.
         """
         branch = self.get_active_branch()
         corresponding_branch = self.get_corresponding_branch(branch)
 
         have_corresponding_branch = branch != corresponding_branch
+
+        if managed_only and not have_corresponding_branch:
+            lgr.debug('No sync necessary, no corresponding branch detected')
+            return
 
         lgr.debug(
             "Sync local 'git-annex' branch%s%s%s.",

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1686,7 +1686,7 @@ def test_get_description(path1, path2):
     # add a little probe file to make sure it stays untracked
     create_tree(path1, {'probe': 'probe'})
     assert_not_in('probe', annex2.get_indexed_files())
-    annex2.merge_annex('annex1')
+    annex2.localsync('annex1')
     assert_not_in('probe', annex2.get_indexed_files())
     # but let's remove the remote
     annex2.remove_remote('annex1')


### PR DESCRIPTION
Per request in https://github.com/datalad/datalad/pull/4206#discussion_r387201686

To consolidate corresponding branches and sync 'git-annex' branches of
one or more given, or all remotes. Does not leave behind 'synced/...'
branches, unless they existed prior calling the method.