### PR TITLE
TST: sshconnector: Loosen assertion about SSH annex version

### DIFF
--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -267,10 +267,10 @@ def test_ssh_git_props():
     remote_url = 'ssh://localhost'
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
-    eq_(ssh.get_annex_version(),
-        external_versions['cmd:annex'])
-    # cannot compare to locally detected, might differ depending on
-    # how annex was installed
+    # Note: Avoid comparing these versions directly to the versions in
+    # external_versions because the ssh://localhost versions detected might
+    # differ depending on how git-annex is installed.
+    ok_(ssh.get_annex_version())
     ok_(ssh.get_git_version())
     manager.close()  # close possibly still present connections
 


### PR DESCRIPTION
test_ssh_git_props() asserts that the ssh://localhost git-annex
version is equal to the version in external_versions.  However, those
versions don't necessarily match.  For example, the local user could
be running a git-annex from conda while the git-annex used by
ssh://localhost is from NeuroDebian.  And if in the future we move
away from a localhost target (e.g., gh-4514), there is no reason to
expect the versions to match at all.

Replace the more specific version assertion with a check that some
output is produced, as is already done for the SSH git version.

Fixes one part of gh-4554.