### PR TITLE
ENH: join_cmdline to complement split_cmdline which uses quote_cmdlinearg

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -49,20 +49,23 @@ from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
-from datalad.utils import assure_bytes
-from datalad.utils import assure_unicode
-from datalad.utils import chpwd
-from datalad.utils import get_dataset_root
-from datalad.utils import getpwd
-from datalad.utils import SequenceFormatter
-from datalad.utils import quote_cmdlinearg
+from datalad.utils import (
+    assure_bytes,
+    assure_unicode,
+    chpwd,
+    get_dataset_root,
+    getpwd,
+    join_cmdline,
+    quote_cmdlinearg,
+    SequenceFormatter,
+)
 
 lgr = logging.getLogger('datalad.core.local.run')
 
 
 def _format_cmd_shorty(cmd):
     """Get short string representation from a cmd argument list"""
-    cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
+    cmd_shorty = (join_cmdline(cmd) if isinstance(cmd, list) else cmd)
     cmd_shorty = u'{}{}'.format(
         cmd_shorty[:40],
         '...' if len(cmd_shorty) > 40 else '')
@@ -413,7 +416,7 @@ def normalize_command(command):
                 # Strip disambiguation marker. Note: "running from Python API"
                 # FIXME from below applies to this too.
                 command = command[1:]
-            command = " ".join(quote_cmdlinearg(c) for c in command)
+            command = join_cmdline(command)
     else:
         command = assure_unicode(command)
     return command

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -35,6 +35,7 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetFound
 from datalad.utils import (
+    join_cmdline,
     quote_cmdlinearg,
     split_cmdline,
 )
@@ -438,7 +439,7 @@ class RunProcedure(Interface):
         cmd = ex['template'].format(
             script=quote_cmdlinearg(procedure_file),
             ds=quote_cmdlinearg(ds.path) if ds else '',
-            args=(u' '.join(quote_cmdlinearg(a) for a in args) if args else ''))
+            args=join_cmdline(args) if args else '')
         lgr.info(u"Running procedure %s", name)
         lgr.debug(u'Full procedure command: %r', cmd)
         for r in Run.__call__(

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -47,12 +47,12 @@ from datalad.utils import (
     assure_list,
     auto_repr,
     ensure_list,
+    join_cmdline,
     linux_distribution_name,
     on_windows,
     partition,
     Path,
     PurePosixPath,
-    quote_cmdlinearg,
     split_cmdline,
     unlink,
 )
@@ -2848,7 +2848,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         stdout, stderr
         """
         cmd = split_cmdline(
-            cmd_str + " " + " ".join(quote_cmdlinearg(f) for f in files)) \
+            cmd_str + " " + join_cmdline(files)) \
             if isinstance(cmd_str, str) \
             else cmd_str + files
 

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -18,6 +18,7 @@ external_versions.check(
 
 from datalad.utils import (
     Path,
+    join_cmdline,
     quote_cmdlinearg,
 )
 
@@ -76,7 +77,7 @@ def compress_files(files, archive, path=None, overwrite=True):
             )
     if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
         cmd = '7z u .tar -so -- {} | 7z u -si -- {}'.format(
-            ' '.join(quote_cmdlinearg(f) for f in files),
+            join_cmdline(files),
             quote_cmdlinearg(str(apath)),
         )
     else:

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -32,14 +32,14 @@ class CommandError(RuntimeError):
         from datalad.utils import (
             ensure_unicode,
             ensure_list,
-            quote_cmdlinearg,
+            join_cmdline,
         )
         to_str = "{}: ".format(self.__class__.__name__)
         if self.cmd:
             to_str += "'{}'".format(
                 # go for a compact, normal looking, properly quoted
                 # command rendering
-                ' '.join(quote_cmdlinearg(c) for c in ensure_list(self.cmd))
+                join_cmdline(ensure_list(self.cmd))
             )
         if self.code:
             to_str += " failed with exitcode {}".format(self.code)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -42,6 +42,7 @@ from datalad.utils import (
     auto_repr,
     better_wraps,
     CMD_MAX_ARG,
+    Path,
     create_tree,
     disable_logger,
     dlabspath,
@@ -59,6 +60,7 @@ from datalad.utils import (
     import_module_from_file,
     import_modules,
     is_explicit_path,
+    join_cmdline,
     knows_annex,
     line_profile,
     make_tempfile,
@@ -68,12 +70,12 @@ from datalad.utils import (
     not_supported_on_windows,
     on_windows,
     partition,
-    Path,
     path_is_subpath,
     path_startswith,
     rotree,
     safe_print,
     setup_exceptionhook,
+    split_cmdline,
     swallow_logs,
     swallow_outputs,
     unique,
@@ -1313,3 +1315,16 @@ def test_is_interactive(fout):
     for o in ('stderr', 'stdin', 'stdout'):
         eq_(get_interactive("import sys; sys.%s.close(); " % o), False)
 
+
+def test_splitjoin_cmdline():
+    # Do full round trip on a number of tricky samples
+    for args in (
+        ['cmd', '-o1', 'simple'],
+        ['c o', r'\m', ''],
+        ['c o', ' '],
+    ):
+        cmdline = join_cmdline(args)
+        assert isinstance(cmdline, str)
+        eq_(split_cmdline(cmdline), args)
+    # assure that there is no needless quoting
+    eq_(join_cmdline(['abc', 'def']), 'abc def')

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -1327,4 +1327,8 @@ def test_splitjoin_cmdline():
         assert isinstance(cmdline, str)
         eq_(split_cmdline(cmdline), args)
     # assure that there is no needless quoting
-    eq_(join_cmdline(['abc', 'def']), 'abc def')
+    if on_windows:
+        # in quote_cmdlinearg we always quote on Windows
+        eq_(join_cmdline(['abc', 'def']), '"abc" "def"')
+    else:
+        eq_(join_cmdline(['abc', 'def']), 'abc def')

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2441,6 +2441,12 @@ def quote_cmdlinearg(arg):
     ) if on_windows else shlex_quote(arg)
 
 
+def join_cmdline(args):
+    """Join command line args into a string using quote_cmdlinearg
+    """
+    return ' '.join(map(quote_cmdlinearg, args))
+
+
 def split_cmdline(s):
     """Perform platform-appropriate command line splitting.
 


### PR DESCRIPTION
Spotted the need while reviewing #4586 

from the 2nd commit message:

    Also includes a change to output produced by
    
         def _format_cmd_shorty(cmd):
             """Get short string representation from a cmd argument list"""
    
    which used to join then without quoting
    
         cmd_shorty = (' '.join(cmd) if isinstance(cmd, list) else cmd)
    
    I thought that quoted would be more correct, especially when it is not
    going to get shortened.

I think the name `join_cmdline` is Ok, but could have been `join_argvs` or `join_commands`.  Let me know if you feel it better be renamed.  Originally I thought to make it `quote_cmdlineargs` but it doesn't fit semantically since it also joins them into a string