### PR TITLE
DOC: manual: Warn about distribution-restrictions interactions

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -138,6 +138,17 @@ Having annotated files this way, we could instruct git-annex
 to :ref:`publish <man_datalad-publish>` all but those restricted files to our
 server: `git annex wanted datalad-public "not metadata=distribution-restrictions=*"`.
 
+.. warning::
+  The above setup depends on `git annex copy --auto` deciding to *not*
+  copy the content.  To avoid inadvertently publishing sensitive data,
+  make sure that public targets ("datalad-public" in the example
+  above) do not want the content for another reason, in particular due
+  to `numcopies` or required content configuration.  If ``numcopies``
+  is set to a value greater than 1 (the default) and the requested
+  number of copies cannot be verified, `git annex copy --auto` will
+  transfer the data regardless of the preferred content expression set
+  by the `git annex wanted` call above.
+
 
 Flexible directory layout
 #########################


### PR DESCRIPTION
The metadata section of the manual describes using the
distribution-restrictions field to mark files that shouldn't be shared
publicly. As described at gh-4605, this setup depends on the caller
not configuring numcopies to a value above the default of 1 (or, less
likely, configuring required content in a way where the public remote
would want the file).