### PR TITLE
BF: Prevent ugly interaction or result and progress reporting

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -201,6 +201,16 @@ class ProgressHandler(logging.Handler):
 
     def emit(self, record):
         from datalad.ui import ui
+        maint = getattr(record, 'dlm_progress_maint', None)
+        if maint == 'clear':
+            # remove the progress bar
+            for pb in self.pbars.values():
+                pb.clear()
+            return
+        elif maint == 'refresh':
+            for pb in self.pbars.values():
+                pb.refresh()
+            return
         pid = getattr(record, 'dlm_progress')
         update = getattr(record, 'dlm_progress_update', None)
         # would be an actual message, not used ATM here,
@@ -287,6 +297,7 @@ def log_progress(lgrcall, pid, *args, **kwargs):
       showing a message at the `lgrcall` level for each step would be too much
       noise. Note that the level here only determines if the record will be
       dropped; it will still be logged at the level of `lgrcall`.
+    maint : {'clear', 'refresh'}
     """
     d = dict(
         {'dlm_progress_{}'.format(n): v for n, v in kwargs.items()

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -76,7 +76,7 @@ class ConsoleLog(object):
         self.out.write(msg)
         if cr:
             self.out.write(cr)
-        log_progress(lgr.info, None, 'Clear progress bars', maint='refresh')
+        log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh')
 
     def error(self, error):
         self.out.write("ERROR: %s\n" % error)

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -71,9 +71,12 @@ class ConsoleLog(object):
         self.out = out
 
     def message(self, msg, cr='\n'):
+        from datalad.log import log_progress
+        log_progress(lgr.info, None, 'Clear progress bars', maint='clear')
         self.out.write(msg)
         if cr:
             self.out.write(cr)
+        log_progress(lgr.info, None, 'Clear progress bars', maint='refresh')
 
     def error(self, error):
         self.out.write("ERROR: %s\n" % error)


### PR DESCRIPTION
This is an excerpt from gh-4444 that solely addresses the suboptimal interaction of result reporting and progress reporting that is presently evident in `push()` usage.

The idea is to clear any progressbar(s) before rendering a result with `ui.message()` and afterward refresh the progressbar(s). With this approach results will appear above any active progress bar in the terminal and do not get half-swallowed by a progress update.

https://github.com/datalad/datalad/pull/4444#issuecomment-620285637 outlines an additional improvement that addresses the analog issue for the interaction of log messages and progress reporting, also pointed out by (but unaddressed in) gh-4444. However, that solution can be seen as an incremental step that should not delay the fix contained herein.

@kyleam this patch should address the visual glitches that you have observed.