### PR TITLE
ENH: Give clone candidates a priority

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -584,7 +584,7 @@ def postclonecfg_ria(ds, props):
     ds.config.set(
         # we use the label 'origin' for this candidate in order to not have to
         # generate a complicated name from the actual source specification.
-        # we pick a priority of 20 to sort it before datalad's default candidates
+        # we pick a priority of 200 to sort it before datalad's default candidates
         # for non-RIA URLs, because they prioritize hierarchical layouts that
         # cannot be found in a RIA store
         'datalad.get.subdataset-source-candidate-200origin',

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -583,8 +583,11 @@ def postclonecfg_ria(ds, props):
     # get probe this RIA store when obtaining subdatasets
     ds.config.set(
         # we use the label 'origin' for this candidate in order to not have to
-        # generate a complicated name from the actual source specification
-        'datalad.get.subdataset-source-candidate-origin',
+        # generate a complicated name from the actual source specification.
+        # we pick a priority of 20 to sort it before datalad's default candidates
+        # for non-RIA URLs, because they prioritize hierarchical layouts that
+        # cannot be found in a RIA store
+        'datalad.get.subdataset-source-candidate-20origin',
         # use the entire original URL, up to the fragment + plus dataset ID
         # placeholder, this should make things work with any store setup we
         # support (paths, ports, ...)

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -584,7 +584,7 @@ def postclonecfg_ria(ds, props):
     ds.config.set(
         # we use the label 'origin' for this candidate in order to not have to
         # generate a complicated name from the actual source specification.
-        # we pick a priority of 200 to sort it before datalad's default candidates
+        # we pick a cost of 200 to sort it before datalad's default candidates
         # for non-RIA URLs, because they prioritize hierarchical layouts that
         # cannot be found in a RIA store
         'datalad.get.subdataset-source-candidate-200origin',

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -587,7 +587,7 @@ def postclonecfg_ria(ds, props):
         # we pick a priority of 20 to sort it before datalad's default candidates
         # for non-RIA URLs, because they prioritize hierarchical layouts that
         # cannot be found in a RIA store
-        'datalad.get.subdataset-source-candidate-20origin',
+        'datalad.get.subdataset-source-candidate-200origin',
         # use the entire original URL, up to the fragment + plus dataset ID
         # placeholder, this should make things work with any store setup we
         # support (paths, ports, ...)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -702,7 +702,7 @@ def test_ria_http(lcl, storepath, url):
             eq_(origds.repo.get_hexsha(), cloneds.repo.get_hexsha())
         ok_(cloneds.config.get('remote.origin.url').startswith(url))
         eq_(cloneds.config.get('remote.origin.annex-ignore'), 'true')
-        eq_(cloneds.config.get('datalad.get.subdataset-source-candidate-origin'),
+        eq_(cloneds.config.get('datalad.get.subdataset-source-candidate-20origin'),
             'ria+%s#{id}' % url)
 
     # now advance the source dataset
@@ -755,7 +755,7 @@ def test_ria_http(lcl, storepath, url):
     # ... the clone candidates go with the label-based URL such that
     # future get() requests acknowlege a (system-wide) configuration
     # update
-    eq_(cloned_by_label.config.get('datalad.get.subdataset-source-candidate-origin'),
+    eq_(cloned_by_label.config.get('datalad.get.subdataset-source-candidate-20origin'),
         'ria+ssh://somelabel#{id}')
 
     if not has_symlink_capability():
@@ -966,7 +966,7 @@ def test_inherit_src_candidates(lcl, storepath, url):
     eq_(len(datasets), 2)
     for ds in datasets:
         eq_(ConfigManager(dataset=ds, source='dataset-local').get(
-            'datalad.get.subdataset-source-candidate-origin'),
+            'datalad.get.subdataset-source-candidate-20origin'),
             'ria+%s#{id}' % url)
 
 

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -702,7 +702,7 @@ def test_ria_http(lcl, storepath, url):
             eq_(origds.repo.get_hexsha(), cloneds.repo.get_hexsha())
         ok_(cloneds.config.get('remote.origin.url').startswith(url))
         eq_(cloneds.config.get('remote.origin.annex-ignore'), 'true')
-        eq_(cloneds.config.get('datalad.get.subdataset-source-candidate-20origin'),
+        eq_(cloneds.config.get('datalad.get.subdataset-source-candidate-200origin'),
             'ria+%s#{id}' % url)
 
     # now advance the source dataset
@@ -755,7 +755,7 @@ def test_ria_http(lcl, storepath, url):
     # ... the clone candidates go with the label-based URL such that
     # future get() requests acknowlege a (system-wide) configuration
     # update
-    eq_(cloned_by_label.config.get('datalad.get.subdataset-source-candidate-20origin'),
+    eq_(cloned_by_label.config.get('datalad.get.subdataset-source-candidate-200origin'),
         'ria+ssh://somelabel#{id}')
 
     if not has_symlink_capability():
@@ -966,7 +966,7 @@ def test_inherit_src_candidates(lcl, storepath, url):
     eq_(len(datasets), 2)
     for ds in datasets:
         eq_(ConfigManager(dataset=ds, source='dataset-local').get(
-            'datalad.get.subdataset-source-candidate-20origin'),
+            'datalad.get.subdataset-source-candidate-200origin'),
             'ria+%s#{id}' % url)
 
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -198,15 +198,15 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                         alternate_suffix=False)
                 )
 
-        for name, tmpl in [(c[12:], ds_repo.config[c])
-                           for c in ds_repo.config.keys()
-                           if c.startswith(
-                               'datalad.get.subdataset-source-candidate-')]:
-            url = tmpl.format(**sm_candidate_props)
-            # we don't want "flexible_source_candidates" here, this is
-            # configuration that can be made arbitrarily precise from the
-            # outside. Additional guesswork can only make it slower
-            clone_urls.append((name, url))
+    for name, tmpl in [(c[12:], ds_repo.config[c])
+                       for c in ds_repo.config.keys()
+                       if c.startswith(
+                           'datalad.get.subdataset-source-candidate-')]:
+        url = tmpl.format(**sm_candidate_props)
+        # we don't want "flexible_source_candidates" here, this is
+        # configuration that can be made arbitrarily precise from the
+        # outside. Additional guesswork can only make it slower
+        clone_urls.append((name, url))
 
     # CANDIDATE: the actual configured gitmodule URL
     if sm_url:

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -122,7 +122,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
 
       `datalad.get.subdataset-source-candidate-<name>`
 
-    where `name` is an arbitrary identifier. If name starts with two digits
+    where `name` is an arbitrary identifier. If name starts with three digits
     (e.g. '400myserver') these will be interpreted as a priority, and the
     respective candidate will be sorted into the generated candidate list
     according to this priority. If no priority is given, a default of 700

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -232,8 +232,6 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
         has_priority = prio_candidate_expr.match(name) is not None
         clone_urls.append(
             # assign a default priority, if a config doesn't have one
-            # use ':' as delimiter for priority indication, should not
-            # be found in the wild
             dict(
                 priority=int(name[:3]) if has_priority else 700,
                 name=name[3:] if has_priority else name,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -332,7 +332,6 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
             # superdataset. if so, inherit the config in the new subdataset
             # clone. if not, keep things clean in order to be able to move with
             # any outside configuration change
-            # .split(':')[1] takes off the priority indicator first
             for c in ('datalad.get.subdataset-source-candidate-{}{}'.format(
                           rec['priority'], rec['name']),
                       'datalad.get.subdataset-source-candidate-{}'.format(

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -220,10 +220,11 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                         alternate_suffix=False)
                 )
     prio_candidate_expr = re.compile('[0-9][0-9][0-9].*')
-    for name, tmpl in [(c[40:], ds_repo.config[c])
+    candcfg_prefix = 'datalad.get.subdataset-source-candidate-'
+    for name, tmpl in [(c[len(candcfg_prefix):],
+                        ds_repo.config[c])
                        for c in ds_repo.config.keys()
-                       if c.startswith(
-                           'datalad.get.subdataset-source-candidate-')]:
+                       if c.startswith(candcfg_prefix)]:
         url = tmpl.format(**sm_candidate_props)
         # we don't want "flexible_source_candidates" here, this is
         # configuration that can be made arbitrarily precise from the

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -87,28 +87,28 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     ds_subpath = str(ds.pathobj / 'sub')
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path)), [])
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path, gitmodule_url=sshurl)),
-        [dict(priority=900, name='local', url=sshurl)])
+        [dict(cost=900, name='local', url=sshurl)])
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path, gitmodule_url=httpurl)),
-        [dict(priority=900, name='local', url=httpurl)])
+        [dict(cost=900, name='local', url=httpurl)])
 
     # but if we work on dsclone then it should also add urls deduced from its
     # own location default remote for current branch
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path)),
-        [dict(priority=500, name='origin', url=ds_subpath)])
+        [dict(cost=500, name='origin', url=ds_subpath)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=sshurl)),
-        [dict(priority=500, name='origin', url=ds_subpath),
-         dict(priority=600, name='origin', url=sshurl)])
+        [dict(cost=500, name='origin', url=ds_subpath),
+         dict(cost=600, name='origin', url=sshurl)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=httpurl)),
-        [dict(priority=500, name='origin', url=ds_subpath),
-         dict(priority=600, name='origin', url=httpurl)])
+        [dict(cost=500, name='origin', url=ds_subpath),
+         dict(cost=600, name='origin', url=httpurl)])
 
     # make sure it does meaningful things in an actual clone with an actual
     # record of a subdataset
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            dict(priority=500, name='origin', url=ds_subpath),
+            dict(cost=500, name='origin', url=ds_subpath),
     ])
 
     # check that a configured remote WITHOUT the desired submodule commit
