### PR TITLE
annexrepo: Tell caller that annex is scanning for unlocked files

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -255,6 +255,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         )
         self.pid = None
         super().__init__()
+        self.encoding = getpreferredencoding(do_setlocale=False)
 
         self._log_outputs = False
         if lgr.isEnabledFor(5):
@@ -310,7 +311,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         # give captured process output back to the runner as string(s)
         results = {
             name:
-            bytes(byt).decode(getpreferredencoding(do_setlocale=False))
+            bytes(byt).decode(self.encoding)
             if byt else ''
             for name, byt in zip(self.FD_NAMES[1:], self.buffer)
         }

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1265,7 +1265,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                                 reload=False)
         self._run_annex_command(
             'init',
-            log_stderr=lambda s: lgr.info(s.rstrip()), log_online=True,
+            runner="gitwitless",
+            protocol=AnnexInitOutput,
             annex_options=opts)
         # TODO: When to expect stderr?
         # on crippled filesystem for example (think so)?
@@ -3639,6 +3640,16 @@ class AnnexJsonProtocol(WitlessProtocol):
                 'Finished',
             )
         super().process_exited()
+
+
+class AnnexInitOutput(WitlessProtocol):
+    proc_out = True
+    proc_err = True
+
+    def pipe_data_received(self, fd, byts):
+        line = byts.decode(self.encoding)
+        if fd == 2:
+            lgr.info(line.strip())
 
 
 # TODO: Why was this commented out?

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3648,7 +3648,11 @@ class AnnexInitOutput(WitlessProtocol):
 
     def pipe_data_received(self, fd, byts):
         line = byts.decode(self.encoding)
-        if fd == 2:
+        if fd == 1:
+            if "scanning for unlocked files" in line:
+                lgr.info("Scanning for unlocked files "
+                         "(this may take some time)")
+        elif fd == 2:
             lgr.info(line.strip())
 
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1039,10 +1039,17 @@ class AnnexRepo(GitRepo, RepoInterface):
             env = self.add_fake_dates(env)
 
         if runner == "gitwitless":
+            log_streams = (kwargs.pop('log_stdout', True),
+                           kwargs.pop('log_stderr', True))
+            if any(map(callable, log_streams)):
+                raise ValueError(
+                    "gitwitless is incompatible with callable"
+                    "for log_std{out,err}: log_stdout=%r, log_stderr=%r",
+                    log_streams[0], log_streams[1])
+
             class _protocol(WitlessProtocol):
-                # TODO: guard for callables being passed as values
-                proc_out = bool(kwargs.pop('log_stdout', True))
-                proc_err = bool(kwargs.pop('log_stderr', True))
+                proc_out = bool(log_streams[0])
+                proc_err = bool(log_streams[1])
             # expect_fail and expect_stderr were all about deciding level
             # at which to log if error or stderr output.  With WitlessRunner
             # and all the handling "from upstairs" we simply would do nothing

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -972,6 +972,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                            files=None,
                            merge_annex_branches=True,
                            runner=None,
+                           protocol=None,
                            **kwargs):
         """Helper to run actual git-annex calls
 
@@ -1000,6 +1001,9 @@ class AnnexRepo(GitRepo, RepoInterface):
             benefit from updating information about remote git-annexes
         runner: {None, "gitwitless"}, optional
             Use specified runner class instead of the bound Runner instance.
+        protocol : WitlessProtocol, optional
+            Protocol class to pass to GitWitlessRunner.run(). This is ignored
+            if `runner` is not "gitwitless".
         **kwargs
             these are passed as additional kwargs to .run() of the runner
 
@@ -1039,17 +1043,20 @@ class AnnexRepo(GitRepo, RepoInterface):
             env = self.add_fake_dates(env)
 
         if runner == "gitwitless":
-            log_streams = (kwargs.pop('log_stdout', True),
-                           kwargs.pop('log_stderr', True))
-            if any(map(callable, log_streams)):
-                raise ValueError(
-                    "gitwitless is incompatible with callable"
-                    "for log_std{out,err}: log_stdout=%r, log_stderr=%r",
-                    log_streams[0], log_streams[1])
+            if protocol:
+                _protocol = protocol
+            else:
+                log_streams = (kwargs.pop('log_stdout', True),
+                               kwargs.pop('log_stderr', True))
+                if any(map(callable, log_streams)):
+                    raise ValueError(
+                        "gitwitless is incompatible with callable"
+                        "for log_std{out,err}: log_stdout=%r, log_stderr=%r",
+                        log_streams[0], log_streams[1])
 
-            class _protocol(WitlessProtocol):
-                proc_out = bool(log_streams[0])
-                proc_err = bool(log_streams[1])
+                class _protocol(WitlessProtocol):
+                    proc_out = bool(log_streams[0])
+                    proc_err = bool(log_streams[1])
             # expect_fail and expect_stderr were all about deciding level
             # at which to log if error or stderr output.  With WitlessRunner
             # and all the handling "from upstairs" we simply would do nothing

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -411,7 +411,6 @@ class GitProgress(WitlessProtocol):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self._encoding = getpreferredencoding(do_setlocale=False)
         self._unprocessed = None
 
     def connection_made(self, transport):
@@ -473,7 +472,7 @@ class GitProgress(WitlessProtocol):
         # Compressing objects:  50% (1/2)
         # Compressing objects: 100% (2/2)
         # Compressing objects: 100% (2/2), done.
-        line = line.decode(self._encoding) if isinstance(line, bytes) else line
+        line = line.decode(self.encoding) if isinstance(line, bytes) else line
         if line.startswith(('warning:', 'error:', 'fatal:')):
             return False
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1282,6 +1282,22 @@ def test_repo_version(path1, path2, path3):
             eq_(version, 5)
 
 
+@with_tempfile
+def test_init_scanning_message(path):
+    # | begin kludge
+    # Before git-annex v7.20190912 (specifically f6fb4b8cd), the "scanning for
+    # unlocked files" won't be shown for an empty tree. We can drop this once
+    # GIT_ANNEX_MIN_VERSION is at or above that version.
+    gr = GitRepo(path, create=True)
+    (gr.pathobj / "foo").write_text("foo")
+    gr.add("foo")
+    gr.commit(msg="add foo")
+    # | end kludge
+    with swallow_logs(new_level=logging.INFO) as cml:
+        AnnexRepo(path, create=True, version=7)
+        assert_in("for unlocked", cml.out)
+
+
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:330
 @known_failure_windows
 @with_testrepos('.*annex.*', flavors=['clone'])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2418,3 +2418,17 @@ def test_get_size_from_key():
 
     for key, value in test_keys.items():
         eq_(AnnexRepo.get_size_from_key(key), value)
+
+
+@with_tempfile(mkdir=True)
+def test_run_annex_gitwitless_invalid_callable(path):
+    ar = AnnexRepo(path, create=True)
+    for log_stdout, log_stderr in [(str, False),
+                                   (False, str),
+                                   (str, str)]:
+        with assert_raises(ValueError):
+            ar._run_annex_command_json(
+                "info",
+                log_stdout=log_stdout,
+                log_stderr=log_stderr,
+                runner="gitwitless")


### PR DESCRIPTION
@yarikoptic mentioned that `git annex init` could take some time on the "scanning for unlocked files" phase.  This series teaches `AnnexRepo._run_annex_command` to take a custom protocol and switches `AnnexRepo._init` over to using a `WitlessProtocol` that logs this at the info level.

---

Example output:

```
$ datalad install ///openneuro                  
[INFO   ] Scanning for unlocked files (this may take some time)                         
install(ok): /tmp/dl-vwEPXnr/openneuro (dataset)   
```