### PR TITLE
ENH+OPT(TST): annotate more of @slow tests, provide rule-of-thumb doc for @slow/turtle/..., fail if any non @slow exceeds 30 sec on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -201,8 +201,11 @@ before_install:
         exit 0;
       fi
     fi
-  # Life was so fast that we needed a slow down
-  # - sleep 60   # TEMP -- to spot diff
+  # If we requested to run only not slow (typically <10sec) tests, fail if a test
+  # takes 3x more than that - it needs to get @slow or @turtle annotation
+  - if echo "$NOSE_SELECTION_OP($NOSE_SELECTION)" | grep -q "^not.*slow"; then
+      NOSE_OPTS=( --with-doctest --with-timer --timer-warning 30 --timer-fail error )
+    fi
   # Just in case we need to check if nfs is there etc
   - sudo lsmod
   # The ultimate one-liner setup for NeuroDebian repository
@@ -259,7 +262,7 @@ script:
   # Run tests
   - http_proxy=
     PATH=$PWD/../tools/coverage-bin:$PATH
-    $NOSE_WRAPPER `which nosetests` $NOSE_OPTS
+    $NOSE_WRAPPER `which nosetests` "${NOSE_OPTS[@]}"
       -A "$NOSE_SELECTION_OP($NOSE_SELECTION) and not(turtle)"
       --with-doctest
       --with-cov --cover-package datalad

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,8 +122,6 @@ matrix:
     - DATALAD_TESTS_SSH=0
     - _DL_TMPDIR="/tmp/nfsmount"
     - TESTS_TO_PERFORM="datalad.tests datalad.support"
-    # since we limit set of tests anyways and only really base ones, run all including @slow
-    - NOSE_SELECTION=
     #
   # The ones to run only on weekends against master.
   # They will not contribute to coverage etc, but might lead to failed status

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,9 @@ matrix:
     - DATALAD_TESTS_SSH=0
     - _DL_TMPDIR="/tmp/nfsmount"
     - TESTS_TO_PERFORM="datalad.tests datalad.support"
-  #
+    # since we limit set of tests anyways and only really base ones, run all including @slow
+    - NOSE_SELECTION=
+    #
   # The ones to run only on weekends against master.
   # They will not contribute to coverage etc, but might lead to failed status
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,8 @@ before_install:
   # If we requested to run only not slow (typically <10sec) tests, fail if a test
   # takes 3x more than that - it needs to get @slow or @turtle annotation
   - if echo "$NOSE_SELECTION_OP($NOSE_SELECTION)" | grep -q "^not.*slow"; then
-      NOSE_OPTS=( --with-doctest --with-timer --timer-warning 30 --timer-fail error )
+      NOSE_OPTS=( --with-doctest --with-timer --timer-ok 5 --timer-warning 30 --timer-fail error --timer-filter warning,
+    error )
     fi
   # Just in case we need to check if nfs is there etc
   - sudo lsmod

--- a/.travis.yml
+++ b/.travis.yml
@@ -204,9 +204,8 @@ before_install:
   # If we requested to run only not slow (typically <10sec) tests, fail if a test
   # takes 3x more than that - it needs to get @slow or @turtle annotation
   - if echo "$NOSE_SELECTION_OP($NOSE_SELECTION)" | grep -q "^not.*slow"; then
-      NOSE_OPTS=( --with-doctest --with-timer --timer-ok 5 --timer-warning 30 --timer-fail error --timer-filter warning,
-    error )
-      export DATALAD_TESTS_SETUP_TESTREPOS=1  # to not bias timing with the first @with_testrepos
+      NOSE_OPTS=( --with-doctest --with-timer --timer-ok 5 --timer-warning 30 --timer-fail error --timer-filter warning,error );
+      export DATALAD_TESTS_SETUP_TESTREPOS=1;
     fi
   # Just in case we need to check if nfs is there etc
   - sudo lsmod

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,6 +206,7 @@ before_install:
   - if echo "$NOSE_SELECTION_OP($NOSE_SELECTION)" | grep -q "^not.*slow"; then
       NOSE_OPTS=( --with-doctest --with-timer --timer-ok 5 --timer-warning 30 --timer-fail error --timer-filter warning,
     error )
