### PR TITLE
BF: use time.time (no timezone offset) while checking expiration for AWS credentials

### DIFF
--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -21,7 +21,6 @@ https://github.com/omab/python-social-auth
 """
 
 import time
-import calendar
 
 from collections import OrderedDict
 
@@ -212,7 +211,7 @@ class AWS_S3(Credential):
         if not exp:
             return True
         exp_epoch = iso8601_to_epoch(exp)
-        expire_in = (exp_epoch - calendar.timegm(time.localtime())) / 3600.
+        expire_in = (exp_epoch - time.time()) / 3600.
 
         lgr.debug(
             ("Credential %s has expired %.2fh ago"

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -202,7 +202,7 @@ def iso8601_to_epoch(datestr):
     iso8601 is used to parse properly the time zone information, which
     can't be parsed with standard datetime strptime
     """
-    return calendar.timegm(iso8601.parse_date(datestr).timetuple())
+    return calendar.timegm(iso8601.parse_date(datestr).utctimetuple())
 
 
 def __urlopen_requests(url):

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -529,8 +529,8 @@ def test_is_ssh():
 def test_iso8601_to_epoch():
     epoch = 1467901515
     eq_(iso8601_to_epoch('2016-07-07T14:25:15+00:00'), epoch)
-    # zone information is actually not used
-    eq_(iso8601_to_epoch('2016-07-07T14:25:15+11:00'), epoch)
+    eq_(iso8601_to_epoch('2016-07-07T14:25:15+11:00'),
+        epoch - 11 * 60 * 60)
     eq_(iso8601_to_epoch('2016-07-07T14:25:15Z'), epoch)
     eq_(iso8601_to_epoch('2016-07-07T14:25:15'), epoch)
 


### PR DESCRIPTION

with time.localtime() we are getting local time without any time zone, calendar.timegm
then produces seconds since epoch for that in GMT thus again - no zone.
With time.time() we seems to be getting seconds since epoch properly.

I kept running into S3 downloads failing while credential reported to
be expiring in some hours to come
