### PR TITLE
ENH(TST): remove from a setup_package a fixture needed for GitPython

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -128,15 +128,6 @@ def setup_package():
 """)
         _TEMP_PATHS_GENERATED.append(new_home)
 
-    # If there is a bundled git, make sure GitPython uses it too
-    # (some parts of the test utilities still rely on GitPython)
-    from datalad.cmd import GitRunner
-    GitRunner._check_git_path()
-    if GitRunner._GIT_PATH:
-        import os
-        os.environ['GIT_PYTHON_GIT_EXECUTABLE'] = \
-            os.path.join(GitRunner._GIT_PATH, 'git')
-
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153
     cfg.reload(force=True)


### PR DESCRIPTION
Since no GitPython is used any longer, no need to tune env variables for it
