### PR TITLE
RF+BF+TST: Discontinue "quick" annex (availability) checks

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1737,27 +1737,24 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         return objects
 
-    def _check_files(self, fn, quick_fn, files, allow_quick, batch):
+    def _check_files(self, fn, files, batch):
         # Helper that isolates the common logic in `file_has_content` and
         # `is_under_annex`. `fn` is the annex command used to do the check, and
         # `quick_fn` is the non-annex variant.
         pointers = self.supports_unlocked_pointers
-        if pointers or batch or not allow_quick:
-            # We're only concerned about modified files in V6+ mode. In V5
-            # `find` returns an empty string for unlocked files.
-            modified = [
-                f for f in self.call_git_items_(
-                    ['diff', '--name-only', '-z'], sep='\0')
-                if f] if pointers else []
-            annex_res = fn(files, normalize_paths=False, batch=batch)
-            return [bool(annex_res.get(f) and
-                         not (pointers and normpath(f) in modified))
-                    for f in files]
-        else:  # ad-hoc check which should be faster than call into annex
-            return [quick_fn(f) for f in files]
+        # We're only concerned about modified files in V6+ mode. In V5
+        # `find` returns an empty string for unlocked files.
+        modified = [
+            f for f in self.call_git_items_(
+                ['diff', '--name-only', '-z'], sep='\0')
+            if f] if pointers else []
+        annex_res = fn(files, normalize_paths=False, batch=batch)
+        return [bool(annex_res.get(f) and
+                     not (pointers and normpath(f) in modified))
+                for f in files]
 
     @normalize_paths
-    def file_has_content(self, files, allow_quick=True, batch=False):
+    def file_has_content(self, files, allow_quick=False, batch=False):
         """Check whether files have their content present under annex.
 
         Parameters
@@ -1765,8 +1762,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         files: list of str
             file(s) to check for being actually present.
         allow_quick: bool, optional
-            allow quick check, based on having a symlink into .git/annex/objects.
-            Works only in non-direct mode (TODO: thin mode)
+            This is no longer supported.
 
         Returns
         -------
@@ -1774,28 +1770,10 @@ class AnnexRepo(GitRepo, RepoInterface):
             For each input file states whether file has content locally
         """
         # TODO: Also provide option to look for key instead of path
-
-        def quick_check(filename):
-            filepath = self.pathobj / filename
-            # MIH wonders why it cannot just return exists(filepath)...
-            # this test must not use op.path.exists(), because automagic
-            # IO patches it to return True for any symlink pointing into
-            # the annex
-            return filepath.exists() and (
-                filepath.is_symlink()
-                # TODO: checks for being not outside of this repository
-                # Note: ben removed '.git/' from '.git/annex/objects',
-                # since it is not true for submodules, whose '.git' is a
-                # symlink and being resolved to some
-                # '.git/modules/.../annex/objects'
-                and opj('annex', 'objects') in os.readlink(str(filepath))  # realpath OK
-            )
-
-        return self._check_files(self.find, quick_check,
-                                 files, allow_quick, batch)
+        return self._check_files(self.find, files, batch)
 
     @normalize_paths
-    def is_under_annex(self, files, allow_quick=True, batch=False):
+    def is_under_annex(self, files, allow_quick=False, batch=False):
         """Check whether files are under annex control
 
         Parameters
@@ -1803,8 +1781,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         files: list of str
             file(s) to check for being under annex
         allow_quick: bool, optional
-            allow quick check, based on having a symlink into .git/annex/objects.
-            Works only in non-direct mode (TODO: thin mode)
+            This is no longer supported.
 
         Returns
         -------
@@ -1826,20 +1803,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             return self.info([f for f in files if not isdir(f)],
                              fast=True, **kwargs)
 
-        def quick_check(filename):
-            filepath = opj(self.path, filename)
-            # todo checks for being not outside of this repository
-            # Note: ben removed '.git/' from '.git/annex/objects',
-            # since it is not true for submodules, whose '.git' is a
-            # symlink and being resolved to some
-            # '.git/modules/.../annex/objects'
-            return (
-                islink(filepath)
-                and opj('annex', 'objects') in os.readlink(filepath)  # realpath OK
-            )
-
-        return self._check_files(check, quick_check,
-                                 files, allow_quick, batch)
+        return self._check_files(check, files, batch)
 
     def init_remote(self, name, options):
         """Creates a new special remote

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -753,9 +753,8 @@ def test_AnnexRepo_on_uninited_annex(origin, path):
     annex = AnnexRepo(path, create=False, init=False)  # so we can initialize without
     # and still can get our things
     assert_false(annex.file_has_content('test-annex.dat'))
-    with swallow_outputs():
-        annex.get('test-annex.dat')
-        ok_(annex.file_has_content('test-annex.dat'))
+    annex.get('test-annex.dat')
+    ok_(annex.file_has_content('test-annex.dat'))
 
 
 @assert_cwd_unchanged


### PR DESCRIPTION
These quick alternative checks yield invalid result on crippled FS.
Moreover, they are not used in non-test code.

Consequently, their removal should improve validity of tests without
impacting the performance of user-facing code.

Fixes gh-4714