### PR TITLE
sshconnector: Fix regression in closing specified control path

### DIFF
--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -581,7 +581,6 @@ class SSHManager(object):
           If specified, only the path(s) provided would be considered
         """
         if self._connections:
-            from datalad.utils import assure_list
             ctrl_paths = assure_list(ctrl_path)
             to_close = [c for c in self._connections
                         # don't close if connection wasn't opened by SSHManager

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -581,7 +581,7 @@ class SSHManager(object):
           If specified, only the path(s) provided would be considered
         """
         if self._connections:
-            ctrl_paths = assure_list(ctrl_path)
+            ctrl_paths = [Path(p) for p in assure_list(ctrl_path)]
             to_close = [c for c in self._connections
                         # don't close if connection wasn't opened by SSHManager
                         if self._connections[c].ctrl_path

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -577,7 +577,7 @@ class SSHManager(object):
         allow_fail: bool, optional
           If True, swallow exceptions which might be thrown during
           connection.close, and just log them at DEBUG level
-        ctrl_path: str or list of str, optional
+        ctrl_path: str, Path, or list of str or Path, optional
           If specified, only the path(s) provided would be considered
         """
         if self._connections:

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -234,6 +234,27 @@ def test_ssh_compound_cmds():
 
 @skip_if_on_windows
 @skip_ssh
+def test_ssh_close_target():
+    manager = SSHManager()
+    path0 = manager.socket_dir / get_connection_hash(
+        'datalad-test', bundled=True)
+    path1 = manager.socket_dir / get_connection_hash(
+        'datalad-test', bundled=False)
+    existed0 = path0.exists()
+    existed1 = path1.exists()
+    manager.get_connection('ssh://datalad-test').open()
+    manager.get_connection('ssh://datalad-test',
+                           use_remote_annex_bundle=False).open()
+    manager.close(ctrl_path=[str(path0)])
+    # The requested path is closed.
+    eq_(existed0, path0.exists())
+    ok_(path1.exists())
+    if not existed1:
+        path1.unlink()
+
+
+@skip_if_on_windows
+@skip_ssh
 def test_ssh_custom_identity_file():
     ifile = "/tmp/dl-test-ssh-id"  # Travis
     if not op.exists(ifile):


### PR DESCRIPTION
`.close(ctrl_path=<str>)` hasn't closed the connection for the specified control path since the switch to using pathlib in the sshconnector module.