### PR TITLE
RF: get: Delete custom_result_summary_renderer

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -782,32 +782,3 @@ class Get(Interface):
                     # we had reports on datasets and subdatasets already
                     # before the annex stage
                     yield res
-
-    @staticmethod
-    def custom_result_summary_renderer(res):
-        from datalad.ui import ui
-        from os import linesep
-        if not len(res):
-            ui.message("Got nothing new")
-            return
-
-        nfiles = count_results(res, type='file')
-        nsuccess_file = count_results(res, type='file', status='ok')
-        nfailure = nfiles - nsuccess_file
-        msg = "Tried to get %d %s that had no content yet." % (
-            nfiles, single_or_plural("file", "files", nfiles))
-        if nsuccess_file:
-            msg += " Successfully obtained %d. " % nsuccess_file
-        if nfailure:
-            msg += " %d (failed)." % (nfailure,)
-        ui.message(msg)
-
-        # if just a few or less than initially explicitly requested
-        if len(res) < 10:
-            msg = linesep.join([
-                "{path}{type} ... {suc}".format(
-                    suc=item.get('status'),
-                    path=item.get('path'),
-                    type=' [{}]'.format(item['type']) if 'type' in item else '')
-                for item in res])
-            ui.message(msg)


### PR DESCRIPTION
The custom_result_summary_renderer for get() was added back in
f558ada4dd (NF: Result summary renderer (more or less useful demo in
`get`), 2017-03-21).  At that time, a caller had to specify "tailored"
as the output format to see the custom summary output.  As of
b8b282d842 (ENH: enable custom summary result rendering also for
default rendering, 2020-03-24), the custom summary is now triggered
for the default renderer as well.

Here's an example of the custom summary when get() is called with two
files that are already present:

    Tried to get 2 files that had no content yet. 2 (failed).
    /tmp/dl-SckMiLB/two [file] ... notneeded
    /tmp/dl-SckMiLB/one [file] ... notneeded

As pointed out in gh-4455, there are a few problems with this
output: 1) the files do have content, 2) a "notneeded" result should not be
counted as a failure, and 3) the path reporting goes against the
current convention of reporting relative paths.  In addition, when
operating on a dataset (gh-4429), there's a confusing message about 0
files having content.

To address these issues, we could either fix the handling in get's
custom_result_summary_renderer or delete the handler.  (Reverting
b8b282d842 to not call the custom summary renderer by default would
only hide away the problems again.)  Go with the second option because
it's unlikely that many users were regularly passing '-f tailored' to
see the custom summary renderer output.  If they were, we probably
would have seen a report about confusing output.  And even if the
problems above weren't enough to prompt a report, the duplicated
summary that has been happening since 0.11.2 (gh-4463) seems unlikely
to have gone unnoticed and unreported, were anyone looking at this
output.

Closes #4455.
Cc: @adswa
