### PR TITLE
RF: Make .get_git_dir to use .dot_git logic, prepare for possible deprecation of .get_git_dir

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1182,8 +1182,27 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         )
 
     @staticmethod
-    def _get_dot_git(pathobj, ok_missing=False, relative=False):
-        """Given a pathobj to a repository return"""
+    def _get_dot_git(pathobj, *, ok_missing=False, relative=False):
+        """Given a pathobj to a repository return path to .git/ directory
+
+        Parameters
+        ----------
+        pathjob: Path
+        ok_missing: bool, optional
+          Allow for .git to be missing (useful while sensing before repo is initialized)
+        relative: bool, optional
+          Return path relative to pathobj
+
+        Raises
+        ------
+        RuntimeError
+          When ok_missing is False and .git path does not exist
+
+        Returns
+        -------
+        Path
+          Absolute (unless relative=True) path to resolved .git/ directory
+        """
         dot_git = pathobj / '.git'
         # Read a potential .git file in order to not do that over and over again, when testing is_valid_git() etc.
         # TODO: There's still some code duplication with static method GitRepo.get_git_dir()

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1213,9 +1213,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         Note
         ----
-        Please try using GitRepo.dot_git instead! That one's not static, but it's cheaper and you should avoid
-        not having an instance of a repo you're working on anyway. Note, that the property in opposition to this method
-        returns an absolute path.
+        This method is likely to get deprecated, please use GitRepo.dot_git instead!
+        That one's not static, but it's cheaper and you should avoid
+        not having an instance of a repo you're working on anyway.
+        Note, that the property in opposition to this method returns an absolute path.
 
 
         Parameters
@@ -1228,24 +1229,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         str
           relative path to the repo's git dir; So, default would be ".git"
         """
-        if hasattr(repo, 'path'):
-            # repo instance like given
-            repo = repo.path
-        dot_git = op.join(repo, ".git")
-        if not op.exists(dot_git):
-            raise RuntimeError("Missing .git in %s." % repo)
-        elif op.islink(dot_git):
-            git_dir = os.readlink(dot_git)
-        elif op.isdir(dot_git):
-            git_dir = ".git"
-        elif op.isfile(dot_git):
-            with open(dot_git) as f:
-                git_dir = f.readline()
-                if git_dir.startswith("gitdir:"):
-                    git_dir = git_dir[7:]
-                git_dir = git_dir.strip()
-
-        return git_dir
+        if isinstance(repo, GitRepo):
+            return str(repo.dot_git)
+        return str(GitRepo._get_dot_git(Path(repo), ok_missing=False, relative=True))
 
     @property
     def config(self):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -888,7 +888,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # are stored for performance. Path object creation comes with a cost. Most noteably,
         # this is used for validity checking of the repository.
         self.pathobj = ut.Path(self.path)
-        self.dot_git = self._get_dot_git(self.pathobj)
+        self.dot_git = self._get_dot_git(self.pathobj, ok_missing=True)
         self._valid_git_test_path = self.dot_git / 'HEAD'
         _valid_repo = self.is_valid_git()
 
@@ -1182,7 +1182,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         )
 
     @staticmethod
-    def _get_dot_git(pathobj):
+    def _get_dot_git(pathobj, ok_missing=False):
         """Given a pathobj to a repository return"""
         dot_git = pathobj / '.git'
         # Read a potential .git file in order to not do that over and over again, when testing is_valid_git() etc.
@@ -1199,6 +1199,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         elif dot_git.is_symlink():
             dot_git = dot_git.resolve()
+        elif not (ok_missing or dot_git.exists()):
+            raise RuntimeError("Missing .git in %s." % pathobj)
         return dot_git
 
     @staticmethod

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1204,10 +1204,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
           Absolute (unless relative=True) path to resolved .git/ directory
         """
         dot_git = pathobj / '.git'
-        # Read a potential .git file in order to not do that over and over again, when testing is_valid_git() etc.
-        # TODO: There's still some code duplication with static method GitRepo.get_git_dir()
-        #       However, it's returning relative path. So, the logic in usage needs to be unified in order to melt both
-        #       pieces.
         if dot_git.is_file():
             with dot_git.open() as f:
                 line = f.readline()
@@ -1215,12 +1211,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                     dot_git = pathobj / line[7:].strip()
                 else:
                     raise InvalidGitRepositoryError("Invalid .git file")
-
         elif dot_git.is_symlink():
             dot_git = dot_git.resolve()
         elif not (ok_missing or dot_git.exists()):
             raise RuntimeError("Missing .git in %s." % pathobj)
-        if relative:  #  primarily compat kludge for get_git_dir, remove when it is deprecated
+        # Primarily a compat kludge for get_git_dir, remove when it is deprecated
+        if relative:
             dot_git = dot_git.relative_to(pathobj)
         return dot_git
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1182,7 +1182,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         )
 
     @staticmethod
-    def _get_dot_git(pathobj, ok_missing=False):
+    def _get_dot_git(pathobj, ok_missing=False, relative=False):
         """Given a pathobj to a repository return"""
         dot_git = pathobj / '.git'
         # Read a potential .git file in order to not do that over and over again, when testing is_valid_git() etc.
@@ -1201,6 +1201,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             dot_git = dot_git.resolve()
         elif not (ok_missing or dot_git.exists()):
             raise RuntimeError("Missing .git in %s." % pathobj)
+        if relative:  #  primarily compat kludge for get_git_dir, remove when it is deprecated
+            dot_git = dot_git.relative_to(pathobj)
         return dot_git
 
     @staticmethod


### PR DESCRIPTION
#2054 made me look into this code path.

Possible changes to consider

- make `._get_dot_git` public so it could be used instead of `.get_git_dir`, thus not requiring an instance if that seems needed; but I think it better be delayed until we know that such functionality is really desired

For now I just position it against master (thus for 0.13) but if we feel that better be delayed, I will reassign milestone and finally produce `next` branch ;)
