### PR TITLE
TST: Add upper git-annex version bound for two resolved SSH hangs

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1128,7 +1128,7 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     # older openssh version. See
     # https://git-annex.branchable.com/bugs/SSH-based_git-annex-init_hang_on_older_systems___40__Xenial__44___Jessie__41__/
     if external_versions['cmd:system-ssh'] < '7.4' and \
-       external_versions['cmd:annex'] > '7.20191230':
+       '7.20191230' < external_versions['cmd:annex'] <= '8.20200720.1':
         raise SkipTest("Test known to hang")
 
     from datalad import ssh_manager

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1085,7 +1085,7 @@ def with_sameas_remote(func, autoenabled=False):
         # indicator. See
         # https://git-annex.branchable.com/bugs/Recent_hang_with_rsync_remote_with_older_systems___40__Xenial__44___Jessie__41__/
         if external_versions['cmd:system-ssh'] < '7.4' and \
-           external_versions['cmd:annex'] > '8.20200522':
+           '8.20200522' < external_versions['cmd:annex'] < '8.20200720':
             raise SkipTest("Test known to hang")
 
         sr_path, repo_path = args[-2:]


### PR DESCRIPTION
The hang of test_annex_ssh with older OpenSSH versions is addressed by
git-annex's cb74cefde (Fix a hang when using git-annex with an old
openssh 7.2p2, 2020-07-21).

The SSH-related hang of the rsync remote that led to
test_sibling_enable_sameas stalling is, for mysterious reasons,
resolved by 4c9ad1de4, which was a part of the 8.20200720 release.
And, if it resurfaces, it should be taken care of by the changes in
aa492bc65 (Fix a hang when using git-annex with an old openssh 7.2p2,
2020-07-22).

---

- [x] Drop temporary commit that runs these tests with the autobuild of git-annex.
  Passing build: https://travis-ci.org/github/datalad/datalad/builds/710837937