### PR TITLE
ENH: HTTP for ORA special remote

### DIFF
--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -94,11 +94,12 @@ def verify_ria_url(url, cfg):
         raise ValueError(
             "Unexpected fragment in RIA-store URL: %s" % url_ri.fragment)
     protocol = url_ri.scheme[4:]
-    if protocol not in ['ssh', 'file']:
-        raise ValueError("Unsupported protocol: %s. Supported: ssh, file" %
+    if protocol not in ['ssh', 'file', 'http', 'https']:
+        raise ValueError("Unsupported protocol: %s. "
+                         "Supported: ssh, file, http(s)" %
                          protocol)
 
-    return url_ri.hostname if protocol == 'ssh' else None, url_ri.path, url
+    return url_ri.hostname if protocol != 'file' else None, url_ri.path, url
 
 
 def create_store(io, base_path, version):

--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -99,7 +99,9 @@ def verify_ria_url(url, cfg):
                          "Supported: ssh, file, http(s)" %
                          protocol)
 
-    return url_ri.hostname if protocol != 'file' else None, url_ri.path, url
+    return url_ri.hostname if protocol != 'file' else None, \
+        url_ri.path if url_ri.path else '/', \
+        url
 
 
 def create_store(io, base_path, version):

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -21,6 +21,8 @@ from datalad.customremotes.ria_utils import (
 
 lgr = logging.getLogger('datalad.customremotes.ria_remote')
 
+DEFAULT_BUFFER_SIZE = 65536
+
 # TODO
 # - make archive check optional
 
@@ -239,7 +241,7 @@ class SSHRemoteIO(IOBase):
     REMOTE_CMD_FAIL = "ora-remote: end - fail"
     REMOTE_CMD_OK = "ora-remote: end - ok"
 
-    def __init__(self, host, buffer_size):
+    def __init__(self, host, buffer_size=DEFAULT_BUFFER_SIZE):
         """
         Parameters
         ----------
@@ -270,7 +272,8 @@ class SSHRemoteIO(IOBase):
                 break
         # TODO: Same for stderr?
 
-        self.buffer_size = buffer_size if buffer_size else 65536
+        # make sure default is used when None was passed, too.
+        self.buffer_size = buffer_size if buffer_size else DEFAULT_BUFFER_SIZE
 
     def close(self):
         # try exiting shell clean first
@@ -530,14 +533,15 @@ class HTTPRemoteIO(object):
     # NOTE: For now read-only. Not sure yet whether an IO class is the right
     # approach.
 
-    def __init__(self, ria_url, dsid, buffer_size):
+    def __init__(self, ria_url, dsid, buffer_size=DEFAULT_BUFFER_SIZE):
         assert ria_url.startswith("ria+http")
         self.base_url = ria_url[4:]
         if self.base_url[-1] == '/':
             self.base_url = self.base_url[:-1]
 
         self.base_url += "/" + dsid[:3] + '/' + dsid[3:]
-        self.buffer_size = buffer_size if buffer_size else 65536
+        # make sure default is used when None was passed, too.
+        self.buffer_size = buffer_size if buffer_size else DEFAULT_BUFFER_SIZE
 
     def checkpresent(self, key_path):
         # Note, that we need the path with hash dirs, since we don't have access

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -752,8 +752,10 @@ class RIARemote(SpecialRemote):
 
         # buffer size for reading files over HTTP and SSH
         self.buffer_size = _get_gitcfg(gitdir,
-                                       "annex.ora-remote.{}.buffer-size"
+                                       "remote.{}.ora-buffer-size"
                                        "".format(name))
+        if self.buffer_size:
+            self.buffer_size = int(self.buffer_size)
 
     def _verify_config(self, gitdir, fail_noid=True):
         # try loading all needed info from (git) config

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -893,8 +893,12 @@ class RIARemote(SpecialRemote):
                 # fall back on the UUID for the annex remote
                 self.archive_id = self.annex.getuuid()
 
-        if not self.ria_store_url.startswith("ria+http"):
+        if not isinstance(self.io, HTTPRemoteIO):
             self.get_store()
+
+        # else:
+        # TODO: consistency with SSH and FILE behavior? In those cases we make
+        #       sure the store exists from within initremote
 
         self.annex.setconfig('archive-id', self.archive_id)
         # make sure, we store the potentially rewritten URL

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -737,7 +737,7 @@ class RIARemote(SpecialRemote):
             store_base_path = _get_gitcfg(
                 gitdir, 'annex.ora-remote.{}.base-path'.format(name))
             self.store_base_path = store_base_path.strip() \
-                if store_base_path else store_base_path
+                if store_base_path else None
         # Whether or not to force writing to the remote. Currently used to overrule write protection due to layout
         # version mismatch.
         self.force_write = _get_gitcfg(

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -1,0 +1,134 @@
+import shutil
+from datalad.api import (
+    Dataset,
+)
+from datalad.utils import Path
+from datalad.tests.utils import (
+    assert_equal,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    assert_repo_status,
+    assert_result_count,
+    known_failure_windows,
+    serve_path_via_http,
+    SkipTest,
+    with_tempfile
+)
+from datalad.distributed.ora_remote import (
+    LocalIO,
+)
+from datalad.support.exceptions import (
+    CommandError,
+)
+from datalad.distributed.tests.ria_utils import (
+    populate_dataset,
+    common_init_opts
+)
+from datalad.customremotes.ria_utils import (
+    create_store,
+    create_ds_in_store,
+)
+
+
+# NOTE: All we want and can test here is the HTTP functionality of the ORA
+#       remote. As of now, this is get and checkpresent only, sending one
+#       request each. The used URI for those requests is based on store layout
+#       version 1 and dataset layout version 2. Serving archives and/or
+#       different layouts via those requests is up to the server side, which we
+#       don't test here.
+
+@known_failure_windows  # see gh-4469
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+@with_tempfile
+def test_initremote(store_path, store_url, ds_path):
+    ds = Dataset(ds_path).create()
+    store_path = Path(store_path)
+    url = "ria+" + store_url
+    init_opts = common_init_opts + ['url={}'.format(url)]
+
+    # fails on non-RIA URL
+    assert_raises(CommandError, ds.repo.init_remote, 'ora-remote',
+                  options=common_init_opts + ['url={}'
+                                              ''.format(store_path.as_uri())]
+                  )
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ora-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+
+    ds.repo.init_remote('ora-remote', options=init_opts)
+    assert_in('ora-remote',
+              [cfg['name']
+               for uuid, cfg in ds.repo.get_special_remotes().items()]
+              )
+    assert_repo_status(ds.path)
+    # git-annex:remote.log should have:
+    #   - url
+    #   - common_init_opts
+    #   - archive_id (which equals ds id)
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'])
+    assert_in("url={}".format(url), remote_log)
+    [assert_in(c, remote_log) for c in common_init_opts]
+    assert_in("archive-id={}".format(ds.id), remote_log)
+
+
+@known_failure_windows  # see gh-4469
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+@with_tempfile
+def test_read_access(store_path, store_url, ds_path):
+
+    ds = Dataset(ds_path).create()
+    populate_dataset(ds)
+    ds.save()
+
+    if ds.repo.is_managed_branch():
+        # TODO: on crippled FS copytree to populate store doesn't seem to work.
+        #       Or may be it's just the serving via HTTP that doesn't work.
+        #       Either way, after copytree and fsck, whereis doesn't report
+        #       the store as an available source.
+        raise SkipTest("Skip on crippled FS")
+
+    files = [Path('one.txt'), Path('subdir') / 'two']
+    store_path = Path(store_path)
+    url = "ria+" + store_url
+    init_opts = common_init_opts + ['url={}'.format(url)]
+
+    io = LocalIO()
+    create_store(io, store_path, '1')
+    create_ds_in_store(io, store_path, ds.id, '2', '1')
+    ds.repo.init_remote('ora-remote', options=init_opts)
+    ds.repo.fsck(remote='ora-remote', fast=True)
+    store_uuid = ds.siblings(name='ora-remote',
+                             return_type='item-or-list')['annex-uuid']
+    here_uuid = ds.siblings(name='here',
+                            return_type='item-or-list')['annex-uuid']
+
+    # nothing in store yet:
+    for f in files:
+        known_sources = ds.repo.whereis(str(f))
+        assert_in(here_uuid, known_sources)
+        assert_not_in(store_uuid, known_sources)
+
+    annex_obj_target = str(store_path / ds.id[:3] / ds.id[3:]
+                           / 'annex' / 'objects')
+    shutil.rmtree(annex_obj_target)
+    shutil.copytree(src=str(ds.repo.dot_git / 'annex' / 'objects'),
+                    dst=annex_obj_target)
+
+    ds.repo.fsck(remote='ora-remote', fast=True)
+    # all in store now:
+    for f in files:
+        known_sources = ds.repo.whereis(str(f))
+        assert_in(here_uuid, known_sources)
+        assert_in(store_uuid, known_sources)
+
+    ds.drop('.')
+    res = ds.get('.')
+    assert_equal(len(res), 2)
+    assert_result_count(res, 2, status='ok', type='file', action='get',
+                        message="from ora-remote...")
+


### PR DESCRIPTION
Implements HTTP support for the ORA special remote (read-only for now).

Closes #4410

In opposition to local and SSH, everything is supposed to happen server-side. ORA sends a request to e location of a key. This location is based on resolved RIA URL to the dataset and assumes dirhashmixed with its `annex/objects` tree. Remapping based on a different layout and archive access needs to be done by the server (That is what PR #4572 is for).
