### PR TITLE
ENH: Make exception thrown by re a bit more informative

### DIFF
--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -23,7 +23,10 @@ from datalad.utils import (
     swallow_logs,
     swallow_outputs,
 )
-from datalad.tests.utils import assert_in
+from datalad.tests.utils import (
+    assert_in,
+    assert_re_in,
+)
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_is_generator
 from datalad.tests.utils import with_tempfile
@@ -271,6 +274,12 @@ type
              " has 1 unique values: '%s'" % ds.id
              ]
         )
+
+    with assert_raises(ValueError) as cme:
+        ds.search('*wrong')
+    assert_re_in(
+        r"regular expression '\(\?i\)\*wrong' \(original: '\*wrong'\) is incorrect: ",
+        str(cme.exception))
 
     # check generated autofield index keys
     with swallow_outputs() as cmo:


### PR DESCRIPTION
Fixes #4393 

So now we would get something like

```
$> datalad search -d /// path:*bu
[ERROR  ] regular expression '(?i)*bu' (original: '*bu') is incorrect: nothing to repeat at position 4 [search.py:_compile_query:934] (ValueError)
```
instead of
```
[ERROR  ] nothing to repeat at position 4 [sre_parse.py:_parse:645] (error)
```

While at it -- completely removed skipped test. It was disabled for a while, and it depends on the external resource (our `///`) so could be flaky without our code changes, and takes awhile. 