### PR TITLE
RF: Make default number of annex jobs configurable and 1 by default

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -309,8 +309,8 @@ definitions = {
     },
     'datalad.runtime.max-annex-jobs': {
         'ui': ('question', {
-               'title': 'Maximum number of git-annex jobs to request',
-               'text': 'Set this value to enable parallel annex jobs that may speed up certain operations (e.g. get file content). The effective number of jobs will not exceed the number of available CPU cores.'}),
+               'title': 'Maximum number of git-annex jobs to request when "jobs" option set to "auto" (default)',
+               'text': 'Set this value to enable parallel annex jobs that may speed up certain operations (e.g. get file content). The effective number of jobs will not exceed the number of available CPU cores (or 3 if there is less than 3 cores).'}),
         'type': EnsureInt(),
         'default': 1,
     },

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -307,6 +307,13 @@ definitions = {
                'text': 'Git-annex large files expression (see https://git-annex.branchable.com/tips/largefiles; given expression will be wrapped in parentheses)'}),
         'default': 'anything',
     },
+    'datalad.runtime.max-annex-jobs': {
+        'ui': ('question', {
+               'title': 'Maximum number of git-annex jobs to request',
+               'text': 'Set this value to enable parallel annex jobs that may speed up certain operations (e.g. get file content). The effective number of jobs will not exceed the number of available CPU cores.'}),
+        'type': EnsureInt(),
+        'default': 1,
+    },
     'datalad.runtime.raiseonerror': {
         'ui': ('question', {
                'title': 'Error behavior',

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -146,7 +146,9 @@ jobs_opt = Parameter(
     metavar="NJOBS",
     default='auto',
     constraints=EnsureInt() | EnsureNone() | EnsureChoice('auto'),
-    doc="""how many parallel jobs (where possible) to use.""")
+    doc="""how many parallel jobs (where possible) to use. "auto" corresponds
+    to the number defined by 'datalad.runtime.max-annex-jobs' configuration
+    item""")
 
 verbose = Parameter(
     args=("-v", "--verbose",),


### PR DESCRIPTION
The previous default behavior `(max(8, min(3, nCPUs)))` could cause
issues (crashes, system stalls) due to the large number of child
processes spawned and file descriptors opened.

This change introduces a new config switch
`datalad.runtime.max-annex-jobs` that can be used to tailor
parallelization behavior, and effectively replaces the previously
hard-coded maximum value of `8`. Moreover, it drops the default to `1`
to disable parallel annex jobs by default to ensure a potentially
slower, but more robust behavior out of the box.

The config switch is specific to annex jobs in order to leave room for
an anticipated parallelization of some functionality in DataLad itself.
This will likely need separate configuration to be able to handle the
multiplicative impact of parallelization on two levels.

Implementation detail: The number of jobs is now lazily evaluated on
first use. While it only takes ~100ns to get the CPU count, adding a
config query would make this longer (still microsecond range). However,
the configuration scope would then be limited to the user-level, and
could not be tailored to individual datasets, which may be desired for
datasets with a huge number of files.

I left the previously defined `N_AUTO_JOBS` symbol in place to avoid
breaking consumer code (I am not aware of any). But it now also reflects
the changed default behavior.

Fixes gh-4404
Fixes gh-4141

PR is targeting `maint` based on this comment: https://github.com/datalad/datalad/issues/4404#issuecomment-614043733