### PR TITLE
BF: progressbar: Add reset() kludge for older tqdm versions

### DIFF
--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -260,11 +260,29 @@ try:
             if self._pbar is None:
                 self._pbar = self._tqdm(initial=initial, **self._pbar_params)
 
+        @staticmethod
+        def _reset_kludge(pbar, total=None):
+            # tqdm didn't have reset() until v4.32.0 (c7015f4,
+            # 2019-05-10).  This code below is copied from
+            # tqdm.reset() in v4.46.1, replacing "self" with "pbar".
+            # It hasn't changed since added in c7015f4.
+            #
+            # TODO: Drop this and set a minimum tqdm version once
+            # Debian stable has v4.32.0.
+            pbar.last_print_n = pbar.n = 0
+            pbar.last_print_t = pbar.start_t = pbar._time()
+            if total is not None:
+                pbar.total = total
+            pbar.refresh()
+
         def update(self, size, increment=False, total=None):
             self._create()
             if total is not None:
                 # only a reset can change the total of an existing pbar
-                self._pbar.reset(total)
+                try:
+                    self._pbar.reset(total)
+                except AttributeError:
+                    self._reset_kludge(self._pbar, total)
                 # we need to (re-)advance the pbar back to the old state
                 self._pbar.update(self.current)
                 # an update() does not (reliably) trigger a refresh, hence


### PR DESCRIPTION
As of c9a066c49 (ENH: Enable changing the total of an existing
progress bar, 2020-04-22), our tqdmProgressBar.update() relies on tqdm
having reset(), but reset() didn't exist until v4.32.0 (c7015f4,
2019-05-10).  Debian Buster currently has v4.28.1.

For compatibility with older versions, copy over the logic to
tqdmProgressBar and fall back to it when tqdm.reset() isn't available.
All of the attributes adjusted in reset() appear to be in v4.28.1 and
manual testing with v4.28.1 didn't reveal any issues.

There is of course some older version that this won't work for, but it
looks like we'll hit other problems before that point.  We rely on
refresh() throughout tqdmProgressBar, and all of the other attributes
used in _reset_kludge() appear to have been around before refresh()
was added (d3c3ad2, 2016-01-30).

Closes #4648.
