### PR TITLE
TST: Disable result renderer for diff() and status() tests

### DIFF
--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -159,15 +159,18 @@ def test_diff(path, norepo):
     assert_repo_status(ds.path)
     # reports stupid revision input
     assert_result_count(
-        ds.diff(fr='WTF', on_failure='ignore'),
+        ds.diff(fr='WTF', on_failure='ignore', result_renderer=None),
         1,
         status='impossible',
         message="Git reference 'WTF' invalid")
     # no diff
-    assert_result_count(_dirty_results(ds.diff()), 0)
-    assert_result_count(_dirty_results(ds.diff(fr='HEAD')), 0)
+    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 0)
+    assert_result_count(
+        _dirty_results(ds.diff(fr='HEAD', result_renderer=None)), 0)
     # bogus path makes no difference
-    assert_result_count(_dirty_results(ds.diff(path='THIS', fr='HEAD')), 0)
+    assert_result_count(
+        _dirty_results(ds.diff(path='THIS', fr='HEAD', result_renderer=None)),
+        0)
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
     ds.save(to_git=True)
@@ -180,64 +183,67 @@ def test_diff(path, norepo):
         fr_base = "HEAD"
         to = None
 
-    res = _dirty_results(ds.diff(fr=fr_base + '~1', to=to))
+    res = _dirty_results(ds.diff(fr=fr_base + '~1', to=to, result_renderer=None))
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, action='diff', path=op.join(ds.path, 'new'), state='added')
     # we can also find the diff without going through the dataset explicitly
     with chpwd(ds.path):
         assert_result_count(
-            _dirty_results(diff(fr=fr_base + '~1', to=to)), 1,
+            _dirty_results(diff(fr=fr_base + '~1', to=to,
+                                result_renderer=None)),
+            1,
             action='diff', path=op.join(ds.path, 'new'), state='added')
     # no diff against HEAD
-    assert_result_count(_dirty_results(ds.diff()), 0)
+    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 0)
     # modify known file
     create_tree(ds.path, {'new': 'notempty'})
-    res = _dirty_results(ds.diff())
+    res = _dirty_results(ds.diff(result_renderer=None))
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, action='diff', path=op.join(ds.path, 'new'),
         state='modified')
     # but if we give another path, it doesn't show up
-    assert_result_count(ds.diff(path='otherpath'), 0)
+    assert_result_count(ds.diff(path='otherpath', result_renderer=None), 0)
     # giving the right path must work though
     assert_result_count(
-        ds.diff(path='new'), 1,
+        ds.diff(path='new', result_renderer=None), 1,
         action='diff', path=op.join(ds.path, 'new'), state='modified')
     # stage changes
     ds.repo.add('.', git=True)
     # no change in diff, staged is not commited
-    assert_result_count(_dirty_results(ds.diff()), 1)
+    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 1)
     ds.save()
     assert_repo_status(ds.path)
-    assert_result_count(_dirty_results(ds.diff()), 0)
+    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 0)
 
     # untracked stuff
     create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
     # a plain diff should report the untracked file
     # but not directly, because the parent dir is already unknown
-    res = _dirty_results(ds.diff())
+    res = _dirty_results(ds.diff(result_renderer=None))
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, state='untracked', type='directory',
         path=op.join(ds.path, 'deep'))
     # report of individual files is also possible
     assert_result_count(
-        ds.diff(untracked='all'), 2, state='untracked', type='file')
+        ds.diff(untracked='all', result_renderer=None), 2, state='untracked',
+        type='file')
     # an unmatching path will hide this result
-    assert_result_count(ds.diff(path='somewhere'), 0)
+    assert_result_count(ds.diff(path='somewhere', result_renderer=None), 0)
     # perfect match and anything underneath will do
     assert_result_count(
-        ds.diff(path='deep'), 1, state='untracked',
+        ds.diff(path='deep', result_renderer=None), 1, state='untracked',
         path=op.join(ds.path, 'deep'),
         type='directory')
     assert_result_count(
-        ds.diff(path='deep'), 1,
+        ds.diff(path='deep', result_renderer=None), 1,
         state='untracked', path=op.join(ds.path, 'deep'))
     ds.repo.add(op.join('deep', 'down2'), git=True)
     # now the remaining file is the only untracked one
     assert_result_count(
-        ds.diff(), 1, state='untracked',
+        ds.diff(result_renderer=None), 1, state='untracked',
         path=op.join(ds.path, 'deep', 'down'),
         type='file')
 
@@ -247,11 +253,12 @@ def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')
     # look at the last change, and confirm a dataset was added
-    res = ds.diff(fr='master~1', to='master')
+    res = ds.diff(fr='master~1', to='master', result_renderer=None)
     assert_result_count(
         res, 1, action='diff', state='added', path=sub.path, type='dataset')
     # now recursive
