### PR TITLE
A more sane post-clone setup for adjusted-branch repos

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -190,6 +190,14 @@ def test_clone_simple_local(src, path):
         uuid_before = ds.repo.uuid
         eq_(ds.repo.get_description(), 'mydummy')
 
+    # make sure we do not have any adjusted branch configured
+    # for push or as destination
+    for v in ('branch.adjusted/master(unlocked).remote',
+              'branch.adjusted/master(unlocked).merge'):
+        assert_not_in(v, ds.config)
+    eq_(ds.config.get('branch.master.remote'), 'origin')
+    eq_(ds.config.get('branch.master.merge'), 'refs/heads/master')
+
     # installing it again, shouldn't matter:
     res = clone(src, path, result_xfm=None, return_type='list')
     assert_result_values_equal(res, 'source_url', [src])

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -206,8 +206,8 @@ def test_update_fetch_all(src, remote_1, remote_2):
     rmt2 = AnnexRepo.clone(src, remote_2)
 
     ds = Dataset(src)
-    ds.siblings('add', name="sibling_1", url=remote_1)
-    ds.siblings('add', name="sibling_2", url=remote_2)
+    ds.siblings('add', name="sibling_1", url=remote_1, result_renderer=None)
+    ds.siblings('add', name="sibling_2", url=remote_2, result_renderer=None)
 
     # modify the remotes:
     with open(opj(remote_1, "first.txt"), "w") as f:
@@ -452,8 +452,8 @@ def test_multiway_merge(path):
     ds = Dataset(op.join(path, 'ds_orig')).create()
     r1 = AnnexRepo(path=op.join(path, 'ds_r1'), git_opts={'bare': True})
     r2 = GitRepo(path=op.join(path, 'ds_r2'), git_opts={'bare': True})
-    ds.siblings(action='add', name='r1', url=r1.path)
-    ds.siblings(action='add', name='r2', url=r2.path)
+    ds.siblings(action='add', name='r1', url=r1.path, result_renderer=None)
+    ds.siblings(action='add', name='r2', url=r2.path, result_renderer=None)
     assert_status('ok', ds.publish(to='r1'))
     assert_status('ok', ds.publish(to='r2'))
     # just a fetch should be no issue

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -720,7 +720,18 @@ def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
 
     ds_clone = install(source=ds_src.path, path=path / "clone",
                        recursive=True, result_xfm="datasets")
+    ds_clone_s0 = Dataset(ds_clone.pathobj / "s0")
     ds_clone_s1 = Dataset(ds_clone.pathobj / "s0" / "s1")
+    if on_adjusted:
+        # after https://github.com/datalad/datalad/pull/4252 a clone of an
+        # adjusted dataset onto a capable filesystem will not be in adjusted
+        # mode automatically, but fall back (or forward) to more the flexible
+        # standard mode
+        # redo adjusting in the clone for the sake of this test
+        _adjust(ds_clone.repo)
+        _adjust(ds_clone_s0.repo)
+        _adjust(ds_clone_s1.repo)
+        ds_clone.save(recursive=True)
 
     ds_src_s1.repo.checkout("master^0")
     (ds_src_s1.pathobj / "foo").write_text("foo content")

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -116,6 +116,7 @@ class BasicAnnexTestRepo(TestRepo):
         self.repo.add_url_to_file("test-annex.dat", fileurl)
         self.repo.commit("Adding a rudimentary git-annex load file")
         self.repo.drop("test-annex.dat")  # since available from URL
+        self.repo.localsync()
 
     def create_info_file(self):
         annex_version = external_versions['cmd:annex']


### PR DESCRIPTION
Summary: A clone of a dataset in adjusted mode no longer ends up being in adjusted mode too, by default -- unless the target filesystem actually imposes this constraint.

fixes #4227 