### PR TITLE
travis: Use a Docker target for the SSH tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # vim ft=yaml
 # travis-ci.org definition for DataLad build
 language: python
+services:
+  - docker
 
 python:
   - 3.5
@@ -209,7 +211,6 @@ before_install:
   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
   - travis_retry sudo apt-get update -qq
   - travis_retry sudo apt-get install eatmydata  # to speedup some installations
-  - sudo eatmydata tools/ci/prep-travis-forssh-sudo.sh
   - tools/ci/prep-travis-forssh.sh
   # Install nvm https://github.com/nvm-sh/nvm/blob/master/README.md
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -512,7 +512,18 @@ Refer datalad/config.py for information on how to add these environment variable
   Skips network tests completely if this flag is set
   Examples include test for s3, git_repositories, openfmri etc
 - *DATALAD_TESTS_SSH*: 
-  Skips SSH tests if this flag is **not** set
+  Skips SSH tests if this flag is **not** set.  If you enable this,
+  you need to set up a "datalad-test" and "datalad-test2" target in
+  your SSH configuration.  The second target is used by only a couple
+  of tests, so depending on the tests you're interested in, you can
+  get by with only "datalad-test" configured.
+
+  A Docker image that is used for DataLad's tests is available at
+  <https://github.com/datalad-tester/docker-ssh-target>.  Note that
+  the DataLad tests assume that target files exist in
+  `DATALAD_TESTS_TEMP_DIR`, which restricts the "datalad-test" target
+  to being either the localhost or a container that mounts
+  `DATALAD_TESTS_TEMP_DIR`.
 - *DATALAD_TESTS_NOTEARDOWN*: 
   Does not execute teardown_package which cleans up temp files and directories created by tests if this flag is set
 - *DATALAD_TESTS_USECASSETTE*:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ install:
   # define test host alias
   - echo. >> %SYSTEMROOT%\System32\drivers\etc\hosts
   - echo.127.0.0.1  datalad-test >> %SYSTEMROOT%\System32\drivers\etc\hosts
+  - echo.127.0.0.1  datalad-test2 >> %SYSTEMROOT%\System32\drivers\etc\hosts
   # OpenSSH server setup
   - appveyor DownloadFile https://github.com/PowerShell/Win32-OpenSSH/releases/download/v7.6.1.0p1-Beta/OpenSSH-Win32.zip -FileName resources\openssh.zip
   - 7z x -o"resources" resources\openssh.zip
@@ -55,6 +56,7 @@ install:
   # test login
   - ssh -v localhost exit
   - ssh datalad-test exit
+  - ssh datalad-test2 exit
   # git annex setup
   # latest version
   #- appveyor DownloadFile https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -FileName resources\git-annex-installer.exe

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -532,7 +532,7 @@ def test_publish_target_url(src, desttop, desturl):
         raise SkipTest(
             'Skipped due to https://github.com/datalad/datalad/issues/4075')
     ds.save('1')
