### PR TITLE
ENH: specify `push` --data modes; keep `--force` to only force git push and checkdatapresent

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -134,10 +134,10 @@ class Push(Interface):
         force=Parameter(
             # multi-mode option https://github.com/datalad/datalad/issues/3414
             args=("-f", "--force",),
-            doc="""force particular operations, overruling automatic decision
-            making: use --force with git-push ('gitpush'); do not use --fast
-            with git-annex copy ('checkdatapresent'); combine force modes
-            'gitpush' and 'checkdatapresent' ('all').""",
+            doc="""force particular operations, possibly overruling safety
+            protections or optimizations: use --force with git-push ('gitpush');
+            do not use --fast with git-annex copy ('checkdatapresent');
+            combine all force modes ('all').""",
             constraints=EnsureChoice(
                 'all', 'gitpush', 'checkdatapresent', None)),
         recursive=recursion_flag,

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -118,16 +118,16 @@ class Push(Interface):
             constraints=EnsureStr() | EnsureNone()),
         data=Parameter(
             args=("--data",),
-            doc="""what to do with data (annex'ed) data. 'anything' would cause
+            doc="""what to do with (annex'ed) data. 'anything' would cause
             transfer of all annexed content, 'nothing' would avoid call to
             `git annex copy` altogether. 'auto' would use 'git annex copy' with
             '--auto' thus transferring only data which would satisfy "wanted"
             or "numcopies" settings for the remote (thus "nothing" otherwise).
             'auto-if-wanted' would enable '--auto' mode only if there is a 
             "wanted" setting for the remote, and transfer 'anything' otherwise.
-            Note: 'anything' and 'nothing' are "wanted" expressions understood
-            by git-annex.""",
-            constraints=EnsureChoice('anything', 'nothing', 'auto', 'auto-if-wanted')),
+            """,
+            constraints=EnsureChoice(
+                'anything', 'nothing', 'auto', 'auto-if-wanted')),
         force=Parameter(
             # multi-mode option https://github.com/datalad/datalad/issues/3414
             args=("-f", "--force",),

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -137,9 +137,9 @@ class Push(Interface):
             doc="""force particular operations, overruling automatic decision
             making: use --force with git-push ('gitpush'); do not use --fast
             with git-annex copy ('checkdatapresent'); combine force modes
-            'gitpush' and 'checkdatapresent' ('pushall').""",
+            'gitpush' and 'checkdatapresent' ('all').""",
             constraints=EnsureChoice(
-                'pushall', 'gitpush', 'checkdatapresent', None)),
+                'all', 'gitpush', 'checkdatapresent', None)),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         jobs=jobs_opt,
@@ -378,7 +378,7 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
           done_fetch=None, got_path_arg=False):
     if not done_fetch:
         done_fetch = set()
-    force_git_push = force in ('pushall', 'gitpush')
+    force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
     ds = Dataset(dspath)
@@ -726,7 +726,7 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
             res_kwargs,
             action='copy',
             status='impossible'
-            if force in ('pushall', 'checkdatapresent')
+            if force in ('all', 'checkdatapresent')
             else 'notneeded',
             message=(
                 "Target '%s' does not appear to be an annex remote",
@@ -760,7 +760,7 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
         c
         for c in content.values()
         # by force
-        if ((force in ('pushall', 'checkdatapresent') or
+        if ((force in ('all', 'checkdatapresent') or
              # or by modification report
              c.get('state', None) not in ('clean', 'deleted'))
             # only consider annex'ed files
@@ -787,14 +787,14 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
     # Since we got here - we already have some  transfer_data != "nothing"
     if (transfer_data == 'auto') or \
         (
-            force not in ('pushall', 'checkdatapresent') and
+            force not in ('all', 'checkdatapresent') and
             ds_repo.config.obtain('datalad.push.copy-auto-if-wanted') and
             ds_repo.get_preferred_content('wanted', target)
         ):
         lgr.debug("Invoking copy --auto")
         cmd.append('--auto')
 
-    if force not in ('pushall', 'checkdatapresent'):
+    if force not in ('all', 'checkdatapresent'):
         # if we force, we do not trust local knowledge and do the checks
         cmd.append('--fast')
 

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -378,6 +378,8 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
           done_fetch=None, got_path_arg=False):
     if not done_fetch:
         done_fetch = set()
+    force_git_push = force in ('pushall', 'gitpush')
+
     # nothing recursive in here, we only need a repo to work with
     ds = Dataset(dspath)
     repo = ds.repo
@@ -559,7 +561,7 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
                 repo,
                 target,
                 refspecs2push,
-                force,
+                force_git_push,
                 res_kwargs.copy()):
             if p['status'] not in ('ok', 'notneeded'):
                 push_ok = False
@@ -652,12 +654,12 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
         ['git-annex'
          if ds.config.get('branch.git-annex.merge', None)
          else 'git-annex:git-annex'],
-        force,
+        force_git_push,
         res_kwargs.copy(),
     )
 
 
-def _push_refspecs(repo, target, refspecs, force, res_kwargs):
+def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
     # TODO inefficient, but push only takes a single refspec at a time
     # at the moment, enhance GitRepo.push() to do all at once
     push_res = []
@@ -665,7 +667,7 @@ def _push_refspecs(repo, target, refspecs, force, res_kwargs):
         push_res.extend(repo.push(
             remote=target,
             refspec=refspec,
-            git_options=['--force'] if force in ('pushall', 'gitpush') else None,
+            git_options=['--force'] if force_git_push else None,
         ))
     # TODO maybe compress into a single message whenever everything is
     # OK?

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -569,9 +569,10 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
             # TODO final global error result for the dataset?!
             return
 
-    # git-annex data move
+    # git-annex data copy
     #
     if not is_annex_repo:
+        lgr.debug("No data transfer: %s is not a git annex repository", repo)
         return
 
     if transfer_data == "nothing":

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -136,10 +136,10 @@ class Push(Interface):
             args=("-f", "--force",),
             doc="""force particular operations, overruling automatic decision
             making: use --force with git-push ('gitpush'); do not use --fast
-            with git-annex copy ('datatransfer'); combine force modes
-            'gitpush' and 'datatransfer' ('pushall').""",
+            with git-annex copy ('checkdatapresent'); combine force modes
+            'gitpush' and 'checkdatapresent' ('pushall').""",
             constraints=EnsureChoice(
-                'pushall', 'gitpush', 'datatransfer', None)),
+                'pushall', 'gitpush', 'checkdatapresent', None)),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         jobs=jobs_opt,
@@ -726,7 +726,7 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
             res_kwargs,
             action='copy',
             status='impossible'
