### PR TITLE
RF: Use WitlessRunner for config manager

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -249,8 +249,16 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
     proc_out = None
     proc_err = None
 
-    def __init__(self, done_future):
-        # future promise to be fulfilled when process exits
+    def __init__(self, done_future, encoding=None):
+        """
+        Parameters
+        ----------
+        done_future : asyncio.Future
+          Future promise to be fulfilled when process exits.
+        encoding : str
+          Encoding to be used for process output bytes decoding. By default,
+          the preferred system encoding is guessed.
+        """
         self.done = done_future
         # capture output in bytearrays while the process is running
         Streams = namedtuple('Streams', ['out', 'err'])
@@ -260,7 +268,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         )
         self.pid = None
         super().__init__()
-        self.encoding = getpreferredencoding(do_setlocale=False)
+        self.encoding = encoding or getpreferredencoding(do_setlocale=False)
 
         self._log_outputs = False
         if lgr.isEnabledFor(5):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -242,8 +242,9 @@ class ConfigManager(object):
             run_kwargs['cwd'] = dataset.path
         self._runner = GitWitlessRunner(**run_kwargs)
         try:
+            # reuse the runner we already have for the version check
             self._gitconfig_has_showorgin = \
-                LooseVersion(get_git_version()) >= '2.8.0'
+                LooseVersion(get_git_version(self._runner)) >= '2.8.0'
         except Exception:
             # no git something else broken, assume git is present anyway
             # to not delay this, but assume it is old

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -292,7 +292,9 @@ class ConfigManager(object):
             if exists(self._dataset_cfgfname):
                 stdout, stderr = self._run(
                     run_args + ['--file', self._dataset_cfgfname],
-                    protocol=StdOutErrCapture
+                    protocol=StdOutErrCapture,
+                    # always expect git-config to output utf-8
+                    encoding='utf-8',
                 )
                 # overwrite existing value, do not amend to get multi-line
                 # values

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -15,7 +15,10 @@ from datalad.consts import (
     DATASET_CONFIG_FILE,
     DATALAD_DOTDIR,
 )
-from datalad.cmd import GitRunner
+from datalad.cmd import (
+    GitWitlessRunner,
+    StdOutErrCapture,
+)
 from datalad.dochelpers import exc_str
 from distutils.version import LooseVersion
 
@@ -58,8 +61,9 @@ _where_reload_doc = """
 @lru_cache()
 def get_git_version(runner=None):
     """Return version of available git"""
-    runner = runner or GitRunner()
-    return runner.run('git version'.split())[0].split()[2]
+    runner = runner or GitWitlessRunner()
+    return runner.run('git version'.split(),
+                      protocol=StdOutErrCapture)['stdout'].split()[2]
 
 
 def _where_reload(obj):
@@ -231,15 +235,12 @@ class ConfigManager(object):
             if source != 'dataset':
                 self._repo_cfgfname = opj(self._dataset_path, '.git', 'config')
         self._src_mode = source
-        # Since configs could contain sensitive information, to prevent
-        # any "facilitated" leakage -- just disable logging of outputs for
-        # this runner
-        run_kwargs = dict(log_outputs=False)
+        run_kwargs = dict()
         if dataset is not None:
             # make sure we run the git config calls in the dataset
             # to pick up the right config files
             run_kwargs['cwd'] = dataset.path
-        self._runner = GitRunner(**run_kwargs)
+        self._runner = GitWitlessRunner(**run_kwargs)
         try:
             self._gitconfig_has_showorgin = \
                 LooseVersion(get_git_version()) >= '2.8.0'
@@ -290,7 +291,7 @@ class ConfigManager(object):
             if exists(self._dataset_cfgfname):
                 stdout, stderr = self._run(
                     run_args + ['--file', self._dataset_cfgfname],
-                    log_stderr=True
+                    protocol=StdOutErrCapture
                 )
                 # overwrite existing value, do not amend to get multi-line
                 # values
@@ -305,7 +306,7 @@ class ConfigManager(object):
 
         if self._src_mode == 'dataset-local':
             run_args.append('--local')
-        stdout, stderr = self._run(run_args, log_stderr=True)
+        stdout, stderr = self._run(run_args, protocol=StdOutErrCapture)
         self._store, self._cfgfiles = _parse_gitconfig_dump(
             stdout, self._store, self._cfgfiles, replace=True,
             cwd=self._runner.cwd)
@@ -598,7 +599,7 @@ class ConfigManager(object):
         out = self._runner.run(self._config_cmd + args, **kwargs)
         if reload:
             self.reload()
-        return out
+        return out['stdout'], out['stderr']
 
     def _get_location_args(self, where, args=None):
         if args is None:
@@ -648,7 +649,8 @@ class ConfigManager(object):
                 self.reload(force=True)
             return
 
-        self._run(['--add', var, value], where=where, reload=reload, log_stderr=True)
+        self._run(['--add', var, value], where=where, reload=reload,
+                  protocol=StdOutErrCapture)
 
     @_where_reload
     def set(self, var, value, where='dataset', reload=True, force=False):
@@ -678,7 +680,7 @@ class ConfigManager(object):
         from datalad.support.gitrepo import to_options
 
         self._run(to_options(replace_all=force) + [var, value],
-                  where=where, reload=reload, log_stderr=True)
+                  where=where, reload=reload, protocol=StdOutErrCapture)
 
     @_where_reload
     def rename_section(self, old, new, where='dataset', reload=True):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -42,24 +42,31 @@ class UnknownVersion:
 #
 # Custom handlers
 #
-from datalad.cmd import Runner
-from datalad.cmd import GitRunner
+from datalad.cmd import (
+    WitlessRunner,
+    GitWitlessRunner,
+    StdOutErrCapture,
+)
 from datalad.support.exceptions import (
     MissingExternalDependency,
     OutdatedExternalDependency,
 )
-_runner = Runner()
-_git_runner = GitRunner()
+_runner = WitlessRunner()
+_git_runner = GitWitlessRunner()
 
 
 def _get_annex_version():
     """Return version of available git-annex"""
     try:
-        return _runner.run('git annex version --raw'.split())[0]
+        return _runner.run(
+            'git annex version --raw'.split(),
+            protocol=StdOutErrCapture)['stdout']
     except CommandError:
         # fall back on method that could work with older installations
-        out, err = _runner.run(['git', 'annex', 'version'])
-        return out.split('\n')[0].split(':')[1].strip()
+        out = _runner.run(
+            ['git', 'annex', 'version'],
+            protocol=StdOutErrCapture)
+        return out['stdout'].split('\n')[0].split(':')[1].strip()
 
 
 def _get_git_version():
@@ -81,7 +88,9 @@ def _get_bundled_git_version():
     """
     path = _git_runner._get_bundled_path()
     if path:
