### PR TITLE
[RFC] ENH: push: Support explicitly requesting --auto

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -123,11 +123,14 @@ class Push(Interface):
             args=("-f", "--force",),
             doc="""force particular operations, overruling automatic decision
             making: use --force with git-push ('gitpush'); do not use --fast
-            with git-annex copy ('datatransfer'); do not attempt to copy
-            annex'ed file content ('no-datatransfer'); combine force modes
-            'gitpush' and 'datatransfer' ('all').""",
+            with git-annex copy ('datatransfer'); use --auto with git-annex
+            copy ('auto-datatransfer'); do not attempt to copy annex'ed file
+            content ('no-datatransfer'); combine force modes 'gitpush' and
+            'datatransfer' ('all').""",
             constraints=EnsureChoice(
-                'all', 'gitpush', 'no-datatransfer', 'datatransfer', None)),
+                'all', 'gitpush',
+                'no-datatransfer', 'auto-datatransfer', 'datatransfer',
+                None)),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         jobs=jobs_opt,
@@ -720,11 +723,10 @@ def _push_data(ds, target, content, force, jobs, res_kwargs):
     if jobs:
         cmd.extend(['--jobs', str(jobs)])
 
-    if not to_transfer and force not in ('all', 'datatransfer'):
+    if force == "auto-datatransfer":
         lgr.debug("Invoking copy --auto")
         cmd.append('--auto')
-
-    if force not in ('all', 'datatransfer'):
+    elif force not in ('all', 'datatransfer'):
         # if we force, we do not trust local knowledge and do the checks
         cmd.append('--fast')
 

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -572,3 +572,55 @@ def test_gh1811(srcpath, clonepath):
         message='There is no active branch, cannot determine remote '
                 'branch',
     )
+
+
+@with_tempfile(mkdir=True)
+def test_auto_data_transfer(path):
+    path = Path(path)
+    ds_a = Dataset(path / "a").create()
+    (ds_a.pathobj / "foo.dat").write_text("foo")
+    ds_a.save()
+
+    # Should be the default, but just in case.
+    ds_a.repo.config.set("annex.numcopies", "1", where="local")
+    ds_a.create_sibling(str(path / "b"), name="b")
+
+    # With numcopies=1, no data is copied with force=auto-datatransfer.
+    res = ds_a.push(to="b", force="auto-datatransfer", since=None)
+    assert_not_in_results(res, action="copy")
+
+    # numcopies=2 changes that.
+    ds_a.repo.config.set("annex.numcopies", "2", where="local")
+    res = ds_a.push(to="b", force="auto-datatransfer", since=None)
+    assert_in_results(
+        res, action="copy", target="b", status="ok",
+        path=str(ds_a.pathobj / "foo.dat"))
+
+    # --since= limits the files considered by --auto.
+    (ds_a.pathobj / "bar.dat").write_text("bar")
+    ds_a.save()
+    (ds_a.pathobj / "baz.dat").write_text("baz")
+    ds_a.save()
+    res = ds_a.push(to="b", force="auto-datatransfer", since="HEAD~1")
+    assert_not_in_results(
+        res,
+        action="copy", path=str(ds_a.pathobj / "bar.dat"))
+    assert_in_results(
+        res,
+        action="copy", target="b", status="ok",
+        path=str(ds_a.pathobj / "baz.dat"))
+
+    # --auto also considers preferred content.
+    ds_a.repo.config.unset("annex.numcopies", where="local")
+    ds_a.repo.set_preferred_content("wanted", "nothing", remote="b")
+    res = ds_a.push(to="b", force="auto-datatransfer", since=None)
+    assert_not_in_results(
+        res,
+        action="copy", path=str(ds_a.pathobj / "bar.dat"))
+
+    ds_a.repo.set_preferred_content("wanted", "anything", remote="b")
+    res = ds_a.push(to="b", force="auto-datatransfer", since=None)
+    assert_in_results(
+        res,
+        action="copy", target="b", status="ok",
+        path=str(ds_a.pathobj / "bar.dat"))


### PR DESCRIPTION
```
As mentioned in gh-4483, push doesn't offer a way to respect preferred
content (as well as other configuration that 'annex copy --auto'
considers, specifically numcopies).  Add another value to force,
auto-datatransfer, and make that mean 'use --auto with annex-copy'.

Closes #4483.
```

---

I don't think this is a great approach for at least two reasons:

  * Conceptually I have a hard time seeing how "use --auto" fits into a force operation.  IMO --fast seems like a bit of a stretch too, but I can at least see how a "datatransfer -> do _not_ use --fast" can be seen as more forceful.  I'd say --auto, on the other hand, is less forceful than the current default (using `git annex copy --fast` if the diff reported content to transfer and `force` isn't datatransfer or all).

  * This means --fast and --auto can't be used together, though they are orthogonal flags.

But I hope maybe this is a starting point for thinking about how we want to handle gh-4483.