### PR TITLE
RF: Remove .asv as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".asv"]
-	path = .asv
-	url = https://github.com/datalad/.asv.git


### PR DESCRIPTION
I think it kept causing more pain than gain with commits of changed .asv to git etc.
.asv/ already in .gitignore.  I am yet not sure how/if it would impair my benchmarking
setup - will deal with it later

Positioning against `maint` so we do not get into issues while switching between maint and master if one has it and another one doesn't (although I guess git might handle it just fine)