### PR TITLE
DOC: Emphasize PATH in parameter descriptions of create

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -136,10 +136,11 @@ class Create(Interface):
             metavar='PATH',
             doc="""path where the dataset shall be created, directories
             will be created as necessary. If no location is provided, a dataset
-            will be created in the location specified by --dataset (if given) or
-            the current working directory. Either way the
-            command will error if the target directory is not empty.
-            Use `force` to create a dataset in a non-empty directory.""",
+            will be created in the location specified by [PY: `dataset`
+            PY][CMD: --dataset CMD] (if given) or the current working
+            directory. Either way the command will error if the target
+            directory is not empty. Use [PY: `force` PY][CMD: --force CMD] to
+            create a dataset in a non-empty directory.""",
             # put dataset 2nd to avoid useless conversion
             constraints=EnsureStr() | EnsureDataset() | EnsureNone()),
         initopts=Parameter(
@@ -157,9 +158,9 @@ class Create(Interface):
             args=("-d", "--dataset"),
             metavar='DATASET',
             doc="""specify the dataset to perform the create operation on. If
-            a dataset is given along with PATH, a new subdataset will be created
-            in it at the PATH provided to the create command. If a dataset is
-            given but PATH is unspecified, a new dataset will be created at the
+            a dataset is given along with `path`, a new subdataset will be created
+            in it at the `path` provided to the create command. If a dataset is
+            given but `path` is unspecified, a new dataset will be created at the
             location specified by this option.""",
             constraints=EnsureDataset() | EnsureNone()),
         force=Parameter(

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -136,7 +136,8 @@ class Create(Interface):
             metavar='PATH',
             doc="""path where the dataset shall be created, directories
             will be created as necessary. If no location is provided, a dataset
-            will be created in the current working directory. Either way the
+            will be created in the location specified by --dataset (if given) or
+            the current working directory. Either way the
             command will error if the target directory is not empty.
             Use `force` to create a dataset in a non-empty directory.""",
             # put dataset 2nd to avoid useless conversion
@@ -156,7 +157,10 @@ class Create(Interface):
             args=("-d", "--dataset"),
             metavar='DATASET',
             doc="""specify the dataset to perform the create operation on. If
-            a dataset is given, a new subdataset will be created in it.""",
+            a dataset is given along with PATH, a new subdataset will be created
+            in it at the PATH provided to the create command. If a dataset is
+            given but PATH is unspecified, a new dataset will be created at the
+            location specified by this option.""",
             constraints=EnsureDataset() | EnsureNone()),
         force=Parameter(
             args=("-f", "--force",),


### PR DESCRIPTION
This applies the description improvements @kyleam and I discussed in  #4754.
Fixes  #4754.