### PR TITLE
ENH: ui.message: Hide non-interactive log_progress output by default

### DIFF
--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -72,11 +72,13 @@ class ConsoleLog(object):
 
     def message(self, msg, cr='\n'):
         from datalad.log import log_progress
-        log_progress(lgr.info, None, 'Clear progress bars', maint='clear')
+        log_progress(lgr.info, None, 'Clear progress bars', maint='clear',
+                     noninteractive_level=5)
         self.out.write(msg)
         if cr:
             self.out.write(cr)
-        log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh')
+        log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh',
+                     noninteractive_level=5)
 
     def error(self, error):
         self.out.write("ERROR: %s\n" % error)


### PR DESCRIPTION
b7e57dfa2 (BF: Prevent ugly interaction or result and progress
reporting, 2020-05-20) taught message() to clear progress bars before
showing its message, refreshing them after.  For non-interactive
operations (e.g., piping datalad output), that dumps a lot of these
irrelevant messages to the caller.

Hide these away by using noninteractive_level to filter them out
unless the logging level is a very noisy 5.

Closes #4570.
