### PR TITLE
Address issue with correctly deleting *Repo instances

### DIFF
--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -47,6 +47,7 @@ from datalad.tests.utils import (
     assert_is_not,
     assert_is_not_none,
     assert_not_equal,
+    assert_not_in,
     assert_raises,
     assert_repo_status,
     assert_result_count,
@@ -56,6 +57,7 @@ from datalad.tests.utils import (
     OBSCURE_FILENAME,
     ok_,
     SkipTest,
+    swallow_logs,
     with_tempfile,
     with_testrepos,
 )
@@ -296,6 +298,9 @@ def test_require_dataset():
 
 @with_tempfile(mkdir=True)
 def test_dataset_id(path):
+
+    import gc
+
     ds = Dataset(path)
     assert_equal(ds.id, None)
     ds.create()
@@ -303,50 +308,41 @@ def test_dataset_id(path):
     # ID is always a UUID
     assert_equal(ds.id.count('-'), 4)
     assert_equal(len(ds.id), 36)
+
+    # Ben: The following part of the test is concerned with creating new objects
+    #      and therefore used to reset the flyweight dict while keeping a ref to
+    #      the old object for comparison etc. This is ugly and in parts
+    #      retesting what is already tested in `test_Dataset_flyweight`. No need
+    #      for that. If we del the last ref to an instance and gc.collect(),
+    #      then we get a new instance on next request. This test should trust
+    #      the result of `test_Dataset_flyweight`.
+
     # creating a new object for the same path
     # yields the same ID
-
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
+    del ds
+    gc.collect()
     newds = Dataset(path)
-    assert_false(ds is newds)
-    assert_equal(ds.id, newds.id)
+    assert_equal(dsorigid, newds.id)
+
     # recreating the dataset does NOT change the id
-    #
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
+    del newds
+    gc.collect()
+
+    ds = Dataset(path)
     ds.create(annex=False, force=True)
     assert_equal(ds.id, dsorigid)
+
     # even adding an annex doesn't
-    #
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
-    AnnexRepo._unique_instances.clear()
+    del ds
+    gc.collect()
+    ds = Dataset(path)
     ds.create(force=True)
     assert_equal(ds.id, dsorigid)
+
     # dataset ID and annex UUID have nothing to do with each other
     # if an ID was already generated
     assert_true(ds.repo.uuid != ds.id)
-    # creating a new object for the same dataset with an ID on record
-    # yields the same ID
-    #
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
-    newds = Dataset(path)
-    assert_false(ds is newds)
-    assert_equal(ds.id, newds.id)
+
     # even if we generate a dataset from scratch with an annex UUID right away,
     # this is also not the ID
     annexds = Dataset(opj(path, 'scratch')).create()
@@ -356,6 +352,8 @@ def test_dataset_id(path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_Dataset_flyweight(path1, path2):
+
+    import gc
 
     ds1 = Dataset(path1)
     assert_is_instance(ds1, Dataset)
@@ -371,14 +369,55 @@ def test_Dataset_flyweight(path1, path2):
         ok_(ds1 == ds3)
         ok_(ds1 is ds3)
 
-    # on windows as symlink is not what you think it is
+    # gc knows one such object only:
+    eq_(1, len([o for o in gc.get_objects()
+                if isinstance(o, Dataset) and o.path == path1]))
+
+
+    # on windows a symlink is not what you think it is
     if not on_windows:
         # reference the same via symlink:
         with chpwd(path2):
             os.symlink(path1, 'linked')
-            ds3 = Dataset('linked')
-            ok_(ds3 == ds1)
-            ok_(ds3 is not ds1)
+            ds4 = Dataset('linked')
+            ds4_id = id(ds4)
+            ok_(ds4 == ds1)
+            ok_(ds4 is not ds1)
+
+        # underlying repo, however, IS the same:
+        ok_(ds4.repo is ds1.repo)
+
+    # deleting one reference has no effect on the other:
+    del ds1
+    ok_(ds2 is not None)
+    ok_(ds2.repo is ds3.repo)
+    if not on_windows:
+        ok_(ds2.repo is ds4.repo)
+
+    # deleting remaining references should lead to garbage collection
+    del ds2
+
+    with swallow_logs(new_level=1) as cml:
+        del ds3
+        gc.collect()
+        # flyweight vanished:
+        assert_not_in(path1, Dataset._unique_instances.keys())
+        # no such instance known to gc anymore:
+        eq_([], [o for o in gc.get_objects()
+                 if isinstance(o, Dataset) and o.path == path1])
+        # underlying repo should only be cleaned up, if ds3 was the last
+        # reference to it. Otherwise the repo instance should live on
+        # (via symlinked ds4):
+        finalizer_log = "Finalizer called on: AnnexRepo(%s)" % path1
+        if on_windows:
+            cml.assert_logged(msg=finalizer_log,
+                              level="Level 1",
+                              regex=False)
+        else:
+            assert_not_in(finalizer_log, cml.out)
+            # symlinked is still there:
+            ok_(ds4 is not None)
+            eq_(ds4_id, id(ds4))
 
 
 @with_tempfile

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -68,8 +68,6 @@ def test_ignored(topdir):
     assert_equal(ignored(opj(topdir, "annexdir"), only_hidden=True), False)
 
 
-# https://github.com/datalad/datalad/pull/4808#issuecomment-674381095
-@known_failure_windows
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '124', 'file2.txt': '123'},

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -325,8 +325,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         # Note, that we can pass required attributes to the finalizer, but not
         # `self` itself. This would create an additional reference to the object
         # and thereby preventing it from being collected at all.
-        self._finalizer = finalize(self, AnnexRepo._cleanup, self._batched,
-                                   self.path)
+        self._finalizer = finalize(self, AnnexRepo._cleanup, self.path,
+                                   self._batched)
 
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
@@ -380,7 +380,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             self.config.set('annex.backends', backend, where='local')
 
     @classmethod
-    def _cleanup(cls, batched, path):
+    def _cleanup(cls, path, batched):
 
         lgr.log(1, "Finalizer called on: AnnexRepo(%s)", path)
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -32,7 +32,10 @@ from os.path import (
     normpath
 )
 from multiprocessing import cpu_count
-from weakref import WeakValueDictionary
+from weakref import (
+    finalize,
+    WeakValueDictionary
+)
 
 from datalad import ssh_manager
 from datalad.consts import WEB_SPECIAL_REMOTE_UUID
@@ -316,6 +319,14 @@ class AnnexRepo(GitRepo, RepoInterface):
         # will be evaluated lazily
         self._n_auto_jobs = None
 
+        # Finally, register a finalizer (instead of having a __del__ method).
+        # This will be called by garbage collection as well as "atexit". By
+        # keeping the reference here, we can also call it explicitly.
+        # Note, that we can pass required attributes to the finalizer, but not
+        # `self` itself. This would create an additional reference to the object
+        # and thereby preventing it from being collected at all.
+        self._finalizer = finalize(self, AnnexRepo._cleanup, self._batched)
+
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
 
@@ -367,7 +378,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             lgr.debug("Setting annex backend to %s (in .git/config)", backend)
             self.config.set('annex.backends', backend, where='local')
 
-    def __del__(self):
+    @classmethod
+    def _cleanup(cls, batched):
+
+        # Ben: With switching to finalize rather than del, I think the
+        #      safe_del_debug isn't needed anymore. However, time will tell and
+        #      it doesn't hurt.
 
         def safe__del__debug(e):
             """We might be too late in the game and either .debug or exc_str
@@ -378,8 +394,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 return
 
         try:
-            if hasattr(self, '_batched') and self._batched is not None:
-                self._batched.close()
+            if batched is not None:
+                batched.close()
         except TypeError as e:
             # Workaround:
             # most likely something wasn't accessible anymore; doesn't really
@@ -389,11 +405,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             # thing to happen, since we check for things being None herein as
             # well as in super class __del__;
             # At least log it:
-            safe__del__debug(e)
-        try:
-            super(AnnexRepo, self).__del__()
-        except TypeError as e:
-            # see above
             safe__del__debug(e)
 
     def _set_shared_connection(self, remote_name, url):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -325,7 +325,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         # Note, that we can pass required attributes to the finalizer, but not
         # `self` itself. This would create an additional reference to the object
         # and thereby preventing it from being collected at all.
-        self._finalizer = finalize(self, AnnexRepo._cleanup, self._batched)
+        self._finalizer = finalize(self, AnnexRepo._cleanup, self._batched,
+                                   self.path)
 
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
@@ -379,7 +380,9 @@ class AnnexRepo(GitRepo, RepoInterface):
             self.config.set('annex.backends', backend, where='local')
 
     @classmethod
-    def _cleanup(cls, batched):
+    def _cleanup(cls, batched, path):
+
+        lgr.log(1, "Finalizer called on: AnnexRepo(%s)", path)
 
         # Ben: With switching to finalize rather than del, I think the
         #      safe_del_debug isn't needed anymore. However, time will tell and

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -36,7 +36,10 @@ from os.path import (
 
 import posixpath
 from functools import wraps
-from weakref import WeakValueDictionary
+from weakref import (
+    finalize,
+    WeakValueDictionary
+)
 
 from datalad.log import log_progress
 from datalad.support.due import due, Doi
@@ -957,6 +960,15 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # Set by fake_dates_enabled to cache config value across this instance.
         self._fake_dates_enabled = None
 
+        # Finally, register a finalizer (instead of having a __del__ method).
+        # This will be called by garbage collection as well as "atexit". By
+        # keeping the reference here, we can also call it explicitly.
+        # Note, that we can pass required attributes to the finalizer, but not
+        # `self` itself. This would create an additional reference to the object
+        # and thereby preventing it from being collected at all.
+        self._finalizer = finalize(self, GitRepo._cleanup, self.path)
+
+
     def _create_empty_repo(self, path, sanity_checks=True, **kwargs):
         if not op.lexists(path):
             os.makedirs(path)
@@ -1121,10 +1133,25 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 lgr.warning("Experienced issues while cloning: %s", exc_str(fix_annex))
         return gr
 
-    def __del__(self):
-        # unbind possibly bound ConfigManager, to prevent all kinds of weird
-        # stalls etc
-        self._cfg = None
+    # Note: __del__ shouldn't be needed anymore as we switched to
+    #       `weakref.finalize`.
+    #       https://docs.python.org/3/library/weakref.html#comparing-finalizers-with-del-methods
+    #
+    #       Keeping both methods and this comment around as a reminder to not
+    #       use __del__, if we figure there's a need for cleanup in the future.
+    #
+    # def __del__(self):
+    #     # unbind possibly bound ConfigManager, to prevent all kinds of weird
+    #     # stalls etc
+    #     self._cfg = None
+
+    @classmethod
+    def _cleanup(cls, path):
+        # Ben: I think in case of GitRepo there's nothing to do ATM. Statements
+        #      like the one in the out commented __del__ above, don't make sense
+        #      with python's GC, IMO, except for manually resolving cyclic
+        #      references (not the case w/ ConfigManager ATM).
+        lgr.log(1, "Finalizer called on: GitRepo(%s)", path)
 
     def __eq__(self, obj):
         """Decides whether or not two instances of this class are equal.

--- a/datalad/support/repo.py
+++ b/datalad/support/repo.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import weakref
 
 from .exceptions import InvalidInstanceRequestError
 from . import path as op
@@ -115,6 +116,8 @@ class Flyweight(type):
     #       False.
     #     """
     #     return False
+
+    # TODO: document the suggestion to implement a finalizer!
 
     def _flyweight_reject(cls, id, *args, **kwargs):
         """decides whether to reject a request for an instance

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1689,6 +1689,31 @@ def test_AnnexRepo_flyweight(path1, path2):
     assert_is_instance(repo4, GitRepo)
     assert_not_is_instance(repo4, AnnexRepo)
 
+    orig_id = id(repo1)
+
+    # deleting one reference doesn't change anything - we still get the same
+    # thing:
+    del repo1
+    #gc.collect()
+    ok_(repo2 is not None)
+    ok_(repo2 is repo3)
+    ok_(repo2 == repo3)
+
+    repo1 = AnnexRepo(path1)
+    eq_(orig_id, id(repo1))
+
+    # killing all references should result in the instance being gc'd and
+    # re-request yields a new object:
+    del repo1
+    del repo2
+    del repo3
+    # Ben: Note, that gc.collect should only be necessary, if we manage to create
+    # cyclic references. Pure refcount collection is supposed to happen
+    # instantly, if I got that right.
+    #gc.collect()
+
+    repo1 = AnnexRepo(path1)
+    assert_not_equal(orig_id, id(repo1))
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:417
 @known_failure_windows

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1691,10 +1691,19 @@ def test_AnnexRepo_flyweight(path1, path2):
 
     orig_id = id(repo1)
 
+    # Be sure we have exactly one object in memory:
+    assert_equal(1, len([o for o in gc.get_objects()
+                         if isinstance(o, AnnexRepo) and o.path == path1]))
+
+
+    # But we have two GitRepos in memory (the AnnexRepo and repo4):
+    assert_equal(2, len([o for o in gc.get_objects()
+                         if isinstance(o, GitRepo) and o.path == path1]))
+
     # deleting one reference doesn't change anything - we still get the same
     # thing:
     del repo1
-    # gc.collect()
+    gc.collect()  # shouldn't do anything
     ok_(repo2 is not None)
     ok_(repo2 is repo3)
     ok_(repo2 == repo3)
@@ -1702,24 +1711,10 @@ def test_AnnexRepo_flyweight(path1, path2):
     repo1 = AnnexRepo(path1)
     eq_(orig_id, id(repo1))
 
-    # killing all references should result in the instance being gc'd and
-    # re-request yields a new object:
     del repo1
     del repo2
-    del repo3
-    # Ben: Note, that gc.collect should only be necessary, if we manage to create
-    # cyclic references. Pure refcount collection is supposed to happen
-    # instantly, if I got that right.
-    # gc.collect()
 
-    # give garbage collection some time
-    from time import sleep
-    sleep(0.1)
-
-    repo1 = AnnexRepo(path1)
-    assert_not_equal(orig_id, id(repo1))
-
-    # destroying the object calls close() on BatchedAnnex
+    # for testing that destroying the object calls close() on BatchedAnnex:
     class Dummy:
         def __init__(self, *args, **kwargs):
             self.close_called = False
@@ -1728,12 +1723,38 @@ def test_AnnexRepo_flyweight(path1, path2):
             self.close_called = True
 
     fake_batch = Dummy()
-    with patch.object(repo1._batched, 'close', fake_batch.close):
-        del repo1
-        # gc.collect()  # same as above: shouldn't be necessary
-    # deleting last strong reference lets it vanish from WeakValueDict, too:
+
+    # Killing last reference will lead to garbage collection which will call
+    # AnnexRepo's finalizer:
+    with patch.object(repo3._batched, 'close', fake_batch.close):
+        with swallow_logs(new_level=1) as cml:
+            del repo3
+            # Note, that we currently seem to require gc.collect! First instantiation
+            # creates 6 references according to sys.getrefcount (returns 7). Not
+            # entirely clear to me why (gc.get_referrers points out several function
+            # frames), but that means that refcount isn't down to zero after last del
+            # and therefore gc.collect() is needed.
+            gc.collect()
+            cml.assert_logged(msg="Finalizer called on: AnnexRepo(%s)" % path1,
+                              level="Level 1",
+                              regex=False)
+            # finalizer called close() on BatchedAnnex:
+            assert_true(fake_batch.close_called)
+
+    # Flyweight is gone:
     assert_not_in(path1, AnnexRepo._unique_instances.keys())
-    assert_true(fake_batch.close_called)
+
+    # gc doesn't know any instance anymore:
+    assert_equal([], [o for o in gc.get_objects()
+                      if isinstance(o, AnnexRepo) and o.path == path1])
+    # GitRepo is unaffected:
+    assert_equal(1, len([o for o in gc.get_objects()
+                         if isinstance(o, GitRepo) and o.path == path1]))
+
+    # new object is created on re-request:
+    repo1 = AnnexRepo(path1)
+    assert_equal(1, len([o for o in gc.get_objects()
+                         if isinstance(o, AnnexRepo) and o.path == path1]))
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:417

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1186,15 +1186,11 @@ def test_GitRepo_flyweight(path1, path2):
 
     orig_id = id(repo1)
 
-    import gc
+    # import gc
     # deleting one reference doesn't change anything - we still get the same
     # thing:
     del repo1
-
-    # Ben: Note, that ATM gc.collect() seems necessary here, which makes little
-    #      sense, since the refcount based collection should be instant and `gc`
-    #      be only required for cyclic references.
-    gc.collect()
+    # gc.collect()
     ok_(repo2 is not None)
     ok_(repo2 is repo3)
     ok_(repo2 == repo3)
@@ -1207,7 +1203,11 @@ def test_GitRepo_flyweight(path1, path2):
     del repo1
     del repo2
     del repo3
-    gc.collect()
+    # gc.collect()
+
+    # give garbage collection some time
+    from time import sleep
+    sleep(0.1)
 
     repo1 = GitRepo(path1)
     assert_not_equal(orig_id, id(repo1))


### PR DESCRIPTION
Closes #4827

Opposed to what was suggested in the issue, what we need is not a helper, but have our clean up of *Repo instances (in particular `AnnexRepo` and its potential `BatchedAnnexes`) be more reliable.

- Switch from `__del__` methods to `weakref.finalize`-registered callbacks for Flyweight classes, which should be called more reliably than `__del__`. 
- Improve testing of those objects behavior regarding (re-)creation and deletion and proof they are properly destroyed once `gc` picks them up.


Note, that there's a failure on crippledFS (config-related) that is unrelated and happens in master, too!

