### PR TITLE
RF: Demote symlinked CWD related log message to debug-level

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -377,7 +377,7 @@ def test_getpwd_change_mode(tdir):
     # The evil plain chdir call
     os.chdir(tdir)
     # Just testing the logic of switching to cwd mode and issuing a warning
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         pwd = getpwd()
         eq_(pwd, str(Path(pwd).resolve()))  # might have symlinks, thus realpath
     assert_in("symlinks in the paths will be resolved", cml.out)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1501,7 +1501,7 @@ _pwd_mode = None
 def _switch_to_getcwd(msg, *args):
     global _pwd_mode
     _pwd_mode = 'cwd'
-    lgr.warning(
+    lgr.debug(
         msg + ". From now on will be returning os.getcwd(). Directory"
                " symlinks in the paths will be resolved",
         *args


### PR DESCRIPTION
This is the message:

`[WARNING] realpath of PWD=</some/path/to/symlinked/file> is </resolved/path/to/symlinked/file> whenever os.getcwd()=<path/to/dataset>`

Questions about it have motivated a dedicated "please ignore it" PR
in the handbook: https://github.com/datalad-handbook/book/pull/438

I think this message is pointless (but still unconditionally shown) if
everything works. When something doesn't work, it is likely caused by
a bug in DataLad. Hence there is no need to bother users with this
warning that they can or should do nothing about.

Fixes gh-4425