### PR TITLE
BF+ENH: search --show-keys -- no incorrect "unhashable", use repr

### DIFF
--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -12,6 +12,7 @@
 import logging
 from shutil import copy
 from unittest.mock import patch
+import os
 from os import makedirs
 from os.path import join as opj
 from os.path import dirname
@@ -249,6 +250,27 @@ parentds
 path
 type
 """
+
+    # test default behavior while limiting set of keys reported
+    with swallow_outputs() as cmo:
+        ds.search(['\.id', 'artist$'], show_keys='short')
+        out_lines = [l for l in cmo.out.split(os.linesep) if l]
+        # test that only the ones matching were returned
+        assert_equal(
+            [l for l in out_lines if not l.startswith(' ')],
+            ['audio.music-artist', 'datalad_core.id']
+        )
+        # more specific test which would also test formatting
+        assert_equal(
+            out_lines,
+            ['audio.music-artist',
+             ' in  1 datasets', " has 1 unique values: 'dlartist'",
+             'datalad_core.id',
+             ' in  1 datasets',
+             # we have them sorted
+             " has 1 unique values: '%s'" % ds.id
+             ]
+        )
 
     # check generated autofield index keys
     with swallow_outputs() as cmo:


### PR DESCRIPTION
+ENH: to be able to limit which keys to report

If you ran smth like `datalad search -d /// --show-keys short` you could see a long list of keys, where you would see smth like
```
annex.age
 in  1 datasets
 has 1 unique values: 'unhashable 1688 out of 1690 entries'
```
which would not only be uninformative but also incorrect.  It is 1688 entries which were "hashable" and the rest not.  But also you wouldn't see a single value.  With first 2 commits (1 commit is the first attempt, superseded by 2nd commit, decided not to squash them) we would use `repr` for all the values so there is no "unhashable" results reported.  With the 3rd commit I added an ENH to be able to limit which keys to report --  a really small/easy addition but quite powerful, so now I can get full result of interest without additional `grep` or alike:

```shell
$> datalad search -d /// --show-keys short '^annex\.age$'     
annex.age
 in  1 datasets
 has 1690 unique values: '13.25'; '19.64'; '26.78'; '29.9685'; '32.63'; '34.28884326'; '8.93'; '9.4'; ....
```
As you can't see here -- output formatting changed a bit as well -- now uses ';' instead of ','.