### PR TITLE
RF: make non-interactive sessions use QuietConsoleLog (with LogProgressBar)

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -457,13 +457,12 @@ class LoggerHelper(object):
         #  logging.Formatter('%(asctime)-15s %(levelname)-6s %(message)s'))
         self.lgr.addHandler(loghandler)
 
-        if is_interactive():
-            phandler = ProgressHandler()
-            # progress only when interactive
-            phandler.addFilter(OnlyProgressLog())
-            # no stream logs of progress messages when interactive
-            loghandler.addFilter(NoProgressLog())
-            self.lgr.addHandler(phandler)
+        phandler = ProgressHandler()
+        # progress only
+        phandler.addFilter(OnlyProgressLog())
+        # no stream logs of progress
+        loghandler.addFilter(NoProgressLog())
+        self.lgr.addHandler(phandler)
 
         self.set_level()  # set default logging level
         return self.lgr

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -38,6 +38,7 @@ KNOWN_BACKENDS = {
     'annex': UnderAnnexUI,
     'tests': UnderTestsUI,
     'tests-noninteractive': QuietConsoleLog,
+    'quiet': QuietConsoleLog,
     'no-progress': SilentConsoleLog,
 }
 
@@ -81,7 +82,7 @@ class _UI_Switcher(object):
                 else:
                     backend = 'dialog'
             else:
-                backend = 'dialog' if is_interactive() else 'no-progress'
+                backend = 'dialog' if is_interactive() else 'quiet'
         self._ui = KNOWN_BACKENDS[backend]()
         lgr.debug("UI set to %s" % self._ui)
         self._backend = backend


### PR DESCRIPTION
Such mode already was used during tests runs (only).

We would gain LOG (at INFO level) messages reporting upon completion of a
process with a progress (bar) reporting.  That would include uses of log_progress.

This also leads to removal of custom interactive vs non-interactive difference
in LoggerHelper.

Example output:

	$> rm -rf datalad && datalad clone https://github.com/datalad/datalad.git  | cat
	[INFO]  Enumerating done in 0.000221014 sec
	[INFO]  Counting 153 Objects done in 0.0139375 sec at 10978 Objects/sec
	[INFO]  Compressing 94 Objects done in 0.0118935 sec at 7903 Objects/sec
	[INFO]  Receiving 69836 Objects done in 3 seconds at 19489 Objects/sec
	[INFO]  Resolving 54608 Deltas done in 0.610522 sec at 89445 Deltas/sec
	[INFO]  Clone attempt 2 Candidate locations done in 5 seconds at 0.398732 Candidate locations/sec
	install(ok): /tmp/datalad (dataset)

This PR (branch) is based on a state of master before #4294 merge, which provides an alternative solution with explicit filtering of the log, thus would conflict in this PR initial version.

Pros:

- would be consistent across logging (INFO vs DEBUG) levels

Cons:

- timing/speed reporting might complicate inclusion of such output snippets
  into a handbook since they would be varying from run to run

- [ ] if deemed worthwhile, should be meld with an alternative solution for empty log lines from `log_progress` in master  (#4294)