### PR TITLE
run_async_cmd: Work around dropped output of speedy commands

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -217,6 +217,9 @@ async def run_async_cmd(loop, cmd, protocol, stdin, protocol_kwargs=None,
         lgr.debug('Launching process %s', cmd)
         transport, protocol = await proc
         lgr.debug('Waiting for process %i to complete', transport.get_pid())
+        # The next wait is a workaround that avoids losing the output of
+        # quickly exiting commands (https://bugs.python.org/issue41594).
+        await asyncio.ensure_future(transport._wait())
         await cmd_done
         result = protocol._prepare_result()
     finally:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -212,17 +212,19 @@ async def run_async_cmd(loop, cmd, protocol, stdin, protocol_kwargs=None,
         **kwargs
     )
     transport = None
+    result = None
     try:
         lgr.debug('Launching process %s', cmd)
         transport, protocol = await proc
         lgr.debug('Waiting for process %i to complete', transport.get_pid())
         await cmd_done
+        result = protocol._prepare_result()
     finally:
         # protect against a crash whe launching the process
         if transport:
             transport.close()
 
-    return cmd_done.result()
+    return result
 
 
 class WitlessProtocol(asyncio.SubprocessProtocol):
@@ -298,11 +300,10 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
 
         Note for derived classes overwriting this method:
 
-        The result set for the `done` future must be a dict with keys
-        that do not unintentionally conflict with the API of
-        CommandError, as the result dict is passed to this exception
-        class as kwargs on error. The Runner will overwrite 'cmd' and
-        'cwd' on error, if they are present in the result.
+        The result must be a dict with keys that do not unintentionally
+        conflict with the API of CommandError, as the result dict is passed to
+        this exception class as kwargs on error. The Runner will overwrite
+        'cmd' and 'cwd' on error, if they are present in the result.
         """
         return_code = self.transport.get_returncode()
         lgr.debug(
@@ -320,7 +321,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
 
     def process_exited(self):
         # actually fulfill the future promise and let the execution finish
-        self.done.set_result(self._prepare_result())
+        self.done.set_result(True)
 
 
 class NoCapture(WitlessProtocol):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -783,13 +783,7 @@ def test_AnnexRepo_commit(path):
         f.write("some")
     assert_raises(FileNotInRepositoryError, ds.commit, files="untracked")
     # not existing file as well:
-    try:
-        ds.commit(files="not-existing")
-    except FileNotInRepositoryError:
-        pass   # expected result
-    except CommandError:  # pragma: no cover
-        # @known_failure (marked for grep)
-        raise SkipTest("test_AnnexRepo_commit hit known failure (gh-4773)")
+    assert_raises(FileNotInRepositoryError, ds.commit, files="not-existing")
 
 
 @with_testrepos('.*annex.*', flavors=['clone'])


### PR DESCRIPTION
These patches hopefully work around the `WitlessRunner` failing to capture the output of quickly exiting commands.

https://github.com/datalad/datalad/issues/4773#issuecomment-676839674

<details>
<summary>datalad-based reproducer mentioned in second commit</summary>

```python
import sys
import tempfile

import datalad.api as dl
from datalad.support.exceptions import CommandError
from datalad.support.exceptions import FileNotInRepositoryError

ntimes = int(sys.argv[1]) if len(sys.argv) > 1 else 40

ds = dl.Dataset(tempfile.mkdtemp(prefix="dl-dropped-stderr-"))
ds.create()
print(ds)

for i in range(ntimes):
    print(i)
    try:
        ds.repo.commit(files="not-existing")
    except FileNotInRepositoryError:
        pass   # expected result
    except CommandError as e:
        print(f"\n\nError on iteration {i + 1}\n\n"
              f"e.stdout {e.stdout!r}\n\n"
              f"e.stderr {e.stderr!r}\n")
        raise

print("no unexpected errors")
```

</details>
