### PR TITLE
BF: get_content_annexinfo: Fix init=None handling

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3346,9 +3346,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         for j in self._run_annex_command_json(cmd, opts=opts, files=files):
             path = self.pathobj.joinpath(ut.PurePosixPath(j['file']))
             rec = info.get(path, None)
-            if init is not None and rec is None:
-                # init constraint knows nothing about this path -> skip
-                continue
+            if rec is None:
+                if init is not None:
+                    # init constraint knows nothing about this path -> skip
+                    continue
+                rec = {}
             rec.update({'{}{}'.format(key_prefix, k): j[k]
                        for k in j if k != 'file'})
             if 'bytesize' in rec:


### PR DESCRIPTION
Passing init=None fails with

    rec.update({'{}{}'.format(key_prefix, k): j[k]
    AttributeError: 'NoneType' object has no attribute 'update'

Set `rec` to an empty dict when init=None.