### PR TITLE
BF(workaround): normpath while asserting if annex returned entry for correct path

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2429,7 +2429,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         # and that they all have 'file' equal to the passed one
         out = {}
         for j, f in zip(json_objects, files):
-            assert(j.pop('file') == f)
+            # Starting with version of annex 8.20200330-100-g957a87b43
+            # annex started to normalize relative paths.
+            # ref: https://github.com/datalad/datalad/issues/4431
+            # Use normpath around each side to ensure it is the same file
+            assert normpath(j.pop('file')) == normpath(f)
             if not j['success']:
                 j = None
             else:


### PR DESCRIPTION
Ideally git-annex should not modify paths - not sure yet if there are other places
where we have an assumption of matching file name.

But this is a candidate to resolve failures of our tests -- do not rush to merge it.  Let's first see 

Closes #4431 
