### PR TITLE
TST: direct_mode: Add comment flagging part of test for removal

### DIFF
--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -59,6 +59,9 @@ def test_direct_cfg(path1, path2):
         raise SkipTest(
             "Rest of test requires direct mode support in git-annex")
 
+    # TODO: Remove the rest of this test once GIT_ANNEX_MIN_VERSION is
+    # at least 7.20190912 (which dropped direct mode support).
+
     if ar.config.obtain("datalad.repo.version") >= 6:
         raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
     # and if repo existed before and was in direct mode, we fail too


### PR DESCRIPTION
test_direct_cfg checks that DataLad errors appropriately if direct
mode is requested.  The second half of the test depends on a git-annex
that supports direct mode, which isn't the case as of git-annex
7.20190912.  Our minimum git-annex version is currently 7.20190503 and
we test with 7.20190819+git2-g908476a9b on Travis, so this test could
still be considered worth keeping around.

Leave a comment so that grepping for GIT_ANNEX_MIN_VERSION will turn
up this spot for a future cleaner that is looking to prune no longer
needed git-annex version conditions.