### PR TITLE
BF: Do not hide `git-push` crashes

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2482,6 +2482,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                     )
                     output = out[info_from] or ''
                 except CommandError as e:
+                    output = None
                     # intercept some errors that we express as an error report
                     # in the info dicts
                     if re.match(
@@ -2493,7 +2494,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                                           if l.startswith('hint: ')])
                         if output is None:
                             output = ''
-                    else:
+                    if not output:
                         raise
 
                 for line in output.splitlines():


### PR DESCRIPTION
Previous setup assumed that any `git-push` error is an orderly
report that could be forensically analyzed. However, in particular
with custom remote helpers, `git-push` can also just crash, and
there is no guarantee that we can inspect anything.

This is a minimal change that makes sure the `CommandError` bubbles
up, when we know that something is fundamentally not right, because
there was an error, but the expected error message channel is empty.

In all likelihood that is still far from comprehensive, but still better
than before.
