### PR TITLE
BF(TST): a few more @slow tests annotations + also place network tests into "slow" group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - NOSE_OPTS=
     # Note, that there's "turtle" as well, which is always excluded from
     # running on Travis.
-    - NOSE_SELECTION="integration or usecase or slow"
+    - NOSE_SELECTION="integration or usecase or slow or network"
     - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -254,6 +254,7 @@ def test_install_dataset_from_just_source(url, path):
     assert_in('INFO.txt', ds.repo.get_indexed_files())
 
 
+@slow   # 25sec on Yarik's laptop
 @with_testrepos(flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_install_dataset_from_instance(src, dst):
@@ -432,6 +433,7 @@ def test_install_into_dataset(source, top_path):
     assert_repo_status(ds.path, untracked=['dummy.txt'])
 
 
+@slow   # 15sec on Yarik's laptop
 @known_failure_windows  #FIXME
 @usecase  # 39.3074s
 @skip_if_no_network

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -307,6 +307,7 @@ def test_install_dataladri(src, topurl, path):
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:338
+@slow   # 46sec on Yarik's laptop and tripped Travis CI
 @known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -52,6 +52,7 @@ from datalad.tests.utils import (
     skip_if_on_windows,
     skip_ssh,
     SkipTest,
+    slow,
     swallow_logs,
     with_tempfile,
     with_testrepos,
@@ -1449,6 +1450,7 @@ def test_custom_runner_protocol(path):
     ok_(all(p['duration'] >= 0 for p in prot))
 
 
+@slow   # 15sec on Yarik's laptop and tripped Travis CI
 @with_tempfile(mkdir=True)
 def test_duecredit(path):
     # Just to check that no obvious side-effects


### PR DESCRIPTION
network tests can delay due to network speed etc, so we cannot really impose time limit on them.