### PR TITLE
BF: fix authentication + download from S3 for NDA

### DIFF
--- a/datalad/downloaders/configs/nda.cfg
+++ b/datalad/downloaders/configs/nda.cfg
@@ -9,6 +9,25 @@ authentication_type = nda-s3
 url = https://ndar.nih.gov/access.html
 type = nda-s3
 
+# Development instance
+[provider:NDA-development]
+url_re = https://development.nimhda.org($|/.*)
+credential = NDA-development
+# or some kind of html_form???
+authentication_type = http_basic_auth
+
+[credential:NDA-development]
+type = nda-s3
+
+[provider:NDA-development-s3]
+url_re = s3://TODO?
+credential = NDA-development-s3
+authentication_type = nda-s3
+
+[credential:NDA-development-s3]
+type = nda-s3
+
+
 #
 # Configuration used by the crawler to fetch "interesting" selection of stuff
 # from miNDAR which has its own authentication scheme, and actually we might need

--- a/datalad/downloaders/configs/nda.cfg
+++ b/datalad/downloaders/configs/nda.cfg
@@ -9,25 +9,6 @@ authentication_type = nda-s3
 url = https://ndar.nih.gov/access.html
 type = nda-s3
 
-# Development instance
-[provider:NDA-development]
-url_re = https://development.nimhda.org($|/.*)
-credential = NDA-development
-# or some kind of html_form???
-authentication_type = http_basic_auth
-
-[credential:NDA-development]
-type = nda-s3
-
-[provider:NDA-development-s3]
-url_re = s3://TODO?
-credential = NDA-development-s3
-authentication_type = nda-s3
-
-[credential:NDA-development-s3]
-type = nda-s3
-
-
 #
 # Configuration used by the crawler to fetch "interesting" selection of stuff
 # from miNDAR which has its own authentication scheme, and actually we might need

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -26,6 +26,7 @@ import calendar
 from collections import OrderedDict
 
 from ..dochelpers import exc_str
+from ..support.exceptions import AccessDeniedError
 from ..support.keyring_ import keyring as keyring_
 from ..ui import ui
 from ..utils import auto_repr
@@ -294,7 +295,15 @@ def _nda_adapter(composite, user=None, password=None):
     from datalad.support.third.nda_aws_token_generator import NDATokenGenerator
     from .. import cfg
     gen = NDATokenGenerator(cfg.obtain('datalad.externals.nda.dbserver'))
-    token = gen.generate_token(user, password)
+    lgr.debug("Generating token for NDA user %s using %s", user, gen)
+    try:
+        token = gen.generate_token(user, password)
+    except Exception as exc:  # it is really just an "Exception"
+        exc_str = str(exc).lower()
+        # ATM it is "Invalid username and/or password"
+        # but who knows what future would bring
+        if "invalid" in exc_str and ("user" in exc_str or "password" in exc_str):
+            raise AccessDeniedError(exc_str)
     # There are also session and expiration we ignore... TODO anything about it?!!!
     # we could create a derived AWS_S3 which would also store session and expiration
     # and then may be Composite could use those????

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -292,7 +292,8 @@ class CompositeCredential(Credential):
 
 def _nda_adapter(composite, user=None, password=None):
     from datalad.support.third.nda_aws_token_generator import NDATokenGenerator
-    gen = NDATokenGenerator()
+    from .. import cfg
+    gen = NDATokenGenerator(cfg.obtain('datalad.externals.nda.dbserver'))
     token = gen.generate_token(user, password)
     # There are also session and expiration we ignore... TODO anything about it?!!!
     # we could create a derived AWS_S3 which would also store session and expiration

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -304,6 +304,7 @@ def _nda_adapter(composite, user=None, password=None):
         # but who knows what future would bring
         if "invalid" in exc_str and ("user" in exc_str or "password" in exc_str):
             raise AccessDeniedError(exc_str)
+        raise
     # There are also session and expiration we ignore... TODO anything about it?!!!
     # we could create a derived AWS_S3 which would also store session and expiration
     # and then may be Composite could use those????

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -294,8 +294,10 @@ class CompositeCredential(Credential):
 def _nda_adapter(composite, user=None, password=None):
     from datalad.support.third.nda_aws_token_generator import NDATokenGenerator
     from .. import cfg
-    gen = NDATokenGenerator(cfg.obtain('datalad.externals.nda.dbserver'))
-    lgr.debug("Generating token for NDA user %s using %s", user, gen)
+    nda_auth_url = cfg.obtain('datalad.externals.nda.dbserver')
+    gen = NDATokenGenerator(nda_auth_url)
+    lgr.debug("Generating token for NDA user %s using %s talking to %s",
+              user, gen, nda_auth_url)
     try:
         token = gen.generate_token(user, password)
     except Exception as exc:  # it is really just an "Exception"

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -158,3 +158,12 @@ def test_boto_host_specification(tempfile):
     with swallow_outputs():
         providers.download(url_dandi1, path=tempfile)
     assert_equal(md5sum(tempfile), '97f4290b2d369816c052607923e372d4')
+
+
+def test_restricted_bucket_on_NDA():
+    get_test_providers('s3://NDAR_Central_4/', reload=True)  # to verify having credentials to access
+    for url, success_str, failed_str in [
+        ("s3://NDAR_Central_4/submission_23075/README", 'BIDS', 'error'),
+        ("s3://NDAR_Central_4/submission_23075/dataset_description.json", 'DA041147', 'error'),
+    ]:
+        yield check_download_external_url, url, failed_str, success_str

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -39,6 +39,8 @@ definitions = {
                'title': 'NDA database server',
                'text': 'Hostname of the database server'}),
         'destination': 'global',
+        # Development one is https://development.nimhda.org
+        'default': 'https://nda.nih.gov/DataManager/dataManager',
     },
     'datalad.locations.cache': {
         'ui': ('question', {

--- a/datalad/support/third/nda_aws_token_generator.py
+++ b/datalad/support/third/nda_aws_token_generator.py
@@ -22,7 +22,7 @@ class NDATokenGenerator(object):
         'data': 'http://gov/nih/ndar/ws/datamanager/server/bean/jaxb'
     }
 
-    def __init__(self, url='https://ndar.nih.gov/DataManager/dataManager'):
+    def __init__(self, url):
         assert url is not None
         self.url = url
         logging.debug('constructed with url %s' % url)


### PR DESCRIPTION
- Uses new version of NDA authenticator to obtain S3 credentials for download
- Makes it possible to download from NDA bucket(s) which are quite "locked down"
  - default boto3 access to a bucket with verification would fail, so upon that specific error we would try to connect without validation
  - getting a key for which versionId is known is not possible while specifying that versionId.  And default boto behavior is to do so.  In this PR I change behavior to "kill" version_id from the key we are requesting if original url requested did not have versionId.

Although it is bug fix in nature, I am ok to reposition it against `master` if so deemed better.
