### PR TITLE
NF: Inter-process locking for configuration modifications

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -22,13 +22,7 @@ from distutils.version import LooseVersion
 
 import re
 import os
-from os.path import (
-    join as opj,
-    exists,
-    getmtime,
-    abspath,
-    isabs,
-)
+from pathlib import Path
 from time import time
 
 import logging
@@ -86,9 +80,9 @@ def _parse_gitconfig_dump(dump, store, fileset, replace, cwd=None):
             continue
         if line.startswith('file:'):
             # origin line
-            fname = line[5:]
-            if not isabs(fname):
-                fname = opj(cwd, fname) if cwd else abspath(fname)
+            fname = Path(line[5:])
+            if not fname.is_absolute():
+                fname = Path(cwd) / fname if cwd else Path.cwd() / fname
             fileset.add(fname)
             continue
         if line.startswith('command line:'):
@@ -211,9 +205,8 @@ class ConfigManager(object):
         self._store = {}
         self._cfgfiles = set()
         self._cfgmtimes = None
-        self._dataset_path = None
-        self._dataset_cfgfname = None
-        self._repo_cfgfname = None
+        self._repo = None if dataset is None else \
+            dataset if hasattr(dataset, 'dot_git') else dataset.repo
         self._config_cmd = ['git', 'config']
         # public dict to store variables that always override any setting
         # read from a file
@@ -232,13 +225,7 @@ class ConfigManager(object):
             # when calling 'git config' to prevent a repository in the current
             # working directory from leaking configuration into the output.
             self._config_cmd = ['git', '--git-dir=', 'config']
-        else:
-            self._dataset_path = dataset.path
-            if source != 'local':
-                self._dataset_cfgfname = opj(self._dataset_path,
-                                             DATASET_CONFIG_FILE)
-            if source != 'dataset':
-                self._repo_cfgfname = opj(self._dataset_path, '.git', 'config')
+
         self._src_mode = source
         # Since configs could contain sensitive information, to prevent
         # any "facilitated" leakage -- just disable logging of outputs for
@@ -271,7 +258,7 @@ class ConfigManager(object):
             # we aren't forcing and we have read files before
             # check if any file we read from has changed
             current_time = time()
-            curmtimes = {c: getmtime(c) for c in self._cfgfiles if exists(c)}
+            curmtimes = {c: c.stat().st_mtime for c in self._cfgfiles if c.exists()}
             if all(curmtimes[c] == self._cfgmtimes.get(c) and
                    # protect against low-res mtimes (FAT32 has 2s, EXT3 has 1s!)
                    # if mtime age is less than worst resolution assume modified
@@ -295,10 +282,12 @@ class ConfigManager(object):
         if self._gitconfig_has_showorgin:
             run_args.append('--show-origin')
 
-        if self._dataset_cfgfname:
-            if exists(self._dataset_cfgfname):
+        dataset_cfgfile = None
+        if self._repo and self._src_mode != 'local':
+            dataset_cfgfile = self._repo.pathobj / DATASET_CONFIG_FILE
+            if dataset_cfgfile.exists():
                 stdout, stderr = self._run(
-                    run_args + ['--file', self._dataset_cfgfname],
+                    run_args + ['--file', str(dataset_cfgfile)],
                     log_stderr=True
                 )
                 # overwrite existing value, do not amend to get multi-line
@@ -320,10 +309,11 @@ class ConfigManager(object):
             cwd=self._runner.cwd)
 
         # always monitor the dataset cfg location, we know where it is in all cases
-        if self._dataset_cfgfname:
-            self._cfgfiles.add(self._dataset_cfgfname)
-            self._cfgfiles.add(self._repo_cfgfname)
-        self._cfgmtimes = {c: getmtime(c) for c in self._cfgfiles if exists(c)}
+        if dataset_cfgfile:
+            self._cfgfiles.add(dataset_cfgfile)
+        if self._src_mode != 'dataset' and self._repo:
+            self._cfgfiles.add(self._repo.dot_git / 'config')
+        self._cfgmtimes = {c: c.stat().st_mtime for c in self._cfgfiles if c.exists()}
 
         # superimpose overrides
         self._store.update(self.overrides)
