### PR TITLE
BF+TST: ephemeral clone to account for bare repo

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -808,8 +808,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
                     gc_response = GitWitlessRunner(
                         cwd=origin_git_path,
                     ).run(['git', 'config', '--local', '--get', 'core.bare'],
-                          protocol=StdOutErrCapture,
-                          encoding='utf-8')
+                          protocol=StdOutErrCapture)
                     if gc_response['stdout'].lower().strip() == 'true':
                         # origin is a bare repo -> use path as is
                         pass

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -850,8 +850,6 @@ def _test_ria_postclonecfg(url, dsid, clone_path):
     assert_result_count(res, 2)
 
 
-
-
 @with_tempfile
 def _postclonetest_prepare(lcl, storepath, link):
 

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -850,6 +850,8 @@ def _test_ria_postclonecfg(url, dsid, clone_path):
     assert_result_count(res, 2)
 
 
+
+
 @with_tempfile
 def _postclonetest_prepare(lcl, storepath, link):
 
@@ -1014,7 +1016,10 @@ def test_ria_http_storedataladorg(path):
 })
 @with_tempfile
 @with_tempfile
-def test_ephemeral(origin_path, clone1_path, clone2_path):
+@with_tempfile
+@with_tempfile
+def test_ephemeral(origin_path, bare_path,
+                   clone1_path, clone2_path, clone3_path):
 
     file_test = Path('ds') / 'test.txt'
     file_testsub = Path('ds') / 'subdir' / 'testsub.txt'
@@ -1048,8 +1053,8 @@ def test_ephemeral(origin_path, clone1_path, clone2_path):
         ok_(clone2_annex.resolve().samefile(origin.repo.dot_git / 'annex'))
         if not clone2.repo.is_managed_branch():
             # TODO: We can't properly handle adjusted branch yet
-            eq_((clone1.pathobj / file_test).read_text(), 'some')
-            eq_((clone1.pathobj / file_testsub).read_text(), 'somemore')
+            eq_((clone2.pathobj / file_test).read_text(), 'some')
+            eq_((clone2.pathobj / file_testsub).read_text(), 'somemore')
 
     # 3. add something to clone1 and push back to origin availability from
     # clone1 should not be propagated (we declared 'here' dead to that end)
@@ -1076,6 +1081,26 @@ def test_ephemeral(origin_path, clone1_path, clone2_path):
         # now origin knows:
     res = origin.repo.whereis("addition.txt")
     eq_(res, [origin.config.get("annex.uuid")])
