### PR TITLE
BF: create-sibling: Avoid overwriting existing web log file

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -948,6 +948,14 @@ fi
 
 mkdir -p "$dsdir/{WEB_META_LOG}"  # assure logs directory exists
 
+# Avoid file name collisions.
+suffix=0
+logfile_orig="$logfile"
+while [ -f "$logfile" ]; do
+  suffix=$(( $suffix + 1 ))
+  logfile="$logfile_orig.$suffix"
+done
+
 ( which datalad > /dev/null \
   && ( cd "$dsdir"; GIT_DIR="$PWD/.git" datalad ls -a --json file .; ) \
   || echo "E: no datalad found - skipping generation of indexes for web frontend"; \


### PR DESCRIPTION
The post-update hook installed by `create-sibling --ui ...` constructs
a log file name using a second-resolution `date` call.  For normal
use, consecutive updates are unlikely to result in a file name
collision, but it can very easily happen in a test setting.

These collisions are very likely behind the intermittent failures that
have been happening in test_replace_and_relative_sshpath, where the
number of log files is coming up one short of the expected number
after a call to publish().

Check if the target file exists and, if needed, append a number.

Fixes #4741.
