### PR TITLE
ENH: Support dataset aliases in RIA stores

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -631,6 +631,19 @@ def test_decode_source_spec():
     # not a dataset UUID
     assert_raises(ValueError, decode_source_spec, 'ria+http://example.com#123')
 
+    # literal dataset name/location
+    eq_(decode_source_spec('ria+http://example.com#~rootds'),
+        {'source': 'ria+http://example.com#~rootds',
+         'version': None, 'type': 'ria',
+         'giturl': 'http://example.com/rootds',
+         'default_destpath': 'rootds'})
+    # version etc still works
+    eq_(decode_source_spec('ria+http://example.com#~rootds@specialbranch'),
+        {'source': 'ria+http://example.com#~rootds@specialbranch',
+         'version': 'specialbranch', 'type': 'ria',
+         'giturl': 'http://example.com/rootds',
+         'default_destpath': 'rootds'})
+
 
 def _move2store(storepath, d):
     # make a bare clone of it into a local that matches the organization
@@ -743,6 +756,18 @@ def test_ria_http(lcl, storepath, url):
     # update
     eq_(cloned_by_label.config.get('datalad.get.subdataset-source-candidate-origin'),
         'ria+ssh://somelabel#{id}')
+
+    if not has_symlink_capability():
+        return
+    # place a symlink in the store to serve as a dataset alias
+    (storepath / 'alias').mkdir()
+    (storepath / 'alias' / 'myname').symlink_to(storeds_loc)
+    with chpwd(lcl):
+        cloned_by_alias = clone('ria+{}#~{}'.format(url, 'myname'))
+    # still get the same data
+    eq_(cloned_by_alias.id, ds.id)
+    # more sensible default install path
+    eq_(cloned_by_alias.pathobj.name, 'myname')
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -635,13 +635,13 @@ def test_decode_source_spec():
     eq_(decode_source_spec('ria+http://example.com#~rootds'),
         {'source': 'ria+http://example.com#~rootds',
          'version': None, 'type': 'ria',
-         'giturl': 'http://example.com/rootds',
+         'giturl': 'http://example.com/alias/rootds',
          'default_destpath': 'rootds'})
     # version etc still works
     eq_(decode_source_spec('ria+http://example.com#~rootds@specialbranch'),
         {'source': 'ria+http://example.com#~rootds@specialbranch',
          'version': 'specialbranch', 'type': 'ria',
-         'giturl': 'http://example.com/rootds',
+         'giturl': 'http://example.com/alias/rootds',
          'default_destpath': 'rootds'})
 
 

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -108,6 +108,11 @@ class CreateSiblingRia(Interface):
     located. At present, this file must contain a single line stating the
     version (currently "1"). This line MUST end with a newline character.
 
+    It is possible to define an alias for an individual dataset in a store by
+    placing a symlink to the dataset location into an 'alias/' directory
+    in the root of the store. This enables dataset access via URLs of format:
+    'ria+<protocol>://<storelocation>#~<aliasname>'.
+
     Error logging
     ~~~~~~~~~~~~~
 


### PR DESCRIPTION
`clone()` can now handle URLs of the format

   `ria+<protocol>://<storelocation>#~<aliasname>`

in addition to those containing UUIDs (examples inside).

A future addition should likely equip `create-sibling-ria()` with the ability
to establish those aliases too. But for now it is not clear to me how to
do that best (in particular how to perform properly on reconfigure).
Given time-pressure this needs to wait for another time.

Fixes gh-4424
