### PR TITLE
BF: use '' as default (not None) while checking for a key not to be a test key

### DIFF
--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -252,8 +252,6 @@ class AnnexCustomRemote(object):
         # Delay introspection until the first instance gets born
         # could in principle be done once in the metaclass I guess
         self.__class__._introspect_req_signatures()
-        self._annex_supports_info = \
-            external_versions['cmd:annex'] >= '6.20180206'
 
     @classmethod
     def _introspect_req_signatures(cls):
@@ -386,8 +384,7 @@ class AnnexCustomRemote(object):
 
     def info(self, msg):
         lgr.info(msg)
-        if self._annex_supports_info:
-            self.send('INFO', msg)
+        self.send('INFO', msg)
 
     def progress(self, bytes):
         bytes = int(bytes)

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -27,7 +27,6 @@ lgr.log(5, "Importing datalad.customremotes.main")
 
 from ..ui import ui
 from ..support.protocol import ProtocolInterface
-from ..support.external_versions import external_versions
 from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 from ..dochelpers import exc_str
@@ -666,7 +665,6 @@ def generate_uuids():
 
 def init_datalad_remote(repo, remote, encryption=None, autoenable=False, opts=[]):
     """Initialize datalad special remote"""
-    from datalad.support.external_versions import external_versions
     from datalad.consts import DATALAD_SPECIAL_REMOTES_UUIDS
     lgr.info("Initiating special remote %s" % remote)
     remote_opts = [
@@ -675,12 +673,11 @@ def init_datalad_remote(repo, remote, encryption=None, autoenable=False, opts=[]
         'autoenable=%s' % str(bool(autoenable)).lower(),
         'externaltype=%s' % remote
     ]
-    if external_versions['cmd:annex'] >= '6.20170208':
-        # use unique uuid for our remotes
-        # This should help with merges of disconnected repos etc
-        # ATM only datalad/datalad-archives is expected,
-        # so on purpose getitem
-        remote_opts.append('uuid=%s' % DATALAD_SPECIAL_REMOTES_UUIDS[remote])
+    # use unique uuid for our remotes
+    # This should help with merges of disconnected repos etc
+    # ATM only datalad/datalad-archives is expected,
+    # so on purpose getitem
+    remote_opts.append('uuid=%s' % DATALAD_SPECIAL_REMOTES_UUIDS[remote])
     return repo.init_remote(remote, remote_opts + opts)
 
 

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -11,6 +11,7 @@
 from ...support.annexrepo import AnnexRepo
 from ...consts import DATALAD_SPECIAL_REMOTE
 from ...tests.utils import *
+from ...support.external_versions import external_versions
 
 from . import _get_custom_runner
 from ...support.exceptions import CommandError
@@ -30,14 +31,19 @@ def check_basic_scenario(url, d):
     # TODO skip if no boto or no credentials
     get_test_providers(url) # so to skip if unknown creds
 
+    # git-annex got a fix where it stopped replacing - in the middle of the filename
+    filename = '3versions%sallversioned.txt' % (
+        '_' if external_versions['cmd:annex'] < '8.20200501+git53-gcabbc91b1' else '-'
+    )
+
     # Let's try to add some file which we should have access to
     with swallow_outputs() as cmo:
         annex.add_urls([url])
         annex.commit("committing")
-        whereis1 = annex.whereis('3versions_allversioned.txt', output='full')
+        whereis1 = annex.whereis(filename, output='full')
         eq_(len(whereis1), 2)  # here and datalad
-        annex.drop('3versions_allversioned.txt')
-    whereis2 = annex.whereis('3versions_allversioned.txt', output='full')
+        annex.drop(filename)
+    whereis2 = annex.whereis(filename, output='full')
     eq_(len(whereis2), 1)  # datalad
 
     # if we provide some bogus address which we can't access, we shouldn't pollute output

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -880,12 +880,6 @@ def check_datasets_datalad_org(suffix, tdir):
     # Windows we get two records due to a duplicate attempt (as res[1]) to get it
     # again, which is reported as "notneeded".  For the purpose of this test
     # it doesn't make a difference.
-    # git-annex version is not "real" - but that is about when fix was introduced
-    from datalad import cfg
-    if on_windows \
-        and cfg.obtain("datalad.repo.version") < 6 \
-        and external_versions['cmd:annex'] <= '7.20181203':
-        raise SkipTest("Known to fail, needs fixed git-annex")
     assert_result_count(
         ds.get(op.join('001-anat-scout_ses-{date}', '000001.dcm')),
         1,

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -42,7 +42,6 @@ from ...utils import rmtree
 from ...utils import on_windows
 from datalad.log import lgr
 from ...api import add_archive_content, clean
-from datalad.support.external_versions import external_versions
 from datalad.consts import DATALAD_SPECIAL_REMOTES_UUIDS
 from datalad.consts import ARCHIVES_SPECIAL_REMOTE
 
@@ -99,10 +98,8 @@ def test_add_archive_dirs(path_orig, url, repo_path):
                             use_current_dir=False,
                             exclude='.*__MACOSX.*')  # some junk penetrates
 
-        if external_versions['cmd:annex'] >= '6.20170208':
-            # should have fixed remotes
-            eq_(repo.get_description(uuid=DATALAD_SPECIAL_REMOTES_UUIDS[ARCHIVES_SPECIAL_REMOTE]),
-                '[%s]' % ARCHIVES_SPECIAL_REMOTE)
+        eq_(repo.get_description(uuid=DATALAD_SPECIAL_REMOTES_UUIDS[ARCHIVES_SPECIAL_REMOTE]),
+            '[%s]' % ARCHIVES_SPECIAL_REMOTE)
 
         all_files = sorted(find_files('.'))
         target_files = {

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2385,7 +2385,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 j['key' if (key or '--all' in options) else 'file']
                 : self._whereis_json_to_dict(j)
                 for j in json_objects
-                if not j.get('key').endswith('.this-is-a-test-key')
+                if not j.get('key', '').endswith('.this-is-a-test-key')
             }
 
     # TODO:


### PR DESCRIPTION
I just saw it in https://github.com/datalad/datalad-extensions/runs/665491656?check_suite_focus=true
which I believe failed for other reasons (but may be not), that there was a traceback
to this line.  And indeed above we might ask for a 'key' or a 'file', so hypothetically
there might be no 'key' field.  I have not really analyzed situation on how we have not
hit it before and how it really emerges in that failure while testing against
bleeding edge git annex
