### PR TITLE
TST: Skip known failure in test_AnnexRepo_commit

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -783,7 +783,12 @@ def test_AnnexRepo_commit(path):
         f.write("some")
     assert_raises(FileNotInRepositoryError, ds.commit, files="untracked")
     # not existing file as well:
-    assert_raises(FileNotInRepositoryError, ds.commit, files="not-existing")
+    try:
+        ds.commit(files="not-existing")
+    except FileNotInRepositoryError:
+        pass   # expected result
+    except CommandError:
+        raise SkipTest("test_AnnexRepo_commit hit known failure (gh-4773)")
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])


### PR DESCRIPTION
The assertion that FileNotInRepositoryError is raised recently started
failing intermittently (gh-4773).  The reason is unknown, but it is
happening frequently enough that the Travis build for most PRs needs
to be manually inspected.
