### PR TITLE
Fixes for recent "suppressed similar messages" feature

### DIFF
--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -396,14 +396,17 @@ def test_utils_suppress_similar():
     with swallow_outputs() as cmo:
         list(tu(9, result_fn=n_foo, result_renderer="default"))
         assert_in("path8", cmo.out)
+        assert_not_in("suppressed", cmo.out)
 
     with swallow_outputs() as cmo:
         list(tu(10, result_fn=n_foo, result_renderer="default"))
         assert_in("path9", cmo.out)
+        assert_not_in("suppressed", cmo.out)
 
     with swallow_outputs() as cmo:
         list(tu(11, result_fn=n_foo, result_renderer="default"))
         assert_not_in("path10", cmo.out)
+        assert_re_in(r"[^-0-9]1 .* suppressed", cmo.out, match=False)
 
     # Check a chain of similar messages, split in half by a distinct one.
 
@@ -422,8 +425,10 @@ def test_utils_suppress_similar():
         list(tu(20, result_fn=n_foo_split_by_a_bar, result_renderer="default"))
         assert_in("path10", cmo.out)
         assert_in("path19", cmo.out)
+        assert_not_in("suppressed", cmo.out)
 
     with swallow_outputs() as cmo:
         list(tu(21, result_fn=n_foo_split_by_a_bar, result_renderer="default"))
         assert_in("path10", cmo.out)
         assert_not_in("path20", cmo.out)
+        assert_re_in("[^-0-9]1 .* suppressed", cmo.out, match=False)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -512,6 +512,14 @@ def default_result_renderer(res):
                 if res.get('message', None) else ''))
 
 
