### PR TITLE
WiP: dirty draft for alternative paths reporting by default renderer

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -318,7 +318,6 @@ def eval_results(func):
       __call__ method of a subclass of Interface,
       i.e. a datalad command definition
     """
-    level = [0]
 
     @wrapt.decorator
     def eval_func(wrapped, instance, args, kwargs):
@@ -369,9 +368,6 @@ def eval_results(func):
         from datalad.distribution.dataset import Dataset
         ds = dataset_arg if isinstance(dataset_arg, Dataset) \
             else Dataset(dataset_arg) if dataset_arg else None
-        level[0] += 1
-        #print(level[0], wrapped, ds, allkwargs.get('path', None))
-        #import pdb; pdb.set_trace()
         # do not reuse a dataset's existing config manager here
         # they are configured to read the committed dataset configuration
         # too. That means a datalad update can silently bring in new
@@ -470,7 +466,6 @@ def eval_results(func):
                                   for status in sorted(action_summary[act])))
                                 for act in sorted(action_summary))))
 
-            level[0] -= 1
             if incomplete_results:
                 raise IncompleteResultsError(
                     failed=incomplete_results,
@@ -508,8 +503,6 @@ def default_result_renderer(res):
     if res.get('status', None) != 'notneeded':
         path = res['path']
         path = str(path)
-        # if 'file' in str(res.get('path', '')):
-        #     import pdb; pdb.set_trace()
         path_ = _get_report_path(path, res.get('reportwd'), res.get('refds'))
         ui.message('{action}({status}): {path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
@@ -602,8 +595,6 @@ def _process_results(
         res_lgr = res.pop('logger', None)
 
         pwd = getpwd()
-        # if '../src' in str(allkwargs):
-        #     import pdb; pdb.set_trace()
         if not reportwd or path_is_under([reportwd.path], pwd) or path_is_under([pwd], reportwd.path):
             res['reportwd'] = pwd
         else:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -510,16 +510,7 @@ def default_result_renderer(res):
         path = str(path)
         # if 'file' in str(res.get('path', '')):
         #     import pdb; pdb.set_trace()
-        reportwd = res.get('reportwd')
-        pref = ""
-        if reportwd:
-            if hasattr(reportwd, 'path'):
-                pref = "-d/"
-                reportwd = reportwd.path
-        else:
-            reportwd = res.get('refds')
-        path_ = pref + relpath(path, reportwd) \
-            if reportwd else path
+        path_ = _get_report_path(path, res.get('reportwd'), res.get('refds'))
         ui.message('{action}({status}): {path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
                 status=ac.color_status(res['status']),
@@ -532,6 +523,23 @@ def default_result_renderer(res):
                         if isinstance(res['message'], tuple) else res[
                             'message'])
                 if res.get('message', None) else ''))
+
+
+def _get_report_path(path, reportwd, refds):
+    """Return path to report to user.
+
+    if reportwd is a dataset (well, has .path), we take is as the reference
+    to report from.
+
+    TODO: detailed documentation, make not private"""
+    pref = ""
+    if reportwd:
+        if hasattr(reportwd, 'path'):
+            pref = "-d/"
+            reportwd = reportwd.path
+    else:
+        reportwd = refds
+    return pref + relpath(path, reportwd) if reportwd else path
 
 
 def _display_suppressed_message(nsimilar, ndisplayed, final=False):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -532,14 +532,20 @@ def _get_report_path(path, reportwd, refds):
     to report from.
 
     TODO: detailed documentation, make not private"""
-    pref = ""
+    make_explicit_relative = True
     if reportwd:
         if hasattr(reportwd, 'path'):
-            pref = "-d/"
+            make_explicit_relative = False
             reportwd = reportwd.path
     else:
         reportwd = refds
