### PR TITLE
RF: Uniform __repr__ for Repo classes

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -975,7 +975,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         return srs
 
     def __repr__(self):
-        return "<AnnexRepo path=%s (%s)>" % (self.path, type(self))
+        return 'AnnexRepo({})'.format(quote_cmdlinearg(self.path))
 
     def _run_annex_command(self, annex_cmd,
                            git_options=None, annex_options=None,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -72,6 +72,7 @@ from datalad.utils import (
     ensure_dir,
     generate_file_chunks,
     ensure_unicode,
+    quote_cmdlinearg,
     split_cmdline,
 )
 
@@ -1144,7 +1145,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         self._cfg = None
 
     def __repr__(self):
-        return "<GitRepo path=%s (%s)>" % (self.path, type(self))
+        return 'GitRepo({})'.format(quote_cmdlinearg(self.path))
 
     def __eq__(self, obj):
         """Decides whether or not two instances of this class are equal.


### PR DESCRIPTION
Continuing where 226bee866d9fa89147c3bbc87a54f3f882108ba3 stopped,
this compacts `__repr__` for the Repo classes. Turning

  `<GitRepo path=/home/mih/hacking/datalad/git (<class 'datalad.support.gitrepo.GitRepo'>)>`

into

  `GitRepo(/home/mih/hacking/datalad/git)`

There is little (if any) practical benefit for reporing the class name.
