### PR TITLE
Add MANIFEST.in to include _datalad_build_support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,12 @@ Files organization
   benchmarking of DataLad.  Implemented in any most appropriate language
   (Python, bash, etc.)
 
+Whenever a new top-level file or folder is added to the repository, it should
+be listed in `MANIFEST.in` so that it will be either included in or excluded
+from source distributions as appropriate.  [See
+here](https://packaging.python.org/guides/using-manifest-in/) for information
+about writing a `MANIFEST.in`.
+
 How to contribute
 -----------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+include CHANGELOG.md CONTRIBUTORS COPYING Gruntfile.js Makefile asv.conf.json 
+include requirements-devel.txt requirements.txt tox.ini .coveragerc
+
+graft _datalad_build_support
+graft benchmarks
+graft docs
+graft tools
+
+prune .github
+prune sandbox
+
+exclude .gitignore .gitmodules .mailmap .noannex .travis.yml .zenodo.json
+exclude CODE_OF_CONDUCT.md CONTRIBUTING.md appveyor.yml readthedocs.yml
+
+global-exclude *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
+# We use both `include`/`graft` and `exclude`/`prune` commands here so that the
+# MANIFEST.in will have the same effect with & without installing
+# setuptools_scm (which adds all files under source control to the source
+# distribution).
+
 include CHANGELOG.md CONTRIBUTING.md CONTRIBUTORS COPYING Gruntfile.js
 include Makefile asv.conf.json requirements-devel.txt requirements.txt
 include tox.ini .coveragerc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
-include CHANGELOG.md CONTRIBUTORS COPYING Gruntfile.js Makefile asv.conf.json 
-include requirements-devel.txt requirements.txt tox.ini .coveragerc
+include CHANGELOG.md CONTRIBUTING.md CONTRIBUTORS COPYING Gruntfile.js
+include Makefile asv.conf.json requirements-devel.txt requirements.txt
+include tox.ini .coveragerc
 
 graft _datalad_build_support
 graft benchmarks
@@ -10,6 +11,6 @@ prune .github
 prune sandbox
 
 exclude .gitignore .gitmodules .mailmap .noannex .travis.yml .zenodo.json
-exclude CODE_OF_CONDUCT.md CONTRIBUTING.md appveyor.yml readthedocs.yml
+exclude CODE_OF_CONDUCT.md appveyor.yml readthedocs.yml
 
 global-exclude *.py[cod]


### PR DESCRIPTION
This PR adds a `MANIFEST.in` file to the project so that `_datalad_build_support/` (et alii) will always be included in sdists regardless of whether the sdists are built in an environment with `setuptools_scm` installed or not.  The file is written so that building an sdist should give the same results with & without `setuptools_scm` (until someone adds a new top-level file or directory, at least).  Read more about `MANIFEST.in` [here](https://packaging.python.org/guides/using-manifest-in/).

Closes #3808.

The decisions about what files to include & exclude in the sdist were based on my own personal packaging policies.  Rough rationales are as follows:

- Included files:
    - `_datalad_build_support/` is necessary for building the project.
    - `COPYING` and `CONTRIBUTORS` are included for legal purposes.
    - Files related to testing and benchmarking (`Makefile`, `asv.conf.json`, `tox.ini`, `.coveragerc`, `benchmarks`, `requirements.txt`, `Gruntfile.js`) are included so that people who receive the sdist can run the tests themselves.
    - `CHANGELOG.md` and `docs/` are included simply because I believe they should be included in sdists.
    - I wasn't sure how necessary `tools/` or `requirements-devel.txt` were, so I erred on the side of caution and left them in.

- Excluded files:
    - `.gitignore`, `.gitmodules`, `.mailmap`, and `.noannex` are only relevant if you're working with the actual Git repository.
    - `.github`, `.travis.yml`, `appveyor.yaml`, and `readthedocs.yml` are only used for third-party integrations that aren't present when you've just got an sdist.
    - `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` are only relevent for people interacting with the project through GitHub.
    - `sandbox/` just sounds like the type of directory that you don't want to distribute.
    - Brief research seems to indicate that `.zenodo.json` only belongs on this repository and this repository alone.
    - Compiled Python bytecode caches should always be excluded from sdists, hence the final line.