### PR TITLE
ENH: Capture hints from Git

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -234,6 +234,23 @@ class Push(Interface):
                 path=ds.path,
             )
 
+    @staticmethod
+    def custom_result_summary_renderer(results):  # pragma: more cover
+        # report on any hints at the end
+        # get all unique hints
+        hints = set([r.get('hints', None) for r in results])
+        hints = [hint for hint in hints if hint is not None]
+        if hints:
+            from datalad.ui import ui
+            from datalad.support import ansi_colors
+            intro = ansi_colors.color_word(
+                "Potential hints to solve encountered errors: ",
+                ansi_colors.YELLOW)
+            ui.message(intro)
+            [ui.message("{}: {}".format(
+                ansi_colors.color_word(id + 1, ansi_colors.YELLOW), hint))
+                for id, hint in enumerate(hints)]
+
 
 def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
     """Generator"""

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -617,6 +617,7 @@ def _push_refspecs(repo, target, refspecs, force, res_kwargs):
             target=pr['remote'],
             refspec=refspec,
             operations=ops,
+            hints=pr.get('hints', None),
             # seems like a good idea to pass on Git's native message
             # TODO maybe implement a dedicated result renderer, instead
             # of duplicating information only so that the default one

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -392,7 +392,7 @@ def eval_results(func):
             # if a custom summary is to be provided, collect the results
             # of the command execution
             results = []
-            do_custom_result_summary = result_renderer in('tailored', 'default') \
+            do_custom_result_summary = result_renderer in ('tailored', 'default') \
                 and hasattr(wrapped_class, 'custom_result_summary_renderer')
 
             # process main results

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -392,7 +392,7 @@ def eval_results(func):
             # if a custom summary is to be provided, collect the results
             # of the command execution
             results = []
-            do_custom_result_summary = result_renderer == 'tailored' \
+            do_custom_result_summary = result_renderer in('tailored', 'default') \
                 and hasattr(wrapped_class, 'custom_result_summary_renderer')
 
             # process main results
@@ -479,7 +479,7 @@ def eval_results(func):
                     # any processing
                     results = list(results)
                 # render summaries
-                if not result_xfm and result_renderer == 'tailored':
+                if not result_xfm and result_renderer in ('tailored', 'default'):
                     # cannot render transformed results
                     if hasattr(wrapped_class, 'custom_result_summary_renderer'):
                         wrapped_class.custom_result_summary_renderer(results)
@@ -575,7 +575,7 @@ def _process_results(
                 sort_keys=True,
                 indent=2 if result_renderer.endswith('_pp') else None,
                 default=lambda x: str(x)))
-        elif result_renderer == 'tailored':
+        elif result_renderer in ('tailored', 'default'):
             if hasattr(cmd_class, 'custom_result_renderer'):
                 cmd_class.custom_result_renderer(res, **allkwargs)
         elif hasattr(result_renderer, '__call__'):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2493,6 +2493,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                             e.stderr,
                             re.DOTALL | re.MULTILINE):
                         output = getattr(e, info_from)
+                        hints = ' '.join([l[6:] for l in e.stderr.splitlines()
+                                          if l.startswith('hint: ')])
                         if output is None:
                             output = ''
                     else:
@@ -2504,6 +2506,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                         pi = info_cls._from_line(line)
                         if add_remote:
                             pi['remote'] = remote
+                        # There were errors, but Git provided hints
+                        if 'error' in pi['operations']:
+                            pi['hints'] = hints if hints is not '' else None
                         yield pi
                     except Exception:
                         # it is not progress and no push info

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2508,7 +2508,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                             pi['remote'] = remote
                         # There were errors, but Git provided hints
                         if 'error' in pi['operations']:
-                            pi['hints'] = hints if hints is not '' else None
+                            pi['hints'] = hints or None
                         yield pi
                     except Exception:
                         # it is not progress and no push info


### PR DESCRIPTION
Sometimes, Git has "hints" why pushing fails. 
For example, if I attempt a push without integrating remote changes, it says

```
error: failed to push some refs to 'git@github.com:datalad-handbook/DataLad-101.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

`datalad push` swallowed these hints. In this PR I'm attempting to catch them and report all hints at the end of the result rendering.

#### A few examples:

```
datalad push --to blubb43
publish(error): . (dataset) [refs/heads/git-annex->blubb43:refs/heads/git-annex [rejected] (fetch first)]
Potential hints to solve encountered errors: 
1: Updates were rejected because the remote contains work that you do not have locally. This is usually caused by another repository pushing to the same ref. You may want to first integrate the remote changes (e.g., 'git pull ...') before pushing again. See the 'Note about fast-forwards' in 'git push --help' for details.

```

A situation with lots of the same hints 

```
datalad push --to public                                                                     1 ↵
publish(error): . (dataset) [refs/heads/master->public:refs/heads/master [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_back_and_forth_in_time->public:refs/heads/sct_back_and_forth_in_time [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_computational_reproducibility->public:refs/heads/sct_computational_reproducibility [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_create_a_dataset->public:refs/heads/sct_create_a_dataset [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_datalad_rerun->public:refs/heads/sct_datalad_rerun [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_hide_content->public:refs/heads/sct_hide_content [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_input_and_output->public:refs/heads/sct_input_and_output [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_install_datasets->public:refs/heads/sct_install_datasets [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_keeping_track->public:refs/heads/sct_keeping_track [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_looking_without_touching->public:refs/heads/sct_looking_without_touching [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_modify_content->public:refs/heads/sct_modify_content [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_more_on_DYI_configurations->public:refs/heads/sct_more_on_DYI_configurations [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_more_on_dataset_nesting->public:refs/heads/sct_more_on_dataset_nesting [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_networking->public:refs/heads/sct_networking [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_populate_a_dataset->public:refs/heads/sct_populate_a_dataset [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_retrace_and_reenact->public:refs/heads/sct_retrace_and_reenact [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_stay_up_to_date->public:refs/heads/sct_stay_up_to_date [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_where_is_waldo->public:refs/heads/sct_where_is_waldo [rejected] (non-fast-forward)]
publish(error): . (dataset) [refs/heads/sct_yoda_project->public:refs/heads/sct_yoda_project [rejected] (non-fast-forward)]
Potential hints to solve encountered errors: 
1: Updates were rejected because the tip of your current branch is behind its remote counterpart. Integrate the remote changes (e.g. 'git pull ...') before pushing again. See the 'Note about fast-forwards' in 'git push --help' for details.
2: Updates were rejected because a pushed branch tip is behind its remote counterpart. Check out this branch and integrate the remote changes (e.g. 'git pull ...') before pushing again. See the 'Note about fast-forwards' in 'git push --help' for details.

```

And with no hints:
```
datalad push --to roommate                                                                   1 ↵
publish(ok): . (dataset) [refs/heads/git-annex->roommate:refs/heads/git-annex f158575..2b80295]      
publish(error): . (dataset) [refs/heads/master->roommate:refs/heads/master [remote rejected] (branch is currently checked out)]

```

#### side effects:

We found out that the [custom result summary renderer of get](https://github.com/datalad/datalad/blob/9b30ac204d7febe0a1a91c36654fdccd0373dcb7/datalad/distribution/get.py#L786) is never executed, because it would previously only be called if  `result_renderer` was set to `tailored`. With b8b282d, it should be called now.