### PR TITLE
Finishing touches to `push` for 0.13

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -16,7 +16,6 @@ import logging
 from tempfile import TemporaryFile
 
 from datalad.cmd import GitWitlessRunner
-from datalad.config import anything2bool
 from datalad.interface.base import (
     Interface,
     build_doc,
@@ -774,8 +773,7 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
         cmd.extend(['--jobs', str(jobs)])
 
     if force not in ('pushall', 'datatransfer') and ds_repo.config.obtain(
-            'datalad.push.copy-auto-if-wanted', default=False,
-            valtype=anything2bool):
+            'datalad.push.copy-auto-if-wanted'):
         if ds_repo.get_preferred_content('wanted', target):
             lgr.debug("Invoking copy --auto")
             cmd.append('--auto')

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -64,9 +64,9 @@ lgr = logging.getLogger('datalad.core.distributed.push')
 class Push(Interface):
     """Push a dataset to a known :term:`sibling`.
 
-    This makes the last saved state of a dataset available to a sibling
-    or special remote data store of a dataset. Any target sibling must already
-    exist and be known to the dataset.
+    This makes a saved state of a dataset available to a sibling or special
+    remote data store of a dataset. Any target sibling must already exist and
+    be known to the dataset.
 
     Optionally, it is possible to limit a push to change sets relative
     to a particular point in the version history of a dataset (e.g. a release

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -125,9 +125,9 @@ class Push(Interface):
             making: use --force with git-push ('gitpush'); do not use --fast
             with git-annex copy ('datatransfer'); do not attempt to copy
             annex'ed file content ('no-datatransfer'); combine force modes
-            'gitpush' and 'datatransfer' ('all').""",
+            'gitpush' and 'datatransfer' ('pushall').""",
             constraints=EnsureChoice(
-                'all', 'gitpush', 'no-datatransfer', 'datatransfer', None)),
+                'pushall', 'gitpush', 'no-datatransfer', 'datatransfer', None)),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         jobs=jobs_opt,
@@ -650,7 +650,7 @@ def _push_refspecs(repo, target, refspecs, force, res_kwargs):
         push_res.extend(repo.push(
             remote=target,
             refspec=refspec,
-            git_options=['--force'] if force in ('all', 'gitpush') else None,
+            git_options=['--force'] if force in ('pushall', 'gitpush') else None,
         ))
     # TODO maybe compress into a single message whenever everything is
     # OK?
@@ -709,7 +709,7 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
             res_kwargs,
             action='copy',
             status='impossible'
-            if force in ('all', 'datatransfer')
+            if force in ('pushall', 'datatransfer')
             else 'notneeded',
             message=(
                 "Target '%s' does not appear to be an annex remote",
@@ -743,7 +743,7 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
         c
         for c in content.values()
         # by force
-        if ((force in ('all', 'datatransfer') or
+        if ((force in ('pushall', 'datatransfer') or
              # or by modification report
              c.get('state', None) not in ('clean', 'deleted'))
             # only consider annex'ed files
@@ -767,11 +767,11 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
     if jobs:
         cmd.extend(['--jobs', str(jobs)])
 
-    if not to_transfer and force not in ('all', 'datatransfer'):
+    if not to_transfer and force not in ('pushall', 'datatransfer'):
         lgr.debug("Invoking copy --auto")
         cmd.append('--auto')
 
-    if force not in ('all', 'datatransfer'):
+    if force not in ('pushall', 'datatransfer'):
         # if we force, we do not trust local knowledge and do the checks
         cmd.append('--fast')
 

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -767,9 +767,11 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
     if jobs:
         cmd.extend(['--jobs', str(jobs)])
 
-    if not to_transfer and force not in ('pushall', 'datatransfer'):
-        lgr.debug("Invoking copy --auto")
-        cmd.append('--auto')
+    if force not in ('pushall', 'datatransfer') and ds_repo.config.get(
+            'datalad.push.copy-auto-if-wanted', False):
+        if ds_repo.get_preferred_content('wanted', target):
+            lgr.debug("Invoking copy --auto")
+            cmd.append('--auto')
 
     if force not in ('pushall', 'datatransfer'):
         # if we force, we do not trust local knowledge and do the checks

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -69,15 +69,17 @@ class Push(Interface):
     remote data store of a dataset. Any target sibling must already exist and
     be known to the dataset.
 
+    || REFLOW >>
     By default, all files tracked in the last saved state (of the current
     branch) will be copied to the target location. Optionally, it is possible
     to limit a push to changes relative to a particular point in the version
     history of a dataset (e.g. a release tag) using the
     [CMD: --since CMD][PY: since PY] option in conjunction with the
-    specification of a reference dataset. Changes can also be evaluated
-    recursively, i.e. only those subdatasets are pushed where a change was
+    specification of a reference dataset. In recursive mode subdatasets will also be
+    evaluated, and only those subdatasets are pushed where a change was
     recorded that is reflected in the current state of the top-level reference
     dataset.
+    << REFLOW ||
 
     Which files are copied can be further tailored via the
     'datalad.push.copy-auto-if-wanted' configuration. If set, push will test

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -78,6 +78,13 @@ class Push(Interface):
     recorded that is reflected in the current state of the top-level reference
     dataset.
 
+    Which files are copied can be further tailored via the
+    'datalad.push.copy-auto-if-wanted' configuration. If set, push will test
+    whether a git-annex "wanted" configuration is present for the target
+    location, and in this case instruct git-annex to obey this configuration
+    when deciding which files to consider for transfer (i.e. use the --auto
+    flag with git-annex copy).
+
     .. note::
       Power-user info: This command uses :command:`git push`, and :command:`git
       annex copy` to push a dataset. Publication targets are either configured

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -68,25 +68,21 @@ class Push(Interface):
     remote data store of a dataset. Any target sibling must already exist and
     be known to the dataset.
 
-    Optionally, it is possible to limit a push to change sets relative
-    to a particular point in the version history of a dataset (e.g. a release
-    tag). By default, the state of the local dataset is evaluated against the
-    last known state of the target sibling. An actual push is only attempted
-    if there was a change compared to the reference state, in order to speed up
-    processing of large collections of datasets. Evaluation with respect to
-    a particular "historic" state is only supported in conjunction with a
-    specified reference dataset. Change sets are also evaluated recursively, i.e.
-    only those subdatasets are pushed where a change was recorded that is
-    reflected in the current state of the top-level reference dataset.
-    See "since" option for more information.
-
-    Only a push of saved changes is supported.
+    By default, all files tracked in the last saved state (of the current
+    branch) will be copied to the target location. Optionally, it is possible
+    to limit a push to changes relative to a particular point in the version
+    history of a dataset (e.g. a release tag) using the
+    [CMD: --since CMD][PY: since PY] option in conjunction with the
+    specification of a reference dataset. Changes can also be evaluated
+    recursively, i.e. only those subdatasets are pushed where a change was
+    recorded that is reflected in the current state of the top-level reference
+    dataset.
 
     .. note::
-      Power-user info: This command uses :command:`git push`, and :command:`git annex copy`
-      to push a dataset. Publication targets are either configured remote
-      Git repositories, or git-annex special remotes (if they support data
-      upload).
+      Power-user info: This command uses :command:`git push`, and :command:`git
+      annex copy` to push a dataset. Publication targets are either configured
+      remote Git repositories, or git-annex special remotes (if they support
+      data upload).
     """
 
     # TODO add examples

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -16,6 +16,7 @@ import logging
 from tempfile import TemporaryFile
 
 from datalad.cmd import GitWitlessRunner
