### PR TITLE
 NF: clone/install --reckless shared-{group|all|...}

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -335,8 +335,13 @@ def test_reckless(src, top_path, sharedpath):
     sub = ds.clone(src, 'sub', result_xfm='datasets', return_type='item-or-list')
     eq_(sub.config.get('datalad.clone.reckless', None), 'auto')
     eq_(sub.config.get('annex.hardlink', None), 'true')
+
+    if ds.repo.is_managed_branch():
+        raise SkipTest("Remainder of test needs proper filesystem permissions")
+
     # the standard setup keeps the annex locks accessible to the user only
-    nok_((ds.pathobj / '.git' / 'annex' / 'index.lck').stat().st_mode & stat.S_IWGRP)
+    nok_((ds.pathobj / '.git' / 'annex' / 'index.lck').stat().st_mode \
+         & stat.S_IWGRP)
     # but we can set it up for group-shared access too
     sharedds = clone(
         src, sharedpath,

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -14,10 +14,14 @@ __docformat__ = 'restructuredtext'
 
 from datalad.interface.results import known_result_xfms
 from datalad.support.param import Parameter
-from datalad.support.constraints import EnsureInt, EnsureNone, EnsureStr
-from datalad.support.constraints import EnsureChoice
-from datalad.support.constraints import EnsureCallable
-
+from datalad.support.constraints import (
+    EnsureCallable,
+    EnsureChoice,
+    EnsureInt,
+    EnsureNone,
+    EnsureStr,
+    EnsureStrPrefix,
+)
 
 location_description = Parameter(
     args=("-D", "--description",),
@@ -131,19 +135,27 @@ reckless_opt = Parameter(
     const='auto',
     nargs='?',
     # boolean types only for backward compatibility
-    constraints=EnsureChoice(None, True, False, 'auto', 'ephemeral'),
-    doc="""Set up the dataset to be able to obtain content in the
-    cheapest/fastest possible way, even if this poses a potential
-    risk the data integrity ('auto': hardlink files from a local clone
-    of the dataset, 'ephemeral': symlink annex to origin's annex and discard 
-    local availability info via git-annex-dead 'here'. Please note, that with a
-    symlinked annex you share the annex with origin w/o git-annex knowing
-    this. In case of a change in origin you need to update the clone before
-    you're able to save new content on your end.).
-    Use with care, and limit to "read-only" use cases. With this flag the
-    installed dataset will be marked as untrusted. The reckless mode is
-    stored in a dataset's local configuration under 'datalad.clone.reckless',
-    and will be inherited to any of its subdatasets.""")
+    constraints=
+    EnsureChoice(None, True, False, 'auto', 'ephemeral') | \
+    EnsureStrPrefix('shared-'),
+    metavar='auto|ephemeral|shared-...',
+    doc="""set up the dataset in a potentially unsafe way for performance,
+    or access reasons -- use with care, any dataset is marked as 'untrusted'.
+    The reckless mode is stored in a dataset's local configuration under
+    'datalad.clone.reckless', and will be inherited to any of its subdatasets.
+    Supported modes are:
+    ['auto']: hard-link files between local clones. In-place
+    modification in any clone will alter original annex content.
+    ['ephemeral']: symlink annex to origin's annex and discard local availability
+    info via git-annex-dead 'here'. Shares an annex between origin and clone
+    w/o git-annex being aware of it. In case of a change in origin you need to
+    update the clone before you're able to save new content on your end.
+    Alternative to 'auto' when hardlinks are not an option, or number of consumed
+    inodes needs to be minimized.
+    ['shared-<mode>']: set up repository and annex permission to enable multi-user
+    access. This disables the standard write protection of annex'ed files.
+    <mode> can be any value support by 'git init --shared=', such as 'group', or
+    'all'.""")
 
 jobs_opt = Parameter(
     args=("-J", "--jobs"),

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -214,6 +214,33 @@ class EnsureStr(Constraint):
         return 'str'
 
 
+class EnsureStrPrefix(EnsureStr):
+    """Ensure an input is a string that starts with a given prefix.
+    """
+    def __init__(self, prefix):
+        """
+        Parameters
+        ----------
+        prefix : str
+           Mandatory prefix.
+        """
+        self._prefix = prefix
+        super().__init__()
+
+    def __call__(self, value):
+        super().__call__(value)
+        if not value.startswith(self._prefix):
+            raise ValueError("%r does not start with '%s'"
+                             % (value, self._prefix))
+        return value
+
+    def long_description(self):
+        return "value must start with '{}'".format(self._prefix)
+
+    def short_description(self):
+        return '{}...'.format(self._prefix)
+
+
 class EnsureNone(Constraint):
     """Ensure an input is of value `None`"""
     def __call__(self, value):


### PR DESCRIPTION
Makes it possible to set up datasets for collaborative write access
on install. This is implemented as a reckless mode, because it bypasses
the standard annex write protection feature (see gh-1893).

- rewrote the `reckless` option docs
- added example to the clone docs
- add test of permission setup validity

This fixes gh-1146 although it doesn't implement a dedicated `--shared`
option. And it mitigates gh-1893, by providing a dedicated, documented mode
that marks the effected datasets as untrusted.