### PR TITLE
NF(TEMP): reincarnated #4182 with parallel via subprocess

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -324,6 +324,9 @@ def clone_dataset(
     dict
       DataLad result records
     """
+    if not isinstance(destds, Dataset):
+        destds = Dataset(destds)
+
     if not result_props:
         # in case the caller had no specific idea on how results should look
         # like, provide sensible defaults

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -289,6 +289,9 @@ class Clone(Interface):
                 yield r
 
 
+def clone_dataset_list(*args, **kwargs):
+    return list(clone_dataset(*args, **kwargs))
+
 def clone_dataset(
         srcs,
         destds,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -267,13 +267,14 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
                 res.get('status', None) == 'ok' and \
                 res.get('type', None) == 'dataset' and \
                 res.get('path', None) == dest_path:
-            _fixup_submodule_dotgit_setup(ds, sm_path)
+            _fixup_submodule_dotgit_setup(ds, dest_path)
 
             # do fancy update
             lgr.debug("Update cloned subdataset {0} in parent".format(dest_path))
-            ds.repo.update_submodule(sm_path, init=True)
+            ds.repo.update_submodule(
+                op.relpath(dest_path, start=ds.path),
+                init=True)
         yield res
-
     subds = Dataset(dest_path)
     if not subds.is_installed():
         lgr.debug('Desired subdataset %s did not materialize, stopping', subds)


### PR DESCRIPTION
This is #4182 with one more commit (6a6425f38e5ab6d70caa46c5571858c5ed83c142):

    TEMP: use ProcessPoolExecutor to parallelize get
    
    I have tried with purely uncommented code -- no core dump, but it seemed
    to do no parallelization whatsoever.  So decided to switch to processpool.
    Had to avoid returning a generator (thus ugly TEMP clone_dataset_list).  But
    overall -- seemed to work on a simple invocation
    
       datalad get -n -r -d ~/datalad/crcns/
    
    and I saw no core dumps
