### PR TITLE
RF: throw dedicated RuntimeError with information about question in case of SilentConsoleLog

### DIFF
--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -131,7 +131,7 @@ class SilentConsoleLog(ConsoleLog):
             if kwargs_str:
                 msg += " Additional arguments: %s" % kwargs_str
         else:
-            msg += " Additional arguments are not shown due to 'hidden' is set."
+            msg += " Additional arguments are not shown because 'hidden' is set."
         raise RuntimeError(msg)
 
 

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -27,6 +27,7 @@ import getpass
 # from unittest.mock import patch
 from collections import deque
 from copy import copy
+from itertools import chain
 
 from ..utils import auto_repr
 from ..utils import on_windows
@@ -117,6 +118,21 @@ class SilentConsoleLog(ConsoleLog):
     def get_progressbar(self, *args, **kwargs):
         from .progressbars import SilentProgressBar
         return SilentProgressBar(*args, **kwargs)
+
+    def question(self, text, title=None, **kwargs):
+        msg = "A non-interactive silent UI was asked for a response to a question: %s." % text
+        if title is not None:
+            msg += ' Title: %s.' % title
+        if not kwargs.get('hidden'):
+            kwargs_str = ', '.join(
+                ('%s=%r' % (k, v)
+                for k, v in kwargs.items()
+                if v is not None))
+            if kwargs_str:
+                msg += " Additional arguments: %s" % kwargs_str
+        else:
+            msg += " Additional arguments are not shown due to 'hidden' is set."
+        raise RuntimeError(msg)
 
 
 @auto_repr

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -17,12 +17,15 @@ from unittest.mock import (
     call,
     patch,
 )
-from ...tests.utils import eq_
-from ...tests.utils import assert_raises
-from ...tests.utils import assert_re_in
-from ...tests.utils import assert_in
-from ...tests.utils import ok_startswith
-from ...tests.utils import ok_endswith
+from ...tests.utils import (
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    assert_re_in,
+    eq_,
+    ok_endswith,
+    ok_startswith,
+)
 from ..dialog import (
     DialogUI,
     IPythonUI,
@@ -163,3 +166,25 @@ def test_IPythonUI():
     ui = IPythonUI()
     pbar = ui.get_progressbar(total=10)
     assert_in('notebook', str(pbar._tqdm))
+
+
+def test_silent_question():
+    # SilentConsoleLog must not be asked questions.
+    # If it is asked, RuntimeError would be thrown with details to help
+    # troubleshooting WTF is happening
+    from ..dialog import SilentConsoleLog
+    ui = SilentConsoleLog()
+    with assert_raises(RuntimeError) as cme:
+        ui.question("could you help me", title="Pretty please")
+    assert_in('question: could you help me. Title: Pretty please.', str(cme.exception))
+
+    with assert_raises(RuntimeError) as cme:
+        ui.question("could you help me", title="Pretty please", choices=['secret1'], hidden=True)
+    assert_in('question: could you help me. Title: Pretty please.', str(cme.exception))
+    assert_not_in('secret1', str(cme.exception))
+    assert_in('not shown', str(cme.exception))
+
+    # additional kwargs, no title, choices
+    with assert_raises(RuntimeError) as cme:
+        ui.question("q", choices=['secret1'])
+    assert_in('secret1', str(cme.exception))


### PR DESCRIPTION
It is hard to impossible to troubleshoot failures of datalad in automated
deployments where we want to ask some question for some reason, but UI simply
does not support that since it is rightfully silent/non-interactive.

See e.g. https://github.com/templateflow/templateflow/issues/50 .

With this PR we would still fail but with a little more informative RuntimeError,
instead of obscure AttributeError stating what was actually asked.  We will not
disclose possible present other fields other than question and title if it was a
question asking for secret information ("hidden").  AFAIK in our use of the dialogues
we do not disclose any sensitive information in title or the question but I could be
proven wrong.

I did position this one on top of maint since might benefit people using released
version in production.  Delaying till 0.13.0 would require them to migrate first to
just be able to troubleshoot
