### PR TITLE
BF: annotate tests in test_utils_cached_dataset with @skip_if_no_network

### DIFF
--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -22,9 +22,10 @@ from datalad.tests.utils import (
     assert_status,
     assert_true,
     has_symlink_capability,
-    known_failure_windows,
-    skip_ssh,
     SkipTest,
+    known_failure_windows,
+    skip_if_no_network,
+    skip_ssh,
     slow,
     swallow_logs,
     turtle,
@@ -497,4 +498,4 @@ def _test_binary_data(host, store, dspath):
 def test_binary_data():
     # TODO: Skipped due to gh-4436
     yield known_failure_windows(skip_ssh(_test_binary_data)), 'datalad-test'
-    yield _test_binary_data, None
+    yield skip_if_no_network(_test_binary_data), None

--- a/datalad/tests/test_utils_cached_dataset.py
+++ b/datalad/tests/test_utils_cached_dataset.py
@@ -25,6 +25,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_result_count,
     assert_true,
+    skip_if_no_network,
     with_tempfile
 )
 from unittest.mock import patch
@@ -34,6 +35,7 @@ CACHE_PATCH_STR = "datalad.tests.utils_cached_dataset.DATALAD_TESTS_CACHE"
 CLONE_PATCH_STR = "datalad.tests.utils_cached_dataset.Clone.__call__"
 
 
+@skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_get_cached_dataset(cache_dir):
 
@@ -150,6 +152,7 @@ def test_get_cached_dataset(cache_dir):
             assert_is(ds, ds2)
 
 
+@skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_cached_dataset(cache_dir):
 
@@ -250,6 +253,7 @@ def test_cached_dataset(cache_dir):
         assert_not_equal(first_repopath, second_repopath)
 
 
+@skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_cached_url(cache_dir):
 


### PR DESCRIPTION
Since they all rely on access to a github repository ATM.
See https://github.com/datalad/datalad/issues/4653 for a possible RF to avoid that
