### PR TITLE
Fix failing docbuild workflow 

### DIFF
--- a/_datalad_build_support/setup.py
+++ b/_datalad_build_support/setup.py
@@ -233,7 +233,7 @@ class BuildConfigInfo(Command):
             categories[v.get('destination', 'misc')][term] = v
 
         for cat in categories:
-            with open(opj(opath, '{}.rst'.format(cat)), 'w') as rst:
+            with open(opj(opath, '{}.rst.in'.format(cat)), 'w') as rst:
                 rst.write('.. glossary::\n')
                 for term, v in sorted(categories[cat].items(), key=lambda x: x[0]):
                     rst.write(_indent(term, '\n  '))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,12 @@ def setup(sphinx):
     sys.path.insert(0, os.path.abspath('utils'))  # travis
     sys.path.insert(0, os.path.abspath(opj(pardir, 'utils')))  # RTD
     from pygments_ansi_color import AnsiColorLexer
+    # TODO: remove when sphinx < 3 is no longer in use.
+    # Older sphinx needs an instance not a class
+    import sphinx as sphinx_mod
+    sphinx_ver = int(sphinx_mod.__version__.split('.')[0])
+    if sphinx_ver < 3:
+        AnsiColorLexer = AnsiColorLexer()
     sphinx.add_lexer("ansi-color", AnsiColorLexer)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,11 +24,11 @@ def setup(sphinx):
     sys.path.insert(0, os.path.abspath('utils'))  # travis
     sys.path.insert(0, os.path.abspath(opj(pardir, 'utils')))  # RTD
     from pygments_ansi_color import AnsiColorLexer
-    # TODO: remove when sphinx < 3 is no longer in use.
-    # Older sphinx needs an instance not a class
+    # As of Sphinx v2.1, passing an instance is deprecated.
+    # TODO: Remove when minimum sphinx version is at least 2.1.
     import sphinx as sphinx_mod
     sphinx_ver = int(sphinx_mod.__version__.split('.')[0])
-    if sphinx_ver < 3:
+    if sphinx_ver < 3:  # Check against 3 rather than 2.1 for simplicity.
         AnsiColorLexer = AnsiColorLexer()
     sphinx.add_lexer("ansi-color", AnsiColorLexer)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ def setup(sphinx):
     sys.path.insert(0, os.path.abspath('utils'))  # travis
     sys.path.insert(0, os.path.abspath(opj(pardir, 'utils')))  # RTD
     from pygments_ansi_color import AnsiColorLexer
-    sphinx.add_lexer("ansi-color", AnsiColorLexer())
+    sphinx.add_lexer("ansi-color", AnsiColorLexer)
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -33,19 +33,19 @@ associated with.
 Global user configuration
 =========================
 
-.. include:: generated/cfginfo/global.rst
+.. include:: generated/cfginfo/global.rst.in
 
 Local repository configuration
 ==============================
 
-.. include:: generated/cfginfo/local.rst
+.. include:: generated/cfginfo/local.rst.in
 
 Sticky dataset configuration
 =============================
 
-.. include:: generated/cfginfo/dataset.rst
+.. include:: generated/cfginfo/dataset.rst.in
 
 Miscellaneous configuration
 ===========================
 
-.. include:: generated/cfginfo/misc.rst
+.. include:: generated/cfginfo/misc.rst.in


### PR DESCRIPTION
As mentioned at gh-4382, the docbuild workflow is now failing due to warnings that are new to the recent Sphinx release. This first commit deals with a deprecation warning (that wasn't actually causing the failure), and the second commit eliminates the "duplicated glossary entry" warnings that were triggering the failure.
