### PR TITLE
ENH: Add support of .tgz archives

### DIFF
--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -30,6 +30,8 @@ from datalad.cmd import Runner
 def _normalize_fname_suffixes(suffixes):
     if suffixes == ['.tgz']:
         suffixes = ['.tar', '.gz']
+    elif suffixes == ['.tbz2']:
+        suffixes = ['.tar', '.bzip2']
     return suffixes
 
 

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -27,6 +27,12 @@ lgr = logging.getLogger('datalad.support.archive_utils_7z')
 from datalad.cmd import Runner
 
 
+def _normalize_fname_suffixes(suffixes):
+    if suffixes == ['.tgz']:
+        suffixes = ['.tar', '.gz']
+    return suffixes
+
+
 def decompress_file(archive, dir_):
     """Decompress `archive` into a directory `dir_`
 
@@ -39,7 +45,8 @@ def decompress_file(archive, dir_):
     """
     apath = Path(archive)
     runner = Runner(cwd=dir_)
-    if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
+    suffixes = _normalize_fname_suffixes(apath.suffixes)
+    if len(suffixes) > 1 and suffixes[-2] == '.tar':
         # we have a compressed tar file that needs to be fed through the
         # decompressor first
         # hangs somehow, do via single string arg
@@ -74,7 +81,8 @@ def compress_files(files, archive, path=None, overwrite=True):
                 'Target archive {} already exists and overwrite is forbidden'.format(
                     apath)
             )
-    if len(apath.suffixes) > 1 and apath.suffixes[-2] == '.tar':
+    suffixes = _normalize_fname_suffixes(apath.suffixes)
+    if len(suffixes) > 1 and suffixes[-2] == '.tar':
         cmd = '7z u .tar -so -- {} | 7z u -si -- {}'.format(
             ' '.join(quote_cmdlinearg(f) for f in files),
             quote_cmdlinearg(str(apath)),

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -125,6 +125,7 @@ def test_compress_dir():
     yield check_compress_dir, '.tar.xz'
     yield check_compress_dir, '.tar.gz'
     yield check_compress_dir, '.tgz'
+    yield check_compress_dir, '.tbz2'
     yield check_compress_dir, '.tar'
     yield check_compress_dir, '.zip'
     yield check_compress_dir, '.7z'

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -124,6 +124,7 @@ def check_compress_dir(ext, path, name):
 def test_compress_dir():
     yield check_compress_dir, '.tar.xz'
     yield check_compress_dir, '.tar.gz'
+    yield check_compress_dir, '.tgz'
     yield check_compress_dir, '.tar'
     yield check_compress_dir, '.zip'
     yield check_compress_dir, '.7z'


### PR DESCRIPTION
I am not aware of any other common extensions that indicate compressed tarballs in a single suffix. There is now a dedicated function to normalize such suffixes to make them detectable with the existing approach -- without affecting the actual filename.

Fixes #4875 
