### PR TITLE
OPT: Speedup of per-subdataset "contains?" matching

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -588,7 +588,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
 # New helpers, courtesy of datalad-revolution.
 
 
-def resolve_path(path, ds=None):
+def resolve_path(path, ds=None, ds_resolved=None):
     """Resolve a path specification (against a Dataset location)
 
     Any path is returned as an absolute path. If, and only if, a dataset
@@ -609,8 +609,11 @@ def resolve_path(path, ds=None):
     path : str or PathLike or list
       Platform-specific path specific path specification. Multiple path
       specifications can be given as a list
-    ds : Dataset or None
+    ds : Dataset or PathLike or None
       Dataset instance to resolve relative paths against.
+    ds_resolved : Dataset or None
+      A dataset instance that was created from `ds` outside can be provided
+      to avoid multiple instantiation on repeated calls.
 
     Returns
     -------
@@ -620,7 +623,7 @@ def resolve_path(path, ds=None):
     """
     got_ds_instance = isinstance(ds, Dataset)
     if ds is not None and not got_ds_instance:
-        ds = require_dataset(
+        ds = ds_resolved or require_dataset(
             ds, check_installed=False, purpose='path resolution')
     out = []
     for p in ensure_list(path):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -49,11 +49,11 @@ lgr = logging.getLogger('datalad.distribution.update')
 
 
 class YieldDatasetAndRevision(YieldDatasets):
-    """Like YieldDatasets, but also provide "revision" value, if any.
+    """Like YieldDatasets, but also provide "gitshasum" value, if any.
     """
     def __call__(self, res):
         ds = super(YieldDatasetAndRevision, self).__call__(res)
-        return ds, res.get("revision")
+        return ds, res.get("gitshasum")
 
 
 @build_doc

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -40,6 +40,7 @@ from datalad.utils import (
     ensure_list,
     getpwd,
     partition,
+    Path,
 )
 
 from datalad.distribution.dataset import (
@@ -224,8 +225,8 @@ class Subdatasets(Interface):
 
         # no constraints given -> query subdatasets under curdir
         if not paths and dataset is None:
-            cwd = getpwd()
-            paths = None if cwd == ds.path else [cwd]
+            cwd = Path(getpwd())
+            paths = None if cwd == ds.pathobj else [cwd]
 
         lgr.debug('Query subdatasets of %s', dataset)
         if paths is not None:

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -77,15 +77,11 @@ def _parse_git_submodules(ds_pathobj, repo, paths):
                 return
     # can we use the reported as such, or do we need to recode wrt to the
     # query context dataset?
-    recode_paths = ds_pathobj != repo.pathobj
-    for props in repo.get_submodules_(paths=paths):
-        path = props["path"]
-        if props.get('type', None) != 'dataset':
-            continue
-        if recode_paths:
-            props['path'] = ds_pathobj / path.relative_to(repo.pathobj)
-        else:
-            props['path'] = path
+    if ds_pathobj == repo.pathobj:
+        yield from repo.get_submodules_(paths=paths)
+    else:
+        for props in repo.get_submodules_(paths=paths):
+            props['path'] = ds_pathobj / paths['path'].relative_to(repo.pathobj)
         yield props
 
 

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -217,8 +217,7 @@ class Subdatasets(Interface):
             bottomup=False,
             set_property=None,
             delete_property=None):
-        paths = [resolve_path(p, dataset) for p in ensure_list(path)] \
-            if path else None
+        paths = resolve_path(ensure_list(path), dataset) if path else None
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='subdataset reporting/modification')

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -213,10 +213,10 @@ class Subdatasets(Interface):
             bottomup=False,
             set_property=None,
             delete_property=None):
-        paths = resolve_path(ensure_list(path), dataset) if path else None
-
         ds = require_dataset(
             dataset, check_installed=True, purpose='subdataset reporting/modification')
+
+        paths = resolve_path(ensure_list(path), dataset, ds) if path else None
 
         # no constraints given -> query subdatasets under curdir
         if not paths and dataset is None:
@@ -239,7 +239,7 @@ class Subdatasets(Interface):
                         "key '%s' is invalid (alphanumeric plus '-' only, must "
                         "start with a letter)" % k)
         if contains:
-            contains = [resolve_path(c, dataset, ds) for c in ensure_list(contains)]
+            contains = resolve_path(ensure_list(contains), dataset, ds)
         contains_hits = set()
         for r in _get_submodules(
                 ds, paths, fulfilled, recursive, recursion_limit,

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -299,7 +299,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                 continue
         # the following used to be done by _parse_git_submodules()
         # but is expensive and does not need to be done for submodules
-        # no matching `contains`
+        # not matching `contains`
         if not sm_path.exists() or not GitRepo.is_valid_repo(sm_path):
             sm['state'] = 'absent'
         # do we just need this to recurse into subdatasets, or is this a

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -81,8 +81,8 @@ def _parse_git_submodules(ds_pathobj, repo, paths):
         yield from repo.get_submodules_(paths=paths)
     else:
         for props in repo.get_submodules_(paths=paths):
-            props['path'] = ds_pathobj / paths['path'].relative_to(repo.pathobj)
-        yield props
+            props['path'] = ds_pathobj / props['path'].relative_to(repo.pathobj)
+            yield props
 
 
 @build_doc

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -38,6 +38,7 @@ from datalad.support.gitrepo import GitRepo
 from datalad.dochelpers import exc_str
 from datalad.utils import (
     ensure_list,
+    getpwd,
     partition,
 )
 
@@ -215,14 +216,17 @@ class Subdatasets(Interface):
             bottomup=False,
             set_property=None,
             delete_property=None):
-        # no constraints given -> query subdatasets under curdir
-        if not path and dataset is None:
-            path = os.curdir
         paths = [resolve_path(p, dataset) for p in ensure_list(path)] \
             if path else None
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='subdataset reporting/modification')
+
+        # no constraints given -> query subdatasets under curdir
+        if not paths and dataset is None:
+            cwd = getpwd()
+            paths = None if cwd == ds.path else [cwd]
+
         lgr.debug('Query subdatasets of %s', dataset)
         if paths is not None:
             lgr.debug('Query subdatasets underneath paths: %s', paths)

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -239,7 +239,7 @@ class Subdatasets(Interface):
                         "key '%s' is invalid (alphanumeric plus '-' only, must "
                         "start with a letter)" % k)
         if contains:
-            contains = [resolve_path(c, dataset) for c in ensure_list(contains)]
+            contains = [resolve_path(c, dataset, ds) for c in ensure_list(contains)]
         contains_hits = set()
         for r in _get_submodules(
                 ds, paths, fulfilled, recursive, recursion_limit,

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -284,8 +284,6 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
     # expand all test cases for the contains test in the loop below
     # leads to ~20% speedup per loop iteration of a non-match
     expanded_contains = [
-        # convert to strings, as sm_path below will be a string and
-        # we do not want repeated type-conversion
         [c] + list(c.parents)
         for c in (contains if contains is not None else [])
     ]

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -192,8 +192,8 @@ def test_get_subdatasets(origpath, path):
     res = ds.subdatasets(recursive=True)
     assert_status('ok', res)
     for r in res:
-        #for prop in ('gitmodule_url', 'state', 'revision', 'gitmodule_name'):
-        for prop in ('gitmodule_url', 'revision', 'gitmodule_name'):
+        #for prop in ('gitmodule_url', 'state', 'gitshasum', 'gitmodule_name'):
+        for prop in ('gitmodule_url', 'gitshasum', 'gitmodule_name'):
             assert_in(prop, r)
         # random property is unknown
         assert_not_in('mike', r)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2875,6 +2875,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 untracked='no',
                 eval_file_type=False).items():
             if props.get('type', None) != 'dataset':
+                # make sure this method never talks about non-dataset
+                # content
                 continue
             props["path"] = path
             props.update(modinfo.get(path, {}))


### PR DESCRIPTION
Speeds up the rejection of non-containing subdatasets. For the UKB dataset with 42k subdatasets, this shaves of 1s of the previous total runtime of 2.5s.

Related to gh-4859

This also removes a backward compatibility kludge that we put in place over a year ago (`revision` instead of the present `gitshasum` property in the submodule records).

Edit: This also ups the plain reporting performance (same 42k subdatasets):

Before: `datalad subdatasets  9.49s user 3.41s system 57% cpu 22.284 total`
After: `datalad subdatasets  9.81s user 2.49s system 74% cpu 16.399 total`
and with a twist: `datalad subdatasets -d .  6.95s user 2.14s system 66% cpu 13.622 total` (see TODO)

TODO:

- [x] `GitRepo.get_submodules_()` calls `GitRepo.get_content_info()`. This might be made faster, by filtering the path-contraints with the `contains` parameter before calling any of this stack. Right now `contains` is considered last and all info is requested without any path constraint in the context of #4859 -> #5063 
- [x] Suprise differences with or without `--dataset`
    ```
    datalad subdatasets -r --contains sub-3507513  2.76s user 0.33s system 103% cpu 2.973 total                                           
    datalad subdatasets -d . -r --contains sub-3507513  1.36s user 0.21s system 104% cpu 1.507 total                                      
    ```
- [x] `update` is broken by the second commit, not clear why yet (likely it is still using the `revision` property)
