### PR TITLE
TST: clone: Fix clock-dependent test

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -57,6 +57,7 @@ from datalad.tests.utils import (
     assert_result_values_equal,
     ok_startswith,
     assert_repo_status,
+    set_date,
     serve_path_via_http,
     swallow_logs,
     use_cassette,
@@ -793,14 +794,17 @@ def test_clone_unborn_head(path):
                     "refs/heads/{}".format(
                         "adjusted/abc(unlocked)" if managed else "abc"),
                     symbolic=True)
+    abc_ts = int(repo.format_commit("%ct"))
     repo.call_git(["checkout", "-b", "chooseme", "abc~1"])
     if managed:
         repo.adjust()
     (ds_origin.pathobj / "bar").write_text("bar content")
-    ds_origin.save(message="bar")
-    # Try to make the git-annex branch the most recently updated ref so that we
-    # test that it is skipped.
-    ds_origin.drop("bar", check=False)
+    with set_date(abc_ts + 1):
+        ds_origin.save(message="bar")
+    # Make the git-annex branch the most recently updated ref so that we test
+    # that it is skipped.
+    with set_date(abc_ts + 2):
+        ds_origin.drop("bar", check=False)
     ds_origin.repo.checkout("master", options=["--orphan"])
 
     ds = clone(ds_origin.path, op.join(path, "b"))


### PR DESCRIPTION
test_clone_unborn_head() is supposed to set up a scenario where the
freshly cloned repo has a master branch with no commits and three
non-master remote tracking branches, including origin/git-annex.  As
of 8f5cc450c (ENH: clone: Try to switch away from an unborn branch,
2020-04-01), clone() handles this situation by checking out the
non-git-annex ref with the most recent committer date.

With Git v2.27.0, specifically 7c5045fc18 (ref-filter: apply fallback
refname sort only after all user sorts, 2020-05-03), this test fails
intermittently.  The failure is due to a bad approach in the test: it
commits a change to the abc branch and then one to the chooseme
branch, with the hope that chooseme will have the later committer
date.  Given the resolution of Git time stamps, though, both refs can
easily have identical values for the committer date.  Before Git's
7c5045fc18, this issue was masked by Git failing to fall back to
alphabetical sorting of the refs.

Use the set_date() helper to generate reliable time stamp differences.
