### PR TITLE
TST: sshrun: Don't fail if target doesn't accept LC_* variables

### DIFF
--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -67,7 +67,7 @@ def test_ssh_option():
     # `AcceptEnv LC_*` in their sshd_config. If it ends up causing problems, we
     # should just scrap it.
     with patch.dict('os.environ', {"LC_DATALAD_HACK": 'hackbert'}):
-        with swallow_outputs() as cmo:  # need to give smth with .fileno ;)
+        with swallow_outputs() as cmo:
             main(["datalad", "sshrun", "-oSendEnv=LC_DATALAD_HACK",
                   "localhost", "echo $LC_DATALAD_HACK"])
             assert_equal(cmo.out.strip(), "hackbert")


### PR DESCRIPTION
```
As mentioned in the comment, this test assumes the target has
`AcceptEnv LC_*` configured.  Instead of failing when that's not the
case (or dropping the test entirely), skip the test if the output is
an empty string, which probably means `AcceptEnv LC_*` isn't set.  (It
could also be an indication that things aren't wired up correctly in
sshrun, but this probably isn't worth worrying about given our test
environments have are configured to accept LC_ variables.)

Fixes one part of gh-4554.
```

---

There is also a commit that cleans up an unintentional comment.

Pointing the test to a docker target configured to _not_ accept `LC_` variables, I've confirmed that the test is skipped (and that it fails with the same error as shown in gh-4554 before this change).