### PR TITLE
NF: Minimalist snakemake wrapper

### DIFF
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -77,7 +77,9 @@ _group_misc = (
         ('datalad.interface.rerun', 'Rerun', 'rerun'),
         ('datalad.interface.run_procedure', 'RunProcedure', 'run-procedure'),
         ('datalad.distributed.export_archive_ora', 'ExportArchiveORA',
-         'export-archive-ora')
+         'export-archive-ora'),
+        ('datalad.local.snakemake', 'SnakeMake',
+         'snakemake'),
     ])
 
 _group_plumbing = (

--- a/datalad/local/snakemake.py
+++ b/datalad/local/snakemake.py
@@ -1,0 +1,112 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Snakemake wrapper"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+from argparse import (
+    REMAINDER,
+)
+
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.support.constraints import (
+    EnsureNone,
+)
+from datalad.support.param import Parameter
+from datalad.distribution.dataset import (
+    require_dataset,
+)
+from datalad.utils import (
+    ensure_list,
+)
+
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+)
+
+lgr = logging.getLogger('datalad.local.snakemake')
+
+
+@build_doc
+class SnakeMake(Interface):
+    """
+    """
+    _params_ = dict(
+        dataset=Parameter(
+            # not really needed on the cmdline, but for PY to resolve relative
+            # paths
+            args=("-d", "--dataset"),
+            doc="""""",
+            constraints=EnsureDataset() | EnsureNone()),
+        smargs=Parameter(
+            args=("smargs",),
+            metavar='SNAKEMAKE ARGUMENTS',
+            nargs=REMAINDER,
+            doc="""Start with '--' before any snakemake argument to ensure
+            such arguments are not processed by DataLad."""),
+    )
+
+    @staticmethod
+    @datasetmethod(name='snakemake')
+    @eval_results
+    def __call__(
+            smargs=None,
+            dataset=None):
+        sm_args = ensure_list(smargs)
+        # DataLad's argparse setup is too funky to understand
+        # it is safe to prepend '--' to the args that should
+        # actually reach snakemake (incl. --help and --version)
+        # otherwise there is a chance that DataLad is very smart and
+        # rejects stuff, even though we declare REMAINDER...
+        if sm_args and sm_args[0] == '--':
+            sm_args = sm_args[1:]
+        sm_argv = ['snakemake']
+        sm_argv.extend(sm_args)
+
+        # we need to inject a dataset handle into snakemake
+        ds = require_dataset(dataset, check_installed=True,
+                             purpose='snakemake data IO')
+
+        # import the patches for snakemake
+        from .snakemake_monkeypatch import DataLadSnakeMakeIOFile
+        from unittest.mock import patch
+        # inject a new file abstraction and patch that one with a
+        # dataset instance. This is within a context manager, so should
+        # be a safe approach, even when other snakemake commands are around.
+        # we also patch sys.argv, because snakemake ignores the argv argument
+        # of the entrypoint
+        with patch('snakemake.io._IOFile', DataLadSnakeMakeIOFile), \
+                patch('snakemake.io._IOFile._datalad_dataset', ds), \
+                patch('sys.argv', sm_argv):
+            # we go in the same way snakemake cmdline does
+            from pkg_resources import load_entry_point
+            sm = load_entry_point('snakemake', 'console_scripts', 'snakemake')
+            # snakemake produces no return value, but uses sys.exit extensively
+            try:
+                sm()
+            except SystemExit as e:
+                # we don't want snakemake to kill datalad (think persistent
+                # python session), so catch, report, return
+                if e.code:
+                    yield dict(
+                        action='snakemake',
+                        status='error',
+                        exitcode=e.code,
+                        message=('snakemake exited with code %i', e.code)
+                    )
+                    return
+        yield dict(
+            action='snakemake',
+            status='ok',
+        )

--- a/datalad/local/snakemake_monkeypatch.py
+++ b/datalad/local/snakemake_monkeypatch.py
@@ -1,0 +1,19 @@
+from snakemake.io import (
+    _IOFile as SnakeMakeIOFile,
+)
+
+
+class DataLadSnakeMakeIOFile(SnakeMakeIOFile):
+
+    __slots__ = SnakeMakeIOFile.__slots__ + ["_datalad_dataset"]
+
+    def inventory(self):
+        # the idea is: Whenever snakemake inspects a file for
+        # properties (exists, mtime, etc.) it should call this
+        # function first to harvest that information efficiently.
+        # we can hook into this, and make sure that the file
+        # that is to be inspected is actually present
+        self._datalad_dataset.get(
+            self.file,
+            on_failure='ignore')
+        return SnakeMakeIOFile.inventory(self)


### PR DESCRIPTION
It injects a `datalad-get` call in front of every file property
inspection by snakemake, and thereby should ensure that the files in a
dataset that are relevant for a workflow are actually around for a valid
inspection.

This approach does not deal with the use case where a file can be
downloaded, but is actually cheaper to recompute.

To play with it, do something along the lines of

edit by @yarikoptic: added `-e` to `echo`

```
datalad create snakeoil
cd snakeoil
echo -e "\n**/Snakefile annex.largefiles=nothing" >> .gitattributes
echo ".snakemake" > .gitignore
git annex addurl --file some.txt http://example.com
cat << EOT > Snakefile
rule length:   
    input:
        "some.txt"
    output:
        "length.txt"
    shell:
        "wc < {input} > {output}"
EOT
datalad save
```

and now run

```
datalad snakemake -- -j1 length.txt
# save by hand, could later be done inside
datalad save
```

so far so good. Snakemake would have done all that on its own. But:

```
# now drop everything (or do a fresh clone)
datalad drop --nocheck .
# and redownload/compute with snakemake
datalad snakemake -- -j1 length.txt
```
