### PR TITLE
RF: make publish understand --since=^ and deprecate --since=

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -623,11 +623,11 @@ class Publish(Interface):
         since=Parameter(
             args=("--since",),
             constraints=EnsureStr() | EnsureNone(),
-            doc="""When publishing dataset(s), specifies commit (treeish, tag, etc)
-            from which to look for changes
-            to decide whether updated publishing is necessary for this and which children.
-            If empty argument is provided, then we would take from the previously 
-            published to that remote/sibling state (for the current branch)"""),
+            doc="""specifies commit-ish (tag, shasum, etc.) from which to look for
+            changes to decide whether pushing is necessary.
+            If '^' is given, the last state of the current branch at the sibling
+            is taken as a starting point. An empty string ('') for the same effect is
+            still supported but will be removed in 0.15.0).."""),
         # since: commit => .gitmodules diff to head => submodules to publish
         missing=missing_sibling_opt,
         path=Parameter(
@@ -689,12 +689,17 @@ class Publish(Interface):
             dataset = require_dataset(
                 dataset, check_installed=True, purpose='publishing')
 
-        if since and not dataset:
+        if (since and since != '^') and not dataset:
             raise InsufficientArgumentsError(
                 'Modification detection (--since) without a base dataset '
                 'is not supported')
 
-        if dataset and since == '':
+        if dataset and since in ('', '^'):
+            # TODO: '' deprecated in favor of '^': remove handling of since='' in 0.15
+            if since == '':
+                import warnings
+                warnings.warn("since='' is deprecated. Use since='^' instead.",
+                              DeprecationWarning)
             # only update since last update so we figure out what was the last update
             active_branch = dataset.repo.get_active_branch()
             if to:

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -627,7 +627,7 @@ class Publish(Interface):
             changes to decide whether pushing is necessary.
             If '^' is given, the last state of the current branch at the sibling
             is taken as a starting point. An empty string ('') for the same effect is
-            still supported but will be removed in 0.15.0).."""),
+            still supported)."""),
         # since: commit => .gitmodules diff to head => submodules to publish
         missing=missing_sibling_opt,
         path=Parameter(
@@ -695,11 +695,6 @@ class Publish(Interface):
                 'is not supported')
 
         if dataset and since in ('', '^'):
-            # TODO: '' deprecated in favor of '^': remove handling of since='' in 0.15
-            if since == '':
-                import warnings
-                warnings.warn("since='' is deprecated. Use since='^' instead.",
-                              DeprecationWarning)
             # only update since last update so we figure out what was the last update
             active_branch = dataset.repo.get_active_branch()
             if to:

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -434,15 +434,6 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # Don't fail when a string is passed as `dataset` and since="".
     assert_status("notneeded", publish(since='^', dataset=source.path))
 
-    # TODO: introduced after 0.13, remove with 0.15
-    import warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        publish(since='', dataset=source.path)
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert "deprecated" in str(w[-1].message)
-
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:452
 @known_failure_windows

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -424,7 +424,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # and test if it could deduce the remote/branch to push to
     source.config.set('branch.master.remote', 'target', where='local')
     with chpwd(source.path):
-        res_ = publish(since='', recursive=True)
+        res_ = publish(since='^', recursive=True)
     # TODO: somehow test that there were no even attempt to diff within "subm 1"
     # since if `--since=''` worked correctly, nothing has changed there and it
     # should have not been even touched
@@ -432,7 +432,16 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     assert_result_count(res_, 1, status='ok', path=source.path, type='dataset')
 
     # Don't fail when a string is passed as `dataset` and since="".
-    assert_status("notneeded", publish(since='', dataset=source.path))
+    assert_status("notneeded", publish(since='^', dataset=source.path))
+
+    # TODO: introduced after 0.13, remove with 0.15
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        publish(since='', dataset=source.path)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:452


### PR DESCRIPTION
Positioned against `maint` since 
- previous code should still work, we will just announce (well, DeprecationWarnings are not shown! by default, heh) deprecation
- it would improve my UX while switching from `publish` to `push` (although #4682 would also help) so I could just use `--since=^` in both

Who knows, may be in 0.15 the entire `publish` would be gone...