### PR TITLE
BF+RF: remove code duplication of (ensure_|anything2)bool and make more consistent with git

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -18,6 +18,7 @@ from datalad.consts import (
 from datalad.cmd import GitRunner
 from datalad.dochelpers import exc_str
 from distutils.version import LooseVersion
+from datalad.utils import ensure_bool
 
 import re
 import os
@@ -117,19 +118,11 @@ def _parse_env(store):
     return store
 
 
+# Adapter used in hirni-toolbox and datalad-hirni
 def anything2bool(val):
-    if hasattr(val, 'lower'):
-        val = val.lower()
-    if val in {"off", "no", "false", "0"} or not bool(val):
-        return False
-    elif val in {"on", "yes", "true", True} \
-            or (hasattr(val, 'isdigit') and val.isdigit() and int(val)) \
-            or isinstance(val, int) and val:
-        return True
-    else:
-        raise TypeError(
-            "Got value %s which could not be interpreted as a boolean"
-            % repr(val))
+    # We do not allow short version here for consistency with git.
+    # Otherwise - should be similar to git
+    return ensure_bool(val, short=False)
 
 
 class ConfigManager(object):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -118,11 +118,8 @@ def _parse_env(store):
     return store
 
 
-# Adapter used in hirni-toolbox and datalad-hirni
-def anything2bool(val):
-    # We do not allow short version here for consistency with git.
-    # Otherwise - should be similar to git
-    return ensure_bool(val, short=False)
+# Compatibility binding: used in hirni-toolbox and datalad-hirni
+anything2bool = ensure_bool
 
 
 class ConfigManager(object):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -118,8 +118,11 @@ def _parse_env(store):
     return store
 
 
-# Compatibility binding: used in hirni-toolbox and datalad-hirni
-anything2bool = ensure_bool
+# Adapter used in hirni-toolbox and datalad-hirni
+def anything2bool(val):
+    # We do not allow casting here to avoid incorrect treatment of multiple
+    # values etc.  Otherwise - should be similar to git
+    return ensure_bool(val, cast=False)
 
 
 class ConfigManager(object):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -107,7 +107,7 @@ def test_something(path, new_home):
     assert_equal(cfg.getint('something', 'myint'), 3)
     assert_equal(cfg.getbool('something', 'myint'), True)
     assert_equal(cfg.getbool('doesnot', 'exist', default=True), True)
-    assert_raises(TypeError, cfg.getbool, 'something', 'user')
+    assert_raises(ValueError, cfg.getbool, 'something', 'user')
 
     # gitpython-style access
     assert_equal(cfg.get('something.myint'), cfg.get_value('something', 'myint'))

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -499,8 +499,7 @@ def test_assure_bool():
     ]:
         for v in values:
             eq_(assure_bool(v), t)
-    assert_raises(ValueError, assure_bool, 'y', short=False)
-    for v in "unknown", "1.0", "-1.0", " ":
+    for v in "unknown", "1.0", "-1.0", " ", "y", "n":
         with assert_raises(ValueError):
             assure_bool(v)
             assert False, "Exception is not raised for %s" % repr(v)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -494,12 +494,16 @@ def test_assure_dict_from_str():
 
 def test_assure_bool():
     for values, t in [
-        (['True', 1, '1', 'yes', 'on'], True),
+        (['True', 1, '1', 'yes', 'on', '-1', '-2'], True),
         (['False', 0, '0', 'no', 'off'], False)
     ]:
         for v in values:
             eq_(assure_bool(v), t)
-    assert_raises(ValueError, assure_bool, "unknown")
+    assert_raises(ValueError, assure_bool, 'y', short=False)
+    for v in "unknown", "1.0", "-1.0":
+        with assert_raises(ValueError):
+            assure_bool(v)
+            assert False, "Exception is not raised for %s" % repr(v)
 
 
 def test_generate_chunks():

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -495,12 +495,12 @@ def test_assure_dict_from_str():
 def test_assure_bool():
     for values, t in [
         (['True', 1, '1', 'yes', 'on', '-1', '-2'], True),
-        (['False', 0, '0', 'no', 'off'], False)
+        (['False', 0, '0', 'no', 'off', ''], False)
     ]:
         for v in values:
             eq_(assure_bool(v), t)
     assert_raises(ValueError, assure_bool, 'y', short=False)
-    for v in "unknown", "1.0", "-1.0":
+    for v in "unknown", "1.0", "-1.0", " ":
         with assert_raises(ValueError):
             assure_bool(v)
             assert False, "Exception is not raised for %s" % repr(v)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -503,6 +503,10 @@ def test_assure_bool():
         with assert_raises(ValueError):
             assure_bool(v)
             assert False, "Exception is not raised for %s" % repr(v)