@@ -117,7 +117,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
                    result_renderer='disabled')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            dict(priority=500, name='origin', url=ds_subpath),
+            dict(cost=500, name='origin', url=ds_subpath),
     ])
     # inject a source URL config, should alter the result accordingly
     with patch.dict(
@@ -125,17 +125,17 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'youredead'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(priority=500, name='origin', url=ds_subpath),
-                dict(priority=700, name='bang', url='youredead', from_config=True),
+                dict(cost=500, name='origin', url=ds_subpath),
+                dict(cost=700, name='bang', url='youredead', from_config=True),
         ])
-    # we can alter the priority by given the name a two-digit prefix
+    # we can alter the cost by given the name a two-digit prefix
     with patch.dict(
             'os.environ',
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__400BANG': 'youredead'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(priority=400, name='bang', url='youredead', from_config=True),
-                dict(priority=500, name='origin', url=ds_subpath),
+                dict(cost=400, name='bang', url='youredead', from_config=True),
+                dict(cost=500, name='origin', url=ds_subpath),
         ])
     # verify template instantiation works
     with patch.dict(
@@ -143,8 +143,8 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'pre-{id}-post'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(priority=500, name='origin', url=ds_subpath),
-                dict(priority=700, name='bang', url='pre-{}-post'.format(sub.id),
+                dict(cost=500, name='origin', url=ds_subpath),
+                dict(cost=700, name='bang', url='pre-{}-post'.format(sub.id),
                      from_config=True),
         ])
     # now again, but have an additional remote besides origin that

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -87,26 +87,28 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     ds_subpath = str(ds.pathobj / 'sub')
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path)), [])
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path, gitmodule_url=sshurl)),
-        [('90local', sshurl)])
+        [dict(priority=900, name='local', url=sshurl)])
     eq_(f(ds, dict(path=ds_subpath, parentds=ds.path, gitmodule_url=httpurl)),
-        [('90local', httpurl)])
+        [dict(priority=900, name='local', url=httpurl)])
 
     # but if we work on dsclone then it should also add urls deduced from its
     # own location default remote for current branch
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path)),
-        [('50origin', ds_subpath)])
+        [dict(priority=500, name='origin', url=ds_subpath)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=sshurl)),
-        [('50origin', ds_subpath), ('60origin', sshurl)])
+        [dict(priority=500, name='origin', url=ds_subpath),
+         dict(priority=600, name='origin', url=sshurl)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=httpurl)),
-        [('50origin', ds_subpath), ('60origin', httpurl)])
+        [dict(priority=500, name='origin', url=ds_subpath),
+         dict(priority=600, name='origin', url=httpurl)])
 
     # make sure it does meaningful things in an actual clone with an actual
     # record of a subdataset
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            ('50origin', ds_subpath),
+            dict(priority=500, name='origin', url=ds_subpath),
     ])
 
     # check that a configured remote WITHOUT the desired submodule commit
