### PR TITLE
DOC: make warning on absent annex appear less like an error

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -549,8 +549,9 @@ def _configure_remote(
                 # which starts to fail with AccessFailedError) if URL is bogus,
                 # so enableremote fails. E.g. as "tested" in test_siblings
                 lgr.info(
-                    "Failed to enable annex remote %s, could be a pure git "
-                    "or not accessible", name)
+                    "Could not enable annex remote %s. This is expected if %s "
+                    "is a pure Git remote, or happens if it is not accessible.",
+                    name, name)
                 lgr.debug("Exception was: %s" % exc_str(exc))
 
             if as_common_datasrc:
@@ -684,10 +685,12 @@ def _query_remotes(
                     if 'cannot determine uuid' in exc.stderr:
                         # not an annex (or no connection), would be marked as
                         #  annex-ignore
-                        msg = "Failed to determine if %s carries annex." % remote
+                        msg = "Could not detect whether %s carries an annex. " \
+                              "If %s is a pure Git remote, this is expected. " %\
+                              (remote, remote)
                         ds.repo.config.reload()
                         if ds.repo.is_remote_annex_ignored(remote):
-                            msg += " Remote was marked by annex as annex-ignore.  " \
+                            msg += "Remote was marked by annex as annex-ignore. " \
                                    "Edit .git/config to reset if you think that was done by mistake due to absent connection etc"
                         lgr.warning(msg)
                         info['annex-ignore'] = True


### PR DESCRIPTION
I have reworded the warning and info messages related to adding siblings without an annex. Mostly, I've removed the word "failed". I've played around with "downgrading" the message from "warning" to "info", but I guess the color coding as a warning helps to not miss a problem should there ever be one. The text should make sure that this Warning is no need for worry if the remote is a pure Git remote. 

I think its better than the previous messages, but I'm not yet 100% satisfied. Here is how the message looks like for the situation described in #4322 

```sh
datalad siblings add --name bitbucket --url https://testing_ittacc@bitbucket.org/testing_ittacc/mydataset.git
[INFO   ] Could not enable annex remote bitbucket. This is expected if bitbucket is a pure Git remote, or happens if it is not accessible. 
[WARNING] Could not detect whether bitbucket carries an annex. If bitbucket is a pure Git remote, this is expected. Remote was marked by annex as annex-ignore. Edit .git/config to reset if you think that was done by mistake due to absent connection etc 
.: bitbucket(-) [https://testing_ittacc@bitbucket.org/testing_ittacc/mydataset.git (git)]
```

If anyone has other suggestions, please say so. :)

This fixes #4322