### PR TITLE
BF: downloaders -  lock (interprocess) initiation of the session or re-authentication

### DIFF
--- a/datalad/support/locking.py
+++ b/datalad/support/locking.py
@@ -1,6 +1,7 @@
-import fasteners
-import os
-
+from fasteners import (
+    InterProcessLock,
+    try_lock,
+)
 from contextlib import contextmanager
 
 from .path import exists
@@ -83,7 +84,7 @@ def lock_if_check_fails(
         lock_filename += operation + '-'
     lock_filename += 'lck'
 
-    lock = fasteners.InterProcessLock(lock_filename)
+    lock = InterProcessLock(lock_filename)
     try:
         lgr.debug("Acquiring a lock %s", lock_filename)
         lock.acquire(blocking=blocking, **kwargs)


### PR DESCRIPTION
This way parallel downloaders/special-remotes (e.g. as launched by git-annex) should not present multiple prompts for logins.  Only one would handle it, and then the others would just follow (since credentials would then be known).

Closes #4284 