### PR TITLE
RF(TST): travis - run nose tests last

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -259,6 +259,10 @@ script:
   - if [ -n "${_DL_TMPDIR:-}" ]; then export TMPDIR="${_DL_TMPDIR}"; fi
   # Test installation system-wide
   - sudo pip install .
+  # Run javascript tests
+  - grunt test --verbose
+  # Report WTF information using system wide installed version
+  - datalad wtf
   - mkdir -p __testhome__
   - cd __testhome__
   # Run tests
@@ -271,10 +275,6 @@ script:
       --logging-level=INFO
       $TESTS_TO_PERFORM
   - cd ..
-  # Run javascript tests
-  - grunt test --verbose
-  # Report WTF information using system wide installed version
-  - datalad wtf
 
 after_success:
   # submit only what we have covered in the PRs


### PR DESCRIPTION
I got tired of scrolling logs all the way down + some amount up to get
to the most often failing tests -- our unittests ran by nose.
With this change   nose failures should be at the bottom making it much
easier to jump to them
