### PR TITLE
RF: AnnexRepo.get_corresponding_branch() -> None without a managed branch

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -756,8 +756,7 @@ def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
     # the explicit revision fetch fails.
     (ds_src_s1.pathobj / "bar").write_text("bar content")
     ds_src.save(recursive=True)
-    ds_src_s1.repo.checkout(
-        ds_src_s1.repo.get_corresponding_branch("master"))
+    ds_src_s1.repo.checkout('master')
     # This is the default, but just in case:
     ds_src_s1.repo.config.set("uploadpack.allowAnySHA1InWant", "false",
                               where="local")

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1914,6 +1914,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 raise e
         return out.strip()[11:]  # strip refs/heads/
 
+    def get_corresponding_branch(self, branch=None):
+        """Always returns None, a plain GitRepo has no managed branches"""
+        return None
+
     def get_branches(self):
         """Get all branches of the repo.
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1984,7 +1984,7 @@ def test_AnnexRepo_get_corresponding_branch(path):
     ar = AnnexRepo(path)
 
     # we should be on master.
-    eq_('master', ar.get_corresponding_branch())
+    eq_('master', ar.get_corresponding_branch() or ar.get_active_branch())
 
     # special case v6 adjusted branch is not provided by a dedicated build:
     if ar.supports_unlocked_pointers:


### PR DESCRIPTION
When dealing with managed branches, one frequently has to switch
behavior depending on their presence. With this change the return value
of `get_corresponding_branch()` carries the information whether there is
such a branch or not, and immediately allows decision making based on
it.

Previously, it required an additional call to `is_managed_branch()`
(that is duplicated in `get_corresponding_branch()` in order to determine
this condition.

This cost reduction is minimal, but the code complexity goes down.
The previous behavior is easily achieved via

    `get_corresponding_branch(branch) or branch`

and seem to communicate more direct what is intended.

A `GitRepo.get_corresponding_branch()` that always returns `None` has been
added to further simplify decision making and avoid type-based
switching.
