### PR TITLE
create(no_annex=False) -> create(annex=True)

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -109,7 +109,7 @@ def mk_push_target(ds, name, path, annex=True, bare=True):
 @with_tempfile(mkdir=True)
 def check_push(annex, src_path, dst_path):
     # prepare src
-    src = Dataset(src_path).create(no_annex=not annex)
+    src = Dataset(src_path).create(annex=annex)
     src_repo = src.repo
     # push should not add branches to the local dataset
     orig_branches = src_repo.get_branches()
@@ -236,7 +236,7 @@ def test_push_recursive(
     origin = Dataset(origin_path).create()
     origin_subm1 = origin.create('sub m')
     origin_subm1.create('subsub m')
-    origin.create('subm noannex', no_annex=True)
+    origin.create('subm noannex', annex=False)
     origin.save()
     assert_repo_status(origin.path)
     # prepare src as a fresh clone with all subdatasets checkout out recursively

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -158,10 +158,16 @@ class Create(Interface):
             action='store_true'),
         description=location_description,
         no_annex=Parameter(
-            args=("--no-annex",),
-            doc="""if set, a plain Git repository will be created without any
-            annex""",
+            # hide this from the cmdline parser, replaced by `annex`
+            args=tuple(),
+            doc="""this option is deprecated, use `annex` instead""",
             action='store_true'),
+        annex=Parameter(
+            args=("--no-annex",),
+            dest='annex',
+            doc="""if [CMD: set CMD][PY: disabled PY], a plain Git repository
+            will be created without any annex""",
+            action='store_false'),
         # TODO seems to only cause a config flag to be set, this could be done
         # in a procedure
         fake_dates=Parameter(
@@ -192,9 +198,23 @@ class Create(Interface):
             description=None,
             dataset=None,
             no_annex=False,
+            annex=True,
             fake_dates=False,
             cfg_proc=None
     ):
+        # TODO: introduced with 0.13, remove with 0.14
+        if annex != (not no_annex) and no_annex:
+            # the two mirror options do not agree and the deprecated one is
+            # not at default value
+            lgr.warning("datalad-create's `no_annex` option is deprecated "
+                        "and will be removed in a future release, "
+                        "use the reversed-sign `annex` option instead.")
+            # honor the old option for now
+            annex = not no_annex
+
+        # we only perform negative tests below
+        no_annex = not annex
+
         if dataset:
             if isinstance(dataset, Dataset):
                 ds = dataset

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -14,9 +14,9 @@ import os
 import logging
 import random
 import uuid
+import warnings
 from argparse import (
     REMAINDER,
-    ONE_OR_MORE,
 )
 
 from os import listdir
@@ -60,6 +60,12 @@ import datalad.utils as ut
 __docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.core.local.create')
+
+
+# Used for handling the no_annex -> annex option transition
+# remove when done
+class _NoAnnexDefault(object):
+    pass
 
 
 @build_doc
@@ -197,18 +203,19 @@ class Create(Interface):
             force=False,
             description=None,
             dataset=None,
-            no_annex=False,
+            no_annex=_NoAnnexDefault,
             annex=True,
             fake_dates=False,
             cfg_proc=None
     ):
         # TODO: introduced with 0.13, remove with 0.14
-        if annex != (not no_annex) and no_annex:
+        if no_annex is not _NoAnnexDefault:
             # the two mirror options do not agree and the deprecated one is
             # not at default value
