### PR TITLE
ENH: Let default result renderer tolerate non-path results

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -498,9 +498,9 @@ def eval_results(func):
 
 def default_result_renderer(res):
     if res.get('status', None) != 'notneeded':
-        path = res['path']
-        path = str(path)
-        ui.message('{action}({status}): {path}{type}{msg}'.format(
+        path = res.get('path', None)
+        path = ' {}'.format(path) if path else ''
+        ui.message('{action}({status}):{path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
                 status=ac.color_status(res['status']),
                 path=relpath(path, res['refds']) if res.get('refds') else path,


### PR DESCRIPTION
Example use case: credential query
(datalad/datalad-osf#105)

There is nothing on the file system that such credentials are (or have
to be) associated with.

Before this change, the default result handler would crash on results
without a `path` key. After this change, it merely doesn't report a
path at all. Spacing is adjusted be

   `<action>(<status>): [<message>]`

in this case.