### PR TITLE
ENH: demote progress bars clear/refresh to debug from info

### DIFF
--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -72,12 +72,12 @@ class ConsoleLog(object):
 
     def message(self, msg, cr='\n'):
         from datalad.log import log_progress
-        log_progress(lgr.info, None, 'Clear progress bars', maint='clear',
+        log_progress(lgr.debug, None, 'Clear progress bars', maint='clear',
                      noninteractive_level=5)
         self.out.write(msg)
         if cr:
             self.out.write(cr)
-        log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh',
+        log_progress(lgr.debug, None, 'Refresh progress bars', maint='refresh',
                      noninteractive_level=5)
 
     def error(self, error):


### PR DESCRIPTION
I had a cron job which filled up my email with a long list of

    [INFO] Clear progress bars
    [INFO] Refresh progress bars

which I do not see bringing much value to any interactive or non-interactive
display - seems to be more of debugging log to me.

But also may be I do not fully grasp desired behavior here, since this
change also doesn't cause failure of any test in

    datalad/ui/tests/test_dialog.py

including test_message_pbar_state_logging_is_demoted .
