### PR TITLE
TST: Refcount is unreliable ATM

### DIFF
--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1172,8 +1172,18 @@ def test_GitRepo_flyweight(path1, path2):
     repo1 = GitRepo(path1, create=True)
     assert_is_instance(repo1, GitRepo)
 
+    # Due to issue 4862, we currently still require gc.collect() under unclear
+    # circumstances to get rid of an exception traceback when creating in an
+    # existing directory. That traceback references the respective function
+    # frames which in turn reference the repo instance (they are methods).
+    # Doesn't happen on all systems, though. Eventually we need to figure that
+    # out.
+    # However, still test for the refcount after gc.collect() to ensure we don't
+    # introduce new circular references and make the issue worse!
+    gc.collect()
+
     # As long as we don't reintroduce any circular references or produce
-    # garbage during instatiation that isn't picked up immediatly, `repo1`
+    # garbage during instantiation that isn't picked up immediately, `repo1`
     # should be the only counted reference to this instance.
     # Note, that sys.getrefcount reports its own argument and therefore one
     # reference too much.
@@ -1204,6 +1214,7 @@ def test_GitRepo_flyweight(path1, path2):
 
     # deleting one reference doesn't change anything - we still get the same
     # thing:
+    gc.collect()  #  TODO: see first comment above
     del repo1
     ok_(repo2 is not None)
     ok_(repo2 is repo3)
@@ -1222,6 +1233,7 @@ def test_GitRepo_flyweight(path1, path2):
     # GitRepo's finalizer:
     with swallow_logs(new_level=1) as cml:
         del repo3
+        gc.collect()  # TODO: see first comment above
         cml.assert_logged(msg="Finalizer called on: GitRepo(%s)" % path1,
                           level="Level 1",
                           regex=False)


### PR DESCRIPTION
In light of (unresolved) issue #4862, it seems necessary to adapt the tests for now.
Since the issue is neither happening for me locally nor on Travis, I need you, @kyleam and @mih to confirm, that these tests are passing for you with this patch.

If so, I'll need to dig out #4849 in addition (and find a better solution for that one).