### PR TITLE
OPT: addurls - no add per file, mock.patch once per dataset

### DIFF
--- a/benchmarks/plugins/addurls.py
+++ b/benchmarks/plugins/addurls.py
@@ -1,0 +1,63 @@
+# Import functions to be tested with _ suffix and name the suite after the
+# original function so we could easily benchmark it e.g. by
+#    asv run --python=same -b get_parent_paths
+# without need to discover what benchmark to use etc
+
+import os
+from pathlib import Path, PurePosixPath
+import datalad.api as dl
+
+from ..common import SuprocBenchmarks
+
+import tempfile
+from datalad.utils import get_tempfile_kwargs, rmtree
+
+from datalad import lgr
+
+
+class addurls1(SuprocBenchmarks):
+
+    # Try with excluding autometa and not
+    params = [None, '*']
+    param_names = ['exclude_metadata']
+
+
+    def setup(self, exclude_metadata):
+        self.nfiles = 20
+        self.temp = Path(
+            tempfile.mkdtemp(
+                **get_tempfile_kwargs({}, prefix='bm_addurls1')))
+
+        self.ds = dl.create(self.temp / "ds")
+        self.ds.config.set('annex.security.allowed-url-schemes', 'file', where='local')
+
+        # populate list.csv and files
+        srcpath = PurePosixPath(self.temp)
+
+        rows = ["url,filename,bogus1,bogus2"]
+        for i in range(self.nfiles):
+            (self.temp / str(i)).write_text(str(i))
+            rows.append(
+              "file://{}/{},{},pocus,focus"
+               .format(srcpath, i, i)
+            )
+
+        self.listfile = self.temp / "list.csv"
+        self.listfile.write_text(os.linesep.join(rows))
+
+    def teardown(self, exclude_metadata):
+        # would make no sense if doesn't work correctly
+        # IIRC we cannot provide custom additional depends so cannot import nose
+        # assert_repo_status(self.ds.path)
+        status = self.ds.status()
+        assert all(r['state'] == 'clean' for r in status)
+        assert len(status) >= self.nfiles
+        rmtree(self.temp)
+
+    def time_addurls(self, exclude_autometa):
+        lgr.warning("CSV: " + self.listfile.read_text())
+        ret = dl.addurls(
+            self.ds, str(self.listfile), '{url}', '{filename}',
+            exclude_autometa=exclude_autometa
+        )
+        assert not any(r['status'] == 'error' for r in ret)

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -9,10 +9,7 @@
 """Create and update a dataset from a list of URLs.
 """
 
-try:
-    from collections.abc import Mapping
-except ImportError:  # Python <= 3.3
-    from collections import Mapping
+from collections.abc import Mapping
 
 import itertools
 import logging

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -515,7 +515,7 @@ def add_urls(rows, ifexists=None, options=None):
     for row in rows:
         filename_abs = row["filename_abs"]
         ds, filename = row["ds"], row["ds_filename"]
-        lgr.debug("Adding metadata to %s in %s", filename, ds.path)
+        lgr.debug("Adding URLs to %s in %s", filename, ds.path)
 
         if os.path.exists(filename_abs) or os.path.islink(filename_abs):
             if ifexists == "skip":

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -925,7 +925,7 @@ url_format='{}'
 filename_format='{}'""".format(url_file, url_format, filename_format)
 
         if files_to_add:
-            meta_rows = [r for r in rows if r["filename_abs"] in files_to_add]
+            meta_rows = [r for r in rows if r["filename_abs"] in files_to_add and r["meta_args"]]
             for r in add_meta(meta_rows):
                 yield r
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -559,20 +559,6 @@ def add_meta(rows):
     for row in rows:
         ds, filename = row["ds"], row["ds_filename"]
         with patch.object(ds.repo, "always_commit", False):
-            res = ds.repo.add(filename)
-            res_status = 'notneeded' if not res \
-                else 'ok' if res.get('success', False) \
-                else 'error'
-
-            yield dict(
-                action='add',
-                # decorator dies with Path()
-                path=str(ds.pathobj / filename),
-                type='file',
-                status=res_status,
-                parentds=ds.path,
-            )
-
             lgr.debug("Adding metadata to %s in %s", filename, ds.path)
             for a in ds.repo.set_metadata_(filename, add=row["meta_args"]):
                 res = annexjson2result(a, ds, type="file", logger=lgr)


### PR DESCRIPTION
I have been running addurls with `-x '*'` to not bother with adding metadata for this datasets with a notable amount of files (will endup with 2M files across subdataset(s)).  In the "batch" it seems to be only 20k files, and actual adding urls completed quite fast.  Now I had been staring at slowly growing `Adding metadata (10240 skipped):...` so majority were skipped but not due to "no metadata" I think but because `.add` was not needed would be my guess (`with_result_progress` maps "notneeded" into "skipped" and does nohow filters by record).

PR is now a collection of small changes intended to optimize (although didn't test yet either there is a real advantage) `addurls` while running on large(r) number of files and not bothering to add metadata.

One change in behavior would be that I removed `repo.add` which now was ran for every file and then message was perculated up and then at the end in a typical use case `ds.save` would have been called on those files again.  Now, if `save=False`, then those files would remain "annexed" (converted to symlinks) but not added to git repository.  IMHO that is Ok since "staging does no longer exists" in datalad world, and `save=False` was IIRC introduced to facilitate use with `datalad run` which would call `save` anyways.

Let me know what you think, and I will probably test next batch of running addurls on this version to see if it feels any better.