### PR TITLE
BF: cmdline: Restore argcomplete functionality

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -88,6 +88,8 @@ def setup_parser(
         cmdlineargs,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         return_subparsers=False,
+        # Was this triggered by argparse?
+        completing=False,
         # prevent loading of extension entrypoints when --help is requested
         # this is enabled when building docs to avoid pollution of generated
         # manpages with extensions commands (that should appear in their own
@@ -204,7 +206,7 @@ def setup_parser(
     try:
         parsed_args, unparsed_args = parser._parse_known_args(
             cmdlineargs[1:], argparse.Namespace())
-        if not unparsed_args:
+        if not (completing or unparsed_args):
             fail_handler(parser, msg="too few arguments", exit_code=2)
         lgr.debug("Command line args 1st pass. Parsed: %s Unparsed: %s",
                   parsed_args, unparsed_args)
@@ -224,7 +226,7 @@ def setup_parser(
         need_single_subparser = False
         if not help_ignore_extensions:
             add_entrypoints_to_interface_groups(interface_groups)
-    elif unparsed_arg.startswith('-'):  # unknown option
+    elif not completing and unparsed_arg.startswith('-'):  # unknown option
         fail_with_short_help(parser,
                              msg="unrecognized argument %s" % unparsed_arg,
                              exit_code=2)
@@ -250,12 +252,13 @@ def setup_parser(
             if unparsed_arg in extension_commands:
                 hint = "Command %s is provided by (not installed) extension %s." \
                       % (unparsed_arg, extension_commands[unparsed_arg])
-            fail_with_short_help(
-                parser,
-                hint=hint,
-                provided=unparsed_arg,
-                known=list(known_commands.keys()) + list(extension_commands.keys())
-            )
+            if not completing:
+                fail_with_short_help(
+                    parser,
+                    hint=hint,
+                    provided=unparsed_arg,
+                    known=list(known_commands.keys()) + list(extension_commands.keys())
+                )
         if need_single_subparser is None:
             need_single_subparser = unparsed_arg
 
@@ -433,7 +436,7 @@ def main(args=None):
         # Possibly present DataLadRIs were stripped of a leading /
         args = [_fix_datalad_ri(s) for s in args]
     # PYTHON_ARGCOMPLETE_OK
-    parser = setup_parser(args)
+    parser = setup_parser(args, completing="_ARGCOMPLETE" in os.environ)
     try:
         import argcomplete
         argcomplete.autocomplete(parser)


### PR DESCRIPTION
The optimization in fb38c7098 (OPT/RF: create only the subparser
needed for the command, offer "closest" choices, 2018-05-17) sped up
datalad, but it (would have [*]) broken the argcomplete-based
command-line completion due to the spots in setup_parser() that raise
an exception rather than returning the parser that argcomplete needs
to inspect.

To make completion work again, add a flag to setup_parser() that
signals that datalad is being called by argcomplete.  In this
scenario, avoid failing early so that argcomplete can do its thing.

Closes #4473.

[*]: When I tried from fb38c7098^, completion still didn't work
     because an exception is raised in config.py due to cfg_kv_regex
     not matching when datalad is run under argcomplete (for reasons I
     haven't looked into).  But, when I worked around that error,
     _then_ fb38c7098 broke completion.  Note that the cfg_kv_regex
     matching has since changed (b733b0472, 2020-04-17) in a way that
     avoids the config.py exception.
