### PR TITLE
Enh wtf short

### DIFF
--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -27,6 +27,7 @@ from ..wtf import SECTION_CALLABLES
 
 from datalad.utils import assure_unicode
 from datalad.tests.utils import (
+    assert_greater,
     assert_in,
     assert_not_in,
     assert_repo_status,
@@ -139,6 +140,17 @@ def test_wtf(topdir):
         wtf(sections=['dependencies'], decor='html_details')
         ok_startswith(cmo.out, '<details><summary>DataLad %s WTF' % __version__)
         assert_in('## dependencies', cmo.out)
+
+    # short flavor
+    with swallow_outputs() as cmo:
+        wtf(flavor='short')
+        assert_in("- datalad: version=%s" % __version__, cmo.out)
+        assert_in("- dependencies: ", cmo.out)
+        eq_(len(cmo.out.splitlines()), 4)  # #WTF, datalad, dependencies, trailing new line
+
+    with swallow_outputs() as cmo:
+        wtf(flavor='short', sections='*')
+        assert_greater(len(cmo.out.splitlines()), 10)  #  many more
 
     # should result only in '# WTF'
     skip_if_no_module('pyperclip')

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -313,9 +313,16 @@ class WTF(Interface):
             action='append',
             dest='sections',
             metavar="SECTION",
-            constraints=EnsureChoice(*sorted(SECTION_CALLABLES)) | EnsureNone(),
-            doc="""section to include.  If not set, all sections.
+            constraints=EnsureChoice(*sorted(SECTION_CALLABLES) + ['*']) | EnsureNone(),
+            doc="""section to include.  If not set - depends on flavor.
+            '*' could be used to force all sections.
             [CMD: This option can be given multiple times. CMD]"""),
+        flavor=Parameter(
+            args=("--flavor",),
+            constraints=EnsureChoice('full', 'short'),
+            doc="""Flavor of WTF. 'full' would produce markdown with exhaustive list of sections.
+            'short' will provide a condensed summary only of datalad and dependencies by default.
+            Use [CMD: --section CMD][PY: `section` PY] to list other sections"""),
         decor=Parameter(
             args=("-D", "--decor"),
             constraints=EnsureChoice('html_details') | EnsureNone(),
@@ -332,7 +339,7 @@ class WTF(Interface):
     @staticmethod
     @datasetmethod(name='wtf')
     @eval_results
-    def __call__(dataset=None, sensitive=None, sections=None, decor=None, clipboard=None):
+    def __call__(dataset=None, sensitive=None, sections=None, flavor="full", decor=None, clipboard=None):
         from datalad.distribution.dataset import require_dataset
         from datalad.support.exceptions import NoDatasetFound
         from datalad.interface.results import get_status_dict
@@ -350,8 +357,8 @@ class WTF(Interface):
                 path=ds.path,
                 status='impossible',
                 message=(
-                'No dataset found at %s. Reporting on the dataset is '
-                'not attempted.', ds.path),
+                    'No dataset found at %s. Reporting on the dataset is '
+                    'not attempted.', ds.path),
                 logger=lgr
             )
             # we don't deal with absent datasets
@@ -376,6 +383,7 @@ class WTF(Interface):
             logger=lgr,
             decor=decor,
             infos=infos,
+            flavor=flavor,
         )
 
         # Define section callables which require variables.
@@ -391,8 +399,14 @@ class WTF(Interface):
             section_callables.pop('dataset')
         assert all(section_callables.values())  # check if none was missed
 
-        if sections is None:
-            sections = sorted(list(section_callables))
+        asked_for_all_sections = sections is not None and any(s == '*' for s in sections)
+        if sections is None or asked_for_all_sections:
+            if flavor == 'full' or asked_for_all_sections:
+                sections = sorted(list(section_callables))
+            elif flavor == 'short':
+                sections = ['datalad', 'dependencies']
+            else:
+                raise ValueError(flavor)
 
         for s in sections:
             infos[s] = section_callables[s]()
@@ -435,8 +449,22 @@ def _render_report(res):
             text += u'{}'.format(val)
         return text
 
-    report = _unwind(report, res.get('infos', {}), '')
+    def _unwind_short(text, val, top):
+        if isinstance(val, dict):
+            if not top:
+                text += '\n'
+                for k, v in val.items():
+                    text += "- " + _unwind_short(k, v, top + ' ') + '\n'
+            else:
+                text += ": " + ' '.join('%s=%s' % i for i in val.items())
+        elif isinstance(val, (list, tuple)):
+            text += (' ' if not top else '\n').join(map(str, val))
+        else:
+            text += u'{}'.format(val)
+        return text
 
+    unwinder = {'full': _unwind, 'short': _unwind_short}[res.get('flavor', 'full')]
+    report = unwinder(report, res.get('infos', {}), '')
     decor = res.get('decor', None)
 
     if not decor:


### PR DESCRIPTION
I find our default WTF output great BUT too long/verbose. It makes it actually
hard to cut/paste and/or locate relevant information.  With --flavor short
I aim to provide a shortened/faster version with most important information

Sample output:

# WTF
- datalad: version=0.13.3.dev230 full_version=0.13.3.dev230-g4f8fe-dirty
- dependencies: cmd:git=2.24.0 cmd:annex=8.20200810+git143-gdee38c54d-1~ndall+1 cmd:bundled-git=2.24.0 cmd:system-git=2.27.0 cmd:system-ssh=8.1p1 cmd:7z=16.02 annexremote=1.4.3 appdirs=1.4.3 boto=2.49.0 exifread=2.1.2 git=3.1.0 gitdb=4.0.2 humanize=2.3.0 iso8601=0.1.12 keyring=18.0.1 keyrings.alt=3.4.0 msgpack=0.6.2 mutagen=1.40.0 requests=2.23.0 scrapy=1.7.3 wrapt=1.11.2

<details>
<summary>All sections with -S*</summary> 

# WTF
- configuration<SENSITIVE, report disabled by configuration>
- datalad: version=0.13.3.dev231 full_version=0.13.3.dev231-gaac2879
- dataset: path=/home/yoh/proj/datalad/datalad-maint repo=GitRepo id=None metadata=<SENSITIVE, report disabled by configuration>
- dependencies: cmd:git=2.24.0 tqdm=4.43.0 cmd:annex=8.20200810+git143-gdee38c54d-1~ndall+1 cmd:bundled-git=2.24.0 cmd:system-git=2.27.0 cmd:system-ssh=8.1p1 cmd:7z=16.02 annexremote=1.4.3 appdirs=1.4.3 boto=2.49.0 exifread=2.1.2 git=3.1.0 gitdb=4.0.2 humanize=2.3.0 iso8601=0.1.12 keyring=18.0.1 keyrings.alt=3.4.0 msgpack=0.6.2 mutagen=1.40.0 requests=2.23.0 scrapy=1.7.3 wrapt=1.11.2
- environment: PATH=/home/yoh/proj/datalad/datalad-maint/venvs/dev3/bin:/home/yoh/gocode/bin:/home/yoh/gocode/bin:/home/yoh/bin:/home/yoh/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/sbin:/usr/sbin:/usr/local/sbin LANG=en_US.UTF-8 GIT_PAGER=less --no-init --quit-if-one-screen
- extensions: osf={'load_error': None, 'description': 'DataLad extension for OSF support', 'module': 'datalad_osf', 'version': '0.2.0', 'entrypoints': {'datalad_osf.credentials.OSFCredentials': {'module': 'datalad_osf.credentials', 'class': 'OSFCredentials', 'names': ('osf-credentials', 'osf_credentials'), 'load_error': None}, 'datalad_osf.create_sibling_osf.CreateSiblingOSF': {'module': 'datalad_osf.create_sibling_osf', 'class': 'CreateSiblingOSF', 'names': ('create-sibling-osf', 'create_sibling_osf'), 'load_error': None}}}
- git-annex: version=8.20200810+git143-gdee38c54d-1~ndall+1 build flags=['Assistant', 'Webapp', 'Pairing', 'S3', 'WebDAV', 'Inotify', 'DBus', 'DesktopNotify', 'TorrentParser', 'MagicMime', 'Feeds', 'Testsuite'] dependency versions=['aws-0.20', 'bloomfilter-2.0.1.0', 'cryptonite-0.25', 'DAV-1.3.3', 'feed-1.0.0.0', 'ghc-8.4.4', 'http-client-0.5.13.1', 'persistent-sqlite-2.8.2', 'torrent-10000.1.1', 'uuid-1.3.13', 'yesod-1.6.0'] key/value backends=['SHA256E', 'SHA256', 'SHA512E', 'SHA512', 'SHA224E', 'SHA224', 'SHA384E', 'SHA384', 'SHA3_256E', 'SHA3_256', 'SHA3_512E', 'SHA3_512', 'SHA3_224E', 'SHA3_224', 'SHA3_384E', 'SHA3_384', 'SKEIN256E', 'SKEIN256', 'SKEIN512E', 'SKEIN512', 'BLAKE2B256E', 'BLAKE2B256', 'BLAKE2B512E', 'BLAKE2B512', 'BLAKE2B160E', 'BLAKE2B160', 'BLAKE2B224E', 'BLAKE2B224', 'BLAKE2B384E', 'BLAKE2B384', 'BLAKE2BP512E', 'BLAKE2BP512', 'BLAKE2S256E', 'BLAKE2S256', 'BLAKE2S160E', 'BLAKE2S160', 'BLAKE2S224E', 'BLAKE2S224', 'BLAKE2SP256E', 'BLAKE2SP256', 'BLAKE2SP224E', 'BLAKE2SP224', 'SHA1E', 'SHA1', 'MD5E', 'MD5', 'WORM', 'URL', 'X*'] remote types=['git', 'gcrypt', 'p2p', 'S3', 'bup', 'directory', 'rsync', 'web', 'bittorrent', 'webdav', 'adb', 'tahoe', 'glacier', 'ddar', 'git-lfs', 'httpalso', 'hook', 'external'] operating system=linux x86_64 supported repository versions=['8'] upgrade supported from repository versions=['0', '1', '2', '3', '4', '5', '6', '7']
- location: path=/home/yoh/proj/datalad/datalad-maint type=dataset
- metadata_extractors: annex={'module': 'datalad.metadata.extractors.annex', 'version': None, 'load_error': None} audio={'module': 'datalad.metadata.extractors.audio', 'version': None, 'load_error': None} datacite={'module': 'datalad.metadata.extractors.datacite', 'version': None, 'load_error': None} datalad_core={'module': 'datalad.metadata.extractors.datalad_core', 'version': None, 'load_error': None} datalad_rfc822={'module': 'datalad.metadata.extractors.datalad_rfc822', 'version': None, 'load_error': None} exif={'module': 'datalad.metadata.extractors.exif', 'version': None, 'load_error': None} frictionless_datapackage={'module': 'datalad.metadata.extractors.frictionless_datapackage', 'version': None, 'load_error': None} image={'module': 'datalad.metadata.extractors.image', 'version': None, 'load_error': None} xmp={'module': 'datalad.metadata.extractors.xmp', 'version': None, 'load_error': None}
- python: version=3.8.5 implementation=CPython
- system: type=posix name=Linux release=5.6.0-1-amd64 version=#1 SMP Debian 5.6.7-1 (2020-04-29) distribution=debian/testing/bullseye max_path_length=292 encoding=OrderedDict([('default', 'utf-8'), ('filesystem', 'utf-8'), ('locale.prefered', 'UTF-8')])

</details>

Positioned against `maint` for now but might be more appropriate to `master`

WDYT?

TODOs
- [x] tests