-            lgr.warning("datalad-create's `no_annex` option is deprecated "
-                        "and will be removed in a future release, "
-                        "use the reversed-sign `annex` option instead.")
+            warnings.warn("datalad-create's `no_annex` option is deprecated "
+                          "and will be removed in a future release, "
+                          "use the reversed-sign `annex` option instead.",
+                          DeprecationWarning)
             # honor the old option for now
             annex = not no_annex
 

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -63,7 +63,7 @@ raw = dict(return_type='list', result_filter=None, result_xfm=None, on_failure='
 def test_create_raises(path, outside_path):
     ds = Dataset(path)
     # incompatible arguments (annex only):
-    assert_raises(ValueError, ds.create, no_annex=True, description='some')
+    assert_raises(ValueError, ds.create, annex=False, description='some')
 
     with open(op.join(path, "somefile.tst"), 'w') as f:
         f.write("some")
@@ -155,7 +155,7 @@ def test_create_curdir(path, path2):
     assert_repo_status(ds.path, annex=True)
 
     with chpwd(path2, mkdir=True):
-        create(no_annex=True)
+        create(annex=False)
     ds = Dataset(path2)
     ok_(ds.is_installed())
     assert_repo_status(ds.path, annex=False)
@@ -227,7 +227,7 @@ def test_create_sub(path):
     assert_not_in("someother", ds.subdatasets(result_xfm='relpaths'))
 
     # 3. create sub via super:
-    subds3 = ds.create("third", no_annex=True)
+    subds3 = ds.create("third", annex=False)
     ok_(isinstance(subds3, Dataset))
     ok_(subds3.is_installed())
     assert_repo_status(subds3.path, annex=False)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -162,8 +162,8 @@ def test_save_message_file(path):
 
 def test_renamed_file():
     @with_tempfile()
-    def check_renamed_file(recursive, no_annex, path):
-        ds = Dataset(path).create(no_annex=no_annex)
+    def check_renamed_file(recursive, annex, path):
+        ds = Dataset(path).create(annex=annex)
         create_tree(path, {'old': ''})
         ds.repo.add('old')
         ds.repo.call_git(["mv"], files=["old", "new"])
@@ -171,8 +171,8 @@ def test_renamed_file():
         assert_repo_status(path)
 
     for recursive in False,:  #, True TODO when implemented
-        for no_annex in True, False:
-            yield check_renamed_file, recursive, no_annex
+        for annex in True, False:
+            yield check_renamed_file, recursive, annex
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -32,7 +32,7 @@ from datalad.tests.utils import eq_
 @with_tempfile(mkdir=True)
 def test_create(outdir):
     from datalad.api import create
-    assert_raises(ValueError, create, outdir, description='Precious data', no_annex=True)
+    assert_raises(ValueError, create, outdir, description='Precious data', annex=False)
 
 
 def test_parse_spec():

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -315,7 +315,7 @@ def test_dataset_id(path):
     # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
     # dict isn't a nice approach. May be create needs a fix/RF?
     Dataset._unique_instances.clear()
-    ds.create(no_annex=True, force=True)
+    ds.create(annex=False, force=True)
     assert_equal(ds.id, dsorigid)
     # even adding an annex doesn't
     #

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -167,7 +167,7 @@ def test_get_invalid_call(path, file_outside):
 
     # have a plain git:
     ds = Dataset(path)
-    ds.create(no_annex=True)
+    ds.create(annex=False)
     with open(opj(path, "some.txt"), "w") as f:
         f.write("whatever")
     ds.save("some.txt", to_git=True, message="Initial commit.")
@@ -444,7 +444,7 @@ def test_get_install_missing_subdataset(src, path):
 @with_tempfile(mkdir=True)
 def test_get_mixed_hierarchy(src, path):
 
-    origin = Dataset(src).create(no_annex=True)
+    origin = Dataset(src).create(annex=False)
     origin_sub = origin.create('subds')
     with open(opj(origin.path, 'file_in_git.txt'), "w") as f:
         f.write('no idea')

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -854,7 +854,7 @@ def test_install_subds_from_another_remote(topdir):
         clone1_ = 'clone1'
         clone2_ = 'clone2'
 
-        origin = create(origin_, no_annex=True)
+        origin = create(origin_, annex=False)
         clone1 = install(source=origin, path=clone1_)
         # print("Initial clone")
         clone1.create_sibling('ssh://localhost%s/%s' % (PathRI(getpwd()).posixpath, clone2_), name=clone2_)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -183,7 +183,7 @@ def test_update_simple(origin, src_path, dst_path):
 @with_tempfile
 def test_update_git_smoke(src_path, dst_path):
     # Apparently was just failing on git repos for basic lack of coverage, hence this quick test
-    ds = Dataset(src_path).create(no_annex=True)
+    ds = Dataset(src_path).create(annex=False)
     target = install(
         dst_path, source=src_path,
         result_xfm='datasets', return_type='item-or-list')

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -653,7 +653,11 @@ class Interface(object):
             param = cls._params_[arg]
             defaults_idx = ndefaults - len(args) + i
             cmd_args = param.cmd_args
-            if cmd_args is None:
+            if cmd_args == tuple():
+                # explicitly provided an empty sequence of argument names
+                # this shall not appear in the parser
+                continue
+            elif cmd_args is None:
                 cmd_args = []
             if not len(cmd_args):
                 if defaults_idx >= 0:
@@ -727,7 +731,11 @@ class Interface(object):
                            'result_renderer', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]