+    # by default we cast
+    assert_false(assure_bool([]))
+    assert_true(assure_bool([1]))
+    assert_raises(ValueError, assure_bool, [], cast=False)
 
 
 def test_generate_chunks():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -793,18 +793,24 @@ def ensure_unicode(s, encoding=None, confidence=None):
         return s.decode(encoding)
 
 
-def ensure_bool(s):
+def ensure_bool(s, short=True):
     """Convert value into boolean following convention for strings
 
-    to recognize on,True,yes as True, off,False,no as False
+    to recognize on,True,yes as True, off,False,no as False.
+
+    Parameters
+    ----------
+    short: bool, optional
+       If `short` is True (default) we also accept 'y' for True and 'n' for False
+       for compatibility.
     """
     if isinstance(s, str):
         if s.isdigit():
             return bool(int(s))
         sl = s.lower()
-        if sl in {'y', 'yes', 'true', 'on'}:
+        if sl in {'yes', 'true', 'on'} or (short and sl == 'y'):
             return True
-        elif sl in {'n', 'no', 'false', 'off'}:
+        elif sl in {'no', 'false', 'off'} or (short and sl == 'n'):
             return False
         else:
             raise ValueError("Do not know how to treat %r as a boolean" % s)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -793,24 +793,20 @@ def ensure_unicode(s, encoding=None, confidence=None):
         return s.decode(encoding)
 
 
-def ensure_bool(s, *, short=True):
+def ensure_bool(s):
     """Convert value into boolean following convention for strings
 
     to recognize on,True,yes as True, off,False,no as False.
 
-    Parameters
-    ----------
-    short: bool, optional
-       If `short` is True (default) we also accept 'y' for True and 'n' for False
-       for compatibility.
+    As of 0.13.0 does not handle short versions 'y' and 'n'
     """
     if isinstance(s, str):
         if s.isdigit() or (len(s) > 1 and s[0] == '-' and s[1:].isdigit()):
             return bool(int(s))
         sl = s.lower()
-        if sl in {'yes', 'true', 'on'} or (short and sl == 'y'):
+        if sl in {'yes', 'true', 'on'}:
             return True
-        elif sl in {'no', 'false', 'off', ''} or (short and sl == 'n'):
+        elif sl in {'no', 'false', 'off', ''}:
             return False
     elif isinstance(s, bool):
         return s

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -796,9 +796,10 @@ def ensure_unicode(s, encoding=None, confidence=None):
 def ensure_bool(s):
     """Convert value into boolean following convention for strings
 
-    to recognize on,True,yes as True, off,False,no as False.
+    "on", True, and "yes" are considered as True. "off", False, and
+    "no" are considered as False.
 
-    As of 0.13.0 does not handle short versions 'y' and 'n'
+    As of 0.13.0, short versions 'y' and 'n' are not accepted.
     """
     if isinstance(s, str):
         if s.isdigit() or (len(s) > 1 and s[0] == '-' and s[1:].isdigit()):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -793,7 +793,7 @@ def ensure_unicode(s, encoding=None, confidence=None):
         return s.decode(encoding)
 
 
-def ensure_bool(s, short=True):
+def ensure_bool(s, *, short=True):
     """Convert value into boolean following convention for strings
 
     to recognize on,True,yes as True, off,False,no as False.
@@ -805,7 +805,7 @@ def ensure_bool(s, short=True):
        for compatibility.
     """
     if isinstance(s, str):
-        if s.isdigit():
+        if s.isdigit() or (len(s) > 1 and s[0] == '-' and s[1:].isdigit()):
             return bool(int(s))
         sl = s.lower()
         if sl in {'yes', 'true', 'on'} or (short and sl == 'y'):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -793,7 +793,7 @@ def ensure_unicode(s, encoding=None, confidence=None):
         return s.decode(encoding)
 
 
