### PR TITLE
BF: set LC_ALL=C while running git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
     # We cannot have empty -A selector, so the one which always will be fulfilled
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+    # To test https://github.com/datalad/datalad/pull/4342 fix.
+    # From our testing in that PR seems to have no effect, but kept around since should not hurt.
+    - LC_ALL=ru_RU.UTF-8
   - python: 3.6
     # Single run for Python 3.6
     env:
@@ -56,6 +59,9 @@ matrix:
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=""
+    # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for NOSE.
+    # From our testing in that PR seems to have no effect, but kept around since should not hurt.
+    - LANG=bg_BG.UTF-8
   - python: 3.5
     # Run slow etc tests under a single tricky scenario
     env:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -704,6 +704,11 @@ class GitRunner(Runner):
             git_env['GIT_SSH_COMMAND'] = GIT_SSH_COMMAND
             git_env['GIT_SSH_VARIANT'] = 'ssh'
 
+        # We are parsing error messages and hints. For those to work more
+        # reliably we are doomed to sacrifice i18n effort of git, and enforce
+        # consistent language of the messages
+        git_env['LC_ALL'] = 'C'
+
         return git_env
 
     def run(self, cmd, env=None, *args, **kwargs):

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -707,7 +707,10 @@ class GitRunner(Runner):
         # We are parsing error messages and hints. For those to work more
         # reliably we are doomed to sacrifice i18n effort of git, and enforce
         # consistent language of the messages
-        git_env['LC_ALL'] = 'C'
+        git_env['LC_MESSAGES'] = 'C'
+		# But since LC_ALL takes precedence, over LC_MESSAGES, we cannot
+		# "leak" that one inside, and are doomed to pop it
+        git_env.pop('LC_ALL', None)
 
         return git_env
 


### PR DESCRIPTION
That should ensure that error messages are hints are in English so
we could still parse them and react accordingly.

Closes #4340

TODO:
- [DID NOT WORK] test - should we set LANG in some of the travis runs?