### PR TITLE
Doc examples opts 4105

### DIFF
--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -110,7 +110,7 @@ class Diff(Interface):
              code_cmd="datalad diff --from branch1 --to branch2"),
         dict(text="Show unsaved changes in the dataset and potential subdatasets",
              code_py="diff(recursive=True)",
-             code_cmd="datalad diff --recursive"),
+             code_cmd="datalad diff -r"),
         dict(text="Show unsaved changes made to a particular file",
              code_py="diff(path='path/to/file')",
              code_cmd="datalad diff <path/to/file>"),

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -133,7 +133,7 @@ class Run(Interface):
         dict(text="Run a command and specify a directory as a dependency "
                   "for the run. The contents of the dependency will be retrieved "
                   "prior to running the script",
-             code_cmd="datalad run -m 'run my script' --input 'data/*' "
+             code_cmd="datalad run -m 'run my script' -i 'data/*' "
              "'code/script.sh'",
              code_py="""\
              run(cmd='code/script.sh', message='run my script',
@@ -144,8 +144,8 @@ class Run(Interface):
              run(cmd='code/script.sh', message='run my script',
                  inputs=['data/*'], outputs=['output_dir'])""",
              code_cmd="""\
-             datalad run -m 'run my script' --input 'data/*' \\
-             --output 'output_dir/*' 'code/script.sh'"""),
+             datalad run -m 'run my script' -i 'data/*' \\
+             -o 'output_dir/*' 'code/script.sh'"""),
         dict(text="Specify multiple inputs and outputs",
              code_py="""\
              run(cmd='code/script.sh',
@@ -153,8 +153,8 @@ class Run(Interface):
                  inputs=['data/*', 'datafile.txt'],
                  outputs=['output_dir', 'outfile.txt'])""",
              code_cmd="""\
-             datalad run -m 'run my script' --input 'data/*' \\
-             --input 'datafile.txt' --output 'output_dir/*' --output \\
+             datalad run -m 'run my script' -i 'data/*' \\
+             -i 'datafile.txt' -o 'output_dir/*' -o \\
              'outfile.txt' 'code/script.sh'""")
     ]
 

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -85,7 +85,7 @@ class Save(Interface):
         dict(text="""Save any content underneath the current directory, and
              recurse into any potential subdatasets""",
              code_py="save(path='.', recursive=True)",
-             code_cmd="datalad save . --recursive"),
+             code_cmd="datalad save . -r"),
         dict(text="Save any modification of known dataset content in the "
                   "current directory, but leave untracked files (e.g. temporary files) "
                   "untouched",

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -231,21 +231,21 @@ class Status(Interface):
              code_cmd="datalad status"),
         dict(text="Report on the state of a dataset and all subdatasets",
              code_py="status(recursive=True)",
-             code_cmd="datalad status --recursive"),
+             code_cmd="datalad status -r"),
         dict(text="Address a subdataset record in a superdataset without "
                   "causing a status query for the state _within_ the subdataset "
                   "itself",
              code_py="status(dataset='.', path='mysubdataset')",
-             code_cmd="datalad status --dataset . mysubdataset"),
+             code_cmd="datalad status -d . mysubdataset"),
         dict(text="Get a status query for the state within the subdataset "
                   "without causing a status query for the superdataset (using trailing "
                   "path separator in the query path):",
              code_py="status(dataset='.', path='mysubdataset/')",
-             code_cmd="datalad status --dataset . mysubdataset/"),
+             code_cmd="datalad status -d . mysubdataset/"),
         dict(text="Report on the state of a subdataset in a superdataset and "
                   "on the state within the subdataset",
              code_py="status(dataset='.', path=['mysubdataset', 'mysubdataset/'])",
-             code_cmd="datalad status --dataset . mysubdataset mysubdataset/"),
+             code_cmd="datalad status -d . mysubdataset mysubdataset/"),
         dict(text="Report the file size of annexed content in a dataset",
              code_py="status(annex=True)",
              code_cmd="datalad status --annex")

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -139,7 +139,7 @@ class Drop(Interface):
              code_cmd="datalad drop"),
         dict(text="Drop all file content in a dataset and all its subdatasets",
              code_py="drop(dataset='.', recursive=True)",
-             code_cmd="datalad drop --dataset <path/to/dataset> --recursive"),
+             code_cmd="datalad drop -d <path/to/dataset> -r"),
         dict(text="Disable check to ensure the configured minimum number of "
                   "remote sources for dropped data",
              code_py="drop(path='path/to/content', check=False)",

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -597,7 +597,7 @@ class Get(Interface):
              code_cmd="datalad get <path/to/dir/>"),
         dict(text="Get all contents of the current dataset and its subdatasets",
              code_py="get(dataset='.', recursive=True)",
-             code_cmd="datalad get . --recursive"),
+             code_cmd="datalad get . -r"),
         dict(text="Get (clone) a registered subdataset, but don't retrieve data",
              code_py="get('path/to/subds', get_data=False)",
              code_cmd="datalad get -n <path/to/subds>"),

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -116,13 +116,13 @@ class Install(Interface):
                      get_data=True)""",
              code_cmd="""\
              datalad install --get-data \\
-             --source https://github.com/datalad-datasets/longnow-podcasts.git"""),
+             -s https://github.com/datalad-datasets/longnow-podcasts.git"""),
         dict(text="Install a dataset with all its subdatasets",
              code_py="""\
              install(source='https://github.com/datalad-datasets/longnow-podcasts.git',
                      recursive=True)""",
              code_cmd="""\
-             datalad install --recursive \\
+             datalad install -r \\
              https://github.com/datalad-datasets/longnow-podcasts.git"""),
     ]
 

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -87,12 +87,12 @@ class Remove(Interface):
              code_cmd="datalad remove -d <path/to/dataset> <path/to/subds>"),
         dict(text="Permanently remove a dataset and all subdatasets",
              code_py="remove(dataset='path/to/dataset', recursive=True)",
-             code_cmd="datalad remove -d <path/to/dataset/> --recursive"),
+             code_cmd="datalad remove -d <path/to/dataset/> -r"),
         dict(text="Permanently remove a dataset and all subdatasets even if there "
                   "are fewer than the configured minimum number of (remote) sources "
                   "for data",
              code_py="remove(dataset='path/to/dataset', recursive=True, check=False)",
-             code_cmd="datalad remove -d <path/to/dataset/> --recursive --nocheck"),
+             code_cmd="datalad remove -d <path/to/dataset/> -r --nocheck"),
     ]
 
     @staticmethod

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -79,7 +79,7 @@ class Update(Interface):
              code_py="update(sibling='origin', merge=True, "
                      "follow='parentds', recursive=True)",
              code_cmd="datalad update -s origin --merge "