-def ensure_bool(s):
+def ensure_bool(s, cast=True):
     """Convert value into boolean following convention for strings
 
     "on", True, and "yes" are considered as True. "off", False, and
@@ -811,7 +811,7 @@ def ensure_bool(s):
             return False
     elif isinstance(s, bool):
         return s
-    elif isinstance(s, int):
+    elif isinstance(s, int) or cast:
         return bool(s)
     elif s is None:
         return False

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -812,9 +812,13 @@ def ensure_bool(s, *, short=True):
             return True
         elif sl in {'no', 'false', 'off'} or (short and sl == 'n'):
             return False
-        else:
-            raise ValueError("Do not know how to treat %r as a boolean" % s)
-    return bool(s)
+    elif isinstance(s, bool):
+        return s
+    elif isinstance(s, int):
+        return bool(s)
+    elif s is None:
+        return False
+    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
 
 
 def as_unicode(val, cast_types=object):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -810,7 +810,7 @@ def ensure_bool(s, *, short=True):
         sl = s.lower()
         if sl in {'yes', 'true', 'on'} or (short and sl == 'y'):
             return True
-        elif sl in {'no', 'false', 'off'} or (short and sl == 'n'):
+        elif sl in {'no', 'false', 'off', ''} or (short and sl == 'n'):
             return False
     elif isinstance(s, bool):
         return s


### PR DESCRIPTION
This is "inspired" by [a recent annex issue discussion](https://git-annex.branchable.com/bugs/does_not_understand___34__yes__34___as_boolean_true_value_for_autoenable/?updated#comment-df028d791f7220741cf9837462618043), where I detected that we were not inline with git-config handling of strings containing negative integers as `True`.  Then I realized that we have two implementations intended for the same thing, which we use pretty much similarly in different points. `ensure_bool` is used in
```python
$> git grep sure_bool | grep -v test_
datalad/core/distributed/clone.py:    assure_bool,
datalad/core/distributed/clone.py:            sr_autoenable = assure_bool(sr_autoenable)
```
and by `datalad-crawler` for handling crawler configuration settings.  `anything2bool` - by datalad.config.  So - both are used for the same purpose but (still) behave slightly different

<details>
<summary>comparison of ensure_bool (anything2bool was ok besides negative int) with git-config before this PR</summary> 

```shell
$> for v in true yes 1 y 200 '' ' ' false no n 0 -1 0.00 0.1 string 1.0; do echo -n "$v="; git -c "sec.blah=$v" config --bool sec.blah; python -c "from datalad.utils import ensure_bool; print(ensure_bool('$v'))" ; echo; done
true=true
True

yes=true
True

1=true
True

y=fatal: bad numeric config value 'y' for 'sec.blah': invalid unit
True

200=true
True

=false
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat '' as a boolean

 =fatal: bad numeric config value ' ' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat ' ' as a boolean

false=false
False

no=false
False

n=fatal: bad numeric config value 'n' for 'sec.blah': invalid unit
False

0=false
False

-1=true
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat '-1' as a boolean

0.00=fatal: bad numeric config value '0.00' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat '0.00' as a boolean

0.1=fatal: bad numeric config value '0.1' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat '0.1' as a boolean

string=fatal: bad numeric config value 'string' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat 'string' as a boolean

1.0=fatal: bad numeric config value '1.0' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 781, in ensure_bool
    raise ValueError("Do not know how to treat %r as a boolean" % s)
ValueError: Do not know how to treat '1.0' as a boolean
```
</details>

<details>
<summary>comparison of anythin2bool with git-config on typical values after this PR</summary> 

```shell
$> for v in true yes 1 y 200 '' ' ' false no n 0 -1 0.00 0.1 string 1.0; do echo -n "$v="; git -c "sec.blah=$v" config --bool sec.blah; python -c "from datalad.config import anything2bool; print(anything2bool('$v'))" ; echo; done           
true=true
True

yes=true
True

1=true
True

y=fatal: bad numeric config value 'y' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat 'y' as a boolean

200=true
True

=false
False

 =fatal: bad numeric config value ' ' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat ' ' as a boolean

false=false
False

no=false
False

n=fatal: bad numeric config value 'n' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat 'n' as a boolean

0=false
False

-1=true
True

0.00=fatal: bad numeric config value '0.00' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat '0.00' as a boolean

0.1=fatal: bad numeric config value '0.1' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat '0.1' as a boolean

string=fatal: bad numeric config value 'string' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat 'string' as a boolean

1.0=fatal: bad numeric config value '1.0' for 'sec.blah': invalid unit
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 125, in anything2bool
    return ensure_bool(val, short=False)
  File "/home/yoh/proj/datalad/datalad-maint/datalad/utils.py", line 792, in ensure_bool
    raise ValueError("Do not know how to treat %s as a boolean" % repr(s))
ValueError: Do not know how to treat '1.0' as a boolean

```
</details>

- [ ] decide if I should just make `short=False` or remove altogether, thus requiring users to say full "yes".  If I run into any stored configuration in the crawler, it should be an easy fix.  So I am leaning towards that

FWIW, this PR is nohow helps #2628 but would change exception type from TypeError to ValueError.