### PR TITLE
Declare minimum supported Git version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,13 @@ matrix:
     - DATALAD_USE_DEFAULT_GIT=1
     - _DL_UPSTREAM_GIT=1
     - _DL_CRON=1
+  # Run with our reported minimum Git version.
+  - python: 3.5
+    env:
+    - DATALAD_USE_DEFAULT_GIT=1
+    - _DL_MIN_GIT=1
+    - PATH="$PWD/git-src/bin-wrappers/:$PATH"
+    - _DL_CRON=1
   - python: 3.5
     env:
     # to test operation under root since also would consider FS "crippled" due to
@@ -223,6 +230,7 @@ before_install:
   - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then
       sudo tools/ci/install-latest-git.sh || { [ $? -eq 100 ] && exit 0; } || exit 1;
     fi
+  - if [ ! -z "${_DL_MIN_GIT:-}" ]; then tools/ci/install-minimum-git.sh; fi
 
 install:
   # Install standalone build of git-annex for the recent enough version

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -16,7 +16,6 @@ import os
 import os.path as op
 from unittest.mock import patch
 
-from datalad.support.external_versions import external_versions
 from datalad.support.exceptions import (
     NoDatasetFound,
 )
@@ -375,7 +374,7 @@ def test_path_diff(_path, linkpath):
     eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all',
                                  result_renderer=None))
     # neither do nested paths
-    if not ("2.24.0" <= external_versions["cmd:git"] < "2.25.0"):
+    if not "2.24.0" <= ds.repo.git_version < "2.25.0":
         # Release 2.24.0 contained a regression that was fixed with 072a231016
         # (2019-12-10).
         eq_(plain_recursive,

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -44,7 +44,6 @@ import datalad.utils as ut
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CommandError
-from datalad.support.external_versions import external_versions
 from datalad.api import (
     create,
     install,
@@ -711,7 +710,7 @@ def test_surprise_subds(path):
     # this test irrelevant because it is about the unborn branch edge case.
     adjusted = somerepo.is_managed_branch()
     # This edge case goes away with Git v2.22.0.
-    fixed_git = external_versions['cmd:git'] >= '2.22.0'
+    fixed_git = somerepo.git_version >= '2.22.0'
 
     # save non-recursive
     res = ds.save(recursive=False, on_failure='ignore')

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -27,6 +27,7 @@ from datalad.utils import (
     chpwd,
     Path,
 )
+from datalad.support.external_versions import external_versions
 from datalad.support.gitrepo import (
     GitRepo,
 )
@@ -744,6 +745,9 @@ def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
             path=ds_clone_s1.path,
             action="update")
         return
+    if external_versions["cmd:git"] < "2.13.2":
+        raise SkipTest("Test depends on fix from Git 2.13.2. Detected git is {}"
+                       .format(external_versions["cmd:git"]))
     assert_repo_status(ds_clone.path)
 
     # We brought in the revision and got to the same state of the remote.

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -27,7 +27,6 @@ from datalad.utils import (
     chpwd,
     Path,
 )
-from datalad.support.external_versions import external_versions
 from datalad.support.gitrepo import (
     GitRepo,
 )
@@ -745,9 +744,6 @@ def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
             path=ds_clone_s1.path,
             action="update")
         return
-    if external_versions["cmd:git"] < "2.13.2":
-        raise SkipTest("Test depends on fix from Git 2.13.2. Detected git is {}"
-                       .format(external_versions["cmd:git"]))
     assert_repo_status(ds_clone.path)
 
     # We brought in the revision and got to the same state of the remote.

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -735,12 +735,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             cmd = ['git']
             if git_options:
                 cmd.extend(git_options)