+      export DATALAD_TESTS_SETUP_TESTREPOS=1  # to not bias timing with the first @with_testrepos
     fi
   # Just in case we need to check if nfs is there etc
   - sudo lsmod

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -191,6 +191,11 @@ def setup_package():
     multiprocess.StringIO = StringIO
     plugintest.StringIO = StringIO
 
+    if cfg.obtain('datalad.tests.setup.testrepos'):
+        lgr.debug("Pre-populating testrepos")
+        from datalad.tests.utils import with_testrepos
+        with_testrepos()(lambda repo: 1)()
+
 
 def teardown_package():
     import os

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -658,6 +658,7 @@ def _move2store(storepath, d):
     Runner(cwd=store_loc).run(['git', 'update-server-info'])
 
 
+@slow  # 12sec on Yarik's laptop
 @with_tree(tree={
     'ds': {
         'test.txt': 'some',
@@ -934,6 +935,7 @@ def test_ria_postclonecfg():
             "ssh://datalad-test:{}".format(Path(store).as_posix()), id
 
 
+@slow  # 17sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @serve_path_via_http

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -904,6 +904,7 @@ def _postclonetest_prepare(lcl, storepath, link):
     return ds.id
 
 
+@slow  # 14 sec on travis
 def test_ria_postclonecfg():
 
     if not has_symlink_capability():

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
@@ -33,6 +32,7 @@ from datalad.tests.utils import (
     serve_path_via_http,
     skip_if_on_windows,
     skip_ssh,
+    slow,
     with_tempfile,
     with_tree,
     SkipTest,
@@ -238,6 +238,7 @@ def test_push():
     yield check_push, True
 
 
+@slow  # 33sec on Yarik's laptop
 @with_tempfile
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -370,6 +371,7 @@ def test_push_recursive(
             refspec=DEFAULT_REFSPEC)
 
 
+@slow  # 12sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
@@ -645,6 +647,7 @@ def test_push_wanted(srcpath, dstpath):
     eq_((dst.pathobj / 'secure.1').read_text(), '1')
 
 
+@slow  # 10sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_auto_data_transfer(path):
     path = Path(path)
@@ -705,6 +708,7 @@ def test_auto_data_transfer(path):
         path=str(ds_a.pathobj / "bar.dat"))
 
 
+@slow  # 16sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_auto_if_wanted_data_transfer_path_restriction(path):
     path = Path(path)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -267,7 +267,6 @@ def test_run_from_subds_gh3551(path):
 # unexpected content of state "modified", likely a more fundamental issue with the
 # testrepo setup
 @known_failure_githubci_win
-@slow  # ~10s
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_run_explicit(path):
     ds = Dataset(path)

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -24,6 +24,7 @@ from datalad.tests.utils import (
     eq_,
     skip_if_on_windows,
     skip_ssh,
+    slow,
     with_tempfile,
     with_tree,
 )
@@ -164,6 +165,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
                    for r in res['{}ed repositories'.format(trust)]])
 
 
+@slow  # 11 + 42 sec on travis
 def test_create_simple():
 
     yield _test_create_store, None

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -282,6 +282,7 @@ def _test_remote_layout(host, dspath, store, archiv_store):
         assert_equal(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
 
 
+@slow  # 12sec + ? on travis
 def test_remote_layout():
     # TODO: Skipped due to gh-4436
     yield known_failure_windows(skip_ssh(_test_remote_layout)), 'datalad-test'
@@ -373,6 +374,7 @@ def _test_version_check(host, dspath, store):
     ds.repo.copy_to('new_file', 'store')
 
 
+@slow  # 17sec + ? on travis
 def test_version_check():
     # TODO: Skipped due to gh-4436
     yield known_failure_windows(skip_ssh(_test_version_check)), 'datalad-test'
@@ -445,6 +447,7 @@ def test_gitannex_ssh():
     _test_gitannex('datalad-test')
 
 
+@slow  # 41sec on travis
 def test_gitannex_local():
     _test_gitannex(None)
 

--- a/datalad/distributed/tests/test_ria_git_remote.py
+++ b/datalad/distributed/tests/test_ria_git_remote.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import (
     assert_status,
     known_failure_windows,
     skip_ssh,
+    slow,
     with_tempfile
 )
 from datalad.distributed.ora_remote import (
@@ -142,6 +143,7 @@ def _test_bare_git_version_1(host, dspath, store):
     eq_(len(ds.repo.whereis('one.txt')), 3)
 
 
+@slow  # 12sec + ? on travis
 def test_bare_git_version_1():
     # TODO: Skipped due to gh-4436
     yield known_failure_windows(skip_ssh(_test_bare_git_version_1)), \
@@ -226,6 +228,7 @@ def _test_bare_git_version_2(host, dspath, store):
     eq_(len(ds.repo.whereis('one.txt')), 1)
 
 
+@slow  # 13sec + ? on travis
 def test_bare_git_version_2():
     # TODO: Skipped due to gh-4436
     yield known_failure_windows(skip_ssh(_test_bare_git_version_2)), \

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -801,6 +801,7 @@ def test_local_path_target_dir(path):
     ok_((path / "e" / "d-subds").exists())
 
 
+@slow  # 12sec on Yarik's laptop
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -172,6 +172,7 @@ def test_invalid_call(path):
                 'bogus'))
 
 
+@slow  # 26sec on travis
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_testrepos('.*basic.*', flavors=['local'])
@@ -422,6 +423,7 @@ def check_target_ssh_recursive(use_ssh, origin, src_path, target_path):
         publish(dataset=source, to=remote_name, recursive=True, since='') # just a smoke test
 
 
+@slow  # 28 + 19sec on travis
 def test_target_ssh_recursive():
     skip_if_on_windows()
     yield skip_ssh(check_target_ssh_recursive), True
@@ -477,6 +479,7 @@ def check_target_ssh_since(use_ssh, origin, src_path, target_path):
     assert_postupdate_hooks(_path_(target_path, 'brandnew'), installed=False)
 
 
+@slow  # 10sec + ? on travis
 def test_target_ssh_since():
     skip_if_on_windows()
     yield skip_ssh(check_target_ssh_since), True
@@ -586,6 +589,7 @@ def check_replace_and_relative_sshpath(use_ssh, src_path, dst_path):
     assert_postupdate_hooks(dst_path)
 
 
+@slow  # 14 + 10sec on travis
 def test_replace_and_relative_sshpath():
     skip_if_on_windows()
     yield skip_ssh(check_replace_and_relative_sshpath), True

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -440,6 +440,7 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:452
+@slow  # 10sec on Yarik's laptop
 @known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
 @with_tempfile(mkdir=True)
@@ -692,6 +693,7 @@ def test_publish_target_url(src, desttop, desturl):
     ok_file_has_content(_path_(desttop, 'subdir/1'), '123')
 
 
+@slow  # 11sec on Yarik's laptop
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tempfile(mkdir=True)
@@ -755,6 +757,7 @@ def test_publish_no_fetch_refspec_configured(path):
     ds.publish(to="origin")
 
 
+@slow  # 14sec on Yarik's laptop
 @skip_ssh
 @with_tempfile(mkdir=True)
 def test_publish_fetch_do_not_recurse_submodules(path):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -52,6 +52,7 @@ from datalad.tests.utils import (
     serve_path_via_http,
     skip_if_on_windows,
     skip_ssh,
+    slow,
     swallow_logs,
     with_tempfile,
     with_testrepos,
@@ -269,6 +270,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
     eq_(res, [source])
 
 
+@slow  # 12sec on travis
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:380
 @known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])
