### PR TITLE
TST: Add Github CI workflow to run core tests on a crippled FS

### DIFF
--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -1,0 +1,48 @@
+name: CrippledFS
+
+on: [pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up system
+      shell: bash
+      run: |
+        bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+        sudo apt-get update -qq
+        sudo apt-get install eatmydata
+        sudo eatmydata apt-get install git-annex-standalone dosfstools
+        # 500 MB VFAT FS in a box
+        sudo dd if=/dev/zero of=/crippledfs.img count=500 bs=1M
+        sudo mkfs.vfat /crippledfs.img
+        # mount
+        sudo mkdir /crippledfs
+        sudo mount -o "uid=$(id -u),gid=$(id -g)" /crippledfs.img /crippledfs
+    - name: Set up environment
+      run: |
+        git config --global user.email "test@github.land"
+        git config --global user.name "GitHub Almighty"
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: WTF!?
+      run: |
+        datalad wtf
+        mount
+    - name: Run benchmarks
+      env:
+        # forces all test repos/paths into the VFAT FS
+        TMPDIR: /crippledfs
+      run: |
+        mkdir -p __testhome__
+        cd __testhome__
+        python -m nose -s -v datalad.core


### PR DESCRIPTION
This aims to disentangle detection of issues with Windows and issues
with adjusted branch operation. There is no expectation that a run
would initially succeed... even on Linux.

Appveyor and Travis runs will be canceled.

TODO

- [ ] VFAT or NTFS?

This seems to be a great success. In 8min we get to see that a large chunk of tests don't work out:

```
Ran 117 tests in 481.873s
FAILED (SKIP=6, errors=43, failures=5)
```

The most popular error is

```
'git annex sync --no-commit --no-push --no-pull' failed with exitcode 1 under /crippledfs/datalad_temp_check_create_path_semantics1p3hq_fs [err: 'fatal: entry '<imagine subdataset path here>' object type (blob) doesn't match mode type (commit)
```

which I feel has been reported before.