+def _display_suppressed_message(nsimilar, ndisplayed):
+    # +1 because there was the original result + nsimilar displayed.
+    n_suppressed = nsimilar - ndisplayed + 1
+    if n_suppressed > 0:
+        ui.message('  [{} similar messages have been suppressed]'
+                   .format(n_suppressed))
+
+
 def _process_results(
         results,
         cmd_class,
@@ -534,7 +542,6 @@ def _process_results(
     result_repetitions = 0
     # how many repetitions to show, before suppression kicks in
     render_n_repetitions = 10
-    result_suppression_msg = '  [{} similar messages have been suppressed]'
 
     for res in results:
         if not res or 'action' not in res:
@@ -589,9 +596,8 @@ def _process_results(
             else:
                 # this one is new, first report on any prev. suppressed results
                 # by number, and then render this fresh one
-                n_suppressed = result_repetitions - render_n_repetitions + 1
-                if n_suppressed > 0:
-                    ui.message(result_suppression_msg.format(n_suppressed))
+                _display_suppressed_message(
+                    result_repetitions, render_n_repetitions)
                 default_result_renderer(res)
                 result_repetitions = 0
             last_result = trimmed_result
@@ -626,9 +632,8 @@ def _process_results(
                 break
         yield res
     # make sure to report on any issues that we had suppressed
-    n_suppressed = result_repetitions - render_n_repetitions + 1
-    if n_suppressed > 0:
-        ui.message(result_suppression_msg.format(n_suppressed))
+    _display_suppressed_message(
+        result_repetitions, render_n_repetitions)
 
 
 def keep_result(res, rfilter, **kwargs):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -589,9 +589,9 @@ def _process_results(
             else:
                 # this one is new, first report on any prev. suppressed results
                 # by number, and then render this fresh one
-                if result_repetitions:
-                    ui.message(result_suppression_msg.format(
-                        result_repetitions - render_n_repetitions))
+                n_suppressed = result_repetitions - render_n_repetitions + 1
+                if n_suppressed > 0:
+                    ui.message(result_suppression_msg.format(n_suppressed))
                 default_result_renderer(res)
                 result_repetitions = 0
             last_result = trimmed_result
@@ -626,9 +626,9 @@ def _process_results(
                 break
         yield res
     # make sure to report on any issues that we had suppressed
-    if result_repetitions:
-        ui.message(result_suppression_msg.format(
-            result_repetitions - render_n_repetitions))
+    n_suppressed = result_repetitions - render_n_repetitions + 1
+    if n_suppressed > 0:
+        ui.message(result_suppression_msg.format(n_suppressed))
 
 
 def keep_result(res, rfilter, **kwargs):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -583,9 +583,9 @@ def _process_results(
             if res.get('status', None) != 'notneeded' \
                     and trimmed_result == last_result:
                 # this is a similar report, suppress if too many, but count it
+                result_repetitions += 1
                 if result_repetitions < render_n_repetitions:
                     default_result_renderer(res)
-                result_repetitions += 1
             else:
                 # this one is new, first report on any prev. suppressed results
                 # by number, and then render this fresh one

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -42,8 +42,10 @@ from datalad.utils import (
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import IncompleteResultsError
 from datalad import cfg as dlcfg
-from datalad.dochelpers import exc_str
-
+from datalad.dochelpers import (
+    exc_str,
+    single_or_plural,
+)
 
 from datalad.ui import ui
 import datalad.support.ansi_colors as ac
@@ -516,8 +518,11 @@ def _display_suppressed_message(nsimilar, ndisplayed):
     # +1 because there was the original result + nsimilar displayed.
     n_suppressed = nsimilar - ndisplayed + 1
     if n_suppressed > 0:
-        ui.message('  [{} similar messages have been suppressed]'
-                   .format(n_suppressed))
+        ui.message('  [{} similar {} been suppressed]'
+                   .format(n_suppressed,
+                           single_or_plural("message has",
+                                            "messages have",
+                                            n_suppressed, False)))
 
 
 def _process_results(


### PR DESCRIPTION
Patches 2 and 3 resolve the issues demonstrated in gh-4352.

```
  [1/5] TST: interface: Extend TestUtils with result_fn parameter
  [2/5] BF: interface: Elide after 10, not 11, similar results
  [3/5] BF: interface: Drop spurious messages about suppressed results
  [4/5] RF: interface: Move "suppressed similar messages" display to helper
  [5/5] ENH: interface: Handle singular case in "suppressed messages" message
```

Fixes #4352.

---

<details>
<summary>Cases from gh-4352</summary>

```
There are 10 files to save

add(ok): foo-001 (file)
add(ok): foo-002 (file)
add(ok): foo-003 (file)
add(ok): foo-004 (file)
add(ok): foo-005 (file)
add(ok): foo-006 (file)
add(ok): foo-007 (file)
add(ok): foo-008 (file)
add(ok): foo-009 (file)
add(ok): foo-010 (file)
save(ok): . (dataset)
action summary:
  add (ok: 10)
  save (ok: 1)
```

```
There are 5 files to save

add(ok): foo-001 (file)
add(ok): foo-002 (file)
add(ok): foo-003 (file)
add(ok): foo-004 (file)
add(ok): foo-005 (file)
save(ok): . (dataset)
action summary:
  add (ok: 5)
  save (ok: 1)
```

```
There are 11 files to save

add(ok): foo-001 (file)
add(ok): foo-002 (file)
add(ok): foo-003 (file)
add(ok): foo-004 (file)
add(ok): foo-005 (file)
add(ok): foo-006 (file)
add(ok): foo-007 (file)
add(ok): foo-008 (file)
add(ok): foo-009 (file)
add(ok): foo-010 (file)
  [1 similar message has been suppressed]
save(ok): . (dataset)
action summary:
  add (ok: 11)
  save (ok: 1)
```

```
There are 12 files to save

add(ok): foo-001 (file)
add(ok): foo-002 (file)
add(ok): foo-003 (file)
add(ok): foo-004 (file)
add(ok): foo-005 (file)
add(ok): foo-006 (file)
add(ok): foo-007 (file)
add(ok): foo-008 (file)
add(ok): foo-009 (file)
add(ok): foo-010 (file)
  [2 similar messages have been suppressed]
save(ok): . (dataset)
action summary:
  add (ok: 12)
  save (ok: 1)
```

</details>
