### PR TITLE
ENH: make logtarget to be a format spec which understands pid

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -449,7 +449,8 @@ class LoggerHelper(object):
             loghandler = logging.StreamHandler(getattr(sys, logtarget.lower()))
             use_color = is_interactive()  # explicitly decide here
         else:
-            # must be a simple filename
+            # must be a filename .format pattern
+            logtarget = logtarget.format(pid=os.getpid())
             # Use RotatingFileHandler for possible future parametrization to keep
             # log succinct and rotating
             loghandler = logging.handlers.RotatingFileHandler(logtarget)


### PR DESCRIPTION
In my case primary use case ATM -- for some reason datalad external special remote logs NOTHING into DATALAD_LOG_TARGET -- may be due to collision for the same file from multiple processes (ie main `datalad` process and then special remote).  By adding the `{pid}` into the mix I hope to tease apart the two log files

If we like it

- [ ] document that new "feature"
- Possible enhancements in the future
  - add `{datetime}`
  - anything else?

edit: ha ha ha -- found why I could not find special remote log lines in the log file... I was specifying relative filename for the log file.  special remote starts in the dataset PWD, so file was generated there!  but among 1000s of files/directories added I have not spotted it in the flood of the git status ;)