### PR TITLE
Towards (minimal) support for bare repos

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -232,10 +232,16 @@ class ConfigManager(object):
         self._src_mode = source
         run_kwargs = dict()
         if dataset is not None:
-            # make sure we run the git config calls in the dataset
-            # to pick up the right config files
-            run_kwargs['cwd'] = dataset.path
-        self._runner = GitWitlessRunner(**run_kwargs)
+            if hasattr(dataset, '_git_runner'):
+                self._runner = dataset._git_runner
+            elif dataset.repo:
+                self._runner = dataset.repo._git_runner
+            else:
+                # make sure we run the git config calls in the dataset
+                # to pick up the right config files
+                run_kwargs['cwd'] = dataset.path
+        else:
+            self._runner = GitWitlessRunner(**run_kwargs)
 
         self.reload(force=True)
 

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -231,6 +231,7 @@ class ConfigManager(object):
 
         self._src_mode = source
         run_kwargs = dict()
+        self._runner = None
         if dataset is not None:
             if hasattr(dataset, '_git_runner'):
                 self._runner = dataset._git_runner
@@ -240,7 +241,7 @@ class ConfigManager(object):
                 # make sure we run the git config calls in the dataset
                 # to pick up the right config files
                 run_kwargs['cwd'] = dataset.path
-        else:
+        if self._runner is None:
             self._runner = GitWitlessRunner(**run_kwargs)
 
         self.reload(force=True)

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -789,7 +789,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
 
         if check_symlink_capability(ds.repo.dot_git / 'dl_link_test',
                                     ds.repo.dot_git / 'dl_target_test'):
-            # symlink the annex to avoid needless copies in an emphemeral clone
+            # symlink the annex to avoid needless copies in an ephemeral clone
             annex_dir = ds.repo.dot_git / 'annex'
             origin_annex_url = ds.config.get("remote.origin.url", None)
             origin_git_path = None
@@ -801,13 +801,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
 
                     # we are local; check for a bare repo first to not mess w/
                     # the path
-                    # Note, that w/o support for bare repos in GitRepo we also
-                    # can't use ConfigManager ATM.
-                    gc_response = GitWitlessRunner(
-                        cwd=origin_git_path,
-                    ).run(['git', 'config', '--local', '--get', 'core.bare'],
-                          protocol=StdOutErrCapture)
-                    if gc_response['stdout'].lower().strip() == 'true':
+                    if GitRepo(origin_git_path).bare:
                         # origin is a bare repo -> use path as is
                         pass
                     elif origin_git_path.name != '.git':

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -801,7 +801,7 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
 
                     # we are local; check for a bare repo first to not mess w/
                     # the path
-                    if GitRepo(origin_git_path).bare:
+                    if GitRepo(origin_git_path, create=False).bare:
                         # origin is a bare repo -> use path as is
                         pass
                     elif origin_git_path.name != '.git':

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -942,18 +942,15 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         self.cmd_call_wrapper = runner or GitRunner(cwd=self.path)
         self._cfg = None
+        self._git_runner = GitWitlessRunner(cwd=self.path)
 
         if do_create:  # we figured it out earlier
             # we briefly need a runner to create the repo, and cannot
             # use the config manager runner yet, as it would try to
             # access the repo config which didn't materialize yet
-            self._git_runner = GitWitlessRunner(cwd=self.path)
             self._create_empty_repo(path, create_sanity_checks, **git_opts)
             # after creation we need to reconsider .git path
             self.dot_git = self._get_dot_git(self.pathobj, ok_missing=True)
-
-        # there is a repo (now), we can use the config runner from now on
-        self._git_runner = self.config._runner
 
         # with DryRunProtocol path might still not exist
         if exists(self.path):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1227,8 +1227,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         return (dot_git_path.exists() and (
             not dot_git_path.is_dir() or (dot_git_path / 'HEAD').exists()
         )) or (path / 'HEAD').exists()
-        # TODO: Same as in _get_dot_git: How expensive a check is okay for
-        #       testing for a bare repo? And how expensive is necessary?
 
     @staticmethod
     def _get_dot_git(pathobj, *, ok_missing=False, maybe_relative=False):
@@ -1268,11 +1266,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 (pathobj / 'config').exists():
                 # looks like a bare repo
                 dot_git = pathobj
