### PR TITLE
BF: Readable SSH error messages

### DIFF
--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -280,7 +280,7 @@ class SSHConnection(object):
 
         if exit_code != 0:
             raise ConnectionOpenFailedError(
-                str(cmd),
+                cmd,
                 'Failed to open SSH connection (could not start ControlMaster process)',
                 exit_code,
                 stdout,


### PR DESCRIPTION
Do not stringify what doesn't need to be -- we have more clever
rendering now, than we had when this was written.

Turns

```
ConnectionOpenFailedError: ''['"'"'ssh'"'"', '"'"'-fN'"'"', '"'"'-o'"'"', '"'"'ControlMaster=auto'"'"', '"'"'-o'"'"', '"'"'ControlPersist=15m'"'"', '"'"'-o'"'"', '"'"'ControlPath=/media/mih/Samsung_T5/tmp/datalad_temp_ml_70qcw/.cache/datalad/sockets/6258b3a7'"'"', '"'"'localhost'"'"']'' failed with exitcode 255 [Failed to open SSH connection (could not start ControlMaster process)]']
```

into

```
ConnectionOpenFailedError: 'ssh -fN -o ControlMaster=auto -o ControlPersist=15m -o ControlPath=/media/mih/Samsung_T5/tmp/datalad_temp_01cz4bxi/.cache/datalad/sockets/6258b3a7 localhost' failed with exitcode 255 [Failed to open SSH connection (could not start ControlMaster process)]']
```
