### PR TITLE
ENH: external_versions: Consider annexremote interesting

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -143,6 +143,7 @@ class ExternalVersions(object):
         'cmd:7z': _get_system_7z_version,
     }
     _INTERESTING = (
+        'annexremote',
         'appdirs',
         'boto',
         'exifread',


### PR DESCRIPTION
This is useful information to include in the wtf output, especially
since 1.4.2 required some adjustments on our end (gh-4573).

---

I noticed this was missing when glancing at the wtf output in gh-4643.