### PR TITLE
BF: resolve() does not imply absolute() on Windows for non-existing paths

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -185,7 +185,9 @@ def _normalize_path(base_dir, path):
         return path
     pathobj = Path(path)
 
-    base_dir = str(Path(base_dir).resolve())  # realpath OK
+    # do absolute() in addition to always get an absolute path
+    # even with non-existing base_dirs on windows
+    base_dir = str(Path(base_dir).resolve().absolute())  # realpath OK
 
     # path = normpath(path)
     # Note: disabled normpath, because it may break paths containing symlinks;

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -917,10 +917,13 @@ def get_local_file_url(fname, compatibility='git-annex'):
         setting has no effect.
     """
     # we resolve the path to circumwent potential short paths on unfortunate
-    # platforms that would ruin the URL format
+    # platforms that would ruin the URL format.
+    #path = Path(fname).resolve().absolute()
     path = Path(fname).resolve()
     if on_windows:
-        path = path.as_posix()
+        # in addition we need to absolute(), as on windows resolve() doesn't
+        # imply that
+        path = path.absolute().as_posix()
         furl = 'file://{}{}'.format(
             '/' if compatibility == 'git' else '',
             urlquote(

--- a/datalad/support/repo.py
+++ b/datalad/support/repo.py
@@ -187,7 +187,9 @@ class PathBasedFlyweight(Flyweight):
         """
         # resolve symlinks to make sure we have exactly one instance per
         # physical repository at a time
-        return str(ut.Path(path).resolve())
+        # do absolute() in addition to always get an absolute path
+        # even with non-existing paths on windows
+        return str(ut.Path(path).resolve().absolute())
 
     def _flyweight_id_from_args(cls, *args, **kwargs):
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -357,7 +357,9 @@ def _prep_file_under_git(path, filename):
     # path to the file within the repository
     # repo.path is a "realpath" so to get relpath working correctly
     # we need to realpath our path as well
-    path = str(Path(path).resolve())  # intentional realpath to match GitRepo behavior
+    # do absolute() in addition to always get an absolute path
+    # even with non-existing paths on windows
+    path = str(Path(path).resolve().absolute())  # intentional realpath to match GitRepo behavior
     file_repo_dir = op.relpath(path, repo.path)
     file_repo_path = filename if file_repo_dir == curdir else opj(file_repo_dir, filename)
     return annex, file_repo_path, filename, path, repo

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -490,7 +490,9 @@ def get_open_files(path, log_open=False):
     files = {}
     # since the ones returned by psutil would not be aware of symlinks in the
     # path we should also get realpath for path
-    path = str(Path(path).resolve())
+    # do absolute() in addition to always get an absolute path
+    # even with non-existing paths on windows
+    path = str(Path(path).resolve().absolute())
     for proc in psutil.process_iter():
         try:
             open_paths = [p.path for p in proc.open_files()] + [proc.cwd()]
@@ -1490,7 +1492,9 @@ def getpwd():
                 raise
         try:
             pwd = os.environ['PWD']
-            pwd_real = str(Path(pwd).resolve())
+            # do absolute() in addition to always get an absolute path
+            # even with non-existing paths on windows
+            pwd_real = str(Path(pwd).resolve().absolute())
             # This logic would fail to catch the case where chdir did happen
             # to the directory where current PWD is pointing to, e.g.
             # $> ls -ld $PWD


### PR DESCRIPTION
This might be an issue in other places too!

The behavior of `resolve()` conflicts with its [documentation](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve) that claims:

> Make the path absolute, resolving any symlinks.