### PR TITLE
ENH(UX): explicitly disallow empty string for --since in push

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -190,6 +190,10 @@ class Push(Interface):
             recursive=False,
             recursion_limit=None,
             jobs=None):
+        # push uses '^' to annotate the previous pushed committish, and None for default
+        # behavior. '' was/is (to be deprecated) used in `publish`. Alert user about the mistake
+        if since == '':
+            raise ValueError("'since' should point to commitish or use '^'.")
         # we resolve here, because we need to perform inspection on what was given
         # as an input argument further down
         paths = [resolve_path(p, dataset) for p in assure_list(path)]

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -75,6 +75,12 @@ def test_invalid_call(origin, tdir):
         ValueError,
         ds.push, to='target', since='09320957509720437523')
 
+    # If a publish() user accidentally passes since='', which push() spells as
+    # since='^', the call is aborted.
+    assert_raises(
+        ValueError,
+        ds.push, to='target', since='')
+
 
 def mk_push_target(ds, name, path, annex=True, bare=True):
     # life could be simple, but nothing is simple on windows


### PR DESCRIPTION
I had forgotten that it got a new magical `^` to operate since the last published state, so ran it (`datalad push --data auto --since= --to=datalad-public -r`) and was confused with all the progress bars (about to transfer 140G etc... disappeared quickly though... some separate issue probably to demonstrate/file) and only then remembered:

```
  --since SINCE         specifies commit-ish (tag, shasum, etc.) from which to
                        look for changes to decide whether pushing is
                        necessary. If '^' is given, the last state of the
                        current branch at the sibling is taken as a starting
                        point. Constraints: value must be a string

```

but I wonder if we should explicitly check if value is not an empty string (not `None`) and fail

Positioned against `maint` since an empty string doesn't match documented allowed values ;-)