### PR TITLE
update: Adjust test for v2 wire protocol default

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -760,6 +760,10 @@ def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
     # This is the default, but just in case:
     ds_src_s1.repo.config.set("uploadpack.allowAnySHA1InWant", "false",
                               where="local")
+    # Configure the fetcher to use v0 because Git defaults to v2 as of
+    # v2.26.0, which allows fetching unadvertised objects regardless
+    # of the value of uploadpack.allowAnySHA1InWant.
+    ds_clone_s1.repo.config.set("protocol.version", "0", where="local")
     res = ds_clone.update(merge=True, recursive=True, follow="parentds",
                           on_failure="ignore")
     # The fetch with the explicit ref fails because it isn't advertised.


### PR DESCRIPTION
An update() test expects a failure when fetching an unadvertised
object, but this failure no longer happens by default with Git
v2.26.0, specifically 684ceae32d (fetch: default to protocol version
2, 2019-12-23).  v2 unconditionally supports fetching unadvertised
objects.

Trigger the desired failure with the latest Git by instructing the
client to use v0.  This is the same approach that Git uses for its own
tests that expect fetching an unadvertised object to fail: ab0c5f5096
(tests: always test fetch of unreachable with v0, 2019-02-25).

---

- [X] drop temp commit after verifying that build with Git 2.26.0 passes
      update: [passed](https://travis-ci.org/github/datalad/datalad/builds/668917060)