### PR TITLE
DOC: build_doc: Document eval_params/_params_ override behavior

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -441,6 +441,10 @@ def build_doc(cls, **kwargs):
     actual command. It expects that __call__-method to be decorated by
     eval_results.
 
+    Note that values for any `eval_params` keys in `cls._params_` are
+    ignored.  This means one class may extend another's `_params_`
+    without worrying about filtering out `eval_params`.
+
     Parameters
     ----------
     cls: Interface
@@ -476,6 +480,10 @@ def build_doc(cls, **kwargs):
 
     # build standard doc and insert eval_doc
     spec = getattr(cls, '_params_', dict())
+    # ATTN: An important consequence of this update() call is that it
+    # fulfills the docstring's promise of overriding any existing
+    # values for eval_params keys in _params_.
+    #
     # get docs for eval_results parameters:
     spec.update(eval_params)
 


### PR DESCRIPTION
```
containers-run builds ContainersRun._params_ from Run._params_ to
extend run's interface with container-specific parameters.  In doing
so, it (presumably unintentionally) populates ContainersRun._params_
with parameters from eval_params because build_doc() modifies
Run._params_ in place.

Having eval_param keys in ContainersRun._params_ doesn't currently
cause any issues because build_doc() does a blanket update of _params_
with eval_params, but a proposed change to build_doc() in gh-4480
shows how this can fail.

Explicitly document this behavior to make it clear to callers that
they can rely on it and to prevent future build_doc() tweakers from
unknowingly changing it.
```

Supersedes datalad/datalad-container#119.

---

This will likely create a conflict with whatever eventually lands from gh-4480, but assuming that those changes keep the behavior documented in this PR, the conflict resolution will be trivial.
