### PR TITLE
ENH: add exception_traceback ("unlimited") to the status dict if exception is passed into get_status_dict

### DIFF
--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -314,7 +314,7 @@ def borrowkwargs(cls=None, methodname=None, exclude=None):
 
 
 # TODO: make limit respect config/environment parameter
-def exc_str(exc=None, limit=None):
+def exc_str(exc=None, limit=None, include_str=True):
     """Enhanced str for exceptions.  Should include original location
 
     Parameters
@@ -326,6 +326,10 @@ def exc_str(exc=None, limit=None):
       Number of levels in the traceback stack from the point where exception
       was raised to include. If `None`, environment variable
       DATALAD_EXC_STR_TBLIMIT is consulted.
+    include_str: bool, optional
+      Either include str (or `repr` if empty `str`) into representation.
+      If False, just ends up reporting traceback without string representation
+      of exception pre-pended.
 
     Returns
     -------
@@ -333,7 +337,7 @@ def exc_str(exc=None, limit=None):
       String representation of the exception with traceback information
       appended.
     """
-    out = str(exc)
+    out = str(exc) if include_str else ""
     if limit is None:
         # TODO: config logging.exceptions.traceback_levels = 1
         limit = int(os.environ.get('DATALAD_EXC_STR_TBLIMIT', '1'))
@@ -341,8 +345,9 @@ def exc_str(exc=None, limit=None):
         exctype, value, tb = sys.exc_info()
         if not exc:
             exc = value
-            out = str(exc)
-        if not out:
+            if include_str:
+                out = str(exc)
+        if include_str and not out:
             out = repr(exc)
         # verify that it seems to be the exception we were passed
         #assert(isinstance(exc, exctype))
@@ -350,12 +355,16 @@ def exc_str(exc=None, limit=None):
             assert(exc is value)
         entries = traceback.extract_tb(tb)
         if entries:
-            out += " [%s]" % (
+            tb_str = "[%s]" % (
                 ','.join(
                     '%s:%s:%d' % (os.path.basename(x[0]), x[2], x[1])
                     for x in entries[-limit:]
                 )
             )
+            if out:
+                out = "%s %s" % (out, tb_str)
+            else:
+                out = tb_str
     except:  # MIH: TypeError?
         return out  # To the best of our abilities
     finally:

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -182,6 +182,7 @@ class DownloadURL(Interface):
                     message=exc_str(e),
                     type="file",
                     path=path,
+                    exception=e,
                     **common_report)
             else:
                 downloaded_paths.append(downloaded_path)

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -14,15 +14,17 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-from os.path import isdir
-from os.path import isabs
-from os.path import join as opj
-from os.path import relpath
-from os.path import abspath
-from os.path import normpath
+from os.path import (
+    isabs,
+    isdir,
+    join as opj,
+    normpath,
+    relpath,
+)
+
+from datalad.dochelpers import exc_str
 from datalad.utils import (
     assure_list,
-    with_pathsep as _with_sep,
     path_is_subpath,
     PurePosixPath,
 )
@@ -44,7 +46,8 @@ success_status_map = {
 
 
 def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
-                    refds=None, status=None, message=None, **kwargs):
+                    refds=None, status=None, message=None, exception=None,
+                    **kwargs):
     # `type` is intentionally not `type_` or something else, as a mismatch
     # with the dict key 'type' causes too much pain all over the place
     # just for not shadowing the builtin `type` in this function
@@ -85,13 +88,15 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
         d['status'] = status
     if message is not None:
         d['message'] = message
