### PR TITLE
TST: Disable coverage submission on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,11 +104,11 @@ test_script:
   # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
   - python -m coverage xml
 
-after_test:
-  - ps: |
-      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
-      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-      bash codecov.sh -f "coverage.xml"
+#after_test:
+#  - ps: |
+#      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
+#      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+#      bash codecov.sh -f "coverage.xml"
 
 on_finish:
   # enable the next to let the build VM block for up to 60min to log in via RDP and debug


### PR DESCRIPTION
ATM it fails unconditionally, and obscures the reporting of actual test
failures. Until this can be investigated there is no point in keeping it
fail.