### PR TITLE
BF: get_content_info: Account for change in ls-tree output

### DIFF
--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -257,3 +257,15 @@ def test_annexinfo_init(path):
     assert_in(foo, cinfo_init_none)
     assert_in(bar, cinfo_init_none)
     assert_not_in("gitshasum", cinfo_init_none[foo])
+
+
+@with_tempfile
+def test_info_path_inside_submodule(path):
+    ds = Dataset(path).create()
+    subds = ds.create("submod")
+    foo = (subds.pathobj / "foo")
+    foo.write_text("foo")
+    ds.save(recursive=True)
+    cinfo = ds.repo.get_content_info(
+        ref="HEAD", paths=[foo.relative_to(ds.pathobj)])
+    assert_in("gitshasum", cinfo[subds.pathobj])


### PR DESCRIPTION
get_content_info() relies on ls-tree showing an entry for a submodule
when given a path _within_ the submodule:

    $ git ls-tree HEAD sub/file
    160000 commit 05b9a93e327b959cd6ead46debf5f67cabab3a2a	sub

However, that longstanding behavior appears to be unintended
consequence of a fix to make 'ls-tree sub' and 'ls-tree sub/' return
the same result.  As of Git's 35a9f1e99c (tree-walk.c: don't match
submodule entries for 'submod/anything', 2020-06-05), the output for
the above command is empty.

That commit makes ls-tree match ls-files in how it treats paths within
submodules [*].  get_content_info() uses ls-tree when ref=None, so it
already has logic to map from sub-paths to submodules.  Reposition
that logic outside so that it can also be applied to paths destined
for ls-tree.

Closes #4681.

[*] ... resolving the inconsistency that @yarikoptic reported at
    <https://lore.kernel.org/git/20190703193305.GF21553@hopa.kiewit.dartmouth.edu>,
    though in the direction that's inconvenient for our purposes.

---

- [x] Drop the temporary tip commit.
  most recent build: https://travis-ci.org/github/datalad/datalad/builds/713712287
- [X] Wait for the Git series (sg/commit-graph-cleanups) to graduate.  It is currently in next. 