-        kwargs = {k: getattr(args, k) for k in argnames if is_api_arg(k)}
+        kwargs = {k: getattr(args, k)
+                  for k in argnames
+                  # some arguments might be Python-only and do not appear in the
+                  # parser Namespace
+                  if hasattr(args, k) and is_api_arg(k)}
         # we are coming from the entry point, this is the toplevel command,
         # let it run like generator so we can act on partial results quicker
         # TODO remove following condition test when transition is complete and

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -510,7 +510,7 @@ def test_new_or_modified(path):
         return [op.relpath(ap["path"], path)
                 for ap in new_or_modified(diff_revision(*args, **kwargs))]
 
-    ds = Dataset(path).create(force=True, no_annex=True)
+    ds = Dataset(path).create(force=True, annex=False)
 
     # Check out an orphan branch so that we can test the "one commit
     # in a repo" case.
@@ -760,7 +760,7 @@ def test_run_inputs_outputs(src, path):
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_run_inputs_no_annex_repo(path):
-    ds = Dataset(path).create(no_annex=True)
+    ds = Dataset(path).create(annex=False)
     # Running --input in a plain Git repo doesn't fail.
     ds.run("cd .> dummy", inputs=["*"])
     ok_exists(op.join(ds.path, "dummy"))

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -65,7 +65,7 @@ def test_unlock_raises(path, path2, path3):
     assert_raises(NoDatasetFound,
                   unlock, dataset=None, path=path2)
 
-    create(path=path, no_annex=True)
+    create(path=path, annex=False)
     ds = Dataset(path)
     # no complaints
     ds.unlock()

--- a/datalad/metadata/extractors/tests/test_base.py
+++ b/datalad/metadata/extractors/tests/test_base.py
@@ -21,8 +21,8 @@ from datalad.tests.utils import (
 
 
 @with_tree(tree={'file.dat': ''})
-def check_api(no_annex, path):
-    ds = Dataset(path).create(force=True, no_annex=no_annex)
+def check_api(annex, path):
+    ds = Dataset(path).create(force=True, annex=annex)
     ds.save()
     assert_repo_status(ds.path)
 
@@ -55,7 +55,7 @@ def check_api(no_annex, path):
         if extractor_ep.name == 'datalad_core':
             assert 'file.dat' in cm
         elif extractor_ep.name == 'annex':
-            if not no_annex:
+            if annex:
                 # verify correct key, which is the same for all files of 0 size
                 assert_equal(
                     cm['file.dat']['key'],
@@ -76,9 +76,9 @@ def check_api(no_annex, path):
 @known_failure_githubci_win
 def test_api_git():
     # should tollerate both pure git and annex repos
-    yield check_api, True
+    yield check_api, False
 
 
 @known_failure_githubci_win
 def test_api_annex():
-    yield check_api, False
+    yield check_api, True

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -327,7 +327,7 @@ def test_extract_wrong_input_type():
 
 @with_tempfile(mkdir=True)
 def test_addurls_nonannex_repo(path):
-    ds = Dataset(path).create(force=True, no_annex=True)
+    ds = Dataset(path).create(force=True, annex=False)
     with assert_raises(IncompleteResultsError) as raised:
         ds.addurls("dummy_arg0", "dummy_arg1", "dummy_arg2")
     assert_in("not an annex repo", str(raised.exception))

--- a/datalad/plugin/tests/test_export_archive.py
+++ b/datalad/plugin/tests/test_export_archive.py
@@ -102,7 +102,7 @@ def test_archive(path):
 
 @with_tree(_dataset_template)
 def test_zip_archive(path):
-    ds = Dataset(opj(path, 'ds')).create(force=True, no_annex=True)
+    ds = Dataset(opj(path, 'ds')).create(force=True, annex=False)
     ds.save()
     with chpwd(path):
         ds.export_archive(filename='my', archivetype='zip')


### PR DESCRIPTION
This avoids double-negative thinking when using the Python API, and fixes gh-4207

There is no change wrt the command-line API.

A warning is emitted if, and only if, using the Python API `no_annex=True` is given in conflict with the value of `annex`.

In order to make this a smooth transition (but possibly with further future benefits), it is now possible to have Python-only arguments for our commands.

This can be achieved by setting the `args` of a `Parameter` instance to be an empty tuple. The value `None` continues to indicate that a default argument name should be derived from the
parameter name. Example:

```
some_param=Parameter(args=tuple(), ...)
```