### PR TITLE
TST: Expand testing on crippled FS to all modern API

### DIFF
--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -47,4 +47,4 @@ jobs:
       run: |
         mkdir -p __testhome__
         cd __testhome__
-        python -m nose -s -v datalad.core
+        python -m nose -s -v datalad.core datalad.local datalad.distributed

--- a/datalad/distributed/tests/test_ria_data_transfer.py
+++ b/datalad/distributed/tests/test_ria_data_transfer.py
@@ -7,6 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
+import os
 from datalad.api import (
     clone,
 )
@@ -17,6 +18,7 @@ from datalad.tests.utils import (
     skip_if_on_windows,
     skip_ssh,
     with_tempfile,
+    SkipTest,
 )
 
 from datalad.distributed.tests.ria_utils import (
@@ -42,6 +44,10 @@ def test_binary_data_local(dspath, store):
                           "datastore")
 
     ds.publish(to="datastore", transfer_data="all")
+    if os.environ.get('TMPDIR', None) == '/crippledfs':
+        raise SkipTest(
+            "ATM drop() doesn't work on crippled FS "
+            "(check https://github.com/datalad/datalad/issues/3368 for status)")
     ds.drop(file)
     ds.get(file, source="datastore-storage")
 

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -61,10 +61,8 @@ def test_get_subdatasets(origpath, path):
     # tests
     ds = clone(source=origpath, path=path)
     # one more subdataset with a name that could ruin config option parsing
-    # no trailing dots on windows!
-    dots = str(Path('subdir') / ('.lots.of.dots'
-                                  if on_windows
-                                  else '.lots.of.dots.'))
+    # no trailing dots on windows and its crippled FS mounted on linux!
+    dots = str(Path('subdir') / ('.lots.of.dots'))
     ds.create(dots)
     # mitigate https://github.com/datalad/datalad/issues/4267
     ds.save()


### PR DESCRIPTION
- [x] datalad.local.tests.test_subdataset.test_get_subdatasets protects against windows limitation, but it really is a file system limitation (trailing dot in filename)
- [x] datalad.distributed.tests.test_ria_data_transfer.test_binary_data_local internally invokes `drop` which is broken on crippled FS