### PR TITLE
ENH: Give insight in push progress with a step-based progress bar

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -223,15 +223,15 @@ class ProgressHandler(logging.Handler):
             # we may want to actually "print" the completion message
             self.pbars.pop(pid).finish()
         else:
+            # Check for an updated label.
+            label = getattr(record, 'dlm_progress_label', None)
+            if label is not None:
+                self.pbars[pid].set_desc(label)
             # an update
             self.pbars[pid].update(
                 update,
                 increment=getattr(record, 'dlm_progress_increment', False),
                 total=getattr(record, 'dlm_progress_total', None))
-            # Check for an updated label.
-            label = getattr(record, 'dlm_progress_label', None)
-            if label is not None:
-                self.pbars[pid].set_desc(label)
 
 
 class NoProgressLog(logging.Filter):


### PR DESCRIPTION
It makes it more obvious what is happening, and also exposes the
processing of publication targets.

This could also be a model for other commands, where presently
`lgr.info()` calls serve this purpose -- which annoyingly interfere
with progressbars and result rendering.

In combination with #4544 and #4545 it looks like this:

![image](https://user-images.githubusercontent.com/136479/82139247-d2246080-9826-11ea-9361-f4cfcddfbf5e.png)