-            if force in ('pushall', 'datatransfer')
+            if force in ('pushall', 'checkdatapresent')
             else 'notneeded',
             message=(
                 "Target '%s' does not appear to be an annex remote",
@@ -760,7 +760,7 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
         c
         for c in content.values()
         # by force
-        if ((force in ('pushall', 'datatransfer') or
+        if ((force in ('pushall', 'checkdatapresent') or
              # or by modification report
              c.get('state', None) not in ('clean', 'deleted'))
             # only consider annex'ed files
@@ -787,14 +787,14 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
     # Since we got here - we already have some  transfer_data != "nothing"
     if (transfer_data == 'auto') or \
         (
-            force not in ('pushall', 'datatransfer') and
+            force not in ('pushall', 'checkdatapresent') and
             ds_repo.config.obtain('datalad.push.copy-auto-if-wanted') and
             ds_repo.get_preferred_content('wanted', target)
         ):
         lgr.debug("Invoking copy --auto")
         cmd.append('--auto')
 
-    if force not in ('pushall', 'datatransfer'):
+    if force not in ('pushall', 'checkdatapresent'):
         # if we force, we do not trust local knowledge and do the checks
         cmd.append('--fast')
 

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -116,8 +116,8 @@ class Push(Interface):
             data or changes for those paths are considered for a push.""",
             nargs='*',
             constraints=EnsureStr() | EnsureNone()),
-        transfer_data=Parameter(
-            args=("--transfer-data",),
+        data=Parameter(
+            args=("--data",),
             doc="""what to do with data (annex'ed) data. 'anything' would cause
             transfer of all annexed content, 'nothing' would avoid call to
             `git annex copy` altogether. 'auto' would use 'git annex copy' with
@@ -185,7 +185,7 @@ class Push(Interface):
             dataset=None,
             to=None,
             since=None,
-            transfer_data='auto-if-wanted',
+            data='auto-if-wanted',
             force=None,
             recursive=False,
             recursion_limit=None,
@@ -254,7 +254,7 @@ class Push(Interface):
             lgr.debug('Attempt push of Dataset at %s', dspath)
             pbars = {}
             yield from _push(
-                dspath, dsrecords, to, transfer_data, force, jobs, res_kwargs.copy(), pbars,
+                dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
                 got_path_arg=True if path else False)
             # take down progress bars for this dataset
             for i, ds in pbars.items():
@@ -371,7 +371,7 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
         yield (cur_ds, ds_res)
 
 
-def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars,
+def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
           done_fetch=None, got_path_arg=False):
     if not done_fetch:
         done_fetch = set()
@@ -533,7 +533,7 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
             content,
             # to this particular dependency
             r,
-            transfer_data,
+            data,
             force,
             jobs,
             res_kwargs.copy(),
@@ -575,7 +575,7 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
         lgr.debug("No data transfer: %s is not a git annex repository", repo)
         return
 
-    if transfer_data == "nothing":
+    if data == "nothing":
         lgr.debug("Data transfer to '%s' disabled by argument", target)
         return
 
@@ -587,7 +587,7 @@ def _push(dspath, content, target, transfer_data, force, jobs, res_kwargs, pbars
         ds,
         target,
         content,
-        transfer_data,
+        data,
         force,
         jobs,
         res_kwargs.copy(),
@@ -706,7 +706,7 @@ def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
         )
 
 
-def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
+def _push_data(ds, target, content, data, force, jobs, res_kwargs,
                got_path_arg=False):
     if ds.config.getbool('remote.{}'.format(target), 'annex-ignore', False):
         lgr.debug(
@@ -782,10 +782,10 @@ def _push_data(ds, target, content, transfer_data, force, jobs, res_kwargs,
     if jobs:
         cmd.extend(['--jobs', str(jobs)])
 
-    # Since we got here - we already have some  transfer_data != "nothing"
-    if (transfer_data == 'auto') or \
+    # Since we got here - we already have some  data != "nothing"
+    if (data == 'auto') or \
         (
-            (transfer_data == 'auto-if-wanted') and
+            (data == 'auto-if-wanted') and
             ds_repo.get_preferred_content('wanted', target)
         ):
         lgr.debug("Invoking copy --auto")

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -398,7 +398,7 @@ def test_force_datatransfer(srcpath, dstpath):
     assert_repo_status(src.path, annex=True)
     whereis_prior = src.repo.whereis(files=['test_mod_annex_file'])[0]
 
-    res = src.push(to='target', force='no-datatransfer')
+    res = src.push(to='target', transfer_data='nothing')
     # nothing reported to be copied
     assert_not_in_results(res, action='copy')
     # we got the git-push nevertheless

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -390,7 +390,7 @@ def test_push_subds_no_recursion(src_path, dst_top, dst_sub, dst_subsub):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-def test_force_datatransfer(srcpath, dstpath):
+def test_force_checkdatapresent(srcpath, dstpath):
     src = Dataset(srcpath).create()
     target = mk_push_target(src, 'target', dstpath, annex=True, bare=True)
     (src.pathobj / 'test_mod_annex_file').write_text("Heavy stuff.")
@@ -430,7 +430,7 @@ def test_force_datatransfer(srcpath, dstpath):
                   src.push(to='target', force=None, since='HEAD~1'))
 
     # now force data transfer
-    res = src.push(to='target', force='datatransfer')
+    res = src.push(to='target', force='checkdatapresent')
     # no branch change, done before
     assert_in_results(res, action='publish', status='notneeded',
                       refspec='refs/heads/master:refs/heads/master')
@@ -444,7 +444,7 @@ def test_force_datatransfer(srcpath, dstpath):
 
     # force data transfer, but data isn't available
     src.repo.drop('test_mod_annex_file')
-    res = src.push(to='target', path='.', force='datatransfer', on_failure='ignore')
+    res = src.push(to='target', path='.', force='checkdatapresent', on_failure='ignore')
     assert_in_results(res, status='impossible',
                       path=str(src.pathobj / 'test_mod_annex_file'),
                       action='copy',

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -398,7 +398,7 @@ def test_force_checkdatapresent(srcpath, dstpath):
     assert_repo_status(src.path, annex=True)
     whereis_prior = src.repo.whereis(files=['test_mod_annex_file'])[0]
 
-    res = src.push(to='target', transfer_data='nothing')
+    res = src.push(to='target', data='nothing')
     # nothing reported to be copied
     assert_not_in_results(res, action='copy')
     # we got the git-push nevertheless

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -632,6 +632,10 @@ def test_push_wanted(srcpath, dstpath):
 def test_auto_data_transfer(path):
     path = Path(path)
     ds_a = Dataset(path / "a").create()
+    if ds_a.repo.is_managed_branch():
+        # on crippled FS post-update hook enabling via create-sibling doesn't
+        # work ATM
+        raise SkipTest("no create-sibling on crippled FS")
     (ds_a.pathobj / "foo.dat").write_text("foo")
     ds_a.save()
 
@@ -688,6 +692,10 @@ def test_auto_data_transfer(path):
 def test_auto_if_wanted_data_transfer_path_restriction(path):
     path = Path(path)
     ds_a = Dataset(path / "a").create()
+    if ds_a.repo.is_managed_branch():
+        # on crippled FS post-update hook enabling via create-sibling doesn't
+        # work ATM
+        raise SkipTest("no create-sibling on crippled FS")
     ds_a_sub0 = ds_a.create("sub0")
     ds_a_sub1 = ds_a.create("sub1")
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -112,13 +112,6 @@ definitions = {
             'text': 'Description for a Personal access token to generate.'}),
         'default': 'DataLad',
     },
-    'datalad.push.copy-auto-if-wanted': {
-        'ui': ('question', {
-            'title': "Use `git-annex copy --auto` with preferred content configured",
-            'text': 'If this flag is set, DataLad looks for preferred content configuration for a push target and instructs git-annex to use auto-mode for copying, if such configuration is detected.'}),
-        'type': EnsureBool(),
-        'default': False,
-    },
     'datalad.tests.nonetwork': {
         'ui': ('yesno', {
                'title': 'Skips network tests completely if this flag is set Examples include test for s3, git_repositories, openfmri etc'}),


### PR DESCRIPTION
This is an implementation for #4604 .

Notes:
- it is not harmonized with `publish` or `get` (see #4604 for notes on that)
- from Python programming side perspective I do dislike that we cannot say `data=True` or `False`. `data='nothing'` is not worse IMHO though than `force=['no-datatransfer']` though.
-  `--force=checkdatapresent`  (resolves #4603) in b20ed1379da540621e48a1515191a9ea32ae258f
- `--force=all` instead of `--force=pushall` in 65aae48ef0cee708a7e0fee89f076b152b64eef2 since IMHO forces should be orthogonal and could all be combined
- Closes #4602 which was an alternative proposed solution (`--force=onlywanteddatatransfer`)
- Removed `datalad.push.copy-auto-if-wanted` config adding a mode `auto-if-wanted` (1be419f0483dde6db939b2263bdbcf3d355dafb5) and making it to be default mode of operation.  It would cause transfer ("anything") if no "wanted" is not set, thus fulfilling the "do the right thing by default".
- Uses `--data` (see #4622)

See individual commits for more information.  I had tried to make them atomic enough so we could drop some if so desired.