### PR TITLE
TST: Robustify tests that rely on symlinks

### DIFF
--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -254,15 +254,15 @@ def test_keeptemp_via_env_variable():
 @with_tempfile
 def test_ok_symlink_helpers(tmpfile):
 
-    if on_windows:  # pragma: no cover
-        raise SkipTest("no sylmlinks on windows")
-
     assert_raises(AssertionError, ok_symlink, tmpfile)
     assert_raises(AssertionError, ok_good_symlink, tmpfile)
     assert_raises(AssertionError, ok_broken_symlink, tmpfile)
 
     tmpfile_symlink = tmpfile + '_symlink'
-    os.symlink(tmpfile, tmpfile_symlink)  
+    try:
+        os.symlink(tmpfile, tmpfile_symlink)
+    except Exception:
+        raise SkipTest("Cannot create a symlink")
 
     # broken symlink
     ok_symlink(tmpfile_symlink)
@@ -651,7 +651,6 @@ def test_ignore_nose_capturing_stdout():
         ignore_nose_capturing_stdout(raise_exc)()
 
 
-@skip_if_on_windows  # no symlinks. may be skip if not hasattr(os, "symlink")
 @with_tree(tree={'ingit': '', 'staged': 'staged', 'notingit': ''})
 def test_ok_file_under_git_symlinks(path):
     # Test that works correctly under symlinked path
@@ -660,7 +659,10 @@ def test_ok_file_under_git_symlinks(path):
     orepo.commit('msg')
     orepo.add('staged')
     lpath = path + "-symlink"  # will also be removed AFAIK by our tempfile handling
-    os.symlink(path, lpath)
+    try:
+        os.symlink(path, lpath)
+    except Exception:
+        raise SkipTest("Cannot create a symlink")
     ok_symlink(lpath)
     ok_file_under_git(op.join(path, 'ingit'))
     ok_file_under_git(op.join(lpath, 'ingit'))

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -390,7 +390,10 @@ def test_getpwd_change_mode(tdir):
 def test_getpwd_symlink(tdir):
     sdir = opj(tdir, 's1')
     pwd_orig = getpwd()
-    os.symlink('.', sdir)
+    try:
+        os.symlink('.', sdir)
+    except Exception:
+        raise SkipTest("Cannot create a symlink")
     s1dir = opj(sdir, 's1')
     s2dir = opj(sdir, 's2')
     try:


### PR DESCRIPTION
Use actual failure to create on as the indicator that it isn't possible.
Inference based on platform name, or `os.symlink` availability isn't
reliable enough.

Fixes gh-4719
Fixes gh-4718
Fixes gh-4715