@@ -529,6 +531,7 @@ def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_c
         filter_fsck_error_msg(source.repo.fsck(remote='target')))
 
 
+@slow  # 10sec on travis
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_testrepos('submodule_annex', flavors=['local'])

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -481,6 +481,7 @@ def test_merge_no_merge_target(path):
     assert_in_results(res, status="impossible", action="update")
 
 
+@slow  # 17sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_merge_conflict(path):
     path = Path(path)
@@ -535,6 +536,7 @@ def test_merge_conflict(path):
                        modified=[ds_clone_s0.path, ds_clone_s1.path])
 
 
+@slow  # 13sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_merge_conflict_in_subdataset_only(path):
     path = Path(path)
@@ -613,6 +615,7 @@ def test_merge_ff_only(path):
         action="merge", status="ok")
 
 
+@slow  # 11sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_merge_follow_parentds_subdataset_other_branch(path):
     path = Path(path)
@@ -793,6 +796,7 @@ def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
         action="update")
 
 
+@slow  # 12 + 21sec on Yarik's laptop
 def test_merge_follow_parentds_subdataset_detached():
     yield check_merge_follow_parentds_subdataset_detached, True
     yield check_merge_follow_parentds_subdataset_detached, False

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -19,6 +19,7 @@ from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import EnsureInt
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureChoice
+from datalad.support.constraints import EnsureListOf
 from datalad.support.constraints import EnsureStr
 
 dirs = AppDirs("datalad", "datalad.org")
