### PR TITLE
BF: get: Inherit reckless configuration when cloning subdatasets

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -214,11 +214,6 @@ class Clone(Interface):
         if reckless is True:
             # so that we can forget about how things used to be
             reckless = 'auto'
-        if reckless is None and ds:
-            # if reckless is not explicitly given, but we operate on a
-            # superdataset, query whether it has been instructed to operate
-            # in a reckless mode, and inherit it for the coming clone
-            reckless = ds.config.get('datalad.clone.reckless', None)
 
         if isinstance(source, Dataset):
             source = source.path
@@ -331,15 +326,15 @@ def clone_dataset(
       Dataset instance for the clone destination
     reckless : {None, 'auto', 'ephemeral', 'shared-...'}, optional
       Mode switch to put cloned dataset into unsafe/throw-away configurations, i.e.
-      sacrifice data safety for performance or resource footprint.
+      sacrifice data safety for performance or resource footprint. When None
+      and `cfg` is specified, use the value of `datalad.clone.reckless`.
     description : str, optional
       Location description for the annex of the dataset clone (if there is any).
     result_props : dict, optional
       Default properties for any yielded result, passed on to get_status_dict().
     cfg : ConfigManager, optional
-      Configuration will be queried from this instance (i.e. from a particular
-      dataset). If None is given, the global DataLad configuration will be
-      queried.
+      Configuration for parent dataset. This will be queried instead
+      of the global DataLad configuration.
 
     Yields
     ------
@@ -354,6 +349,12 @@ def clone_dataset(
             logger=lgr,
             ds=destds,
         )
+
+    if reckless is None and cfg:
+        # if reckless is not explicitly given, but we operate on a
+        # superdataset, query whether it has been instructed to operate
+        # in a reckless mode, and inherit it for the coming clone
+        reckless = cfg.get('datalad.clone.reckless', None)
 
     dest_path = destds.pathobj
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -298,6 +298,7 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
     for res in clone_dataset(
             clone_urls_,
             Dataset(dest_path),
+            cfg=ds.config,
             **kwargs):
         # make sure to fix a detached HEAD before yielding the install success
         # result. The resetting of the branch would undo any change done


### PR DESCRIPTION
```
Cloning a subdataset is supposed to inherit the parent's
`datalad.clone.reckless` value.  This works as intended when using
install() to get an existing dataset or using clone() to create a new
subdataset, but the parent's configuration is ignored when the clone
is triggered by get().

The "inherit reckless" logic is handled in Clone.__call__(), but
that's upstream of clone_dataset(), where get() hooks into.  Move the
handling into clone_dataset() to avoid repeating it in get().

Note that we don't have access to the parent dataset in
clone_dataset(), but we need to query its configuration.  We could add
the parent dataset as a parameter.  However, there's already a cfg
parameter, and Clone.__call__()---the only caller that specifies
cfg---passes the parent's configuration.  So instead just update get()
to pass in cfg and query that, adjusting the documentation to note
that cfg should be the parent's.
```

Closes #4655.
