### PR TITLE
RF: Change ConfigManager.get() behavior for multiple identical key specs

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -504,9 +504,27 @@ class ConfigManager(object):
         return self._merged_store.keys()
 
     # XXX should this be *args?
-    def get(self, key, default=None):
-        """D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None."""
-        return self._merged_store.get(key, default)
+    def get(self, key, default=None, get_all=False):
+        """D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None.
+
+        Parameters
+        ----------
+        default : optional
+          Value to return when key is not present. `None` by default.
+        get_all : bool, optional
+          If True, return all values of multiple identical configuration keys.
+          By default only the last specified value is returned.
+        """
+        try:
+            val = self[key]
+            if get_all or not isinstance(val, tuple):
+                return val
+            else:
+                return val[-1]
+        except KeyError:
+            # return as-is, default could be a tuple, hence do not subject to
+            # get_all processing
+            return default
 
     def get_from_source(self, source, key, default=None):
         """Like get(), but a source can be specific.

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -595,6 +595,10 @@ class ConfigManager(object):
         """A convenience method which coerces the option value to an integer"""
         return int(self.get_value(section, option))
 
+    def getfloat(self, section, option):
+        """A convenience method which coerces the option value to a float"""
+        return float(self.get_value(section, option))
+
     def getbool(self, section, option, default=None):
         """A convenience method which coerces the option value to a bool
 
@@ -607,10 +611,6 @@ class ConfigManager(object):
         if val is None:  # no value at all, git treats it as True
             return True
         return anything2bool(val)
-
-    def getfloat(self, section, option):
-        """A convenience method which coerces the option value to a float"""
-        return float(self.get_value(section, option))
 
     # this is a hybrid of ConfigParser and dict API
     def items(self, section=None):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -591,13 +591,21 @@ class ConfigManager(object):
                 return True
         return False
 
+    def _get_type(self, typefn, section, option):
+        key = '.'.join([section, option])
+        # Mimic the handling of get_value(..., default=None), while still going
+        # through get() in order to get its default tuple handling.
+        if key not in self:
+            raise KeyError(key)
+        return typefn(self.get(key))
+
     def getint(self, section, option):
         """A convenience method which coerces the option value to an integer"""
-        return int(self.get_value(section, option))
+        return self._get_type(int, section, option)
 
     def getfloat(self, section, option):
         """A convenience method which coerces the option value to a float"""
-        return float(self.get_value(section, option))
+        return self._get_type(float, section, option)
 
     def getbool(self, section, option, default=None):
         """A convenience method which coerces the option value to a bool
@@ -607,7 +615,12 @@ class ConfigManager(object):
         False
         TypeError is raised for other values.
         """
-        val = self.get_value(section, option, default=default)
+        key = '.'.join([section, option])
+        # Mimic the handling of get_value(..., default=None), while still going
+        # through get() in order to get its default tuple handling.
+        if default is None and key not in self:
+            raise KeyError(key)
+        val = self.get(key, default=default)
         if val is None:  # no value at all, git treats it as True
             return True
         return anything2bool(val)

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -648,11 +648,6 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
     if sidecar is None:
         use_sidecar = ds.config.get('datalad.run.record-sidecar', default=False)
-        # If ConfigManager gets the ability to say "return single value",
-        # update this code to use that.
-        if isinstance(use_sidecar, tuple):
-            # Use same precedence as 'git config'.
-            use_sidecar = use_sidecar[-1]
         use_sidecar = anything2bool(use_sidecar)
     else:
         use_sidecar = sidecar

--- a/datalad/core/local/tests/test_resulthooks.py
+++ b/datalad/core/local/tests/test_resulthooks.py
@@ -42,7 +42,7 @@ def test_basics(src, dst):
     clone.config.set(
         'datalad.result-hook.alwaysbids.call-json',
         # string substitutions based on the result record are supported
-        'run_procedure {{"dataset":"{path}","spec":"cfg_metadatatypes bids"}}',
+        'run_procedure {{"dataset":"{path}","spec":"cfg_metadatatypes bids dicom"}}',
         where='local',
     )
     # config on which kind of results this hook should operate
@@ -93,11 +93,13 @@ def test_basics(src, dst):
     # setup done, now see if it works
     clone.get('subds')
     clone_sub = Dataset(clone.pathobj / 'subds')
-    eq_(clone_sub.config.get('datalad.metadata.nativetype'), 'bids')
+    eq_(clone_sub.config.get('datalad.metadata.nativetype', get_all=True),
+        ('bids', 'dicom'))
     # now the same thing with a result_xfm, should make no difference
     clone.get('subds2')
     clone_sub2 = Dataset(clone.pathobj / 'subds2')
