### PR TITLE
TST: Avoid hard coding the default branch

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -101,6 +101,12 @@ def setup_package():
     _test_states['DATASETS_TOPURL'] = consts.DATASETS_TOPURL
     os.environ['DATALAD_DATASETS_TOPURL'] = consts.DATASETS_TOPURL = 'http://datasets-tests.datalad.org/'
 
+    from datalad.tests.utils import DEFAULT_BRANCH
+    _test_states["GIT_CONFIG_PARAMETERS"] = os.environ.get(
+        "GIT_CONFIG_PARAMETERS")
+    os.environ["GIT_CONFIG_PARAMETERS"] = "'init.defaultBranch={}'".format(
+        DEFAULT_BRANCH)
+
     # To overcome pybuild overriding HOME but us possibly wanting our
     # own HOME where we pre-setup git for testing (name, email)
     if 'GIT_HOME' in os.environ:
@@ -227,6 +233,12 @@ def teardown_package():
 
     if _test_states['HOME'] is not None:
         os.environ['HOME'] = _test_states['HOME']
+
+    git_config_params = _test_states["GIT_CONFIG_PARAMETERS"]
+    if git_config_params is None:
+        os.environ.pop("GIT_CONFIG_PARAMETERS")
+    else:
+        os.environ["GIT_CONFIG_PARAMETERS"] = git_config_params
 
     # Re-establish correct global config after changing $HOME.
     # Might be superfluous, since after teardown datalad.cfg shouldn't be

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1063,7 +1063,7 @@ def test_clone_unborn_head(path):
     # The setup below is involved, mostly because it's accounting for adjusted
     # branches. The scenario itself isn't so complicated, though:
     #
