### PR TITLE
NF: create GitHub sibling as private repo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -92,6 +92,11 @@
       "affiliation": "Psychoinformatics Lab, INM-7, Research Centre Juelich",
       "name": "Wagner, Adina S.",
       "orcid": "0000-0003-2917-3450"
+    },
+    {
+      "affiliation": "Maze Therapeutics, South San Francisco, CA, United States",
+      "name": "Nichols, B. Nolan",
+      "orcid": "0000-0003-1099-3328"
     }
   ],
   "grants": [

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -128,6 +128,13 @@ class CreateSiblingGithub(Interface):
             constraints=EnsureChoice('https', 'ssh'),
             doc="""Which access protocol/URL to configure for the sibling"""),
         publish_depends=publish_depends,
+        private=Parameter(
+            args=("--private",),
+            action="store_true",
+            doc="""If this flag is set, the repository created on github
+            will be marked as private and only visible to those granted 
+            access or by membership of a team/organization/etc.
+            """),
         dryrun=Parameter(
             args=("--dryrun",),
             action="store_true",
@@ -151,6 +158,7 @@ class CreateSiblingGithub(Interface):
             github_organization=None,
             access_protocol='https',
             publish_depends=None,
+            private=None,
             dryrun=False):
         # this is an absolute leaf package, import locally to avoid
         # unnecessary dependencies
@@ -199,7 +207,7 @@ class CreateSiblingGithub(Interface):
         # actually make it happen on Github
         rinfo = _make_github_repos(
             github_login, github_passwd, github_organization, filtered,
-            existing, access_protocol, dryrun)
+            existing, access_protocol, private, dryrun)
 
         # lastly configure the local datasets
         for d, url, existed in rinfo:

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -131,6 +131,7 @@ class CreateSiblingGithub(Interface):
         private=Parameter(
             args=("--private",),
             action="store_true",
+            default=False,
             doc="""If this flag is set, the repository created on github
             will be marked as private and only visible to those granted 
             access or by membership of a team/organization/etc.
@@ -158,7 +159,7 @@ class CreateSiblingGithub(Interface):
             github_organization=None,
             access_protocol='https',
             publish_depends=None,
-            private=None,
+            private=False,
             dryrun=False):
         # this is an absolute leaf package, import locally to avoid
         # unnecessary dependencies

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -304,7 +304,7 @@ def _gen_github_entity(
 
 def _make_github_repos(
         github_login, github_passwd, github_organization, rinfo, existing,
-        access_protocol, dryrun):
+        access_protocol, private, dryrun):
     res = []
     if not rinfo:
         return res  # no need to even try!
@@ -327,6 +327,7 @@ def _make_github_repos(
                     reponame,
                     existing,
                     access_protocol,
+                    private,
                     dryrun)
                 # output will contain whatever is returned by _make_github_repo
                 # but with a dataset prepended to the record
@@ -360,7 +361,8 @@ def _make_github_repos(
         raise RuntimeError("Did not even try to create a repo on github")
 
 
-def _make_github_repo(github_login, entity, reponame, existing, access_protocol, dryrun):
+def _make_github_repo(github_login, entity, reponame, existing,
+                      access_protocol, private, dryrun):
     repo = None
     try:
         repo = entity.get_repo(reponame)
@@ -391,7 +393,7 @@ def _make_github_repo(github_login, entity, reponame, existing, access_protocol,
                 reponame,
                 # TODO description='',
                 # TODO homepage='',
-                # TODO private=False,
+                private=private,
                 has_issues=False,
                 has_wiki=False,
                 has_downloads=False,

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -64,6 +64,7 @@ def test__make_github_repos():
     ]
     existing = '???'
     access_protocol = '???'
+    private = False
     dryrun = False
     args = (
             github_login,
@@ -72,6 +73,7 @@ def test__make_github_repos():
             rinfo,
             existing,
             access_protocol,
+            private,
             dryrun,
     )
 


### PR DESCRIPTION
### Overview
This PR adds a new `--private` flag to the `datalad create-sibling-github` command that result in a GitHub repo being created that is only viewable by members that have been given access.

### How it was tested
Created both public and private repositories successfully using the following

`datalad create-sibling-github --github-organization $TEST --access-protocol ssh --name $TEST --private  $TEST`

