### PR TITLE
BF: annexrepo: Future-proof "has --include-dotfiles" check

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -608,7 +608,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             cls._check_git_annex_version()
 
         ver = cls.git_annex_version
-        kludges["has-include-dotfiles"] = ver <= "7.20200226"
+        kludges["has-include-dotfiles"] = ver < "8"
         cls._version_kludges = kludges
         return kludges[key]
 


### PR DESCRIPTION
AnnexRepo checks whether the git-annex version is at or below
7.20200226 to decide whether the installed git-annex has
--include-dotfiles.  That was a poorly chosen check because the
annex.dotfiles/--include-dotfiles change happened with the transition
to v8 (currently git-annex's master), which means DataLad will need a
compatibility fix if another release is cut for v7.  (This is
particuarly relevant given that 7.20200309 has been tagged in the
git-annex repo.)

Make this check use the v8 boundary.