### PR TITLE
BF: Safe guard rmtree

### DIFF
--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -69,7 +69,7 @@ def test_ignored(topdir):
 
 
 # https://github.com/datalad/datalad/pull/4808#issuecomment-674381095
-@known_failure_windows
+#@known_failure_windows
 @with_tree(
     tree={'dir': {'.fgit': {'ab.txt': '123'},
                   'subdir': {'file1.txt': '124', 'file2.txt': '123'},

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -445,10 +445,13 @@ def rmtree(path, chmod_files='auto', children_only=False, *args, **kwargs):
     # Give W permissions back only to directories, no need to bother with files
     if chmod_files == 'auto':
         chmod_files = on_windows
-    # TODO:  yoh thinks that if we could quickly check our Flyweight for
-    #        repos if any of them is under the path, and could call .precommit
-    #        on those to possibly stop batched processes etc, we did not have
-    #        to do it on case by case
+
+    # Make sure *Repo instances that used to point to `path` are
+    # actually destructed before trying to delete anything. This is particularly
+    # important regarding git-annex batch processes that might not have been
+    # closed yet otherwise.
+    gc.collect()
+
     # Check for open files
     assert_no_open_files(path)
 
@@ -468,6 +471,13 @@ def rmtree(path, chmod_files='auto', children_only=False, *args, **kwargs):
 
 def rmdir(path, *args, **kwargs):
     """os.rmdir with our optional checking for open files"""
+
+    # Make sure *Repo instances that used to point to `path` are
+    # actually destructed before trying to delete anything. This is particularly
+    # important regarding git-annex batch processes that might not have been
+    # closed yet otherwise.
+    gc.collect()
+
     assert_no_open_files(path)
     os.rmdir(path)
 


### PR DESCRIPTION
In issues like this: https://github.com/datalad/datalad/pull/4808#issuecomment-674381095
we encountered failures to tear-down tests due to hanging batch processes several times. AFAICT this is because garbage collection isn't that fast. Those processes are tied to an `AnnexRepo` instance, which isn't immediately destroyed if we leave the context of the last reference (like in a test decorator running the actual test within `try ... finally`). Therefore those processes aren't closed yet. Originally fixed the issue by adding `gc.collect()` into such `finally`-clause in PR #4842.
Looking for other spots that are likely to create a similar issue, I decided to go one level down and integrate that call into `rmtree`/`rmdir` helpers.

Re-enabled the windows test from above mentioned issue as proof.

Disclaimer: Some situations may require #4838 in addition for this change to take full effect.