### PR TITLE
create-sibling: Skip permissions test when running under sudo

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -482,6 +482,7 @@ def test_target_ssh_since():
     yield check_target_ssh_since, False
 
 
+@skip_if_on_windows
 @skip_if_root
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -507,7 +508,6 @@ def check_failon_no_permissions(use_ssh, src_path, target_path):
 
 
 def test_failon_no_permissions():
-    skip_if_on_windows()
     yield skip_ssh(check_failon_no_permissions), True
     yield check_failon_no_permissions, False
 

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -46,6 +46,7 @@ from datalad.tests.utils import (
     ok_file_under_git,
     skip_if_on_windows,
     skip_ssh,
+    skip_if_root,
     slow,
     swallow_logs,
     with_tempfile,
@@ -481,6 +482,7 @@ def test_target_ssh_since():
     yield check_target_ssh_since, False
 
 
+@skip_if_root
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def check_failon_no_permissions(use_ssh, src_path, target_path):

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -40,6 +40,7 @@ from datalad.tests.utils import (
     with_tree,
     on_windows,
     skip_if,
+    skip_if_root,
     assert_in_results,
     assert_not_in_results,
     assert_result_count,
@@ -92,7 +93,7 @@ def test_unlock_raises(path, path2, path3):
 #       Therefore don't know what to test for yet.
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789027#step:8:134
 @known_failure_windows
-@skip_if(cond=not on_windows and os.geteuid() == 0)  # uid not available on windows
+@skip_if_root
 @with_testrepos('.*annex.*', flavors=['clone'])
 def test_unlock(path):
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -86,6 +86,8 @@ from datalad.tests.utils import (
     serve_path_via_http,
     set_annex_version,
     skip_if,
+    skip_if_on_windows,
+    skip_if_root,
     skip_ssh,
     SkipTest,
     slow,
@@ -2287,7 +2289,8 @@ def test_files_split():
         yield check_files_split, cls
 
 
-@skip_if(cond=(on_windows or os.geteuid() == 0))  # uid and sudo not available on windows
+@skip_if_on_windows
+@skip_if_root
 @with_tree({
     'repo': {
         'file1': 'file1',
@@ -2348,7 +2351,8 @@ def test_ro_operations(path):
     repo2.repo_info()
 
 
-@skip_if(cond=(on_windows or os.geteuid() == 0))  # uid and sudo not available on windows
+@skip_if_on_windows
+@skip_if_root
 @with_tree({
     'file1': 'file1',
 })

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -189,6 +189,29 @@ def skip_if_on_windows(func=None):
         check_and_raise()
 
 
+def skip_if_root(func=None):
+    """Skip test if uid == 0.
+
+    Note that on Windows (or anywhere else `os.geteuid` is not available) the
+    test is _not_ skipped.
+    """
+    check_not_generatorfunction(func)
+
+    def check_and_raise():
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            raise SkipTest("Skipping: test assumptions fail under root")
+
+    if func:
+        @wraps(func)
+        @attr('skip_if_root')
+        def newfunc(*args, **kwargs):
+            check_and_raise()
+            return func(*args, **kwargs)
+        return newfunc
+    else:
+        check_and_raise()
+
+
 @optional_args
 def skip_if(func, cond=True, msg=None, method='raise'):
     """Skip test for specific condition


### PR DESCRIPTION
test_failon_no_permissions() is failing on master's 'sudo -E' cron
build (*) because, not surprisingly, the "no permissions" error that
the test looks for is not raised.  The entire purpose of this test
isn't relevant when running under sudo, so skip it.

Note that this failure is specific to master.  Before 154e22281 (TST:
create-sibling: Extend some existing tests to test local paths,
2020-02-24), the test was restricted to an SSH target, and all
SSH-based tests are already disabled for the 'sudo -E' build.

(*) https://travis-ci.org/github/datalad/datalad/jobs/684799579#L1117
