### PR TITLE
test_annex_ssh: Skip with older SSH versions

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1121,6 +1121,14 @@ def test_annex_backends(path):
 @with_testrepos('basic_annex', flavors=['local'])
 @with_testrepos('basic_annex', flavors=['local'])
 def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
+    # On Xenial, this hangs with a recent git-annex. It bisects to git-annex's
+    # 7.20191230-142-g75059c9f3. This is likely due to an interaction with an
+    # older openssh version. See
+    # https://git-annex.branchable.com/bugs/SSH-based_git-annex-init_hang_on_older_systems___40__Xenial__44___Jessie__41__/
+    if external_versions['cmd:system-ssh'] < '7.4' and \
+       external_versions['cmd:annex'] > '7.20191230':
+        raise SkipTest("Test known to hang")
+
     from datalad import ssh_manager
     # create remotes:
     rm1 = AnnexRepo(remote_1_path, create=False)


### PR DESCRIPTION
test_annex_ssh used to be skipped for newer git-annex versions, but
that skip was just recently removed in 760c8075f (TST: annexrepo:
Clear repo instances when testing shared connections).  That commit
pointed to a passing build [0].  Checking that build again, it does
look good: it gets through the entire test suite, including
test_annex_ssh, *on Xenial* with a very recent git-annex.
Nevertheless, test_annex_ssh has since shown a failure on Xenial but
not on Bionic [1].  Based on a few runs, the stall is consistent, so
it's not clear what's going on.

In a Xenial VM, I bisected the stall to git-annex's 75059c9f3 (better
error message when git config fails to parse remote config,
2020-01-22).  I've opened a git-annex report about that commit [1],
though it's possible that the reproducer (which doesn't involve
DataLad) may not actually be showing the same issue that is causing
test_annex_ssh to hang.

Follow the same approach as 64c279ca9 (TST: with_sameas_remote: Skip
on older systems, 2020-07-07), and skip the test when using a newer
git-annex *and* running on a system with an older openssh.

[0] https://travis-ci.org/github/datalad/datalad/jobs/705850665
    Another passing run for that PR's tree is here:
    https://travis-ci.org/github/datalad/datalad/builds/705920487
[1] https://travis-ci.org/github/datalad/datalad/builds/706998369
[2] https://git-annex.branchable.com/bugs/SSH-based_git-annex-init_hang_on_older_systems___40__Xenial__44___Jessie__41__/

---

- [x] Drop tip commit that tests with latest git-annex on Xenial and Bionic.