### PR TITLE
interface: Provide more timely feedback when suppressing results

### DIFF
--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -417,6 +417,14 @@ def test_utils_suppress_similar():
         assert_not_in("path10", cmo.out)
         assert_re_in(r"[^-0-9]1 .* suppressed", cmo.out, match=False)
 
+    with _swallow_outputs() as cmo:
+        list(tu(13, result_fn=n_foo, result_renderer="default"))
+        assert_not_in("path10", cmo.out)
+        # We see an update for each result.
+        assert_re_in(r"1 .* suppressed", cmo.out, match=False)
+        assert_re_in(r"2 .* suppressed", cmo.out, match=False)
+        assert_re_in(r"3 .* suppressed", cmo.out, match=False)
+
     with _swallow_outputs(isatty=False) as cmo:
         list(tu(11, result_fn=n_foo, result_renderer="default"))
         assert_in("path10", cmo.out)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -514,7 +514,7 @@ def default_result_renderer(res):
                 if res.get('message', None) else ''))
 
 
-def _display_suppressed_message(nsimilar, ndisplayed):
+def _display_suppressed_message(nsimilar, ndisplayed, final=False):
     # +1 because there was the original result + nsimilar displayed.
     n_suppressed = nsimilar - ndisplayed + 1
     if n_suppressed > 0:
@@ -522,7 +522,8 @@ def _display_suppressed_message(nsimilar, ndisplayed):
                    .format(n_suppressed,
                            single_or_plural("message has",
                                             "messages have",
-                                            n_suppressed, False)))
+                                            n_suppressed, False)),
+                   cr="\n" if final else "\r")
 
 
 def _process_results(
@@ -598,11 +599,15 @@ def _process_results(
                 result_repetitions += 1
                 if result_repetitions < render_n_repetitions:
                     default_result_renderer(res)
+                else:
+                    _display_suppressed_message(
+                        result_repetitions, render_n_repetitions)
             else:
                 # this one is new, first report on any prev. suppressed results
                 # by number, and then render this fresh one
                 _display_suppressed_message(
-                    result_repetitions, render_n_repetitions)
+                    result_repetitions, render_n_repetitions,
+                    final=True)
                 default_result_renderer(res)
                 result_repetitions = 0
             last_result = trimmed_result
@@ -638,7 +643,7 @@ def _process_results(
         yield res
     # make sure to report on any issues that we had suppressed
     _display_suppressed_message(
-        result_repetitions, render_n_repetitions)
+        result_repetitions, render_n_repetitions, final=True)
 
 
 def keep_result(res, rfilter, **kwargs):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -546,7 +546,7 @@ def _process_results(
     # counter for detected repetitions
     result_repetitions = 0
     # how many repetitions to show, before suppression kicks in
-    render_n_repetitions = 10
+    render_n_repetitions = 10 if sys.stdout.isatty() else float("inf")
 
     for res in results:
         if not res or 'action' not in res:


### PR DESCRIPTION
This resolves the confusing silence that can occur during the suppression of similar results (described in gh-4413).  As a needed piece, it addresses gh-4416 as well.

I played around with the "jump out of suppression after N seconds" idea.  It's not too complicated code-wise, but it's more complicated than just emitting/overwriting a message about suppressed results for each result.  And I think more importantly overwriting the line leads to output that is easier for the caller to digest.  This matches (at least in spirit) one of @yarikoptic's proposals in gh-4413.