@@ -115,7 +117,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
                    result_renderer='disabled')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            ('50origin', ds_subpath),
+            dict(priority=500, name='origin', url=ds_subpath),
     ])
     # inject a source URL config, should alter the result accordingly
     with patch.dict(
@@ -123,17 +125,17 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'youredead'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                ('50origin', ds_subpath),
-                ('70:subdataset-source-candidate-bang', 'youredead'),
+                dict(priority=500, name='origin', url=ds_subpath),
+                dict(priority=700, name='bang', url='youredead', from_config=True),
         ])
     # we can alter the priority by given the name a two-digit prefix
     with patch.dict(
             'os.environ',
-            {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__40BANG': 'youredead'}):
+            {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__400BANG': 'youredead'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                ('40bang:subdataset-source-candidate-40bang', 'youredead'),
-                ('50origin', ds_subpath),
+                dict(priority=400, name='bang', url='youredead', from_config=True),
+                dict(priority=500, name='origin', url=ds_subpath),
         ])
     # verify template instantiation works
     with patch.dict(
@@ -141,8 +143,9 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'pre-{id}-post'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                ('50origin', ds_subpath),
-                ('70:subdataset-source-candidate-bang', 'pre-{}-post'.format(sub.id)),
+                dict(priority=500, name='origin', url=ds_subpath),
+                dict(priority=700, name='bang', url='pre-{}-post'.format(sub.id),
+                     from_config=True),
         ])
     # now again, but have an additional remote besides origin that
     # actually has the relevant commit