-    #   * a checked out master branch with no commits
+    #   * a checked out default branch with no commits
     #   * a (potentially adjusted) "abc" branch with commits.
     #   * a (potentially adjusted) "chooseme" branch whose tip commit has a
     #     more recent commit than any in "abc".

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -42,6 +42,7 @@ from datalad.tests.utils import (
     assert_result_values_equal,
     assert_status,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     get_datasets_topdir,
     integration,
@@ -1070,8 +1071,8 @@ def test_clone_unborn_head(path):
     ds_origin.save(message="foo")
     for res in repo.for_each_ref_(fields="refname"):
         ref = res["refname"]
-        if "master" in ref:
-            repo.update_ref(ref.replace("master", "abc"), ref)
+        if DEFAULT_BRANCH in ref:
+            repo.update_ref(ref.replace(DEFAULT_BRANCH, "abc"), ref)
             repo.call_git(["update-ref", "-d", ref])
     repo.update_ref("HEAD",
                     "refs/heads/{}".format(
@@ -1088,7 +1089,7 @@ def test_clone_unborn_head(path):
     # that it is skipped.
     with set_date(abc_ts + 2):
         ds_origin.drop("bar", check=False)
-    ds_origin.repo.checkout("master", options=["--orphan"])
+    ds_origin.repo.checkout(DEFAULT_BRANCH, options=["--orphan"])
 
     ds = clone(ds_origin.path, op.join(path, "b"))
     # We landed on the branch with the most recent commit, ignoring the
@@ -1106,7 +1107,8 @@ def test_clone_unborn_head(path):
 @with_tempfile(mkdir=True)
 def test_clone_unborn_head_no_other_ref(path):
     ds_origin = Dataset(op.join(path, "a")).create(annex=False)
-    ds_origin.repo.call_git(["update-ref", "-d", "refs/heads/master"])
+    ds_origin.repo.call_git(["update-ref", "-d",
+                             "refs/heads/" + DEFAULT_BRANCH])
     with swallow_logs(new_level=logging.WARNING) as cml:
         clone(source=ds_origin.path, path=op.join(path, "b"))
         assert_in("could not find a branch with commits", cml.out)
@@ -1117,9 +1119,9 @@ def test_clone_unborn_head_sub(path):
     ds_origin = Dataset(op.join(path, "a")).create()
     ds_origin_sub = Dataset(op.join(path, "a", "sub")).create()
     managed = ds_origin_sub.repo.is_managed_branch()
-    ds_origin_sub.repo.call_git(["branch", "-m", "master", "other"])
+    ds_origin_sub.repo.call_git(["branch", "-m", DEFAULT_BRANCH, "other"])
     ds_origin.save()
-    ds_origin_sub.repo.checkout("master", options=["--orphan"])
+    ds_origin_sub.repo.checkout(DEFAULT_BRANCH, options=["--orphan"])
 
     ds_cloned = clone(source=ds_origin.path, path=op.join(path, "b"))
     ds_cloned_sub = ds_cloned.get(

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -229,7 +229,7 @@ def check_push(annex, src_path, dst_path):
             list(src_repo.get_branch_commits_(DEFAULT_BRANCH)))
 
     # we do not have more branches than we had in the beginning
-    # in particular no 'synced/master'
+    # in particular no 'synced/<default branch>'
     eq_(orig_branches, src_repo.get_branches())
 
 
@@ -300,7 +300,7 @@ def test_push_recursive(
             eq_(list(s.repo.get_branch_commits_("git-annex")),
                 list(d.get_branch_commits_("git-annex")))
 
-    # rerun should not result in further pushes of master
+    # rerun should not result in further pushes of the default branch
     res = top.push(to="target", recursive=True)
     assert_not_in_results(
         res, status='ok', refspec=DEFAULT_REFSPEC)

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -35,6 +35,7 @@ from datalad.tests.utils import (
     assert_status,
     chpwd,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     get_deeply_nested_structure,
     has_symlink_capability,
@@ -73,8 +74,8 @@ def test_repo_diff(path, norepo):
     assert_raises(ValueError, ds.repo.diff, fr='WTF', to='MIKE')
 
     if ds.repo.is_managed_branch():
-        fr_base = "master"
-        to = "master"
+        fr_base = DEFAULT_BRANCH
+        to = DEFAULT_BRANCH
     else:
         fr_base = "HEAD"
         to = None
@@ -179,8 +180,8 @@ def test_diff(path, norepo):
     assert_repo_status(ds.path)
 
     if ds.repo.is_managed_branch():
-        fr_base = "master"
-        to = "master"
+        fr_base = DEFAULT_BRANCH
+        to = DEFAULT_BRANCH
     else:
         fr_base = "HEAD"
         to = None
@@ -255,11 +256,12 @@ def test_diff_recursive(path):
     ds = Dataset(path).create()
     sub = ds.create('sub')
     # look at the last change, and confirm a dataset was added
-    res = ds.diff(fr='master~1', to='master', result_renderer=None)
+    res = ds.diff(fr=DEFAULT_BRANCH + '~1', to=DEFAULT_BRANCH,
+                  result_renderer=None)
     assert_result_count(
         res, 1, action='diff', state='added', path=sub.path, type='dataset')
     # now recursive
-    res = ds.diff(recursive=True, fr='master~1', to='master',
+    res = ds.diff(recursive=True, fr=DEFAULT_BRANCH + '~1', to=DEFAULT_BRANCH,
                   result_renderer=None)
     # we also get the entire diff of the subdataset from scratch
     assert_status('ok', res)
@@ -291,7 +293,7 @@ def test_diff_recursive(path):
     ds.save()
     assert_repo_status(ds.path)
 
-    head_ref = 'master' if ds.repo.is_managed_branch() else 'HEAD'
+    head_ref = DEFAULT_BRANCH if ds.repo.is_managed_branch() else 'HEAD'
 
     # look at the last change, only one file was added
     res = ds.diff(fr=head_ref + '~1', to=head_ref, result_renderer=None)
@@ -514,7 +516,7 @@ def test_no_worktree_impact_false_deletions(path):
     # create a branch that has no new content
     ds.repo.call_git(['checkout', '-b', 'test'])
     # place to successive commits with file additions into the master branch
-    ds.repo.call_git(['checkout', 'master'])
+    ds.repo.call_git(['checkout', DEFAULT_BRANCH])
     (ds.pathobj / 'identical').write_text('should be')
     ds.save()
     (ds.pathobj / 'new').write_text('yes')
@@ -522,7 +524,8 @@ def test_no_worktree_impact_false_deletions(path):
     # now perform a diff for the last commit, there is one file that remained
     # identifical
     ds.repo.call_git(['checkout', 'test'])
-    res = ds.diff(fr='master~1', to='master', result_renderer=None)
+    res = ds.diff(fr=DEFAULT_BRANCH + '~1', to=DEFAULT_BRANCH,
+                  result_renderer=None)
     # under no circumstances can there be any reports on deleted files
     # because we never deleted anything
     assert_result_count(res, 0, state='deleted')

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -515,7 +515,7 @@ def test_no_worktree_impact_false_deletions(path):
     ds = Dataset(path).create()
     # create a branch that has no new content
     ds.repo.call_git(['checkout', '-b', 'test'])
-    # place to successive commits with file additions into the master branch
+    # place two successive commits with file additions into the master branch
     ds.repo.call_git(['checkout', DEFAULT_BRANCH])
     (ds.pathobj / 'identical').write_text('should be')
     ds.save()

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -515,7 +515,7 @@ def test_no_worktree_impact_false_deletions(path):
     ds = Dataset(path).create()
     # create a branch that has no new content
     ds.repo.call_git(['checkout', '-b', 'test'])
-    # place two successive commits with file additions into the master branch
+    # place two successive commits with file additions into the default branch
     ds.repo.call_git(['checkout', DEFAULT_BRANCH])
     (ds.pathobj / 'identical').write_text('should be')
     ds.save()

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -54,6 +54,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     known_failure_appveyor,
     known_failure_githubci_win,
@@ -86,7 +87,7 @@ def test_invalid_call(path):
 def last_commit_msg(repo):
     # ATTN: Use master explicitly so that this check works when we're on an
     # adjusted branch too (e.g., when this test is executed under Windows).
-    return repo.format_commit("%B", "master")
+    return repo.format_commit("%B", DEFAULT_BRANCH)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -85,7 +85,7 @@ def test_invalid_call(path):
 
 
 def last_commit_msg(repo):
-    # ATTN: Use master explicitly so that this check works when we're on an
+    # ATTN: Pass branch explicitly so that this check works when we're on an
     # adjusted branch too (e.g., when this test is executed under Windows).
     return repo.format_commit("%B", DEFAULT_BRANCH)
 

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -155,8 +155,9 @@ def test_save_message_file(path):
                        "msg": "add foo"})
     ds.repo.add("foo")
     ds.save(message_file=op.join(ds.path, "msg"))
-    # ATTN: Use master explicitly so that this check works when we're on an
-    # adjusted branch too (e.g., when this test is executed under Windows).
+    # ATTN: Consider corresponding branch so that this check works when we're
+    # on an adjusted branch too (e.g., when this test is executed under
+    # Windows).
     eq_(ds.repo.format_commit("%s", DEFAULT_BRANCH),
         "add foo")
 

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -27,6 +27,7 @@ from datalad.tests.utils import (
     assert_status,
     chpwd,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     known_failure_appveyor,
     known_failure_windows,
@@ -156,7 +157,7 @@ def test_save_message_file(path):
     ds.save(message_file=op.join(ds.path, "msg"))
     # ATTN: Use master explicitly so that this check works when we're on an
     # adjusted branch too (e.g., when this test is executed under Windows).
-    eq_(ds.repo.format_commit("%s", "master"),
+    eq_(ds.repo.format_commit("%s", DEFAULT_BRANCH),
         "add foo")
 
 

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -366,13 +366,12 @@ def _create_dataset_sibling(
     branch = ds_repo.get_active_branch()
     if branch is not None:
         branch = ds_repo.get_corresponding_branch(branch) or branch
-        if branch != "master":
-            # Setting the HEAD for the created sibling to the original
-            # repo's current branch should be unsurprising, and it
-            # helps with consumers that don't properly handle the
-            # default master with no commits. See gh-4349.
-            shell("git -C {} symbolic-ref HEAD refs/heads/{}"
-                  .format(sh_quote(remoteds_path), branch))
+        # Setting the HEAD for the created sibling to the original repo's
+        # current branch should be unsurprising, and it helps with consumers
+        # that don't properly handle the default branch with no commits. See
+        # gh-4349.
+        shell("git -C {} symbolic-ref HEAD refs/heads/{}"
+              .format(sh_quote(remoteds_path), branch))
 
     if install_postupdate_hook:
         # enable metadata refresh on dataset updates to publication server

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -37,6 +37,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     get_mtimes_and_digests,
     ok_,
@@ -238,7 +239,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
                 dataset=source,
                 name="local_target",
                 sshurl="ssh://localhost" + target_path,
-                publish_by_default='master',
+                publish_by_default=DEFAULT_BRANCH,
                 existing='replace',
                 ui=True,
             )
@@ -257,7 +258,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             # valid uuid
             eq_(lclcfg.get('remote.local_target.annex-uuid').count('-'), 4)
             # should be added too, even if URL matches prior state
-            eq_(lclcfg.get('remote.local_target.push'), 'master')
+            eq_(lclcfg.get('remote.local_target.push'), DEFAULT_BRANCH)
 
         # again, by explicitly passing urls. Since we are on localhost, the
         # local path should work:
@@ -807,7 +808,7 @@ def test_non_master_branch(src_path, target_path):
     ds_a = Dataset(src_path).create()
     # Rename rather than checking out another branch so that master
     # doesn't exist in any state.
-    ds_a.repo.call_git(["branch", "-m", "master", "other"])
+    ds_a.repo.call_git(["branch", "-m", DEFAULT_BRANCH, "other"])
     (ds_a.pathobj / "afile").write_text("content")
     sa = ds_a.create("sub-a")
     sa.repo.checkout("other-sub", ["-b"])
@@ -832,4 +833,4 @@ def test_non_master_branch(src_path, target_path):
     eq_(get_branch(Dataset(target_path / "b" / "sub-a").repo),
         "other-sub")
     eq_(get_branch(Dataset(target_path / "b" / "sub-b").repo),
-        "master")
+        DEFAULT_BRANCH)

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -806,7 +806,7 @@ def test_non_master_branch(src_path, target_path):
     target_path = Path(target_path)
 
     ds_a = Dataset(src_path).create()
-    # Rename rather than checking out another branch so that master
+    # Rename rather than checking out another branch so that the default branch
     # doesn't exist in any state.
     ds_a.repo.call_git(["branch", "-m", DEFAULT_BRANCH, "other"])
     (ds_a.pathobj / "afile").write_text("content")

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -61,6 +61,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     assert_in_results,
+    DEFAULT_BRANCH,
     ok_startswith,
     serve_path_via_http,
     swallow_logs,
@@ -770,7 +771,7 @@ def test_install_consistent_state(src, dest, dest2, dest3):
         assert len(datasets) == 2  # in this test
         for ds in datasets:
             # all of them should be in master branch
-            eq_(ds.repo.get_active_branch(), "master")
+            eq_(ds.repo.get_active_branch(), DEFAULT_BRANCH)
             # all of them should be clean, so sub should be installed in a "version"
             # as pointed by the super
             ok_(not ds.repo.dirty)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -770,7 +770,7 @@ def test_install_consistent_state(src, dest, dest2, dest3):
                                         result_xfm='paths')))
         assert len(datasets) == 2  # in this test
         for ds in datasets:
-            # all of them should be in master branch
+            # all of them should be in the default branch
             eq_(ds.repo.get_active_branch(), DEFAULT_BRANCH)
             # all of them should be clean, so sub should be installed in a "version"
             # as pointed by the super

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -43,6 +43,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     known_failure_windows,
     neq_,
@@ -172,8 +173,8 @@ def test_publish_simple(origin, src_path, dst_path):
 
     assert_repo_status(source.repo, annex=None)
     assert_repo_status(target, annex=None)
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
 
     # don't fail when doing it again
     res = publish(dataset=source, to="target")
@@ -182,8 +183,8 @@ def test_publish_simple(origin, src_path, dst_path):
 
     assert_repo_status(source.repo, annex=None)
     assert_repo_status(target, annex=None)
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(source.repo, target)
 
     # 'target/master' should be tracking branch at this point, so
@@ -201,8 +202,8 @@ def test_publish_simple(origin, src_path, dst_path):
     eq_(res, [source])
 
     assert_repo_status(dst_path, annex=None)
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(source.repo, target)
 
     eq_(filter_fsck_error_msg(source.repo.fsck()),
@@ -231,8 +232,8 @@ def test_publish_plain_git(origin, src_path, dst_path):
 
     assert_repo_status(source.repo, annex=None)
     assert_repo_status(target, annex=None)
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
 
     # don't fail when doing it again
     res = publish(dataset=source, to="target")
@@ -241,8 +242,8 @@ def test_publish_plain_git(origin, src_path, dst_path):
 
     assert_repo_status(source.repo, annex=None)
     assert_repo_status(target, annex=None)
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
 
     # some modification:
     with open(opj(src_path, 'test_mod_file'), "w") as f:
@@ -255,8 +256,8 @@ def test_publish_plain_git(origin, src_path, dst_path):
     eq_(res, [source])
 
     assert_repo_status(dst_path, annex=None)
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
 
     # amend and change commit msg in order to test for force push:
     source.repo.commit("amended", options=['--amend'])
@@ -332,14 +333,14 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     eq_({r['path'] for r in res},
         {src_path, sub1.path, sub2.path})
 
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(source.repo, target)
-    eq_(list(sub1_target.get_branch_commits_("master")),
-        list(sub1.get_branch_commits_("master")))
+    eq_(list(sub1_target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(sub1.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(sub1, sub1_target)
-    eq_(list(sub2_target.get_branch_commits_("master")),
-        list(sub2.get_branch_commits_("master")))
+    eq_(list(sub2_target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(sub2.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(sub2, sub2_target)
 
     # we are tracking origin but origin has different git-annex, since we
@@ -422,7 +423,8 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # merge point"
     source.save(message="Changes in subm2")
     # and test if it could deduce the remote/branch to push to
-    source.config.set('branch.master.remote', 'target', where='local')
+    source.config.set('branch.{}.remote'.format(DEFAULT_BRANCH),
+                      'target', where='local')
     with chpwd(source.path):
         res_ = publish(since='', recursive=True)
     # TODO: somehow test that there were no even attempt to diff within "subm 1"
@@ -473,12 +475,12 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
     eq_(set(res), set([opj(source.path, 'test-annex.dat'), source.path]))
     # XXX master was not checked out in dst!
 
-    eq_(list(target.get_branch_commits_("master")),
-        list(source.repo.get_branch_commits_("master")))
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(source.repo, target)
 
     # we need compare target/master:
-    target.checkout("master")
+    target.checkout(DEFAULT_BRANCH)
     ok_(target.file_has_content('test-annex.dat'))
 
     # make sure that whatever we published is actually consumable

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -187,7 +187,7 @@ def test_publish_simple(origin, src_path, dst_path):
         list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(source.repo, target)
 
-    # 'target/master' should be tracking branch at this point, so
+    # 'target/<default branch>' should be tracking branch at this point, so
     # try publishing without `to`:
     # MIH: Nope, we don't automatically add this anymore
 
@@ -479,7 +479,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
         list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
     assert_git_annex_branch_published(source.repo, target)
 
-    # we need compare target/master:
+    # we need compare target/<default branch>:
     target.checkout(DEFAULT_BRANCH)
     ok_(target.file_has_content('test-annex.dat'))
 

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -96,7 +96,7 @@ def test_update_simple(origin, src_path, dst_path):
     # modification is not known to active branch:
     assert_not_in("update.txt",
                   dest.repo.get_files(dest.repo.get_active_branch()))
-    # modification is known to branch origin/master
+    # modification is known to branch origin/<default branch>
     assert_in("update.txt", dest.repo.get_files("origin/" + DEFAULT_BRANCH))
 
     # merge:

--- a/datalad/interface/tests/test_ls.py
+++ b/datalad/interface/tests/test_ls.py
@@ -25,6 +25,7 @@ from ...api import ls
 from ...utils import swallow_outputs, chpwd
 from ...tests.utils import assert_equal
 from ...tests.utils import assert_in
+from ...tests.utils import DEFAULT_BRANCH
 from ...tests.utils import use_cassette
 from ...tests.utils import with_tempfile
 from ...tests.utils import skip_if_no_network
@@ -70,7 +71,7 @@ def test_ls_repos(toppath):
                     assert_equal(len(cmo.out.rstrip().split('\n')), len(args))
                     assert_in('[annex]', cmo.out)
                     assert_in('[git]', cmo.out)
-                    assert_in('master', cmo.out)
+                    assert_in(DEFAULT_BRANCH, cmo.out)
                     if "bogus" in args:
                         assert_in('unknown', cmo.out)
 

--- a/datalad/interface/tests/test_rerun_merges.py
+++ b/datalad/interface/tests/test_rerun_merges.py
@@ -16,6 +16,7 @@ import os.path as op
 from datalad.distribution.dataset import Dataset
 from datalad.tests.utils import (
     assert_false,
+    DEFAULT_BRANCH,
     eq_,
     known_failure_windows,
     neq_,
@@ -44,9 +45,9 @@ from datalad.tests.utils import (
 @with_tempfile(mkdir=True)
 def test_rerun_fastforwardable(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
     ds.run("echo foo >foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["-m", "Merge side", "--no-ff"])
     #  o                 c_n
     #  |\
@@ -60,18 +61,18 @@ def test_rerun_fastforwardable(path):
     #  | o               b_R
     #  |/
     #  o                 a_n
-    eq_(ds.repo.get_hexsha("master^"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
         ds.repo.get_hexsha("HEAD^"))
     ok_(ds.repo.commit_exists("HEAD^2"))
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^2")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     #  o                 b_r
     #  o                 a_n
-    eq_(ds.repo.get_hexsha("master^2"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
         ds.repo.get_hexsha())
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     #  o                 c_n
@@ -79,7 +80,7 @@ def test_rerun_fastforwardable(path):
     #  | o               b_r
     #  |/
     #  o                 a_n
-    eq_(ds.repo.get_active_branch(), "master")
+    eq_(ds.repo.get_active_branch(), DEFAULT_BRANCH)
     eq_(hexsha_before,
         ds.repo.get_hexsha())
 
@@ -89,9 +90,9 @@ def test_rerun_fastforwardable(path):
 @with_tempfile(mkdir=True)
 def test_rerun_fastforwardable_mutator(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
     ds.run("echo foo >>foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["-m", "Merge side", "--no-ff"])
     #  o                 c_n
     #  |\
@@ -99,14 +100,14 @@ def test_rerun_fastforwardable_mutator(path):
     #  |/
     #  o                 a_n
 
-    ds.rerun(since="", onto="master^2")
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     #  o                 b_R
     #  o                 b_r
     #  o                 a_n
-    neq_(ds.repo.get_hexsha("master^2"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
          ds.repo.get_hexsha())
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     #  o                 b_R
@@ -115,10 +116,10 @@ def test_rerun_fastforwardable_mutator(path):
     #  | o               b_r
     #  |/
     #  o                 a_n
-    eq_(ds.repo.get_active_branch(), "master")
-    assert_false(ds.repo.commit_exists("master^2"))
+    eq_(ds.repo.get_active_branch(), DEFAULT_BRANCH)
+    assert_false(ds.repo.commit_exists(DEFAULT_BRANCH + "^2"))
     eq_(hexsha_before,
-        ds.repo.get_hexsha("master^"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^"))
 
 
 @slow
@@ -126,9 +127,9 @@ def test_rerun_fastforwardable_mutator(path):
 @with_tempfile(mkdir=True)
 def test_rerun_left_right_runs(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
     ds.run("echo foo >foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.run("echo bar >bar")
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 d_n
@@ -145,25 +146,25 @@ def test_rerun_left_right_runs(path):
     # | o               b_R
     # |/
     # o                 a_n
-    neq_(ds.repo.get_hexsha("master^"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
          ds.repo.get_hexsha("HEAD^"))
-    neq_(ds.repo.get_hexsha("master^2"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
          ds.repo.get_hexsha("HEAD^2"))
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^")
     # o                 d_M
     # |\
     # | o               b_R
     # |/
     # o                 c_r
     # o                 a_n
-    eq_(ds.repo.get_hexsha("master^"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
         ds.repo.get_hexsha("HEAD^"))
-    neq_(ds.repo.get_hexsha("master^2"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
          ds.repo.get_hexsha("HEAD^2"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     # o                 d_n
@@ -180,9 +181,9 @@ def test_rerun_left_right_runs(path):
 @with_tempfile(mkdir=True)
 def test_rerun_run_left_mutator_right(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
     ds.run("echo ichange >>ichange")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.run("echo idont >idont")
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 d_n
@@ -202,7 +203,7 @@ def test_rerun_run_left_mutator_right(path):
     # |/
     # o                 a_n
     eq_(ds.repo.get_hexsha(hexsha_before),
-        ds.repo.get_hexsha("master^"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^"))
 
 
 @slow
@@ -213,9 +214,9 @@ def test_rerun_nonrun_left_run_right(path):
     with open(op.join(path, "nonrun-file"), "w") as f:
         f.write("blah")
     ds.save()
-    ds.repo.checkout("master~", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["-b", "side"])
     ds.run("echo foo >foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 d_n
     # |\
@@ -231,13 +232,13 @@ def test_rerun_nonrun_left_run_right(path):
     # o |               b_n
     # |/
     # o                 a_n
-    eq_(ds.repo.get_hexsha("master^"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
         ds.repo.get_hexsha("HEAD^"))
-    neq_(ds.repo.get_hexsha("master^2"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
          ds.repo.get_hexsha("HEAD^2"))
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^2")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     # o                 d_n
     # |\
     # | o               c_r
@@ -245,14 +246,14 @@ def test_rerun_nonrun_left_run_right(path):
     # |/
     # o                 a_n
     ok_(ds.repo.get_active_branch() is None)
-    eq_(ds.repo.get_hexsha("master"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH),
         ds.repo.get_hexsha())
-    eq_(ds.repo.get_hexsha("master^"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
         ds.repo.get_hexsha("HEAD^"))
-    eq_(ds.repo.get_hexsha("master^2"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
         ds.repo.get_hexsha("HEAD^2"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     # o                 d_n
@@ -270,11 +271,11 @@ def test_rerun_nonrun_left_run_right(path):
 def test_rerun_run_left_nonrun_right(path):
     ds = Dataset(path).create()
     ds.run("echo foo >foo")
-    ds.repo.checkout("master~", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["-b", "side"])
     with open(op.join(path, "nonrun-file"), "w") as f:
         f.write("blah")
     ds.save()
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 d_n
     # |\
@@ -290,21 +291,21 @@ def test_rerun_run_left_nonrun_right(path):
     # o |               b_R
     # |/
     # o                 a_n
-    neq_(ds.repo.get_hexsha("master^"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
          ds.repo.get_hexsha("HEAD^"))
-    eq_(ds.repo.get_hexsha("master^2"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
         ds.repo.get_hexsha("HEAD^2"))
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^2")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     # o                 b_R
     # o                 c_n
     # o                 a_n
     assert_false(ds.repo.commit_exists("HEAD^2"))
-    eq_(ds.repo.get_hexsha("master^2"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
         ds.repo.get_hexsha("HEAD^"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     # o                 d_n
@@ -322,11 +323,11 @@ def test_rerun_run_left_nonrun_right(path):
 def test_rerun_mutator_left_nonrun_right(path):
     ds = Dataset(path).create()
     ds.run("echo foo >>foo")
-    ds.repo.checkout("master~", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["-b", "side"])
     with open(op.join(path, "nonrun-file"), "w") as f:
         f.write("blah")
     ds.save()
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 d_n
     # |\
@@ -344,9 +345,9 @@ def test_rerun_mutator_left_nonrun_right(path):
     # o |               b_r
     # |/
     # o                 a_n
-    assert_false(ds.repo.commit_exists("master^2"))
+    assert_false(ds.repo.commit_exists(DEFAULT_BRANCH + "^2"))
     eq_(hexsha_before,
-        ds.repo.get_hexsha("master^"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^"))
 
 
 @slow
@@ -358,11 +359,11 @@ def test_rerun_mutator_stem_nonrun_merges(path):
     with open(op.join(path, "nonrun-file0"), "w") as f:
         f.write("blah")
     ds.save()
-    ds.repo.checkout("master~", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["-b", "side"])
     with open(op.join(path, "nonrun-file1"), "w") as f:
         f.write("more blah")
     ds.save()
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 e_n
     # |\
@@ -381,11 +382,11 @@ def test_rerun_mutator_stem_nonrun_merges(path):
     # o                 b_R
     # o                 a_n
     ok_(ds.repo.commit_exists("HEAD^2"))
-    neq_(ds.repo.get_hexsha("master"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH),
          ds.repo.get_hexsha())
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^2")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     # o                 c_C
     # o                 b_R
     # o                 d_n
@@ -393,9 +394,9 @@ def test_rerun_mutator_stem_nonrun_merges(path):
     # o                 a_n
     assert_false(ds.repo.commit_exists("HEAD^2"))
     eq_(ds.repo.get_hexsha("HEAD~2"),
-        ds.repo.get_hexsha("master^2"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     # o                 b_R
@@ -407,7 +408,7 @@ def test_rerun_mutator_stem_nonrun_merges(path):
     # o                 b_r
     # o                 a_n
     eq_(hexsha_before,
-        ds.repo.get_hexsha("master^"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^"))
     assert_false(ds.repo.commit_exists("HEAD^2"))
 
 
@@ -416,9 +417,9 @@ def test_rerun_mutator_stem_nonrun_merges(path):
 @with_tempfile(mkdir=True)
 def test_rerun_exclude_side(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
     ds.run("echo foo >foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.run("echo bar >bar")
     ds.repo.merge("side", options=["-m", "Merge side"])
     # o                 d_n
@@ -428,18 +429,18 @@ def test_rerun_exclude_side(path):
     # |/
     # o                 a_n
 
-    ds.rerun("HEAD", since="master^2", onto="")
+    ds.rerun("HEAD", since=DEFAULT_BRANCH + "^2", onto="")
     # o                 d_M
     # |\
     # o |               c_R
     # | o               b_r
     # |/
     # o                 a_n
-    neq_(ds.repo.get_hexsha("master"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH),
          ds.repo.get_hexsha())
-    neq_(ds.repo.get_hexsha("master^"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
          ds.repo.get_hexsha("HEAD^"))
-    eq_(ds.repo.get_hexsha("master^2"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"),
         ds.repo.get_hexsha("HEAD^2"))
 
 
@@ -449,9 +450,9 @@ def test_rerun_exclude_side(path):
 def test_rerun_unrelated_run_left_nonrun_right(path):
     ds = Dataset(path).create()
     ds.run("echo foo >foo")
-    ds.repo.checkout("master~", options=["--orphan", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["--orphan", "side"])
     ds.save(message="squashed")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side",
                   options=["-m", "Merge side", "--allow-unrelated-histories"])
     # o                 d_n
@@ -467,27 +468,27 @@ def test_rerun_unrelated_run_left_nonrun_right(path):
     # o                 b_R
     # o                 a_n
     neq_(ds.repo.get_hexsha("HEAD^"),
-         ds.repo.get_hexsha("master^"))
+         ds.repo.get_hexsha(DEFAULT_BRANCH + "^"))
     eq_(ds.repo.get_hexsha("HEAD^2"),
-        ds.repo.get_hexsha("master^2"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"))
     assert_false(ds.repo.commit_exists("HEAD^2^"))
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^2")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     # o                 b_R
     # o                 c_n
     assert_false(ds.repo.commit_exists("HEAD^2"))
     eq_(ds.repo.get_hexsha("HEAD^"),
-        ds.repo.get_hexsha("master^2"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.rerun(since="")
     # o                 d_n
     # |\
     # | o               c_n
     # o                 b_r
     # o                 a_n
-    eq_(ds.repo.get_hexsha("master"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH),
         ds.repo.get_hexsha())
 
 
@@ -497,9 +498,9 @@ def test_rerun_unrelated_run_left_nonrun_right(path):
 def test_rerun_unrelated_mutator_left_nonrun_right(path):
     ds = Dataset(path).create()
     ds.run("echo foo >>foo")
-    ds.repo.checkout("master~", options=["--orphan", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["--orphan", "side"])
     ds.save(message="squashed")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side",
                   options=["-m", "Merge side", "--allow-unrelated-histories"])
     # o                 d_n
@@ -517,7 +518,7 @@ def test_rerun_unrelated_mutator_left_nonrun_right(path):
     # o                 b_r
     # o                 a_n
     eq_(hexsha_before,
-        ds.repo.get_hexsha("master^"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^"))
 
 
 @slow
@@ -525,10 +526,10 @@ def test_rerun_unrelated_mutator_left_nonrun_right(path):
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_nonrun_left_run_right(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["--orphan", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["--orphan", "side"])
     ds.save(message="squashed")
     ds.run("echo foo >foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side",
                   options=["-m", "Merge side", "--allow-unrelated-histories"])
     # o                 d_n
@@ -544,26 +545,26 @@ def test_rerun_unrelated_nonrun_left_run_right(path):
     # | o               b_n
     # o                 a_n
     ok_(ds.repo.commit_exists("HEAD^2"))
-    neq_(ds.repo.get_hexsha("master"),
+    neq_(ds.repo.get_hexsha(DEFAULT_BRANCH),
          ds.repo.get_hexsha())
-    eq_(ds.repo.get_hexsha("master^"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^"),
         ds.repo.get_hexsha("HEAD^"))
-    eq_(ds.repo.get_hexsha("master^2^"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH + "^2^"),
         ds.repo.get_hexsha("HEAD^2^"))
     assert_false(ds.repo.commit_exists("HEAD^2^^"))
 
-    ds.repo.checkout("master")
-    ds.rerun(since="", onto="master^2")
+    ds.repo.checkout(DEFAULT_BRANCH)
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     # o                 d_n
     # |\
     # | o               c_r
     # | o               b_n
     # o                 a_n
-    eq_(ds.repo.get_hexsha("master"),
+    eq_(ds.repo.get_hexsha(DEFAULT_BRANCH),
         ds.repo.get_hexsha())
     assert_false(ds.repo.commit_exists("HEAD^2^^"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     # o                 d_n
@@ -579,10 +580,10 @@ def test_rerun_unrelated_nonrun_left_run_right(path):
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_nonrun_left_mutator_right(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["--orphan", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["--orphan", "side"])
     ds.save(message="squashed")
     ds.run("echo foo >>foo")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side",
                   options=["-m", "Merge side", "--allow-unrelated-histories"])
     # o                 d_n
@@ -591,7 +592,7 @@ def test_rerun_unrelated_nonrun_left_mutator_right(path):
     # | o               b_n
     # o                 a_n
 
-    ds.rerun(since="", onto="master^2")
+    ds.rerun(since="", onto=DEFAULT_BRANCH + "^2")
     # o                 d_M
     # |\
     # | o               c_R
@@ -599,10 +600,10 @@ def test_rerun_unrelated_nonrun_left_mutator_right(path):
     # | o               b_n
     # o                 a_n
     eq_(ds.repo.get_hexsha("HEAD^2^"),
-        ds.repo.get_hexsha("master^2"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"))
     assert_false(ds.repo.commit_exists("HEAD^2~3"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     # o                 c_R
@@ -621,7 +622,7 @@ def test_rerun_unrelated_nonrun_left_mutator_right(path):
 @with_tempfile(mkdir=True)
 def test_rerun_multifork(path):
     ds = Dataset(path).create()
-    ds.repo.checkout("master", options=["-b", "side"])
+    ds.repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
     ds.run("echo foo >foo")
     ds.repo.checkout("side", options=["-b", "side-nonrun"])
     with open(op.join(path, "nonrun-file0"), "w") as f:
@@ -640,7 +641,7 @@ def test_rerun_multifork(path):
     ds.repo.checkout("side")
     ds.repo.merge("side-side")
     ds.run("echo after-side-side >after-side-side")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.merge("side", options=["--no-ff"])
     ds.repo.merge("side-nonrun")
     # o                 k_n
@@ -680,16 +681,16 @@ def test_rerun_multifork(path):
     # |/
     # o                 a_n
     eq_(ds.repo.get_hexsha("HEAD~2"),
-        ds.repo.get_hexsha("master~2"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "~2"))
     neq_(ds.repo.get_hexsha("HEAD^2"),
-         ds.repo.get_hexsha("master^2"))
+         ds.repo.get_hexsha(DEFAULT_BRANCH + "^2"))
     neq_(ds.repo.get_hexsha("HEAD^^2"),
-         ds.repo.get_hexsha("master^^2"))
+         ds.repo.get_hexsha(DEFAULT_BRANCH + "^^2"))
     assert_false(ds.repo.commit_exists("HEAD^^2^2"))
     eq_(ds.repo.get_hexsha("HEAD^2^^"),
-        ds.repo.get_hexsha("master^2^^"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "^2^^"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     eq_(hexsha_before, ds.repo.get_hexsha())
@@ -704,11 +705,11 @@ def test_rerun_octopus(path):
     with open(op.join(ds.path, "non-run"), "w") as nrfh:
         nrfh.write("non-run")
     ds.save()
-    ds.repo.checkout("master~", options=["-b", "topic-1"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["-b", "topic-1"])
     ds.run("echo bar >bar")
-    ds.repo.checkout("master~", options=["-b", "topic-2"])
+    ds.repo.checkout(DEFAULT_BRANCH + "~", options=["-b", "topic-2"])
     ds.run("echo baz >baz")
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     ds.repo.call_git(
         ["merge", "-m", "Merge octopus", "topic-1", "topic-2"])
     # o-.               f_M
@@ -723,12 +724,12 @@ def test_rerun_octopus(path):
 
     ds.rerun(since="", onto="")
     neq_(ds.repo.get_hexsha("HEAD^3"),
-         ds.repo.get_hexsha("master^3"))
+         ds.repo.get_hexsha(DEFAULT_BRANCH + "^3"))
     eq_(ds.repo.get_hexsha("HEAD~3"),
-        ds.repo.get_hexsha("master~3"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "~3"))
 
-    ds.repo.checkout("master")
+    ds.repo.checkout(DEFAULT_BRANCH)
     hexsha_before = ds.repo.get_hexsha()
     ds.rerun(since="")
     eq_(hexsha_before,
-        ds.repo.get_hexsha("master~"))
+        ds.repo.get_hexsha(DEFAULT_BRANCH + "~"))

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1972,15 +1972,15 @@ def test_AnnexRepo_get_corresponding_branch(path):
 
     ar = AnnexRepo(path)
 
-    # we should be on master.
+    # we should be on the default branch.
     eq_(DEFAULT_BRANCH,
         ar.get_corresponding_branch() or ar.get_active_branch())
 
     # special case v6 adjusted branch is not provided by a dedicated build:
     if ar.supports_unlocked_pointers:
         ar.adjust()
-        # as above, we still want to get 'master', while being on
-        # 'adjusted/master(unlocked)'
+        # as above, we still want to get the default branch, while being on
+        # 'adjusted/<default branch>(unlocked)'
         eq_('adjusted/{}(unlocked)'.format(DEFAULT_BRANCH),
             ar.get_active_branch())
         eq_(DEFAULT_BRANCH, ar.get_corresponding_branch())

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -70,6 +70,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_true,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     find_files,
     get_most_obscure_supported_name,
@@ -1972,15 +1973,17 @@ def test_AnnexRepo_get_corresponding_branch(path):
     ar = AnnexRepo(path)
 
     # we should be on master.
-    eq_('master', ar.get_corresponding_branch() or ar.get_active_branch())
+    eq_(DEFAULT_BRANCH,
+        ar.get_corresponding_branch() or ar.get_active_branch())
 
     # special case v6 adjusted branch is not provided by a dedicated build:
     if ar.supports_unlocked_pointers:
         ar.adjust()
         # as above, we still want to get 'master', while being on
         # 'adjusted/master(unlocked)'
-        eq_('adjusted/master(unlocked)', ar.get_active_branch())
-        eq_('master', ar.get_corresponding_branch())
+        eq_('adjusted/{}(unlocked)'.format(DEFAULT_BRANCH),
+            ar.get_active_branch())
+        eq_(DEFAULT_BRANCH, ar.get_corresponding_branch())
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
@@ -1989,7 +1992,7 @@ def test_AnnexRepo_get_tracking_branch(path):
     ar = AnnexRepo(path)
 
     # we want the relation to original branch, e.g. in v6+ adjusted branch
-    eq_(('origin', 'refs/heads/master'), ar.get_tracking_branch())
+    eq_(('origin', 'refs/heads/' + DEFAULT_BRANCH), ar.get_tracking_branch())
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:433

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -39,6 +39,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_repo_status,
     create_tree,
+    DEFAULT_BRANCH,
     eq_,
     get_most_obscure_supported_name,
     integration,
@@ -548,7 +549,8 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     eq_([], repo.get_remote_branches())
 
     fetched = repo.fetch(remote="ssh-remote")
-    assert_in('ssh-remote/master', [commit['ref'] for commit in fetched])
+    assert_in('ssh-remote/' + DEFAULT_BRANCH,
+              [commit['ref'] for commit in fetched])
     assert_repo_status(repo)
 
     # the connection is known to the SSH manager, since fetch() requested it:
@@ -557,7 +559,8 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     ok_(op.exists(socket_path))
 
     # we actually fetched it:
-    assert_in('ssh-remote/master', repo.get_remote_branches())
+    assert_in('ssh-remote/' + DEFAULT_BRANCH,
+              repo.get_remote_branches())
 
 
 # broken,possibly due to a GitPy issue with windows sshurls
@@ -675,7 +678,7 @@ def test_GitRepo_push_n_checkout(orig_path, clone_path):
     clone.add(filename)
     clone.commit("new file added.")
     # TODO: need checkout first:
-    clone.push('origin', '+master:new-branch')
+    clone.push('origin', '+{}:new-branch'.format(DEFAULT_BRANCH))
     origin.checkout('new-branch')
     ok_(op.exists(op.join(orig_path, filename)))
 
@@ -744,7 +747,7 @@ def test_GitRepo_get_files(url, path):
 
     # get the files via GitRepo:
     local_files = set(gr.get_files())
-    remote_files = set(gr.get_files(branch="origin/master"))
+    remote_files = set(gr.get_files(branch="origin/" + DEFAULT_BRANCH))
 
     eq_(local_files, set(gr.get_indexed_files()))
     eq_(local_files, remote_files)
@@ -762,12 +765,12 @@ def test_GitRepo_get_files(url, path):
     local_files = set(gr.get_files())
     eq_(local_files, os_files.union({filename}))
     # retrieve remote branch again, which should not have changed:
-    remote_files = set(gr.get_files(branch="origin/master"))
+    remote_files = set(gr.get_files(branch="origin/" + DEFAULT_BRANCH))
     eq_(remote_files, os_files)
     eq_(set([filename]), local_files.difference(remote_files))
 
     # switch back and query non-active branch:
-    gr.checkout('master')
+    gr.checkout(DEFAULT_BRANCH)
     local_files = set(gr.get_files())
     branch_files = set(gr.get_files(branch="new_branch"))
     eq_(set([filename]), branch_files.difference(local_files))
@@ -898,7 +901,7 @@ def test_GitRepo_git_get_branch_commits_(src):
     repo.commit('committing')
 
     commits_default = list(repo.get_branch_commits_())
-    commits = list(repo.get_branch_commits_('master'))
+    commits = list(repo.get_branch_commits_(DEFAULT_BRANCH))
     eq_(commits, commits_default)
     eq_(len(commits), 1)
 
@@ -997,7 +1000,7 @@ def check_update_submodule_init_adjust_branch(is_ancestor, path):
         src_sub.commit(msg="c2", options=["--allow-empty"])
     else:
         # ... where the registered commit is NOT an ancestor of the new one.
-        src_sub.call_git(["reset", "--hard", "master~1"])  # c0
+        src_sub.call_git(["reset", "--hard", DEFAULT_BRANCH + "~1"])  # c0
     hexsha_sub = src_sub.get_hexsha()
 
     clone = GitRepo.clone(url=src.path,
@@ -1007,7 +1010,7 @@ def check_update_submodule_init_adjust_branch(is_ancestor, path):
                               path=op.join(clone.path, "sub"),
                               create=True)
     ok_(clone.dirty)
-    eq_(clone_sub.get_active_branch(), "master")
+    eq_(clone_sub.get_active_branch(), DEFAULT_BRANCH)
     eq_(hexsha_sub, clone_sub.get_hexsha())
 
     clone.update_submodule("sub", init=True)
@@ -1015,7 +1018,7 @@ def check_update_submodule_init_adjust_branch(is_ancestor, path):
     assert_false(clone.dirty)
     eq_(hexsha_registered, clone_sub.get_hexsha())
     if is_ancestor:
-        eq_(clone_sub.get_active_branch(), "master")
+        eq_(clone_sub.get_active_branch(), DEFAULT_BRANCH)
     else:
         assert_false(clone_sub.get_active_branch())
 
@@ -1382,11 +1385,11 @@ def test_get_commit_date(path):
     neq_(date, None)
     eq_(date, DATE_EPOCH)
 
-    eq_(date, gr.get_commit_date('master'))
+    eq_(date, gr.get_commit_date(DEFAULT_BRANCH))
     # and even if we get into a detached head
     gr.checkout(gr.get_hexsha())
     eq_(gr.get_active_branch(), None)
-    eq_(date, gr.get_commit_date('master'))
+    eq_(date, gr.get_commit_date(DEFAULT_BRANCH))
 
 
 @with_tree(tree={"foo": "foo content",
@@ -1494,7 +1497,7 @@ def test_GitRepo_get_revisions(path):
 
     # But will raise if on a bad ref name, including an unborn branch.
     with assert_raises(CommandError):
-        gr.get_revisions("master")
+        gr.get_revisions(DEFAULT_BRANCH)
 
     # By default, we query HEAD.
     commit("1")
@@ -1504,24 +1507,24 @@ def test_GitRepo_get_revisions(path):
     commit("2")
 
     # We can also query branch by name.
-    eq_(len(gr.get_revisions("master")), 1)
+    eq_(len(gr.get_revisions(DEFAULT_BRANCH)), 1)
     eq_(len(gr.get_revisions("other")), 2)
 
     # "name" is sugar for ["name"].
-    eq_(gr.get_revisions("master"),
-        gr.get_revisions(["master"]))
+    eq_(gr.get_revisions(DEFAULT_BRANCH),
+        gr.get_revisions([DEFAULT_BRANCH]))
 
-    gr.checkout("master")
+    gr.checkout(DEFAULT_BRANCH)
     commit("3")
-    eq_(len(gr.get_revisions("master")), 2)
+    eq_(len(gr.get_revisions(DEFAULT_BRANCH)), 2)
     # We can pass multiple revisions...
-    eq_(len(gr.get_revisions(["master", "other"])), 3)
+    eq_(len(gr.get_revisions([DEFAULT_BRANCH, "other"])), 3)
     # ... or options like --all and --branches
-    eq_(gr.get_revisions(["master", "other"]),
+    eq_(gr.get_revisions([DEFAULT_BRANCH, "other"]),
         gr.get_revisions(options=["--all"]))
 
     # Ranges are supported.
-    eq_(gr.get_revisions("master.."), [])
+    eq_(gr.get_revisions(DEFAULT_BRANCH + ".."), [])
 
 
 @with_tree({"foo": "foo"})

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -100,6 +100,12 @@ _TEMP_PATHS_CLONES = set()
 # Additional indicators
 on_travis = bool(os.environ.get('TRAVIS', False))
 
+if external_versions["cmd:git"] >= "2.28":
+    # The specific value here doesn't matter, but it should not be the default
+    # from any Git version to test that we work with custom values.
+    DEFAULT_BRANCH = "dl-test-branch"  # Set by setup_package().
+else:
+    DEFAULT_BRANCH = "master"
 
 # additional shortcuts
 neq_ = assert_not_equal


### PR DESCRIPTION
This draft series prepares our tests for an in-flight series in Git that makes the default branch name configurable.  ~Locally I ran specific tests with v2.27.0-92-gb5081fbf16, but I didn't do a full test sweep.~ The temporary tip commit sets up a [Travis job][0] with 2.27.0.92.g0068f2116e, the corresponding git.git series.  Anyway, this of course needs to wait for things to land on Git's end, but it gives a sense of the spots that will likely need to eventually change.

The first commit (c4578fc6a) contains for more information about the plans on Git's side.

[0]: https://travis-ci.org/github/datalad/datalad/jobs/704052356
