### PR TITLE
RF: `push since=''` -> `push --since='^'`

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -828,7 +828,10 @@ def _push_data(ds, target, content, force, jobs, res_kwargs,
 
 def _get_corresponding_remote_state(repo, to):
     since = None
-    active_branch = repo.get_active_branch()
+    # for managed branches we cannot assume a matching one at the remote end
+    # instead we target the corresponding branch
+    active_branch = repo.get_corresponding_branch() or repo.get_active_branch()
+
     if to:
         # XXX here we assume one to one mapping of names from local branches
         # to the remote

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -114,8 +114,8 @@ class Push(Interface):
             constraints=EnsureStr() | EnsureNone(),
             doc="""specifies commit-ish (tag, shasum, etc.) from which to look for
             changes to decide whether pushing is necessary.
-            If an empty string is given, the last state of the current branch
-            at the sibling is taken as a starting point."""),
+            If '^' is given, the last state of the current branch at the sibling
+            is taken as a starting point."""),
         path=Parameter(
             args=("path",),
             metavar='PATH',
@@ -218,18 +218,17 @@ class Push(Interface):
                     else 'No targets configured in dataset.'))
             return
 
-        if since:
-            # will blow with ValueError if unusable
-            ds_repo.get_hexsha(since)
-
-        if not since and since is not None:
-            # special case: --since=''
+        if since == '^':
             # figure out state of remote branch and set `since`
             since = _get_corresponding_remote_state(ds_repo, to)
             if not since:
                 lgr.info(
                     "No tracked remote for active branch, "
                     "detection of last pushed state not in effect.")
+        elif since:
+            # will blow with ValueError if unusable
+            ds_repo.get_hexsha(since)
+
 
         # obtain a generator for information on the datasets to process
         # idea is to turn the `paths` argument into per-dataset

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -161,7 +161,10 @@ def check_push(annex, src_path, dst_path):
     src.save(to_git=not annex, message="Modified again.")
     assert_repo_status(src_repo, annex=annex)
 
-    res = src.push(to='target', since="HEAD~2", jobs=2)
+    # we could say since='HEAD~2' to make things fast, or we are lazy
+    # and say since='^' to indicate the state of the tracking remote
+    # which is the same, because we made to commits since the last push.
+    res = src.push(to='target', since="^", jobs=2)
     assert_in_results(
         res,
         action='publish', status='ok', target='target',


### PR DESCRIPTION
Implements the decision made in gh-4582 to use this character as a more
intuitive alternative than an empty string.

Fixes gh-4582