-    res = ds.diff(recursive=True, fr='master~1', to='master')
+    res = ds.diff(recursive=True, fr='master~1', to='master',
+                  result_renderer=None)
     # we also get the entire diff of the subdataset from scratch
     assert_status('ok', res)
     ok_(len(res) > 3)
@@ -264,7 +271,7 @@ def test_diff_recursive(path):
     create_tree(
         ds.path,
         {'onefile': 'tobeadded', 'sub': {'twofile': 'tobeadded'}})
-    res = ds.diff(recursive=True, untracked='all')
+    res = ds.diff(recursive=True, untracked='all', result_renderer=None)
     assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,
@@ -285,7 +292,7 @@ def test_diff_recursive(path):
     head_ref = 'master' if ds.repo.is_managed_branch() else 'HEAD'
 
     # look at the last change, only one file was added
-    res = ds.diff(fr=head_ref + '~1', to=head_ref)
+    res = ds.diff(fr=head_ref + '~1', to=head_ref, result_renderer=None)
     assert_result_count(_dirty_results(res), 1)
     assert_result_count(
         res, 1,
@@ -294,7 +301,8 @@ def test_diff_recursive(path):
 
     # now the exact same thing with recursion, must not be different from the
     # call above
-    res = ds.diff(recursive=True, fr=head_ref + '~1', to=head_ref)
+    res = ds.diff(recursive=True, fr=head_ref + '~1', to=head_ref,
+                  result_renderer=None)
     assert_result_count(_dirty_results(res), 1)
     # last change in parent
     assert_result_count(
@@ -306,7 +314,8 @@ def test_diff_recursive(path):
             "Test assumption broken: https://github.com/datalad/datalad/issues/3818")
     # one further back brings in the modified subdataset, and the added file
     # within it
-    res = ds.diff(recursive=True, fr=head_ref + '~2', to=head_ref)
+    res = ds.diff(recursive=True, fr=head_ref + '~2', to=head_ref,
+                  result_renderer=None)
     assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,
@@ -343,7 +352,7 @@ def test_path_diff(_path, linkpath):
         # check the premise of this test
         assert ds.pathobj != ds.repo.pathobj
 
-    plain_recursive = ds.diff(recursive=True, annex='all')
+    plain_recursive = ds.diff(recursive=True, annex='all', result_renderer=None)
     # check integrity of individual reports with a focus on how symlinks
     # are reported
     for res in plain_recursive:
@@ -361,22 +370,27 @@ def test_path_diff(_path, linkpath):
 
     # bunch of smoke tests
     # query of '.' is same as no path
-    eq_(plain_recursive, ds.diff(path='.', recursive=True, annex='all'))
+    eq_(plain_recursive, ds.diff(path='.', recursive=True, annex='all',
+                                 result_renderer=None))
     # duplicate paths do not change things
-    eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all'))
+    eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all',
+                                 result_renderer=None))
     # neither do nested paths
     if not ("2.24.0" <= external_versions["cmd:git"] < "2.25.0"):
         # Release 2.24.0 contained a regression that was fixed with 072a231016
         # (2019-12-10).
         eq_(plain_recursive,
-            ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all'))
+            ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all',
+                    result_renderer=None))
     # when invoked in a subdir of a dataset it still reports on the full thing
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):
-        plain_recursive = diff(recursive=True, annex='all')
+        plain_recursive = diff(recursive=True, annex='all',
+                               result_renderer=None)
     # should be able to take absolute paths and yield the same
     # output
-    eq_(plain_recursive, ds.diff(path=ds.path, recursive=True, annex='all'))
+    eq_(plain_recursive, ds.diff(path=ds.path, recursive=True, annex='all',
+                                 result_renderer=None))
 
     # query for a deeply nested path from the top, should just work with a
     # variety of approaches
@@ -392,12 +406,12 @@ def test_path_diff(_path, linkpath):
                 res = ds.diff(
                     path=op.join('.', rpath),
                     recursive=True,
-                    annex='all')
+                    annex='all', result_renderer=None)
         else:
             res = ds.diff(
                 path=p,
                 recursive=True,
-                annex='all')
+                annex='all', result_renderer=None)
         assert_result_count(
             res,
             1,
@@ -410,20 +424,20 @@ def test_path_diff(_path, linkpath):
 
     assert_result_count(
         ds.diff(
-            recursive=True),
+            recursive=True, result_renderer=None),
         1,
         path=apath)
     # limiting recursion will exclude this particular path
     assert_result_count(
         ds.diff(
             recursive=True,
-            recursion_limit=1),
+            recursion_limit=1, result_renderer=None),
         0,
         path=apath)
     # negative limit is unlimited limit
     eq_(
-        ds.diff(recursive=True, recursion_limit=-1),
-        ds.diff(recursive=True)
+        ds.diff(recursive=True, recursion_limit=-1, result_renderer=None),
+        ds.diff(recursive=True, result_renderer=None)
     )
 
 
