### PR TITLE
MNT: tree-wide: Avoid use of deprecated get_submodules(compat=True)

### DIFF
--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -94,8 +94,8 @@ class supers(SampleSuperDatasetBenchmarks):
         next(self.ds.subdatasets(recursive=True, return_type='generator'))
 
     def time_uninstall(self):
-        for subm in self.ds.repo.get_submodules():
-            self.ds.uninstall(subm.path, recursive=True, check=False)
+        for subm in self.ds.repo.get_submodules_():
+            self.ds.uninstall(subm["path"], recursive=True, check=False)
 
     def time_remove(self):
         remove(self.ds.path, recursive=True)

--- a/datalad/interface/ls_webui.py
+++ b/datalad/interface/ls_webui.py
@@ -220,8 +220,8 @@ def fs_traverse(path, repo, parent=None,
     subdatasets = subdatasets or []
     fs = fs_extract(path, repo, basepath=basepath or path)
     dataset = Dataset(repo.path)
-    submodules = {sm.path: sm
-                  for sm in repo.get_submodules()}
+    submodules = {str(sm["path"].relative_to(repo.pathobj)): sm
+                  for sm in repo.get_submodules_()}
     # TODO:  some submodules might not even have a local empty directory
     # (git doesn't care about those), so us relying on listdir here and
     # for _traverse_handle_subds might not work out.
@@ -263,7 +263,7 @@ def fs_traverse(path, repo, parent=None,
                     json=json
                 )
                 # Enhance it with external url if available
-                submod_url = submodules[node_relpath].url
+                submod_url = submodules[node_relpath]["gitmodule_url"]
                 if submod_url and is_datalad_compat_ri(submod_url):
                     subds['url'] = submod_url
                 children.append(subds)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3315,7 +3315,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 # we need to get their within repo elements since ls-tree
                 # for paths within submodules returns nothing!
                 # see https://public-inbox.org/git/20190703193305.GF21553@hopa.kiewit.dartmouth.edu/T/#u
-                submodules = [s.path for s in self.get_submodules()]
+                submodules = [str(s["path"].relative_to(self.pathobj))
+                              for s in self.get_submodules_()]
                 path_strs = get_parent_paths(path_strs, submodules)
         else:
             cmd = ['git', 'ls-tree', ref, '-z', '-r', '--full-tree', '-l']

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1768,7 +1768,8 @@ def test_AnnexRepo_add_submodule(source, path):
 
     top_repo.add_submodule('sub', name='sub', url=source)
     top_repo.commit('submodule added')
-    eq_([s.name for s in top_repo.get_submodules()], ['sub'])
+    eq_([s["gitmodule_name"] for s in top_repo.get_submodules_()],
+        ['sub'])
 
     assert_repo_status(top_repo, annex=True)
     assert_repo_status(opj(path, 'sub'), annex=False)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -936,7 +936,8 @@ def test_submodule_deinit(path):
     from datalad.support.annexrepo import AnnexRepo
 
     top_repo = AnnexRepo(path, create=False)
-    eq_({'subm 1', '2'}, {s.name for s in top_repo.get_submodules()})
+    eq_({'subm 1', '2'},
+        {s["gitmodule_name"] for s in top_repo.get_submodules_()})
     # note: here init=True is ok, since we are using it just for testing
     with swallow_logs(new_level=logging.WARN) as cml:
         top_repo.update_submodule('subm 1', init=True)
@@ -947,8 +948,8 @@ def test_submodule_deinit(path):
     # TODO: old assertion above if non-bare? (can't use "direct mode" in test_gitrepo)
     # Alternatively: New testrepo (plain git submodules) and have a dedicated
     # test for annexes in addition
-    ok_(all([GitRepo.is_valid_repo(op.join(top_repo.path, s.path))
-             for s in top_repo.get_submodules()]))
+    ok_(all(GitRepo.is_valid_repo(s["path"])
+            for s in top_repo.get_submodules_()))
 
     # modify submodule:
     with open(op.join(top_repo.path, 'subm 1', 'file_ut.dat'), "w") as f:
@@ -970,7 +971,8 @@ def test_GitRepo_add_submodule(source, path):
 
     top_repo.add_submodule('sub', name='sub', url=source)
     top_repo.commit('submodule added')
-    eq_([s.name for s in top_repo.get_submodules()], ['sub'])
+    eq_([s["gitmodule_name"] for s in top_repo.get_submodules_()],
+        ['sub'])
     assert_repo_status(path)
     assert_repo_status(op.join(path, 'sub'))
 
@@ -1033,7 +1035,7 @@ def test_get_submodules_parent_on_unborn_branch(path):
     subrepo = GitRepo(op.join(path, "sub"), create=True)
     subrepo.commit(msg="s", options=["--allow-empty"])
     repo.add_submodule(path="sub")
-    eq_([s.name for s in repo.get_submodules()],
+    eq_([s["gitmodule_name"] for s in repo.get_submodules_()],
         ["sub"])
 
 

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -84,7 +84,7 @@ def test_direct_cfg(path1, path2):
     del ar2; del ar2sub1; AnnexRepo._unique_instances.clear()  # fight flyweight
 
     ar2 = AnnexRepo(path2)
-    ar2.get_submodules()
+    list(ar2.get_submodules_())
 
     # And what if we are trying to add pre-cloned repo in direct mode?
     ar2sub2 = AnnexRepo.clone(path1, op.join(path2, 'sub2'))


### PR DESCRIPTION
bea8551d76 (RF: gitrepo: Rewrite get_submodules() to avoid GitPython,
2019-07-30) switched get_submodules() over to using the recently added
get_submodules_() method, adding a `compat` parameter to
get_submodules() that is true by default and leads to a return value
that mimics the old GitPython-based one for backward-compatibility.

That commit left a good number of spots in our internal code base
using the deprecated interface.  Clean up all remaining uses of
get_submodules(..., compat=True).