### PR TITLE
BF: resolve stalls in Runner while trying to access stdout/err from exited process

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -318,7 +318,14 @@ class Runner(object):
                 outputstream, proc.stdout.read(), *stdout_args)
             stderr += self._process_remaining_output(
                 errstream, proc.stderr.read(), *stderr_args)
-        stdout_, stderr_ = proc.communicate()
+        # Since the process is already dead, we don't need to wait
+        # too long:
+        try:
+            stdout_, stderr_ = proc.communicate(timeout=1)
+        except subprocess.TimeoutExpired as exc:
+            stdout_ = exc.stdout
+            stderr_ = exc.stderr
+
         # ??? should we condition it on log_stdout in {'offline'} ???
         stdout += self._process_remaining_output(outputstream, stdout_, *stdout_args)
         stderr += self._process_remaining_output(errstream, stderr_, *stderr_args)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1160,21 +1160,11 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     from datalad import lgr
     # remote interaction causes socket to be created:
     try:
-        # Note: For some reason, it hangs if log_stdout/err True
-        # TODO: Figure out what's going on
-        #  yoh: I think it is because of what is "TODOed" within cmd.py --
-        #       trying to log/obtain both through PIPE could lead to lock
-        #       downs.
-        # here we use our swallow_logs to overcome a problem of running under
-        # nosetests without -s, when nose then tries to swallow stdout by
-        # mocking it with StringIO, which is not fully compatible with Popen
-        # which needs its .fileno()
-        with swallow_outputs():
-            ar._run_annex_command('sync',
-                                  expect_stderr=True,
-                                  log_stdout=False,
-                                  log_stderr=False,
-                                  expect_fail=True)
+        ar._run_annex_command('sync',
+                              expect_stderr=True,
+                              log_stdout=True,
+                              log_stderr=True,
+                              expect_fail=True)
     # sync should return exit code 1, since it can not merge
     # doesn't matter for the purpose of this test
     except CommandError as e:


### PR DESCRIPTION
Got to it while troubleshooting https://github.com/datalad/datalad/pull/4265 but for unclear to me reason, I see no bloody effect on the actual run (even annex  `--debug` output is not printed): https://travis-ci.org/datalad/datalad/builds/660779184?utm_medium=notification&utm_source=github_status

Want to test across all tests now.