### PR TITLE
BF: Error handling when magic Dataset identifiers '^' and '^.' do not resolve

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -85,14 +85,19 @@ class Dataset(object, metaclass=PathBasedFlyweight):
     def _flyweight_preproc_path(cls, path):
         """Custom handling for few special abbreviations for datasets"""
         path_ = path
-        if path == '^':
-            # get the topmost dataset from current location. Note that 'zsh'
-            # might have its ideas on what to do with ^, so better use as -d^
-            path_ = Dataset(get_dataset_root(curdir)).get_superdataset(
-                topmost=True).path
-        elif path == '^.':
-            # get the dataset containing current directory
-            path_ = get_dataset_root(curdir)
+        if path in ('^', '^.'):
+            dsroot = get_dataset_root(curdir)
+            if dsroot is None:
+                raise NoDatasetFound('No dataset contains path: {}'.format(
+                    str(Path.cwd())))
+            if path == '^':
+                # get the topmost dataset from current location. Note that 'zsh'
+                # might have its ideas on what to do with ^, so better use as -d^
+                path_ = Dataset(dsroot).get_superdataset(
+                    topmost=True).path
+            elif path == '^.':
+                # the dataset containing current directory
+                path_ = dsroot
         elif path == '///':
             # TODO: logic/UI on installing a default dataset could move here
             # from search?

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -59,7 +59,10 @@ from datalad.tests.utils import (
     with_tempfile,
     with_testrepos,
 )
-from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.exceptions import (
+    InsufficientArgumentsError,
+    NoDatasetFound,
+)
 
 
 def test_EnsureDataset():
@@ -126,10 +129,13 @@ def test_is_installed(src, path):
 
 
 @with_tempfile(mkdir=True)
-def test_dataset_contructor(path):
+def test_dataset_constructor(path):
     # dataset needs a path
     assert_raises(TypeError, Dataset)
     assert_raises(ValueError, Dataset, None)
+    with chpwd(path):
+        assert_raises(NoDatasetFound, Dataset, '^.')
+        assert_raises(NoDatasetFound, Dataset, '^')
     dsabs = Dataset(path)
     # always abspath
     ok_(os.path.isabs(dsabs.path))


### PR DESCRIPTION
Raise `NoDatasetFound` exception immediately, instead of letting
subsequent code fail in cryptic ways.

Fixes gh-4758