### PR TITLE
gitrepo: Restrict non-interactive log_progress() output 

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -571,7 +571,7 @@ class GitProgress(WitlessProtocol):
             log_progress(
                 lgr.info,
                 pbar_id,
-                message,
+                line,
                 update=float(cur_count),
             )
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -573,6 +573,7 @@ class GitProgress(WitlessProtocol):
                 pbar_id,
                 line,
                 update=float(cur_count),
+                noninteractive_level=logging.DEBUG,
             )
 
         if done_progress:
@@ -583,6 +584,7 @@ class GitProgress(WitlessProtocol):
                     op_props[0].lower(),
                     op_props[1].lower(),
                 ),
+                noninteractive_level=logging.DEBUG,
             )
             self._pbars.discard(pbar_id)
         return True


### PR DESCRIPTION
This sits on top of gh-4293 and is meant to solve the problem of `log_progress` producing overly verbose non-interactive logging for the default INFO-level configuration.

It changes

```
[INFO] Cloning dataset to <Dataset path=/tmp/dl-nqnScvV> 
[INFO] Attempting to clone from https://github.com/datalad/datalad.git to /tmp/dl-nqnScvV 
[INFO] Start enumerating objects 
[INFO] Finished enumerating objects 
[INFO] Start counting objects 
[... 416 lines ...]
[INFO] Finished resolving deltas 
[INFO] Completed clone attempts for <Dataset path=/tmp/dl-nqnScvV> 
install(ok): /tmp/dl-nqnScvV (dataset)
```

into

```
[INFO] Cloning dataset to <Dataset path=/tmp/dl-nJ2rgU2> 
[INFO] Attempting to clone from https://github.com/datalad/datalad.git to /tmp/dl-nJ2rgU2 
[INFO] Start enumerating objects 
[INFO] Start counting objects 
[INFO] Start compressing objects 
[INFO] Start receiving objects 
[INFO] Start resolving deltas 
[INFO] Completed clone attempts for <Dataset path=/tmp/dl-nJ2rgU2> 
install(ok): /tmp/dl-nJ2rgU2 (dataset)
```

`datalad -ldebug clone ...` can be used to restore the original level of verbosity.

attn: @adswa