### PR TITLE
ENH(UX): silence datalad's metadata while querying for possible metadata for duecredit

### DIFF
--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -7,6 +7,7 @@ Support functionality for using DueCredit
 # Note Text was added/exposed only since DueCredit 0.6.5
 from .due import due, Doi, Url, Text
 from ..utils import never_fail
+from ..dochelpers import exc_str
 
 import logging
 lgr = logging.getLogger('datalad.duecredit')
@@ -54,9 +55,9 @@ def duecredit_dataset(dataset):
             return_type='item-or-list'  # Expecting a single record
         )
     except Exception as exc:
-        lgr.warning(
-            "Failed to obtain metadata for %s. Will not provide duecredit entry",
-            dataset
+        lgr.debug(
+            "Failed to obtain metadata for %s. Will not provide duecredit entry: %s",
+            dataset, exc_str(exc)
         )
         return
 

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -6,7 +6,7 @@ Support functionality for using DueCredit
 
 # Note Text was added/exposed only since DueCredit 0.6.5
 from .due import due, Doi, Url, Text
-from ..utils import never_fail
+from ..utils import never_fail, swallow_logs
 from ..dochelpers import exc_str
 
 import logging
@@ -49,11 +49,16 @@ def duecredit_dataset(dataset):
     """
 
     try:
-        res = dataset.metadata(
-            reporton='datasets',  # Interested only in the dataset record
-            result_renderer=None,  # No need
-            return_type='item-or-list'  # Expecting a single record
-        )
+        # probably with metalad RFing we would gain better control
+        # over reporting of warnings etc, ATM the warnings are produced
+        # directly within get_ds_aggregate_db_locations down below and
+        # we have no other way but pacify all of them.
+        with swallow_logs(logging.ERROR) as cml:
+            res = dataset.metadata(
+                reporton='datasets',  # Interested only in the dataset record
+                result_renderer=None,  # No need
+                return_type='item-or-list'  # Expecting a single record
+            )
     except Exception as exc:
         lgr.debug(
             "Failed to obtain metadata for %s. Will not provide duecredit entry: %s",

--- a/datalad/support/tests/test_due_utils.py
+++ b/datalad/support/tests/test_due_utils.py
@@ -49,7 +49,7 @@ def test_duecredit_dataset(path):
     # TODO: possibly reconsider - may be our catch-all should be used there
     # as well
     with patch.object(due, 'cite') as mcite:
-        with swallow_logs(new_level=logging.WARNING) as cml:
+        with swallow_logs(new_level=logging.DEBUG) as cml:
             duecredit_dataset(dataset)  # should not crash or anything
             # since no metadata - we issue warning and return without citing
             # anything


### PR DESCRIPTION
Grave problems (exception raised) would still be logged but now at DEBUG not WARNING level if needed to debug.  The other warnings etc would be completely swallowed (FWIW - tried but decided to not over-complicate code there to try to log them after being swallowed).

Closes #4562 