### PR TITLE
Deprecate datalad.utils.assure_* aliases

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -40,8 +40,8 @@ from .support.protocol import (
     ExecutionTimeExternalsProtocol,
 )
 from .utils import (
-    assure_bytes,
-    assure_unicode,
+    ensure_bytes,
+    ensure_unicode,
     auto_repr,
     generate_file_chunks,
     get_tempfile_kwargs,
@@ -290,7 +290,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         lgr.log(5, 'Read %i bytes from %i[%s]%s',
                 len(data), self.pid, fd_name, ':' if self._log_outputs else '')
         if self._log_outputs:
-            log_data = assure_unicode(data)
+            log_data = ensure_unicode(data)
             # The way we log is to stay consistent with Runner.
             # TODO: later we might just log in a single entry, without
             # fd_name prefix
@@ -779,13 +779,13 @@ class Runner(object):
             lgr.log(3, "Processing provided line")
         if line and log_is_callable:
             # Let it be processed
-            line = log_(assure_unicode(line))
+            line = log_(ensure_unicode(line))
             if line is not None:
                 # we are working with binary type here
-                line = assure_bytes(line)
+                line = ensure_bytes(line)
         if line:
             if out_type == 'stdout':
-                self._log_out(assure_unicode(line))
+                self._log_out(ensure_unicode(line))
             elif out_type == 'stderr':
                 self._log_err(line.decode('utf-8'),
                               expected)
@@ -1154,7 +1154,7 @@ class GitRunner(Runner, GitRunnerBase):
             *args, **kwargs)
         # All communication here will be returned as unicode
         # TODO: do that instead within the super's run!
-        return assure_unicode(out), assure_unicode(err)
+        return ensure_unicode(out), ensure_unicode(err)
 
 
 class GitWitlessRunner(WitlessRunner, GitRunnerBase):
@@ -1309,7 +1309,7 @@ class BatchedCommand(SafeDelCloseMixin):
         #       it is just a "get"er - we could resend it few times
         # The default output_proc expects a single line output.
         # TODO: timeouts etc
