### PR TITLE
ENH(TST): Run travis against oldest supported annex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,14 @@ matrix:
     # Just so we test if we did not screw up running under nose without -s as well
     - NOSE_OPTS=
     - _DL_CRON=1
+  # run with minimal supported git-annex version as defined in AnnexRepo.GIT_ANNEX_MIN_VERSION
+  # TODO: ATM we do not have that minimal version as a Debian package in
+  # snapshots! When we do match - add a unit-test to guarantee that if
+  # _DL_DEBURL_ANNEX is set, we are using that particular version
+  - python: 3.5
+    env:
+    - _DL_DEBURL_ANNEX=http://snapshot-neuro.debian.net/archive/neurodebian/20190710T050502Z/pool/main/g/git-annex/git-annex-standalone_7.20190708%2Bgit9-gfa3524b95-1~ndall%2B1_amd64.deb
+    - _DL_CRON=1
   # run if git-annex version in neurodebian -devel differs
   - python: 3.5
     env:
@@ -216,6 +224,7 @@ before_install:
   - if [ ! -z "${_DL_UPSTREAM_GITANNEX:-}" ]; then sudo tools/ci/install-annex-snapshot.sh; sudo ln -s `find /usr/local/lib/git-annex.linux -maxdepth 1 -type f -perm /+x` /usr/local/bin/; else sudo eatmydata apt-get install git-annex-standalone ; fi
   # Install optionally -devel version of annex, and if goes wrong (we have most recent), exit right away
   - if [ ! -z "${_DL_DEVEL_ANNEX:-}" ]; then tools/ci/prep-travis-devel-annex.sh || { ex="$?"; if [ "$ex" -eq 99 ]; then exit 0; else exit "$ex"; fi; }; fi
+  - if [ ! -z "${_DL_DEBURL_ANNEX:-}" ]; then wget -O /tmp/git-annex.deb "${_DL_DEBURL_ANNEX}" && sudo dpkg -i /tmp/git-annex.deb; fi
   # Optionally install the latest Git.  Exit code 100 indicates that bundled is same as the latest.
   - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then
       sudo tools/ci/install-latest-git.sh || { [ $? -eq 100 ] && exit 0; } || exit 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
+    # TEMP
+    - _DL_DEBURL_ANNEX=http://snapshot-neuro.debian.net/archive/neurodebian/20190710T050502Z/pool/main/g/git-annex/git-annex-standalone_7.20190708%2Bgit9-gfa3524b95-1~ndall%2B1_amd64.deb
   matrix:
 ##1    - DATALAD_REPO_VERSION=6
     - DATALAD_REPO_VERSION=5


### PR DESCRIPTION
Unfortunately ATM we do not have in snapshots-neuro the minimal version matching the one we claim to support (7.20190503): http://snapshot-neuro.debian.net/package/git-annex/, so I went for the next one available from two months after.

TODOs:
- [x] verify that all tests pass.  If not -- we need to either skip some tests or boost our minimal version or both ;) (not sure if worth fixing anything in the actual code)
- [ ] ideally there should be a unittest which would verify that if that env var is set, that used git-annex is the one we expect so we do not miss something breaking that "installed minimal version" testing 
- [ ] Remove TEMP commit so we run only one matrix run on cron (actually may be I should just add another cron entry which would just set that variable explicitly in its settings so all matrix runs run?)