### PR TITLE
RF: Strip AnnexRepo._set_direct_mode() from class and make test helper

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -25,10 +25,8 @@ from os.path import (
     curdir,
     join as opj,
     exists,
-    islink,
     lexists,
     isdir,
-    isabs,
     normpath
 )
 from multiprocessing import cpu_count
@@ -76,7 +74,6 @@ from datalad.cmd import (
 from .repo import RepoInterface
 from .gitrepo import (
     GitRepo,
-    _normalize_path,
     normalize_path,
     normalize_paths,
     to_options
@@ -279,7 +276,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             self._init(version=version, description=description)
 
         # TODO: RM DIRECT  eventually, but should remain while we have is_direct_mode
-        # and _set_direct_mode
         self._direct_mode = None
 
         # Handle cases of detecting repositories with no longer supported
@@ -1191,46 +1187,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             # If annex.version isn't set (e.g., an uninitialized repo), assume
             # that unlocked pointers aren't supported.
             return False
-
-    # TODO: RM DIRECT  might be gone but pieces might be useful for establishing
-    #       migration to v6+ mode and testing. For now is made protected to
-    #       avoid use by users
-    def _set_direct_mode(self, enable_direct_mode=True):
-        """Switch to direct or indirect mode
-
-        WARNING!  To be used only for internal development purposes.
-                  We no longer support direct mode and thus setting it in a
-                  repository would render it unusable for DataLad
-
-        Parameters
-        ----------
-        enable_direct_mode: bool
-            True means switch to direct mode,
-            False switches to indirect mode
-
-        Raises
-        ------
-        CommandNotAvailableError
-            in case you try to switch to indirect mode on a crippled filesystem
-        """
-        if self.is_crippled_fs() and not enable_direct_mode:
-            # TODO: ?? DIRECT - should we call git annex upgrade?
-            raise CommandNotAvailableError(
-                cmd="git-annex indirect",
-                msg="Can't switch to indirect mode on that filesystem.")
-
-        self._run_annex_command(
-            'direct' if enable_direct_mode else 'indirect',
-            expect_stderr=True,
-            runner="gitwitless"
-        )
-        self.config.reload()
-
-        # For paranoid we will just re-request
-        self._direct_mode = None
-        assert(self.is_direct_mode() == enable_direct_mode)
-
-        # All further workarounds were stripped - no direct mode is supported
 
     def _init(self, version=None, description=None):
         """Initializes an annex repository.

--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -14,7 +14,10 @@ from unittest.mock import patch
 
 from datalad.support.annexrepo import AnnexRepo
 
-from datalad.support.exceptions import DirectModeNoLongerSupportedError
+from datalad.support.exceptions import (
+    CommandNotAvailableError,
+    DirectModeNoLongerSupportedError,
+)
 from datalad.support import path as op
 
 from datalad.tests.utils import (
@@ -32,6 +35,46 @@ from datalad.tests.utils import (
 # if repo_version and int(repo_version) >= 6:
 #     raise SkipTest("Can't test direct mode switch, "
 #                    "if repository version 6 or later is enforced.")
+
+
+# originally lifted from AnnexRepo, kept here to simulate a repo
+# that is still in direct mode
+def _set_direct_mode(self, enable_direct_mode=True):
+    """Switch to direct or indirect mode
+
+    WARNING!  To be used only for internal development purposes.
+              We no longer support direct mode and thus setting it in a
+              repository would render it unusable for DataLad
+
+    Parameters
+    ----------
+    enable_direct_mode: bool
+        True means switch to direct mode,
+        False switches to indirect mode
+
+    Raises
+    ------
+    CommandNotAvailableError
+        in case you try to switch to indirect mode on a crippled filesystem
+    """
+    if self.is_crippled_fs() and not enable_direct_mode:
+        # TODO: ?? DIRECT - should we call git annex upgrade?
+        raise CommandNotAvailableError(
+            cmd="git-annex indirect",
+            msg="Can't switch to indirect mode on that filesystem.")
+
+    self._run_annex_command(
+        'direct' if enable_direct_mode else 'indirect',
+        expect_stderr=True,
+        runner="gitwitless"
+    )
+    self.config.reload()
+
+    # For paranoid we will just re-request
+    self._direct_mode = None
+    assert(self.is_direct_mode() == enable_direct_mode)
+
+    # All further workarounds were stripped - no direct mode is supported
 
 
 @with_tempfile
@@ -66,7 +109,7 @@ def test_direct_cfg(path1, path2):
         raise SkipTest("Created repo not v5, cannot test detection of direct mode repos")
     # and if repo existed before and was in direct mode, we fail too
     # Since direct= option was deprecated entirely, we use protected method now
-    ar._set_direct_mode(True)
+    _set_direct_mode(ar, True)
     assert ar.is_direct_mode()
     del ar  # but we would need to disable somehow the flywheel
     with patch.dict('os.environ', {'DATALAD_REPO_DIRECT': 'True'}):
@@ -82,7 +125,7 @@ def test_direct_cfg(path1, path2):
     ar2sub1 = AnnexRepo(op.join(path2, 'sub1'))
     # but now let's convert that sub1 to direct mode
     assert not ar2sub1.is_direct_mode()
-    ar2sub1._set_direct_mode(True)
+    _set_direct_mode(arsub1, True)
     assert ar2sub1.is_direct_mode()
     del ar2; del ar2sub1; AnnexRepo._unique_instances.clear()  # fight flyweight
 
@@ -91,6 +134,6 @@ def test_direct_cfg(path1, path2):
 
     # And what if we are trying to add pre-cloned repo in direct mode?
     ar2sub2 = AnnexRepo.clone(path1, op.join(path2, 'sub2'))
-    ar2sub2._set_direct_mode(True)
+    _set_direct_mode(arsub2, True)
     del ar2sub2; AnnexRepo._unique_instances.clear()  # fight flyweight
     ar2.add('sub2')


### PR DESCRIPTION
That is its only purpose. Any chance to reduce clutter in this monster class should be used.