### PR TITLE
common_cfg: Tweak log.outputs entry

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -217,7 +217,10 @@ definitions = {
     },
     'datalad.log.outputs': {
         'ui': ('question', {
-               'title': 'Used to control whether both stdout and stderr of external commands execution are logged in detail (at DEBUG level)'}),
+               'title': 'Whether to log stdout and stderr for executed commands',
+               'text': 'When enabled, setting the log level to 5 '
+                       'should catch all execution output, '
+                       'though some output may be logged at higher levels'}),
         'default': False,
         'type': EnsureBool(),
     },

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -218,6 +218,8 @@ definitions = {
     'datalad.log.outputs': {
         'ui': ('question', {
                'title': 'Used to control whether both stdout and stderr of external commands execution are logged in detail (at DEBUG level)'}),
+        'default': False,
+        'type': EnsureBool(),
     },
     'datalad.log.timestamp': {
         'ui': ('yesno', {


### PR DESCRIPTION
The description for `datalad.log.outputs` says that the output is logged at DEBUG, which isn't the case.  Fix that and make a few other minor changes.