### PR TITLE
TST: Pin git-annex version to 7.20191107 for windows CI runs

### DIFF
--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -31,7 +31,10 @@ jobs:
         python-version: 3.7
     - name: Set up git-annex
       run: |
-        python -c "import urllib.request as r; r.urlretrieve('https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe', 'C:\\git-annex-installer.exe')"
+        # latest version
+        #python -c "import urllib.request as r; r.urlretrieve('https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe', 'C:\\git-annex-installer.exe')"
+        # specific version mih uses to debug on real win10 box
+        python -c "import urllib.request as r; r.urlretrieve('http://store.datalad.org/git-annex/windows/git-annex_7.20191107-g8ea269ef7.exe', 'C:\\git-annex-installer.exe')"
         7z x -o"C:\\Program Files\Git" C:\\git-annex-installer.exe
     - name: Install dependencies
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,10 @@ install:
   - ssh -v localhost exit
   - ssh datalad-test exit
   # git annex setup
-  - appveyor DownloadFile https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -FileName resources\git-annex-installer.exe
+  # latest version
+  #- appveyor DownloadFile https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -FileName resources\git-annex-installer.exe
+  # specific version mih uses to debug on real win10 box
+  - appveyor DownloadFile http://store.datalad.org/git-annex/windows/git-annex_7.20191107-g8ea269ef7.exe -FileName resources\git-annex-installer.exe
   # extract git annex into the system Git installation path
   - 7z x -o"C:\\Program Files\Git" resources\git-annex-installer.exe
   # info on how python is ticking


### PR DESCRIPTION
Version was picked, because it happened to have been installed on @mih debug win10 box.

As expressed elsewhere, datalad+git-annex on windows is moving to fast as a target for me to ever catch up. I'd rather have some things working reasonably well with a particular annex version that nothing with the latest version. Also, the noise contributed by the windows tests is hurting, because they make devs more likely to ignore actual failures caused by regressions.

Will cancel Travis run.