### PR TITLE
ENH: Avoid needless calls with diff(fr=None, annex=!None)

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -232,8 +232,7 @@ class Push(Interface):
         ds_spec = _datasets_since_(
             # important to pass unchanged dataset arg
             dataset,
-            # use the diff "since before time"
-            since if since else PRE_INIT_COMMIT_SHA,
+            since,
             paths,
             recursive,
             recursion_limit)

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -15,7 +15,6 @@ __docformat__ = 'restructuredtext'
 import logging
 from tempfile import TemporaryFile
 
-from datalad.consts import PRE_INIT_COMMIT_SHA
 from datalad.cmd import GitWitlessRunner
 from datalad.interface.base import (
     Interface,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -322,14 +322,14 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
         return
 
     if annexinfo and hasattr(repo, 'get_content_annexinfo'):
-        # this will ammend `status`
+        # this will ammend `diff_state`
         repo.get_content_annexinfo(
             paths=paths.keys() if paths is not None else paths,
             init=diff_state,
             eval_availability=annexinfo in ('availability', 'all'),
             ref=to)
         # if `fr` is None, we compare against a preinit state, and
-        # nothing needs to be done
+        # a get_content_annexinfo on that state doesn't get us anything new
         if fr and fr != to:
             repo.get_content_annexinfo(
                 paths=paths.keys() if paths is not None else paths,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -38,7 +38,6 @@ from datalad.support.constraints import (
     EnsureStr,
 )
 from datalad.support.param import Parameter
-from datalad.consts import PRE_INIT_COMMIT_SHA
 
 from datalad.core.local.status import (
     Status,
@@ -329,7 +328,9 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
             init=diff_state,
             eval_availability=annexinfo in ('availability', 'all'),
             ref=to)
-        if fr != to:
+        # if `fr` is None, we compare against a preinit state, and
+        # nothing needs to be done
+        if fr and fr != to:
             repo.get_content_annexinfo(
                 paths=paths.keys() if paths is not None else paths,
                 init=diff_state,
@@ -372,7 +373,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                     subds,
                     # from before time or from the reported state
                     fr if constant_refs
-                    else PRE_INIT_COMMIT_SHA
+                    else None
                     if subds_state == 'added'
                     else props['prev_gitshasum'],
                     # to the last recorded state, or the worktree


### PR DESCRIPTION
`diff` treats `fr=None` as a diff-from-scratch. However, when recursing
into subdatasets it breaks this paradigm by translating this into
`fr=PRE_INIT_COMMIT_SHA`. This can lead to a needless call to
`AnnexRepo.get_content_annexinfo()`. This changes rectifies that by
using `None` also for subdatasets.

Moreover, `push` uses `diff(fr=since)`, which can also be `None`. This
change also avoid an equivalent needless call for a top-level dataset.
