### PR TITLE
Test updates for git-annex dotfiles fix 

### DIFF
--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -174,8 +174,10 @@ def test_py2_unicode_command(path):
 def test_sidecar(path):
     ds = Dataset(path).create()
     if ds.repo.is_managed_branch():
-        if not ds.repo._check_version_kludges("has-include-dotfiles"):
-            # FIXME(annex.dotfiles)
+        if "8" < ds.repo.git_annex_version < "8.20200309":
+            # git-annex's 1978a2420 (2020-03-09) fixed a bug where
+            # annexed dotfiles could switch when annex.dotfiles=true
+            # was not set in .git/config or git-annex:config.log.
             ds.repo.config.set("annex.dotfiles", "true",
                                where="local", reload=True)
     # Simple sidecar message checks.

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -765,8 +765,10 @@ def check_save_dotfiles(to_git, save_path, path):
     ok_(paths)
     ds = Dataset(path).create(force=True)
     if not to_git and ds.repo.is_managed_branch():
-        if not ds.repo._check_version_kludges("has-include-dotfiles"):
-            # FIXME(annex.dotfiles)
+        if "8" < ds.repo.git_annex_version < "8.20200309":
+            # git-annex's 1978a2420 (2020-03-09) fixed a bug where
+            # annexed dotfiles could switch when annex.dotfiles=true
+            # was not set in .git/config or git-annex:config.log.
             ds.repo.config.set("annex.dotfiles", "true",
                                where="local", reload=True)
     ds.save(save_path, to_git=to_git)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -51,6 +51,7 @@ from datalad.api import (
 
 from datalad.tests.utils import (
     assert_repo_status,
+    SkipTest,
     skip_wo_symlink_capability,
 )
 
@@ -765,12 +766,16 @@ def check_save_dotfiles(to_git, save_path, path):
     ok_(paths)
     ds = Dataset(path).create(force=True)
     if not to_git and ds.repo.is_managed_branch():
-        if "8" < ds.repo.git_annex_version < "8.20200309":
+        ver = ds.repo.git_annex_version
+        if "8" < ver < "8.20200309":
             # git-annex's 1978a2420 (2020-03-09) fixed a bug where
             # annexed dotfiles could switch when annex.dotfiles=true
             # was not set in .git/config or git-annex:config.log.
             ds.repo.config.set("annex.dotfiles", "true",
                                where="local", reload=True)
+        elif ver < "8" and save_path is None:
+            raise SkipTest("Fails with annex version below v8.*")
+
     ds.save(save_path, to_git=to_git)
     if save_path is None:
         assert_repo_status(ds.path)


### PR DESCRIPTION
- Two tests needed a workaround for an annex.dotfiles-related failure on adjusted branches.  This has been fixed upstream, so limit the workaround to versions of git-annex that need it.
- For older git-annex versions, skip failing cases of `check_save_dotfiles` on adjusted branches.  This failure became apparent when the windows ci runs were pinned to 7.20191107 (gh-4264).