### PR TITLE
ENH: addurls: Support reading records from stdin

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -644,6 +644,12 @@ class Addurls(Interface):
 
       $ datalad addurls --fast avatars.csv '{link}' 'avatars//{who}.{ext}'
 
+    If the information is represented as JSON lines instead of comma separated
+    values or a JSON array, you can use a utility like jq to transform the JSON
+    lines into an array that addurls accepts::
+
+      $ ... | jq --slurp . | datalad addurls - '{link}' '{who}.{ext}'
+
     .. note::
 
        For users familiar with 'git annex addurl': A large part of this


### PR DESCRIPTION
URL-FILE can be a csv file or a JSON file with an array of records.
To allow the user to supply records on stdin, avoiding an intermediate
file in some cases, read from stdin when URL-FILE is "-".

There are two main options for the JSON input on stdin: JSON lines or
a JSON array.  Go with an array, which has the advantage that it
matches what addurls expects for a JSON file, which is good for both
user expectations and not introducing divergent code paths.  It also
makes it clearer that addurls slurps all the records into memory
rather than working with them as they come in. The disadvantage is the
need for another intermediate reformatting step, though it's trivial
to reformat JSON lines as an array with jq or similar tools.

The --input-type default value is "ext", which means to infer the
input type based on the file extension.  For stdin, we could rework
things to try json.load() and then fall back to processing the input
as a csv.  But for now, assume that stdin should be treated as JSON by
default unless --input-type specifies that it is a csv.

Closes #3557.

---

Note: Using this triggers what I think is a mistake (even if deliberate) in our "is interactive?" check: the check says "no" when feeding stdin even when output streams are still attached to a tty.  I'll have to look more into the history of that and will open a separate PR if I think we can drop the stdin part from `is_interactive`.