@@ -157,7 +160,8 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     # registered under two different names
     assert_in(
         ds_subpath,
-        [i[1] for i in f(clone3, clone3.subdatasets(return_type='item-or-list'))]
+        [i['url']
+         for i in f(clone3, clone3.subdatasets(return_type='item-or-list'))]
     )
 
     # TODO: check that http:// urls for the dataset itself get resolved


### PR DESCRIPTION
This is achieved by prefixing their existing label with three digits and sorting them before processing them.

This implementation makes no change to the previously established order, it just makes that order explicit in the labels.

The default setup uses the priorities in the second half of the spectrum:

- 500 for remote URL + submodule path
- 600 for the configured submodule URL
- 700 for any unprioritized 'datalad.get.subdataset-source-candidate' config
- 900 for the local subdataset path

The first half of the spectrum and the spaces inbetween are available for re-prioritizing clone attempts. The idea is to be able to configure

  `datalad.get.subdataset-source-candidate-000takemefirst = http://some`

and have this be processed first.

I have confirmed manually that this solution enables successful clones on first attempt, and substantially speeds up dataset installation. Likewise using '999label' it is possible to configure a fallback source candidate.

Towards a resolution of gh-4613

TODO:
- [x] adjust `clone` to use this feature
- [x] adjust documentation
- [x] add test
- ~~potentially prevent "flexibilizing" of explicitly configured URLs (e.g. `/.git` appending)~~