### PR TITLE
BF: Fix results from create-sibling-ria --recursive

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -392,6 +392,8 @@ def _create_sibling_ria(
         res_kwargs):
     # be safe across datasets
     res_kwargs = res_kwargs.copy()
+    # update dataset
+    res_kwargs['ds'] = ds
 
     if not isinstance(ds.repo, AnnexRepo):
         # No point in dealing with a special remote when there's no annex.

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -136,7 +136,9 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore",
                                 recursive=True, existing='reconfigure')
     eq_(len(res), 3)
-    assert_result_count(res, 3, status='ok', action="create-sibling-ria")
+    assert_result_count(res, 1, path=str(ds.pathobj), status='ok', action="create-sibling-ria")
+    assert_result_count(res, 1, path=str(subds.pathobj), status='ok', action="create-sibling-ria")
+    assert_result_count(res, 1, path=str(subds2.pathobj), status='ok', action="create-sibling-ria")
 
     # remotes now exist in super and sub
     siblings = ds.siblings(result_renderer=None)


### PR DESCRIPTION
`create-sibling-ria` didn't adjust dataset record for results with recursive invocation.

Closes #4484 