### PR TITLE
BF: Do not fail result rendering with no `path` but `refds`

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -216,6 +216,7 @@ class Push(Interface):
             yield dict(
                 res_kwargs,
                 status='error',
+                path=ds.path,
                 message="Unknown push target '{}'. {}".format(
                     to,
                     'Known targets: {}.'.format(', '.join(repr(s) for s in sr))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -503,7 +503,7 @@ def default_result_renderer(res):
         ui.message('{action}({status}):{path}{type}{msg}'.format(
                 action=ac.color_word(res['action'], ac.BOLD),
                 status=ac.color_status(res['status']),
-                path=relpath(path, res['refds']) if res.get('refds') else path,
+                path=relpath(path, res['refds']) if path and res.get('refds') else path,
                 type=' ({})'.format(
                         ac.color_word(res['type'], ac.MAGENTA)
                 ) if 'type' in res else '',


### PR DESCRIPTION
The employed `relpath` call cannot handle it.

Also remove the condition that triggered the specific observed crash
that prompted this change -- push was not reporting the dataset path
in question for one of its errors.