### PR TITLE
Use a fully random UUID as dataset ID

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -460,7 +460,7 @@ class Create(Interface):
         if _seed is None:
             # just the standard way
             # use a fully random identifier (i.e. UUID version 4)
-            uuid_id = uuid.uuid4().urn.split(':')[-1]
+            uuid_id = str(uuid.uuid4())
         else:
             # Let's generate preseeded ones
             uuid_id = str(uuid.UUID(int=random.getrandbits(128)))

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -459,7 +459,8 @@ class Create(Interface):
 
         if _seed is None:
             # just the standard way
-            uuid_id = uuid.uuid1().urn.split(':')[-1]
+            # use a fully random identifier (i.e. UUID version 4)
+            uuid_id = uuid.uuid4().urn.split(':')[-1]
         else:
             # Let's generate preseeded ones
             uuid_id = str(uuid.UUID(int=random.getrandbits(128)))


### PR DESCRIPTION
Until now the dataset ID encoded the time of dataset creation, and  a machine-identifying MAC-address (which may or may not be a reliable/persistent identifier).

DataLad neither used, nor advertised this encoded information in the ID. Moreover, having such information unconditionally encoded can counteract other features (e.g. "fake dates").

I'd argue that if identifying information of this kind is desired, it should be placed explicitly into a dataset. If UUIDs with encoded content are desired, the UUID of a dataset can be altered (right after creation) to match such needs.

Fixes gh-4785

This issue is related to https://github.com/datalad/datalad-metalad/issues/30 and impacts the suitability of an identifier for use in anonymous metadata on personal data.

This PR goes against `maint`, because it should have no functional impact, but there is value in getting this change out sooner.