-                      "--follow=parentds --recursive"),
+                      "--follow=parentds -r"),
     ]
 
     _params_ = dict(


### PR DESCRIPTION
    DOC: examples: shortened opts for all code_cmds Closes #4105

    This accompanies previous few commits..
    Where I mostly just changed the obvious options:
    --input -> -i
    --output -> -o
    --dataset -> -d
    --recursive -> -r
maybe a few others (?)

    the ones that I deemed non-obvious can be seen using
    Something like that below

    bash-3.2$ pwd
    /Users/andy/Projects/datalad
    bash-3.2$ pyfiles=`ls *py`; for pf in $pyfiles; do  cat $pf | grep code_cmd -A 2 | grep " --"; done
    bash-3.2$ pyfiles=`ls */*py`; for pf in $pyfiles; do  cat $pf | grep code_cmd -A 2 | grep " --"; done
    bash-3.2$ pyfiles=`ls */*/*py`; for pf in $pyfiles; do  cat $pf | grep code_cmd -A 2 | grep " --"; done
                 code_cmd="datalad drop <path/to/content> --nocheck"),
                 --source='https://github.com/datalad-datasets/longnow-podcasts.git'"""),
                 datalad install --get-data \\
                 code_cmd="datalad remove -d <path/to/dataset/> -r --nocheck"),
                 code_cmd="datalad uninstall <path/to/subds> --nocheck"),
                 code_cmd="datalad update --merge -s <siblingname>"),
                 code_cmd="datalad update -s origin --merge "
                 code_cmd="datalad rerun --since=HEAD~5"),
                 code_cmd="datalad rerun --onto= --since=HEAD~5"),
                    % datalad rerun --branch=verify --since=
                 code_cmd="datalad run-procedure --discover"),
    bash-3.2$ pyfiles=`ls */*/*/*py`; for pf in $pyfiles; do  cat $pf | grep code_cmd -A 2 | grep " --"; done
                "datalad clone http://example.com/dataset --reckless shared-group"),
                 code_cmd="datalad create --force"),
                 code_cmd="datalad create --no-annex mydataset"),
                 code_cmd="datalad diff --from <SHASUM>"),
                 code_cmd="datalad diff --from branch1 --to branch2"),
                 code_cmd="datalad save --version-tag 'bestyet'"),
                 code_cmd="datalad status --annex")
    cat: tools/testing/bad_internals/_scrapy:: No such file or directory
    cat: scrapy.py: No such file or directory
    bash-3.2$ pyfiles=`ls */*/*/*/*py`; for pf in $pyfiles; do  cat $pf | grep code_cmd -A 2 | grep " --"; done
    bash-3.2$