-                # TODO: How expensive a check is okay?
-                #       Is an existing HEAD sufficient?
-                #       We might want to double-check config for core.bare=true.
-                #       And/or check for ./refs + ./objects dirs in addition
-
         elif not (ok_missing or dot_git.exists()):
             raise RuntimeError("Missing .git in %s." % pathobj)
         # Primarily a compat kludge for get_git_dir, remove when it is deprecated

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -44,6 +44,7 @@ from datalad.tests.utils import (
     assert_not_in,
     assert_raises,
     assert_repo_status,
+    assert_true,
     create_tree,
     DEFAULT_BRANCH,
     eq_,
@@ -151,6 +152,47 @@ def test_GitRepo_init_options(path):
     # passing an option, not explicitly defined in GitRepo class:
     gr = GitRepo(path, create=True, bare=True)
     ok_(gr.config.getbool(section="core", option="bare"))
+
+
+@with_tempfile
+@with_tempfile(mkdir=True)
+@with_tree(tree={'somefile': 'content'})
+@with_tree(tree={'afile': 'other',
+                 '.git': {}})
+def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git):
+
+    import gc
+
+    # create a bare repo:
+    gr = GitRepo(path1, create=True, bare=True)
+    assert_equal(gr.dot_git, gr.pathobj)
+    assert_true(gr.bare)
+    assert_true(gr.config.getbool("core", "bare"))
+    assert_false((gr.pathobj / '.git').exists())
+    assert_false(gr.call_git_success(['status'], expect_stderr=True))
+
+    # kill the object and try to get a new instance on an existing bare repo:
+    del gr
+    gc.collect()
+
+    gr = GitRepo(path1, create=False)
+    assert_equal(gr.dot_git, gr.pathobj)
+    assert_true(gr.bare)
+    assert_true(gr.config.getbool("core", "bare"))
+    assert_false((gr.pathobj / '.git').exists())
+    assert_false(gr.call_git_success(['status'], expect_stderr=True))
+
+    # an empty dir is not a bare repo:
+    assert_raises(InvalidGitRepositoryError, GitRepo, empty_dir,
+                  create=False)
+
+    # an arbitrary dir is not a bare repo:
+    assert_raises(InvalidGitRepositoryError, GitRepo, non_empty_dir,
+                  create=False)
+
+    # nor is a path with an empty .git:
+    assert_raises(InvalidGitRepositoryError, GitRepo, empty_dot_git,
+                  create=False)
 
 
 @with_tree(

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -160,12 +160,14 @@ def test_GitRepo_init_options(path):
 @with_tree(tree={'afile': 'other',
                  '.git': {}})
 @with_tempfile
-def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git, non_bare):
+@with_tempfile
+def test_GitRepo_bare(path, empty_dir, non_empty_dir, empty_dot_git, non_bare,
+                      clone_path):
 
     import gc
 
     # create a bare repo:
-    gr = GitRepo(path1, create=True, bare=True)
+    gr = GitRepo(path, create=True, bare=True)
     assert_equal(gr.dot_git, gr.pathobj)
     assert_true(gr.bare)
     assert_true(gr.config.getbool("core", "bare"))
@@ -176,7 +178,7 @@ def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git, non_bare):
     del gr
     gc.collect()
 
-    gr = GitRepo(path1, create=False)
+    gr = GitRepo(path, create=False)
     assert_equal(gr.dot_git, gr.pathobj)
     assert_true(gr.bare)
     assert_true(gr.config.getbool("core", "bare"))
@@ -196,8 +198,12 @@ def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git, non_bare):
                   create=False)
 
     # a regular repo is not bare
-    non_bare = GitRepo(non_bare, create=True)
-    assert_false(non_bare.bare)
+    non_bare_repo = GitRepo(non_bare, create=True)
+    assert_false(non_bare_repo.bare)
+
+    # we can have a bare clone
+    clone = GitRepo.clone(non_bare, clone_path, clone_options={'bare': True})
+    assert_true(clone.bare)
 
 @with_tree(
     tree={

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -156,10 +156,11 @@ def test_GitRepo_init_options(path):
 
 @with_tempfile
 @with_tempfile(mkdir=True)
-@with_tree(tree={'somefile': 'content'})
+@with_tree(tree={'somefile': 'content', 'config': 'not a git config'})
 @with_tree(tree={'afile': 'other',
                  '.git': {}})
-def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git):
+@with_tempfile
+def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git, non_bare):
 
     import gc
 
@@ -194,6 +195,9 @@ def test_GitRepo_bare(path1, empty_dir, non_empty_dir, empty_dot_git):
     assert_raises(InvalidGitRepositoryError, GitRepo, empty_dot_git,
                   create=False)
 
+    # a regular repo is not bare
+    non_bare = GitRepo(non_bare, create=True)
+    assert_false(non_bare.bare)
 
 @with_tree(
     tree={

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -527,6 +527,8 @@ def test_global_config():
 def test_bare(path):
     # can we handle a bare repo?
     gr = GitRepo(path, create=True, bare=True)
+    # do we read the correct local config?
+    assert_in(gr.pathobj / 'config', gr.config._stores['git']['files'])
     # any sensible (and also our CI) test environment(s) should have this
     assert_in('user.name', gr.config)
     # not set something that wasn't there


### PR DESCRIPTION
This PR aims to add minimal support for bare repositories to `GitRepo`. We should now be able to properly create one (not just pass `--bare` to `git-init`, which is insufficient) and instantiate on an existing bare repo. Added `bare` property, so `GitRepo` is aware and we can enhance it to react to that knowledge from within its methods. That property does not only check the config but also does an additional consistency check on `pathobj` and `dot_git` (should be cheap enough, I think).

Please have a look, @datalad/developers 