### PR TITLE
ENH: dataset cache for tests

### DIFF
--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -47,4 +47,4 @@ jobs:
       run: |
         mkdir -p __testhome__
         cd __testhome__
-        python -m nose -s -v -A "not (turtle)" datalad.core datalad.local datalad.distributed
+        python -m nose -s -v -A "not (turtle)" datalad.core datalad.local datalad.distributed datalad.tests.test_utils_cached_dataset

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -194,6 +194,13 @@ definitions = {
         'ui': ('question', {
                'title': 'Specifies the location of the file to record network transactions by the VCR module. Currently used by when testing custom special remotes'}),
     },
+    'datalad.tests.cache': {
+        'ui': ('question', {
+            'title': 'Cache directory for tests',
+            'text': 'Where should datalad cache test files?'}),
+        'destination': 'global',
+        'default': opj(dirs.user_cache_dir, 'tests')
+    },
     'datalad.log.level': {
         'ui': ('question', {
             'title': 'Used for control the verbosity of logs printed to '

--- a/datalad/tests/test_utils_cached_dataset.py
+++ b/datalad/tests/test_utils_cached_dataset.py
@@ -1,0 +1,302 @@
+"""Testing cached test dataset utils"""
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.gitrepo import GitRepo
+from datalad.tests.utils_cached_dataset import (
+    get_cached_dataset,
+    cached_dataset,
+    cached_url,
+    url2filename
+)
+from datalad.utils import (
+    ensure_list,
+    opj,
+    Path,
+)
+from datalad.tests.utils import (
+    assert_equal,
+    assert_false,
+    assert_in,
+    assert_is,
+    assert_is_instance,
+    assert_not_in,
+    assert_not_equal,
+    assert_raises,
+    assert_result_count,
+    assert_true,
+    with_tempfile
+)
+from unittest.mock import patch
+
+
+CACHE_PATCH_STR = "datalad.tests.utils_cached_dataset.DATALAD_TESTS_CACHE"
+CLONE_PATCH_STR = "datalad.tests.utils_cached_dataset.Clone.__call__"
+
+
+@with_tempfile(mkdir=True)
+def test_get_cached_dataset(cache_dir):
+
+    # patch DATALAD_TESTS_CACHE to not use the actual cache with
+    # the test testing that very cache.
+    cache_dir = Path(cache_dir)
+
+    # store file-based values for testrepo-minimalds for readability:
+    annexed_file = opj('inannex', 'animated.gif')
+    annexed_file_key = "MD5E-s144625--4c458c62b7ac8ec8e19c8ff14b2e34ad.gif"
+
+    with patch(CACHE_PATCH_STR, new=cache_dir):
+
+        # tuples to test (url, version, keys, class):
+        test_cases = [
+
+            # a simple testrepo
+            ("https://github.com/datalad/testrepo--minimalds",
+             "541cf855d13c2a338ff2803d4488daf0035e568f",
+             None,
+             AnnexRepo),
+            # Same repo, but request paths to be present. This should work
+            # with a subsequent call, although the first one did not already
+            # request any:
+            ("https://github.com/datalad/testrepo--minimalds",
+             "9dd8b56cc706ab56185f2ceb75fbe9de9b606724",
+             annexed_file_key,
+             AnnexRepo),
+            # Same repo again, but invalid version
+            ("https://github.com/datalad/testrepo--minimalds",
+             "nonexistent",
+             "irrelevantkey",  # invalid version; don't even try to get the key
+             AnnexRepo),
+            # same thing with different name should be treated as a new thing:
+            ("https://github.com/datalad/testrepo--minimalds",
+             "git-annex",
+             None,
+             AnnexRepo),
+            # try a plain git repo to make sure we can deal with that:
+            # Note, that we first need a test case w/o a `key` parameter to not
+            # blow up the test when Clone is patched, resulting in a MagicMock
+            # instead of a Dataset instance within get_cached_dataset. In the
+            # second case it's already cached then, so the patched Clone is
+            # never executed.
+            ("https://github.com/datalad/datalad.org",
+             None,
+             None,
+             GitRepo),
+            ("https://github.com/datalad/datalad.org",
+             "gh-pages",
+             "ignored-key",  # it's a git repo; don't even try to get a key
+             GitRepo),
+
+        ]
+        for url, version, keys, cls in test_cases:
+            target = cache_dir / url2filename(url)
+
+            # assuming it doesn't exist yet - patched cache dir!
+            in_cache_before = target.exists()
+            with patch(CLONE_PATCH_STR) as exec_clone:
+                try:
+                    ds = get_cached_dataset(url, version, keys)
+                    invalid_version = False
+                except AssertionError:
+                    # should happen only if `version` wasn't found. Implies
+                    # that the dataset exists in cache (although not returned
+                    # due to exception)
+                    assert_true(version)
+                    assert_false(Dataset(target).repo.commit_exists(version))
+                    # mark for later assertions (most of them should still hold
+                    # true)
+                    invalid_version = True
+
+            assert_equal(exec_clone.call_count, 0 if in_cache_before else 1)
+
+            # Patch prevents actual execution. Now do it for real. Note, that
+            # this might be necessary for content retrieval even if dataset was
+            # in cache before.
+            try:
+                ds = get_cached_dataset(url, version, keys)
+            except AssertionError:
+                # see previous call
+                assert_true(invalid_version)
+
+            assert_is_instance(ds, Dataset)
+            assert_true(ds.is_installed())
+            assert_equal(target, ds.pathobj)
+            assert_is_instance(ds.repo, cls)
+
+            if keys and not invalid_version and \
+                    AnnexRepo.is_valid_repo(ds.path):
+                # Note: it's not supposed to get that content if passed
+                # `version` wasn't available. get_cached_dataset would then
+                # raise before and not download anything only to raise
+                # afterwards.
+                here = ds.config.get("annex.uuid")
+                where = ds.repo.whereis(ensure_list(keys), key=True)
+                assert_true(all(here in remotes for remotes in where))
+
+            # version check. Note, that all `get_cached_dataset` is supposed to
+            # do, is verifying, that specified version exists - NOT check it
+            # out"
+            if version and not invalid_version:
+                assert_true(ds.repo.commit_exists(version))
+
+            # re-execution
+            with patch(CLONE_PATCH_STR) as exec_clone:
+                try:
+                    ds2 = get_cached_dataset(url, version, keys)
+                except AssertionError:
+                    assert_true(invalid_version)
+            exec_clone.assert_not_called()
+            # returns the same Dataset as before:
+            assert_is(ds, ds2)
+
+
+@with_tempfile(mkdir=True)
+def test_cached_dataset(cache_dir):
+
+    # patch DATALAD_TESTS_CACHE to not use the actual cache with
+    # the test testing that very cache.
+    cache_dir = Path(cache_dir)
+    ds_url = "https://github.com/datalad/testrepo--minimalds"
+    name_in_cache = url2filename(ds_url)
+    annexed_file = Path("inannex") / "animated.gif"
+
+    with patch(CACHE_PATCH_STR, new=cache_dir):
+
+        @cached_dataset(url=ds_url)
+        def decorated_test1(ds):
+            # we get a Dataset instance
+            assert_is_instance(ds, Dataset)
+            # it's a clone in a temp. location, not within the cache
+            assert_not_in(cache_dir, ds.pathobj.parents)
+            assert_result_count(ds.siblings(), 1, type="sibling",
+                                name="origin",
+                                url=str(cache_dir / name_in_cache))
+            here = ds.config.get("annex.uuid")
+            origin = ds.config.get("remote.origin.annex-uuid")
+            where = ds.repo.whereis(str(annexed_file))
+            assert_not_in(here, where)
+            assert_not_in(origin, where)
+
+            return ds.pathobj, ds.repo.pathobj
+
+        @cached_dataset(url=ds_url, paths=str(annexed_file))
+        def decorated_test2(ds):
+            # we get a Dataset instance
+            assert_is_instance(ds, Dataset)
+            # it's a clone in a temp. location, not within the cache
+            assert_not_in(cache_dir, ds.pathobj.parents)
+            assert_result_count(ds.siblings(), 1, type="sibling",
+                                name="origin",
+                                url=str(cache_dir / name_in_cache))
+            here = ds.config.get("annex.uuid")
+            origin = ds.config.get("remote.origin.annex-uuid")
+            where = ds.repo.whereis(str(annexed_file))
+            assert_in(here, where)
+            assert_in(origin, where)
+
+            return ds.pathobj, ds.repo.pathobj
+
+        @cached_dataset(url=ds_url)
+        def decorated_test3(ds):
+            # we get a Dataset instance
+            assert_is_instance(ds, Dataset)
+            # it's a clone in a temp. location, not within the cache
+            assert_not_in(cache_dir, ds.pathobj.parents)
+            assert_result_count(ds.siblings(), 1, type="sibling",
+                                name="origin",
+                                url=str(cache_dir / name_in_cache))
+            # origin is the same cached dataset, that got this content in
+            # decorated_test2 before. Should still be there. But "here" we
+            # didn't request it
+            here = ds.config.get("annex.uuid")
+            origin = ds.config.get("remote.origin.annex-uuid")
+            where = ds.repo.whereis(str(annexed_file))
+            assert_not_in(here, where)
+            assert_in(origin, where)
+
+            return ds.pathobj, ds.repo.pathobj
+
+        @cached_dataset(url=ds_url,
+                        version="541cf855d13c2a338ff2803d4488daf0035e568f")
+        def decorated_test4(ds):
+            # we get a Dataset instance
+            assert_is_instance(ds, Dataset)
+            # it's a clone in a temp. location, not within the cache
+            assert_not_in(cache_dir, ds.pathobj.parents)
+            assert_result_count(ds.siblings(), 1, type="sibling",
+                                name="origin",
+                                url=str(cache_dir / name_in_cache))
+            # origin is the same cached dataset, that got this content in
+            # decorated_test2 before. Should still be there. But "here" we
+            # didn't request it
+            here = ds.config.get("annex.uuid")
+            origin = ds.config.get("remote.origin.annex-uuid")
+            where = ds.repo.whereis(str(annexed_file))
+            assert_not_in(here, where)
+            assert_in(origin, where)
+
+            assert_equal(ds.repo.get_hexsha(),
+                         "541cf855d13c2a338ff2803d4488daf0035e568f")
+
+            return ds.pathobj, ds.repo.pathobj
+
+        first_dspath, first_repopath = decorated_test1()
+        second_dspath, second_repopath = decorated_test2()
+        decorated_test3()
+        decorated_test4()
+
+        # first and second are not the same, only their origin is:
+        assert_not_equal(first_dspath, second_dspath)
+        assert_not_equal(first_repopath, second_repopath)
+
+
+@with_tempfile(mkdir=True)
+def test_cached_url(cache_dir):
+
+    # patch DATALAD_TESTS_CACHE to not use the actual cache with
+    # the test testing that very cache.
+    cache_dir = Path(cache_dir)
+
+    ds_url = "https://github.com/datalad/testrepo--minimalds"
+    name_in_cache = url2filename(ds_url)
+    annexed_file = Path("inannex") / "animated.gif"
+    annexed_file_key = "MD5E-s144625--4c458c62b7ac8ec8e19c8ff14b2e34ad.gif"
+
+    with patch(CACHE_PATCH_STR, new=cache_dir):
+
+        @cached_url(url=ds_url)
+        def decorated_test1(url):
+            # we expect a file-scheme url to a cached version of `ds_url`
+            expect_origin_path = cache_dir / name_in_cache
+            assert_equal(expect_origin_path.as_uri(),
+                         url)
+            origin = Dataset(expect_origin_path)
+            assert_true(origin.is_installed())
+            assert_false(origin.repo.file_has_content(str(annexed_file)))
+
+        decorated_test1()
+
+        @cached_url(url=ds_url, keys=annexed_file_key)
+        def decorated_test2(url):
+            # we expect a file-scheme url to a "different" cached version of
+            # `ds_url`
+            expect_origin_path = cache_dir / name_in_cache
+            assert_equal(expect_origin_path.as_uri(),
+                         url)
+            origin = Dataset(expect_origin_path)
+            assert_true(origin.is_installed())
+            assert_true(origin.repo.file_has_content(str(annexed_file)))
+
+        decorated_test2()
+
+    # disable caching. Note, that in reality DATALAD_TESTS_CACHE is determined
+    # on import time of datalad.tests.fixtures based on the config
+    # "datalad.tests.cache". We patch the result here, not the config itself.
+    with patch(CACHE_PATCH_STR, new=None):
+
+        @cached_url(url=ds_url)
+        def decorated_test3(url):
+            # we expect the original url, since caching is disabled
+            assert_equal(url, ds_url)
+
+        decorated_test3()

--- a/datalad/tests/utils_cached_dataset.py
+++ b/datalad/tests/utils_cached_dataset.py
@@ -1,0 +1,238 @@
+"""Utils for cached test datasets"""
+
+from datalad import cfg
+from datalad.core.distributed.clone import (
+    Clone,
+)
+from datalad.distribution.dataset import Dataset
+from datalad.utils import (
+    better_wraps,
+    ensure_list,
+    optional_args,
+    Path,
+    rmtree
+)
+from datalad.support.annexrepo import AnnexRepo
+from datalad.tests.utils import with_tempfile
+
+
+DATALAD_TESTS_CACHE = cfg.obtain("datalad.tests.cache")
+
+
+def url2filename(url):
+    """generate file/directory name from a URL"""
+
+    # TODO: Not really important for now, but there should be a more
+    #       sophisticated approach to replace. May be just everything that
+    #       isn't alphanumeric? Or simply hash the URL?
+    #       URL: Will include version eventually. Would need parsing to hash
+    #       w/o any parameters. Having separate clones per requested version
+    #       would defy point of cache, particularly wrt downloading content.
+    #       Depends on usecase, of course, but immediate one is about container
+    #       images -> not cheap.
+    # make it a Path, too, so pathlib can raise if we are creating an invalid
+    # path on some system we run the tests on.
+    return Path(
+        url.lower().replace("/", "_").replace(":", "_").replace("?", "_"))
+
+
+def get_cached_dataset(url, version=None, keys=None):
+    """ Helper to get a cached clone from url
+
+    Intended for use from within `cached_dataset` and `cached_url` decorators.
+    Clones `url` into user's cache under datalad/tests/`name`. If such a clone
+    already exists, don't clone but return the existing one. So, it's supposed
+    to cache the original source in order to reduce time and traffic for tests,
+    by letting subsequent requests clone from a local location directly.
+
+    If it's an annex get the content as provided by `keys`, too.
+    Note, that as a transparent cache replacing the repo at URL from the POV of
+    a test, we can't address content via paths, since those are valid only with
+    respect to a particular worktree. If different tests clone from the same
+    cached dataset, each requesting different versions and different paths
+    thereof, we run into trouble if the cache itself checks out a particular
+    requested version.
+
+    Verifies that `version` can be checked out, but doesn't actually do it,
+    since the cached dataset is intended to be used as origin instead of the
+    original remote at URL by the `cached_dataset` test decorator. Checkout of
+    a particular version should happen in its clone.
+
+    Parameters
+    ----------
+    url: str
+        URL to clone from
+    keys: str or list or None
+        (list of) annex keys to get content for.
+    version: str or None
+        A commit or an object that can be dereferenced to one.
+
+    Returns
+    -------
+    Dataset
+    """
+
+    # TODO: What about recursive? Might be complicated. We would need to make
+    #       sure we can recursively clone _from_ here then, potentially
+    #       requiring submodule URL rewrites. Not sure about that ATM.
+
+    # TODO: Given that it is supposed to be a cache for the original repo at
+    #       `url`, we prob. should make this a bare repository. We don't need
+    #       a potentially expensive checkout here. Need to double check
+    #       `annex-get --key` in bare repos, though. Plus datalad-clone doesn't
+    #       have --bare yet. But we want all the annex/special-remote/ria magic
+    #       of datalad. So, plain git-clone --bare is not an option.
+
+    if not DATALAD_TESTS_CACHE:
+        raise ValueError("Caching disabled by config")
+
+    ds = Dataset(DATALAD_TESTS_CACHE / url2filename(url))
+
+    if not ds.is_installed():
+        ds = Clone()(url, ds.pathobj)
+
+    # When/How to update a dataset in cache? If version is a commit SHA and we
+    # have it, there's no need for an update. Otherwise it gets tricky, because
+    # this is a cache, not a checkout a test would operate on. It needs to
+    # behave as if it was the thing at `url` from the point of view of the test
+    # using it (cloning/getting content from here). We would need to update all
+    # references, not just fetch them!
+    #
+    # Can we even (cheaply) tell whether `version` is an absolute reference
+    # (actual SHA, not a branch/tag)?
+    #
+    # NOTE: - consider git-clone --mirror, but as w/ --bare: not an option for
+    #         datalad-clone yet.
+    #       - --reference[-if-able] might also be worth thinking about for
+    #         the clone @cached_dataset creates wrt clone in cacheq
+    #
+    # So, for now fetch, figure whether there actually was something to fetch
+    # and if so simply invalidate cache and re-clone/get. Don't overcomplicate
+    # things. It's about datasets used in the tests - they shouldn't change too
+    # frequently.
+    elif any('uptodate' not in c['operations']
+             for c in ds.repo.fetch('origin')):
+        rmtree(ds.path)
+        ds = Clone()(url, ds.pathobj)
+
+    if version:
+        # check whether version is available
+        assert ds.repo.commit_exists(version)
+    if keys and AnnexRepo.is_valid_repo(ds.path):
+        ds.repo.get(keys, key=True)
+
+    return ds
+
+
+@optional_args
+def cached_dataset(f, url=None, version=None, paths=None):
+    """Test decorator providing a clone of `url` from cache
+
+    If config datalad.tests.cache is not set, delivers a clone in a temporary
+    location of the original `url`. Otherwise that clone is in fact a clone of a
+    cached dataset (origin being the cache instead of `url`).
+    This allows to reduce time and network traffic when using a dataset in
+    different tests.
+
+    The clone will checkout `version` and get the content for `paths`.
+
+    Parameters
+    ----------
+    url: str
+        URL to the to be cloned dataset
+    version: str
+        committish to checkout in the clone
+    paths: str or list
+        annexed content to get
+
+    Returns
+    -------
+    Dataset
+        a clone of the dataset at `url` at a temporary location (cleaned up,
+        after decorated test is finished - see with_tempfile). If caching is
+        enabled, it's actually a clone of a clone, 'origin' being the clone in
+        cache rather than the original repo at `url`.
+    """
+    @better_wraps(f)
+    @with_tempfile
+    def newfunc(*arg, **kw):
+
+        if DATALAD_TESTS_CACHE:
+            # Note: We can't pass keys based on `paths` parameter to
+            # get_cached_dataset yet, since translation to keys depends on a
+            # worktree. We'll have the worktree of `version` only after cloning.
+            ds = get_cached_dataset(url, version=version)
+            clone_ds = Clone()(ds.pathobj, arg[-1])
+        else:
+            clone_ds = Clone()(url, arg[-1])
+        if version:
+            clone_ds.repo.checkout(version)
+        if paths and AnnexRepo.is_valid_repo(clone_ds.path):
+            # just assume ds is annex as well. Otherwise `Clone` wouldn't
+            # work correctly - we don't need to test its implementation here
+            if DATALAD_TESTS_CACHE:
+                # cache is enabled; we need to make sure it has the desired
+                # content, so clone_ds can get it from there. However, we got
+                # `paths` and potentially a `version` they refer to. We can't
+                # assume the same (or any) worktree in cache. Hence we need to
+                # translate to keys.
+                keys = clone_ds.repo.get_file_key(paths)
+                ds.repo.get(keys, key=True)
+                clone_ds.repo.fsck(remote='origin', fast=True)
+
+            clone_ds.get(paths)
+        return f(*(arg[:-1] + (clone_ds,)), **kw)
+
+    return newfunc
+
+
+@optional_args
+def cached_url(f, url=None, keys=None):
+    """Test decorator providing a URL to clone from, pointing to cached dataset
+
+    If config datalad.tests.cache is not set, delivers the original `url`,
+    otherwise a file-scheme url to the cached clone thereof.
+
+    Notes
+    -----
+
+    While this is similar to `cached_dataset`, there are important differences.
+
+    1. As we deliver an URL, `version` parameter is irrelevant. The only
+       relevant notion of version would need to be included in the URL
+
+    2. We cannot request particular paths to be present in cache, since we
+       a version to refer to by those paths. Therefore keys need to be
+       specified.
+
+    Parameters
+    ----------
+    url: str
+        URL to the original dataset
+    keys: str or list or None
+        (list of) annex keys to get content for.
+
+    Returns
+    -------
+    str
+        URL to the cached dataset or the original URL if caching was disabled
+    """
+
+    # TODO: See Notes 1.)
+    #       Append fragments/parameters of `url` to what we return -
+    #       depending on how we generally decide to address versioned
+    #       URLs for clone etc.
+
+    @better_wraps(f)
+    def newfunc(*arg, **kw):
+        if DATALAD_TESTS_CACHE:
+            ds = get_cached_dataset(url, version=None)
+            if keys:
+                ds.repo.get(keys, key=True)
+            new_url = ds.pathobj.as_uri()
+        else:
+            new_url = url
+
+        return f(*(arg + (new_url,)), **kw)
+
+    return newfunc


### PR DESCRIPTION
Inspired by discussion in https://github.com/datalad/datalad-extensions/pull/12 and internal chat.

This allows to use remote datasets in tests via a cache, in order to reduce time and network traffic.
The goal is to replace the original remote repository (specified by a URL) by a local clone in a caching location. From the point of view of a test, this is kind of transparent - the cached dataset simply replaces the actually remote one. It introduces a config variable `datalad.tests.cache` to specify the caching location or disable caching entirely. Default location is `<user's cache dir>/datalad/tests`, which would result in datasets used by tests that way being persistent across test *runs*, not only across tests! This should be convenient for ourselves and irrelevant in CI builds, where the only thing interesting is to be persistent across tests (entire environment is fresh every time after all).

This PR brings two test decorators:

1. `cached_dataset`:
    This delivers a `Dataset` to the test, that is a temporary clone of the dataset in the cache (or of the actual URL if caching was disabled). That clone intentionally is *not* persistent - each test gets its own clone. The difference is that not every test using it, needs to clone (and get content) via network again, making it much cheaper (plus reducing chance to be rejected/blacklisted by flooding some services during our CI runs). In addition this decorator allows to specify paths to get and a version to checkout in that clone (of a clone).

2. `cached_url`:
    In opposition to above, this decorator merely delivers a URL, not a clone, to a test. If caching is disabled it merely passes on the specified URL, otherwise it delivers a file-scheme URL to the instance in cache. If the test merely needs something to clone from rather than to actually operate on, this is the way to go.


Note, that there are TODOs in the code wrt to enhancing this concept. If everything apart from that is fine with the rest of @datalad/developers , I'd rather postpone that and get the current version into 0.13.0 in order to solve the immediate usecase with datalad-hirni, which therefore needs to depend on a datalad version, that actually has those decorators.
Also: Those TODOs raise some questions to explore.