### PR TITLE
BF: introduce GitTransportRI - a basic implementation only

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -829,7 +829,7 @@ class GitTransportRI(RI, RegexBasedURLMixin):
     # Due to poor design, `ri` argument already present in various
     # places intermixed with **kwargs treatment. So we will use RI
     # here instead of ri.
-    _REGEX = re.compile(r'(?P<transport>[^:/@]+)::(?P<RI>.*)$')
+    _REGEX = re.compile(r'(?P<transport>[A-Za-z0-9][A-Za-z0-9+.-]*)::(?P<RI>.*)$')
 
     def as_str(self):
         return '{self.transport}::{self.RI}'.format(self=self)

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -320,7 +320,8 @@ def _guess_ri_cls(ri):
         'url': URL,
         'ssh':  SSHRI,
         'file': PathRI,
-        'datalad': DataLadRI
+        'datalad': DataLadRI,
+        'git-transport': GitTransportRI,
     }
     if isinstance(ri, PurePath):
         lgr.log(5, "Detected file ri")
@@ -339,8 +340,12 @@ def _guess_ri_cls(ri):
     # file:///path should stay file:
     if fields['scheme'] and fields['scheme'] not in {'file'} \
             and not fields['hostname']:
+        # transport::URL-or-path
+        if fields['path'].startswith(':'):  # there was ::
+            lgr.log(5, "Assuming git transport style ri and returning")
+            type_ = 'git-transport'
         # dl+archive:... or just for ssh   hostname:path/p1
-        if '+' not in fields['scheme']:
+        elif '+' not in fields['scheme']:
             type_ = 'ssh'
             lgr.log(5, "Assuming ssh style ri, adjusted: %s" % (fields,))
 
@@ -810,6 +815,24 @@ class DataLadRI(RI, RegexBasedURLMixin):
         if self.remote:
             raise NotImplementedError("not supported ATM to reference additional remotes")
         return "{}{}".format(consts.DATASETS_TOPURL, urlquote(self.path))
+
+
+class GitTransportRI(RI, RegexBasedURLMixin):
+    """RI for some other RI with git transport prefix"""
+
+    # TODO: check how crticial to "inherit" RI._FIELDS asking to provide path
+    _FIELDS = RI._FIELDS + (
+        'transport',
+        'RI',
+    )
+
+    # Due to poor design, `ri` argument already present in various
+    # places intermixed with **kwargs treatment. So we will use RI
+    # here instead of ri.
+    _REGEX = re.compile(r'(?P<transport>[^:/@]+)::(?P<RI>.*)$')
+
+    def as_str(self):
+        return '{self.transport}::{self.RI}'.format(self=self)
 
 
 def _split_colon(s, maxsplit=1):

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -41,23 +41,24 @@ from datalad.tests.utils import (
 )
 
 from datalad.support.network import (
-    same_website,
-    dlurljoin,
-    get_tld,
-    get_url_straight_filename,
-    get_response_disposition_filename,
-    parse_url_opts,
+    DataLadRI,
+    GitTransportRI,
+    PathRI,
     RI,
     SSHRI,
-    PathRI,
-    DataLadRI,
     URL,
     _split_colon,
-    is_url,
-    is_datalad_compat_ri,
+    dlurljoin,
     get_local_file_url,
+    get_response_disposition_filename,
+    get_tld,
+    get_url_straight_filename,
+    is_datalad_compat_ri,
     is_ssh,
+    is_url,
     iso8601_to_epoch,
+    parse_url_opts,
+    same_website,
 )
 
 
@@ -175,6 +176,10 @@ def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
         with assert_raises(ValueError):
             ri_.localpath
 
+    # This one does not have a path. TODO: either proxy path from its .RI or adjust
+    # hierarchy of classes to make it more explicit
+    if cls == GitTransportRI:
+        return
     # do changes in the path persist?
     old_str = str(ri_)
     ri_.path = newpath = opj(ri_.path, 'sub')
@@ -335,6 +340,18 @@ def test_url_samples():
 
 
     raise SkipTest("TODO: file://::1/some does complain about parsed version dropping ::1")
+
+
+def test_git_transport_ri():
+    _check_ri("gcrypt::http://somewhere", GitTransportRI, RI='http://somewhere', transport='gcrypt')
+    # man git-push says
+    #  <transport>::<address>
+    #    where <address> may be a path, a server and path, or an arbitrary URL-like string...
+    # so full path to my.com/... should be ok?
+    _check_ri("http::/my.com/some/path", GitTransportRI, RI='/my.com/some/path', transport='http')
+    # some ssh server.  And we allow for some additional chars in transport.
+    # Git doesn't define since it does not care! we will then be flexible too
+    _check_ri("trans-port::server:path", GitTransportRI, RI='server:path', transport='trans-port')
 
 
 def _test_url_quote_path(cls, clskwargs, target_url):


### PR DESCRIPTION
this should be sufficient to address https://github.com/datalad/datalad/issues/4489
to avoid treating such RIs as ssh addresses.  Current implementation of
GitTransportRI simply splits apart transport and underlying RI attributes.
Since directed toward maint I have refrained from doing any code refactoring, such as
in RI().__init__ and in the tests check() to avoid using "ri" (and other) arguments
which might collide with fields provided in **kwargs.  May be in some next sweep
those all could become prefixed (or suffixed) with  _ to avoid such collisions.

We could also make this GitTransportRI immediately turn underlying RI into an
instance (ATM it is just a string), and also expose .path as all other RIs
apparently do.  But again, for the sake of the quick fix for now to not cause
hard to decypher errors, I decided to postpone that.

Note: I have not attempted to actually use it in some sample case fully since
e.g. our create-sibling-github has no clue about transport::, would need to
override url it provides for the remote and may be more...

Closes #4489 