### PR TITLE
RF: Require Python >=3.6

### DIFF
--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ services:
   - docker
 
 python:
-  - 3.5
-##1  - 3.6
+  - 3.6
 
 cache:
   - apt
@@ -64,19 +63,19 @@ matrix:
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
     - _DL_CRON=1
-  - python: 3.5
+  - python: 3.6
     # Split runs for v6 since a single one is too long now
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=not
-  - python: 3.5
+  - python: 3.6
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=""
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for NOSE.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LANG=bg_BG.UTF-8
-  - python: 3.5
+  - python: 3.6
     # Run slow etc tests under a single tricky scenario
     env:
     - _DL_TMPDIR="/var/tmp/sym link"
@@ -84,7 +83,7 @@ matrix:
     # And the leading - in filenames for the most challenge
     - DATALAD_TESTS_OBSCURE_PREFIX=-
     - DATALAD_LOG_TRACEBACK=collide  # just a smoke test for now
-  - python: 3.5
+  - python: 3.6
     # A run loaded with various customizations to smoke test those functionalities
     # apparently moving symlink outside has different effects on abspath
     # see  https://github.com/datalad/datalad/issues/878
@@ -97,7 +96,7 @@ matrix:
     - DATALAD_LOG_LEVEL=INFO
     - DATALAD_LOG_TRACEBACK=1  # just a smoke test for now
     - DATALAD_LOG_VMEM=1
-  - python: 3.5
+  - python: 3.6
     # By default no logs will be output. This one is to test with low level but dumped to /dev/null
     env:
     - DATALAD_LOG_LEVEL=2
@@ -117,7 +116,7 @@ matrix:
     - GIT_COMMITTER_DATE="Thu, 07 Apr 2005 22:13:13 +0200"
     - GIT_COMMITTER_NAME=blah
     - GIT_COMMITTER_EMAIL=committer@example.com
-  - python: 3.5
+  - python: 3.6
     # Test some under NFS mount  (only selected sub-set)
     env:
     # do not run SSH-based tests due to stall(s)
@@ -132,24 +131,24 @@ matrix:
   # run with minimal supported git-annex version as defined in AnnexRepo.GIT_ANNEX_MIN_VERSION
   # TODO: ATM we do not have that minimal version as a Debian package in
   # snapshots!
-  - python: 3.5
+  - python: 3.6
     env:
     - _DL_ANNEX_INSTALL_SCENARIO="deb-url http://snapshot-neuro.debian.net/archive/neurodebian/20190710T050502Z/pool/main/g/git-annex/git-annex-standalone_7.20190708%2Bgit9-gfa3524b95-1~ndall%2B1_amd64.deb"
     - _DL_CRON=1
   # Run with git's master branch rather the default one on the system.
-  - python: 3.5
+  - python: 3.6
     env:
     - DATALAD_USE_DEFAULT_GIT=1
     - _DL_UPSTREAM_GIT=1
     - _DL_CRON=1
   # Run with our reported minimum Git version.
-  - python: 3.5
+  - python: 3.6
     env:
     - DATALAD_USE_DEFAULT_GIT=1
     - _DL_MIN_GIT=1
     - PATH="$PWD/git-src/bin-wrappers/:$PATH"
     - _DL_CRON=1
-  - python: 3.5
+  - python: 3.6
     env:
     # to test operation under root since also would consider FS "crippled" due to
     # ability to rewrite R/O files
@@ -157,23 +156,23 @@ matrix:
     # no key authentication for root:
     - DATALAD_TESTS_SSH=0
     - _DL_CRON=1
-  - python: 3.5
+  - python: 3.6
     env:
     - DATALAD_TESTS_NONETWORK=1
     # must operate nicely with those env variables set
     - http_proxy=
     - https_proxy=
     - _DL_CRON=1
-  - python: 3.5
+  - python: 3.6
     env:
     - PYTHONPATH=$PWD/tools/testing/bad_internals/_scrapy/
     - _DL_CRON=1
-  - python: 3.5
+  - python: 3.6
     # Test under NFS mount  (full, only in master)
     env:
     - _DL_TMPDIR="/tmp/nfsmount"
     - _DL_CRON=1
-#  - python: 3.5
+#  - python: 3.6
 #    # test whether known v6 failures still fail
 #    env:
 #    - DATALAD_REPO_VERSION=6
@@ -184,7 +183,7 @@ matrix:
 
   allow_failures:
   # Test under NFS mount  (full, only in master)
-  - python: 3.5
+  - python: 3.6
     env:
     - _DL_TMPDIR="/tmp/nfsmount"
     - _DL_CRON=1
@@ -198,7 +197,7 @@ matrix:
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)
-#  - python: 3.5
+#  - python: 3.6
 #    # we would need to migrate to boto3 to test it fully, but SSH should work
 #    env:
 #    - DATALAD_TESTS_SSH=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ we outline the workflow used by the developers:
 Development environment
 -----------------------
 
-We support Python 3 only (>= 3.5).
+We support Python 3 only (>= 3.6).
 
 See [README.md:Dependencies](README.md#Dependencies) for basic information
 about installation of datalad itself.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,11 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.8"
       PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
+      MINICONDA: C:\Miniconda36
       DATALAD_TESTS_SSH: 1
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
-      DATALAD_TESTS_SSH: 1
-      DATALAD_REPO_VERSION: 6
 
 cache:
   # cache the pip cache

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ datalad_setup(
     install_requires=
         requires['core'] + requires['downloaders'] +
         requires['publish'] + requires['metadata'],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     extras_require=requires,
     cmdclass=cmdclass,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py36
 #,flake8
 
 [testenv]


### PR DESCRIPTION
PY35 will come to its end-of-life (EOL) in a week from now.

https://devguide.python.org/#status-of-python-branches

Fixes gh-4878

TODO

- [x] Can more travis runs be stripped?
- [ ] Scan the code base to remove PY35 compatibility kludges