### PR TITLE
ENH: Disable full submodule evaluation for diff(to=!None)

### DIFF
--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -313,6 +313,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
             paths=None if not paths else [p for p in paths],
             untracked=untracked,
             eval_file_type=eval_file_type,
+            eval_submodule_state='full' if to is None else 'commit',
             _cache=cache)
     except InvalidGitReferenceError as e:
         yield dict(


### PR DESCRIPTION
In all such cases the comparison is made with respect to a recorded
state, so that any worktree inspection can be completely avoided.
This can lead to substantial speed-ups in large dataset hierarchies,
and helps to mitigate the needs for alternatively tailored `diff`
implementations, such as the one proposed in gh-4507.
