### PR TITLE
ENH: (+minor DOC fix) pretty print IncompleteResultsError

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -320,8 +320,10 @@ class IncompleteResultsError(RuntimeError):
     # such results have been yielded already at the time this exception is
     # raised, little point in collecting them just for the sake of a possible
     # exception
-    # MIH: AnnexRepo is the last remaining user of this functionality, in a
-    # single context
+    # MIH+YOH: AnnexRepo.copy_to and @eval_results are the last
+    # remaining user of this functionality.
+    # General use (as in AnnexRepo) of it discouraged but use in @eval_results
+    # is warranted
     def __init__(self, results=None, failed=None, msg=None):
         super(IncompleteResultsError, self).__init__(msg)
         self.results = results

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -11,7 +11,7 @@
 
 import re
 from os import linesep
-
+from pprint import pformat
 
 
 class CommandError(RuntimeError):
@@ -332,7 +332,7 @@ class IncompleteResultsError(RuntimeError):
     def __str__(self):
         super_str = super(IncompleteResultsError, self).__str__()
         return "{} {}" \
-               "".format(super_str, self.failed)
+               "".format(super_str, pformat(self.failed))
 
 class InstallFailedError(CommandError):
     """Generic exception to raise whenever `install` command fails"""

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -331,8 +331,14 @@ class IncompleteResultsError(RuntimeError):
 
     def __str__(self):
         super_str = super(IncompleteResultsError, self).__str__()
-        return "{} {}" \
-               "".format(super_str, pformat(self.failed))
+        return "{}{}{}".format(
+            super_str,
+            ". {} result(s)".format(len(self.results)) if self.results else "",
+            ". {} failed:{}{}".format(
+                len(self.failed),
+                linesep,
+                pformat(self.failed)) if self.failed else "")
+
 
 class InstallFailedError(CommandError):
     """Generic exception to raise whenever `install` command fails"""


### PR DESCRIPTION
Someone recently had asked me why we are not having "multiline" exception renderings... and I forgot what actually was the reason for us (may be if only for logging) why we leaned toward one liners.

I think the change is trivial enough to be submitted against maint.

    ENH: Use pprint.pformat for IncompleteResultsError str
    
    Those are are now more rare but when they come, they become hard to parse visually,
    see e.g. one in https://github.com/datalad/datalad/pull/4581#issuecomment-636239700 .
    With pprint they become much more human friendly/informative even though might occupy
    considerable amount of terminal output space.
    
    E.g. here is the exception from that issue pprinted
    
            ======================================================================
            ERROR: test.test
            ----------------------------------------------------------------------
            Traceback (most recent call last):
              File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
                    self.test(*self.arg)
              File "/tmp/testds/test.py", line 5, in test
                    raise IncompleteResultsError(
            datalad.support.exceptions.IncompleteResultsError: None [{'action': 'create_sibling',
              'message': ('failed to run post-update hook under remote path %s (%s)',
                                      'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_3jb32evv',
                                      'CommandError: \'"cd '
                                      '""C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_3jb32evv\\.git"" '
                                      '&& ( [ -x hooks/post-update ] && hooks/post-update || : )"\' '
                                      "failed with exitcode 1 [err: '':' is not recognized as an "
                                      'internal or external command,\r\n'
                                      "operable program or batch file.'] [cmd.py:run:930]"),
              'orig_request': 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_hh9cpvut',
              'path': 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_hh9cpvut',
              'raw_input': True,
              'refds': 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\datalad_temp_hh9cpvut',
              'status': 'error',
              'type': 'dataset'}]
    
    it has not become the prettiest thing, BUT it became much more approachable