+from datalad.config import anything2bool
 from datalad.interface.base import (
     Interface,
     build_doc,
@@ -770,8 +771,9 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
     if jobs:
         cmd.extend(['--jobs', str(jobs)])
 
-    if force not in ('pushall', 'datatransfer') and ds_repo.config.get(
-            'datalad.push.copy-auto-if-wanted', False):
+    if force not in ('pushall', 'datatransfer') and ds_repo.config.obtain(
+            'datalad.push.copy-auto-if-wanted', default=False,
+            valtype=anything2bool):
         if ds_repo.get_preferred_content('wanted', target):
             lgr.debug("Invoking copy --auto")
             cmd.append('--auto')

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -112,6 +112,13 @@ definitions = {
             'text': 'Description for a Personal access token to generate.'}),
         'default': 'DataLad',
     },
+    'datalad.push.copy-auto-if-wanted': {
+        'ui': ('question', {
+            'title': "Use `git-annex copy --auto` with preferred content configured",
+            'text': 'If this flag is set, DataLad looks for preferred content configuration for a push target and instructs git-annex to use auto-mode for copying, if such configuration is detected.'}),
+        'type': EnsureBool(),
+        'default': False,
+    },
     'datalad.tests.nonetwork': {
         'ui': ('yesno', {
                'title': 'Skips network tests completely if this flag is set Examples include test for s3, git_repositories, openfmri etc'}),


### PR DESCRIPTION
Rename push(force='all') -> push(force='pushall')  to better forward-compatibility.

This also adds the implementation of the conclusion of a discussion on this topic. Follow-up to gh-4541.

Add --auto to `git annex copy` if `datalad.push.copy-auto-if-wanted` is set, and `--force datatransfer` isn't given.

Fixes gh-4550: --auto is never added, unless requested via config

Fixes gh-4551 and fixes gh-4483: now obeys distribution-restrictions in a "default"  `datalad push --to target` if configuration says so (not the default (yet?))

TODO:

- [x] Is this secure enough (see gh-4357). A dataset could set this flag in its own config (.datalad/config). Are we confident that it would never override a user config (add test)?
- [x] update docstring to say that be default "all content" will be pushed, and explain under which conditions exactly (tracking remote, etc.)

<details>
<summary>Script to play with the changes</summary>

```sh

#!/bin/bash

export PS4='> '
set -eu
cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"
set -x

datalad create src

(
cd src
# Produce and annotate some data
echo -e '\x00' > data.0
echo -e '\x01' > secure.1
echo -e '\x02' > secure.2
datalad save -m "added some files"

# Dropping a file to mimic a case of simply not having it locally (thus not to be "pushed")
git annex drop --force secure.2

# Annotate sensitive content, actual value "verysecure" does not matter in this example
git annex metadata --set distribution-restrictions=verysecure secure.1 secure.2

datalad save -m "added a file"
datalad create-sibling --annex-wanted "not metadata=distribution-restrictions=*" -r -s target ../target
#datalad -c datalad.push.copy-auto-if-wanted=true push --to target
datalad push --to target

)

(
cd target
git annex list
)
```

</details>
