### PR TITLE
BF+RF: AnnexRepo - add set_shared_connection to (effective) set_remote_url

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -782,10 +782,29 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._set_shared_connection(name, url)
 
     def set_remote_url(self, name, url, push=False):
-        """Overrides method from GitRepo in order to set
-        remote.<name>.annex-ssh-options in case of a SSH remote."""
+        """Set the URL a remote is pointing to
 
-        super(AnnexRepo, self).set_remote_url(name, url, push=push)
+        Sets the URL of the remote `name`. Requires the remote to already exist.
+
+        Parameters
+        ----------
+        name: str
+          name of the remote
+        url: str
+        push: bool
+          if True, set the push URL, otherwise the fetch URL;
+          if True, additionally set annexurl to `url`, to make sure annex uses
+          it to talk to the remote, since access via fetch URL might be
+          restricted.
+        """
+
+        if push:
+            # if we are to set a push url, also set 'annexUrl' for this remote,
+            # in order to make git-annex use it, when talking to the remote.
+            # (see http://git-annex.branchable.com/bugs/annex_ignores_pushurl_and_uses_only_url_upon___34__copy_--to__34__/)
+            var = 'remote.{0}.{1}'.format(name, 'annexurl')
+            self.config.set(var, url, where='local', reload=True)
+        super(AnnexRepo, self).set_remote_url(name, url, push)
         self._set_shared_connection(name, url)
 
     def set_remote_dead(self, name):
@@ -3073,31 +3092,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             return matches[0]
         else:
             return None
-
-    def set_remote_url(self, name, url, push=False):
-        """Set the URL a remote is pointing to
-
-        Sets the URL of the remote `name`. Requires the remote to already exist.
-
-        Parameters
-        ----------
-        name: str
-          name of the remote
-        url: str
-        push: bool
-          if True, set the push URL, otherwise the fetch URL;
-          if True, additionally set annexurl to `url`, to make sure annex uses
-          it to talk to the remote, since access via fetch URL might be
-          restricted.
-        """
-
-        if push:
-            # if we are to set a push url, also set 'annexUrl' for this remote,
-            # in order to make git-annex use it, when talking to the remote.
-            # (see http://git-annex.branchable.com/bugs/annex_ignores_pushurl_and_uses_only_url_upon___34__copy_--to__34__/)
-            var = 'remote.{0}.{1}'.format(name, 'annexurl')
-            self.config.set(var, url, where='local', reload=True)
-        super(AnnexRepo, self).set_remote_url(name, url, push)
 
     def get_metadata(self, files, timestamps=False, batch=False):
         """Query git-annex file metadata


### PR DESCRIPTION
(effective) because apparently we had 2 set_remote_url definitions.
Earlier (in time and in the code) was located among other methods dealing
with remotes (thus I kept that location, which also invoked
self._set_shared_connection.

And later one, which added custom to AnnexRepo handling  of annexurl, but
lacked invocation of self._set_shared_connection.  I took later version,
placed it inplace of the older (earlier in the code) one, while maintaining
the self._set_shared_connection invocation.

This now causes ssh call to have socket defined for target2, so later
enableremote has a better chance to reuse it.

Closes #4195 and has resolved regression/difference in behavior of the recent git-annex-standalone build in #4116
