### PR TITLE
BF: github - cycle to the next credential when we fail to obtain organization

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -69,6 +69,7 @@ PRE_INIT_COMMIT_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 # git/datalad configuration item to provide a token for github
 CONFIG_HUB_TOKEN_FIELD = 'hub.oauthtoken'
+GITHUB_LOGIN_URL = 'https://github.com/login'
 
 # format of git-annex adjusted branch names
 ADJUSTED_BRANCH_EXPR = re.compile(r'^adjusted/(?P<name>[^(]+)\(.*\)$')

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -21,20 +21,24 @@ from ...tests.utils import (
     assert_raises,
     eq_,
     patch_config,
+    skip_if,
     skip_if_no_network,
 )
 from ...consts import (
     CONFIG_HUB_TOKEN_FIELD,
-    GITHUB_LOGIN_URL,
 )
-from ...downloaders.tests.utils import get_test_providers
 from ...utils import swallow_logs
 
 from .. import github_
 from ..github_ import (
     _gen_github_entity,
+    _get_github_cred,
     get_repo_url,
 )
+
+
+skip_if_no_github_cred = skip_if(cond=not _get_github_cred().is_known)
+
 
 def test_get_repo_url():
     from collections import namedtuple
@@ -127,8 +131,8 @@ def test__make_github_repos():
 
 
 @skip_if_no_network
+@skip_if_no_github_cred
 def test__gen_github_entity_organization():
-    get_test_providers(GITHUB_LOGIN_URL)
     # to test effectiveness of the fix, we need to provide some
     # token which would not work
     with patch_config({CONFIG_HUB_TOKEN_FIELD: "ed51111111111111111111111111111111111111"}):


### PR DESCRIPTION
Without it we immediately might fail if there is a known token which
does not have necessary permissions.  Typically this would lead to just
a failure like

    github.GithubException.BadCredentialsException: 401 {'message': 'Bad credentials', 'documentation_url': 'https://developer.github.com/v3'

now we will just go to the next credential while also providing an
informative log message on either we succeeded or not.  So the interaction
would look like

	$> datalad create-sibling-github --github-organization datalad-collection-1 testds
	[WARNING] Having authenticated using token, we failed (401 {'message': 'Bad credentials', 'documentation_url': 'https://developer.github.com/v3'}) to access information about organization datalad-collection-1. We will try next authentication method (if any left available)
	[INFO   ] Successfully obtained information about organization datalad-collection-1 using UserPassword(name='github', url='https://github.com/login') credential
	.: github(-) [https://github.com/datalad-collection-1/testds.git (git)]
	'https://github.com/datalad-collection-1/testds.git' configured as sibling 'github' for <Dataset path=/tmp/testds>

Closes #3946 

Note: Merge to master would cause conflicts since it RFed many (but not all) relative imports to absolute, and thus merge of test_*py would require resolving them.