-    ds.create_sibling('ssh://localhost:%s/subdir' % desttop,
+    ds.create_sibling('ssh://datalad-test:%s/subdir' % desttop,
                       name='target',
                       target_url=desturl + 'subdir/.git')
     results = ds.push(to='target')

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -517,7 +517,6 @@ def check_replace_and_relative_sshpath(use_ssh, src_path, dst_path):
         from datalad import ssh_manager
         ssh = ssh_manager.get_connection('datalad-test')
         remote_home, err = ssh('pwd')
-        assert not err
         remote_home = remote_home.rstrip('\n')
         dst_relpath = os.path.relpath(dst_path, remote_home)
         url = 'datalad-test:%s' % dst_relpath

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -148,14 +148,14 @@ def test_invalid_call(path):
         # needs an actual dataset
         assert_raises(
             ValueError,
-            create_sibling, 'localhost:/tmp/somewhere', dataset='/nothere')
+            create_sibling, 'datalad-test:/tmp/somewhere', dataset='/nothere')
     # pre-configure a bogus remote
     ds = Dataset(path).create()
     ds.repo.add_remote('bogus', 'http://bogus.url.com')
     # fails to reconfigure by default with generated
     # and also when given an existing name
     for res in (ds.create_sibling('bogus:/tmp/somewhere', on_failure='ignore'),
-                ds.create_sibling('localhost:/tmp/somewhere', name='bogus', on_failure='ignore')):
+                ds.create_sibling('datalad-test:/tmp/somewhere', name='bogus', on_failure='ignore')):
         assert_result_count(
             res, 1,
             status='error',
@@ -204,7 +204,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         assert_create_sshwebserver(
             dataset=source,
             name="local_target_alt",
-            sshurl="ssh://localhost",
+            sshurl="ssh://datalad-test",
             target_dir=target_path)
     ok_(str(cm.exception).startswith(
         "Target path %s already exists." % target_path))
@@ -230,14 +230,14 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             assert_create_sshwebserver(
                 dataset=source,
                 name="local_target",
-                sshurl="ssh://localhost" + target_path,
+                sshurl="ssh://datalad-test" + target_path,
                 publish_by_default=DEFAULT_BRANCH,
                 existing='replace',
                 ui=True,
             )
         interactive_assert_create_sshwebserver()
 
-        eq_("ssh://localhost" + urlquote(target_path),
+        eq_("ssh://datalad-test" + urlquote(target_path),
             source.repo.get_remote_url("local_target"))
         ok_(source.repo.get_remote_url("local_target", push=True) is None)
 
@@ -252,15 +252,15 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
             # should be added too, even if URL matches prior state
             eq_(lclcfg.get('remote.local_target.push'), DEFAULT_BRANCH)
 
-        # again, by explicitly passing urls. Since we are on localhost, the
+        # again, by explicitly passing urls. Since we are on datalad-test, the
         # local path should work:
         cpkwargs = dict(
             dataset=source,
             name="local_target",
-            sshurl="ssh://localhost",
+            sshurl="ssh://datalad-test",
             target_dir=target_path,
             target_url=target_path,
-            target_pushurl="ssh://localhost" + target_path,
+            target_pushurl="ssh://datalad-test" + target_path,
             ui=True,
         )
 
@@ -276,7 +276,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
 
         eq_(target_path,
             source.repo.get_remote_url("local_target"))
-        eq_("ssh://localhost" + target_path,
+        eq_("ssh://datalad-test" + target_path,
             source.repo.get_remote_url("local_target", push=True))
 
         assert_publish_with_ui(target_path)
@@ -360,7 +360,7 @@ def check_target_ssh_recursive(use_ssh, origin, src_path, target_path):
             sep = os.path.sep
 
         if use_ssh:
-            sshurl = "ssh://localhost" + target_path_
+            sshurl = "ssh://datalad-test" + target_path_
         else:
             sshurl = target_path_
 
@@ -425,7 +425,7 @@ def test_target_ssh_recursive():
 @with_tempfile
 def check_target_ssh_since(use_ssh, origin, src_path, target_path):
     if use_ssh:
-        sshurl = "ssh://localhost" + target_path
+        sshurl = "ssh://datalad-test" + target_path
     else:
         sshurl = target_path
     # prepare src
@@ -481,7 +481,7 @@ def test_target_ssh_since():
 @with_tempfile(mkdir=True)
 def check_failon_no_permissions(use_ssh, src_path, target_path):
     if use_ssh:
-        sshurl = "ssh://localhost" + opj(target_path, 'ds')
+        sshurl = "ssh://datalad-test" + opj(target_path, 'ds')
     else:
         sshurl = opj(target_path, 'ds')
     ds = Dataset(src_path).create()
@@ -514,13 +514,13 @@ def check_replace_and_relative_sshpath(use_ssh, src_path, dst_path):
     # different even though a datalad-test. So we need to query it
     if use_ssh:
         from datalad import ssh_manager
-        ssh = ssh_manager.get_connection('localhost')
+        ssh = ssh_manager.get_connection('datalad-test')
         remote_home, err = ssh('pwd')
         assert not err
         remote_home = remote_home.rstrip('\n')
         dst_relpath = os.path.relpath(dst_path, remote_home)
-        url = 'localhost:%s' % dst_relpath
-        sibname = 'localhost'
+        url = 'datalad-test:%s' % dst_relpath
+        sibname = 'datalad-test'
     else:
         url = dst_path
         sibname = 'local'
@@ -589,7 +589,7 @@ def test_replace_and_relative_sshpath():
 def _test_target_ssh_inherit(standardgroup, ui, use_ssh, src_path, target_path):
     ds = Dataset(src_path).create()
     if use_ssh:
-        target_url = 'localhost:%s' % target_path
+        target_url = 'datalad-test:%s' % target_path
     else:
         target_url = target_path
     remote = "magical"
@@ -700,7 +700,7 @@ def check_exists_interactive(use_ssh, path):
     create_tree(sibling_path, {'stuff': ''})
 
     if use_ssh:
-        sshurl = 'localhost:' + sibling_path
+        sshurl = 'datalad-test:' + sibling_path
     else:
         sshurl = sibling_path
 

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -107,18 +107,10 @@ def assert_publish_with_ui(target_path, rootds=False, flat=True):
                         flags=re.DOTALL)
 
 
-# shortcut
-# but we can rely on it ATM only if "server" (i.e. localhost) has
-# recent enough git since then we expect an error msg to be spit out
-from datalad.support.external_versions import external_versions
-# But with custom GIT_PATH pointing to non-bundled annex, which would not be
-# used on remote, so we will compare against system-git
-assert_create_sshwebserver = (
-    assert_no_errors_logged(create_sibling)
-    if (external_versions['cmd:system-git'] >= '2.4' and
-        lgr.getEffectiveLevel() > logging.DEBUG)
-    else create_sibling
-)
+if lgr.getEffectiveLevel() > logging.DEBUG:
+    assert_create_sshwebserver = assert_no_errors_logged(create_sibling)
+else:
+    assert_create_sshwebserver = create_sibling
 
 
 def assert_postupdate_hooks(path, installed=True, flat=False):

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -40,6 +40,7 @@ from datalad.tests.utils import (
     DEFAULT_BRANCH,
     eq_,
     get_mtimes_and_digests,
+    get_ssh_port,
     ok_,
     ok_endswith,
     ok_exists,
@@ -170,7 +171,7 @@ def test_invalid_call(path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_target_ssh_simple(origin, src_path, target_rootpath):
-
+    port = get_ssh_port("datalad-test")
     # prepare src
     source = install(
         src_path, source=origin,
@@ -181,7 +182,7 @@ def test_target_ssh_simple(origin, src_path, target_rootpath):
         create_sibling(
             dataset=source,
             name="local_target",
-            sshurl="ssh://localhost:22",
+            sshurl="ssh://datalad-test:{}".format(port),
             target_dir=target_path,
             ui=True)
         assert_not_in('enableremote local_target failed', cml.out)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -819,12 +819,12 @@ def test_install_subds_with_space(opath, tpath):
     # works even now, boring
     # install(tpath, source=opath, recursive=True)
     if on_windows:
-        # on windows we cannot simply prepend localhost: to a path
+        # on windows we cannot simply prepend datalad-test: to a path
         # and get a working sshurl...
         install(tpath, source=opath, recursive=True)
     else:
         # do via ssh!
-        install(tpath, source="localhost:" + opath, recursive=True)
+        install(tpath, source="datalad-test:" + opath, recursive=True)
     assert Dataset(opj(tpath, 'sub ds')).is_installed()
 
 
@@ -858,7 +858,7 @@ def test_install_subds_from_another_remote(topdir):
         origin = create(origin_, annex=False)
         clone1 = install(source=origin, path=clone1_)
         # print("Initial clone")
-        clone1.create_sibling('ssh://localhost%s/%s' % (PathRI(getpwd()).posixpath, clone2_), name=clone2_)
+        clone1.create_sibling('ssh://datalad-test%s/%s' % (PathRI(getpwd()).posixpath, clone2_), name=clone2_)
 
         # print("Creating clone2")
         clone1.publish(to=clone2_)

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -103,7 +103,7 @@ def test_smth_about_not_supported(p1, p2):
     source = Dataset(p1).create()
     from datalad.support.network import PathRI
     source.create_sibling(
-        'ssh://localhost' + PathRI(p2).posixpath,
+        'ssh://datalad-test' + PathRI(p2).posixpath,
         name='target1')
     # source.publish(to='target1')
     with chpwd(p1):
@@ -552,7 +552,7 @@ def test_publish_depends(
 
     # two remote sibling on two "different" hosts
     source.create_sibling(
-        'ssh://localhost' + target1_path,
+        'ssh://datalad-test' + target1_path,
         annex_wanted='standard',
         annex_group='backup',
         name='target1')
@@ -659,7 +659,7 @@ def test_publish_gh1691(origin, src_path, dst_path):
 
     # create the target(s):
     source.create_sibling(
-        'ssh://localhost:' + dst_path,
+        'ssh://datalad-test:' + dst_path,
         name='target', recursive=True)
 
     # publish recursively, which silently ignores non-installed datasets
@@ -681,7 +681,7 @@ def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
     ds.save('1')
-    ds.create_sibling('ssh://localhost:%s/subdir' % desttop,
+    ds.create_sibling('ssh://datalad-test:%s/subdir' % desttop,
                       name='target',
                       target_url=desturl + 'subdir/.git')
     results = ds.publish(to='target', transfer_data='all')

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -237,7 +237,7 @@ def test_publish_aggregated(path):
     spath = opj(path, 'remote')
     base.create_sibling(
         name="local_target",
-        sshurl="ssh://localhost",
+        sshurl="ssh://datalad-test",
         target_dir=spath)
     base.publish('.', to='local_target', transfer_data='all')
     remote = Dataset(spath)

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -234,7 +234,10 @@ def test_publish_aggregated(path):
     assert_repo_status(base.path)
 
     # create sibling and publish to it
-    spath = opj(path, 'remote')
+    # Note: Use realpath() below because we know that the resolved temporary
+    # test directory exists in the target (many tests rely on that), but it
+    # doesn't necessarily have the unresolved variant.
+    spath = op.realpath(opj(path, 'remote'))
     base.create_sibling(
         name="local_target",
         sshurl="ssh://datalad-test",

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1119,10 +1119,8 @@ def test_annex_backends(path):
 
 
 @skip_ssh
-@with_tempfile
-@with_testrepos('basic_annex', flavors=['local'])
-@with_testrepos('basic_annex', flavors=['local'])
-def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
+@with_tempfile(mkdir=True)
+def test_annex_ssh(topdir):
     # On Xenial, this hangs with a recent git-annex. It bisects to git-annex's
     # 7.20191230-142-g75059c9f3. This is likely due to an interaction with an
     # older openssh version. See
@@ -1131,10 +1129,23 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
        '7.20191230' < external_versions['cmd:annex'] <= '8.20200720.1':
         raise SkipTest("Test known to hang")
 
+    topdir = Path(topdir)
+    rm1 = AnnexRepo(topdir / "remote1", create=True)
+    rm2 = AnnexRepo.clone(rm1.path, str(topdir / "remote2"))
+    rm2.remove_remote("origin")
+
+    main_tmp = AnnexRepo.clone(rm1.path, str(topdir / "main"))
+    main_tmp.remove_remote("origin")
+    repo_path = main_tmp.path
+    del main_tmp
+    remote_1_path = rm1.path
+    remote_2_path = rm2.path
+
+    # Clear instances so that __init__() is invoked and
+    # _set_shared_connection() the next time AnnexRepo is called.
+    AnnexRepo._unique_instances.clear()
+
     from datalad import ssh_manager
-    # create remotes:
-    rm1 = AnnexRepo(remote_1_path, create=False)
-    rm2 = AnnexRepo(remote_2_path, create=False)
 
     # check whether we are the first to use these sockets:
     hash_1 = get_connection_hash('datalad-test', bundled=True)
@@ -1148,13 +1159,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     # At first, directly use git to add the remote, which should be recognized
     # by AnnexRepo's constructor
     gr = GitRepo(repo_path, create=True)
-    AnnexRepo(repo_path)
     gr.add_remote("ssh-remote-1", "ssh://datalad-test" + remote_1_path)
 
-    # Now, make it an annex:
-    # Clear instances so that __init__() is invoked and
-    # _set_shared_connection() is called.
-    AnnexRepo._unique_instances.clear()
     ar = AnnexRepo(repo_path, create=False)
     ok_(any(hash_1 in opt for opt in ar._annex_common_options))
     ok_(all(hash_2 not in opt for opt in ar._annex_common_options))
@@ -1168,28 +1174,11 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
         ok_(not exists(socket_1))
 
     # remote interaction causes socket to be created:
-    try:
-        # Note: For some reason, it hangs if log_stdout/err True
-        # TODO: Figure out what's going on
-        #  yoh: I think it is because of what is "TODOed" within cmd.py --
-        #       trying to log/obtain both through PIPE could lead to lock
-        #       downs.
-        # here we use our swallow_logs to overcome a problem of running under
-        # nosetests without -s, when nose then tries to swallow stdout by
-        # mocking it with StringIO, which is not fully compatible with Popen
-        # which needs its .fileno()
-        with swallow_outputs():
-            ar._run_annex_command('sync',
-                                  expect_stderr=True,
-                                  log_stdout=False,
-                                  log_stderr=False,
-                                  expect_fail=True)
-    # sync should return exit code 1, since it can not merge
-    # doesn't matter for the purpose of this test
-    except CommandError as e:
-        if e.code == 1:
-            pass
+    (ar.pathobj / "foo").write_text("foo")
+    ar.add("foo")
+    ar.commit("add foo")
 
+    ar.copy_to(["foo"], remote="ssh-remote-1")
     ok_(exists(socket_1))
 
     # add another remote:
@@ -1207,19 +1196,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     else:
         ok_(not exists(socket_2))
 
-    # sync with the new remote:
-    try:
-        with swallow_outputs():
-            ar._run_annex_command('sync', annex_options=['ssh-remote-2'],
-                                  expect_stderr=True,
-                                  log_stdout=False,
-                                  log_stderr=False,
-                                  expect_fail=True)
-    # sync should return exit code 1, since it can not merge
-    # doesn't matter for the purpose of this test
-    except CommandError as e:
-        if e.code == 1:
-            pass
+    # copy to the new remote:
+    ar.copy_to(["foo"], remote="ssh-remote-2")
 
     ok_(exists(socket_2))
     ssh_manager.close(ctrl_path=[socket_1, socket_2])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1139,10 +1139,10 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     # check whether we are the first to use these sockets:
     hash_1 = get_connection_hash('datalad-test', bundled=True)
     socket_1 = opj(str(ssh_manager.socket_dir), hash_1)
-    hash_2 = get_connection_hash('localhost', bundled=True)
+    hash_2 = get_connection_hash('datalad-test2', bundled=True)
     socket_2 = opj(str(ssh_manager.socket_dir), hash_2)
     datalad_test_was_open = exists(socket_1)
-    localhost_was_open = exists(socket_2)
+    datalad_test2_was_open = exists(socket_2)
 
     # repo to test:AnnexRepo(repo_path)
     # At first, directly use git to add the remote, which should be recognized
@@ -1193,14 +1193,14 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     ok_(exists(socket_1))
 
     # add another remote:
-    ar.add_remote('ssh-remote-2', "ssh://localhost" + remote_2_path)
+    ar.add_remote('ssh-remote-2', "ssh://datalad-test2" + remote_2_path)
 
-    # now, this connection to localhost was requested:
+    # now, this connection was requested:
     assert_in(socket_2, list(map(str, ssh_manager._connections)))
     ok_(any(hash_1 in opt for opt in ar._annex_common_options))
     ok_(any(hash_2 in opt for opt in ar._annex_common_options))
     # but socket was not touched:
-    if localhost_was_open:
+    if datalad_test2_was_open:
         # FIXME: occasionally(?) fails in V6:
         if not ar.supports_unlocked_pointers:
             ok_(exists(socket_2))

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -525,7 +525,7 @@ def _path2localsshurl(path):
     p = Path(path)
     if p.drive:
         path = '/'.join(('/{}'.format(p.drive[0]),) + p.parts[1:])
-    url = "ssh://localhost{}".format(path)
+    url = "ssh://datalad-test{}".format(path)
     return url
 
 
@@ -541,7 +541,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     remote_repo = GitRepo(remote_path, create=False)
     url = _path2localsshurl(remote_path)
     socket_path = op.join(str(ssh_manager.socket_dir),
-                          get_connection_hash('localhost', bundled=True))
+                          get_connection_hash('datalad-test', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -575,7 +575,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
     remote_repo = GitRepo(remote_path, create=True)
     url = _path2localsshurl(remote_path)
     socket_path = op.join(str(ssh_manager.socket_dir),
-                          get_connection_hash('localhost', bundled=True))
+                          get_connection_hash('datalad-test', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -614,7 +614,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     remote_repo = GitRepo(remote_path, create=True)
     url = _path2localsshurl(remote_path)
     socket_path = op.join(str(ssh_manager.socket_dir),
-                          get_connection_hash('localhost', bundled=True))
+                          get_connection_hash('datalad-test', bundled=True))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -46,23 +46,23 @@ def test_ssh_get_connection():
     manager = SSHManager()
     assert manager._socket_dir is None, \
         "Should be unset upon initialization. Got %s" % str(manager._socket_dir)
-    c1 = manager.get_connection('ssh://localhost')
+    c1 = manager.get_connection('ssh://datalad-test')
     assert manager._socket_dir, "Should be set after interactions with the manager"
     assert_is_instance(c1, SSHConnection)
 
     # subsequent call returns the very same instance:
-    ok_(manager.get_connection('ssh://localhost') is c1)
+    ok_(manager.get_connection('ssh://datalad-test') is c1)
 
     # fail on malformed URls (meaning: our fancy URL parser can't correctly
     # deal with them):
     #assert_raises(ValueError, manager.get_connection, 'localhost')
     # we now allow those simple specifications of host to get_connection
-    c2 = manager.get_connection('localhost')
+    c2 = manager.get_connection('datalad-test')
     assert_is_instance(c2, SSHConnection)
 
     # but should fail if it looks like something else
-    assert_raises(ValueError, manager.get_connection, 'localhost/')
-    assert_raises(ValueError, manager.get_connection, ':localhost')
+    assert_raises(ValueError, manager.get_connection, 'datalad-test/')
+    assert_raises(ValueError, manager.get_connection, ':datalad-test')
 
     # we can do what urlparse cannot
     # assert_raises(ValueError, manager.get_connection, 'someone@localhost')
@@ -233,7 +233,7 @@ def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
 @skip_if_on_windows
 @skip_ssh
 def test_ssh_compound_cmds():
-    ssh = SSHManager().get_connection('ssh://localhost')
+    ssh = SSHManager().get_connection('ssh://datalad-test')
     out, err = ssh('[ 1 = 2 ] && echo no || echo success')
     eq_(out.strip(), 'success')
     ssh.close()  # so we get rid of the possibly lingering connections
@@ -271,11 +271,11 @@ def test_ssh_custom_identity_file():
     with patch_config({"datalad.ssh.identityfile": ifile}):
         with swallow_logs(new_level=logging.DEBUG) as cml:
             manager = SSHManager()
-            ssh = manager.get_connection('ssh://localhost')
+            ssh = manager.get_connection('ssh://datalad-test')
             cmd_out, _ = ssh("echo blah")
             expected_socket = op.join(
                 str(manager.socket_dir),
-                get_connection_hash("localhost", identity_file=ifile,
+                get_connection_hash("datalad-test", identity_file=ifile,
                                     bundled=True))
             ok_(exists(expected_socket))
             manager.close()
@@ -286,7 +286,7 @@ def test_ssh_custom_identity_file():
 @skip_if_on_windows
 @skip_ssh
 def test_ssh_git_props():
-    remote_url = 'ssh://localhost'
+    remote_url = 'ssh://datalad-test'
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
     # Note: Avoid comparing these versions directly to the versions in
@@ -304,7 +304,7 @@ def test_ssh_git_props():
 @skip_ssh
 @with_tempfile(mkdir=True)
 def test_bundle_invariance(path):
-    remote_url = 'ssh://localhost'
+    remote_url = 'ssh://datalad-test'
     manager = SSHManager()
     testfile = Path(path) / 'dummy'
     for flag in (True, False):

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -84,11 +84,11 @@ def test_ssh_open_close(tfile1):
     manager = SSHManager()
 
     path = opj(str(manager.socket_dir),
-               get_connection_hash('localhost', bundled=True))
+               get_connection_hash('datalad-test', bundled=True))
     # TODO: facilitate the test when it didn't exist
     existed_before = exists(path)
 
-    c1 = manager.get_connection('ssh://localhost')
+    c1 = manager.get_connection('ssh://datalad-test')
     c1.open()
     # control master exists for sure now
     ok_(exists(path))
@@ -124,30 +124,30 @@ def test_ssh_manager_close():
 
     # check for previously existing sockets:
     existed_before_1 = exists(opj(str(manager.socket_dir),
-                                  get_connection_hash('localhost')))
-    existed_before_2 = exists(opj(str(manager.socket_dir),
                                   get_connection_hash('datalad-test')))
+    existed_before_2 = exists(opj(str(manager.socket_dir),
+                                  get_connection_hash('datalad-test2')))
 
-    manager.get_connection('ssh://localhost').open()
     manager.get_connection('ssh://datalad-test').open()
+    manager.get_connection('ssh://datalad-test2').open()
 
     if existed_before_1 and existed_before_2:
         # we need one connection to be closed and therefore being opened
         # by `manager`
-        manager.get_connection('ssh://localhost').close()
-        manager.get_connection('ssh://localhost').open()
+        manager.get_connection('ssh://datalad-test').close()
+        manager.get_connection('ssh://datalad-test').open()
 
     ok_(exists(opj(str(manager.socket_dir),
-                   get_connection_hash('localhost', bundled=True))))
-    ok_(exists(opj(str(manager.socket_dir),
                    get_connection_hash('datalad-test', bundled=True))))
+    ok_(exists(opj(str(manager.socket_dir),
+                   get_connection_hash('datalad-test2', bundled=True))))
 
     manager.close()
 
     still_exists_1 = exists(opj(str(manager.socket_dir),
-                                get_connection_hash('localhost')))
-    still_exists_2 = exists(opj(str(manager.socket_dir),
                                 get_connection_hash('datalad-test')))
+    still_exists_2 = exists(opj(str(manager.socket_dir),
+                                get_connection_hash('datalad-test2')))
 
     eq_(existed_before_1, still_exists_1)
     eq_(existed_before_2, still_exists_2)

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import (
     assert_raises,
     eq_,
     get_most_obscure_supported_name,
+    get_ssh_port,
     ok_,
     patch_config,
     skip_if_on_windows,
@@ -184,8 +185,8 @@ def test_ssh_manager_close_no_throw(bogus_socket):
 @with_tempfile(content="one")
 @with_tempfile(content="two")
 def test_ssh_copy(sourcedir, sourcefile1, sourcefile2):
-
-    remote_url = 'ssh://localhost:22'
+    port = get_ssh_port('datalad-test')
+    remote_url = 'ssh://datalad-test:{}'.format(port)
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
 

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -28,7 +28,7 @@ from datalad.tests.utils import with_tempfile
 @skip_ssh
 def test_exit_code():
     # will relay actual exit code on CommandError
-    cmd = ['datalad', 'sshrun', 'localhost', 'exit 42']
+    cmd = ['datalad', 'sshrun', 'datalad-test', 'exit 42']
     with assert_raises(SystemExit) as cme:
         # running nosetests without -s
         if isinstance(sys.stdout, StringIO):  # pragma: no cover
@@ -45,7 +45,7 @@ def test_exit_code():
 @with_tempfile(content="123magic")
 def test_no_stdin_swallow(fname):
     # will relay actual exit code on CommandError
-    cmd = ['datalad', 'sshrun', 'localhost', 'cat']
+    cmd = ['datalad', 'sshrun', 'datalad-test', 'cat']
 
     out, err = Runner().run(cmd, stdin=open(fname))
     assert_equal(out.rstrip(), '123magic')
@@ -59,7 +59,7 @@ def test_no_stdin_swallow(fname):
 @skip_ssh
 @with_tempfile(suffix="1 space", content="magic")
 def test_fancy_quotes(f):
-    cmd = ['datalad', 'sshrun', 'localhost', """'cat '"'"'%s'"'"''""" % f]
+    cmd = ['datalad', 'sshrun', 'datalad-test', """'cat '"'"'%s'"'"''""" % f]
     out, err = Runner().run(cmd)
     assert_equal(out, 'magic')
 
@@ -73,7 +73,7 @@ def test_ssh_option():
     with patch.dict('os.environ', {"LC_DATALAD_HACK": 'hackbert'}):
         with swallow_outputs() as cmo:
             main(["datalad", "sshrun", "-oSendEnv=LC_DATALAD_HACK",
-                  "localhost", "echo $LC_DATALAD_HACK"])
+                  "datalad-test", "echo $LC_DATALAD_HACK"])
             out = cmo.out.strip()
             if not out:
                 raise SkipTest(
@@ -86,17 +86,17 @@ def test_ssh_option():
 @skip_ssh
 def test_ssh_ipv4_6_incompatible():
     with assert_raises(SystemExit):
-        main(["datalad", "sshrun", "-4", "-6", "localhost", "true"])
+        main(["datalad", "sshrun", "-4", "-6", "datalad-test", "true"])
 
 
 @skip_if_on_windows
 @skip_ssh
 def test_ssh_ipv4_6():
     # This should fail with a RuntimeError if a version is not supported (we're
-    # not bothering to check what localhost supports), but if the processing
+    # not bothering to check what datalad-test supports), but if the processing
     # fails, it should be something else.
     for kwds in [{"ipv4": True}, {"ipv6": True}]:
         try:
-            sshrun("localhost", "true", **kwds)
+            sshrun("datalad-test", "true", **kwds)
         except RuntimeError:
             pass

--- a/tools/ci/appveyor_ssh_config
+++ b/tools/ci/appveyor_ssh_config
@@ -3,3 +3,6 @@ Host localhost
 
 Host datalad-test
 	StrictHostKeyChecking no
+
+Host datalad-test2
+	StrictHostKeyChecking no

--- a/tools/ci/prep-travis-forssh-sudo.sh
+++ b/tools/ci/prep-travis-forssh-sudo.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-echo "127.0.0.1  datalad-test" >> /etc/hosts
-apt-get install openssh-client

--- a/tools/ci/prep-travis-forssh.sh
+++ b/tools/ci/prep-travis-forssh.sh
@@ -1,20 +1,37 @@
 #!/bin/bash
 
-mkdir -p ~/.ssh
-echo -e "Host localhost\n\tStrictHostKeyChecking no\n\tIdentityFile /tmp/dl-test-ssh-id\n" >> ~/.ssh/config
-echo -e "Host datalad-test\n\tStrictHostKeyChecking no\n\tIdentityFile /tmp/dl-test-ssh-id\n" >> ~/.ssh/config
+mkdir -p "$HOME/.ssh"
+
+cat >>"$HOME/.ssh/config" <<'EOF'
+
+Host datalad-test
+HostName localhost
+Port 42241
+User dl
+StrictHostKeyChecking no
+IdentityFile /tmp/dl-test-ssh-id
+EOF
+
+cat >>"$HOME/.ssh/config" <<'EOF'
+
+Host datalad-test2
+HostName localhost
+Port 42242
+User dl
+StrictHostKeyChecking no
+IdentityFile /tmp/dl-test-ssh-id
+EOF
+
 ssh-keygen -f /tmp/dl-test-ssh-id -N ""
-cat /tmp/dl-test-ssh-id.pub >> ~/.ssh/authorized_keys
-eval $(ssh-agent)
-ssh-add /tmp/dl-test-ssh-id
 
-echo "DEBUG: test connection to localhost ..."
-ssh -v localhost exit
-echo "DEBUG: test connection to datalad-test ..."
+curl -fSsL \
+     https://raw.githubusercontent.com/datalad-tester/docker-ssh-target/master/setup \
+     >setup-docker-ssh
+sh setup-docker-ssh --key=/tmp/dl-test-ssh-id.pub -2 \
+   --from=dataladtester/docker-ssh-target:latest
+
+# FIXME: This is hacky and likely too long, but we need to sleep at least a
+# little.
+sleep 8
 ssh -v datalad-test exit
-
-# tmp: don't run the actual tests:
-# exit 1
-
-
-
+ssh -v datalad-test2 exit


### PR DESCRIPTION
This series adjusts the SSH-dependent tests to facilitate using a target other than localhost and switches Travis over to using a Docker target.  The motivation for this is to make it easier to run our SSH tests outside of Travis without requiring that the localhost allows SSH connections and maps datalad-test to localhost.  The new setup here can hopefully be adapted easily for use in the testing at datalad-extensions (right now those builds skip SSH tests).

I've been using an earlier iteration of this Docker container for a while to run our SSH-based tests locally, replacing "localhost" if present with "datalad-test" temporarily.

---

Things to do:

- [X] Figure out why the last assertion in `test_annex_ssh` is failing

  I thought I blindly worked around it in the commit marked with "[maybe]", but I've seen it since, so I guess that was a fluke.

  This failure happens with `_DL_ANNEX_INSTALL_SCENARIO="conda-forge 7.20190819"`.  If Travis is switched to using neurodebian (7.20190819) or the autobuild, the assertion doesn't fail.  It also doesn't fail if I use install-annex.sh to install "conda-forge 7.20190819" locally and test with the Docker SSH target.  I tried the same in a Xenial VM and cannot get it to fail.  I suppose at least it isn't hanging.

  Update: "Figure out" is too strong for this item or the next, but these failures are avoided by b527a75b4 (TST: test_annex_ssh: Avoid syncing unrelated histories, 2020-07-21), hopefully.

- [X] Figure out non-SSH related failures

   Based on a recent scratch run of this branch on Travis, I expect `test_AnnexRepo_get_remote_na` and `test_is_available` to fail: <https://travis-ci.org/github/datalad/datalad/builds/710864799#L3171>.  I don't think these should involve SSH, I didn't see them fail in earlier runs with this PR's changes, and I can't trigger the failures locally, so I'm puzzled.

- [X] Move temporary git repo for Docker image to datalad-tester account

  Perhaps "datalad-tester/docker-ssh-target".

  https://github.com/kyleam/datalad-tests-docker-ssh-target

  Update: Now at <https://github.com/datalad-tester/docker-ssh-target>.  Thanks @yarikoptic.

- [X] Connect the git repo to Docker Hub repo under the datalad organization

  Update: Now at <https://hub.docker.com/r/dataladtester/docker-ssh-target>.  Thanks @yarikoptic.


Close #4514.