@@ -158,6 +159,12 @@ definitions = {
     'datalad.tests.knownfailures.probe': {
         'ui': ('yesno', {
                'title': 'Probes tests that are known to fail on whether or not they are actually still failing'}),
+        'type': EnsureBool(),
+        'default': False,
+    },
+    'datalad.tests.setup.testrepos': {
+        'ui': ('question', {
+            'title': 'Pre-creates repositories for @with_testrepos within setup_package'}),
         'type': EnsureBool(),
         'default': False,
     },

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -181,7 +181,6 @@ tree4uargs = dict(
 
 
 @known_failure_windows
-@slow  # 29.4293s
 #  apparently fails only sometimes in PY3, but in a way that's common in V6
 @assert_cwd_unchanged(ok_to_chdir=True)
 @with_tree(**tree1args)

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -13,13 +13,14 @@ import logging
 from genericpath import exists
 from datalad.tests.utils import (
     assert_equal,
-    assert_raises,
-    assert_in,
     assert_false,
+    assert_in,
     assert_not_in,
+    assert_raises,
+    known_failure_windows,
     ok_startswith,
     serve_path_via_http,
-    known_failure_windows,
+    slow,
     with_tree,
 )
 from os.path import join as opj
@@ -148,6 +149,7 @@ def test_fs_traverse(topdir):
 
 # underlying code cannot deal with adjusted branches
 # https://github.com/datalad/datalad/pull/3817
+@slow  # 9sec on Yarik's laptop
 @known_failure_windows
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},

--- a/datalad/interface/tests/test_rerun_merges.py
+++ b/datalad/interface/tests/test_rerun_merges.py
@@ -317,7 +317,7 @@ def test_rerun_run_left_nonrun_right(path):
     eq_(hexsha_before, ds.repo.get_hexsha())
 
 
-@slow
+# @slow  # ~5sec on Yarik's laptop
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_mutator_left_nonrun_right(path):
@@ -412,7 +412,7 @@ def test_rerun_mutator_stem_nonrun_merges(path):
     assert_false(ds.repo.commit_exists("HEAD^2"))
 
 
-@slow
+# @slow  # ~4.5sec
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_exclude_side(path):
@@ -492,7 +492,7 @@ def test_rerun_unrelated_run_left_nonrun_right(path):
         ds.repo.get_hexsha())
 
 
