### PR TITLE
TST: wtf: Adjust test for gh-4331

### DIFF
--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -72,7 +72,7 @@ def test_wtf(topdir):
     path = opj(topdir, OBSCURE_FILENAME)
     # smoke test for now
     with swallow_outputs() as cmo:
-        wtf(dataset=path)
+        wtf(dataset=path, on_failure="ignore")
         assert_not_in('## dataset', cmo.out)
         assert_in('## configuration', cmo.out)
         # Those sections get sensored out by default now


### PR DESCRIPTION
I merged 6a60cc230c (ENH: Warn when provided dataset to wtf does not
exist, 2020-03-24) without doing a proper check of which tests failed.
Do the minimum fix to get the now failing `test_wtf` into a passing
state.