### PR TITLE
Adding cmdline support submission with helpme

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,5 +33,6 @@ jobs:
       env:
         # fake environment to be able to reuse script for travis
         TRAVIS_PULL_REQUEST: true
+        DATALAD_HELPME_DISABLE: yes
       run: |
         tools/ci/benchmark-travis-pr.sh

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -44,6 +44,7 @@ jobs:
       env:
         # forces all test repos/paths into the VFAT FS
         TMPDIR: /crippledfs
+        DATALAD_HELPME_DISABLE: yes
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -51,6 +51,8 @@ jobs:
       run: |
         datalad wtf
     - name: ${{ matrix.extension }} tests
+      env:
+        DATALAD_HELPME_DISABLE: yes
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -52,6 +52,8 @@ jobs:
         datalad wtf
         dir
     - name: ${{ matrix.module }} tests
+      env:
+        DATALAD_HELPME_DISABLE: yes
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=datalad
     - NOSE_OPTS=
-    # Disabble helpme interactive interface
+    # Disable helpme interactive interface
     - DATALAD_HELPME_DISABLE=yes
     # Note, that there's "turtle" as well, which is always excluded from
     # running on Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=datalad
     - NOSE_OPTS=
+    # Disabble helpme interactive interface
+    - DATALAD_HELPME_DISABLE=yes
     # Note, that there's "turtle" as well, which is always excluded from
     # running on Travis.
     - NOSE_SELECTION="integration or usecase or slow"

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -255,6 +255,7 @@ def get_repo_instance(path=curdir, class_=None):
     else:
         raise RuntimeError("No datalad repository found in %s" % abspath_)
 
+
 from appdirs import AppDirs
 from os.path import join as opj
 

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -255,7 +255,6 @@ def get_repo_instance(path=curdir, class_=None):
     else:
         raise RuntimeError("No datalad repository found in %s" % abspath_)
 
-
 from appdirs import AppDirs
 from os.path import join as opj
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -560,15 +560,18 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
-                identifier = generate_datalad_identifier(
-                    stack = traceback.extract_stack(), exc=exc,
-                )
-                submit_helpme(
-                    title = str(exc),
-                    tb = traceback.format_exc(),
-                    identifier = identifier,
-                    detail = " ".join(map(quote_cmdlinearg, sys.argv)),
-                )
+
+                # If the user requests to disable, or in testing environment don't submit
+                if os.environ.get("DATALAD_HELPME_DISABLE") is None:
+                    identifier = generate_datalad_identifier(
+                        stack = traceback.extract_stack(), exc=exc,
+                    )
+                    submit_helpme(
+                        title = str(exc),
+                        tb = traceback.format_exc(),
+                        identifier = identifier,
+                        detail = " ".join(map(quote_cmdlinearg, sys.argv)),
+                    )
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
                 sys.exit(1)
     else:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -30,6 +30,7 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
