### PR TITLE
ENH: run github workflows on push as well

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,6 +1,6 @@
 name: Benchmarks
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   vs-master:

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -1,6 +1,6 @@
 name: Docs
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -1,6 +1,6 @@
 name: Extensions
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -1,6 +1,6 @@
 name: Win2019
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
I was confused to not see any "master" builds in the github actions.  That
precluded to see what last state of master was ok on windows.