-    eq_(clone_sub2.config.get('datalad.metadata.nativetype'), 'bids')
+    eq_(clone_sub2.config.get('datalad.metadata.nativetype', get_all=True),
+        ('bids', 'dicom'))
 
     # hook auto-unlocks the file
     if not clone.repo.is_managed_branch():

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -77,24 +77,21 @@ def _get_proc_config(name, ds=None):
     """
     # figure what ConfigManager to ask
     cm = cfg if ds is None else ds.config
+    # ConfigManager might return a tuple for different reasons.
+    # The config might have been defined multiple times in the same location
+    # (within .datalad/config for example) or there are multiple values for
+    # it on different levels of git-config (system, user, repo). git-config
+    # in turn does report such things ordered from most general to most
+    # specific configuration. We do want the most specific one here, so
+    # config.get(), which returns the last entry, works here.
+    # TODO: At this point we cannot determine whether it was actually
+    # configured to yield several values by the very same config, in which
+    # case we should actually issue a warning, since we then have no idea
+    # of a priority. But ConfigManager isn't able yet to tell us or to
+    # restrict the possibility to define multiple values to particular items
     v = cm.get('datalad.procedures.{}.call-format'.format(name), None)
     h = cm.get('datalad.procedures.{}.help'.format(name), None)
-    if isinstance(v, tuple):
-        # ConfigManager might return a tuple for different reasons.
-        # The config might have been defined multiple times in the same location
-        # (within .datalad/config for example) or there are multiple values for
-        # it on different levels of git-config (system, user, repo). git-config
-        # in turn does report such things ordered from most general to most
-        # specific configuration. We do want the most specific one here, so we
-        # go with the last entry of that tuple.
-        # TODO: At this point we cannot determine whether it was actually
-        # configured to yield several values by the very same config, in which
-        # case we should actually issue a warning, since we then have no idea
-        # of a priority. But ConfigManager isn't able yet to tell us or to
-        # restrict the possibility to define multiple values to particular items
-        return v[-1], h
-    else:
-        return v, h
+    return v, h
 
 
 def _get_procedure_implementation(name='*', ds=None):

--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -9,6 +9,7 @@ import os.path as op
 from datalad.consts import (
     DATASET_CONFIG_FILE
 )
+from datalad.utils import ensure_tuple_or_list
 from datalad.distribution.dataset import require_dataset
 
 ds = require_dataset(
@@ -16,8 +17,11 @@ ds = require_dataset(
     check_installed=True,
     purpose='configuration')
 
+existing_types = ensure_tuple_or_list(
+    ds.config.get('datalad.metadata.nativetype', [], get_all=True))
+
 for nt in sys.argv[2:]:
-    if nt in ds.config.get('datalad.metadata.nativetype', []):
+    if nt in existing_types:
         # do not duplicate
         continue
     ds.config.add(

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -99,7 +99,9 @@ def _gen_github_ses(github_login, github_passwd):
 
     # see if we have tokens - might be many. Doesn't cost us much so get at once
     all_tokens = tokens = unique(
-        ensure_list(cfg.get(CONFIG_HUB_TOKEN_FIELD, None)),
+        # use get_all=True to support specification of multiple tokens
+        # using identical config keys
+        ensure_list(cfg.get(CONFIG_HUB_TOKEN_FIELD, None, get_all=True)),
         reverse=True
     )
 

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -105,9 +105,12 @@ def test_something(path, new_home):
          ('something.novalue', None),
          ('something.user', ('name=Jane Doe', 'email=jd@example.com'))])
 
-    # always get all values
+    # by default get last value only
     assert_equal(
-        cfg.get('something.user'),
+        cfg.get('something.user'), 'email=jd@example.com')
+    # but can get all values
+    assert_equal(
+        cfg.get('something.user', get_all=True),
         ('name=Jane Doe', 'email=jd@example.com'))
     assert_raises(KeyError, cfg.__getitem__, 'somedthing.user')
     assert_equal(cfg.getfloat(u'onemore.complicated の beast with.dot', 'findme'), 5.0)


### PR DESCRIPTION
Before this change, the values of all specifications of an identical key
were returned as a tuple. Now only the last value is returned, and
`get_all=True` has to be set to get the previous behavior.

Rationale: That a single value is returned is a sensible default
expectation. Valid use cases for multiple values are few, and require
custom handling in consuming code. The previous behavior would require
protection against the multi-value-return possibility all throughout
the code base. This switch is disruptive, but makes overall operation
more robust.

Fixes gh-2628
Fixes gh-4919
