### PR TITLE
BF: config - become consistent with git in treating key without any value as True

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -93,7 +93,13 @@ def _parse_gitconfig_dump(dump, store, fileset, replace, cwd=None):
         if line.startswith('command line:'):
             # nothing we could handle
             continue
-        k, v = cfg_kv_regex.match(line).groups()
+        kv_match = cfg_kv_regex.match(line)
+        if kv_match:
+            k, v = kv_match.groups()
+        else:
+            # could be just a key without = value, which git treats as True
+            # if asked for a bool
+            k, v = line, None
         present_v = dct.get(k, None)
         if present_v is None:
             dct[k] = v
@@ -542,6 +548,8 @@ class ConfigManager(object):
         TypeError is raised for other values.
         """
         val = self.get_value(section, option, default=default)
+        if val is None:  # no value at all, git treats it as True
+            return True
         return anything2bool(val)
 
     def getfloat(self, section, option):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -48,6 +48,8 @@ _config_file_content = """\
 [something]
 user = name=Jane Doe
 user = email=jd@example.com
+novalue
+empty =
 myint = 3
 
 [onemore "complicated の beast with.dot"]
@@ -67,7 +69,7 @@ def test_something(path, new_home):
     assert_raises(ValueError, ConfigManager, source='dataset')
     # now read the example config
     cfg = ConfigManager(Dataset(opj(path, 'ds')), source='dataset')
-    assert_equal(len(cfg), 3)
+    assert_equal(len(cfg), 5)
     assert_in('something.user', cfg)
     # multi-value
     assert_equal(len(cfg['something.user']), 2)
@@ -80,17 +82,21 @@ def test_something(path, new_home):
     assert_true(cfg.has_option('something', 'user'))
     assert_false(cfg.has_option('something', 'us?er'))
     assert_false(cfg.has_option('some?thing', 'user'))
-    assert_equal(sorted(cfg.options('something')), ['myint', 'user'])
+    assert_equal(sorted(cfg.options('something')), ['empty', 'myint', 'novalue', 'user'])
     assert_equal(cfg.options(u'onemore.complicated の beast with.dot'), ['findme'])
 
     assert_equal(
         sorted(cfg.items()),
         [(u'onemore.complicated の beast with.dot.findme', '5.0'),
+         ('something.empty', ''),
          ('something.myint', '3'),
+         ('something.novalue', None),
          ('something.user', ('name=Jane Doe', 'email=jd@example.com'))])
     assert_equal(
         sorted(cfg.items('something')),
-        [('something.myint', '3'),
+        [('something.empty', ''),
+         ('something.myint', '3'),
+         ('something.novalue', None),
          ('something.user', ('name=Jane Doe', 'email=jd@example.com'))])
 
     # always get all values
@@ -101,6 +107,12 @@ def test_something(path, new_home):
     assert_equal(cfg.getfloat(u'onemore.complicated の beast with.dot', 'findme'), 5.0)
     assert_equal(cfg.getint('something', 'myint'), 3)
     assert_equal(cfg.getbool('something', 'myint'), True)
+    # git demands a key without value at all to be used as a flag, thus True
+    assert_equal(cfg.getbool('something', 'novalue'), True)
+    assert_equal(cfg.get('something.novalue'), None)
+    # empty value is False
+    assert_equal(cfg.getbool('something', 'empty'), False)
+    assert_equal(cfg.get('something.empty'), '')
     assert_equal(cfg.getbool('doesnot', 'exist', default=True), True)
     assert_raises(TypeError, cfg.getbool, 'something', 'user')
 


### PR DESCRIPTION
In our case these changes will

- result in `None` being the value
- `getbool` returning `True` (really adhoc, not part of any2bool since
  makes little sense generally)

Without this fix our code would simply crash while reading a legit (to
git) .git/config with

      File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 301, in reload
        log_stderr=True
      File "/home/yoh/proj/datalad/datalad-maint/datalad/config.py", line 96, in _parse_gitconfig_dump
        kv_match = cfg_kv_regex.match(line)
    AttributeError: 'NoneType' object has no attribute 'groups'

A little more on this messy issue of boolean values could be found
in a recent discussion on git-annex:

https://git-annex.branchable.com/bugs/does_not_understand___34__yes__34___as_boolean_true_value_for_autoenable/