@@ -432,13 +446,13 @@ def test_path_diff(_path, linkpath):
 def test_diff_nods(path, otherpath):
     ds = Dataset(path).create()
     assert_result_count(
-        ds.diff(path=otherpath, on_failure='ignore'),
+        ds.diff(path=otherpath, on_failure='ignore', result_renderer=None),
         1,
         status='error',
         message='path not underneath this dataset')
     otherds = Dataset(otherpath).create()
     assert_result_count(
-        ds.diff(path=otherpath, on_failure='ignore'),
+        ds.diff(path=otherpath, on_failure='ignore', result_renderer=None),
         1,
         path=otherds.path,
         status='error',
@@ -454,12 +468,13 @@ def test_diff_rsync_syntax(path):
     ds = Dataset(path).create()
     subds = ds.create('sub')
     subsubds = subds.create(Path('subdir', 'deep'))
-    justtop = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub')
+    justtop = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub', result_renderer=None)
     # we only get a single result, the subdataset in question
     assert_result_count(justtop, 1)
     assert_result_count(justtop, 1, type='dataset', path=subds.path)
     # now with "peak inside the dataset" syntax
-    inside = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub' + os.sep)
+    inside = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub' + os.sep,
+                     result_renderer=None)
     # we get both subdatasets, but nothing else inside the nested one
     assert_result_count(inside, 2, type='dataset')
     assert_result_count(inside, 1, type='dataset', path=subds.path)
@@ -468,7 +483,9 @@ def test_diff_rsync_syntax(path):
     # if we point to the subdir in 'sub' the reporting wrt the subsubds
     # doesn't change. It is merely a path constraint within the queried
     # subds, but because the subsubds is still underneath it, nothing changes
-    inside_subdir = ds.diff(fr=PRE_INIT_COMMIT_SHA, path=op.join('sub', 'subdir'))
+    inside_subdir = ds.diff(
+        fr=PRE_INIT_COMMIT_SHA, path=op.join('sub', 'subdir'),
+        result_renderer=None)
     assert_result_count(inside_subdir, 2, type='dataset')
     assert_result_count(inside_subdir, 1, type='dataset', path=subds.path)
     assert_result_count(inside_subdir, 1, type='dataset', path=subsubds.path)
@@ -476,7 +493,8 @@ def test_diff_rsync_syntax(path):
     # but the rest is different (e.g. all the stuff in .datalad is gone)
     neq_(inside, inside_subdir)
     # just for completeness, we get more when going full recursive
-    rec = ds.diff(fr=PRE_INIT_COMMIT_SHA, recursive=True, path='sub' + os.sep)
+    rec = ds.diff(fr=PRE_INIT_COMMIT_SHA, recursive=True, path='sub' + os.sep,
+                  result_renderer=None)
     assert(len(inside) < len(rec))
 
 
@@ -484,7 +502,7 @@ def test_diff_rsync_syntax(path):
 def test_diff_nonexistent_ref_unicode(path):
     ds = Dataset(path).create()
     assert_result_count(
-        ds.diff(fr="HEAD", to=u"β", on_failure="ignore"),
+        ds.diff(fr="HEAD", to=u"β", on_failure="ignore", result_renderer=None),
         1,
         path=ds.path,
         status="impossible")
@@ -505,7 +523,7 @@ def test_no_worktree_impact_false_deletions(path):
     # now perform a diff for the last commit, there is one file that remained
     # identifical
     ds.repo.call_git(['checkout', 'test'])
-    res = ds.diff(fr='master~1', to='master')
+    res = ds.diff(fr='master~1', to='master', result_renderer=None)
     # under no circumstances can there be any reports on deleted files
     # because we never deleted anything
     assert_result_count(res, 0, state='deleted')

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -45,7 +45,7 @@ def test_runnin_on_empty(path):
     # just wrap with a dataset
     ds = Dataset(path)
     # and run status ... should be good and do nothing
-    eq_([], ds.status())
+    eq_([], ds.status(result_renderer=None))
 
 
 @with_tempfile(mkdir=True)
@@ -63,8 +63,8 @@ def test_status_basics(path, linkpath, otherdir):
     # outcome identical between ds= and auto-discovery
     with chpwd(path):
         assert_raises(IncompleteResultsError, status, path=otherdir)
-        stat = status()
-    eq_(stat, ds.status())
+        stat = status(result_renderer=None)
+    eq_(stat, ds.status(result_renderer=None))
     assert_status('ok', stat)
     # we have a bunch of reports (be vague to be robust to future changes
     assert len(stat) > 2
