### PR TITLE
TST: travis: Pin grunt-contrib-qunit version to avoid failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -252,7 +252,8 @@ install:
   - if [ ! -z "$UNSET_S3_SECRETS" ]; then echo "usetting"; unset DATALAD_datalad_test_s3_key_id DATALAD_datalad_test_s3_secret_id; fi
   # Install grunt to test run javascript frontend tests
   - npm install grunt
-  - npm install grunt-contrib-qunit@>=3.0.1
+  # FIXME: Pinned because v4.0.0 caused failure (gh-4635).
+  - npm install grunt-contrib-qunit@3.1.0
 
 script:
   # Test installation system-wide


### PR DESCRIPTION
The `npm install grunt-contrib-qunit` call has started to fail (e.g.,
<https://travis-ci.org/github/datalad/datalad/jobs/699391908>).  This
is presumably due to the v4.0.0 release today.  Pin it to the previous
release.

Re: #4635
