### PR TITLE
OPT: Avoid multiple calls to `git-push` with multiple refspecs

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -668,15 +668,11 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
 
 
 def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
-    # TODO inefficient, but push only takes a single refspec at a time
-    # at the moment, enhance GitRepo.push() to do all at once
-    push_res = []
-    for refspec in refspecs:
-        push_res.extend(repo.push(
-            remote=target,
-            refspec=refspec,
-            git_options=['--force'] if force_git_push else None,
-        ))
+    push_res = repo.push(
+        remote=target,
+        refspec=refspecs,
+        git_options=['--force'] if force_git_push else None,
+    )
     # TODO maybe compress into a single message whenever everything is
     # OK?
     for pr in push_res:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2249,8 +2249,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         remote : str, optional
           name of the remote to fetch from. If no remote is given and
           `all_` is not set, the tracking branch is fetched.
-        refspec : str, optional
-          refspec to fetch.
+        refspec : str or list, optional
+          refspec(s) to fetch.
         all_ : bool, optional
           fetch all remotes (and all of their branches).
           Fails if `remote` was given.
@@ -2351,8 +2351,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         remote : str, optional
           name of the remote to push to. If no remote is given and
           `all_` is not set, the tracking branch is pushed.
-        refspec : str, optional
-          refspec to push.
+        refspec : str or list, optional
+          refspec(s) to push.
         all_ : bool, optional
           push to all remotes. Fails if `remote` was given.
         git_options : list, optional


### PR DESCRIPTION
As noted in gh-4667, `GitRepo.push()` can actually do all at once.
It just claimed not to be able to. Fixed the docs, and adjusted
the call to the method in the `push()` command.