### PR TITLE
ENH: A bit more flexibility for progress bars

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -227,7 +227,8 @@ class ProgressHandler(logging.Handler):
             # an update
             self.pbars[pid].update(
                 update,
-                increment=getattr(record, 'dlm_progress_increment', False))
+                increment=getattr(record, 'dlm_progress_increment', False),
+                total=getattr(record, 'dlm_progress_total', None))
             # Check for an updated label.
             label = getattr(record, 'dlm_progress_label', None)
             if label is not None:

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -214,9 +214,8 @@ class ProgressHandler(logging.Handler):
                 label=getattr(record, 'dlm_progress_label', ''),
                 unit=getattr(record, 'dlm_progress_unit', ''),
                 total=getattr(record, 'dlm_progress_total', None,),
-                initial=getattr(record, 'dlm_progress_initial', 0)
             )
-            pbar.start()
+            pbar.start(initial=getattr(record, 'dlm_progress_initial', 0))
             self.pbars[pid] = pbar
         elif update is None:
             # not an update -> done

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -213,7 +213,9 @@ class ProgressHandler(logging.Handler):
             pbar = ui.get_progressbar(
                 label=getattr(record, 'dlm_progress_label', ''),
                 unit=getattr(record, 'dlm_progress_unit', ''),
-                total=getattr(record, 'dlm_progress_total', None))
+                total=getattr(record, 'dlm_progress_total', None,),
+                initial=getattr(record, 'dlm_progress_initial', 0)
+            )
             pbar.start()
             self.pbars[pid] = pbar
         elif update is None:
@@ -275,6 +277,8 @@ def log_progress(lgrcall, pid, *args, **kwargs):
       To which quantity to advance the progress.
     increment : bool
       If set, `update` is interpreted as an incremental value, not absolute.
+    initial : int
+      If set, start value for progress bar
     noninteractive_level : int, optional
       When a level is specified here and progress is being logged
       non-interactively (i.e. without progress bars), do not log the message if

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -274,12 +274,20 @@ try:
                 self._pbar.update(self.current)
                 # an update() does not (reliably) trigger a refresh, hence
                 # without the next, the pbar may still show zero progress
-                self._pbar.refresh()
+                if not size:
+                    # whenever a total is changed, we need a refresh. If there is
+                    # no progress update, we do it here, else we'll do it after
+                    # the progress update
+                    self._pbar.refresh()
+                # if we set a new total and also advance the progress bar:
             if not size:
                 return
             inc = size - self.current
             try:
                 self._pbar.update(size if increment else inc)
+                if total:
+                    # refresh to new total and progress
+                    self._pbar.refresh()
             except ValueError:
                 # Do not crash entire process because of some glitch with
                 # progressbar update

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -260,8 +260,16 @@ try:
             if self._pbar is None:
                 self._pbar = self._tqdm(**self._pbar_params)
 
-        def update(self, size, increment=False):
+        def update(self, size, increment=False, total=None):
             self._create()
+            if total is not None:
+                # only a reset can change the total of an existing pbar
+                self._pbar.reset(total)
+                # we need to (re-)advance the pbar back to the old state
+                self._pbar.update(self.current)
+                # an update() does not (reliably) trigger a refresh, hence
+                # without the next, the pbar may still show zero progress
+                self._pbar.refresh()
             if not size:
                 return
             inc = size - self.current

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -26,13 +26,13 @@ from .. import lgr
 class ProgressBarBase(object):
     """Base class for any progress bar"""
 
-    def __init__(self, label=None, fill_text=None, total=None, out=None, unit='B', initial=0):
+    def __init__(self, label=None, fill_text=None, total=None, out=None, unit='B'):
         self.label = label
         self.fill_text = fill_text
         self.total = total
         self.unit = unit
         self.out = out
-        self._current = self._initial = initial
+        self._current = 0
 
     def refresh(self):
         """Force update"""
@@ -57,11 +57,8 @@ class ProgressBarBase(object):
         assert value >= 0, "Total cannot be negative"
         self._current = value
 
-    def start(self, initial=None):
-        if initial is not None:
-            self._initial = initial
-        self._current = self._initial
-
+    def start(self, initial=0):
+        self._current = initial
 
     def finish(self, partial=False):
         """
@@ -215,7 +212,7 @@ try:
 
         def __init__(self, label='', fill_text=None,
                      total=None, unit='B', out=sys.stdout, leave=False,
-                     frontend=None, initial=0):
+                     frontend=None):
             """
 
             Parameters