+
+    # 4. ephemeral clone from a bare repo
+    from datalad.cmd import GitWitlessRunner
+    runner = GitWitlessRunner()
+    runner.run(['git', 'clone', '--bare', origin_path, bare_path])
+    runner.run(['git', 'annex', 'init'], cwd=bare_path)
+
+    eph_from_bare = clone(bare_path, clone3_path, reckless='ephemeral')
+    can_symlink = has_symlink_capability()
+
+    if can_symlink:
+        # Bare repo uses dirhashlower by default, while a standard repo uses
+        # dirhashmixed. Symlinking different object trees doesn't really work.
+        # Don't test that here, since this is not a matter of the "ephemeral"
+        # option alone. We should have such a setup in the RIA tests and test
+        # for data access there.
+        # Here we only test for the correct linking.
+        eph_annex = eph_from_bare.repo.dot_git / 'annex'
+        ok_(eph_annex.is_symlink())
+        ok_(eph_annex.resolve().samefile(Path(bare_path) / 'annex'))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distributed/tests/test_ria.py
+++ b/datalad/distributed/tests/test_ria.py
@@ -1,0 +1,77 @@
+"""Test workflow (pieces) for RIA stores"""
+
+from datalad.api import (
+    Dataset,
+    clone,
+)
+from datalad.utils import Path
+from datalad.tests.utils import (
+    assert_equal,
+    assert_result_count,
+    assert_true,
+    has_symlink_capability,
+    skip_if,
+    skip_if_on_windows,
+    with_tempfile,
+    with_tree,
+)
+
+
+@skip_if_on_windows  # currently all tests re RIA/ORA don't run on windows
+@skip_if(cond=not has_symlink_capability(),
+         msg="skip testing ephemeral clone w/o symlink capabilities")
+@with_tree({'file1.txt': 'some',
+            'sub': {'other.txt': 'other'}})
+@with_tempfile
+@with_tempfile
+def test_ephemeral(ds_path, store_path, clone_path):
+
+    dspath = Path(ds_path)
+    store = Path(store_path)
+    file_test =  Path('file1.txt')
+    file_testsub = Path('sub') / 'other.txt'
+
+
+    # create the original dataset
+    ds = Dataset(dspath)
+    ds.create(force=True)
+    ds.save()
+
+    # put into store:
+    ds.create_sibling_ria("ria+{}".format(store.as_uri()), "riastore")
+    ds.publish(to="riastore", transfer_data="all")
+
+    # now, get an ephemeral clone from the RIA store:
+    eph_clone = clone('ria+{}#{}'.format(store.as_uri(), ds.id), clone_path,
+                      reckless="ephemeral")
+
+    # ephemeral clone was properly linked (store has bare repos!):
+    clone_annex = (eph_clone.repo.dot_git / 'annex')
+    assert_true(clone_annex.is_symlink())
+    assert_true(clone_annex.resolve().samefile(
+        store / ds.id[:3] / ds.id[3:] / 'annex'))
+    if not eph_clone.repo.is_managed_branch():
+        # TODO: We can't properly handle adjusted branch yet
+        # we don't need to get files in order to access them:
+        assert_equal((eph_clone.pathobj / file_test).read_text(), "some")
+        assert_equal((eph_clone.pathobj / file_testsub).read_text(), "other")
+
+        # can we unlock those files?
+        eph_clone.unlock(file_test)
+        # change content
+        (eph_clone.pathobj / file_test).write_text("new content")
+        eph_clone.save()
+
+        # new content should already be in store
+        # (except the store doesn't know yet)
+        res = eph_clone.repo.fsck(remote="riastore-storage", fast=True)
+        assert_equal(len(res), 2)
+        assert_result_count(res, 1, success=True, file=file_test.as_posix())
+        assert_result_count(res, 1, success=True, file=file_testsub.as_posix())
+
+        # push back git history
+        eph_clone.publish(to="origin", transfer_data="none")
+
+        # get an update in origin
+        ds.update(merge=True, reobtain_data=True)
+        assert_equal((ds.pathobj / file_test).read_text(), "new content")

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -151,7 +151,9 @@ reckless_opt = Parameter(
     w/o git-annex being aware of it. In case of a change in origin you need to
     update the clone before you're able to save new content on your end.
     Alternative to 'auto' when hardlinks are not an option, or number of consumed
-    inodes needs to be minimized.
+    inodes needs to be minimized. Please note, that you might run into issues
+    when using this mode to link a bare (or any tuned annex) and a non-bare 
+    repository that way, since their annex object trees are organized differently.
     ['shared-<mode>']: set up repository and annex permission to enable multi-user
     access. This disables the standard write protection of annex'ed files.
     <mode> can be any value support by 'git init --shared=', such as 'group', or

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -151,9 +151,9 @@ reckless_opt = Parameter(
     w/o git-annex being aware of it. In case of a change in origin you need to
     update the clone before you're able to save new content on your end.
     Alternative to 'auto' when hardlinks are not an option, or number of consumed
-    inodes needs to be minimized. Please note, that you might run into issues
-    when using this mode to link a bare (or any tuned annex) and a non-bare 
-    repository that way, since their annex object trees are organized differently.
+    inodes needs to be minimized. Please note, that this is unlikely to work,
+    if origin is a bare or tuned repository outside of a RIA store, since their 
+    annex object trees are organized differently.
     ['shared-<mode>']: set up repository and annex permission to enable multi-user
     access. This disables the standard write protection of annex'ed files.
     <mode> can be any value support by 'git init --shared=', such as 'group', or

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -151,9 +151,10 @@ reckless_opt = Parameter(
     w/o git-annex being aware of it. In case of a change in origin you need to
     update the clone before you're able to save new content on your end.
     Alternative to 'auto' when hardlinks are not an option, or number of consumed
-    inodes needs to be minimized. Please note, that this is unlikely to work,
-    if origin is a bare or tuned repository outside of a RIA store, since their 
-    annex object trees are organized differently.
+    inodes needs to be minimized. Please note, that this is meant to be used
+    with either non-bare repositories or a RIA store as origin! Do not come up
+    with your own usecase unless you are absolutely sure you know your git-annex 
+    internals very well!
     ['shared-<mode>']: set up repository and annex permission to enable multi-user
     access. This disables the standard write protection of annex'ed files.
     <mode> can be any value support by 'git init --shared=', such as 'group', or


### PR DESCRIPTION
Somehow we managed to ignore the intial usecase leading to the development of RIA stores and ephemeral clones! *facepalm*

This fixes `clone` to symlink an ephemeral clone's annex correctly, if `origin` is a bare repo.
Tests are enhanced in two ways:

1. Test merely the right link in `test_clone.py` as this is all `clone` itself is concerned with.
2. Add a new test file for usecases/workflows involving RIA stores and add the first one, which is an enhancement of what @dickscheid described in #4893 in that it writes to the unlocked file in the clone and propagates everything back to origin via the store.

Ping @mih 