### PR TITLE
RF: Reduce use of "ria" label

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -66,7 +66,7 @@ class CreateSiblingRia(Interface):
     """Creates a sibling to a dataset in a RIA store
 
     Communication with a dataset in a RIA store is implemented via two
-    siblings. A regular Git remote (repository siblings) and a git-annex
+    siblings. A regular Git remote (repository sibling) and a git-annex
     special remote for data transfer (storage sibling) -- with the former
     having a publication dependency on the latter. By default, the name of the
     storage sibling is derived from the repository sibling's name by appending

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -76,7 +76,7 @@ class CreateSiblingRia(Interface):
     or a valid RIA store.
 
     RIA store layout
-    ----------------
+    ~~~~~~~~~~~~~~~~
 
     A RIA store is a directory tree with a dedicated subdirectory for each
     dataset in the store. The subdirectory name is constructed from the
@@ -110,10 +110,10 @@ class CreateSiblingRia(Interface):
     version (currently "1"). This line MUST end with a newline character.
 
     Error logging
-    -------------
+    ~~~~~~~~~~~~~
 
     To enable error logging at the remote end, append a pipe symbol and an "l"
-    to the version number in ria-layout-version (like so '1|l\n').
+    to the version number in ria-layout-version (like so '1|l\\n').
 
     Error logging will create files in an "error_log" directory whenever the
     git-annex special remote (storage sibling) raises an exception, storing the

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -56,7 +56,7 @@ def test_invalid_calls(path):
 
     # same name for git- and special remote:
     assert_raises(ValueError, ds.create_sibling_ria, 'ria+file:///some/where',
-                  name='some', ria_remote_name='some')
+                  name='some', storage_name='some')
 
 
 @skip_if_on_windows  # running into short path issues; same as gh-4131
@@ -74,14 +74,15 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     ds.save(recursive=True)
     assert_repo_status(ds.path)
 
-    # don't specify special remote. By default should be git-remote + "-ria"
+    # don't specify special remote. By default should be git-remote + "-storage"
     res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore")
     assert_result_count(res, 1, status='ok', action='create-sibling-ria')
     eq_(len(res), 1)
 
     # remotes exist, but only in super
     siblings = ds.siblings(result_renderer=None)
-    eq_({'datastore', 'datastore-ria', 'here'}, {s['name'] for s in siblings})
+    eq_({'datastore', 'datastore-storage', 'here'},
+        {s['name'] for s in siblings})
     sub_siblings = subds.siblings(result_renderer=None)
     eq_({'here'}, {s['name'] for s in sub_siblings})
 
@@ -119,9 +120,10 @@ def _test_create_store(host, base_path, ds_path, clone_path):
 
     # remotes now exist in super and sub
     siblings = ds.siblings(result_renderer=None)
-    eq_({'datastore', 'datastore-ria', 'here'}, {s['name'] for s in siblings})
+    eq_({'datastore', 'datastore-storage', 'here'},
+        {s['name'] for s in siblings})
     sub_siblings = subds.siblings(result_renderer=None)
-    eq_({'datastore', 'datastore-ria', 'here'},
+    eq_({'datastore', 'datastore-storage', 'here'},
         {s['name'] for s in sub_siblings})
 
     # for testing trust_level parameter, redo for each label:
@@ -131,7 +133,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
                               existing='reconfigure',
                               trust_level=trust)
         res = ds.repo.repo_info()
-        assert_in('[datastore-ria]',
+        assert_in('[datastore-storage]',
                   [r['description']
                    for r in res['{}ed repositories'.format(trust)]])
 


### PR DESCRIPTION
Remove entirely when not necessary. If necessary 'ria' refers to the
concept of a store, whether the datasets are addressable by their
dataset ID.

A further renaming will happen as part of gh-4164, where 'ria-remote'
(the special remote implementation) is replaced by 'ora-remote'.

Together, this changes disambiguate the term 'ria'.

This change also removes TODOs from the documentation.