### PR TITLE
RF: <Dataset path=...> -> <Dataset ...>

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -48,6 +48,7 @@ from datalad.utils import (
     Path,
     PurePath,
     assure_list,
+    quote_cmdlinearg,
 )
 
 
@@ -148,7 +149,7 @@ class Dataset(object, metaclass=PathBasedFlyweight):
         return self._pathobj
 
     def __repr__(self):
-        return "<Dataset path=%s>" % self.path
+        return 'Dataset({})'.format(quote_cmdlinearg(self.path))
 
     def __eq__(self, other):
         if not hasattr(other, 'pathobj'):


### PR DESCRIPTION
__repr__ of a dataset always uses the 'path=' prefix to the path, but a
dataset is also always and only identified by a path. Hence the prefix
is superfluous, and only takes space. On any platform an absolute path
is easy to recognize as such.

This change removes the 'path=' prefix.
