### PR TITLE
MNT: Drop compatibility kludge for collections.abc imports

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -19,11 +19,7 @@ import os.path as op
 from collections import (
     OrderedDict,
 )
-
-try:
-    from collections.abc import Mapping
-except ImportError:  # Python <= 3.3
-    from collections import Mapping
+from collections.abc import Mapping
 
 from datalad import cfg
 from datalad.interface.annotate_paths import AnnotatePaths

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -9,11 +9,7 @@
 """Create and update a dataset from a list of URLs.
 """
 
-try:
-    from collections.abc import Mapping
-except ImportError:  # Python <= 3.3
-    from collections import Mapping
-
+from collections.abc import Mapping
 from functools import partial
 import logging
 import os

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -8,15 +8,11 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import collections
+from collections.abc import Callable
 import hashlib
 import re
 import builtins
 import time
-
-try:
-    from collections.abc import Callable
-except ImportError:  # Python <= 3.3
-    from collections import Callable
 
 import logging
 import shutil


### PR DESCRIPTION
Our minimal Python version is 3.5.