### PR TITLE
BF: .reload() config upon each access to repo.config

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1256,6 +1256,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         if self._cfg is None:
             # associate with this dataset and read the entire config hierarchy
             self._cfg = ConfigManager(dataset=self, source='any')
+        else:
+            self._cfg.reload()
         return self._cfg
 
     def is_with_annex(self):


### PR DESCRIPTION
Fixes #4363  although I am not sure if that is the fix we actually want.

this difference probably has  bad effect on performance, although on smaug only got:
```
       before           after         ratio
     [2a1e96c1]       [efe2fe0c]
     <bf-config~1>       <bf-config>
+      1.66±0.07s       2.09±0.02s     1.25  api.supers.time_createadd_to_dataset
+      1.81±0.02s       2.14±0.01s     1.18  api.supers.time_createadd
-           48.28            36.48     0.76  core.runner.track_overhead_heavyout_online_through
+           -1.81              2.2    -1.22  core.runner.track_overhead_heavyout
```

I really think we should stop trying to be "reactive" to outside
config changes -- it hurts performance and probably cannot be
relied upon anyways.  ~~And when we know that the config changed outside, we explicitly reload -- I will submit a separate alternative PR to fix #4363 that way~~

