### PR TITLE
ENH+RF: use repr, not quote_cmdlinearg for repr, all *Repos need a single __repr__ implementation

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -149,7 +149,7 @@ class Dataset(object, metaclass=PathBasedFlyweight):
         return self._pathobj
 
     def __repr__(self):
-        return 'Dataset({})'.format(quote_cmdlinearg(self.path))
+        return 'Dataset({!r})'.format(self.path)
 
     def __eq__(self, other):
         if not hasattr(other, 'pathobj'):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -974,9 +974,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             srs[sr_id] = sr_info
         return srs
 
-    def __repr__(self):
-        return 'AnnexRepo({})'.format(quote_cmdlinearg(self.path))
-
     def _run_annex_command(self, annex_cmd,
                            git_options=None, annex_options=None,
                            backend=None, jobs=None,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1145,7 +1145,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         self._cfg = None
 
     def __repr__(self):
-        return 'GitRepo({})'.format(quote_cmdlinearg(self.path))
+        return '{}({!r})'.format(self.__class__.__name__, self.path)
 
     def __eq__(self, obj):
         """Decides whether or not two instances of this class are equal.


### PR DESCRIPTION
Continuing #4435 et al (since merged already)

With quote_cmdlinearg we would get inconsistent reprs -- quotes will be used
only if needed, thus it would be less of a true repr and imho it is suboptimal
to have such a jumpy appearance. e.g. in master we would have

	$> python -c 'from datalad.api import Dataset; ds = Dataset("/tmp/v e\" ры"); print(ds, ds.repo)'
	Dataset('/tmp/v e" ры') AnnexRepo('/tmp/v e" ры')
	$> python -c 'from datalad.api import Dataset; ds = Dataset("///"); print(ds, ds.repo)'
	Dataset(/home/yoh/datalad) AnnexRepo(/home/yoh/datalad)

with the changes here it would be more consistent imho:

	$> python -c 'from datalad.api import Dataset; ds = Dataset("/tmp/v e\" ры"); print(ds, ds.repo)'
	Dataset('/tmp/v e" ры') AnnexRepo('/tmp/v e" ры')
	$> python -c 'from datalad.api import Dataset; ds = Dataset("///"); print(ds, ds.repo)'
	Dataset('/home/yoh/datalad') AnnexRepo('/home/yoh/datalad')

Also it is really not needed to duplicate code in __repr__s of *Repos.
Better imho to rely on inheritance and knowing the class name.