### PR TITLE
Modernize appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ install:
   # latest version
   #- appveyor DownloadFile https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -FileName resources\git-annex-installer.exe
   # specific version mih uses to debug on real win10 box
-  - appveyor DownloadFile http://store.datalad.org/git-annex/windows/git-annex_8.20200309.exe -FileName resources\git-annex-installer.exe
+  - appveyor DownloadFile http://store.datalad.org/git-annex/windows/git-annex_8.20200720.2.exe -FileName resources\git-annex-installer.exe
   # extract git annex into the system Git installation path
   - 7z x -o"C:\\Program Files\Git" resources\git-annex-installer.exe
   # info on how python is ticking

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,11 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.8"
       PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
+      MINICONDA: C:\Miniconda36
       DATALAD_TESTS_SSH: 1
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
-      DATALAD_TESTS_SSH: 1
-      DATALAD_REPO_VERSION: 6
 
 cache:
   # cache the pip cache


### PR DESCRIPTION
- Move to PY36 for testing
- Strip dedicated annex v6 test run
- use latest git-annex

[canceled other CIs]

Tests stall on windows. The only difference between this PR and #4879 (which passes https://ci.appveyor.com/project/mih/datalad/builds/35051602) is the newer git-annex version. Something to watch out for.

