### PR TITLE
RF: publish - remove code duplication for publishing data to dependencies and target repo

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -358,8 +358,15 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     if transfer_data != 'none' and isinstance(ds.repo, AnnexRepo):
         # publishing of `remote` might depend on publishing other
         # remote(s) first, so they need to receive the data first:
-        for d in publish_depends:
-            lgr.info("Transferring data to configured publication dependency: '%s'" % d)
+        for d, desc in [
+            (d, "configured publication dependency")
+            for d in publish_depends
+        ] + [
+            # no message the target remote as before
+            (remote, None)
+        ]:
+            if desc:
+                lgr.info("Transferring data to %s: '%s'", desc, d)
             # properly initialized remote annex -> publish data
             for r in _publish_data(
                     ds,
@@ -374,20 +381,6 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
                         r.get('type', None) == 'file':
                     copied_data = True
                 yield r
-        # and for the main target
-        for r in _publish_data(
-                ds,
-                remote,
-                paths,
-                annex_copy_options,
-                force,
-                transfer_data,
-                **kwargs):
-            # note if we published any data, notify to sync annex branch below
-            if r['status'] == 'ok' and r['action'] == 'publish' and \
-                    r.get('type', None) == 'file':
-                copied_data = True
-            yield r
 
     #
     # publish dataset (git push)


### PR DESCRIPTION
A very small RF, decided just to have it done while spotted.

There should be no change in behavior or log output.  Minor additional OPT is not
doing string interpolation for lgr.info

