### PR TITLE
TST: Honor TMPDIR if DATALAD_TESTS_TEMP_DIR is not defined

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1068,7 +1068,10 @@ def get_tempfile_kwargs(tkwargs=None, prefix="", wrapped=None):
             ([prefix] if prefix else []) +
             ([''] if (on_windows or not wrapped) else [wrapped.__name__]))
 
-    directory = os.environ.get('DATALAD_TESTS_TEMP_DIR')
+    directory = os.environ.get(
+        'DATALAD_TESTS_TEMP_DIR',
+        os.environ.get('TMPDIR')
+    )
     if directory and 'dir' not in tkwargs_:
         tkwargs_['dir'] = directory
 


### PR DESCRIPTION
Rational: We are using TMPDIR in quite a few places to direct where
tests do IO (to have pathnames with spaces, symlinks, different
filesystems, etc.). However, setting TMPDIR did not affect
paths created by our own test helpers. For example:

```
TMPDIR=/tmp/dltest DATALAD_TESTS_TEMP_KEEP=1 python -m nose -s -v datalad
[INFO   ] Keeping temp file: /tmp/datalad_temp_get_most_obscure_supported_name4v4gmbdq
[INFO   ] Keeping temp file: /tmp/datalad_temp_e3h1pw_e
...
```

This change rectifies this (and with it might reveal other issues):

```
TMPDIR=/tmp/dltest DATALAD_TESTS_TEMP_KEEP=1 python -m nose -s -v datalad
[INFO   ] Keeping temp file: /tmp/dltest/datalad_temp_get_most_obscure_supported_namej5wa186s
[INFO   ] Keeping temp file: /tmp/dltest/datalad_temp_pf8hschp
```