### PR TITLE
ENH: ExternalVersions.add - for extensions etc to add custom checkers

### DIFF
--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -14,6 +14,7 @@ import logging
 import os
 import os.path as op
 from functools import partial
+from itertools import chain
 from collections import OrderedDict
 
 
@@ -221,7 +222,7 @@ def _describe_metadata_extractors():
 def _describe_dependencies():
     # query all it got
     [external_versions[k]
-     for k in tuple(external_versions.CUSTOM) + external_versions.INTERESTING]
+     for k in chain(external_versions.CUSTOM, external_versions.INTERESTING)]
 
     return {
         k: str(external_versions[k]) for k in external_versions.keys()

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -220,12 +220,8 @@ def _describe_metadata_extractors():
 
 
 def _describe_dependencies():
-    # query all it got
-    [external_versions[k]
-     for k in chain(external_versions.CUSTOM, external_versions.INTERESTING)]
-
     return {
-        k: str(external_versions[k]) for k in external_versions.keys()
+        k: str(external_versions[k]) for k in external_versions.keys(query=True)
     }
 
 

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -248,8 +248,17 @@ class ExternalVersions(object):
 
         return self._versions.get(modname, self.UNKNOWN)
 
-    def keys(self):
-        """Return names of the known modules"""
+    def keys(self, query=False):
+        """Return names of the known modules
+
+        Parameters
+        ----------
+        query: bool, optional
+          If True, we will first query all CUSTOM and INTERESTING entries
+          to make sure we have them known.
+        """
+        if query:
+            [self[k] for k in chain(self.CUSTOM, self.INTERESTING)]
         return self._versions.keys()
 
     def __contains__(self, item):
@@ -309,11 +318,9 @@ class ExternalVersions(object):
           To query for versions of all "registered" custom externals, so to
           get those which weren't queried for yet
         """
-        if query:
-            [self[k] for k in chain(self.CUSTOM, self.INTERESTING)]
         if indent and (indent is True):
             indent = ' '
-        items = ["%s=%s" % (k, self._versions[k]) for k in sorted(self._versions)]
+        items = ["%s=%s" % (k, self._versions[k]) for k in sorted(self.keys(query=query))]
         out = "%s" % preamble if preamble else ''
         if indent is not None:
             if preamble:

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -255,12 +255,13 @@ class ExternalVersions(object):
     def __contains__(self, item):
         return bool(self[item])
 
-    def add(self, name, func=None, interesting=True):
+    def add(self, name, func=None):
         """Add a version checker
 
         This method allows third-party libraries to define additional checks.
         It will not add `name` if already exists.  If `name` exists and `func`
-        is different - it will override with a new `func`.
+        is different - it will override with a new `func`.  Added entries will
+        be included in the output of `dumps(query=True)`.
 
         Parameters
         ----------
@@ -272,10 +273,6 @@ class ExternalVersions(object):
           defined when checking the version of something that is not a Python
           module or when this class's method for determining the version of a
           Python module isn't sufficient.
-        interesting: bool, optional
-          Makes sense only for entries without func - whether it is considered
-          "interesting" and should be included in output of dumps
-           (with query=True).
         """
         if func:
             func_existing = self.CUSTOM.get(name, None)
@@ -290,7 +287,7 @@ class ExternalVersions(object):
                 # pop and query it again right away to possibly replace with a new value
                 self._versions.pop(name)
                 _ = self[name]
-        if interesting and name not in self.INTERESTING:
+        elif name not in self.INTERESTING:
             self.INTERESTING.append(name)
 
     @property

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -272,7 +272,13 @@ def test_add():
     assert_not_in("numpy", ev.INTERESTING)  # we do not have it by default yet
     assert_not_in("numpy=", ev.dumps(query=True))
     ev.add('numpy')
-    assert_in("numpy=", ev.dumps(query=True))
+    try:
+        import numpy
+    except ImportError:
+        # no numpy, we do not have some bogus entry
+        assert_not_in("numpy=", ev.dumps(query=True))
+    else:
+        assert_in("numpy=%s" % numpy.__version__, ev.dumps(query=True))
     assert_in("custom1=0.1.0", ev.dumps(query=True))  # we still have that one
 
     # override with a new function will work

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -271,9 +271,7 @@ def test_add():
     assert_in("custom1=0.1.0", ev.dumps(query=True))
     assert_not_in("numpy", ev.INTERESTING)  # we do not have it by default yet
     assert_not_in("numpy=", ev.dumps(query=True))
-    ev.add('numpy', interesting=False)  # effectively does nothing
-    assert_not_in("numpy=", ev.dumps(query=True))
-    ev.add('numpy', interesting=True)
+    ev.add('numpy')
     assert_in("numpy=", ev.dumps(query=True))
     assert_in("custom1=0.1.0", ev.dumps(query=True))  # we still have that one
 

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -25,16 +25,17 @@ from datalad.tests.utils import (
     create_tree,
     set_annex_version,
     swallow_logs,
+    patch,
     with_tempfile,
 )
 
-from unittest.mock import patch
 from datalad.tests.utils import (
     assert_equal,
     assert_false,
     assert_greater,
     assert_greater_equal,
     assert_in,
+    assert_not_in,
     assert_raises,
     assert_true,
 )
@@ -262,3 +263,20 @@ def test_check():
 
     with assert_raises(OutdatedExternalDependency):
         ev.check('datalad', min_version="10000000")  # we will never get there!
+
+
+def test_add():
+    ev = ExternalVersions()
+    ev.add('custom1', lambda: "0.1.0")
+    assert_in("custom1=0.1.0", ev.dumps(query=True))
+    assert_not_in("numpy", ev.INTERESTING)  # we do not have it by default yet
+    assert_not_in("numpy=", ev.dumps(query=True))
+    ev.add('numpy', interesting=False)  # effectively does nothing
+    assert_not_in("numpy=", ev.dumps(query=True))
+    ev.add('numpy', interesting=True)
+    assert_in("numpy=", ev.dumps(query=True))
+    assert_in("custom1=0.1.0", ev.dumps(query=True))  # we still have that one
+
+    # override with a new function will work
+    ev.add('custom1', lambda: "0.2.0")
+    assert_in("custom1=0.2.0", ev.dumps(query=True))


### PR DESCRIPTION
Use case: datalad-neuroimaging started to fail tests.  Preliminary
check seems to point toward newer dcm2niix.

It would be nice if extensions, where matters, could check for their
externals and possibly even register them within our "central"
ExternalVersions checker.  This is what `add` effectively does.  Also
for regular python modules, it would pretty much just allow to add
them to "INTERESTING" list - displayed by dumps.

I have positioned it against maint for now since it would allow extensions to use this feature sooner than later, and it is largely a minor enhancement which should not have negative side-effects (I hope ;)).  But if there are objections, I am ok to change it to go to master.