### PR TITLE
RF/OPT: just assign None to linux_distribution*, and False to on_debian_wheezy

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -47,7 +47,7 @@ from datalad.utils import (
     assure_list,
     auto_repr,
     ensure_list,
-    linux_distribution_name,
+    get_linux_distribution,
     on_windows,
     partition,
     Path,
@@ -552,11 +552,16 @@ class AnnexRepo(GitRepo, RepoInterface):
     def _check_git_annex_version(cls):
         ver = external_versions['cmd:annex']
         # in case it is missing
-        if linux_distribution_name in {'debian', 'ubuntu'}:
-            msg = "Install  git-annex-standalone  from NeuroDebian " \
-                  "(http://neuro.debian.net)"
-        else:
-            msg = "Visit http://git-annex.branchable.com/install/"
+        msg = "Visit http://git-annex.branchable.com/install/"
+        # we might be able to do better
+        try:
+            linux_distribution_name = get_linux_distribution()[0]
+            if linux_distribution_name in {'debian', 'ubuntu'}:
+                msg = "Install  git-annex-standalone  from NeuroDebian " \
+                      "(http://neuro.debian.net)"
+        except:  # pragma: no cover
+            pass
+
         exc_kwargs = dict(
             name="git-annex",
             msg=msg,

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -48,7 +48,7 @@ from datalad.support.sshconnector import get_connection_hash
 
 from datalad.utils import (
     chpwd,
-    linux_distribution_name,
+    get_linux_distribution,
     on_windows,
     rmtree,
     unlink,
@@ -1546,6 +1546,7 @@ def test_annex_version_handling_bad_git_annex(path):
         eq_(AnnexRepo.git_annex_version, None)
         with assert_raises(MissingExternalDependency) as cme:
             AnnexRepo(path)
+        linux_distribution_name = get_linux_distribution()[0]
         if linux_distribution_name == 'debian':
             assert_in("http://neuro.debian.net", str(cme.exception))
         eq_(AnnexRepo.git_annex_version, None)


### PR DESCRIPTION
Those are too expensive to assign a proper value on recent Pythons where
we have to use distro (see https://github.com/datalad/datalad/issues/4690).

on_debian_wheezy was not used anywere in this code base and cannot be True these days
anyways since wheezy EOLed 2 years back, and we do not even provide backports of datalad
for it from neurodebian.

The other variables were used only for a better git-annex installation
suggestion message -- we might want to get away from that and just refer to
installation instructions anyways, but or now I just kept it around.

Even though these changes can possibly considered a "breakage", I think the
actual breakage of anything is very unlikely since code should not really rely in any
critical functionality on what distribution and its release it is running on.

I had kept variables with None values to really avoid any breakage, and so we could in
0.14 announce their proper deprecation cycle and remove them later on
