### PR TITLE
travis: Add job for python 3.8, restrict cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,11 @@ matrix:
     # To test https://github.com/datalad/datalad/pull/4342 fix.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LC_ALL=ru_RU.UTF-8
+  - python: 3.8
+    dist: bionic # Xenial doesn't have 3.8 pre-installed (only 3.8-dev).
+    env:
+    - NOSE_SELECTION=
+    - NOSE_SELECTION_OP=not
   - python: 3.6
     # Single run for Python 3.6
     env:
@@ -52,6 +57,7 @@ matrix:
     # We cannot have empty -A selector, so the one which always will be fulfilled
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+    - _DL_CRON=1
   - python: 3.5
     # Split runs for v6 since a single one is too long now
     env:

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -765,7 +765,7 @@ def test_assure_unicode():
         assure_unicode(mixedin, confidence=0.9)
     # For other, non string values, actually just returns original value
     # TODO: RF to actually "assure" or fail??  For now hardcoding that assumption
-    assert assure_unicode(1) is 1
+    assert assure_unicode(1) == 1
 
 
 def test_pathlib_unicode():


### PR DESCRIPTION
* gh-4659 pointed to a failure in the conda py3.8 runs.  Before Python 3.8 was released, we tested against 3.8 on Travis and fixed up the issues at the time, but we didn't add as a regular job.  Add it now, demoting the 3.6 job to a cron job so we don't increase our testing time.

* ~Restrict the cron builds to `_DL_CRON=1` jobs.~
