### PR TITLE
TST: Re-enable win test for issue replication

### DIFF
--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -47,6 +47,7 @@ from datalad.tests.utils import (
     assert_is_not,
     assert_is_not_none,
     assert_not_equal,
+    assert_not_in,
     assert_raises,
     assert_repo_status,
     assert_result_count,
@@ -56,6 +57,7 @@ from datalad.tests.utils import (
     OBSCURE_FILENAME,
     ok_,
     SkipTest,
+    swallow_logs,
     with_tempfile,
     with_testrepos,
 )
@@ -296,6 +298,9 @@ def test_require_dataset():
 
 @with_tempfile(mkdir=True)
 def test_dataset_id(path):
+
+    import gc
+
     ds = Dataset(path)
     assert_equal(ds.id, None)
     ds.create()
@@ -303,50 +308,41 @@ def test_dataset_id(path):
     # ID is always a UUID
     assert_equal(ds.id.count('-'), 4)
     assert_equal(len(ds.id), 36)
+
+    # Ben: The following part of the test is concerned with creating new objects
+    #      and therefore used to reset the flyweight dict while keeping a ref to
+    #      the old object for comparison etc. This is ugly and in parts
+    #      retesting what is already tested in `test_Dataset_flyweight`. No need
+    #      for that. If we del the last ref to an instance and gc.collect(),
+    #      then we get a new instance on next request. This test should trust
+    #      the result of `test_Dataset_flyweight`.
+
     # creating a new object for the same path
     # yields the same ID
-
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
+    del ds
+    gc.collect()
     newds = Dataset(path)
-    assert_false(ds is newds)
-    assert_equal(ds.id, newds.id)
+    assert_equal(dsorigid, newds.id)
+
     # recreating the dataset does NOT change the id
-    #
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
+    del newds
+    gc.collect()
+
+    ds = Dataset(path)
     ds.create(annex=False, force=True)
     assert_equal(ds.id, dsorigid)
+
     # even adding an annex doesn't
-    #
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
-    AnnexRepo._unique_instances.clear()
+    del ds
+    gc.collect()
+    ds = Dataset(path)
     ds.create(force=True)
     assert_equal(ds.id, dsorigid)
+
     # dataset ID and annex UUID have nothing to do with each other
     # if an ID was already generated
     assert_true(ds.repo.uuid != ds.id)
-    # creating a new object for the same dataset with an ID on record
-    # yields the same ID
-    #
-    # Note: Since we switched to singletons, a reset is required in order to
-    # make sure we get a new object
-    # TODO: Reconsider the actual intent of this assertion. Clearing the flyweight
-    # dict isn't a nice approach. May be create needs a fix/RF?
-    Dataset._unique_instances.clear()
-    newds = Dataset(path)
-    assert_false(ds is newds)
-    assert_equal(ds.id, newds.id)
+
     # even if we generate a dataset from scratch with an annex UUID right away,
     # this is also not the ID
     annexds = Dataset(opj(path, 'scratch')).create()
@@ -356,6 +352,8 @@ def test_dataset_id(path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_Dataset_flyweight(path1, path2):
+
+    import gc
 
     ds1 = Dataset(path1)
     assert_is_instance(ds1, Dataset)
@@ -371,14 +369,55 @@ def test_Dataset_flyweight(path1, path2):
         ok_(ds1 == ds3)
         ok_(ds1 is ds3)
 
-    # on windows as symlink is not what you think it is
+    # gc knows one such object only:
+    eq_(1, len([o for o in gc.get_objects()
+                if isinstance(o, Dataset) and o.path == path1]))
+
+
+    # on windows a symlink is not what you think it is
     if not on_windows:
         # reference the same via symlink:
         with chpwd(path2):
             os.symlink(path1, 'linked')
-            ds3 = Dataset('linked')
-            ok_(ds3 == ds1)
-            ok_(ds3 is not ds1)
+            ds4 = Dataset('linked')
+            ds4_id = id(ds4)
+            ok_(ds4 == ds1)
+            ok_(ds4 is not ds1)
+
+        # underlying repo, however, IS the same:
+        ok_(ds4.repo is ds1.repo)
+
+    # deleting one reference has no effect on the other:
+    del ds1
+    ok_(ds2 is not None)
+    ok_(ds2.repo is ds3.repo)
+    if not on_windows:
+        ok_(ds2.repo is ds4.repo)
+
+    # deleting remaining references should lead to garbage collection
+    del ds2
+
+    with swallow_logs(new_level=1) as cml:
+        del ds3
+        gc.collect()
+        # flyweight vanished:
+        assert_not_in(path1, Dataset._unique_instances.keys())
+        # no such instance known to gc anymore:
+        eq_([], [o for o in gc.get_objects()
+                 if isinstance(o, Dataset) and o.path == path1])
+        # underlying repo should only be cleaned up, if ds3 was the last
+        # reference to it. Otherwise the repo instance should live on
+        # (via symlinked ds4):
+        finalizer_log = "Finalizer called on: AnnexRepo(%s)" % path1
+        if on_windows:
+            cml.assert_logged(msg=finalizer_log,
+                              level="Level 1",
+                              regex=False)
+        else:
+            assert_not_in(finalizer_log, cml.out)
+            # symlinked is still there:
+            ok_(ds4 is not None)
+            eq_(ds4_id, id(ds4))
 
 
 @with_tempfile

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -69,7 +69,7 @@ def test_ignored(topdir):
 
 
 # https://github.com/datalad/datalad/pull/4808#issuecomment-674381095
-@known_failure_windows
+#@known_failure_windows
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '124', 'file2.txt': '123'},

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -32,7 +32,10 @@ from os.path import (
     normpath
 )
 from multiprocessing import cpu_count
-from weakref import WeakValueDictionary
+from weakref import (
+    finalize,
+    WeakValueDictionary
+)
 
 from datalad import ssh_manager
 from datalad.consts import WEB_SPECIAL_REMOTE_UUID
@@ -316,6 +319,15 @@ class AnnexRepo(GitRepo, RepoInterface):
         # will be evaluated lazily
         self._n_auto_jobs = None
 
+        # Finally, register a finalizer (instead of having a __del__ method).
+        # This will be called by garbage collection as well as "atexit". By
+        # keeping the reference here, we can also call it explicitly.
+        # Note, that we can pass required attributes to the finalizer, but not
+        # `self` itself. This would create an additional reference to the object
+        # and thereby preventing it from being collected at all.
+        self._finalizer = finalize(self, AnnexRepo._cleanup, self._batched,
+                                   self.path)
+
     def _allow_local_urls(self):
         """Allow URL schemes and addresses which potentially could be harmful.
 
@@ -367,7 +379,14 @@ class AnnexRepo(GitRepo, RepoInterface):
             lgr.debug("Setting annex backend to %s (in .git/config)", backend)
             self.config.set('annex.backends', backend, where='local')
 
-    def __del__(self):
+    @classmethod
+    def _cleanup(cls, batched, path):
+
+        lgr.log(1, "Finalizer called on: AnnexRepo(%s)", path)
+
+        # Ben: With switching to finalize rather than del, I think the
+        #      safe_del_debug isn't needed anymore. However, time will tell and
+        #      it doesn't hurt.
 
         def safe__del__debug(e):
             """We might be too late in the game and either .debug or exc_str
@@ -378,8 +397,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 return
 
         try:
-            if hasattr(self, '_batched') and self._batched is not None:
-                self._batched.close()
+            if batched is not None:
+                batched.close()
         except TypeError as e:
             # Workaround:
             # most likely something wasn't accessible anymore; doesn't really
@@ -389,11 +408,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             # thing to happen, since we check for things being None herein as
             # well as in super class __del__;
             # At least log it:
-            safe__del__debug(e)
-        try:
-            super(AnnexRepo, self).__del__()
-        except TypeError as e:
-            # see above
             safe__del__debug(e)
 
     def _set_shared_connection(self, remote_name, url):

--- a/datalad/support/repo.py
+++ b/datalad/support/repo.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import weakref
 
 from .exceptions import InvalidInstanceRequestError
 from . import path as op
@@ -115,6 +116,8 @@ class Flyweight(type):
     #       False.
     #     """
     #     return False
+
+    # TODO: document the suggestion to implement a finalizer!
 
     def _flyweight_reject(cls, id, *args, **kwargs):
         """decides whether to reject a request for an instance

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -541,6 +541,8 @@ def ok_file_has_content(path, content, strip=False, re_=False,
 @optional_args
 def with_tree(t, tree=None, archives_leading_dir=True, delete=True, **tkwargs):
 
+    import gc
+
     @wraps(t)
     def newfunc(*arg, **kw):
         if 'dir' not in tkwargs.keys():
@@ -553,6 +555,7 @@ def with_tree(t, tree=None, archives_leading_dir=True, delete=True, **tkwargs):
         try:
             return t(*(arg + (d,)), **kw)
         finally:
+            gc.collect()
             if delete:
                 rmtemp(d)
     return newfunc


### PR DESCRIPTION
Trying to reproduce the windows issue in https://github.com/datalad/datalad/pull/4808#issuecomment-674381095 and see whether the switch to finalizers in PR #4838 does anything about it (calling `BatchedAnnex.close()` correctly).

No intention to merge. Will abort other CI runs.
