### PR TITLE
BF: interface: Drop repeated custom_result_summary_renderer call

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -725,9 +725,6 @@ class Interface(object):
             ret = cls.__call__(**kwargs)
             if inspect.isgenerator(ret):
                 ret = list(ret)
-            if args.common_output_format == 'tailored' and \
-                    hasattr(cls, 'custom_result_summary_renderer'):
-                cls.custom_result_summary_renderer(ret)
             return ret
         except KeyboardInterrupt as exc:
             ui.error("\nInterrupted by user while doing magic: %s" % exc_str(exc))


### PR DESCRIPTION
Since 8e7950d5f0 (ENH: Add the ability for custom result summary
rendering, 2018-12-05), command-line calls that request tailored
output from commands with a custom_result_summary_renderer() method
show repeated lines:

    $ datalad -f tailored status --annex
    1 annex'd file (4.0 B recorded total size)
    1 annex'd file (4.0 B recorded total size)

With that commit, there are three custom_result_summary_renderer()
calls:

  * one in setup_parser(), added by f558ada4dd (NF: Result summary
    renderer [...], 2017-03-21)

  * another in the return_type!="generator" path of eval_func(), again
    added by f558ada4dd.

  * a newer one in the return_type="generator" path of eval_func(),
    added by 8e7950d5f0

While the latest addition exposed the issue from the command line, it
is actually the older call in setup_parser() that seems most
problematic.  The two original call sites meant that calls from the
command line honored custom_result_summary_renderer() while Python API
calls with return_type="generator" did not.  So, drop the call in
setup_parser(), which is now handled by the return_type="generator"
path from 8e7950d5f0.

---

I'm not sure if it's worth carrying the added regression test.