### PR TITLE
OPT: Consolidate on a single `git-push` call in `push()`

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -668,15 +668,11 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
 
 
 def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
-    # TODO inefficient, but push only takes a single refspec at a time
-    # at the moment, enhance GitRepo.push() to do all at once
-    push_res = []
-    for refspec in refspecs:
-        push_res.extend(repo.push(
-            remote=target,
-            refspec=refspec,
-            git_options=['--force'] if force_git_push else None,
-        ))
+    push_res = repo.push(
+        remote=target,
+        refspec=refspecs,
+        git_options=['--force'] if force_git_push else None,
+    )
     # TODO maybe compress into a single message whenever everything is
     # OK?
     for pr in push_res:

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -201,7 +201,6 @@ def check_push(annex, src_path, dst_path):
         # push should be rejected (non-fast-forward):
         res = src.push(to='target', since='HEAD~2', on_failure='ignore')
         # fails before even touching the annex branch
-        assert_result_count(res, 1)
         assert_in_results(
             res,
             action='publish', status='error', target='target',

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2266,8 +2266,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         remote : str, optional
           name of the remote to fetch from. If no remote is given and
           `all_` is not set, the tracking branch is fetched.
-        refspec : str, optional
-          refspec to fetch.
+        refspec : str or list, optional
+          refspec(s) to fetch.
         all_ : bool, optional
           fetch all remotes (and all of their branches).
           Fails if `remote` was given.
@@ -2368,8 +2368,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         remote : str, optional
           name of the remote to push to. If no remote is given and
           `all_` is not set, the tracking branch is pushed.
-        refspec : str, optional
-          refspec to push.
+        refspec : str or list, optional
+          refspec(s) to push.
         all_ : bool, optional
           push to all remotes. Fails if `remote` was given.
         git_options : list, optional


### PR DESCRIPTION
Instead of splitting between regular branches and the git-annex branch, in order to improve efficiency -- in particular with expensive operations in custom git-remote-helper implementations.

Fixes gh-4667

This PR includes #4692 which is a related, but more focused optimization that was proposed for inclusion into `maint`.