@@ -610,9 +600,9 @@ class ConfigManager(object):
 
         # all other calls are modifications
         lockfile = None
-        if self._repo_cfgfname and ('--local' in args or '--file' in args):
+        if self._repo and ('--local' in args or '--file' in args):
             # modification of config in a dataset
-            lockfile = self._repo_cfgfname + '_dataladlock'
+            lockfile = self._repo.dot_git / 'config_dataladlock'
 
         # we are not protecting against concurrent modification of the
         # global config, because MIH cannot think of a use case and
@@ -636,18 +626,19 @@ class ConfigManager(object):
                 "unknown configuration label '{}' (not in {})".format(
                     where, cfg_labels))
         if where == 'dataset':
-            if not self._dataset_cfgfname:
+            if not self._repo:
                 raise ValueError(
                     'ConfigManager cannot store configuration to dataset, '
                     'none specified')
             # create an empty config file if none exists, `git config` will
             # fail otherwise
-            dscfg_dirname = opj(self._dataset_path, DATALAD_DOTDIR)
-            if not exists(dscfg_dirname):
-                os.makedirs(dscfg_dirname)
-            if not exists(self._dataset_cfgfname):
-                open(self._dataset_cfgfname, 'w').close()
-            args.extend(['--file', self._dataset_cfgfname])
+            dscfg_dir = self._repo.pathobj / DATALAD_DOTDIR
+            if not dscfg_dir.exists():
+                dscfg_dir.mkdir()
+            dataset_cfgfile = self._repo.pathobj / DATASET_CONFIG_FILE
+            if not dataset_cfgfile.exists():
+                dataset_cfgfile.touch()
+            args.extend(['--file', str(dataset_cfgfile)])
         elif where == 'global':
             args.append('--global')
         elif where == 'local':

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -9,6 +9,7 @@
 """
 """
 
+from fasteners import InterProcessLock
 from functools import lru_cache
 import datalad
 from datalad.consts import (
@@ -603,7 +604,25 @@ class ConfigManager(object):
         """
         if where:
             args = self._get_location_args(where) + args
-        out = self._runner.run(self._config_cmd + args, **kwargs)
+        if '-l' in args:
+            # we are just reading, no need to reload, no need to lock
+            return self._runner.run(self._config_cmd + args, **kwargs)
+
+        # all other calls are modifications
+        lockfile = None
+        if self._repo_cfgfname and ('--local' in args or '--file' in args):
+            # modification of config in a dataset
+            lockfile = self._repo_cfgfname + '_dataladlock'
+
+        # we are not protecting against concurrent modification of the
+        # global config, because MIH cannot think of a use case and
+        # it is unclear where a lockfile should be placed
+        if lockfile:
+            with InterProcessLock(lockfile, logger=lgr):
+                out = self._runner.run(self._config_cmd + args, **kwargs)
+        else:
+            out = self._runner.run(self._config_cmd + args, **kwargs)
+
         if reload:
             self.reload()
         return out

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -602,15 +602,13 @@ class ConfigManager(object):
         lockfile = None
         if self._repo and ('--local' in args or '--file' in args):
             # modification of config in a dataset
-            lockfile = self._repo.dot_git / 'config_dataladlock'
-
-        # we are not protecting against concurrent modification of the
-        # global config, because MIH cannot think of a use case and
-        # it is unclear where a lockfile should be placed
-        if lockfile:
-            with InterProcessLock(lockfile, logger=lgr):
-                out = self._runner.run(self._config_cmd + args, **kwargs)
+            lockfile = self._repo.dot_git / 'config.dataladlock'
         else:
+            # follow pattern in downloaders for lockfile location
+            lockfile = Path(self.obtain('datalad.locations.cache')) \
+                / 'locks' / 'gitconfig.lck'
+
+        with InterProcessLock(lockfile, logger=lgr):
             out = self._runner.run(self._config_cmd + args, **kwargs)
 
         if reload:

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -454,6 +454,16 @@ class RunProcedure(Interface):
         ):
             yield r
 
+        if ds:
+            # the procedure ran and we have to anticipate that it might have
+            # changed the dataset config, so we need to trigger an unforced
+            # reload.
+            # we have to do this despite "being done here", because
+            # run_procedure() runs in the same process and reuses dataset (config
+            # manager) instances, and the next interaction with a dataset should
+            # be able to count on an up-to-date config
+            ds.config.reload()
+
     @staticmethod
     def custom_result_renderer(res, **kwargs):
         from datalad.ui import ui

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -68,6 +68,8 @@ def test_ignored(topdir):
     assert_equal(ignored(opj(topdir, "annexdir"), only_hidden=True), False)
 
 
+# https://github.com/datalad/datalad/pull/4808#issuecomment-674381095
+@known_failure_windows
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '124', 'file2.txt': '123'},

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -73,7 +73,7 @@ def test_something(path, new_home):
     # will refuse to work on dataset without a dataset
     assert_raises(ValueError, ConfigManager, source='dataset')
     # now read the example config
-    cfg = ConfigManager(Dataset(opj(path, 'ds')), source='dataset')
+    cfg = ConfigManager(GitRepo(opj(path, 'ds'), create=True), source='dataset')
     assert_equal(len(cfg), 5)
     assert_in('something.user', cfg)
     # multi-value
@@ -226,7 +226,7 @@ def test_something(path, new_home):
     padry = !git paremotes | tr ' ' '\\n' | xargs -r -l1 git push --dry-run
 """}}})
 def test_crazy_cfg(path):
