### PR TITLE
BF: publish: Tell git-fetch to not recurse into submodules

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -263,7 +263,7 @@ def _check_and_update_remote_server_info(ds, remote):
 
 def _maybe_fetch(repo, remote):
     if repo.config.get("remote.{}.fetch".format(remote)):
-        repo.fetch(remote=remote)
+        repo.fetch(remote=remote, recurse_submodules="no")
     else:
         # Fetching would lead to "Couldn't find remote ref HEAD" if no
         # branch" error.  See gh-4199 for an example.

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -731,3 +731,29 @@ def test_publish_no_fetch_refspec_configured(path):
     (ds.repo.pathobj / "foo").write_text("a")
     ds.save()
     ds.publish(to="origin")
+
+
+@skip_ssh
+@with_tempfile(mkdir=True)
+def test_publish_fetch_do_not_recurse_submodules(path):
+    # This sets up a situation where git (2.26.2 at the time of writing) will
+    # fail trying to fetch a non-existent 'origin' remote if
+    # --no-recurse-submodules is not set during the fetch.
+    path = Path(path)
+    ds_a = Dataset(path / "a").create()
+    ds_a.create("sub")
+    ds_a.save(recursive=True)
+    # TODO: This can be switched to a local path on master, dropping the
+    # skip_ssh().
+    ds_a.create_sibling("ssh://datalad-test:{}/b".format(path), name="b",
+                        recursive=True)
+    publish(dataset=ds_a, to="b")
+
+    ds_b = Dataset(path / "b")
+    ds_b.repo.checkout("other", options=["-b"])
+    (ds_b.pathobj / "sub" / "foo").write_text("foo")
+    ds_b.save(recursive=True)
+
+    (ds_a.pathobj / "bar").write_text("bar")
+    ds_a.save()
+    assert_status("ok", publish(dataset=ds_a, to="b"))


### PR DESCRIPTION
publish() fetches the sibling before pushing, and has done so for a
long time (f07fc5194, 2017-08-26).  If the fetch brings down a
recorded submodule commit that is not yet present locally, by default
git also fetch in the submodule with the missing commit.

This is problematic because, as explained in dbd84e5662 (ENH: update:
Try to fetch submodule commit explicitly if needed, 2020-02-07),
submodule.c hard codes 'origin' as a fallback to fetch from, so the
fetch will fail unless there's a remote named 'origin'.  Also,
conceptually, the goal of this fetch seems to be to obtain up-to-date
information on the current repository, not its submodules, which
publish() will handle itself if called with --recursive.

Fetch with --recurse-submodules=no.