### PR TITLE
ENH: list datalad-container extension provided commands

### DIFF
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -91,6 +91,7 @@ _group_plumbing = (
 
 # Some known extensions and their commands to suggest whenever lookup fails
 _known_extension_commands = {
+    'datalad-container': ('containers-list', 'containers-remove', 'containers-add', 'containers-run'),
     'datalad-crawler': ('crawl', 'crawl-init'),
     'datalad-neuroimaging': ('bids2scidata',)
 }


### PR DESCRIPTION
Cherry picked for maint #4174 -- not sure how it made it into master but not 0.12.x releases although was set to be for 0.12.x milestone.  Here is description:


So a user would get a hint when he uses the command without datalad-container
extension being installed:

    $> datalad containers-list
    datalad: Unknown command 'containers-list'.  See 'datalad --help'.

Hint: Command containers-list is provided by (not installed) extension datalad-container.