-    cfg = ConfigManager(Dataset(opj(path, 'ds')), source='dataset')
+    cfg = ConfigManager(GitRepo(opj(path, 'ds'), create=True), source='dataset')
     assert_in('crazy.padry', cfg)
     # make sure crazy config is not read when in local mode
     cfg = ConfigManager(Dataset(opj(path, 'ds')), source='local')
@@ -456,11 +456,11 @@ def test_no_leaks(path1, path2):
         assert_not_in('i.was.here', ds2.config.keys())
 
         # and that we do not track the wrong files
-        assert_not_in(opj(ds1.path, '.git', 'config'), ds2.config._cfgfiles)
-        assert_not_in(opj(ds1.path, '.datalad', 'config'), ds2.config._cfgfiles)
+        assert_not_in(ds1.pathobj / '.git' / 'config', ds2.config._cfgfiles)
+        assert_not_in(ds1.pathobj / '.datalad' / 'config', ds2.config._cfgfiles)
         # these are the right ones
-        assert_in(opj(ds2.path, '.git', 'config'), ds2.config._cfgfiles)
-        assert_in(opj(ds2.path, '.datalad', 'config'), ds2.config._cfgfiles)
+        assert_in(ds2.pathobj / '.git' / 'config', ds2.config._cfgfiles)
+        assert_in(ds2.pathobj / '.datalad' / 'config', ds2.config._cfgfiles)
 
 
 @with_tempfile()


### PR DESCRIPTION
As described here:
https://github.com/datalad/datalad/issues/450#issuecomment-670365732
the manipulation of configuration is a collision point for multiple
processes interacting with a single dataset.

This change introduces an inter-process locking mechanism using the
`fasteners` package. Relevant bits from the docs:

- does not require any cleanup
- lock gets dropped automatically if the process crashes, even if
  `__exit__` is not executed

Locking behavior is logged at level 5 and looks like this:

```
[Level 5] Acquired file lock `b'/tmp/datalad_temp_test_obtaink1uf9sf9/.git/config_dataladlock'` after waiting 0.000s [1 attempts were required]
[Level 5] Unlocked and closed file lock open on `b'/tmp/datalad_temp_test_obtaink1uf9sf9/.git/config_dataladlock'`
```

The `fasteners` package is already a direct dependency. It seems to
provide the standard solution for this problem.

Doing locking only at config-write, instead of more global "dataset is
in use"-locks has the advantage of minimizing bottlenecks with external
parallelization approaches (i.e. via `xargs -P`). However, it is
obviously not sufficient in general.

One could debate whether the lock should also cover read operations to
avoid missing partial update done by process A when process B is
reloading a dataset configuration.

Related : #1455

Update: This PR now also fixes #4809 