+    if exception is not None:
+        d['exception_traceback'] = exc_str(exception, limit=1000, include_str=False)
     if kwargs:
         d.update(kwargs)
     return d
 
 
 def results_from_paths(paths, action=None, type=None, logger=None, refds=None,
-                       status=None, message=None):
+                       status=None, message=None, exception=None):
     """
     Helper to yield analog result dicts for each path in a sequence.
 
@@ -109,7 +114,9 @@ def results_from_paths(paths, action=None, type=None, logger=None, refds=None,
     for p in assure_list(paths):
         yield get_status_dict(
             action, path=p, type=type, logger=logger, refds=refds,
-            status=status, message=(message, p) if '%s' in message else message)
+            status=status, message=(message, p) if '%s' in message else message,
+            exception=exception
+        )
 
 
 def is_ok_dataset(r):

--- a/datalad/tests/test_dochelpers.py
+++ b/datalad/tests/test_dochelpers.py
@@ -144,12 +144,15 @@ def test_borrow_kwargs():
     assert_true('B.met_nodockwargs' in B.met_nodockwargs.__doc__)
     assert_true('boguse' in B.met_excludes.__doc__)
 
+
 def test_exc_str():
     try:
         raise Exception("my bad")
     except Exception as e:
         estr = exc_str(e)
+        estr_tb_only = exc_str(e, include_str=False)
     assert_re_in("my bad \[test_dochelpers.py:test_exc_str:...\]", estr)
+    assert_re_in("^\[.*\]", estr_tb_only)  # only traceback
 
     def f():
         def f2():


### PR DESCRIPTION
And for demonstration of utility - added to a single sample invocation within download_url.
One of the main use cases is to be able to troubleshoot failed travis runs, where
at most we see only the last location in the traceback due to exc_str being used.
Like

    'message': "'ConsoleLog' object has no attribute 'yesno' "
             '[__init__.py:__getattribute__:101]',

Due to all the generators for results status messages processing etc, there is no
idea about original stack which lead to the failure :

      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
        self.test(*self.arg)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/tests/utils.py", line 271, in _wrap_skip_ssh
        return func(*args, **kwargs)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/tests/utils.py", line 731, in _wrap_with_tempfile
        return t(*(arg + (filename,)), **kw)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/tests/utils.py", line 731, in _wrap_with_tempfile
        return t(*(arg + (filename,)), **kw)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/distributed/tests/test_ria_basics.py", line 468, in _test_binary_data
        ds.download_url(url, path=file, message="Add DICOM file from github")
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/distribution/dataset.py", line 503, in apply_func
        return f(**kwargs)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/interface/utils.py", line 494, in eval_func
        return return_func(generator_func)(*args, **kwargs)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/interface/utils.py", line 482, in return_func
        results = list(results)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/datalad/interface/utils.py", line 469, in generator_func
        msg="Command did not complete successfully")
    datalad.support.exceptions.IncompleteResultsError: Command did not complete successfully. 1 failed:
    [{'action': 'download_url',
      'message': "'ConsoleLog' object has no attribute 'yesno' "
                 '[__init__.py:__getattribute__:101]',
      'path': '/tmp/datalad_temp__test_binary_datajhq0ejj_/dicomfile',
      'status': 'error',
      'type': 'file'}]

If we add that exception_traceback into the record, it would not be
displayed to the user in their invocation, e.g:

    $> datalad download-url s3://NDAR_Central_4/submission_XXX/dataset_description.json
    [INFO   ] Downloading 's3://NDAR_Central_4/submission_XXX/dataset_description.json' into '/tmp/'
    INFO:datalad.ui.dialog:Clear progress bars
    download_url(error): /tmp/ (file) [__init__() missing 4 required positional arguments: 'access_key', 'secret_key', 'session', and 'expiration' [nda_aws_token_generator.py:__parse_response:95]]
    INFO:datalad.ui.dialog:Refresh progress bars

but would be visible in cases where we dump entire record (tests?) or
explicitly requested:

    $> datalad -f json_pp download-url s3://NDAR_Central_4/submission_XXX/dataset_description.json
    [INFO   ] Downloading 's3://NDAR_Central_4/submission_XXX/dataset_description.json' into '/tmp/'
    INFO:datalad.ui.dialog:Clear progress bars
    {
      "action": "download_url",
      "exception_traceback": "[download_url.py:__call__:178,providers.py:download:478,base.py:download:503,base.py:access:159,s3.py:_establish_session:210,s3.py:authenticate:92,credentials.py:__call__:287,credentials.py:_nda_adapter:296,nda_aws_token_generator.py:generate_token:34,nda_aws_token_generator.py:__make_request:82,nda_aws_token_generator.py:__parse_response:95]",
      "path": "/tmp/",
      "status": "error",
      "type": "file"
    }
    INFO:datalad.ui.dialog:Refresh progress bars

thus making it easier to troubleshoot.

TODOs:
- [x] see if there is a better name (than `exception_traceback`)  -- nope, it seems to be perfect
- Add passing exception in other relevant spots -- later