-    return pref + relpath(path, reportwd) if reportwd else path
+
+    path_ = path
+    if reportwd:
+        path_ = relpath(path, reportwd)
+        if make_explicit_relative and not path_.startswith(pardir):
+            path_ = op.join(curdir, path_)
+    return path_
 
 
 def _display_suppressed_message(nsimilar, ndisplayed, final=False):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -525,20 +525,15 @@ def _get_report_path(path, reportwd, refds):
     to report from.
 
     TODO: detailed documentation, make not private"""
-    make_explicit_relative = True
+    pref = ''
     if reportwd:
         if hasattr(reportwd, 'path'):
-            make_explicit_relative = False
+            pref = '//'
             reportwd = reportwd.path
     else:
         reportwd = refds
 
-    path_ = path
-    if reportwd:
-        path_ = relpath(path, reportwd)
-        path_first = path_.split(op.sep, 1)[0]
-        if make_explicit_relative and path_first not in (pardir, curdir):
-            path_ = op.join(curdir, path_)
+    path_ = pref + relpath(path, reportwd) if reportwd else path
     return path_
 
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -536,7 +536,8 @@ def _get_report_path(path, reportwd, refds):
     path_ = path
     if reportwd:
         path_ = relpath(path, reportwd)
-        if make_explicit_relative and not path_.startswith(pardir):
+        path_first = path_.split(op.sep, 1)[0]
+        if make_explicit_relative and path_first not in (pardir, curdir):
             path_ = op.join(curdir, path_)
     return path_
 


### PR DESCRIPTION
**Warnings**: Don't look at the diff, this is more of a "tech preview", tests guaranteed to fail, diff has unrelated changes etc. Authors of the handbook and/or documentation which hardcoded outputs most likely would start hating me.

Prior attempt was gh-2679 but didn't proceed on that one since then the main problem I was fighting was full paths, and then paths relative to `refds` came to resolve that aspect. I kept running into situations where "relative to refds" made little sense, if not to say that it was misleading since `subds` could differ -- see gh-3442 .  The reason is that although the behavior of "always to refds" is easy to describe, since the actual `refds` is not shown, user is likely to be provided with paths he cannot just cut/paste in majority of the cases IMHO, and would not even know that they are not really such.

So, with this PR output paths would be either relative
- to the CWD
- to the specified dataset, and thus prefixed with an explicit `-d/` prefix (could be anything, but would be nice to have some explicit indication) to signal that.

Behavior: The second case is excercised only if that dataset is outside of the CWD.

Appearance: we could use some other demarkation between the two, e.g. make all relative paths start with `os.curdir` and relative to the dataset not have any `os.curdir` prefix.

<details>
<summary>Here is a demo script which exercises a number of scenarios invoking basic commands with or without `-d` and possibly from within a subdirectory of a dataset</summary> 

```bash
#!/bin/bash

export PS4="> "
set -eu
cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"

which datalad
datalad --version

set -x
datalad create src
datalad create -d src src/subds
datalad create -d src src/subds/subsubds

(
cd src/subds
touch file
touch subsubds/file

mkdir d1 d2
touch d1/f1 d2/f2
cd d1
datalad save -d^  -r 
#file subsubds/file
)

# now we will try from some very outside directory which has nothing in
# common with the dataset path
mkdir outside

# introduce some changes to the dataset somewhere deep
rm src/subds/d2/f2
touch src/newfile

(
cd outside
datalad save -r -d ../src
)
```
</details>

<details>
<summary>Full output on master</summary> 

```shell
/home/yoh/proj/datalad/datalad-master/venvs/dev3/bin/datalad
datalad 0.12.6.dev611
> datalad create src
[INFO   ] Creating a new annex repo at /home/yoh/.tmp/dl-zHdjBPX/src 
create(ok): /home/yoh/.tmp/dl-zHdjBPX/src (dataset)
> datalad create -d src src/subds
[INFO   ] Creating a new annex repo at /home/yoh/.tmp/dl-zHdjBPX/src/subds 
add(ok): subds (file)
add(ok): .gitmodules (file)
save(ok): . (dataset)
create(ok): subds (dataset)
action summary:
  add (ok: 2)
  create (ok: 1)
  save (ok: 1)
> datalad create -d src src/subds/subsubds
[INFO   ] Creating a new annex repo at /home/yoh/.tmp/dl-zHdjBPX/src/subds/subsubds 
add(ok): subsubds (file)
add(ok): .gitmodules (file)
save(ok): subds (dataset)
add(ok): subds (file)
save(ok): . (dataset)
create(ok): subds/subsubds (dataset)
action summary:
  add (ok: 3)
  create (ok: 1)
  save (ok: 2)
> cd src/subds
> touch file
> touch subsubds/file
> mkdir d1 d2
> touch d1/f1 d2/f2
> cd d1
> datalad save '-d^' -r
add(ok): file (file)
save(ok): subds/subsubds (dataset)
add(ok): subsubds (file)
add(ok): d1/f1 (file)                                                                                            
add(ok): d2/f2 (file)
add(ok): file (file)
save(ok): subds (dataset)
add(ok): subds (file)
save(ok): . (dataset)
action summary:
  add (ok: 6)
  save (ok: 3)
> mkdir outside
> rm src/subds/d2/f2
> touch src/newfile
> cd outside
> datalad save -r -d ../src
delete(ok): d2/f2 (file)
save(ok): subds (dataset)
add(ok): subds (file)
add(ok): newfile (file)                                                                                          
save(ok): . (dataset)
action summary:
  add (ok: 2)
  delete (ok: 1)
  save (notneeded: 1, ok: 2)
bash ../trash/demo-paths.sh  6.36s user 2.32s system 103% cpu 8.372 total
```
</details>

<details>
<summary>Full output on this PR</summary> 

```shell
/home/yoh/proj/datalad/datalad-master/venvs/dev3/bin/datalad
datalad 0.12.6.dev612
> datalad create src
[INFO   ] Creating a new annex repo at /home/yoh/.tmp/dl-Gok1gmK/src 
create(ok): src (dataset)
> datalad create -d src src/subds
[INFO   ] Creating a new annex repo at /home/yoh/.tmp/dl-Gok1gmK/src/subds 
add(ok): src/subds (file)
add(ok): src/.gitmodules (file)
save(ok): src (dataset)
create(ok): src/subds (dataset)
action summary:
  add (ok: 2)
  create (ok: 1)
  save (ok: 1)
> datalad create -d src src/subds/subsubds
[INFO   ] Creating a new annex repo at /home/yoh/.tmp/dl-Gok1gmK/src/subds/subsubds 
add(ok): src/subds/subsubds (file)
add(ok): src/subds/.gitmodules (file)
save(ok): src/subds (dataset)
add(ok): src/subds (file)
save(ok): src (dataset)
create(ok): src/subds/subsubds (dataset)
action summary:
  add (ok: 3)
  create (ok: 1)
  save (ok: 2)
> cd src/subds
> touch file
> touch subsubds/file
> mkdir d1 d2
> touch d1/f1 d2/f2
> cd d1
> datalad save '-d^' -r
add(ok): ../subsubds/file (file)
save(ok): ../subsubds (dataset)
add(ok): ../subsubds (file)
add(ok): f1 (file)                                                                                               
add(ok): ../d2/f2 (file)
add(ok): ../file (file)
save(ok): .. (dataset)
add(ok): .. (file)
save(ok): ../.. (dataset)
action summary:
  add (ok: 6)
  save (ok: 3)
> mkdir outside
> rm src/subds/d2/f2
> touch src/newfile
> cd outside
> datalad save -r -d ../src
delete(ok): -d/subds/d2/f2 (file)
save(ok): -d/subds (dataset)
add(ok): -d/subds (file)
add(ok): -d/newfile (file)                                                                                       
save(ok): -d/. (dataset)
action summary:
  add (ok: 2)
  delete (ok: 1)
  save (notneeded: 1, ok: 2)
bash ../trash/demo-paths.sh  5.91s user 2.00s system 104% cpu 7.599 total
```
</details>

A brief excerpt from the above outputs could be the one where I am saving a number of changes while being in the subdirectory of a dataset:

```
> datalad save '-d^' -r
add(ok): file (file)
save(ok): subds/subsubds (dataset)
add(ok): subsubds (file)
add(ok): d1/f1 (file)                                                                                            
add(ok): d2/f2 (file)
add(ok): file (file)
save(ok): subds (dataset)
add(ok): subds (file)
save(ok): . (dataset)
```
vs
```
> datalad save '-d^' -r
add(ok): ../subsubds/file (file)
save(ok): ../subsubds (dataset)
add(ok): ../subsubds (file)
add(ok): f1 (file)                                                                                               
add(ok): ../d2/f2 (file)
add(ok): ../file (file)
save(ok): .. (dataset)
add(ok): .. (file)
save(ok): ../.. (dataset)
```

Closes gh-3442 (if we get there)

[ci skip]

TODOs:
- [ ] seek feedback and if decided to proceed - may be in some use cases it would make no sense
- [ ] fixup diff to make it sensible
- [ ] fixup tests