### PR TITLE
annexrepo: Set annex.retry=3 when calling git-annex

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -248,6 +248,17 @@ definitions = {
         'destination': 'global',
         'default': None,
     },
+    'datalad.annex.retry': {
+        'ui': ('question',
+               {'title': 'Value for annex.retry to use for git-annex calls',
+                'text': 'On transfer failure, annex.retry (sans "datalad.") '
+                        'controls the number of times that git-annex retries. '
+                        'DataLad will call git-annex with annex.retry set '
+                        'to the value here unless the annex.retry '
+                        'is explicitly configured'}),
+        'type': EnsureInt(),
+        'default': 3,
+    },
     'datalad.repo.backend': {
         'ui': ('question', {
                'title': 'git-annex backend',

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -260,8 +260,9 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         self.always_commit = always_commit
 
+        config = self.config
         if version is None:
-            version = self.config.get("datalad.repo.version", None)
+            version = config.get("datalad.repo.version", None)
             # we might get an empty string here
             # TODO: if we use obtain() instead, we get an error complaining
             # '' cannot be converted to int (via Constraint as defined for
@@ -287,7 +288,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 "Git configuration reports repository being in direct mode"
             )
 
-        if self.config.getbool("datalad", "repo.direct", default=False):
+        if config.getbool("datalad", "repo.direct", default=False):
             raise DirectModeNoLongerSupportedError(
                 self,
                 "datalad.repo.direct configuration instructs to use direct mode"

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -306,6 +306,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         if self._ALLOW_LOCAL_URLS:
             self._allow_local_urls()
 
+        if config.get("annex.retry") is None:
+            self._annex_common_options.extend(
+                ["-c",
+                 "annex.retry={}".format(
+                     config.obtain("datalad.annex.retry"))])
+
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
 


### PR DESCRIPTION
git-annex has an annex.retry option that instructs it to retry on
transfer failure, but it defaults to 0.  Add a datalad.annex.retry
option that defaults to 3 and is used as the value for annex.retry in
our calls to git-annex, taking care to not override annex.retry if the
user has configured it.

This implements @yarikoptic's proposal from gh-2896 and will hopefully
help resolve some flaky test failures (e.g., gh-3653 and gh-4371).

Closes #2896.
