### PR TITLE
ENH: Warn when provided dataset to wtf does not exist

### DIFF
--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -347,6 +347,16 @@ class WTF(Interface):
             # failure is already logged
             pass
         if ds and not ds.is_installed():
+            # warn that the dataset is bogus
+            yield dict(
+                action='wtf',
+                path=ds.path,
+                status='impossible',
+                message=(
+                'No dataset found at %s. Reporting on the dataset is '
+                'not attempted.', ds.path),
+                logger=lgr
+            )
             # we don't deal with absent datasets
             ds = None
         if sensitive:


### PR DESCRIPTION
it now says:

```sh
 datalad wtf -d ../nada                                                                       1 ↵
[WARNING] No dataset found at /tmp/nada. Reporting on the dataset is not attempted. [wtf(/tmp/nada)] 
# WTF
# WTF
## configuration <SENSITIVE, report disabled by configuration>
## datalad 
  - full_version: 0.12.3.dev547-g6a60c
  - version: 0.12.3.dev547
## dependencies 


```

fixes #4100
