### PR TITLE
Fix test_clone_unborn_head_sub on a managed branch

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -566,6 +566,11 @@ def postclone_check_head(ds):
         for rbranch in remote_branches:
             if rbranch in ["origin/git-annex", "HEAD"]:
                 continue
+            if rbranch.startswith("origin/adjusted/"):
+                # If necessary for this file system, a downstream
+                # git-annex-init call will handle moving into an
+                # adjusted state.
+                continue
             repo.call_git(["checkout", "-b", rbranch[7:],  # drop "origin/"
                            "--track", rbranch])
             lgr.debug("Checked out local branch from %s", rbranch)


### PR DESCRIPTION
This fixes the test failure that @mih reported in gh-4727.  The first commit is the main fix.  It updates the test itself, which was setting up an unintended and bizarre repo state that happened to pass before Git 2.27.  The second commit prevents `postclone_check_head` from checking out adjusted branches.  Either of these commits on their own avoid the failure.

I've confirmed that the test passes when executed under `tools/eval_under_testloopfs` both before and after the git commit mentioned in that issue.
