### PR TITLE
test_AnnexRepo_always_commit: Update for unreleased git-annex changes

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -717,23 +717,20 @@ def test_AnnexRepo_always_commit(path):
                        if commit.startswith('commit')])
     eq_(num_commits, 3)
 
+    out, err = repo._run_annex_command('log')
+
+    # And we see only the file before always_commit was set to false:
+    assert_in(file1, out)
+    assert_not_in(file2, out)
+
     repo.always_commit = True
-
-    # Still one commit only in git-annex log,
-    # but 'git annex log' was called when always_commit was true again,
-    # so it should commit the addition at the end. Calling it again should then
-    # show two commits.
-    out, err = repo._run_annex_command('log')
-    out_list = out.rstrip(os.linesep).splitlines()
-    eq_(len(out_list), 2, "Output:\n%s" % out_list)
-    assert_in(file1, out_list[0])
-    assert_in("recording state in git", out_list[1])
+    # With always_commit back to True, do something that will trigger a commit
+    # on the annex branches.
+    repo.sync()
 
     out, err = repo._run_annex_command('log')
-    out_list = out.rstrip(os.linesep).splitlines()
-    eq_(len(out_list), 2, "Output:\n%s" % out_list)
-    assert_in(file1, out_list[0])
-    assert_in(file2, out_list[1])
+    assert_in(file1, out)
+    assert_in(file2, out)
 
     # Now git knows as well:
     out, err = runner.run(['git', 'log', 'git-annex'])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -707,23 +707,22 @@ def test_AnnexRepo_always_commit(path):
                        if commit.startswith('commit')])
     eq_(num_commits, 3)
 
-    repo.always_commit = False
-    repo.add(file2)
+    with patch.object(repo, "always_commit", False):
+        repo.add(file2)
 
-    # No additional git commit:
-    out, err = runner.run(['git', 'log', 'git-annex'])
-    num_commits = len([commit
-                       for commit in out.rstrip(os.linesep).split('\n')
-                       if commit.startswith('commit')])
-    eq_(num_commits, 3)
+        # No additional git commit:
+        out, err = runner.run(['git', 'log', 'git-annex'])
+        num_commits = len([commit
+                           for commit in out.rstrip(os.linesep).split('\n')
+                           if commit.startswith('commit')])
+        eq_(num_commits, 3)
 
-    out, err = repo._run_annex_command('log')
+        out, err = repo._run_annex_command('log')
 
-    # And we see only the file before always_commit was set to false:
-    assert_in(file1, out)
-    assert_not_in(file2, out)
+        # And we see only the file before always_commit was set to false:
+        assert_in(file1, out)
+        assert_not_in(file2, out)
 
-    repo.always_commit = True
     # With always_commit back to True, do something that will trigger a commit
     # on the annex branches.
     repo.sync()


### PR DESCRIPTION
Two [failing tests][0] in the datalad-extensions repository caught a not-yet-released regression in git-annex.  That was fixed on git-annex's side, but one of the tests (`test_AnnexRepo_always_commit`) still fails due to making unwarranted (IMO) assumptions about git-annex's behavior.  The first patch brings the test into a passing state with the latest git-annex (a7840c0e0).  The following two are small tweaks that I think are improvements but would be fine dropping.

```
  [1/3] TST: annexrepo: Loosen assumptions about alwayscommit=false behavior
  [2/3] TST: annexrepo: Handle alwayscommit set/restore with patch()
  [3/3] TST: annexrepo: Don't assume initial number of git-annex commits
```

[0]: https://github.com/datalad/datalad-extensions/pull/9#issuecomment-613545934
