### PR TITLE
RF: Suppress similar repeated messages in the default result renderer

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -524,6 +524,16 @@ def _process_results(
     # private helper pf @eval_results
     # loop over results generated from some source and handle each
     # of them according to the requested behavior (logging, rendering, ...)
+
+    # used to track repeated messages in the default renderer
+    last_result = None
+    # which result dict keys to inspect for changes to discover repetions
+    # of similar messages
+    repetition_keys = set(('action', 'status', 'type', 'refds'))
+    # counter for detected repetitions
+    result_repetitions = 0
+    result_suppression_msg = '  [{} similar messages have been suppressed]'
+
     for res in results:
         if not res or 'action' not in res:
             # XXX Yarik has to no clue on how to track the origin of the
@@ -567,7 +577,18 @@ def _process_results(
         if result_renderer is None or result_renderer == 'disabled':
             pass
         elif result_renderer == 'default':
-            default_result_renderer(res)
+            trimmed_result = {k: v for k, v in res.items() if k in repetition_keys}
+            if trimmed_result == last_result:
+                # this is a similar report, suppress, but count
+                result_repetitions += 1
+            else:
+                # this one is new, first report on any prev. suppressed results
+                # by number, and then render this fresh one
+                if result_repetitions:
+                    ui.message(result_suppression_msg.format(result_repetitions))
+                default_result_renderer(res)
+                result_repetitions = 0
+            last_result = trimmed_result
         elif result_renderer in ('json', 'json_pp'):
             ui.message(json.dumps(
                 {k: v for k, v in res.items()
@@ -598,6 +619,9 @@ def _process_results(
                 # raise will happen after the loop
                 break
         yield res
+    # make sure to report on any issues that we had suppressed
+    if result_repetitions:
+        ui.message(result_suppression_msg.format(result_repetitions))
 
 
 def keep_result(res, rfilter, **kwargs):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -578,8 +578,10 @@ def _process_results(
             pass
         elif result_renderer == 'default':
             trimmed_result = {k: v for k, v in res.items() if k in repetition_keys}
-            if trimmed_result == last_result:
-                # this is a similar report, suppress, but count
+            if res.get('status', None) != 'notneeded' \
+                    and trimmed_result == last_result:
+                # this is a similar report, suppress, but count it
+                # do not attempt
                 result_repetitions += 1
             else:
                 # this one is new, first report on any prev. suppressed results


### PR DESCRIPTION
Saving a dataset with a 1000 files will now look like this:

```
% datalad save
add(ok): 1 (file)
  [999 similar messages have been suppressed]
save(ok): . (dataset)
action summary:
  add (ok: 1000)
  save (ok: 1)
```

Failing to get a 1000 files looks like this (with `datalad.log.result-level=debug`)

```
% datalad get .
Total (0 ok, 1000 failed out of 1000):   0%|                     | 0.00/3.89k [00:01<?, ?B/s][WARNING] Running get resulted in stderr output: git-annex: get: 1000 failed

                                                                                             get(error): 1 (file) [Unable to access these remotes: origin; Try making some of these repositories available:;      2cc06516-5731-43a5-88e9-39499f2114e9 -- mih@meiner:/tmp/massive [origin]]
  [999 similar messages have been suppressed]
action summary:
  get (error: 1000)
```

Without the config switch, the second example would still produce a
thousand additional log messages, because we still report every error
twice. I decided to not address this in the logger, because while I can
relatively safely suppress result rendering based on a handful of result
keys, it is unclear to me what threshold we would use for the logger.
In any case, this can be done later by someone who is still suffering
from those messages ;-)

Fixes gh-2620 in spirit.