-        out = _runner.run([op.join(path, "git"), "version"])[0]
+        out = _runner.run(
+            [op.join(path, "git"), "version"],
+            protocol=StdOutErrCapture)['stdout']
         # format: git version 2.22.0
         return out.split()[2]
 
@@ -92,30 +101,31 @@ def _get_system_ssh_version():
     Annex prior 20170302 was using bundled version, but now would use system one
     if installed
     """
-    out, err = _runner.run('ssh -V'.split(),
-                           expect_fail=True, expect_stderr=True)
+    out = _runner.run(
+        'ssh -V'.split(),
+        protocol=StdOutErrCapture)
     # apparently spits out to err but I wouldn't trust it blindly
-    if err.startswith('OpenSSH'):
-        out = err
-    assert out.startswith('OpenSSH')  # that is the only one we care about atm
-    return out.split(' ', 1)[0].rstrip(',.').split('_')[1]
+    stdout = out['stdout']
+    if out['stderr'].startswith('OpenSSH'):
+        stdout = out['stderr']
+    assert stdout.startswith('OpenSSH')  # that is the only one we care about atm
+    return stdout.split(' ', 1)[0].rstrip(',.').split('_')[1]
 
 
 def _get_system_7z_version():
     """Return version of 7-Zip"""
-    out, err = _runner.run(
-        ['7z'], expect_fail=True, expect_stderr=True,
-    )
+    out = _runner.run(
+        ['7z'],
+        protocol=StdOutErrCapture)
     # reporting in variable order across platforms
     # Linux: 7-Zip [64] 16.02
     # Windows: 7-Zip 19.00 (x86)
-    pieces = out.strip().split(':', maxsplit=1)[0].strip().split()
+    pieces = out['stdout'].strip().split(':', maxsplit=1)[0].strip().split()
     for p in pieces:
         # the one with the dot is the version
         if '.' in p:
             return p
-    lgr.debug("Could not determine version of 7z from stdout. "
-              "stdout: %s, stderr: %s", out, err)
+    lgr.debug("Could not determine version of 7z from stdout. %s", out)
 
 
 class ExternalVersions(object):

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -66,7 +66,7 @@ def _get_annex_version():
         out = _runner.run(
             ['git', 'annex', 'version'],
             protocol=StdOutErrCapture)
-        return out['stdout'].split('\n')[0].split(':')[1].strip()
+        return out['stdout'].splitlines()[0].split(':')[1].strip()
 
 
 def _get_git_version():

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -164,10 +164,10 @@ def test_custom_versions():
 def test_ancient_annex():
 
     class _runner(object):
-        def run(self, cmd):
+        def run(self, cmd, *args, **kwargs):
             if '--raw' in cmd:
                 raise CommandError
-            return "git-annex version: 0.1", ""
+            return dict(stdout="git-annex version: 0.1", stderr="")
 
     ev = ExternalVersions()
     with patch('datalad.support.external_versions._runner', _runner()):
@@ -176,8 +176,8 @@ def test_ancient_annex():
 
 def _test_annex_version_comparison(v, cmp_):
     class _runner(object):
-        def run(self, cmd):
-            return v, ""
+        def run(self, cmd, *args, **kwargs):
+            return dict(stdout=v, stderr="")
 
     ev = ExternalVersions()
     with set_annex_version(None), \
@@ -237,8 +237,8 @@ def test_system_ssh_version():
         ev = ExternalVersions()
         # TODO: figure out leaner way
         class _runner(object):
-            def run(self, cmd, expect_fail, expect_stderr):
-                return "", s
+            def run(self, cmd, *args, **kwargs):
+                return dict(stdout="", stderr=s)
         with patch('datalad.support.external_versions._runner', _runner()):
             assert_equal(ev['cmd:system-ssh'], v)
 


### PR DESCRIPTION
Includes 109ac04 from #4703 that exposed a critical flaw in `GitWitlessRunner` and a limitation in `WitlessRunner`