### PR TITLE
BF: log_progress: Start progress bar

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -213,6 +213,7 @@ class ProgressHandler(logging.Handler):
                 label=getattr(record, 'dlm_progress_label', ''),
                 unit=getattr(record, 'dlm_progress_unit', ''),
                 total=getattr(record, 'dlm_progress_total', None))
+            pbar.start()
             self.pbars[pid] = pbar
         elif update is None:
             # not an update -> done


### PR DESCRIPTION
```
The tqdm progress bars created by log_progress() have two related
issues:

  * Following the first log_progress() call, a bar does not show up
    until after the next call to log_progress() (i.e. the first
    update).  This is because log_progress() does not call
    tqdmProgressBar.start(), so the tqdm class isn't initialized until
    ._create() gets called within .update().

  * At that point, the bar shows up at the initial value.  On the
    second update, it jumps from the initial value to the correct
    value (say, 0 -> 2 if incrementing by 1).  The first update isn't
    displayed because tqdm has logic to skip updates that happen at
    too fast of a rate, so the first .update() call that creates the
    bar gets its update skipped.

Fix these issues by calling .start() on the first call to
log_progress().
```

---

Here's a script that shows the problem.

<details>
<summary>script</summary>

```python
import time
import logging
from datalad.log import log_progress

lgr = logging.getLogger("datalad.foo")

nthings = 4

log_progress(lgr.info, "foo",
             "Checking %d things", nthings,
             label="Checking things", total=nthings, unit=" things")

time.sleep(2)
for i in range(nthings):
    log_progress(lgr.info, "foo",
                 "Checking thing %d", i,
                 increment=True, update=1)
    time.sleep(2)

log_progress(lgr.info, "foo",
             "Finished checking %d things", nthings)
```

</details>
