### PR TITLE
OPT: use locally bound variables instead of dataset.repo and .config

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -365,7 +365,7 @@ class Create(Interface):
             tbrepo.set_default_backend(
                 cfg.obtain('datalad.repo.backend'),
                 persistent=True, commit=False)
-            add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
+            add_to_git[tbrepo.pathobj / '.gitattributes'] = {
                 'type': 'file',
                 'state': 'added'}
             # make sure that v6 annex repos never commit content under .datalad
@@ -375,7 +375,7 @@ class Create(Interface):
                 ('metadata/objects/**', 'annex.largefiles',
                  '({})'.format(cfg.obtain(
                      'datalad.metadata.create-aggregate-annex-limit'))))
-            attrs = tbds.repo.get_gitattributes(
+            attrs = tbrepo.get_gitattributes(
                 [op.join('.datalad', i[0]) for i in attrs_cfg])
             set_attrs = []
             for p, k, v in attrs_cfg:
@@ -383,18 +383,18 @@ class Create(Interface):
                         op.join('.datalad', p), {}).get(k, None) == v:
                     set_attrs.append((p, {k: v}))
             if set_attrs:
-                tbds.repo.set_gitattributes(
+                tbrepo.set_gitattributes(
                     set_attrs,
                     attrfile=op.join('.datalad', '.gitattributes'))
 
             # prevent git annex from ever annexing .git* stuff (gh-1597)
-            attrs = tbds.repo.get_gitattributes('.git')
+            attrs = tbrepo.get_gitattributes('.git')
             if not attrs.get('.git', {}).get(
                     'annex.largefiles', None) == 'nothing':
-                tbds.repo.set_gitattributes([
+                tbrepo.set_gitattributes([
                     ('**/.git*', {'annex.largefiles': 'nothing'})])
                 # must use the repo.pathobj as this will have resolved symlinks
-                add_to_git[tbds.repo.pathobj / '.gitattributes'] = {
+                add_to_git[tbrepo.pathobj / '.gitattributes'] = {
                     'type': 'file',
                     'state': 'untracked'}
 
@@ -434,14 +434,14 @@ class Create(Interface):
         tbds.config.reload()
 
         # must use the repo.pathobj as this will have resolved symlinks
-        add_to_git[tbds.repo.pathobj / '.datalad'] = {
+        add_to_git[tbrepo.pathobj / '.datalad'] = {
             'type': 'directory',
             'state': 'untracked'}
 
         # save everything, we need to do this now and cannot merge with the
         # call below, because we may need to add this subdataset to a parent
         # but cannot until we have a first commit
-        tbds.repo.save(
+        tbrepo.save(
             message='[DATALAD] new dataset',
             git=True,
             # we have to supply our own custom status, as the repo does

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -404,10 +404,11 @@ class Create(Interface):
         # Note, that Dataset property `id` will change when we unset the
         # respective config. Therefore store it before:
         tbds_id = tbds.id
-        if id_var in tbds.config:
+        tbds_config = tbds.config
+        if id_var in tbds_config:
             # make sure we reset this variable completely, in case of a
             # re-create
-            tbds.config.unset(id_var, where='dataset')
+            tbds_config.unset(id_var, where='dataset')
 
         if _seed is None:
             # just the standard way
@@ -415,7 +416,7 @@ class Create(Interface):
         else:
             # Let's generate preseeded ones
             uuid_id = str(uuid.UUID(int=random.getrandbits(128)))
-        tbds.config.add(
+        tbds_config.add(
             id_var,
             tbds_id if tbds_id is not None else uuid_id,
             where='dataset',
@@ -427,11 +428,11 @@ class Create(Interface):
         # a dedicated argument, because it is sufficient for the cmdline
         # and unnecessary for the Python API (there could simply be a
         # subsequence ds.config.add() call)
-        for k, v in tbds.config.overrides.items():
-            tbds.config.add(k, v, where='local', reload=False)
+        for k, v in tbds_config.overrides.items():
+            tbds_config.add(k, v, where='local', reload=False)
 
         # all config manipulation is done -> fll reload
-        tbds.config.reload()
+        tbds_config.reload()
 
         # must use the repo.pathobj as this will have resolved symlinks
         add_to_git[tbrepo.pathobj / '.datalad'] = {

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -337,8 +337,8 @@ class Dataset(object, metaclass=PathBasedFlyweight):
         -------
         ConfigManager
         """
-
-        if self.repo is None:
+        repo = self.repo  # local binding
+        if repo is None:
             # if there's no repo (yet or anymore), we can't read/write config at
             # dataset level, but only at user/system level
             # However, if this was the case before as well, we don't want a new
@@ -348,7 +348,7 @@ class Dataset(object, metaclass=PathBasedFlyweight):
                 self._cfg_bound = False
 
         else:
-            self._cfg = self.repo.config
+            self._cfg = repo.config
             self._cfg_bound = True
 
         return self._cfg


### PR DESCRIPTION
Also includes the helper decorator in the first commit (`@collect_method_callstats`) -- see that commit for an example use.

Let's see what benchmarks run would say ;-)