### PR TITLE
TST: archive: Skip tests that depend on p7zip

### DIFF
--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -22,6 +22,7 @@ from datalad.tests.utils import (
     ok_generator,
     OBSCURE_FILENAME,
     SkipTest,
+    skip_if,
 )
 
 from datalad.dochelpers import exc_str
@@ -33,6 +34,7 @@ from datalad.support.archives import (
 )
 from datalad.support.archive_utils_patool import unixify_path
 from datalad.support.exceptions import MissingExternalDependency
+from datalad.support.external_versions import external_versions
 from datalad.support import path as op
 
 
@@ -131,6 +133,8 @@ def test_compress_dir():
 _filename = 'fi le.dat'
 
 
+@skip_if("cmd:7z" not in external_versions,
+         msg="Known to fail if p7zip is not installed")
 @with_tree(((_filename, 'content'),))
 @with_tempfile()
 def check_compress_file(ext, annex, path, name):


### PR DESCRIPTION
All of the checks of the test generator fail on a system without
p7zip.  Before gh-4041 (in particular, before beb5d045e), the subset
of checks that existed at that time was skipped with (see gh-3176):

    SKIP: cmd:7z is missing. (Not) Funny enough but ATM we need p7zip
    installation to handle .gz files extraction 'correctly'

However, with the change to the archive file name in 05e9353d7 (TST:
Expand test coverage to additional relevant compression formats,
2020-01-17), the MissingExternalDependency exception that led to the
skip for gzip formats is no longer triggered.  And even if it were,
the other file formats tested would fail.

Mark these tests as known failures when p7zip isn't available.
