### PR TITLE
ENH: Draft of an improved progress experience

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -201,6 +201,16 @@ class ProgressHandler(logging.Handler):
 
     def emit(self, record):
         from datalad.ui import ui
+        maint = getattr(record, 'dlm_progress_maint', None)
+        if maint == 'clear':
+            # remove the progress bar
+            for pb in self.pbars.values():
+                pb.clear()
+            return
+        elif maint == 'refresh':
+            for pb in self.pbars.values():
+                pb.refresh()
+            return
         pid = getattr(record, 'dlm_progress')
         update = getattr(record, 'dlm_progress_update', None)
         # would be an actual message, not used ATM here,
@@ -287,6 +297,7 @@ def log_progress(lgrcall, pid, *args, **kwargs):
       showing a message at the `lgrcall` level for each step would be too much
       noise. Note that the level here only determines if the record will be
       dropped; it will still be logged at the level of `lgrcall`.
+    maint : {'clear', 'refresh'}
     """
     d = dict(
         {'dlm_progress_{}'.format(n): v for n, v in kwargs.items()

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -71,9 +71,12 @@ class ConsoleLog(object):
         self.out = out
 
     def message(self, msg, cr='\n'):
+        from datalad.log import log_progress
+        log_progress(lgr.info, None, 'Clear progress bars', maint='clear')
         self.out.write(msg)
         if cr:
             self.out.write(cr)
+        log_progress(lgr.info, None, 'Clear progress bars', maint='refresh')
 
     def error(self, error):
         self.out.write("ERROR: %s\n" % error)


### PR DESCRIPTION
Results of an exploration with @adswa

- give `subdatasets()` a progress bar, because it gives `get()` a
  progress bar (and many other functionality that iterates over
  datasets). Similarly, such progress logging can be put into
  status/diff.

- update the subdataset total, as new information comes in. It is
  prohibitive expensive to precompute this information. This is the
  majority of time spend in this command

- clear the bars before each ui.message() (this include result renderer
  output) to keep them nicely at the bottom of the screen, instead of
  butchering them with our own output

#### Issues

- any INFO log message ruins any progress bar display (all git/annex
  output is reported at the info level: Scanning for unlocked files,
  etc)

- we cannot prevent that using logger config, because we log progress
  also at the INFO level. It would be better to position a dedicated
  PROGRESS level between INFO and WARNING

Fixes gh-4390