### PR TITLE
OPT: save - do not bother running full status within subdatasets unless recursive

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -206,6 +206,8 @@ class Save(Interface):
                 recursive=recursive,
                 recursion_limit=recursion_limit,
                 on_failure='ignore',
+                # for save without recursion only commit matters
+                eval_subdataset_state='full' if recursive else 'commit',
                 result_renderer='disabled'):
             if s['status'] == 'error':
                 # Downstream code can't do anything with these. Let the caller

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -138,6 +138,12 @@ def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried,
         )
         queried.add(ds.pathobj)
         if recursion_limit and props.get('type', None) == 'dataset':
+            if cpath == ds.pathobj:
+                # ATM can happen if there is something wrong with this repository
+                # We will just skip it here and rely on some other exception to bubble up
+                # See https://github.com/datalad/datalad/pull/4526 for the usecase
+                lgr.debug("Got status for itself, which should not happen, skipping %s", path)
+                continue
             subds = Dataset(str(cpath))
             if subds.is_installed():
                 for r in _yield_status(

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -106,7 +106,7 @@ STATE_COLOR_MAP = {
 
 def _yield_status(ds, paths, annexinfo, untracked, recursion_limit, queried,
                   eval_submodule_state, eval_filetype, cache):
-    # take the datase that went in first
+    # take the dataset that went in first
     repo = ds.repo
     repo_path = repo.pathobj
     lgr.debug('query %s.diffstatus() for paths: %s', repo, paths)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -229,12 +229,12 @@ def test_subsuperdataset_save(path):
     # and should fail if we demand recursive operation
     # Fun part: causes RecursionError, not just CommandError ATM but that is IMHO
     # a separate issue, TODO.
-    assert_raises(Exception, parent.save, 'sub1', recursive=True)
+    assert_raises(CommandError, parent.save, 'sub1', recursive=True)
     # and should fail if we request saving while in the parent directory
     # but while not providing a dataset, since operation would run within
     # pointed subdataset
     with chpwd(sub1.path):
-        assert_raises(Exception, save, 'sub2')
+        assert_raises(CommandError, save, 'sub2')
     # but should not fail in the top level superdataset
     with chpwd(parent.path):
         save('sub1')


### PR DESCRIPTION
Closes: #4523 

I guess if all the other tests pass, this change does not break any "semantic" which would be great.

Notes:
- Even while being very basic, the unittest is quite slow (24sec) on my laptop. ~~`save` is "non trivial" even in this tiny datasets, heh.~~ my bet has to do with that infinite recursion mentioned below 

Possible TODOs:

- It is an incomplete solution: it would still do "full" (and thus eg fail the test if added) if I do recursive=True even if should be cut off by `recursion_limit` parameter, which suggests that this location is not ideal for this fix (if there is any better).
- That exception I am catching in the test, which is supposed to be  CommandError causes some other meltdown somewhere

<details>
<summary>Here is the displayed traceback which I do not know where to attribute to</summary> 

```shell
======================================================================
ERROR: datalad.core.local.tests.test_save.test_subsuperdataset_save
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/yoh/proj/datalad/datalad-master/datalad/tests/utils.py", line 691, in newfunc
    return t(*(arg + (filename,)), **kw)
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/tests/test_save.py", line 232, in test_subsuperdataset_save
    assert_raises(CommandError, parent.save, 'sub1', recursive=True)
  File "/usr/lib/python3.7/unittest/case.py", line 756, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/lib/python3.7/unittest/case.py", line 178, in handle
    callable_obj(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/wrapt/wrappers.py", line 603, in __call__
    args, kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/distribution/dataset.py", line 498, in apply_func
    return f(**kwargs)
  File "/usr/lib/python3/dist-packages/wrapt/wrappers.py", line 564, in __call__
    args, kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 494, in eval_func
    return return_func(generator_func)(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/wrapt/wrappers.py", line 564, in __call__
    args, kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 482, in return_func
    results = list(results)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 413, in generator_func
    allkwargs):
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 552, in _process_results
    for res in results:
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/save.py", line 211, in __call__
    result_renderer='disabled'):
  File "/usr/lib/python3/dist-packages/wrapt/wrappers.py", line 564, in __call__
    args, kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 494, in eval_func
    return return_func(generator_func)(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/wrapt/wrappers.py", line 564, in __call__
    args, kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 482, in return_func
    results = list(results)
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 413, in generator_func
    allkwargs):
  File "/home/yoh/proj/datalad/datalad-master/datalad/interface/utils.py", line 552, in _process_results
    for res in results:
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/status.py", line 413, in __call__
    content_info_cache):
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/status.py", line 152, in _yield_status
    cache):
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/status.py", line 152, in _yield_status
    cache):
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/status.py", line 152, in _yield_status
    cache):
  [Previous line repeated 924 more times]
  File "/home/yoh/proj/datalad/datalad-master/datalad/core/local/status.py", line 114, in _yield_status
    fr='HEAD' if repo.get_hexsha() else None,
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py", line 1747, in get_hexsha
    commitish)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py", line 1718, in format_commit
    '', cmd, expect_stderr=True, expect_fail=True)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py", line 328, in newfunc
    result = func(self, files_new, *args, **kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/support/gitrepo.py", line 2058, in _git_custom_command
    expect_fail=expect_fail)
  File "/home/yoh/proj/datalad/datalad-master/datalad/cmd.py", line 143, in run_gitcommand_on_file_list_chunks
    results.append(func(cmd, *args, **kwargs))
  File "/home/yoh/proj/datalad/datalad-master/datalad/cmd.py", line 1114, in run
    *args, **kwargs)
  File "/home/yoh/proj/datalad/datalad-master/datalad/cmd.py", line 883, in run
    stdin=stdin)
  File "/usr/lib/python3.7/subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.7/subprocess.py", line 1472, in _execute_child
    for dir in os.get_exec_path(env))
  File "/home/yoh/proj/datalad/datalad-master/venvs/dev3/lib/python3.7/os.py", line 637, in get_exec_path
    warnings.simplefilter("ignore", BytesWarning)
  File "/home/yoh/proj/datalad/datalad-master/venvs/dev3/lib/python3.7/warnings.py", line 179, in simplefilter
    _add_filter(action, None, category, None, lineno, append=append)
  File "/home/yoh/proj/datalad/datalad-master/venvs/dev3/lib/python3.7/warnings.py", line 186, in _add_filter
    filters.remove(item)
RecursionError: maximum recursion depth exceeded in comparison
```
</details>
Running with high log level eventually started to bombard me with the lines

<details>
<summary>at the bottom of this:</summary> 

```shell
2020-05-13 19:14:45,797 [DEBUG  ] ...>gitrepo:3399  Done AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).get_content_info(...) 
2020-05-13 19:14:45,798 [Level 5] ...>cmd:1010  Running: ['git', 'ls-files', '-z', '-m'] 
2020-05-13 19:14:45,825 [Level 8] ...>cmd:1010  Finished running ['git', 'ls-files', '-z', '-m'] with status 0 
2020-05-13 19:14:45,827 [DEBUG  ] ...>gitrepo:3289  AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).get_content_info(...) 
2020-05-13 19:14:45,827 [DEBUG  ] ...>gitrepo:3339  Query repo: ['git', 'ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l'] 
2020-05-13 19:14:45,827 [Level 5] ...>cmd:1010  Running: ['git', 'ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l'] 
2020-05-13 19:14:45,865 [Level 8] ...>cmd:1010  Finished running ['git', 'ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l'] with status 0 
2020-05-13 19:14:45,866 [DEBUG  ] ...>gitrepo:3356  Done query repo: ['git', 'ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l'] 
2020-05-13 19:14:45,867 [DEBUG  ] ...>gitrepo:3399  Done AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).get_content_info(...) 
2020-05-13 19:14:45,868 [DEBUG  ] ...>status:112  query AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).diffstatus() for paths: None 
2020-05-13 19:14:45,870 [Level 5] ...>cmd:1010  Running: ['git', 'show', '-z', '--no-patch', '--format=%H', '--'] 
2020-05-13 19:14:45,916 [Level 8] ...>cmd:1010  Finished running ['git', 'show', '-z', '--no-patch', '--format=%H', '--'] with status 0 
2020-05-13 19:14:45,917 [DEBUG  ] ...>status:112  query AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).diffstatus() for paths: None 
2020-05-13 19:14:45,918 [Level 5] ...>cmd:1010  Running: ['git', 'show', '-z', '--no-patch', '--format=%H', '--'] 
2020-05-13 19:14:45,956 [Level 8] ...>cmd:1010  Finished running ['git', 'show', '-z', '--no-patch', '--format=%H', '--'] with status 0 
2020-05-13 19:14:45,957 [DEBUG  ] ...>status:112  query AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).diffstatus() for paths: None 
2020-05-13 19:14:45,959 [Level 5] ...>cmd:1010  Running: ['git', 'show', '-z', '--no-patch', '--format=%H', '--'] 
2020-05-13 19:14:46,001 [Level 8] ...>cmd:1010  Finished running ['git', 'show', '-z', '--no-patch', '--format=%H', '--'] with status 0 
2020-05-13 19:14:46,005 [DEBUG  ] ...>status:112  query AnnexRepo(/home/yoh/.tmp/datalad_temp_test_subsuperdataset_savewi9yqcg_/sub1/sub2/sub3).diffstatus() for paths: None 
...
```
</details>