-
-            cmd.append("rev-parse")
-            if external_versions['cmd:git'] >= '2.13.0':
-                cmd.append("--absolute-git-dir")
-            else:
-                cmd.append("--git-dir")
+            cmd.extend(["rev-parse", "--absolute-git-dir"])
 
             try:
                 toppath, err = GitRunner().run(
@@ -755,10 +750,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 toppath = AnnexRepo.get_toppath(dirname(path),
                                                 follow_up=follow_up,
                                                 git_options=git_options)
-
-            if external_versions['cmd:git'] < '2.13.0':
-                # we got a path relative to `path` instead of an absolute one
-                toppath = opj(path, toppath)
 
             # we got the git-dir. Assuming the root dir we are looking for is
             # one level up:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1740,6 +1740,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         if pointers or batch or not allow_quick:
             # We're only concerned about modified files in V6+ mode. In V5
             # `find` returns an empty string for unlocked files.
+            #
+            # ATTN: test_AnnexRepo_file_has_content has a failure before Git
+            # v2.13 (tested back to v2.9) because this diff call unexpectedly
+            # reports a type change as modified.
             modified = [
                 f for f in self.call_git_items_(
                     ['diff', '--name-only', '-z'], sep='\0')

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -124,7 +124,11 @@ class OutdatedExternalDependency(MissingExternalDependency):
 
     def __str__(self):
         to_str = super(OutdatedExternalDependency, self).__str__()
-        to_str += ". You have version %s" % self.ver_present \
+        # MissingExternalDependency ends with a period unless msg is
+        # given, in which case it's up to the msg and no callers in
+        # our code base currently give a msg ending with a period.
+        to_str += "." if self.msg else ""
+        to_str += " You have version %s" % self.ver_present \
             if self.ver_present else \
             " Some unknown version of dependency found."
         return to_str

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -980,13 +980,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     def _create_empty_repo(self, path, sanity_checks=True, **kwargs):
         if not op.lexists(path):
             os.makedirs(path)
-        elif sanity_checks and external_versions['cmd:git'] < '2.14.0':
-            warnings.warn(
-                "Your git version (%s) is too old, we will not safe-guard "
-                "against creating a new repository under already known to git "
-                "subdirectory" % external_versions['cmd:git'],
-                OutdatedExternalDependencyWarning
-            )
         elif sanity_checks:
             # Verify that we are not trying to initialize a new git repository
             # under a directory some files of which are already tracked by git
@@ -2610,8 +2603,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             options = []
         if msg:
             options = options + ["-m", msg]
-        if allow_unrelated and external_versions['cmd:git'] >= '2.9':
-            options += ['--allow-unrelated-histories']
+        options += ['--allow-unrelated-histories']
         self._git_custom_command(
             '', ['git', 'merge'] + options + [name],
             check_fake_dates=True,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -795,6 +795,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
     _unique_instances = WeakValueDictionary()
 
+    GIT_MIN_VERSION = "2.19.1"
+    git_version = None
+
     def _flyweight_invalid(self):
         return not self.is_valid_git()
 
@@ -819,6 +822,11 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # the flyweight key is already determining unique instances
         # add the class name to distinguish from strings of a path
         return hash((self.__class__.__name__, self.__weakref__.key))
+
+    @classmethod
+    def _check_git_version(cls):
+        external_versions.check("cmd:git", min_version=cls.GIT_MIN_VERSION)
+        cls.git_version = external_versions['cmd:git']
 
     # This is the least common denominator to claim that a user
     # used DataLad.
@@ -876,6 +884,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
           C='/my/path'   => -C /my/path
 
         """
+        if self.git_version is None:
+            self._check_git_version()
 
         # BEGIN Repo validity test
         # We want to fail early for tests, that would be performed a lot. In particular this is about

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1468,7 +1468,8 @@ def test_duecredit(path):
     out, err = run(cmd, env=env, expect_stderr=True)
     outs = out + err  # Let's not depend on where duecredit decides to spit out
     # All quiet
-    eq_(outs, '')
+    test_string = 'Data management and distribution platform'
+    assert_not_in(test_string, outs)
 
     # and now enable DUECREDIT - output could come to stderr
     env['DUECREDIT_ENABLE'] = '1'
@@ -1476,9 +1477,9 @@ def test_duecredit(path):
     outs = out + err
 
     if external_versions['duecredit']:
-        assert_in('Data management and distribution platform', outs)
+        assert_in(test_string, outs)
     else:
-        eq_(outs, '')
+        assert_not_in(test_string, outs)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -46,7 +46,6 @@ from datalad.tests.utils import (
     local_testrepo_flavors,
     neq_,
     ok_,
-    skip_if,
     skip_if_no_network,
     skip_if_on_windows,
     skip_ssh,
@@ -146,7 +145,6 @@ def test_GitRepo_init_options(path):
     ok_(gr.config.getbool(section="core", option="bare"))
 
 
-@skip_if(external_versions['cmd:git'] < '2.14.0')
 @with_tree(
     tree={
         'subds': {

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -26,7 +26,6 @@ from datalad.tests.utils import (
     assert_true,
     chpwd,
     ok_file_has_content,
-    skip_if,
     with_tempfile,
     with_testsui,
     with_tree,
@@ -44,7 +43,6 @@ from datalad.config import (
 )
 from datalad.cmd import CommandError
 
-from datalad.support.external_versions import external_versions
 from datalad.support.gitrepo import GitRepo
 
 
@@ -203,11 +201,6 @@ def test_something(path, new_home):
         # but after we unset the only value -- that section is no longer listed
         assert (not globalcfg.has_section('datalad.unittest'))
         assert_not_in('datalad.unittest.youcan', globalcfg)
-        if external_versions['cmd:git'] < '2.18':
-            # older versions leave empty section behind in the file
-            ok_file_has_content(global_gitconfig, '[datalad "unittest"]', strip=True)
-            # remove_section to clean it up entirely
-            globalcfg.remove_section('datalad.unittest', where='global')
         ok_file_has_content(global_gitconfig, "")
 
     cfg = ConfigManager(
@@ -467,7 +460,6 @@ def test_no_leaks(path1, path2):
         assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)
 
 
-@skip_if(external_versions["cmd:git"] < "2.13.2")
 @with_tempfile()
 def test_no_local_write_if_no_dataset(path):
     Dataset(path).create()

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import (
     assert_true,
     chpwd,
     ok_file_has_content,
+    skip_if,
     with_tempfile,
     with_testsui,
     with_tree,
@@ -466,6 +467,7 @@ def test_no_leaks(path1, path2):
         assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)
 
 
+@skip_if(external_versions["cmd:git"] < "2.13.2")
 @with_tempfile()
 def test_no_local_write_if_no_dataset(path):
     Dataset(path).create()

--- a/tools/ci/install-minimum-git.sh
+++ b/tools/ci/install-minimum-git.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+MIN_VERSION="$(perl -ne 'print $1 if /^ *GIT_MIN_VERSION = "(\S+)"$/' datalad/support/gitrepo.py)"
+if test -z "$MIN_VERSION"
+then
+    echo "Failed to extract minimum git version" >&2
+    exit 1
+fi
+
+target_dir="$PWD/git-src"
+git clone https://github.com/git/git "$target_dir"
+cd "$target_dir"
+git checkout "refs/tags/v$MIN_VERSION"
+make --jobs
+./git version


### PR DESCRIPTION
This series sets a minimum Git version (currently v2.19.1, as suggested in gh-4636), and adds a cron build to test against it.

---

- [X] Make sure run with v2.19.1 passes and then drop the tip commit.

   v2.19.1 will hopefully pass because [v2.13.0 fared okay][0], though the tests needed a couple of skips for behavior that changed with v2.13.2.  The idea with that test is to get an idea of what our functional minimal version is at this point, regardless of whether we choose a higher floor.  I chose v2.13.0 because it is the earliest version that I didn't find issues with when testing locally.

  https://travis-ci.org/github/datalad/datalad/builds/701074711

- [x] Decide where to introduce the minimal version.  As I mentioned in gh-4636, I'd prefer not to introduce a hard floor in a bug fix release, as it runs the risk of making datalad not work at all for users where a subset of functionality may have been working fine.  And we've gone a long time without specifying a minimum requirement.

  My current thinking is that we should target this series for 0.13.1.  Instead of aborting if an unsupported version is detected, we should just tell the user via `warnings.warn` that v2.19.1 (or whatever version we end up deciding to go with) is the oldest version we test against.  If their version is below v2.13.0, we might want to give a bit stronger warning, given there are known issues at that point.

  Then, on the master branch (so targeting 0.14), we can switch the warning over to the `external_versions.check` call that is currently in this PR.


[0]: https://travis-ci.org/github/datalad/datalad/builds/701067382
