### PR TITLE
Avoid SSH-based stalling with recent git-annex versions

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -21,7 +21,6 @@ from os import mkdir
 from os.path import (
     join as opj,
     basename,
-    realpath,
     relpath,
     curdir,
     pardir,
@@ -1159,7 +1158,6 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
         # See https://github.com/datalad/datalad/pull/4265 for more info
         raise SkipTest("Version of git-annex might cause us to stall.")
 
-    from datalad import lgr
     # remote interaction causes socket to be created:
     try:
         # Note: For some reason, it hangs if log_stdout/err True
@@ -2231,7 +2229,6 @@ def test_commit_annex_commit_changed():
 
 @with_tempfile(mkdir=True)
 def check_files_split_exc(cls, topdir):
-    from glob import glob
     r = cls(topdir)
     # absent files -- should not crash with "too long" but some other more
     # meaningful exception

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1215,9 +1215,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
 
 
 @with_testrepos('basic_annex', flavors=['clone'])
-@with_tempfile(mkdir=True)
-def test_annex_remove(path1, path2):
-    repo = AnnexRepo(path1, create=False)
+def test_annex_remove(path):
+    repo = AnnexRepo(path, create=False)
 
     file_list = repo.get_annexed_files()
     assert len(file_list) >= 1
@@ -1233,10 +1232,7 @@ def test_annex_remove(path1, path2):
     repo.add("rm-test.dat")
 
     # remove without '--force' should fail, due to staged changes:
-    if repo.is_direct_mode():
-        assert_raises(CommandError, repo.remove, "rm-test.dat")
-    else:
-        assert_raises(ValueError, repo.remove, "rm-test.dat")
+    assert_raises(CommandError, repo.remove, "rm-test.dat")
     assert_in("rm-test.dat", repo.get_annexed_files())
 
     # now force:
@@ -1437,33 +1433,6 @@ def test_annex_get_annexed_files(path):
 
     eq_(set(repo.get_annexed_files(with_content_only=True)),
         set(repo.get_annexed_files(with_content_only=True, patterns=["*"])))
-
-
-@with_testrepos('basic_annex', flavors=['clone'])
-def test_annex_remove(path):
-    repo = AnnexRepo(path, create=False)
-
-    file_list = repo.get_annexed_files()
-    assert len(file_list) >= 1
-    # remove a single file
-    out = repo.remove(file_list[0])
-    assert_not_in(file_list[0], repo.get_annexed_files())
-    eq_(out[0], file_list[0])
-
-    with open(opj(repo.path, "rm-test.dat"), "w") as f:
-        f.write("whatever")
-
-    # add it
-    repo.add("rm-test.dat")
-
-    # remove without '--force' should fail, due to staged changes:
-    assert_raises(CommandError, repo.remove, "rm-test.dat")
-    assert_in("rm-test.dat", repo.get_annexed_files())
-
-    # now force:
-    out = repo.remove("rm-test.dat", force=True)
-    assert_not_in("rm-test.dat", repo.get_annexed_files())
-    eq_(out[0], "rm-test.dat")
 
 
 @with_parametric_batch

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -82,6 +82,7 @@ from datalad.utils import (
 from ..cmd import Runner
 from .. import utils
 from ..support.exceptions import CommandNotAvailableError
+from ..support.external_versions import external_versions
 from ..support.vcr_ import *
 from ..support.keyring_ import MemoryKeyring
 from ..support.network import RI
@@ -1072,6 +1073,15 @@ def with_sameas_remote(func, autoenabled=False):
     @with_tempfile(mkdir=True)
     @with_tempfile(mkdir=True)
     def newfunc(*args, **kwargs):
+        # With git-annex's 8.20200522-77-g1f2e2d15e, transferring from an rsync
+        # special remote hangs on Xenial. This is likely due to an interaction
+        # with an older rsync or openssh version. Use openssh as a rough
+        # indicator. See
+        # https://git-annex.branchable.com/bugs/Recent_hang_with_rsync_remote_with_older_systems___40__Xenial__44___Jessie__41__/
+        if external_versions['cmd:system-ssh'] < '7.4' and \
+           external_versions['cmd:annex'] > '8.20200522':
+            raise SkipTest("Test known to hang")
+
         sr_path, repo_path = args[-2:]
         fn_args = args[:-2]
         repo = AnnexRepo(repo_path)


### PR DESCRIPTION
Most of the hanging we were seeing with recent git-annex versions was recently fixed by git-annex's [8.20200617-134-gf912f8e5f](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=f912f8e5f) (refix bug in a better way, 2020-07-02, [bug report][0]).  That affected a good number of SSH tests.  This series should avoid the remaining stalls.

```
  [1/4] CLN: test_annexrepo: Prune unused imports
  [2/4] CLN: test_annexrepo: Merge a near-duplicate test
  [3/4] TST: annexrepo: Clear repo instances when testing shared connections
  [4/4] TST: with_sameas_remote: Skip on older systems
```

The first two commits are test_annex cleanups, followed by a commit that fixes our connection handling in `test_annex_ssh` and removes the skip added in gh-4288.

The final commit deals with a remaining [hang][1] exposed by our sameas testing setup.  That is a different source that looks to be an interaction between a recent git-annex change ([8.20200522-77-g1f2e2d15e AKA 8.20200617~99](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=1f2e2d15e)) and the old openssh or rsync versions on Xenial.  It may be limited to rsync special remotes.  I filed [an issue][2] on git-annex's side.  In terms of openssh/rsync versions, things should be okay for all non-EOL Debian releases (no hanging until we get to the Jessie).  On the other hand, Xenial's EOL isn't until April 2021.

Anyway, the final commit skips tests that use the rsync/dir sameas setup if it looks like we're on an older system with a new enough git-annex.  Even if we start using a newer git-annex for our regular Travis jobs, these tests will still be executed in our Bionic job.

Our current Travis setup of course won't test this out.  A run with this PR's tree and git-annex's current master (8.20200618-gc9d0bf0e6) is at <https://travis-ci.org/github/datalad/datalad/builds/705920487>.  None of the jobs stalled.

[0]: https://git-annex.branchable.com/bugs/annex-ssh-options_dropped_since_8.20200330/
[1]: https://travis-ci.org/github/datalad/datalad/builds/704464417
[2]: https://git-annex.branchable.com/bugs/Recent_hang_with_rsync_remote_with_older_systems___40__Xenial__44___Jessie__41__/
