### PR TITLE
ENH: gitrepo: Use matched line as message for log_progress()

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -571,7 +571,7 @@ class GitProgress(WitlessProtocol):
             log_progress(
                 lgr.info,
                 pbar_id,
-                message,
+                line,
                 update=float(cur_count),
             )
 


### PR DESCRIPTION
When the GitProgress protocol receives a line like

    Receiving objects:  32% (22269/69588), 7.98 MiB | 7.98 MiB/s

it extracts anything after (M/N) as the message.  This message is used
to detect when a particular action is done, but it's also used as the
"message" parameter to log_progress().

The latter is problematic when running non-interactively---where the
messages are shown with standard logging rather than progress
bars---because many lines have an empty message, leading to many lines
of uninformative output (as in this example [0]).

Prevent this by using the entire matched line as the message.  This
leads to the non-interactive logging closely matching what the caller
would see from the command line.

[0]: https://github.com/datalad-handbook/book/issues/390

---

This changes non-interactive output like

```
[INFO] Attempting to clone from https://github.com/datalad/datalad.git to /tmp/dl-Qcqewf2/c 
[INFO] Start enumerating objects 
[INFO] Finished enumerating objects 
[INFO] Start counting objects 
[INFO]  
[INFO]  
[... many more ...]
```

to

```
[INFO] Attempting to clone from https://github.com/datalad/datalad.git to /tmp/dl-FGiAQa2/c 
[INFO] Start enumerating objects 
[INFO] Finished enumerating objects 
[INFO] Start counting objects 
[INFO] remote: Counting objects:   0% (1/307) 
[INFO] remote: Counting objects:   1% (4/307)
[...]
```

While it matches what you'd see from Git, it's perhaps still a bit noisy for the `info` level.  However, I don't see a clean solution for that, at least within `GitProgress`, because it feels like a core issue with `log_progress`/`ProgressHandler`: a logging level that is good to decide "show a progress bar" doesn't necessarily align with the level that would be appropriate if all those progress bar ticks are mapped to regular log messages.  I'm thinking about how to extend the log handling to account for that.

attn: @adswa 