### PR TITLE
BF(TST): skip some tests which would fail to Encode a unicode (or just read a unicode file?) with python 3.6

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -13,6 +13,8 @@ import os
 from os import chmod
 import stat
 import re
+import sys
+
 from os.path import join as opj, exists, basename
 
 from ..dataset import Dataset
@@ -26,6 +28,8 @@ from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import urlquote
 from datalad.tests.utils import (
+    DEFAULT_BRANCH,
+    SkipTest,
     assert_dict_equal,
     assert_false,
     assert_in,
@@ -37,7 +41,6 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     create_tree,
-    DEFAULT_BRANCH,
     eq_,
     get_mtimes_and_digests,
     get_ssh_port,
@@ -47,8 +50,8 @@ from datalad.tests.utils import (
     ok_file_has_content,
     ok_file_under_git,
     skip_if_on_windows,
-    skip_ssh,
     skip_if_root,
+    skip_ssh,
     slow,
     swallow_logs,
     with_tempfile,
@@ -531,7 +534,16 @@ def check_replace_and_relative_sshpath(use_ssh, src_path, dst_path):
     ds = Dataset(src_path).create()
     create_tree(ds.path, {'sub.dat': 'lots of data'})
     ds.save('sub.dat')
-    ds.create_sibling(url, ui=True)
+    try:
+        ds.create_sibling(url, ui=True)
+    except UnicodeDecodeError:
+        if sys.version_info < (3, 7):
+            # observed test failing on ubuntu 18.04 with python 3.6
+            # (reproduced in conda env locally with python 3.6.10 when LANG=C
+            # We will just skip this tricky one
+            raise SkipTest("Known failure")
+        raise
+
     published = ds.publish(to=sibname, transfer_data='all')
     assert_result_count(published, 1, path=opj(ds.path, 'sub.dat'))
     # verify that hook runs and there is nothing in stderr

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -10,6 +10,8 @@
 import logging
 
 import os
+import sys
+
 from os.path import (
     join as opj,
     isabs,
@@ -470,6 +472,16 @@ def test_get_local_file_url():
                 #('/a b/', 'file:///a%20b/'),
                 ('/a b/name', 'file:///a%20b/name'),
             ):
+        try:
+            # Yarik found no better way to trigger.  .decode() isn't enough
+            print("D: %s" % path)
+        except UnicodeEncodeError:
+            if sys.version_info < (3, 7):
+                # observed test failing on ubuntu 18.04 with python 3.6
+                # (reproduced in conda env locally with python 3.6.10 when LANG=C
+                # We will just skip this tricky one
+                continue
+            raise
         if isabs(path):
             eq_(get_local_file_url(path), url)
         else:


### PR DESCRIPTION
fails detected while building for ubuntu 18.04 with python 3.6 but also replicate in conda env with `LANG=C`.  I think that later pythons are Ok. I might add more skips later on if we agree that such ugly workaround is ok