### PR TITLE
BF: Store reckless config in no-annex superdatasets

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -532,6 +532,14 @@ def clone_dataset(
     if result_props['source']['type'] == 'ria':
         yield from postclonecfg_ria(destds, result_props['source'])
 
+    if reckless:
+        # store the reckless setting in the dataset to make it
+        # known to later clones of subdatasets via get()
+        destds.config.set(
+            'datalad.clone.reckless', reckless,
+            where='local',
+            reload=True)
+
     # yield successful clone of the base dataset now, as any possible
     # subdataset clone down below will not alter the Git-state of the
     # parent
@@ -809,15 +817,6 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
             # TODO: What level? + note, that annex-dead is independ
             lgr.warning("reckless=ephemeral mode: Unable to create symlinks on "
                         "this file system.")
-
-    if reckless:
-        # we successfully dealt with reckless here.
-        # store the reckless setting in the dataset to make it
-        # known to later clones of subdatasets via get()
-        ds.config.set(
-            'datalad.clone.reckless', reckless,
-            where='local',
-            reload=True)
 
     srs = {True: [], False: []}  # special remotes by "autoenable" key
     remote_uuids = None  # might be necessary to discover known UUIDs

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -347,10 +347,13 @@ def check_reckless(annex, src_path, top_path, sharedpath):
         eq_(ds.repo.repo_info()['untrusted repositories'][0]['here'], True)
     # now, if we clone another repo into this one, it will inherit the setting
     # without having to provide it explicitly
-    sub = ds.clone(srcsub, 'sub', result_xfm='datasets', return_type='item-or-list')
-    eq_(sub.config.get('datalad.clone.reckless', None), 'auto')
-    if not is_crippled:
-        eq_(sub.config.get('annex.hardlink', None), 'true')
+    newsub = ds.clone(srcsub, 'newsub', result_xfm='datasets', return_type='item-or-list')
+    # and `get` the original subdataset
+    origsub = ds.get('sub', result_xfm='datasets', return_type='item-or-list')
+    for sds in (newsub, origsub):
+        eq_(sds.config.get('datalad.clone.reckless', None), 'auto')
+        if not is_crippled:
+            eq_(sds.config.get('annex.hardlink', None), 'true')
 
     if is_crippled:
         raise SkipTest("Remainder of test needs proper filesystem permissions")
@@ -359,13 +362,12 @@ def check_reckless(annex, src_path, top_path, sharedpath):
         # the standard setup keeps the annex locks accessible to the user only
         nok_((ds.pathobj / '.git' / 'annex' / 'index.lck').stat().st_mode \
              & stat.S_IWGRP)
-    # but we can set it up for group-shared access too
-    sharedds = clone(
-        src, sharedpath,
-        reckless='shared-group',
-        result_xfm='datasets',
-        return_type='item-or-list')
-    if annex:
+        # but we can set it up for group-shared access too
+        sharedds = clone(
+            src, sharedpath,
+            reckless='shared-group',
+            result_xfm='datasets',
+            return_type='item-or-list')
         ok_((sharedds.pathobj / '.git' / 'annex' / 'index.lck').stat().st_mode \
             & stat.S_IWGRP)
 


### PR DESCRIPTION
Otherwise, such configuration could not be inherited to annex subdatasets, even if a plain-git superdataset may not be directly
affected by a particular reckless mode.

Fixes gh-4749

Also:

- RF'ed test to run on windows