### PR TITLE
ENH: Overall progressbar for AnnexJsonProtocol

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3563,6 +3563,7 @@ class AnnexJsonProtocol(WitlessProtocol):
     # capture both streams and handle messaging completely
     proc_out = True
     proc_err = True
+    total_res_count = None
 
     def __init__(self, done_future):
         # to collect parsed JSON command output
@@ -3572,6 +3573,7 @@ class AnnexJsonProtocol(WitlessProtocol):
     def connection_made(self, transport):
         super().connection_made(transport)
         self._pbars = set()
+        self._res_count = 0
 
     def pipe_data_received(self, fd, data):
         if fd != 1:
@@ -3594,6 +3596,19 @@ class AnnexJsonProtocol(WitlessProtocol):
             self._proc_json_record(j)
 
     def _proc_json_record(self, j):
+        global_pbar_id = 'annexprogress-{}'.format(id(self))
+        if self.total_res_count and not self._res_count:
+            # init global pbar, do here to be on top of first file
+            log_progress(
+                lgr.info,
+                global_pbar_id,
+                'Start annex {}'.format(j.get('command', '')),
+                # do not crash if no command is reported
+                unit=' Files',
+                total=self.total_res_count,
+            )
+            self._pbars.add(global_pbar_id)
+
         # check for progress reports and act on them immediately
         # but only if there is something to build a progress report from
         if 'action' in j and 'byte-progress' in j:
@@ -3637,11 +3652,31 @@ class AnnexJsonProtocol(WitlessProtocol):
             )
             # do not let progress reports leak into the return value
             return
+        self._res_count += 1
         # don't do anything to the results for now in terms of normalization
         # TODO the protocol could be made aware of the runner's CWD and
         # also any dataset the annex command is operating on. This would
         # enable 'file' property conversion to absolute paths
         self.json_out.append(j)
+
+        if self.total_res_count:
+            if self.total_res_count == self._res_count:
+                # discard global pbar
+                log_progress(
+                    lgr.info,
+                    global_pbar_id,
+                    'Finished annex {}'.format(j.get('command', '')),
+                )
+                self._pbars.discard(global_pbar_id)
+            else:
+                # log actual progress
+                log_progress(
+                    lgr.info,
+                    global_pbar_id,
+                    j.get('file', ''),
+                    update=1,
+                    increment=True,
+                )
 
     def _prepare_result(self):
         # first let the base class do its thing


### PR DESCRIPTION
Until now it would only create individual progress bars for items that
git-annex would report progress about. This change adds an additional
global progress bar that counts the number of results, if a total number
of expected results was provided.

This fixes gh-4501

Or rather, it fixes the underlying desire to see something happen, it
won't change how and when results are emitted.
