### PR TITLE
BF: custom remotes - replace os.linesep with an explicit \n in messages to annex

### DIFF
--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -322,6 +322,8 @@ class AnnexCustomRemote(object):
            arguments to be joined by a space and passed to git-annex
         """
         msg = " ".join(map(str, args))
+        # Sanitize since there must be no new lines
+        msg = msg.replace(os.linesep, r'\n')
         if not self._in_the_loop:
             lgr.debug("We are not yet in the loop, thus should not send to annex"
                       " anything.  Got: %s" % msg.encode())


### PR DESCRIPTION
Otherwise it make annex puke since it does not expect multiple lines in a
single command message/content.

E.g. seeing (thanks to #4925 )

	datalad.cmd     [Level 5] stderr| datalad.customremotes [Level 4] Sending 'DEBUG Failed to check url s3://NDAR_Central_2/submission_23229/sub-XXX/ses-baselineYear1Arm1/fmap/sub-XXX_ses-baselineYear1Arm1_dir-AP_run-01_epi.nii.gz: Cannot connect to any (originally requested NDAR_Central_2) S3 bucket. Exception: S3ResponseError: 400 Bad Request\n [s3.py:_handle_exception:75]'
	datalad.cmd     [Level 5] stderr|   external special remote protocol error, unexpectedly received " [s3.py:_handle_exception:75]" (unable to parse command)
	datalad.cmd     [Level 5] stderr| datalad.customremotes [Level 4] Sending 'CHECKURL-FAILURE'
	datalad.cmd     [Level 5] stderr| datalad         [Level 5] Instantiating ssh manager
	datalad.cmd     [Level 5] stderr| datalad         [Level 5] Done importing main __init__
	datalad.cmd     [Level 5] stderr| datalad.customremotes [Level 5] Importing datalad.customremotes.main
	datalad.cmd     [Level 5] stderr| datalad         [Level 5] Requested to provide version for tqdm

since credentials timed out and downloader puked an exception with multiple
lines.  That \n is due to repr on the msg when we log, so in reality we were
trying to send multiline string
