### PR TITLE
BF: gitrepo: Revert changes to store branch in .gitmodules

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -397,8 +397,6 @@ def test_add_subdataset(path, other):
         path=op.join(ds.path, 'dir'),
         gitmodule_url='./dir',
         gitmodule_name='dir',
-        # but also the branch, by default
-        gitmodule_branch='master',
     )
     #  create another one
     other = create(other)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -67,7 +67,6 @@ from datalad.config import (
 
 from datalad.consts import (
     GIT_SSH_COMMAND,
-    ADJUSTED_BRANCH_EXPR,
 )
 from datalad.dochelpers import exc_str
 import datalad.utils as ut
@@ -3829,16 +3828,11 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 if sm_props.get('type', None) == 'directory']
             to_add_submodules = _prune_deeper_repos(to_add_submodules)
             for cand_sm in to_add_submodules:
-                branch = self.get_active_branch()
-                adjusted_match = ADJUSTED_BRANCH_EXPR.match(
-                    branch if branch else '')
                 try:
                     self.add_submodule(
                         str(cand_sm.relative_to(self.pathobj)),
                         url=None,
                         name=None,
-                        branch=adjusted_match.group('name') if adjusted_match
-                        else branch
                     )
                 except (CommandError, InvalidGitRepositoryError) as e:
                     yield get_status_dict(


### PR DESCRIPTION
As of v0.12.0, specifically 2fda83e2ca (ENH: Record the active branch
of a subdataset in the parent, 2019-10-20, gh-3817), we record the
current branch in the _parent_ repository as the value for
`submodule.<name>.branch` in .gitmodules when saving a new submodule.

There are a few problems with this:

  * The current branch in the parent is recorded.  It seems unlikely
    that that was the intent because there is no reason to assume a
    branch with that name exists in the submodule repository or, if it
    does, to assume that the parent and submodule branches are
    necessarily coupled.  2fda83e2ca mentions gh-1424
    (`Datalad.recall_state()` -> `load` command) as the motivation,
    which makes it seem likely the current branch in the submodule,
    not the parent, was supposed be recorded.

    This was mentioned in a currently open PR:
    <https://github.com/datalad/datalad/pull/4275#discussion_r390596089>

  * Discussion of recording the branch at gh-1424 suggests that the
    idea is to record this information with every save, but 2fda83e2ca
    records it only when the submodule is initially added.  2fda83e2ca
    doesn't say explicitly that its intent was to do it with every
    save (just that the change moves in the direction of gh-1424), but
    still it doesn't seem a particularly useful incremental step to
    have a one-shot record of the current branch at the time the
    submodule is added.

  * It's not clear that `submodule.<name>.branch` is a good spot to
    record the branch information required by gh-1424.
    `submodule.<name>.branch` is about which _remote_ branch is used
    when `--remote` is passed to `submodule update`.  The goal in
    gh-1424 seems to be tracking what the current _local_ branch was
    at the time of a save.  Given these different purposes, it seems
    like it'd be a good idea to track this information in a different
    way (perhaps an entry in .gitmodules with a different key).

Given these issues, let's revert the changes from 2fda83e2ca, along
with the changes from the follow-up commit ee5010713f (BF: Do not
record adjust branch in submodule config, 2019-10-21).

Fixes #4373.