### PR TITLE
BF: annexrepo: Set annex.dotfiles=true in .git/config

### DIFF
--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -173,11 +173,6 @@ def test_py2_unicode_command(path):
 @with_tempfile(mkdir=True)
 def test_sidecar(path):
     ds = Dataset(path).create()
-    if ds.repo.is_managed_branch():
-        if not ds.repo._check_version_kludges("has-include-dotfiles"):
-            # FIXME(annex.dotfiles)
-            ds.repo.config.set("annex.dotfiles", "true",
-                               where="local", reload=True)
     # Simple sidecar message checks.
     ds.run("cd .> dummy0", message="sidecar arg", sidecar=True)
     assert_not_in('"cmd":', ds.repo.format_commit("%B"))

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -764,11 +764,6 @@ def check_save_dotfiles(to_git, save_path, path):
              for fname in fnames]
     ok_(paths)
     ds = Dataset(path).create(force=True)
-    if not to_git and ds.repo.is_managed_branch():
-        if not ds.repo._check_version_kludges("has-include-dotfiles"):
-            # FIXME(annex.dotfiles)
-            ds.repo.config.set("annex.dotfiles", "true",
-                               where="local", reload=True)
     ds.save(save_path, to_git=to_git)
     if save_path is None:
         assert_repo_status(ds.path)


### PR DESCRIPTION
As of version 8.20200226, git-annex no longer has --include-dotfiles
and, instead of skipping dotfiles that are not explicitly given as
paths, now adds dotfiles to git by default.  When the new
annex.dotfiles option is configured to true, git-annex decides the
fate of dotfiles based on the normal annex.largefiles mechanism.

97c28c7bc5 (RF: annexrepo: Adjust for removal of --include-dotfiles,
gh-4214) dealt with the removal of --include-dotfiles, but it only
_partially_ dealt with the new "dot files to git" behavior.  That
commit set annex.dotfiles=true for our calls to git-annex.  However,
when we set this transiently, later actions can result in annexed
dotfiles being added as regular git files [0], a problem that was
hinted at by the workarounds needed for test_run.test_sidecar and
test_save.test_save_dotfiles in adjusted mode.

We rely on annexing dotfiles (e.g., `.datalad/metadata/objects`), so
it seems we can't get around setting annex.dotfiles=true in the
repository.  When AnnexRepo is initialized, check whether
annex.dotfiles is configured in .git/config.  If it's not, set it to
true unless it has explicitly been set to false outside of DataLad.

Note that this solution doesn't consider the annex.dotfiles
configuration that could be stored in git-annex:config.log, which is
overridden by the value in .git/config.  This could be added to the
check if we decide the correctness is worth the expense for each
AnnexRepo initialization.

[0] Two posts on the git-annex site have discussion and demo scripts
    related to this:
    https://git-annex.branchable.com/forum/Get_annex.dotfiles__61__true_behavior_without_persistent_configuration__63__/
    https://git-annex.branchable.com/bugs/Guard_against_previously_annexed_dotfiles_being_converted_to_git_files__63__/

---

to-dos:

- [ ] wait a bit to see what comes of any discussion on git-annex's site
- [ ] explicitly test this behavior