### PR TITLE
RF: Remove legacy API from config manager

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -177,8 +177,6 @@ class ConfigManager(object):
       If provided, all `git config` calls are executed in this dataset's
       directory. Moreover, any modifications are, by default, directed to
       this dataset's configuration file (which will be created on demand)
-    dataset_only : bool
-      Legacy option, do not use.
     overrides : dict, optional
       Variable overrides, see general class documentation for details.
     source : {'any', 'local', 'dataset', 'dataset-local'}, optional
@@ -194,16 +192,10 @@ class ConfigManager(object):
 
     _checked_git_identity = False
 
-    def __init__(self, dataset=None, dataset_only=False, overrides=None, source='any'):
+    def __init__(self, dataset=None, overrides=None, source='any'):
         if source not in ('any', 'local', 'dataset', 'dataset-local'):
             raise ValueError(
                 'Unkown ConfigManager(source=) setting: {}'.format(source))
-            # legacy compat
-        if dataset_only:
-            if source != 'any':
-                raise ValueError('Refuse to combine legacy dataset_only flag, with '
-                                 'source setting')
-            source = 'dataset'
         # store in a simple dict
         # no subclassing, because we want to be largely read-only, and implement
         # config writing separately

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -347,7 +347,7 @@ class Dataset(object, metaclass=PathBasedFlyweight):
             # However, if this was the case before as well, we don't want a new
             # instance of ConfigManager
             if self._cfg_bound in (True, None):
-                self._cfg = ConfigManager(dataset=None, dataset_only=False)
+                self._cfg = ConfigManager(dataset=None)
                 self._cfg_bound = False
 
         else:


### PR DESCRIPTION
The `dataset_only` option was deprecated with the release of 0.12, and
can be removed with the release of 0.14.