@@ -84,18 +84,19 @@ def test_status_basics(path, linkpath, otherdir):
 def test_status_nods(path, otherpath):
     ds = Dataset(path).create()
     assert_result_count(
-        ds.status(path=otherpath, on_failure='ignore'),
+        ds.status(path=otherpath, on_failure='ignore', result_renderer=None),
         1,
         status='error',
         message='path not underneath this dataset')
     otherds = Dataset(otherpath).create()
     assert_result_count(
-        ds.status(path=otherpath, on_failure='ignore'),
+        ds.status(path=otherpath, on_failure='ignore', result_renderer=None),
         1,
         path=otherds.path,
         status='error',
         message=(
-            'dataset containing given paths is not underneath the reference dataset %s: %s',
+            'dataset containing given paths is not underneath the reference '
+            'dataset %s: %s',
             ds, [])
         )
 
@@ -123,7 +124,7 @@ def test_status(_path, linkpath):
     # spotcheck that annex status reporting and availability evaluation
     # works
     assert_result_count(
-        ds.status(annex='all'),
+        ds.status(annex='all', result_renderer=None),
         1,
         path=str(ds.pathobj / 'subdir' / 'annexed_file.txt'),
         key='MD5E-s5--275876e34cf609db118f3d84b799a790.txt',
@@ -135,7 +136,7 @@ def test_status(_path, linkpath):
         'MD5E-s5--275876e34cf609db118f3d84b799a790.txt' /
         'MD5E-s5--275876e34cf609db118f3d84b799a790.txt'))
 
-    plain_recursive = ds.status(recursive=True)
+    plain_recursive = ds.status(recursive=True, result_renderer=None)
     # check integrity of individual reports with a focus on how symlinks
     # are reported
     for res in plain_recursive:
@@ -153,19 +154,23 @@ def test_status(_path, linkpath):
 
     # bunch of smoke tests
     # query of '.' is same as no path
-    eq_(plain_recursive, ds.status(path='.', recursive=True))
+    eq_(plain_recursive, ds.status(path='.', recursive=True,
+                                   result_renderer=None))
     # duplicate paths do not change things
-    eq_(plain_recursive, ds.status(path=['.', '.'], recursive=True))
+    eq_(plain_recursive, ds.status(path=['.', '.'], recursive=True,
+                                   result_renderer=None))
     # neither do nested paths
     eq_(plain_recursive,
-        ds.status(path=['.', 'subds_modified'], recursive=True))
+        ds.status(path=['.', 'subds_modified'], recursive=True,
+                  result_renderer=None))
     # when invoked in a subdir of a dataset it still reports on the full thing
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):
-        plain_recursive = status(recursive=True)
+        plain_recursive = status(recursive=True, result_renderer=None)
     # should be able to take absolute paths and yield the same
     # output
-    eq_(plain_recursive, ds.status(path=ds.path, recursive=True))
+    eq_(plain_recursive, ds.status(path=ds.path, recursive=True,
+                                   result_renderer=None))
 
     # query for a deeply nested path from the top, should just work with a
     # variety of approaches
@@ -181,9 +186,9 @@ def test_status(_path, linkpath):
             # change into the realpath of the dataset and
             # query with an explicit path
             with chpwd(ds.repo.path):
-                res = ds.status(path=op.join('.', rpath))
+                res = ds.status(path=op.join('.', rpath), result_renderer=None)
         else:
-            res = ds.status(path=p)
+            res = ds.status(path=p, result_renderer=None)
         assert_result_count(
             res,
             1,
@@ -196,20 +201,20 @@ def test_status(_path, linkpath):
 
     assert_result_count(
         ds.status(
-            recursive=True),
+            recursive=True, result_renderer=None),
         1,
         path=apath)
     # limiting recursion will exclude this particular path
     assert_result_count(
         ds.status(
             recursive=True,
-            recursion_limit=1),
+            recursion_limit=1, result_renderer=None),
         0,
         path=apath)
     # negative limit is unlimited limit
     eq_(
-        ds.status(recursive=True, recursion_limit=-1),
-        ds.status(recursive=True)
+        ds.status(recursive=True, recursion_limit=-1, result_renderer=None),
+        ds.status(recursive=True, result_renderer=None)
     )
 
 
@@ -224,7 +229,7 @@ def test_subds_status(path):
     assert_repo_status(subds.path)
     assert_repo_status(ds.path, modified=['subds'])
     assert_result_count(
-        ds.status(path='subds'),
+        ds.status(path='subds', result_renderer=None),
         1,
         # must be modified, not added (ds was clean after it was added)
         state='modified',
@@ -235,7 +240,7 @@ def test_subds_status(path):
     # path="." gets treated as "this dataset's content" without requiring a
     # trailing "/".
     assert_result_count(
-        subds.status(path="."),
+        subds.status(path=".", result_renderer=None),
         1,
         type="dataset",
         path=op.join(subds.path, "someotherds"),


### PR DESCRIPTION
Those are particularly noisy and blow up the logs.