### PR TITLE
ENH: Add separate  asv compare  step within Benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,3 +35,7 @@ jobs:
         TRAVIS_PULL_REQUEST: true
       run: |
         tools/ci/benchmark-travis-pr.sh
+    - name: Compare
+      run: |
+        # Invocation from tools/ci/benchmark-travis-pr.sh for convenience
+        asv compare refs/bm/merge-target refs/bm/pr


### PR DESCRIPTION
It always takes time and cursing to get to the actual comparison within
the long output of "Run benchmarks".  This is the simplest (and quick -
no benchmarks should be reran) way to get a dedicated action step which
would show the comparison.

PS I will cancel travis run since not relevant