### PR TITLE
RF: Bypass `git-submodule update --init` when getting subdatasets

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -47,6 +47,7 @@ from datalad.support.gitrepo import (
     _fixup_submodule_dotgit_setup,
 )
 from datalad.support.exceptions import (
+    CommandError,
     InsufficientArgumentsError,
 )
 from datalad.support.network import (
@@ -326,7 +327,10 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
             # expensive and possibly error-prone fetch conditional on cheap
             # local check
             if not sub.commit_exists(target_commit):
-                sub.fetch(remote='origin', refspec=target_commit)
+                try:
+                    sub.fetch(remote='origin', refspec=target_commit)
+                except CommandError:
+                    pass
                 # instead of inspecting the fetch results for possible ways
                 # with which it could failed to produced the desired result
                 # let's verify the presence of the commit directly, we are in

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -348,7 +348,7 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
                     # MIH thinks that removing the clone is not needed, as a likely
                     # next step will have to be a manual recovery intervention
                     # and not another blind attempt
-                    break
+                    continue
             # checkout the desired commit
             sub.call_git(['checkout', target_commit])
             # did we detach?

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -309,16 +309,61 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
                 res.get('path', None) == dest_path:
             _fixup_submodule_dotgit_setup(ds, sm_path)
 
+            target_commit = sm['gitshasum']
             lgr.debug("Update cloned subdataset {0} in parent".format(dest_path))
             section_name = 'submodule.{}'.format(sm['gitmodule_name'])
             # do not use `git-submodule update --init`, it would make calls
             # to git-config which will not obey datalad inter-process locks for
             # modifying .git/config
             sub = GitRepo(res['path'])
-            # TODO we could simulatanously check out a configured branch
-            # and setup a tracking branch. This should be fine, as the implied
-            # config manipulation is local to the subdataset.
-            sub.call_git(['reset', '--hard', sm['gitshasum']])
+            # record what branch we were on right after the clone
+            # TODO instead of the active branch, this should first consider
+            # a configured branch in the submodule record of the superdataset
+            sub_orig_branch = sub.get_active_branch()
+            # if we are on a branch this hexsha will be the tip of that branch
+            sub_orig_hexsha = sub.get_hexsha()
+            # make sure we have the desired commit locally
+            sub.fetch(remote='origin', refspec=target_commit)
+            # checkout the desired commit
+            sub.call_git(['checkout', target_commit])
+            # did we detach?
+            # XXX: This is a less generic variant of a part of
+            # GitRepo.update_submodule(). It makes use of already available
+            # information and trusts the existence of the just cloned repo
+            # and avoids (redoing) some safety checks
+            if sub_orig_branch and not sub.get_active_branch():
+                # trace if current state is a predecessor of the branch_hexsha
+                lgr.debug(
+                    "Detached HEAD after updating submodule %s "
+                    "(original branch: %s)", sub, sub_orig_branch)
+                if sub.get_merge_base(
+                        [sub_orig_hexsha, target_commit]) == target_commit:
+                    # TODO: config option?
+                    # MIH: There is no real need here. IMHO this should all not
+                    # happen, unless the submodule record has a branch
+                    # configured. And Datalad should leave such a record, when
+                    # a submodule is registered.
+
+                    # we assume the target_commit to be from the same branch,
+                    # because it is an ancestor -- update that original branch
+                    # to point to the target_commit, and update HEAD to point to
+                    # that location -- this readies the subdataset for
+                    # further modification
+                    lgr.info(
+                        "Reset subdataset branch '%s' to %s (from %s) to "
+                        "avoid a detached HEAD",
+                        sub_orig_branch, target_commit[:8], sub_orig_hexsha[:8])
+                    branch_ref = 'refs/heads/%s' % sub_orig_branch
+                    sub.update_ref(branch_ref, target_commit)
+                    sub.update_ref('HEAD', branch_ref, symbolic=True)
+                else:
+                    lgr.warning(
+                        "%s has a detached HEAD, because the recorded "
+                        "subdataset state %s has no unique ancestor with "
+                        "branch '%s'",
+                        sub, target_commit[:8], sub_orig_branch)
+
+            # register the submodule as "active" in the superdataset
             ds.config.set(
                 '{}.active'.format(section_name),
                 'true',


### PR DESCRIPTION
Doing it with config settings has two advantages.

- benefits from interprocess locking of datalad ConfigManager, such that
  we can "get" in parallel without running into locking issues.
  (`datalad -f '{path}' subdatasets | xargs -n 1 -P10 datalad get -n`)

- we can set the real source URL of the successful clone, whereas
  `GitRepo.update_submodule()` is what cause a guess to be made.

  For example, cloning a superdataset from

  git@github.com:datalad-datasets/human-connectome-project-openaccess.git

  would lead to invalid submodule URLs like:

  git@github.com:datalad-datasets/human-connectome-project-openaccess.git/HCP1200/100307

  whereas the actual clone came from

  http://store.datalad.org/8fd/bc694-2c2b-11ea-b467-0025904abcb0

This change has a high potential for missed corner-cases. It would be good to get this into master a long time before a planned release.

For example, we are resetting the existing master branch to the recorded commit. Before, we might have had to fix a detached state that was created by `git-submodule update`. I think this is a net win, but maybe we are missing out on other standardizations.