### PR TITLE
OPT: WitlessRunner -- reuse event loop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -487,6 +487,8 @@ Refer datalad/config.py for information on how to add these environment variable
   Whether to log cwd where command to be executed
 - *DATALAD_LOG_PID*
   To instruct datalad to log PID of the process
+- *DATALAD_LOG_NAME*
+  To instruct datalad to log name of the logger (corresponds to submodules or outside loggers like asyncio)
 - *DATALAD_LOG_TARGET*
   Where to log: `stderr` (default), `stdout`, or another filename
 - *DATALAD_LOG_TIMESTAMP*:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -403,6 +403,18 @@ class WitlessRunner(object):
         if WitlessRunner._event_loop is None:
             WitlessRunner._event_loop = WitlessEventLoop()
             asyncio.set_event_loop(WitlessRunner._event_loop)
+            if lgr.isEnabledFor(2):
+                # make asyncio talk to us too
+                from asyncio.log import logger as asyncio_lgr
+                # asyncio_lgr = logging.getLogger('asyncio')
+                asyncio_lgr_setup = True
+                asyncio_lgr.setLevel(logging.DEBUG)
+                # lgr.handlers are empty since delegated to its parent.
+                asyncio_lgr.handlers = lgr.parent.handlers
+                # enable debugging in the loop
+                WitlessRunner._event_loop.set_debug(True)
+
+
 
     def run(self, cmd, protocol=None, stdin=None, **kwargs):
         """Execute a command and communicate with it.


### PR DESCRIPTION
Comments in the code (removed in this WiP PR) mentioned `BlockingIOError`. I have tried on datalad/tests/test_witless_runner.py and a limited selection of unittests and then with other pythons (using conda) and didn't trigger it.

<details>
<summary>the only strange side effect I got is with python 3.5.5 which was not present on master is an ignored TypeError from `__del__` deeper within python </summary> 

```shell
$> python -m nose -s -v datalad/tests/test_witless_runner.py
datalad.tests.test_witless_runner.test_runner_stderr_capture ... ok
datalad.tests.test_witless_runner.test_runner_stdout_capture ... ok
datalad.tests.test_witless_runner.test_runner_parametrized_protocol ... ok
datalad.tests.test_witless_runner.test_runner_cwd_encoding ... ok
datalad.tests.test_witless_runner.test_runner_failure ... ok
datalad.tests.test_witless_runner.test_runner_fix_PWD ... ok
datalad.tests.test_witless_runner.test_runner_stdin ... ok
datalad.tests.test_witless_runner.test_runner ... ok
Versions: appdirs=1.4.3 boto=2.49.0 cmd:7z=16.02 cmd:annex=8.20200226-g2d3ef2c07 cmd:bundled-git=2.25.1 cmd:git=2.25.1 cmd:system-git=2.26.2 cmd:system-ssh=8.1p1 exifread=2.1.2 git=3.1.2 gitdb=4.0.5 humanize=0.5.1 iso8601=0.1.12 keyring=13.2.1 keyrings.alt=3.1 msgpack=0.5.6 mutagen=1.41.1 requests=2.23.0 wrapt=1.10.11
Obscure filename: str=b' "\';a&b&c\xce\x94\xd0\x99\xd7\xa7\xd9\x85\xe0\xb9\x97\xe3\x81\x82 `| ' repr=' "\';a&b&cΔЙקم๗あ `| '
Encodings: default='utf-8' filesystem='utf-8' locale.prefered='UTF-8'
Environment: GIT_PYTHON_GIT_EXECUTABLE='/home/yoh/anaconda-5.2.0-2.7/envs/datalad-py3.5/share/git-annex-8.20200226-1/git' GIT_PAGER='less --no-init --quit-if-one-screen' PATH='/home/yoh/anaconda-5.2.0-2.7/envs/datalad-py3.5/bin:/home/yoh/anaconda-5.2.0-2.7/bin/:/home/yoh/gocode/bin:/home/yoh/gocode/bin:/home/yoh/bin:/home/yoh/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/sbin:/usr/sbin:/usr/local/sbin' LANG='en_US.UTF-8'

----------------------------------------------------------------------
Ran 8 tests in 1.745s

OK
Exception ignored in: <bound method BaseEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
  File "/home/yoh/anaconda-5.2.0-2.7/envs/datalad-py3.5/lib/python3.5/asyncio/base_events.py", line 511, in __del__
  File "/home/yoh/anaconda-5.2.0-2.7/envs/datalad-py3.5/lib/python3.5/asyncio/unix_events.py", line 65, in close
  File "/home/yoh/anaconda-5.2.0-2.7/envs/datalad-py3.5/lib/python3.5/asyncio/unix_events.py", line 146, in remove_signal_handler
  File "/home/yoh/anaconda-5.2.0-2.7/envs/datalad-py3.5/lib/python3.5/signal.py", line 47, in signal
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object

$> python --version
Python 3.5.5

```
</details>

So decided to test across our CIs while hopefully they aren't too busy doing useful stuff.
I also moved loop into class variable since I guess eventually if we introduce more of async, we would need a central one (I guess).  On local run of benchmarks, no notable differences were detected.