### PR TITLE
BF: http - fix handling of fetched in bytes content, re-enable testing using httpretty

### DIFF
--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -19,7 +19,11 @@ import requests.auth
 import io
 from time import sleep
 
-from ..utils import assure_list_from_str, assure_dict_from_str
+from ..utils import (
+    assure_list_from_str,
+    assure_dict_from_str,
+    ensure_bytes,
+)
 from ..dochelpers import borrowkwargs
 
 from ..ui import ui
@@ -208,8 +212,11 @@ class HTTPBaseAuthenticator(Authenticator):
 
     def check_for_auth_failure(self, content, err_prefix=""):
         if self.failure_re:
+            content_is_bytes = isinstance(content, bytes)
             # verify that we actually logged in
             for failure_re in self.failure_re:
+                if content_is_bytes:
+                    failure_re = ensure_bytes(failure_re)
                 if re.search(failure_re, content):
                     raise AccessDeniedError(
                         err_prefix + "returned output which matches regular expression %s" % failure_re

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -30,6 +30,7 @@ from ..credentials import (
 )
 from ..http import (
     HTMLFormAuthenticator,
+    HTTPBaseAuthenticator,
     HTTPDownloader,
     HTTPBearerTokenAuthenticator,
     process_www_authenticate,
@@ -556,6 +557,17 @@ def check_httpretty_authfail404(exp_called, d):
     # first one goes with regular DownloadError -- was 404 with not matching content
     assert_raises(DownloadError, downloader.download, url, path=d)
     assert_equal(was_called, exp_called)
+
+
+def test_auth_bytes_content():
+    # Our regexes are strings, but we can get content in bytes:
+    # I am not sure yet either we shouldn't just skip then testing for regex,
+    # but we definetely should not crash.
+    authenticator = HTTPBaseAuthenticator(failure_re="Failed")
+    authenticator.check_for_auth_failure(b"bytes")
+    # but ATM we do test bytes content, let's ENSURE that!
+    with assert_raises(AccessDeniedError):
+        authenticator.check_for_auth_failure(b"Failed")
 
 
 class FakeCredential2(UserPassword):

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -40,7 +40,6 @@ from ...utils import ensure_unicode
 
 # BTW -- mock_open is not in mock on wheezy (Debian 7.x)
 try:
-    raise ImportError("Not yet ready apparently: https://travis-ci.org/datalad/datalad/jobs/111659666")
     import httpretty
 except (ImportError, AttributeError):
     # Attribute Error happens with newer httpretty and older ssl module

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -17,24 +17,25 @@ import builtins
 from os.path import join as opj
 
 from datalad.downloaders.tests.utils import get_test_providers
-from ..base import DownloadError
-from ..base import IncompleteDownloadError
-from ..base import BaseDownloader
-from ..base import NoneAuthenticator
-from ..credentials import UserPassword
-from ..credentials import Token
-from ..credentials import LORIS_Token
-from ..http import HTMLFormAuthenticator
-from ..http import HTTPDownloader
-from ..http import HTTPBearerTokenAuthenticator
-from ..http import process_www_authenticate
+from ..base import (
+    BaseDownloader,
+    DownloadError,
+    IncompleteDownloadError,
+    NoneAuthenticator,
+)
+from ..credentials import (
+    LORIS_Token,
+    Token,
+    UserPassword,
+)
+from ..http import (
+    HTMLFormAuthenticator,
+    HTTPDownloader,
+    HTTPBearerTokenAuthenticator,
+    process_www_authenticate,
+)
 from ...support.exceptions import AccessFailedError
 from ...support.network import get_url_straight_filename
-from ...tests.utils import with_fake_cookies_db
-from ...tests.utils import skip_if_no_network
-from ...tests.utils import with_testsui
-from ...tests.utils import with_memory_keyring
-from ...tests.utils import known_failure_githubci_win
 from ...utils import ensure_unicode
 
 # BTW -- mock_open is not in mock on wheezy (Debian 7.x)
@@ -50,23 +51,32 @@ except (ImportError, AttributeError):
     httpretty = NoHTTPPretty()
 
 from unittest.mock import patch
-from ...tests.utils import SkipTest
-from ...tests.utils import assert_in
-from ...tests.utils import assert_not_in
-from ...tests.utils import assert_equal
-from ...tests.utils import assert_greater
-from ...tests.utils import assert_false
-from ...tests.utils import assert_raises
-from ...tests.utils import ok_file_has_content
-from ...tests.utils import serve_path_via_http, with_tree
-from ...tests.utils import swallow_logs
-from ...tests.utils import swallow_outputs
-from ...tests.utils import with_tempfile
-from ...tests.utils import use_cassette
-from ...tests.utils import skip_if
-from ...tests.utils import without_http_proxy
-from ...support.exceptions import AccessDeniedError
-from ...support.exceptions import AnonymousAccessDeniedError
+from ...tests.utils import (
+    SkipTest,
+    assert_equal,
+    assert_false,
+    assert_greater,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    known_failure_githubci_win,
+    ok_file_has_content,
+    serve_path_via_http, with_tree,
+    skip_if,
+    skip_if_no_network,
+    swallow_logs,
+    swallow_outputs,
+    use_cassette,
+    with_fake_cookies_db,
+    with_memory_keyring,
+    with_tempfile,
+    with_testsui,
+    without_http_proxy,
+)
+from ...support.exceptions import (
+    AccessDeniedError,
+    AnonymousAccessDeniedError,
+)
 from ...support.status import FileStatus
 from ...support.network import get_url_disposition_filename
 

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -449,7 +449,7 @@ def test_HTMLFormAuthenticator_httpretty(d):
         return (200, headers, "Got {} response from {}".format(request.method, uri))
 
     def request_get_callback(request, uri, headers):
-        assert_equal(request.body, '')
+        assert_equal(request.body, b'')
         assert_in('Cookie', request.headers)
         assert_equal(request.headers['Cookie'], test_cookie)
         return (200, headers, "correct body")
@@ -602,7 +602,7 @@ def test_scenario_2(d):
         return (200, headers, "Got {} response from {}".format(request.method, uri))
 
     def request_get_callback(request, uri, headers):
-        assert_equal(request.body, '')
+        assert_equal(request.body, b'')
         assert_in('Cookie', request.headers)
         assert_equal(request.headers['Cookie'], test_cookie)
         return (200, headers, "correct body")
@@ -672,7 +672,7 @@ def test_HTTPBearerTokenAuthenticator(d):
 
     # Perform assertions. See note above.
     r = request_get_callback.req
-    assert_equal(r.body, '')
+    assert_equal(r.body, b'')
     assert_in('Authorization', r.headers)
     assert_equal(r.headers['Authorization'], "Bearer testtoken")
 
@@ -714,7 +714,7 @@ def test_HTTPLorisTokenAuthenticator(d):
 
     # Perform assertions. See note above.
     r = request_get_callback.req
-    assert_equal(r.body, '')
+    assert_equal(r.body, b'')
     assert_in('Authorization', r.headers)
     assert_equal(r.headers['Authorization'], "Bearer testtoken")
 
@@ -757,7 +757,7 @@ def test_lorisadapter(d, keyring):
     downloader.download(url, path=d)
 
     r = request_get_callback.req
-    assert_equal(r.body, '')
+    assert_equal(r.body, b'')
     assert_in('Authorization', r.headers)
     assert_equal(r.headers['Authorization'], "Bearer testtoken33")
     # Verify credentials correctly set to test user:pass

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ requires = {
     ],
     'tests': [
         'BeautifulSoup4',  # VERY weak requirement, still used in one of the tests
-        'httpretty>=0.8.14',
+        'httpretty>=0.9.4',  # Introduced py 3.6 support
         'nose>=1.3.4',
         'vcrpy',
     ],


### PR DESCRIPTION
absorbs #4540 . 

Individual commits provide more info but here is two major summaries:

commit d366600f04c3f9739e75a6ba66a9feae76cfb651

    ENH: reenable testing using httpretty (and other tests)
    
    Apparently we had the entire test_http disabled due to httpretty not supporting
    python3 in the past.  That masked some bugs in our code which need to be fixed up
    (done in prior commit) and minimal compatible version of httpretty
    verified.
    
    0.9.4 seems to work fine for me in conda environments with python 3.6
    and 3.8.
    
    The only leftover inconvenience (does not cause failed tests) is a
    complaint from cookies upon exit:
    https://github.com/datalad/datalad/issues/4542

commit 3b55eb4e9d23fc22d175b0cfa9f1a8320b2258be

    BF(TST): http - compare content to bytes not string
    
    In https://github.com/datalad/datalad/pull/3210 (specifically
    622cada63d1876627c75fde8af2da862494f2b15) we stopped decoding
    fetched content while checking the status.  It was initially triggered
    within datalad-crawler pipelines and has further discussion on
    https://github.com/datalad/datalad-crawler/pull/9 .  So tests should
    compare to bytes not strings if not explicitly decoding.
    
    Situation got grave with the entire test module being disabled due to
    httpretty at those times not supporting python3. That lead to these
    lines not exercised at all.  This PR series includes one more fix
    addressing switch from string to bytes for content and also enables
    back testing using httpretty.