-        stdout = assure_unicode(self.output_proc(process.stdout)) \
+        stdout = ensure_unicode(self.output_proc(process.stdout)) \
             if not process.stdout.closed else None
         if stderr:
             lgr.warning("Received output in stderr: %r", stderr)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -40,9 +40,9 @@ from .support.protocol import (
     ExecutionTimeExternalsProtocol,
 )
 from .utils import (
+    auto_repr,
     ensure_bytes,
     ensure_unicode,
-    auto_repr,
     generate_file_chunks,
     get_tempfile_kwargs,
     split_cmdline,

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -31,8 +31,8 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
 from ..utils import (
-    ensure_unicode,
     chpwd,
+    ensure_unicode,
     get_suggestions_msg,
     on_msys_tainted_paths,
     setup_exceptionhook,

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -31,7 +31,7 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
 from ..utils import (
-    assure_unicode,
+    ensure_unicode,
     chpwd,
     get_suggestions_msg,
     on_msys_tainted_paths,
@@ -145,7 +145,7 @@ def setup_parser(
     parser.add_argument(
         '-f', '--output-format', dest='common_output_format',
         default='default',
-        type=assure_unicode,
+        type=ensure_unicode,
         metavar="{default,json,json_pp,tailored,'<template>'}",
         help="""select format for returned command results. 'default' give one line
         per result reporting action, status, path and an optional message;

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -701,8 +701,8 @@ class ConfigManager(object):
           Variable value
         %s"""
         if where == 'override':
-            from datalad.utils import assure_list
-            val = assure_list(self.overrides.pop(var, None))
+            from datalad.utils import ensure_list
+            val = ensure_list(self.overrides.pop(var, None))
             val.append(value)
             self.overrides[var] = val[0] if len(val) == 1 else val
             if reload:

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -58,7 +58,7 @@ from datalad.dochelpers import (
     single_or_plural,
 )
 from datalad.utils import (
-    assure_bool,
+    ensure_bool,
     knows_annex,
     make_tempfile,
     Path,
@@ -839,7 +839,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
             continue
         sr_autoenable = config.get('autoenable', False)
         try:
-            sr_autoenable = assure_bool(sr_autoenable)
+            sr_autoenable = ensure_bool(sr_autoenable)
         except ValueError:
             lgr.warning(
                 'Failed to process "autoenable" value %r for sibling %s in '

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -46,7 +46,7 @@ from datalad.support.constraints import (
 from datalad.support.exceptions import CommandError
 from datalad.utils import (
     Path,
-    assure_list,
+    ensure_list,
 )
 
 from datalad.distribution.dataset import (
@@ -198,7 +198,7 @@ class Push(Interface):
             raise ValueError("'since' should point to commitish or use '^'.")
         # we resolve here, because we need to perform inspection on what was given
         # as an input argument further down
-        paths = [resolve_path(p, dataset) for p in assure_list(path)]
+        paths = [resolve_path(p, dataset) for p in ensure_list(path)]
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='pushing')
@@ -462,7 +462,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     depvar = 'remote.{}.datalad-publish-depends'.format(target)
     # list of remotes that are publication dependencies for the
     # target remote
-    publish_depends = assure_list(ds.config.get(depvar, []))
+    publish_depends = ensure_list(ds.config.get(depvar, []))
     if publish_depends:
         lgr.debug("Discovered publication dependencies for '%s': %s'",
                   target, publish_depends)

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -39,7 +39,7 @@ from datalad.support.constraints import (
 from datalad.support.param import Parameter
 from datalad.utils import (
     getpwd,
-    assure_list,
+    ensure_list,
     get_dataset_root,
 )
 
@@ -268,7 +268,7 @@ class Create(Interface):
         assert(path is not None)
 
         # assure cfg_proc is a list (relevant if used via Python API)
-        cfg_proc = assure_list(cfg_proc)
+        cfg_proc = ensure_list(cfg_proc)
 
         # prep for yield
         res = dict(action='create', path=str(path),

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -15,8 +15,8 @@ import logging
 import os.path as op
 from collections import OrderedDict
 from datalad.utils import (
-    assure_list,
-    assure_unicode,
+    ensure_list,
+    ensure_unicode,
     get_dataset_root,
 )
 from datalad.interface.base import (
@@ -129,8 +129,8 @@ class Diff(Interface):
             recursion_limit=None):
         yield from diff_dataset(
             dataset=dataset,
-            fr=assure_unicode(fr),
-            to=assure_unicode(to),
+            fr=ensure_unicode(fr),
+            to=ensure_unicode(to),
             constant_refs=False,
             path=path,
             annex=annex,
@@ -210,7 +210,7 @@ def diff_dataset(
     if path:
         ps = []
         # sort any path argument into the respective subdatasets
-        for p in sorted(assure_list(path)):
+        for p in sorted(ensure_list(path)):
             # it is important to capture the exact form of the
             # given path argument, before any normalization happens
             # distinguish rsync-link syntax to identify

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -50,9 +50,9 @@ from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
 from datalad.utils import (
+    chpwd,
     ensure_bytes,
     ensure_unicode,
-    chpwd,
     get_dataset_root,
     getpwd,
     join_cmdline,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -50,8 +50,8 @@ from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
 
 from datalad.utils import (
-    assure_bytes,
-    assure_unicode,
+    ensure_bytes,
+    ensure_unicode,
     chpwd,
     get_dataset_root,
     getpwd,
@@ -399,7 +399,7 @@ def normalize_command(command):
     """Convert `command` to the string representation.
     """
     if isinstance(command, list):
-        command = list(map(assure_unicode, command))
+        command = list(map(ensure_unicode, command))
         if len(command) == 1 and command[0] != "--":
             # This is either a quoted compound shell command or a simple
             # one-item command. Pass it as is.
@@ -418,7 +418,7 @@ def normalize_command(command):
                 command = command[1:]
             command = join_cmdline(command)
     else:
-        command = assure_unicode(command)
+        command = ensure_unicode(command)
     return command
 
 
@@ -688,7 +688,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             repo = ds.repo
             msg_path = relpath(opj(str(repo.dot_git), "COMMIT_EDITMSG"))
             with open(msg_path, "wb") as ofh:
-                ofh.write(assure_bytes(msg))
+                ofh.write(ensure_bytes(msg))
             lgr.info("The command had a non-zero exit code. "
                      "If this is expected, you can save the changes with "
                      "'datalad save -d . -r -F %s'",

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -35,7 +35,7 @@ from datalad.support.constraints import (
 )
 from datalad.support.exceptions import CommandError
 from datalad.utils import (
-    assure_list,
+    ensure_list,
 )
 import datalad.utils as ut
 
@@ -155,7 +155,7 @@ class Save(Interface):
             raise ValueError(
                 "Both a message and message file were specified for save()")
 
-        path = assure_list(path)
+        path = ensure_list(path)
 
         if message_file:
             with open(message_file) as mfh:

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -17,8 +17,8 @@ import os.path as op
 from collections import OrderedDict
 
 from datalad.utils import (
-    assure_list,
-    assure_unicode,
+    ensure_list,
+    ensure_unicode,
     bytes2human,
     get_dataset_root,
 )
@@ -327,7 +327,7 @@ class Status(Interface):
         paths_by_ds = OrderedDict()
         if path:
             # sort any path argument into the respective subdatasets
-            for p in sorted(map(assure_unicode, assure_list(path))):
+            for p in sorted(map(ensure_unicode, ensure_list(path))):
                 # it is important to capture the exact form of the
                 # given path argument, before any normalization happens
                 # for further decision logic below

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -17,9 +17,9 @@ import os.path as op
 from collections import OrderedDict
 
 from datalad.utils import (
+    bytes2human,
     ensure_list,
     ensure_unicode,
-    bytes2human,
     get_dataset_root,
 )
 from datalad.interface.base import (

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -26,7 +26,7 @@ import sys
 from unittest.mock import patch
 
 from datalad.utils import (
-    assure_unicode,
+    ensure_unicode,
     chpwd,
     on_windows,
 )
@@ -336,7 +336,7 @@ def test_inputs_quotes_needed(path):
         list(sorted([OBSCURE_FILENAME + u".t", "bar.txt", "foo blah.txt"])) +
         ["out0"])
     with open(op.join(path, "out0")) as ifh:
-        eq_(assure_unicode(ifh.read()), expected)
+        eq_(ensure_unicode(ifh.read()), expected)
     # ... but the list form of a command does not. (Don't test this failure
     # with the obscure file name because we'd need to know its composition to
     # predict the failure.)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -26,8 +26,8 @@ import sys
 from unittest.mock import patch
 
 from datalad.utils import (
-    ensure_unicode,
     chpwd,
+    ensure_unicode,
     on_windows,
 )
 

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -12,7 +12,7 @@ import os
 import os.path as op
 
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     Path,
     on_windows,
     rmtree,
@@ -398,10 +398,10 @@ def test_add_files(path):
             status = ds.repo.annexstatus(['dir'])
         else:
             result = ds.save(arg[0], to_git=arg[1])
-            for a in assure_list(arg[0]):
+            for a in ensure_list(arg[0]):
                 assert_result_count(result, 1, path=str(ds.pathobj / a))
             status = ds.repo.get_content_annexinfo(
-                ut.Path(p) for p in assure_list(arg[0]))
+                ut.Path(p) for p in ensure_list(arg[0]))
         for f, p in status.items():
             if arg[1]:
                 assert p.get('key', None) is None, f

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -28,7 +28,7 @@ from ..support.locking import lock_if_check_fails
 from ..support.path import exists
 from ..utils import getpwd
 from ..utils import unique
-from ..utils import assure_bytes
+from ..utils import ensure_bytes
 from ..utils import unlink
 from .base import AnnexCustomRemote
 from .main import main as super_main
@@ -257,7 +257,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 # if for testing we want to force getting the archive extracted
                 # _ = self.cache.assure_extracted(self._get_key_path(akey)) # TEMP
                 efile = self.cache[akey_path].get_extracted_filename(afile)
-                efile = assure_bytes(efile)
+                efile = ensure_bytes(efile)
 
                 if exists(efile):
                     size = os.stat(efile).st_size

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -31,7 +31,7 @@ from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 from ..dochelpers import exc_str
 from datalad.utils import (
-    assure_unicode,
+    ensure_unicode,
     getargspec,
     Path,
 )
@@ -122,7 +122,7 @@ send () {
             lgr.debug("Commenting out previous entries")
             # comment out all the past entries
             with open(_file, 'rb') as f:
-                entries = list(map(assure_unicode, f.readlines()))
+                entries = list(map(ensure_unicode, f.readlines()))
             for i in range(len(self.HEADER.split(os.linesep)), len(entries)):
                 e = entries[i]
                 if e.startswith('recv ') or e.startswith('send '):

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -31,7 +31,7 @@ from ..support.constraints import (
     EnsureStr,
 )
 from ..utils import (
-    assure_list,
+    ensure_list,
 )
 from ..distribution.dataset import (
     datasetmethod,
@@ -219,7 +219,7 @@ class CreateSiblingGitlab(Interface):
             publish_depends=None,
             description=None,
             dryrun=False):
-        path = resolve_path(assure_list(path), ds=dataset) \
+        path = resolve_path(ensure_list(path), ds=dataset) \
             if path else None
 
         if project and (recursive or (path and len(path) > 1)):

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -89,7 +89,7 @@ from datalad.utils import (
     make_tempfile,
     _path_,
     slash_join,
-    assure_list,
+    ensure_list,
     quote_cmdlinearg,
 )
 
@@ -673,7 +673,7 @@ class CreateSibling(Interface):
                 # make sure dependencies are valid
                 # TODO: inherit -- we might want to automagically create
                 # those dependents as well???
-                unknown_deps = set(assure_list(publish_depends)).difference(checkds_remotes)
+                unknown_deps = set(ensure_list(publish_depends)).difference(checkds_remotes)
                 if unknown_deps:
                     ap['status'] = 'error'
                     ap['message'] = (

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -33,7 +33,7 @@ from ..support.constraints import (
     EnsureStr,
 )
 from ..utils import (
-    assure_list,
+    ensure_list,
 )
 from .dataset import (
     datasetmethod,
@@ -233,7 +233,7 @@ class CreateSiblingGithub(Interface):
     @staticmethod
     def result_renderer_cmdline(res, args):
         from datalad.ui import ui
-        res = assure_list(res)
+        res = ensure_list(res)
         if args.dryrun:
             ui.message('DRYRUN -- Anticipated results:')
         if not len(res):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -48,7 +48,7 @@ from datalad.utils import (
     get_dataset_root as rev_get_dataset_root,
     Path,
     PurePath,
-    assure_list,
+    ensure_list,
     quote_cmdlinearg,
 )
 
@@ -623,7 +623,7 @@ def resolve_path(path, ds=None):
         ds = require_dataset(
             ds, check_installed=False, purpose='path resolution')
     out = []
-    for p in assure_list(path):
+    for p in ensure_list(path):
         if ds is None or not got_ds_instance:
             # no dataset at all or no instance provided -> CWD is always the reference
             # nothing needs to be done here. Path-conversion and absolutification

--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -18,7 +18,7 @@ from os.path import join as opj
 from os.path import isabs
 from os.path import normpath
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone
 from datalad.support.exceptions import InsufficientArgumentsError
@@ -80,7 +80,7 @@ def _drop_files(ds, paths, check, noannex_iserror=False, **kwargs):
         kwargs['action'] = 'drop'
     # always need to make sure that we pass a list
     # `normalize_paths` decorator will otherwise screw all logic below
-    paths = assure_list(paths)
+    paths = ensure_list(paths)
     if not hasattr(ds.repo, 'drop'):
         for p in paths:
             r = get_status_dict(

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -39,7 +39,7 @@ from datalad.support.network import (
     RI,
     PathRI,
 )
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.dochelpers import exc_str
 
 from datalad.distribution.dataset import (
@@ -180,7 +180,7 @@ class Install(Interface):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`
-        path = assure_list(path)
+        path = ensure_list(path)
 
         if not source and not path:
             raise InsufficientArgumentsError(

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -36,7 +36,7 @@ from datalad.support.exceptions import (
 )
 from datalad.support.network import URL, RI, SSHRI, is_ssh
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.dochelpers import exc_str
 
 from .dataset import EnsureDataset
@@ -295,7 +295,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
     depvar = 'remote.{}.datalad-publish-depends'.format(remote)
     # list of remotes that are publication dependencies for the
     # target remote
-    publish_depends = assure_list(ds.config.get(depvar, []))
+    publish_depends = ensure_list(ds.config.get(depvar, []))
 
     # remote might be set to be ignored by annex, or we might not even know yet its uuid
     # make sure we are up-to-date on this topic on all affected remotes, before

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -64,7 +64,7 @@ from datalad.distribution.dataset import (
 )
 from datalad.distribution.update import Update
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     slash_join,
     Path,
 )
@@ -445,7 +445,7 @@ def _configure_remote(
 
         if publish_depends:
             # Check if all `deps` remotes are known to the `repo`
-            unknown_deps = set(assure_list(publish_depends)).difference(
+            unknown_deps = set(ensure_list(publish_depends)).difference(
                 known_remotes)
             if unknown_deps:
                 result_props['status'] = 'error'
@@ -511,7 +511,7 @@ def _configure_remote(
                 # config vars are incremental, so make sure we start from
                 # scratch
                 ds.config.unset(depvar, where='local', reload=False)
-            for d in assure_list(publish_depends):
+            for d in ensure_list(publish_depends):
                 lgr.info(
                     'Configure additional publication dependency on "%s"',
                     d)
@@ -521,7 +521,7 @@ def _configure_remote(
         if publish_by_default:
             if dfltvar in ds.config:
                 ds.config.unset(dfltvar, where='local', reload=False)
-            for refspec in assure_list(publish_by_default):
+            for refspec in ensure_list(publish_by_default):
                 lgr.info(
                     'Configure additional default publication refspec "%s"',
                     refspec)

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -20,8 +20,8 @@ import io
 from time import sleep
 
 from ..utils import (
-    assure_list_from_str,
-    assure_dict_from_str,
+    ensure_list_from_str,
+    ensure_dict_from_str,
     ensure_bytes,
 )
 from ..dochelpers import borrowkwargs
@@ -142,9 +142,9 @@ class HTTPBaseAuthenticator(Authenticator):
         """
         super(HTTPBaseAuthenticator, self).__init__(**kwargs)
         self.url = url
-        self.failure_re = assure_list_from_str(failure_re)
-        self.success_re = assure_list_from_str(success_re)
-        self.session_cookies = assure_list_from_str(session_cookies)
+        self.failure_re = ensure_list_from_str(failure_re)
+        self.success_re = ensure_list_from_str(success_re)
+        self.session_cookies = ensure_list_from_str(session_cookies)
 
     def authenticate(self, url, credential, session, update=False):
         # we should use specified URL for this authentication first
@@ -262,7 +262,7 @@ class HTMLFormAuthenticator(HTTPBaseAuthenticator):
           Passed to super class HTTPBaseAuthenticator
         """
         super(HTMLFormAuthenticator, self).__init__(**kwargs)
-        self.fields = assure_dict_from_str(fields)
+        self.fields = ensure_dict_from_str(fields)
         self.tagid = tagid
 
     def _post_credential(self, credentials, post_url, session):

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -34,7 +34,7 @@ from ..support.configparserinc import SafeConfigParserWithIncludes
 from ..support.external_versions import external_versions
 from ..support.network import RI
 from ..support import path
-from ..utils import assure_list_from_str
+from ..utils import ensure_list_from_str
 from ..utils import auto_repr
 from ..utils import get_dataset_root
 
@@ -89,7 +89,7 @@ class Provider(object):
 
         """
         self.name = name
-        self.url_res = assure_list_from_str(url_res)
+        self.url_res = ensure_list_from_str(url_res)
         self.credential = credential
         self.authenticator = authenticator
         self._downloader = downloader
@@ -296,7 +296,7 @@ class Providers(object):
             authenticator = None
 
         # bringing url_re to "standard" format of a list and populating _providers_ordered
-        url_res = assure_list_from_str(items.pop('url_re', []))
+        url_res = ensure_list_from_str(items.pop('url_re', []))
         assert url_res, "current implementation relies on having url_re defined"
 
         credential = items.pop('credential', None)

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -34,8 +34,8 @@ from ..support.configparserinc import SafeConfigParserWithIncludes
 from ..support.external_versions import external_versions
 from ..support.network import RI
 from ..support import path
-from ..utils import ensure_list_from_str
 from ..utils import auto_repr
+from ..utils import ensure_list_from_str
 from ..utils import get_dataset_root
 
 from ..interface.common_cfg import dirs

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -14,7 +14,7 @@ import re
 from urllib.parse import urlsplit, unquote as urlunquote
 
 from ..utils import auto_repr
-from ..utils import assure_dict_from_str
+from ..utils import ensure_dict_from_str
 from ..dochelpers import borrowkwargs
 from ..support.network import get_url_straight_filename
 from ..support.network import rfc2822_to_epoch, iso8601_to_epoch
@@ -177,9 +177,9 @@ class S3Downloader(BaseDownloader):
         if re.search('%[0-9a-fA-F]{2}', filepath):
             lgr.debug("URL unquoting S3 URL filepath %s", filepath)
             filepath = urlunquote(filepath)
-        # TODO: needs replacement to assure_ since it doesn't
+        # TODO: needs replacement to ensure_ since it doesn't
         # deal with non key=value
-        return rec.netloc, filepath, assure_dict_from_str(rec.query, sep='&') or {}
+        return rec.netloc, filepath, ensure_dict_from_str(rec.query, sep='&') or {}
 
     def _establish_session(self, url, allow_old=True):
         """

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -41,7 +41,7 @@ from ..cmdline.helpers import get_repo_instance
 from ..utils import getpwd, rmtree, file_basename
 from ..utils import md5sum
 from ..utils import Path
-from ..utils import assure_tuple_or_list
+from ..utils import ensure_tuple_or_list
 from ..utils import get_dataset_root
 from ..utils import split_cmdline
 
@@ -206,9 +206,9 @@ class AddArchiveContent(Interface):
         annex
         """
         if exclude:
-            exclude = assure_tuple_or_list(exclude)
+            exclude = ensure_tuple_or_list(exclude)
         if rename:
-            rename = assure_tuple_or_list(rename)
+            rename = ensure_tuple_or_list(rename)
 
         # TODO: actually I see possibly us asking user either he wants to convert
         # his git repo into annex

--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -46,7 +46,7 @@ from datalad.utils import get_dataset_root
 from datalad.utils import with_pathsep as _with_sep
 from datalad.utils import path_startswith
 from datalad.utils import path_is_subpath
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.utils import dlabspath
 from datalad.utils import expandpath
 from datalad.utils import is_explicit_path
@@ -551,7 +551,7 @@ class AnnotatePaths(Interface):
         # goal: structure in a way that makes most information on any path
         # available in a single pass, at the cheapest possible cost
         reported_paths = {}
-        requested_paths = assure_list(path)
+        requested_paths = ensure_list(path)
 
         if modified is not None:
             # modification detection would silently kill all nondataset paths

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -109,12 +109,12 @@ def _get_untracked_content(dspath, report_untracked, paths=None):
             # nothing to filter
             paths = None
 
-    from datalad.utils import assure_unicode
+    from datalad.utils import ensure_unicode
 
     for line in stdout.split('\0'):
         if not line:
             continue
-        line = assure_unicode(line)
+        line = ensure_unicode(line)
         if not line.startswith('?? '):
             # nothing untracked, ignore, task of `diff`
             continue

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -20,7 +20,7 @@ from ..interface.common_opts import nosave_opt
 from ..interface.common_opts import save_message_opt
 from ..interface.results import get_status_dict
 from ..interface.utils import eval_results
-from ..utils import assure_list_from_str
+from ..utils import ensure_list_from_str
 from ..utils import Path
 from ..utils import PurePosixPath
 from ..distribution.dataset import Dataset
@@ -126,7 +126,7 @@ class DownloadURL(Interface):
             # resolve_path() doesn't preserve trailing separators. Add one for
             # the download() call.
             path = path + op.sep
-        urls = assure_list_from_str(urls)
+        urls = ensure_list_from_str(urls)
 
         if not dir_is_target:
             if len(urls) > 1:

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -21,7 +21,7 @@ from os.path import relpath
 from os.path import abspath
 from os.path import normpath
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     with_pathsep as _with_sep,
     path_is_subpath,
     PurePosixPath,
@@ -106,7 +106,7 @@ def results_from_paths(paths, action=None, type=None, logger=None, refds=None,
     generator
 
     """
-    for p in assure_list(paths):
+    for p in ensure_list(paths):
         yield get_status_dict(
             action, path=p, type=type, logger=logger, refds=refds,
             status=status, message=(message, p) if '%s' in message else message)
@@ -251,7 +251,7 @@ def count_results(res, **kwargs):
 
 def only_matching_paths(res, **kwargs):
     # TODO handle relative paths by using a contained 'refds' value
-    paths = assure_list(kwargs.get('path', []))
+    paths = ensure_list(kwargs.get('path', []))
     respath = res.get('path', None)
     return respath in paths
 
@@ -276,7 +276,7 @@ def is_result_matching_pathsource_argument(res, **kwargs):
         # otherwise this is not what we are looking for
         return source == res.get('source_url', None)
     # the only thing left is a potentially heterogeneous list of paths/URLs
-    paths = assure_list(kwargs.get('path', []))
+    paths = ensure_list(kwargs.get('path', []))
     # three cases left:
     # 1. input arg was an absolute path -> must match 'path' property
     # 2. input arg was relative to a dataset -> must match refds/relpath

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -40,7 +40,7 @@ from datalad.utils import (
     split_cmdline,
 )
 
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 import datalad.support.ansi_colors as ac
 
 from datalad.core.local.run import Run
@@ -122,13 +122,13 @@ def _get_procedure_implementation(name='*', ds=None):
     # 1. check system and user account for procedure
     for loc in (cfg.obtain('datalad.locations.user-procedures'),
                 cfg.obtain('datalad.locations.system-procedures')):
-        for dir in assure_list(loc):
+        for dir in ensure_list(loc):
             for m, n in _get_file_match(dir, name):
                 yield (m, n,) + _get_proc_config(n)
     # 2. check dataset for procedure
     if ds is not None and ds.is_installed():
         # could be more than one
-        dirs = assure_list(
+        dirs = ensure_list(
                 ds.config.obtain('datalad.locations.dataset-procedures'))
         for dir in dirs:
             # TODO `get` dirs if necessary

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 import datalad
 from .base import Interface
 from datalad.interface.base import build_doc
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from ..support.param import Parameter
 
 import logging
@@ -63,7 +63,7 @@ class Test(Interface):
             from pkg_resources import iter_entry_points
             module = ['datalad']
             module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
-        module = assure_list(module)
+        module = ensure_list(module)
         lgr.info('Starting test run for module(s): %s', module)
         for mod in module:
             datalad.test(module=mod, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/interface/unlock.py
+++ b/datalad/interface/unlock.py
@@ -32,7 +32,7 @@ from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
-from datalad.utils import assure_list
+from datalad.utils import ensure_list
 from datalad.utils import Path
 
 from .base import Interface
@@ -91,7 +91,7 @@ class Unlock(Interface):
         paths_nondir = set()
         paths_lexist = None
         if path:
-            path = resolve_path(assure_list(path), ds=dataset)
+            path = resolve_path(ensure_list(path), ds=dataset)
             paths_lexist = []
             for p in path:
                 if p.exists() or p.is_symlink():

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -35,7 +35,7 @@ from datalad.utils import with_pathsep as _with_sep  # TODO: RF whenever merge c
 from datalad.utils import (
     path_startswith,
     path_is_subpath,
-    assure_unicode,
+    ensure_unicode,
     getargspec,
     get_wrapped_class,
 )
@@ -230,7 +230,7 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
     filematch = False
     if isdir(basepath):
         for p in listdir(basepath):
-            p = assure_unicode(opj(basepath, p))
+            p = ensure_unicode(opj(basepath, p))
             if not isdir(p):
                 if p in targetpaths:
                     filematch = True

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -37,7 +37,7 @@ from datalad.distribution.dataset import (
 from datalad.support.gitrepo import GitRepo
 from datalad.dochelpers import exc_str
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     partition,
 )
 
@@ -221,7 +221,7 @@ class Subdatasets(Interface):
         # no constraints given -> query subdatasets under curdir
         if not path and dataset is None:
             path = os.curdir
-        paths = [resolve_path(p, dataset) for p in assure_list(path)] \
+        paths = [resolve_path(p, dataset) for p in ensure_list(path)] \
             if path else None
 
         ds = require_dataset(
@@ -242,7 +242,7 @@ class Subdatasets(Interface):
                         "key '%s' is invalid (alphanumeric plus '-' only, must "
                         "start with a letter)" % k)
         if contains:
-            contains = [resolve_path(c, dataset) for c in assure_list(contains)]
+            contains = [resolve_path(c, dataset) for c in ensure_list(contains)]
         contains_hits = set()
         for r in _get_submodules(
                 ds, paths, fulfilled, recursive, recursion_limit,
@@ -302,7 +302,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                    for p in paths)
         if to_report and (set_property or delete_property):
             # first deletions
-            for dprop in assure_list(delete_property):
+            for dprop in ensure_list(delete_property):
                 try:
                     repo.call_git(
                         ['config', '--file', '.gitmodules',
@@ -324,7 +324,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                 # also kick from the info we just read above
                 sm.pop('gitmodule_{}'.format(dprop), None)
             # and now setting values
-            for sprop in assure_list(set_property):
+            for sprop in ensure_list(set_property):
                 prop, val = sprop
                 if val.startswith('<') and val.endswith('>') and '{' in val:
                     # expand template string

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -73,7 +73,7 @@ from datalad.support.path import split_ext
 from datalad.utils import (
     path_is_subpath,
     all_same,
-    assure_list,
+    ensure_list,
 )
 
 lgr = logging.getLogger('datalad.metadata.aggregate')
@@ -444,7 +444,7 @@ def _extract_metadata(agginto_ds, aggfrom_ds, db, to_save, objid, metasources,
     # paths to extract from
     relevant_paths = sorted(_get_metadatarelevant_paths(aggfrom_ds, subds_relpaths))
     # get extractors to engage from source dataset
-    nativetypes = ['datalad_core', 'annex'] + assure_list(get_metadata_type(aggfrom_ds))
+    nativetypes = ['datalad_core', 'annex'] + ensure_list(get_metadata_type(aggfrom_ds))
     # store esssential extraction config in dataset record
     agginfo['extractors'] = nativetypes
     agginfo['datalad_version'] = datalad.__version__
@@ -914,7 +914,7 @@ class AggregateMetaData(Interface):
         # it really doesn't work without a dataset
         ds = require_dataset(
             dataset, check_installed=True, purpose='metadata aggregation')
-        path = assure_list(path)
+        path = ensure_list(path)
         if not path:
             # then current/reference dataset is "aggregated"
             # We should not add ds.path always since then --recursive would

--- a/datalad/metadata/extractors/xmp.py
+++ b/datalad/metadata/extractors/xmp.py
@@ -20,7 +20,7 @@ from datalad.log import log_progress
 from libxmp.utils import file_to_dict
 from datalad.metadata.definitions import vocabulary_id
 from datalad.metadata.extractors.base import BaseMetadataExtractor
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 
 
 xmp_field_re = re.compile(r'^([^\[\]]+)(\[\d+\]|)(/?.*|)')
@@ -87,7 +87,7 @@ class MetadataExtractor(BaseMetadataExtractor):
                         # we'll catch the actuall array values later
                         continue
                     # normalize value
-                    val = assure_unicode(val)
+                    val = ensure_unicode(val)
                     # non-breaking space
                     val = val.replace(u"\xa0", ' ')
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -52,7 +52,7 @@ from datalad.distribution.dataset import (
     require_dataset,
 )
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     path_is_subpath,
     path_startswith,
     as_unicode,
@@ -465,7 +465,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
             )
 
     # pull out potential metadata field blacklist config settings
-    blacklist = [re.compile(bl) for bl in assure_list(ds.config.obtain(
+    blacklist = [re.compile(bl) for bl in ensure_list(ds.config.obtain(
         'datalad.metadata.aggregate-ignore-fields',
         default=[]))]
     # enforce size limits
@@ -1080,4 +1080,4 @@ class Metadata(Interface):
                           if k not in ('tag', '@context', '@id'))
                  if meta else ' -' if 'metadata' in res else ' aggregated',
             tags='' if 'tag' not in meta else ' [{}]'.format(
-                 ','.join(assure_list(meta['tag'])))))
+                 ','.join(ensure_list(meta['tag'])))))

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -40,8 +40,8 @@ from datalad.support.constraints import EnsureInt
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
 from datalad.utils import (
     as_unicode,
-    assure_list,
-    assure_unicode,
+    ensure_list,
+    ensure_unicode,
     get_suggestions_msg,
     shortened_repr,
     unicode_srctypes,
@@ -314,7 +314,7 @@ class _WhooshSearch(_Search):
         self._mk_parser()
         # for convenience we accept any number of args-words from the
         # shell and put them together to a single string here
-        querystr = ' '.join(assure_list(query))
+        querystr = ' '.join(ensure_list(query))
         # this gives a formal whoosh query
         wquery = self.parser.parse(querystr)
         return wquery
@@ -470,7 +470,7 @@ class _WhooshSearch(_Search):
                 old_ds_rpath = admin['path']
                 admin['id'] = res.get('dsid', None)
 
-            doc.update({k: assure_unicode(v) for k, v in admin.items()})
+            doc.update({k: ensure_unicode(v) for k, v in admin.items()})
             lgr.debug("Adding document to search index: {}".format(doc))
             # inject into index
             idx.add_document(**doc)
@@ -536,7 +536,7 @@ class _WhooshSearch(_Search):
             for i, hit in enumerate(hits):
                 annotated_hit = dict(
                     path=normpath(opj(self.ds.path, hit['path'])),
-                    query_matched={assure_unicode(k): assure_unicode(v)
+                    query_matched={ensure_unicode(k): ensure_unicode(v)
                                    if isinstance(v, unicode_srctypes) else v
                                    for k, v in hit.matched_terms()},
                     parentds=normpath(
@@ -799,7 +799,7 @@ class _EGrepCSSearch(_Search):
             stat = keys[k]
             all_uvals = uvals = sorted(stat.uvals)
 
-            stat.uvals_str = assure_unicode(
+            stat.uvals_str = ensure_unicode(
                 "{} unique values: ".format(len(all_uvals))
             )
 
@@ -882,7 +882,7 @@ class _EGrepCSSearch(_Search):
         return set(shortened_repr(x, 50) for x in kvals_iter)
 
     def get_query(self, query):
-        query = assure_list(query)
+        query = ensure_list(query)
         simple_fieldspec = re.compile(r"(?P<field>\S*?):(?P<query>.*)")
         quoted_fieldspec = re.compile(r"'(?P<field>[^']+?)':(?P<query>.*)")
         query_rec_matches = [

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -29,7 +29,7 @@ from datalad.metadata.metadata import (
     query_aggregated_metadata,
 )
 from datalad.utils import (
-    assure_unicode,
+    ensure_unicode,
     chpwd,
 )
 from datalad.tests.utils import (
@@ -163,7 +163,7 @@ def test_aggregation(path):
     for name in ('MOTHER_äöü東', 'child_äöü東', 'grandchild_äöü東'):
         assert_true(
             sum([s['metadata']['frictionless_datapackage']['name'] \
-                    == assure_unicode(name) for s in origres
+                    == ensure_unicode(name) for s in origres
                  if s['type'] == 'dataset']))
 
     # now clone the beast to simulate a new user installing an empty dataset

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -29,8 +29,8 @@ from datalad.metadata.metadata import (
     query_aggregated_metadata,
 )
 from datalad.utils import (
-    ensure_unicode,
     chpwd,
+    ensure_unicode,
 )
 from datalad.tests.utils import (
     assert_dict_equal,

--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -64,7 +64,7 @@ class AddReadme(Interface):
         lgr = logging.getLogger('datalad.plugin.add_readme')
 
         from datalad.distribution.dataset import require_dataset
-        from datalad.utils import assure_list
+        from datalad.utils import ensure_list
 
         dataset = require_dataset(dataset, check_installed=True,
                                   purpose='add README')
@@ -103,11 +103,11 @@ class AddReadme(Interface):
         for label, content in (
                 ('', meta.get('description', meta.get('shortdescription', ''))),
                 ('Author{}'.format('s' if isinstance(meta.get('author', None), list) else ''),
-                    u'\n'.join([u'- {}'.format(a) for a in assure_list(meta.get('author', []))])),
+                    u'\n'.join([u'- {}'.format(a) for a in ensure_list(meta.get('author', []))])),
                 ('Homepage', meta.get('homepage', '')),
                 ('Reference', meta.get('citation', '')),
                 ('License', meta.get('license', '')),
-                ('Keywords', u', '.join([u'`{}`'.format(k) for k in assure_list(meta.get('tag', []))])),
+                ('Keywords', u', '.join([u'`{}`'.format(k) for k in ensure_list(meta.get('tag', []))])),
                 ('Funding', meta.get('fundedby', '')),
                 ):
             if label and content:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -34,7 +34,7 @@ from datalad.support.network import get_url_filename
 from datalad.support.path import split_ext
 from datalad.support.s3 import get_versioned_url
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     get_suggestions_msg,
     unlink,
 )
@@ -449,7 +449,7 @@ def extract(stream, input_type, url_format="{0}", filename_format="{1}",
     for each row in `stream` and the second item a list subdataset paths,
     sorted breadth-first.
     """
-    meta = assure_list(meta)
+    meta = ensure_list(meta)
 
     rows, colidx_to_name = _read(stream, input_type)
     if not rows:

--- a/datalad/plugin/no_annex.py
+++ b/datalad/plugin/no_annex.py
@@ -81,9 +81,9 @@ class NoAnnex(Interface):
         from os import makedirs as makedirsfx
         from datalad.distribution.dataset import require_dataset
         from datalad.support.annexrepo import AnnexRepo
-        from datalad.utils import assure_list
+        from datalad.utils import ensure_list
 
-        pattern = assure_list(pattern)
+        pattern = ensure_list(pattern)
         ds = require_dataset(dataset, check_installed=True,
                              purpose='no_annex configuration')
 

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -25,7 +25,7 @@ from datalad.version import __version__
 
 from ..wtf import SECTION_CALLABLES
 
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.tests.utils import (
     assert_in,
     assert_not_in,
@@ -89,7 +89,7 @@ def test_wtf(topdir):
         assert_in('## configuration', cmo.out)
         assert_in('## dataset', cmo.out)
         assert_in(u'path: {}'.format(ds.path),
-                  assure_unicode(cmo.out))
+                  ensure_unicode(cmo.out))
 
     # and if we run with all sensitive
     for sensitive in ('some', True):

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.utils import (
-    assure_unicode,
+    ensure_unicode,
     getpwd,
     unlink,
 )
@@ -83,8 +83,8 @@ def get_max_path_length(top_path=None, maxl=1000):
 def _describe_datalad():
 
     return {
-        'version': assure_unicode(__version__),
-        'full_version': assure_unicode(__full_version__),
+        'version': ensure_unicode(__version__),
+        'full_version': ensure_unicode(__full_version__),
     }
 
 
@@ -370,7 +370,7 @@ class WTF(Interface):
         infos = OrderedDict()
         res = get_status_dict(
             action='wtf',
-            path=ds.path if ds else assure_unicode(op.abspath(op.curdir)),
+            path=ds.path if ds else ensure_unicode(op.abspath(op.curdir)),
             type='dataset' if ds else 'directory',
             status='ok',
             logger=lgr,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -45,7 +45,6 @@ from datalad.dochelpers import (
 from datalad.ui import ui
 import datalad.utils as ut
 from datalad.utils import (
-    assure_list,
     auto_repr,
     ensure_list,
     get_linux_distribution,
@@ -1770,7 +1769,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                                content=content, no_content=not content,
                                all=all,
                                fast=fast))
-        args.extend(assure_list(remotes))
+        args.extend(ensure_list(remotes))
         self._run_annex_command('sync', annex_options=args, runner="gitwitless")
 
     @normalize_path
@@ -1976,12 +1975,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             raise InsufficientArgumentsError("drop() requires at least to "
                                              "specify 'files' or 'options'")
 
-        options = assure_list(options)
+        options = ensure_list(options)
 
         if key:
             # we can't drop multiple in 1 line, and there is no --batch yet, so
             # one at a time
-            files = assure_list(files)
+            files = ensure_list(files)
             options = options + ['--key']
             res = [
                 self._run_annex_command_json(
@@ -2302,7 +2301,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 % (output, ', '.join(map(repr, OUTPUTS)))
             )
 
-        options = assure_list(options, copy=True)
+        options = ensure_list(options, copy=True)
         if key:
             kwargs = {'opts': options + ["--key"] + files}
         else:
@@ -3012,7 +3011,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             return
         if batch is False:
             # we can be lazy
-            files = assure_list(files)
+            files = ensure_list(files)
         else:
             if isinstance(files, str):
                 files = [files]
@@ -3077,7 +3076,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """Like set_metadata() but returns a generator"""
 
         def _genspec(expr, d):
-            return [expr.format(k, v) for k, vs in d.items() for v in assure_list(vs)]
+            return [expr.format(k, v) for k, vs in d.items() for v in ensure_list(vs)]
 
         args = []
         spec = []
@@ -3385,7 +3384,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         had_synced_branch = synced_branch in self.get_branches()
         cmd = ['annex', 'sync']
         if remote:
-            cmd.extend(assure_list(remote))
+            cmd.extend(ensure_list(remote))
         cmd.extend([
             # disable any external interaction and other magic
             '--no-push', '--no-pull', '--no-commit', '--no-resolvemerge',

--- a/datalad/support/archive_utils_patool.py
+++ b/datalad/support/archive_utils_patool.py
@@ -22,7 +22,7 @@ from .path import (
 )
 
 from datalad.utils import (
-    assure_bytes,
+    ensure_bytes,
     chpwd,
     rmdir,
 )
@@ -56,7 +56,7 @@ import patoolib.util
 from ..support.exceptions import CommandError
 from ..utils import swallow_outputs
 from ..cmd import Runner
-from ..utils import assure_unicode
+from ..utils import ensure_unicode
 
 from ..utils import on_windows
 
@@ -130,15 +130,15 @@ def decompress_file(archive, dir_):
     dir_: str
     """
     with swallow_outputs() as cmo:
-        archive = assure_bytes(archive)
-        dir_ = assure_bytes(dir_)
+        archive = ensure_bytes(archive)
+        dir_ = ensure_bytes(dir_)
         patoolib.util.check_existing_filename(archive)
         patoolib.util.check_existing_filename(dir_, onlyfiles=False)
         # Call protected one to avoid the checks on existence on unixified path
         outdir = unixify_path(dir_)
         # should be supplied in PY3 to avoid b''
-        outdir = assure_unicode(outdir)
-        archive = assure_unicode(archive)
+        outdir = ensure_unicode(outdir)
+        archive = ensure_unicode(archive)
 
         format_compression = patoolib.get_archive_format(archive)
         if format_compression == ('gzip', None):

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -16,7 +16,7 @@ from ..consts import (
 from ..dochelpers import exc_str
 from ..downloaders.credentials import UserPassword
 from ..ui import ui
-from ..utils import unique, assure_list, assure_tuple_or_list
+from ..utils import unique, ensure_list, ensure_tuple_or_list
 
 from .exceptions import (
     AccessDeniedError,
@@ -99,7 +99,7 @@ def _gen_github_ses(github_login, github_passwd):
 
     # see if we have tokens - might be many. Doesn't cost us much so get at once
     all_tokens = tokens = unique(
-        assure_list(cfg.get(CONFIG_HUB_TOKEN_FIELD, None)),
+        ensure_list(cfg.get(CONFIG_HUB_TOKEN_FIELD, None)),
         reverse=True
     )
 
@@ -331,7 +331,7 @@ def _make_github_repos(
                     dryrun)
                 # output will contain whatever is returned by _make_github_repo
                 # but with a dataset prepended to the record
-                res.append((ds,) + assure_tuple_or_list(res_))
+                res.append((ds,) + ensure_tuple_or_list(res_))
             except gh.BadCredentialsException as e:
                 if res:
                     # so we have succeeded with at least one repo already -

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -13,7 +13,7 @@ import glob
 import logging
 import os.path as op
 
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.utils import chpwd
 from datalad.utils import getpwd
 from datalad.utils import partition
@@ -45,7 +45,7 @@ class GlobbedPaths(object):
             self._maybe_dot = []
             self._paths = {"patterns": [], "sub_patterns": {}}
         else:
-            patterns = list(map(assure_unicode, patterns))
+            patterns = list(map(ensure_unicode, patterns))
             patterns, dots = partition(patterns, lambda i: i.strip() == ".")
             self._maybe_dot = ["."] if list(dots) else []
             self._paths = {

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -13,8 +13,8 @@ import glob
 import logging
 import os.path as op
 
-from datalad.utils import ensure_unicode
 from datalad.utils import chpwd
+from datalad.utils import ensure_unicode
 from datalad.utils import getpwd
 from datalad.utils import partition
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -41,7 +41,7 @@ from datalad.utils import (
     PurePath,
     Path,
 )
-from datalad.utils import assure_dir, assure_bytes, assure_unicode, map_items
+from datalad.utils import ensure_dir, ensure_bytes, ensure_unicode, map_items
 from datalad import consts
 from datalad import cfg
 from datalad.support.cache import lru_cache
@@ -525,7 +525,7 @@ class RI(object):
             v = fields.get(f)
             if isinstance(v, dict):
 
-                ev = urlencode(map_items(assure_bytes, v))
+                ev = urlencode(map_items(ensure_bytes, v))
                 # / is reserved char within query
                 if f == 'fragment' and '%2F' not in str(v):
                     # but seems to be ok'ish within the fragment which is
@@ -670,7 +670,7 @@ class URL(RI):
         """Helper around parse_qs to strip unneeded 'list'ing etc and return a dict of key=values"""
         if not s:
             return {}
-        out = map_items(assure_unicode, OrderedDict(parse_qsl(s, 1)))
+        out = map_items(ensure_unicode, OrderedDict(parse_qsl(s, 1)))
         if not auto_delist:
             return out
         for k in out:
@@ -1017,7 +1017,7 @@ def get_cached_url_content(url, name=None, fetcher=None, maxage=None):
             fetcher = providers.fetch
 
         doc = fetcher(url)
-        assure_dir(dirname(doc_fname))
+        ensure_dir(dirname(doc_fname))
         # use pickle to store the entire request result dict
         pickle.dump(doc, open(doc_fname, 'wb'))
         lgr.debug("stored result of request to '{}' in {}".format(url, doc_fname))

--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -22,7 +22,7 @@ from functools import wraps
 from itertools import dropwhile
 
 from ..utils import (
-    assure_bytes,
+    ensure_bytes,
     getpwd,
 )
 
@@ -34,7 +34,7 @@ def _get_unicode_robust_version(f):
         try:
             return f(*args, **kwargs)
         except UnicodeEncodeError:
-            return f(assure_bytes(*args, **kwargs))
+            return f(ensure_bytes(*args, **kwargs))
     doc = getattr(f, '__doc__', None)
     # adjust only if __doc__ is not completely absent (None)
     if doc is not None:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -36,7 +36,7 @@ from datalad.dochelpers import exc_str
 from datalad.utils import (
     auto_repr,
     Path,
-    assure_list,
+    ensure_list,
     on_windows,
 )
 from datalad.cmd import Runner
@@ -349,7 +349,7 @@ class SSHConnection(object):
         self.open()
         scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
         # add source filepath(s) to scp command
-        scp_cmd += assure_list(source)
+        scp_cmd += ensure_list(source)
         # add destination path
         scp_cmd += ['%s:%s' % (
             self.sshri.hostname,
@@ -388,7 +388,7 @@ class SSHConnection(object):
         scp_cmd = self._get_scp_command_spec(recursive, preserve_attrs)
         # add source filepath(s) to scp command, prefixed with the remote host
         scp_cmd += ["%s:%s" % (self.sshri.hostname, _quote_filename_for_scp(s))
-                    for s in assure_list(source)]
+                    for s in ensure_list(source)]
         # add destination path
         scp_cmd += [destination]
         return self.runner.run(scp_cmd)
@@ -581,7 +581,7 @@ class SSHManager(object):
           If specified, only the path(s) provided would be considered
         """
         if self._connections:
-            ctrl_paths = [Path(p) for p in assure_list(ctrl_path)]
+            ctrl_paths = [Path(p) for p in ensure_list(ctrl_path)]
             to_close = [c for c in self._connections
                         # don't close if connection wasn't opened by SSHManager
                         if self._connections[c].ctrl_path

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -17,7 +17,7 @@ from datalad.support.exceptions import (
     AccessDeniedError,
     AccessFailedError,
 )
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 
 
 class LORISTokenGenerator(object):
@@ -44,7 +44,7 @@ class LORISTokenGenerator(object):
         except HTTPError:
             raise AccessDeniedError("Could not authenticate into LORIS")
 
-        str_response = assure_unicode(response.read())
+        str_response = ensure_unicode(response.read())
         data = json.loads(str_response)
         return data["token"]
 

--- a/datalad/tests/test_version.py
+++ b/datalad/tests/test_version.py
@@ -15,7 +15,7 @@ from ..version import (
     __version__,
 )
 from datalad.support import path as op
-from datalad.utils import assure_unicode
+from datalad.utils import ensure_unicode
 from datalad.tests.utils import (
     assert_equal,
     assert_greater,
@@ -44,7 +44,7 @@ def test__version__():
             if not line.startswith(b'## '):
                 # The first section header we hit, must be our changelog entry
                 continue
-            reg = regex.match(assure_unicode(line))
+            reg = regex.match(ensure_unicode(line))
             if not reg:  # first one at that level is the one
                 raise AssertionError(
                     "Following line must have matched our regex: %r" % line)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1278,8 +1278,8 @@ def assert_status(label, results):
     `label` can be a sequence, in which case status must be one of the items
     in this sequence.
     """
-    label = assure_list(label)
-    results = assure_list(results)
+    label = ensure_list(label)
+    results = ensure_list(results)
     for i, r in enumerate(results):
         try:
             assert_in('status', r)
@@ -1298,7 +1298,7 @@ def assert_message(message, results):
     This only tests the message template string, and not a formatted message
     with args expanded.
     """
-    for r in assure_list(results):
+    for r in ensure_list(results):
         assert_in('message', r)
         m = r['message'][0] if isinstance(r['message'], tuple) else r['message']
         assert_equal(m, message)
@@ -1313,7 +1313,7 @@ def _format_res(x):
 def assert_result_count(results, n, **kwargs):
     """Verify specific number of results (matching criteria, if any)"""
     count = 0
-    results = assure_list(results)
+    results = ensure_list(results)
     for r in results:
         if not len(kwargs):
             count += 1
@@ -1333,7 +1333,7 @@ def assert_in_results(results, **kwargs):
     """Verify that the particular combination of keys and values is found in
     one of the results"""
     found = False
-    for r in assure_list(results):
+    for r in ensure_list(results):
         if all(k in r and r[k] == v for k, v in kwargs.items()):
             found = True
     if not found:
@@ -1345,7 +1345,7 @@ def assert_in_results(results, **kwargs):
 def assert_not_in_results(results, **kwargs):
     """Verify that the particular combination of keys and values is not in any
     of the results"""
-    for r in assure_list(results):
+    for r in ensure_list(results):
         assert any(k not in r or r[k] != v for k, v in kwargs.items())
 
 
@@ -1367,7 +1367,7 @@ def assert_result_values_cond(results, prop, cond):
     prop: str
     cond: callable
     """
-    for r in assure_list(results):
+    for r in ensure_list(results):
         ok_(cond(r[prop]),
             msg="r[{prop}]: {value}".format(prop=prop, value=r[prop]))
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2479,16 +2479,32 @@ def get_wrapped_class(wrapped):
     return _func_class
 
 
-# TODO whenever we feel ready for English kill the compat block below
-assure_tuple_or_list = ensure_tuple_or_list
-assure_iter = ensure_iter
-assure_list = ensure_list
-assure_list_from_str = ensure_list_from_str
-assure_dict_from_str = ensure_dict_from_str
-assure_bytes = ensure_bytes
-assure_unicode = ensure_unicode
-assure_bool = ensure_bool
-assure_dir = ensure_dir
+def _make_assure_kludge(fn):
+    old_name = fn.__name__.replace("ensure", "assure")
+
+    @wraps(fn)
+    def compat_fn(*args, **kwargs):
+        warnings.warn(
+            "{} is deprecated and will be removed in a future release. "
+            "Use {} instead."
+            .format(old_name, fn.__name__),
+            DeprecationWarning)
+        return fn(*args, **kwargs)
+
+    compat_fn.__doc__ = ("Note: This function is deprecated. Use {} instead."
+                         .format(fn.__name__))
+    return compat_fn
+
+
+assure_tuple_or_list = _make_assure_kludge(ensure_tuple_or_list)
+assure_iter = _make_assure_kludge(ensure_iter)
+assure_list = _make_assure_kludge(ensure_list)
+assure_list_from_str = _make_assure_kludge(ensure_list_from_str)
+assure_dict_from_str = _make_assure_kludge(ensure_dict_from_str)
+assure_bytes = _make_assure_kludge(ensure_bytes)
+assure_unicode = _make_assure_kludge(ensure_unicode)
+assure_bool = _make_assure_kludge(ensure_bool)
+assure_dir = _make_assure_kludge(ensure_dir)
 
 
 lgr.log(5, "Done importing datalad.utils")


### PR DESCRIPTION
This series follows up on gh-3909, removing all uses of `datalad.utils.assure_*` functions from the code base and then marking the functions as deprecated.
