### PR TITLE
RF: Demote log message and make generation conditional

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -443,13 +443,13 @@ class RI(object):
         self._set_from_fields(**fields)
 
         # If was initialized from a string representation
-        if self._str is not None:
+        if lgr.isEnabledFor(5) and self._str is not None:
             # well -- some ris might not unparse identically back
             # strictly speaking, but let's assume they do
             ri_ = self.as_str()
             if ri != ri_:
-                lgr.debug("Parsed version of %s %r differs from original %r",
-                          self.__class__.__name__, ri_, ri)
+                lgr.log(5, "Parsed version of %s %r differs from original %r",
+                        self.__class__.__name__, ri_, ri)
 
     @classmethod
     def _get_blank_fields(cls, **fields):

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -150,7 +150,7 @@ def test_url_eq():
 
 def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
     """just a helper to carry out few checks on urls"""
-    with swallow_logs(new_level=logging.DEBUG) as cml:
+    with swallow_logs(new_level=5) as cml:
         ri_ = cls(**fields)
         murl = RI(ri)
         eq_(murl.__class__, cls)  # not just a subclass
@@ -321,13 +321,15 @@ def test_url_samples():
 
     # actually this one is good enough to trigger a warning and I still don't know
     # what it should exactly be!?
-    with swallow_logs(new_level=logging.DEBUG) as cml:
+    with swallow_logs(new_level=5) as cml:
         weired_str = 'weired://'
         weired_url = RI(weired_str)
         repr(weired_url)
         cml.assert_logged(
             'Parsed version of SSHRI .weired:/. '
-            'differs from original .weired://.'
+            'differs from original .weired://.',
+            level="Level 5",
+            match=False
         )
         # but we store original str
         eq_(str(weired_url), weired_str)


### PR DESCRIPTION
Pretty much any recursive operation will yield log messages like:

```
Parsed version of PathRI '/tmp/crcns/vim-2' differs from original PosixPath('/tmp/crcns/vim-2')
```

at the `debug` level. Not only are they largely uninformative, they are
also inconsequential.

Here I make the processing that leads to that log message conditional on
that log level being actually active. This is a frequently used code
path, so it makes sense to pay a bit more attention to performance.

Additionally, due to the nature of the test and message, I demote the
log level from `debug` to `5`, to match other inconsequential log messages
in the RI code.

This cuts down the logging caused by, for example,
`subdatasets(recursive=True)` dramatically, and improves comprehension
what is actually going on.