### PR TITLE
BF: check that files are extracted after normalizing suffixes

### DIFF
--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -32,6 +32,7 @@ from datalad.support.path import (
 
 from datalad.support.locking import lock_if_check_fails
 from datalad.support.external_versions import external_versions
+from datalad.support.archive_utils_7z import _normalize_fname_suffixes
 from datalad.consts import ARCHIVES_TEMP_DIR
 from datalad.utils import (
     any_re_search,
@@ -291,7 +292,7 @@ class ExtractedArchive(object):
     def assure_extracted(self):
         """Return path to the extracted `archive`.  Extract archive if necessary
         """
-        path = self.path
+        path = _normalize_fname_suffixes(self.path)
 
         with lock_if_check_fails(
             check=(lambda s: s.is_extracted, (self,)),

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -289,7 +289,7 @@ class ExtractedArchive(object):
         return exists(self.path) and exists(self.stamp_path) \
             and os.stat(self.stamp_path).st_mtime >= os.stat(self.path).st_mtime
 
-    def assure_extracted(self):
+    def ensure_extracted(self):
         """Return path to the extracted `archive`.  Extract archive if necessary
         """
         path = _normalize_fname_suffixes(self.path)
@@ -347,7 +347,7 @@ class ExtractedArchive(object):
     def get_extracted_files(self):
         """Generator to provide filenames which are available under extracted archive
         """
-        path = self.assure_extracted()
+        path = self.ensure_extracted()
         path_len = len(path) + (len(os.sep) if not path.endswith(os.sep) else 0)
         for root, dirs, files in os.walk(path):  # TEMP
             for name in files:
@@ -406,7 +406,7 @@ class ExtractedArchive(object):
         # filenames within archive are too obscure for local file system.
         # We could somehow adjust them while extracting and here channel back
         # "fixed" up names since they are only to point to the load
-        self.assure_extracted()
+        self.ensure_extracted()
         path = self.get_extracted_filename(afile)
         # TODO: make robust
         lgr.log(2, "Verifying that %s exists" % abspath(path))


### PR DESCRIPTION
I think this was a missing piece from #4877. With this change, the problem I described in https://github.com/datalad/datalad/issues/4875#issuecomment-688767763 is fixed.