### PR TITLE
Skip known failure in test_annex_ssh

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -788,6 +788,7 @@ def test_AnnexRepo_commit(path):
     except FileNotInRepositoryError:
         pass   # expected result
     except CommandError:
+        # @known_failure (marked for grep)
         raise SkipTest("test_AnnexRepo_commit hit known failure (gh-4773)")
 
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -787,7 +787,7 @@ def test_AnnexRepo_commit(path):
         ds.commit(files="not-existing")
     except FileNotInRepositoryError:
         pass   # expected result
-    except CommandError:
+    except CommandError:  # pragma: no cover
         # @known_failure (marked for grep)
         raise SkipTest("test_AnnexRepo_commit hit known failure (gh-4773)")
 
@@ -1205,7 +1205,7 @@ def test_annex_ssh(topdir):
     # copy to the new remote:
     ar.copy_to(["foo"], remote="ssh-remote-2")
 
-    if not exists(socket_2):
+    if not exists(socket_2):  # pragma: no cover
         # @known_failure (marked for grep)
         raise SkipTest("test_annex_ssh hit known failure (gh-4781)")
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1205,7 +1205,10 @@ def test_annex_ssh(topdir):
     # copy to the new remote:
     ar.copy_to(["foo"], remote="ssh-remote-2")
 
-    ok_(exists(socket_2))
+    if not exists(socket_2):
+        # @known_failure (marked for grep)
+        raise SkipTest("test_annex_ssh hit known failure (gh-4781)")
+
     ssh_manager.close(ctrl_path=[socket_1, socket_2])
 
 


### PR DESCRIPTION
The `test_annex_ssh` failure in gh-4781 is turning many PRs red.  Skip the failing assertion.

Add a comment to this test and the recently skipped failure in `test_AnnexRepo_commit` so that it can be discovered by someone grepping for the known failure decorator (as discussed in gh-4798).
