### PR TITLE
BF: fix handling of environment variables that contain whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 
 bin:
 	mkdir -p $@
-	PYTHONPATH=bin:$(PYTHONPATH) $(PYTHON) setup.py develop --install-dir $@
+	PYTHONPATH="bin:$(PYTHONPATH)" $(PYTHON) setup.py develop --install-dir $@
 
 test-code: bin
 	PATH="bin:$(PATH)" PYTHONPATH="bin:$(PYTHONPATH)" $(NOSETESTS) -s -v $(MODULE)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bin:
 	PYTHONPATH=bin:$(PYTHONPATH) $(PYTHON) setup.py develop --install-dir $@
 
 test-code: bin
-	PATH=bin:$(PATH) PYTHONPATH=bin:$(PYTHONPATH) $(NOSETESTS) -s -v $(MODULE)
+	PATH="bin:$(PATH)" PYTHONPATH="bin:$(PYTHONPATH)" $(NOSETESTS) -s -v $(MODULE)
 
 test-coverage:
 	rm -rf coverage .coverage


### PR DESCRIPTION
This PR encloses the shell-substitution for PATH and PYTHONPATH in the test-code target of the Makefile in double-quotes. That prevents errors where the original PATH or PYTHONPATH environment variables contain whitespaces.
