### PR TITLE
ENH: provide INFO level logging for an action about to be reran

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -360,6 +360,7 @@ def _rerun(dset, results, explicit=False):
     branch_to_restore = dset.repo.get_active_branch()
     head = onto = dset.repo.get_hexsha()
     for res in results:
+        lgr.info(_get_rerun_log_msg(res))
         rerun_action = res.get("rerun_action")
         if not rerun_action:
             yield res
@@ -490,6 +491,26 @@ def _rerun(dset, results, explicit=False):
         dset.repo.update_ref("refs/heads/" + branch_to_restore,
                              "HEAD")
         dset.repo.checkout(branch_to_restore)
+
+
+def _get_rerun_log_msg(res):
+    "Prepare log message for a rerun to summarize an action about to happen"
+    msg = ''
+    rerun_action = res.get("rerun_action")
+    if rerun_action:
+        msg += rerun_action
+    if res.get('commit'):
+        msg += " commit %s;" % res.get('commit')[:7]
+    rerun_run_message = res.get("run_message")
+    if rerun_run_message:
+        if len(rerun_run_message) > 20:
+            rerun_run_message = rerun_run_message[:17] + '...'
+        msg += " (%s)" % rerun_run_message
+    rerun_message = res.get("message")
+    if rerun_message:
+        msg += " " + rerun_message[0] % rerun_message[1:]
+    msg = msg.lstrip()
+    return msg
 
 
 def _report(dset, results):


### PR DESCRIPTION
I do not exactly like increasing verbosity here, but DEBUG level would
be not appropriate -- at that level we display already much more of details
effectively forbidding tracking ongoing activities.

Here is the result of rerunning on some ad-hoc repo (sorry - I have not
scripted it, here is tarball: http://www.onerussian.com/tmp/test-rerun.tgz) which has a merge and some cherry picks

	$> datalad rerun --since=
	[INFO   ] run commit d4a55bb (md5)
	[INFO   ] Making sure inputs are available (this may take some time)
	unlock(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] == Command start (output follows) =====
	[INFO   ] == Command exit (modification check follows) =====
	add(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] run commit 66a4fee (md5)
	[INFO   ] Making sure inputs are available (this may take some time)
	unlock(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] == Command start (output follows) =====
	[INFO   ] == Command exit (modification check follows) =====
	add(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] skip-or-pick commit c2275fc c2275fc does not have a command; skipping or cherry picking
	run(ok): /home/yoh/proj/datalad/trash/test-rerun (dataset) [c2275fc does not have a command; skipping]
	[INFO   ] run commit c406290 (md5)
	[INFO   ] Making sure inputs are available (this may take some time)
	unlock(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] == Command start (output follows) =====
	[INFO   ] == Command exit (modification check follows) =====
	add(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] run commit b3ac331 (touching file2)
	unlock(ok): /home/yoh/proj/datalad/trash/test-rerun/file2 (file)
	[INFO   ] == Command start (output follows) =====
	[INFO   ] == Command exit (modification check follows) =====
	add(ok): /home/yoh/proj/datalad/trash/test-rerun/file2 (file)
	[INFO   ] skip-or-pick commit 5c0bad1 5c0bad1 does not have a command; skipping or cherry picking
	run(ok): /home/yoh/proj/datalad/trash/test-rerun (dataset) [5c0bad1 does not have a command; skipping]
	[INFO   ] merge commit ce53a0d
	run(ok): /home/yoh/proj/datalad/trash/test-rerun (dataset)
	[INFO   ] run commit d962936 (md5)
	[INFO   ] Making sure inputs are available (this may take some time)
	unlock(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	[INFO   ] == Command start (output follows) =====
	[INFO   ] == Command exit (modification check follows) =====
	add(ok): /home/yoh/proj/datalad/trash/test-rerun/MD5SUMS (file)
	action summary:
	  add (ok: 5)
	  get (notneeded: 20)
	  run (ok: 3)
	  save (notneeded: 5)
	  unlock (ok: 5)

Also note that we do already report "run" results records for "strip-or-pick"
but not for actual "run".  Even if we start reporting more of "run" records, I
still see value in reporting on "what about to happen" in the log.  Or may be
we somehow could provide "progress indication" across rerun steps?  after all
it is jus a loop (over a generator though)

Closes #3584

