### PR TITLE
TST: Fix documentation and use of LOG_ environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     # will be used in the matrix, where neither other variable is used
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
-    - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
+    - DATALAD_LOG_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=datalad
     - NOSE_OPTS=
     # Note, that there's "turtle" as well, which is always excluded from
@@ -103,10 +103,10 @@ matrix:
     - DATALAD_LOG_TARGET=/dev/null
     - DATALAD_TESTS_PROTOCOLREMOTE=1
     - DATALAD_TESTS_DATALADREMOTE=1
-    - DATALAD_LOG_CMD_CWD=1
-    - DATALAD_LOG_CMD_OUTPUTS=1
-    - DATALAD_LOG_CMD_ENV=1
-    - DATALAD_LOG_CMD_STDIN=1
+    - DATALAD_LOG_CWD=1
+    - DATALAD_LOG_OUTPUTS=1
+    - DATALAD_LOG_ENV=1
+    - DATALAD_LOG_STDIN=1
     - DATALAD_TESTS_UI_BACKEND=console
     - DATALAD_TESTS_OBSCURE_PREFIX=-
     - DATALAD_SEED=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -475,15 +475,15 @@ Refer datalad/config.py for information on how to add these environment variable
   tests preferred to be set to http://datasets-tests.datalad.org
 - *DATALAD_LOG_LEVEL*:
   Used for control the verbosity of logs printed to stdout while running datalad commands/debugging
-- *DATALAD_LOG_CMD_OUTPUTS*:
+- *DATALAD_LOG_OUTPUTS*:
   Used to control either both stdout and stderr of external commands execution are logged in detail (at DEBUG level)
-- *DATALAD_LOG_CMD_ENV*:
+- *DATALAD_LOG_ENV*:
   If contains a digit (e.g. 1), would log entire environment passed into
   the Runner.run's popen call.  Otherwise could be a comma separated list
   of environment variables to log
-- *DATALAD_LOG_CMD_STDIN*:
+- *DATALAD_LOG_STDIN*:
   Whether to log stdin for the command
-- *DATALAD_LOG_CMD_CWD*:
+- *DATALAD_LOG_CWD*:
   Whether to log cwd where command to be executed
 - *DATALAD_LOG_PID*
   To instruct datalad to log PID of the process


### PR DESCRIPTION
8397bde59 (RF+ENH: unify and extend CMD execution logging - ENV, CWD,
STDIN now are options, 2017-04-07) added options for logging several
other aspects of command execution in addition to stdout and stderr.
_get_log_setting() was updated to look at datalad.log.cmd.<name>, and
the DATALAD_LOG_OUTPUTS environment variable in .travis.yml and
CONTRIBUTING.md was renamed to DATALAD_LOG_CMD_OUTPUTS to match the
new DATALAD_LOG_CMD_* variables.  However, the datalad.log.outputs
option in common_cfg was not renamed.  (None of the new variables were
added to common_cfg, though they arguably should be mentioned there if
datalad.log.outputs is worth including.)

Noticing the datalad.log.outputs was not being picked up, 1a578f478
(BF: it is datalad.log not datalad.log.cmd section to decide destiny
of logging parameters, 2020-02-25) reversed the _get_log_setting()
change from 8397bde59, but it didn't update the variables names in
CONTRIBUTING.md or .travis.yml.

To fix this mismatch, we could either (1) revert the change from
1a578f478 and update the datalad.log.outputs value in common_cfg or
(2) update the DATALAD_LOG_CMD_* variables in CONTRIBUTING.md and
.travis.yml.  Go with the latter because it avoids introducing
additional breakage.