+from .support import submit_helpme
 from ..utils import (
     assure_unicode,
     chpwd,
@@ -557,6 +558,8 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
+                title = "DataLad Cmd Error: %s" % exc.__class__.__name__
+                submit_helpme(title = title, detail = exc_str(exc))
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
                 sys.exit(1)
     else:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -560,9 +560,8 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
-                title = "DataLad Cmd Error: %s" % exc.__class__.__name__
                 submit_helpme(
-                    title=title,
+                    title="[helpme] %s" % str(exc),
                     traceback=traceback.format_exc(),
                     detail=" ".join(map(quote_cmdlinearg, sys.argv))
                 )

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -502,9 +502,6 @@ def main(args=None):
     # enable overrides
     datalad.cfg.reload(force=True)
 
-    import IPython
-    IPython.embed()
-
     if cmdlineargs.change_path is not None:
         from .common_args import change_path as change_path_opt
         for path in cmdlineargs.change_path:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -20,6 +20,7 @@ import argparse
 from collections import defaultdict
 import sys
 import textwrap
+import traceback
 import os
 
 
@@ -559,7 +560,11 @@ def main(args=None):
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
                 title = "DataLad Cmd Error: %s" % exc.__class__.__name__
-                submit_helpme(title = title, detail = exc_str(exc))
+                submit_helpme(
+                    title = title, 
+                    traceback = traceback.format_exc(),
+                    detail = ' '.join(sys.argv)
+                )
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
                 sys.exit(1)
     else:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -31,7 +31,7 @@ from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
-from .support import submit_helpme
+from .support import submit_helpme, generate_datalad_identifier
 from ..utils import (
     assure_unicode,
     chpwd,
@@ -502,6 +502,9 @@ def main(args=None):
     # enable overrides
     datalad.cfg.reload(force=True)
 
+    import IPython
+    IPython.embed()
+
     if cmdlineargs.change_path is not None:
         from .common_args import change_path as change_path_opt
         for path in cmdlineargs.change_path:
@@ -560,10 +563,14 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
+                identifier = generate_datalad_identifier(
+                    stack = traceback.extract_stack(), exc=exc,
+                )
                 submit_helpme(
-                    title="[helpme] %s" % str(exc),
-                    traceback=traceback.format_exc(),
-                    detail=" ".join(map(quote_cmdlinearg, sys.argv))
+                    title = str(exc),
+                    tb = traceback.format_exc(),
+                    identifier = identifier,
+                    detail = " ".join(map(quote_cmdlinearg, sys.argv)),
                 )
                 lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
                 sys.exit(1)

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -21,10 +21,6 @@ from logging import getLogger
 
 lgr = getLogger("datalad.cmdline")
 
-# Disable helpme additional verbosity
-os.environ["MESSAGELEVEL"] = "QUIET"
-os.putenv("MESSAGELEVEL", "QUIET")
-
 # Set defaults for repository and title for issue
 default_repo = "datalad/datalad-helpme"
 default_title = "Test issue opened manually by helpme"
@@ -36,12 +32,18 @@ def submit_helpme(title=None, traceback="", detail="", identifier=None, repo=Non
        we skip this step. The basic submission includes the entire grab from
        wtf (capturing system and library information) and an optional message.
 
-       Arguments:
-        - title (str)     : the title for the GitHub issue
-        - detail (str)    : any extra string content to include with the message.
-        - traceback (str) : the full traceback
-        - identifier (str): the identifier string (will use traceback if not defined)
-        - repo (str)      : GitHub repo (<username>/<repo>) to submit to.
+       Parameters
+       ----------
+       title : str
+         the title for the GitHub issue
+       detail : str
+         any extra string content to include with the message.
+       traceback : str
+         the full traceback
+       identifier : str 
+         the identifier string (will use traceback if not defined)
+       repo : str
+         GitHub repo (<username>/<repo>) to submit to.
     """
     title = title or default_title
     repo = repo or default_repo
@@ -67,6 +69,10 @@ def submit_helpme(title=None, traceback="", detail="", identifier=None, repo=Non
         "dependencies",
         "dataset",
     ]
+
+    # Disable helpme additional verbosity
+    os.environ["HELPME_MESSAGELEVEL"] = "QUIET"
+    os.putenv("HELPME_MESSAGELEVEL", "QUIET")
 
     try:
         from helpme.main import get_helper

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -1,0 +1,85 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+"""
+
+__docformat__ = "restructuredtext"
+
+from datalad.utils import swallow_outputs
+from datalad.api import wtf
+import sys
+import os
+
+from logging import getLogger
+
+lgr = getLogger("datalad.cmdline")
+
+os.environ["MESSAGELEVEL"] = "QUIET"
+os.putenv("MESSAGELEVEL", "QUIET")
+
+repo = "datalad/datalad-helpme"
+default_title = "Test issue opened manually by helpme"
+
+
+def submit_helpme(detail=None, title=None):
+    """Submit a request to the datalad-helpme repository at
+       https://github.com/datalad/datalad-helpme. If helpme isn't installed,
+       we skip this step. The basic submission includes the entire grab from
+       wtf (capturing system and library information) and an optional message.
+    """
+    title = title or default_title
+
+    # If the user requests to disable, don't submit
+    if os.environ.get("DATALAD_HELPME_DISABLE") is not None:
+        return
+
+    # Default sections to include for a reasonably sized message
+    sections = [
+        "datalad",
+        "python",
+        "system",
+        "environment",
+        "configuration",
+        "location",
+        "extensions",
+        "metadata_extractors",
+        "dependencies",
+        "dataset",
+    ]
+
+    try:
+        from helpme.main import get_helper
+
+        helper = get_helper(name="github")
+
+        with swallow_outputs() as cmo:
+            wtf(decor="html_details", sections=sections)
+            body = """
+**What were you trying to do?**
+
+**Is there anything else you want to tell us**
+
+<!-- Have you had any success using DataLad before? (to assess your expertise/prior luck.  We would welcome your testimonial additions to https://github.com/datalad/datalad/wiki/Testimonials as well)-->
+
+----------------------------------------------------------------
+### Metadata
+**Error Message :name_badge:**
+%s
+
+**WTF Output** :open_file_folder:
+%s""" % (
+                detail or "",
+                cmo.out,
+            )
+
+        # Submit the issue
+        issue = helper.run_headless(repo=repo, body=body, title=title)
+
+    except:
+        pass

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -35,8 +35,12 @@ def submit_helpme(detail=None, title=None):
     """
     title = title or default_title
 
-    # If the user requests to disable, don't submit
-    if os.environ.get("DATALAD_HELPME_DISABLE") is not None:
+    # If the user requests to disable, or in testing environment don't submit
+    if (
+        os.environ.get("DATALAD_HELPME_DISABLE") is not None
+        or os.environ.get("TESTS_TO_PERFORM") is not None
+        or os.environ.get("DATALAD_TESTS_SSH") is not None
+    ):
         return
 
     # Default sections to include for a reasonably sized message

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -13,8 +13,9 @@ __docformat__ = "restructuredtext"
 
 from datalad.utils import swallow_outputs
 from datalad.api import wtf
-import sys
+
 import os
+import sys
 
 from logging import getLogger
 
@@ -27,13 +28,23 @@ repo = "datalad/datalad-helpme"
 default_title = "Test issue opened manually by helpme"
 
 
-def submit_helpme(detail=None, title=None):
+def submit_helpme(title=None, traceback="", detail="", identifier=None):
     """Submit a request to the datalad-helpme repository at
        https://github.com/datalad/datalad-helpme. If helpme isn't installed,
        we skip this step. The basic submission includes the entire grab from
        wtf (capturing system and library information) and an optional message.
+
+       Arguments:
+        - title (str)     : the title for the GitHub issue
+        - detail (str)    : any extra string content to include with the message.
+        - traceback (str) : the full traceback
+        - identifier (str): the identifier string (will use traceback if not defined)
     """
     title = title or default_title
+
+    # If no identifier defined, use traceback
+    if identifier is None:
+        identifier = traceback
 
     # If the user requests to disable, or in testing environment don't submit
     if os.environ.get("DATALAD_HELPME_DISABLE") is not None:
@@ -69,17 +80,21 @@ def submit_helpme(detail=None, title=None):
 
 ----------------------------------------------------------------
 ### Metadata
-**Error Message :name_badge:**
+**Command :star:**
+```bash
 %s
-
+```
+**Error Message :name_badge:**
+```python
+%s
+```
 **WTF Output** :open_file_folder:
-%s""" % (
-                detail or "",
-                cmo.out,
-            )
+%s""" % (detail, traceback, cmo.out)
 
         # Submit the issue
-        issue = helper.run_headless(repo=repo, body=body, title=title)
+        issue = helper.run_headless(
+            repo=repo, body=body, title=title, identifier=identifier
+        )
 
     except:
         pass

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -111,10 +111,6 @@ def submit_helpme(title=None, tb="", detail="", identifier=None, repo=None):
         identifier = tb
         generate_md5 = True
 
-    # If the user requests to disable, or in testing environment don't submit
-    if os.environ.get("DATALAD_HELPME_DISABLE") is not None:
-        return
-
     # Default sections to include for a reasonably sized message
     sections = [
         "datalad",

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -21,14 +21,16 @@ from logging import getLogger
 
 lgr = getLogger("datalad.cmdline")
 
+# Disable helpme additional verbosity
 os.environ["MESSAGELEVEL"] = "QUIET"
 os.putenv("MESSAGELEVEL", "QUIET")
 
-repo = "datalad/datalad-helpme"
+# Set defaults for repository and title for issue
+default_repo = "datalad/datalad-helpme"
 default_title = "Test issue opened manually by helpme"
 
 
-def submit_helpme(title=None, traceback="", detail="", identifier=None):
+def submit_helpme(title=None, traceback="", detail="", identifier=None, repo=None):
     """Submit a request to the datalad-helpme repository at
        https://github.com/datalad/datalad-helpme. If helpme isn't installed,
        we skip this step. The basic submission includes the entire grab from
@@ -39,8 +41,10 @@ def submit_helpme(title=None, traceback="", detail="", identifier=None):
         - detail (str)    : any extra string content to include with the message.
         - traceback (str) : the full traceback
         - identifier (str): the identifier string (will use traceback if not defined)
+        - repo (str)      : GitHub repo (<username>/<repo>) to submit to.
     """
     title = title or default_title
+    repo = repo or default_repo
 
     # If no identifier defined, use traceback
     if identifier is None:
@@ -96,5 +100,6 @@ def submit_helpme(title=None, traceback="", detail="", identifier=None):
             repo=repo, body=body, title=title, identifier=identifier
         )
 
-    except:
+    except ImportError:
+        lgr.debug("helpme is not installed to report issues: pip install helpme[github]")
         pass

--- a/datalad/cmdline/support.py
+++ b/datalad/cmdline/support.py
@@ -36,11 +36,7 @@ def submit_helpme(detail=None, title=None):
     title = title or default_title
 
     # If the user requests to disable, or in testing environment don't submit
-    if (
-        os.environ.get("DATALAD_HELPME_DISABLE") is not None
-        or os.environ.get("TESTS_TO_PERFORM") is not None
-        or os.environ.get("DATALAD_TESTS_SSH") is not None
-    ):
+    if os.environ.get("DATALAD_HELPME_DISABLE") is not None:
         return
 
     # Default sections to include for a reasonably sized message

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Concepts and technologies
    metadata
    customization
    designpatterns
+   reporting
    glossary
 
 Commands and API

--- a/docs/source/reporting.rst
+++ b/docs/source/reporting.rst
@@ -1,0 +1,68 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_reporting:
+
+*********
+Reporting
+*********
+
+When you trigger an error, we want to make it easy to ask for help. By adding
+an integration, helpme_, DataLad can automatically send a traceback of your error
+to datalad_helpme_ where the development team can help you out.
+
+Setup
+=====
+
+To use helpme, you should have the full install of Datalad, or install helpme
+separately:
+
+.. code-block:: console
+
+    $ pip install helpme[github]
+
+
+To submit to GitHub, HelpMe only requires requests, which is already required by
+Datalad, so the install above will not add any additional dependencies other
+than the helpme library itself. If you don't choose to
+
+
+Usage
+=====
+
+When you run a Datalad command that triggers an error that isn't well understood
+(meaning that we go through many except statements and don't catch a known error)
+it will hit the last statement and run a function to run helpme. HelpMe will
+first verify with you environment variables to share (a basic set is shared):
+
+.. code-block:: console
+
+    Environment  USER|TERM|SHELL|PATH|LD_LIBRARY_PATH|PWD|JAVA_HOME|LANG|HOME|DISPLAY
+    Is this list ok to share?
+    Please enter your choice [Y/N/y/n] : y
+    
+
+And then the browser will open to the issue repository, where you can write more content
+into the issue. Using the standard template, useful information about your system 
+and libraries is shared so you don't need to do it. You can look at a sample_issue_
+for an example of what is shared.
+
+If you need a completely headless and non-interactive interaction, then you can
+simply export a ``HELPME_GITHUB_TOKEN`` to the environment and it will
+be discovered, and use the GitHub API to open the same issue. See the helpme_
+documentation for more details.
+
+Disable
+=======
+
+To disable submitting helpme issues, simply export this variable to the environment,
+set as anything:
+
+.. code-block:: console
+
+    export DATALAD_HELPME_DISABLE=yes
+
+
+.. _datalad_helpme: https://github.com/datalad/datalad-helpme
+.. _helpme: https://vsoch.github.io/helpme/helper-github#headless
+.. _sample_issue: https://github.com/datalad/datalad-helpme/issues/4

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,9 @@ requires = {
         'PyGithub',          # nice to have
     ],
     'misc': [
-        'helpme[github]',    # support for helpme error submission
-        'pyperclip',         # clipboard manipulations
-        'python-dateutil',   # add support for more date formats to check_dates
+        'helpme[github]>=0.0.41',    # support for helpme error submission
+        'pyperclip',                 # clipboard manipulations
+        'python-dateutil',           # add support for more date formats to check_dates
     ],
     'tests': [
         'BeautifulSoup4',  # VERY weak requirement, still used in one of the tests

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ requires = {
         'PyGithub',          # nice to have
     ],
     'misc': [
-        'helpme[github]>=0.0.42',    # support for helpme error submission
+        'helpme[github]>=0.0.43',    # support for helpme error submission
         'pyperclip',                 # clipboard manipulations
         'python-dateutil',           # add support for more date formats to check_dates
     ],

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ requires = {
         'PyGithub',          # nice to have
     ],
     'misc': [
+        'helpme[github]',    # support for helpme error submission
         'pyperclip',         # clipboard manipulations
         'python-dateutil',   # add support for more date formats to check_dates
     ],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ requires = {
         'PyGithub',          # nice to have
     ],
     'misc': [
-        'helpme[github]>=0.0.41',    # support for helpme error submission
+        'helpme[github]>=0.0.42',    # support for helpme error submission
         'pyperclip',                 # clipboard manipulations
         'python-dateutil',           # add support for more date formats to check_dates
     ],


### PR DESCRIPTION
This pull request will address #3649 and #3942 , specifically adding the helpme client (used with GitHub) to support handling the "other errors not known" at the end of the except statements in the datalad/cmdline/main.py.  I developed this interactively and used a different error that I could trigger with:

```bash
datalad --cmd search
```

I wasn't sure what kind of real use case would lead to the last error, so I was only able to get there by commenting out the other exceptions. It would be good to have a few examples to trigger the error so I can test the final thing **and** add an example to the user docs. Interactively, the example issue is here https://github.com/datalad/datalad-helpme/issues/4. 

## Fixes
 - #3649 
 - #3942

## Changes
Changes include:

 - a reporting.rst documentation page to describe helpme and how it works with datalad
 - a submit_helpme function defined in datalad/cmdline/support.py, which doesn't trigger an error if helpme isn't installed (just skips over)
 - adding helpme to install under misc (note that the github and base of helpme only requires requests, which is already required by datalad)
 - an envar `DATALAD_HELPME_DISABLE` that the user can set to disable it.
 - instructions for exporting `HELPME_GITHUB_TOKEN` if they don't want the interactive submission.

Signed-off-by: vsoch <vsochat@stanford.edu