### PR TITLE
ENH: add ..HEAD to since statement if defined upon publish

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -701,6 +701,10 @@ class Publish(Interface):
                 # XXX here we assume one to one mapping of names from local branches
                 # to the remote
                 since = '%s/%s' % (to, active_branch)
+                # test if such branch already exists,
+                if since not in dataset.repo.get_remote_branches():
+                    lgr.debug("No remote branch %s yet, so since will not be used", since)
+                    since = None
             else:
                 # take tracking remote for the active branch
                 tracked_remote, tracked_refspec = dataset.repo.get_tracking_branch()

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -737,7 +737,7 @@ class Publish(Interface):
                 action='publish',
                 unavailable_path_status='impossible',
                 nondataset_path_status='error',
-                modified=since,
+                modified="%s..HEAD" % since if since else since,
                 return_type='generator',
                 on_failure='ignore',
                 force_no_revision_change_discovery=False, # we cannot publish what was not committed

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -114,7 +114,7 @@ def test_smth_about_not_supported(p1, p2):
             publish(to='target1', since='HEAD^^', on_failure='ignore'),
             1,
             status='impossible',
-            message="fatal: bad revision 'HEAD^^'")
+            message="fatal: bad revision 'HEAD^^..HEAD'")
         # but now let's add one more commit, we should be able to pusblish
         source.repo.commit("msg", options=['--allow-empty'])
         publish(to='target1', since='HEAD^')  # must not fail now

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -100,13 +100,15 @@ def test_invalid_call(origin, tdir):
 @skip_ssh
 @with_tempfile
 @with_tempfile
-def test_smth_about_not_supported(p1, p2):
+def test_since_empty_and_unsupported(p1, p2):
     source = Dataset(p1).create()
     from datalad.support.network import PathRI
     source.create_sibling(
         'ssh://datalad-test' + PathRI(p2).posixpath,
         name='target1')
-    # source.publish(to='target1')
+    # see https://github.com/datalad/datalad/pull/4448#issuecomment-620847327
+    # Test that it doesn't fail without a prior push
+    source.publish(to='target1', since='')
     with chpwd(p1):
         # since we have only two commits (set backend, init dataset)
         # -- there is no HEAD^^

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -96,16 +96,12 @@ def test_invalid_call(origin, tdir):
         type='dataset')
 
 
-@skip_if_on_windows  # create_sibling incompatible with win servers
-@skip_ssh
 @with_tempfile
 @with_tempfile
 def test_since_empty_and_unsupported(p1, p2):
     source = Dataset(p1).create()
     from datalad.support.network import PathRI
-    source.create_sibling(
-        'ssh://datalad-test' + PathRI(p2).posixpath,
-        name='target1')
+    source.create_sibling(p2, name='target1')
     # see https://github.com/datalad/datalad/pull/4448#issuecomment-620847327
     # Test that it doesn't fail without a prior push
     source.publish(to='target1', since='')


### PR DESCRIPTION
This should avoid lengthy annotatepath in heavy hierarchies while trying to
look for possible changes in the wortree.

I think this would not be entirelly correct in case if subdataset is
progressed forward but change was not recorded in the superdaset yet, but it
might work as desired (publish modified in its forwarded on remote end as well)
which might be current behavior as well anyways (did not test).

Might be that it Closes #4446 ;-)