### PR TITLE
ENH: extend message for a NoDatasetArgumentFound in require_dataset

### DIFF
--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -16,7 +16,7 @@ import os
 import os.path as op
 from datalad.support.external_versions import external_versions
 from datalad.support.exceptions import (
-    NoDatasetArgumentFound,
+    NoDatasetFound,
 )
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
@@ -154,7 +154,7 @@ def _dirty_results(res):
 @with_tempfile(mkdir=True)
 def test_diff(path, norepo):
     with chpwd(norepo):
-        assert_raises(NoDatasetArgumentFound, diff)
+        assert_raises(NoDatasetFound, diff)
     ds = Dataset(path).create()
     assert_repo_status(ds.path)
     # reports stupid revision input

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -34,7 +34,7 @@ from datalad.utils import (
 from datalad.cmdline.main import main
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import (
-    NoDatasetArgumentFound,
+    NoDatasetFound,
     CommandError,
 )
 from datalad.api import (
@@ -76,7 +76,7 @@ from datalad.tests.utils import (
 def test_invalid_call(path):
     with chpwd(path):
         # no dataset, no luck
-        assert_raises(NoDatasetArgumentFound, run, 'doesntmatter')
+        assert_raises(NoDatasetFound, run, 'doesntmatter')
         # dirty dataset
         ds = Dataset(path).create()
         create_tree(ds.path, {'this': 'dirty'})

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -24,7 +24,7 @@ from datalad.tests.utils import (
     with_tempfile,
 )
 from datalad.support.exceptions import (
-    NoDatasetArgumentFound,
+    NoDatasetFound,
     IncompleteResultsError,
 )
 from datalad.distribution.dataset import Dataset
@@ -60,7 +60,7 @@ def test_status_basics(path, linkpath, otherdir):
         path = linkpath
 
     with chpwd(path):
-        assert_raises(NoDatasetArgumentFound, status)
+        assert_raises(NoDatasetFound, status)
     ds = Dataset(path).create()
     # outcome identical between ds= and auto-discovery
     with chpwd(path):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -29,7 +29,7 @@ from datalad.support.constraints import Constraint
 # DueCredit
 from datalad.support.due import due
 from datalad.support.due_utils import duecredit_dataset
-from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import NoDatasetFound
 from datalad.support.gitrepo import (
     GitRepo,
     InvalidGitRepositoryError,
@@ -563,7 +563,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
     if dataset is None:  # possible scenario of cmdline calls
         dspath = get_dataset_root(getpwd())
         if not dspath:
-            raise NoDatasetArgumentFound(
+            raise NoDatasetFound(
                 "No dataset found at '{}'.  Specify a dataset to work with "
                 "by providing its path via the `dataset` option, "
                 "or change the current working directory to be in a "

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -564,9 +564,10 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dspath = get_dataset_root(getpwd())
         if not dspath:
             raise NoDatasetArgumentFound(
-                "No dataset found.  You must either specify or 'cd' to the "
-                "(super)dataset containing your path(s) and reissue the "
-                "command.")
+                "No dataset found at '{}'.  Specify a dataset to work with "
+                "by providing its path via the `dataset` option, "
+                "or change the current working directory to be in a "
+                "dataset.".format(getpwd()))
         dataset = Dataset(dspath)
 
     assert(dataset is not None)

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -563,7 +563,10 @@ def require_dataset(dataset, check_installed=True, purpose=None):
     if dataset is None:  # possible scenario of cmdline calls
         dspath = get_dataset_root(getpwd())
         if not dspath:
-            raise NoDatasetArgumentFound("No dataset found")
+            raise NoDatasetArgumentFound(
+                "No dataset found.  You must either specify or 'cd' to the "
+                "(super)dataset containing your path(s) and reissue the "
+                "command.")
         dataset = Dataset(dspath)
 
     assert(dataset is not None)

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -33,7 +33,7 @@ from ..dochelpers import exc_str
 from ..support.annexrepo import AnnexRepo, AnnexBatchCommandError
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr, EnsureNone
-from ..support.exceptions import NoDatasetArgumentFound
+from ..support.exceptions import NoDatasetFound
 
 from logging import getLogger
 lgr = getLogger('datalad.api.download-url')
@@ -104,7 +104,7 @@ class DownloadURL(Interface):
                 ds = require_dataset(
                     dataset, check_installed=True,
                     purpose='downloading urls')
-            except NoDatasetArgumentFound:
+            except NoDatasetFound:
                 pass
 
         common_report = {"action": "download_url",

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -33,7 +33,7 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import NoDatasetFound
 from datalad.utils import (
     quote_cmdlinearg,
     split_cmdline,
@@ -320,7 +320,7 @@ class RunProcedure(Interface):
             ds = require_dataset(
                 dataset, check_installed=False,
                 purpose='run a procedure')
-        except NoDatasetArgumentFound:
+        except NoDatasetFound:
             ds = None
 
         if discover:

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -21,7 +21,7 @@ from datalad.api import create
 from datalad.api import unlock
 from datalad.utils import Path
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import NoDatasetFound
 from datalad.support.annexrepo import AnnexRepo
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import assert_false
@@ -58,7 +58,7 @@ def test_unlock_raises(path, path2, path3):
     assert_raises(InsufficientArgumentsError,
                   unlock, dataset=None, path=None)
     # no dataset and path not within a dataset:
-    assert_raises(NoDatasetArgumentFound,
+    assert_raises(NoDatasetFound,
                   unlock, dataset=None, path=path2)
 
     create(path=path, no_annex=True)

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -44,7 +44,7 @@ from datalad.utils import (
     get_suggestions_msg,
     unique,
 )
-from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import NoDatasetFound
 from datalad.ui import ui
 from datalad.dochelpers import single_or_plural
 from datalad.dochelpers import exc_str
@@ -191,7 +191,7 @@ def _search_from_virgin_install(dataset, query):
     exc_info = sys.exc_info()
     if dataset is None:
         if not ui.is_interactive:
-            raise NoDatasetArgumentFound(
+            raise NoDatasetFound(
                 "No DataLad dataset found. Specify a dataset to be "
                 "searched, or run interactively to get assistance "
                 "installing a queriable superdataset."
@@ -212,7 +212,7 @@ def _search_from_virgin_install(dataset, query):
                 else:
                     raise exc_info[1]
             else:
-                raise NoDatasetArgumentFound(
+                raise NoDatasetFound(
                     "No DataLad dataset found at current location. "
                     "The DataLad superdataset location %r exists, "
                     "but does not contain an dataset."
@@ -1207,11 +1207,11 @@ class Search(Interface):
         try:
             ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
             if ds.id is None:
-                raise NoDatasetArgumentFound(
+                raise NoDatasetFound(
                     "This does not seem to be a dataset (no DataLad dataset ID "
                     "found). 'datalad create --force %s' can initialize "
                     "this repository as a DataLad dataset" % ds.path)
-        except NoDatasetArgumentFound:
+        except NoDatasetFound:
             for r in _search_from_virgin_install(dataset, query):
                 yield r
             return

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -40,7 +40,7 @@ from datalad.tests.utils import swallow_logs
 from datalad.tests.utils import assert_re_in
 from datalad.tests.utils import known_failure_githubci_win
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import NoDatasetFound
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 
@@ -228,7 +228,7 @@ def test_ignore_nondatasets(path):
 
 @with_tempfile(mkdir=True)
 def test_get_aggregates_fails(path):
-    with chpwd(path), assert_raises(NoDatasetArgumentFound):
+    with chpwd(path), assert_raises(NoDatasetFound):
         metadata(get_aggregates=True)
     ds = Dataset(path).create()
     res = ds.metadata(get_aggregates=True, on_failure='ignore')

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -33,7 +33,7 @@ from datalad.tests.utils import patch_config
 from datalad.tests.utils import SkipTest
 from datalad.tests.utils import eq_
 from datalad.tests.utils import known_failure_githubci_win
-from datalad.support.exceptions import NoDatasetArgumentFound
+from datalad.support.exceptions import NoDatasetFound
 
 from datalad.api import search
 
@@ -46,7 +46,7 @@ from ..search import _meta2autofield_dict
 def test_search_outside1_noninteractive_ui(tdir):
     # we should raise an informative exception
     with chpwd(tdir):
-        with assert_raises(NoDatasetArgumentFound) as cme:
+        with assert_raises(NoDatasetFound) as cme:
             list(search("bu"))
         assert_in('run interactively', str(cme.exception))
 
@@ -60,7 +60,7 @@ def test_search_outside1(tdir, newhome):
         with patch_config({'datalad.locations.default-dataset': newhome}):
             gen = search("bu", return_type='generator')
             assert_is_generator(gen)
-            assert_raises(NoDatasetArgumentFound, next, gen)
+            assert_raises(NoDatasetFound, next, gen)
 
         # and if we point to some non-existing dataset
         with assert_raises(ValueError):
@@ -94,14 +94,14 @@ def test_search_outside1_install_default_ds(tdir, default_dspath):
             # and what if we say "no" to install?
             ui.add_responses('no')
             mock_install.reset_mock()
-            with assert_raises(NoDatasetArgumentFound):
+            with assert_raises(NoDatasetFound):
                 list(search("."))
 
             # and if path exists and is a valid dataset and we say "no"
             Dataset(default_dspath).create()
             ui.add_responses('no')
             mock_install.reset_mock()
-            with assert_raises(NoDatasetArgumentFound):
+            with assert_raises(NoDatasetFound):
                 list(search("."))
 
 
@@ -173,7 +173,7 @@ def test_our_metadataset_search(tdir):
 def test_search_non_dataset(tdir):
     from datalad.support.gitrepo import GitRepo
     GitRepo(tdir, create=True)
-    with assert_raises(NoDatasetArgumentFound) as cme:
+    with assert_raises(NoDatasetFound) as cme:
         list(search('smth', dataset=tdir))
     # Should instruct user how that repo could become a datalad dataset
     assert_in("datalad create --force", str(cme.exception))

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -335,13 +335,13 @@ class WTF(Interface):
     @eval_results
     def __call__(dataset=None, sensitive=None, sections=None, decor=None, clipboard=None):
         from datalad.distribution.dataset import require_dataset
-        from datalad.support.exceptions import NoDatasetArgumentFound
+        from datalad.support.exceptions import NoDatasetFound
         from datalad.interface.results import get_status_dict
 
         ds = None
         try:
             ds = require_dataset(dataset, check_installed=False, purpose='reporting')
-        except NoDatasetArgumentFound:
+        except NoDatasetFound:
             # failure is already logged
             pass
         if ds and not ds.is_installed():

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -224,6 +224,11 @@ class NoDatasetArgumentFound(InsufficientArgumentsError):
     pass
 
 
+class NoDatasetFound(NoDatasetArgumentFound):
+    """Raised whenever a dataset is required, but none could be determined"""
+    pass
+
+
 class OutOfSpaceError(CommandError):
     """To be raised whenever a command fails if we have no sufficient space
 


### PR DESCRIPTION
This exception is now (since 0.12) is frequently shown to users due to breakage
of behavior as discussed in https://github.com/datalad/datalad/issues/3759 .
As it is worded minimally, it provides no instructions to the users and just
brings frustration.  This commit extends message to provide instructions on how
to mitigate the error they start to observe