@@ -228,12 +225,10 @@ try:
             leave
             frontend: (None, 'ipython'), optional
               tqdm module to use.  Could be tqdm_notebook if under IPython
-            initial: (0, int), where to start the progress bar
             """
             super(tqdmProgressBar, self).__init__(label=label,
                                                   total=total,
-                                                  unit=unit,
-                                                  initial=initial)
+                                                  unit=unit)
 
             if frontend not in self._frontends:
                 raise ValueError(
@@ -257,13 +252,13 @@ try:
                 self._default_pbar_params,
                 dict(desc=label, unit=unit,
                      unit_scale=True, total=total, file=out,
-                     leave=leave, initial=initial,
+                     leave=leave,
                      ))
             self._pbar = None
 
-        def _create(self):
+        def _create(self, initial=0):
             if self._pbar is None:
-                self._pbar = self._tqdm(**self._pbar_params)
+                self._pbar = self._tqdm(initial=initial, **self._pbar_params)
 
         def update(self, size, increment=False, total=None):
             self._create()
@@ -297,9 +292,9 @@ try:
                                                 increment=increment,
                                                 total=total)
 
-        def start(self):
-            super(tqdmProgressBar, self).start()
-            self._create()
+        def start(self, initial=0):
+            super(tqdmProgressBar, self).start(initial=initial)
+            self._create(initial=initial)
 
         def refresh(self):
             super(tqdmProgressBar, self).refresh()

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -32,7 +32,7 @@ class ProgressBarBase(object):
         self.total = total
         self.unit = unit
         self.out = out
-        self._current = initial
+        self._current = self._initial = initial
 
     def refresh(self):
         """Force update"""
@@ -55,8 +55,8 @@ class ProgressBarBase(object):
         assert value >= 0, "Total cannot be negative"
         self._current = value
 
-    def start(self, initial=0):
-        self._current = initial
+    def start(self, initial=None):
+        self._current = initial if initial is not None else self._initial
 
     def finish(self, partial=False):
         """
@@ -210,7 +210,7 @@ try:
 
         def __init__(self, label='', fill_text=None,
                      total=None, unit='B', out=sys.stdout, leave=False,
-                     frontend=None):
+                     frontend=None, initial=0):
             """
 
             Parameters
@@ -223,8 +223,12 @@ try:
             leave
             frontend: (None, 'ipython'), optional
               tqdm module to use.  Could be tqdm_notebook if under IPython
+            initial: (0, int), where to start the progress bar
             """
-            super(tqdmProgressBar, self).__init__(label=label, total=total, unit=unit)
+            super(tqdmProgressBar, self).__init__(label=label,
+                                                  total=total,
+                                                  unit=unit,
+                                                  initial=initial)
 
             if frontend not in self._frontends:
                 raise ValueError(
@@ -248,7 +252,7 @@ try:
                 self._default_pbar_params,
                 dict(desc=label, unit=unit,
                      unit_scale=True, total=total, file=out,
-                     leave=leave
+                     leave=leave, initial=initial,
                      ))
             self._pbar = None
 

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -56,7 +56,10 @@ class ProgressBarBase(object):
         self._current = value
 
     def start(self, initial=None):
-        self._current = initial if initial is not None else self._initial
+        if initial is not None:
+            self._initial = initial
+        self._current = self._initial
+
 
     def finish(self, partial=False):
         """

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -38,7 +38,9 @@ class ProgressBarBase(object):
         """Force update"""
         pass
 
-    def update(self, size, increment=False):
+    def update(self, size, increment=False, total=None):
+        if total:
+            self.total = total
         if not size:
             return
         if increment:
@@ -283,7 +285,9 @@ try:
                 # progressbar update
                 # TODO: issue a warning?
                 pass
-            super(tqdmProgressBar, self).update(size, increment=increment)
+            super(tqdmProgressBar, self).update(size,
+                                                increment=increment,
+                                                total=total)
 
         def start(self):
             super(tqdmProgressBar, self).start()


### PR DESCRIPTION
This PR enhances the existing progress bars with the ability to
1) set an initial value for the progress bar
```
 log_progress(lgr.info, '3',  'whee!', total=400, initial=20)                  
  5%|██▊                                                     | 20.0/400 [00:00<?, ?/s]
```
and 2) update the total of an existing progress bar
```
log_progress(lgr.info, '3',  'whee!', update=0, increment=True, total=1000)   
  2%|▉                                              | 20.0/1.00k [00:00<00:00, 154k/s]

```

This is hopefully some ground work towards #4390.