### PR TITLE
clone: Fetch autoenabled type=git special remotes

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -844,6 +844,15 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
                 sr_autoenable, sr_name, ds.path)
             continue
 
+        # If it looks like a type=git special remote, make sure we have up to
+        # date information. See gh-2897.
+        if sr_autoenable and repo_config.get("remote.{}.fetch".format(sr_name)):
+            try:
+                repo.fetch(remote=sr_name)
+            except CommandError as exc:
+                lgr.warning("Failed to fetch type=git special remote %s: %s",
+                            sr_name, exc_str(exc))
+
         # determine whether there is a registered remote with matching UUID
         if uuid:
             if remote_uuids is None:

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -821,6 +821,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
     srs = {True: [], False: []}  # special remotes by "autoenable" key
     remote_uuids = None  # might be necessary to discover known UUIDs
 
+    repo_config = repo.config
     # Note: The purpose of this function is to inform the user. So if something
     # looks misconfigured, we'll warn and move on to the next item.
     for uuid, config in repo.get_special_remotes().items():
@@ -851,8 +852,8 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
                     # this will point to the UUID for the configuration (i.e.
                     # the key returned by get_special_remotes) rather than the
                     # shared UUID.
-                    (repo.config.get('remote.%s.annex-config-uuid' % r) or
-                     repo.config.get('remote.%s.annex-uuid' % r))
+                    (repo_config.get('remote.%s.annex-config-uuid' % r) or
+                     repo_config.get('remote.%s.annex-uuid' % r))
                     for r in repo.get_remotes()
                 }
             if uuid not in remote_uuids:

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1172,3 +1172,38 @@ def test_gin_cloning(path):
     eq_(result[0]['path'], op.join(ds.path, annex_path))
     ok_file_has_content(op.join(ds.path, annex_path), 'two\n')
     ok_file_has_content(op.join(ds.path, git_path), 'one\n')
+
+
+@with_tree(tree={"special": {"f0": "0"}})
+@serve_path_via_http
+@with_tempfile(mkdir=True)
+def test_fetch_git_special_remote(url_path, url, path):
+    url_path = Path(url_path)
+    path = Path(path)
+    ds_special = Dataset(url_path / "special").create(force=True)
+    if ds_special.repo.is_managed_branch():
+        # TODO: git-annex-init fails in the first clone call below when this is
+        # executed under ./tools/eval_under_testloopfs.
+        raise SkipTest("Test fails on managed branch")
+    ds_special.save()
+    ds_special.repo.call_git(["update-server-info"])
+
+    clone_url = url + "special/.git"
+    ds_a = clone(clone_url, path / "a")
+    ds_a.repo._run_annex_command(
+        "initremote",
+        annex_options=["special", "type=git", "autoenable=true",
+                       "location=" + clone_url])
+
+    # Set up a situation where a file is present only on the special remote,
+    # and its existence is known only to the special remote's git-annex branch.
+    (ds_special.pathobj / "f1").write_text("1")
+    ds_special.save()
+    ds_special.repo.call_git(["update-server-info"])
+
+    ds_a.repo.fetch("origin")
+    ds_a.repo.merge("origin/" + DEFAULT_BRANCH)
+
+    ds_b = clone(ds_a.path, path / "other")
+    ds_b.get("f1")
+    ok_(ds_b.repo.file_has_content("f1"))


### PR DESCRIPTION
Otherwise `datalad get` fails to get content that is only in the
special remote and not known to the other remotes.

Fixes #2897.
