### PR TITLE
addurls: Don't trip over "./" in the file name format

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -865,10 +865,9 @@ class Addurls(Interface):
             if row["subpath"]:
                 ds_current = Dataset(os.path.join(ds.path,
                                                   row["subpath"]))
-                ds_filename = os.path.relpath(filename_abs, ds_current.path)
             else:
                 ds_current = ds
-                ds_filename = row["filename"]
+            ds_filename = os.path.relpath(filename_abs, ds_current.path)
             row.update({"filename_abs": filename_abs,
                         "ds": ds_current,
                         "ds_filename": ds_filename})

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -466,10 +466,8 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_unbound_dataset(self, path):
-        ds = Dataset(path).create(force=True)
-
-        def check(subpath, dataset_arg, url_file):
-            subdir = op.join(path, subpath)
+        def check(ds, dataset_arg, url_file):
+            subdir = op.join(ds.path, "subdir")
             os.mkdir(subdir)
             with chpwd(subdir):
                 shutil.copy(self.json_file, "in.json")
@@ -481,10 +479,12 @@ class TestAddurls(object):
 
         # The input file is relative to the current working directory, as
         # with other commands.
-        check("subdir0", None, "in.json")
+        ds0 = Dataset(op.join(path, "ds0")).create()
+        check(ds0, None, "in.json")
         # Likewise the input file is relative to the current working directory
         # if a string dataset argument is given.
-        check("subdir1", ds.path, "in.json")
+        ds1 = Dataset(op.join(path, "ds1")).create()
+        check(ds1, ds1.path, "in.json")
 
     @with_tempfile(mkdir=True)
     def test_addurls_create_newdataset(self, path):

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -466,12 +466,12 @@ class TestAddurls(object):
 
     @with_tempfile(mkdir=True)
     def test_addurls_unbound_dataset(self, path):
-        def check(ds, dataset_arg, url_file):
+        def check(ds, dataset_arg, url_file, fname_format):
             subdir = op.join(ds.path, "subdir")
             os.mkdir(subdir)
             with chpwd(subdir):
                 shutil.copy(self.json_file, "in.json")
-                addurls(dataset_arg, url_file, "{url}", "{name}")
+                addurls(dataset_arg, url_file, "{url}", fname_format)
                 # Files specified in the CSV file are always relative to the
                 # dataset.
                 for fname in ["a", "b", "c"]:
@@ -480,11 +480,15 @@ class TestAddurls(object):
         # The input file is relative to the current working directory, as
         # with other commands.
         ds0 = Dataset(op.join(path, "ds0")).create()
-        check(ds0, None, "in.json")
+        check(ds0, None, "in.json", "{name}")
         # Likewise the input file is relative to the current working directory
         # if a string dataset argument is given.
         ds1 = Dataset(op.join(path, "ds1")).create()
-        check(ds1, ds1.path, "in.json")
+        check(ds1, ds1.path, "in.json", "{name}")
+        # A leading "./" doesn't confuse addurls() into downloading the file
+        # into the subdirectory.
+        ds2 = Dataset(op.join(path, "ds2")).create()
+        check(ds2, None, "in.json", "./{name}")
 
     @with_tempfile(mkdir=True)
     def test_addurls_create_newdataset(self, path):


### PR DESCRIPTION
As described in d46846716 (DOC: addurls: Clarify what filename format
is relative to, 2019-08-02) and the tests, the file format is intended
to be taken relative to the dataset.  However, when the file name
format begins with "./", we keep "./" on the relative name, while
constructing the absolute file name without the subdirectory as
documented.  The relative file name is passed to AnnexRepo.addurl(),
causing the file to be treated as relative to the current working
directory and downloaded there.

Achieve the documented behavior by applying the same handling to the
top-level dataset as we use for subdatasets.

Note that there is mention of changing this relative path handling in
gh-4498.  Even if we decide that this change in behavior is
worthwhile, it still makes sense to fix this bug, and doing so doesn't
make the future change harder.