-@slow
+# @slow  # ~3.5sec on Yarik's laptop
 @known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_mutator_left_nonrun_right(path):

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -41,6 +41,7 @@ from datalad.tests.utils import (
     on_windows,
     skip_if,
     skip_if_root,
+    slow,
     assert_in_results,
     assert_not_in_results,
     assert_result_count,
@@ -92,6 +93,7 @@ def test_unlock_raises(path, path2, path3):
 # Note: As root there is no actual lock/unlock.
 #       Therefore don't know what to test for yet.
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789027#step:8:134
+@slow  # 12sec on Yarik's laptop
 @known_failure_windows
 @skip_if_root
 @with_testrepos('.*annex.*', flavors=['clone'])

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -250,6 +250,7 @@ def test_copy_file_into_dshierarchy(srcdir, destdir):
     ])
 
 
+@slow  # 11sec on Yarik's laptop
 @with_tree(tree={
     'lvl1': {
         'file1': '123',

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -29,6 +29,7 @@ from datalad.tests.utils import (
     nok_,
     ok_file_has_content,
     serve_path_via_http,
+    slow,
     with_tempfile,
     with_tree,
 )
@@ -126,6 +127,7 @@ def test_copy_file_errors(dspath1, dspath2, nondspath):
         'impossible', copy_file(specs_from=['somepath'], on_failure='ignore'))
 
 
+@slow  # 11sec + ? on travis
 @with_tempfile(mkdir=True)
 @with_tree(tree={
     'webfile1': '123',

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -35,6 +35,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     eq_,
+    slow,
     with_tempfile,
 )
 
@@ -43,6 +44,7 @@ def _p(rpath):
     return str(Path(PurePosixPath(rpath)))
 
 
+@slow  # 13sec on travis
 @with_tempfile
 @with_tempfile
 def test_get_subdatasets(origpath, path):

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import (
     known_failure_githubci_win,
     skip_if_on_windows,
     skip_ssh,
+    slow,
     with_tempfile,
     with_tree,
 )
@@ -58,6 +59,7 @@ _dataset_hierarchy_template = {
 
 # underlying code cannot deal with adjusted branches
 # https://github.com/datalad/datalad/pull/3817
+@slow  # 20sec on Yarik's laptop
 @known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 def test_basic_aggregate(path):
@@ -149,6 +151,7 @@ def test_aggregate_query(path):
 
 
 # this is for gh-1971
+@slow  # 23sec on Yarik's laptop
 @known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 def test_reaggregate_with_unavailable_objects(path):
@@ -183,6 +186,7 @@ def test_reaggregate_with_unavailable_objects(path):
     )
 
 
+@slow  # 26sec on Yarik's laptop
 @known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 @with_tempfile(mkdir=True)
@@ -218,6 +222,7 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
 
 
 # this is for gh-1987
+@slow  # 23sec on Yarik's laptop
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree=_dataset_hierarchy_template)
@@ -304,6 +309,7 @@ def test_aggregate_removal(path):
 
 # underlying code cannot deal with adjusted branches
 # https://github.com/datalad/datalad/pull/3817
+@slow  # 22sec on Yarik's laptop
 @known_failure_githubci_win
 @with_tree(tree=_dataset_hierarchy_template)
 def test_update_strategy(path):
@@ -360,6 +366,7 @@ def test_update_strategy(path):
     eq_(target_meta, base.metadata(return_type='list'))
 
 
+@slow  # 14sec on Yarik's laptop
 @known_failure_githubci_win  # fails since upgrade to 8.20200226-g2d3ef2c07
 @with_tree({
     'this': 'that',

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -40,7 +40,6 @@ from datalad.tests.utils import (
     HTTPPath,
     known_failure_githubci_win,
     ok_exists,
-    slow,
     swallow_logs,
     with_tempfile,
     with_tree,
@@ -394,7 +393,6 @@ def test_addurls_dry_run(path):
                   cml.out)
 
 
-@slow  # ~9s
 class TestAddurls(object):
 
     @classmethod

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2225,6 +2225,7 @@ def check_files_split_exc(cls, topdir):
         assert_not_in('too many', str(ecm.exception))
 
 
+@slow  # 15 + 17sec on travis
 def test_files_split_exc():
     for cls in GitRepo, AnnexRepo:
         yield check_files_split_exc, cls

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1119,10 +1119,8 @@ def test_annex_backends(path):
 
 
 @skip_ssh
-@with_tempfile
-@with_testrepos('basic_annex', flavors=['local'])
-@with_testrepos('basic_annex', flavors=['local'])
-def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
+@with_tempfile(mkdir=True)
+def test_annex_ssh(topdir):
     # On Xenial, this hangs with a recent git-annex. It bisects to git-annex's
     # 7.20191230-142-g75059c9f3. This is likely due to an interaction with an
     # older openssh version. See
@@ -1131,10 +1129,23 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
        '7.20191230' < external_versions['cmd:annex'] <= '8.20200720.1':
         raise SkipTest("Test known to hang")
 
+    topdir = Path(topdir)
+    rm1 = AnnexRepo(topdir / "remote1", create=True)
+    rm2 = AnnexRepo.clone(rm1.path, str(topdir / "remote2"))
+    rm2.remove_remote("origin")
+
+    main_tmp = AnnexRepo.clone(rm1.path, str(topdir / "main"))
+    main_tmp.remove_remote("origin")
+    repo_path = main_tmp.path
+    del main_tmp
+    remote_1_path = rm1.path
+    remote_2_path = rm2.path
+
+    # Clear instances so that __init__() is invoked and
+    # _set_shared_connection() the next time AnnexRepo is called.
+    AnnexRepo._unique_instances.clear()
+
     from datalad import ssh_manager
-    # create remotes:
-    rm1 = AnnexRepo(remote_1_path, create=False)
-    rm2 = AnnexRepo(remote_2_path, create=False)
 
     # check whether we are the first to use these sockets:
     hash_1 = get_connection_hash('datalad-test', bundled=True)
@@ -1148,13 +1159,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     # At first, directly use git to add the remote, which should be recognized
     # by AnnexRepo's constructor
     gr = GitRepo(repo_path, create=True)
-    AnnexRepo(repo_path)
     gr.add_remote("ssh-remote-1", "ssh://datalad-test" + remote_1_path)
 
-    # Now, make it an annex:
-    # Clear instances so that __init__() is invoked and
-    # _set_shared_connection() is called.
-    AnnexRepo._unique_instances.clear()
     ar = AnnexRepo(repo_path, create=False)
     ok_(any(hash_1 in opt for opt in ar._annex_common_options))
     ok_(all(hash_2 not in opt for opt in ar._annex_common_options))
@@ -1168,28 +1174,11 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
         ok_(not exists(socket_1))
 
     # remote interaction causes socket to be created:
-    try:
-        # Note: For some reason, it hangs if log_stdout/err True
-        # TODO: Figure out what's going on
-        #  yoh: I think it is because of what is "TODOed" within cmd.py --
-        #       trying to log/obtain both through PIPE could lead to lock
-        #       downs.
-        # here we use our swallow_logs to overcome a problem of running under
-        # nosetests without -s, when nose then tries to swallow stdout by
-        # mocking it with StringIO, which is not fully compatible with Popen
-        # which needs its .fileno()
-        with swallow_outputs():
-            ar._run_annex_command('sync',
-                                  expect_stderr=True,
-                                  log_stdout=False,
-                                  log_stderr=False,
-                                  expect_fail=True)
-    # sync should return exit code 1, since it can not merge
-    # doesn't matter for the purpose of this test
-    except CommandError as e:
-        if e.code == 1:
-            pass
+    (ar.pathobj / "foo").write_text("foo")
+    ar.add("foo")
+    ar.commit("add foo")
 
+    ar.copy_to(["foo"], remote="ssh-remote-1")
     ok_(exists(socket_1))
 
     # add another remote:
@@ -1207,19 +1196,8 @@ def test_annex_ssh(repo_path, remote_1_path, remote_2_path):
     else:
         ok_(not exists(socket_2))
 
-    # sync with the new remote:
-    try:
-        with swallow_outputs():
-            ar._run_annex_command('sync', annex_options=['ssh-remote-2'],
-                                  expect_stderr=True,
-                                  log_stdout=False,
-                                  log_stderr=False,
-                                  expect_fail=True)
-    # sync should return exit code 1, since it can not merge
-    # doesn't matter for the purpose of this test
-    except CommandError as e:
-        if e.code == 1:
-            pass
+    # copy to the new remote:
+    ar.copy_to(["foo"], remote="ssh-remote-2")
 
     ok_(exists(socket_2))
     ssh_manager.close(ctrl_path=[socket_1, socket_2])

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -18,6 +18,7 @@ from datalad.tests.utils import (
     assert_not_in,
     assert_raises,
     known_failure_githubci_win,
+    slow,
     with_tempfile,
 )
 
@@ -29,6 +30,7 @@ from datalad.tests.utils import (
 )
 
 
+@slow  # 10sec on travis
 @known_failure_githubci_win
 @with_tempfile
 def test_get_content_info(path):

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -23,6 +23,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.tests.utils import (
     assert_repo_status,
     get_convoluted_situation,
+    slow,
 )
 
 
@@ -64,12 +65,14 @@ def _test_save_all(path, repocls):
     return ds
 
 
+@slow  # 11sec on travis
 @known_failure_githubci_win
 @with_tempfile
 def test_gitrepo_save_all(path):
     _test_save_all(path, GitRepo)
 
 
+@slow  # 11sec on travis
 @known_failure_githubci_win
 @with_tempfile
 def test_annexrepo_save_all(path):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1923,25 +1923,33 @@ from nose.plugins.attrib import attr
 def integration(f):
     """Mark test as an "integration" test which generally is not needed to be run
     
-    Generally tend to be slower
+    Generally tend to be slower.
+    Should be used in combination with @slow and @turtle if that is the case.
     """
     return attr('integration')(f)
 
 
 def slow(f):
     """Mark test as a slow, although not necessarily integration or usecase test
+
+    Rule of thumb cut-off to mark as slow is 10 sec
     """
     return attr('slow')(f)
 
 
 def turtle(f):
     """Mark test as very slow, meaning to not run it on Travis due to its
-    time limit"""
+    time limit
+
+    Rule of thumb cut-off to mark as turtle is 2 minutes
+    """
     return attr('turtle')(f)
 
 
 def usecase(f):
     """Mark test as a usecase user ran into and which (typically) caused bug report
     to be filed/troubleshooted
+
+    Should be used in combination with @slow and @turtle if slow.
     """
     return attr('usecase')(f)


### PR DESCRIPTION
Inspired by #4766 but took me too deep down the rabbit hole... with this PR I hope to "encourage" (well -- force) proper annotation of @slow tests:  I have provided an ad-hoc rule of thumb description for `@slow` tests -- those which exceed 10 seconds.  I have annotated the majority of those which exceed that timing on my laptop ATM. 
Travis run would fail if any test exceeds 30 seconds when ran in the matrix run which says "not slow". After we annotate all `@slow` and merge this PR, it could happen due to

- PR introduced changes making corresponding test considerably slower.  So either changes should be analyzed to avoid adding slow-down or the test annotated as `@slow`.  If a change caused **many** tests to exceed 30 sec, need even more seriously reconsider OPT **or** boost our "threshold" for `@slow` up altogether (should be the measure of the last resort).
- test environment got considerably slower (e.g. switch to new bionic? new annex OPT regression?) - also needs analysis and possible "boost" beyond 10/30 sec decision making.

Timings on my laptop could be positively biased due to use of standalone build which we know is slower.

TODOs:
- [x] make sure that no test is getting close to the 30sec mark in current travis run, and annotate more if needed... may be boost to 40sec cut off on travis
- check the balance in run time between slow and non-slow travis matrix runs (may be I moved too many of `@slow` :-/
- [x] make a (local) run through `@slow` and see may be some are no longer slow and should get `@slow` removed?