### PR TITLE
ENH+RF: @try_multiple_dec_s3 to retry interaction with S3 upon "retriable" errors

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -137,7 +137,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
         if authenticator:
             needs_authentication = authenticator.requires_authentication
         else:
-            needs_authentication = self.credential
+            needs_authentication = self.credential is None
         attempt, incomplete_attempt = 0, 0
         result = None
         while True:
@@ -242,7 +242,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                     auth_types=supported_auth_types,
                     new_provider=False)
         else:  # None or False
-            if needs_authentication is False:
+            if not needs_authentication:
                 # those urls must or should NOT require authentication
                 # but we got denied
                 raise DownloadError(
@@ -251,8 +251,6 @@ class BaseDownloader(object, metaclass=ABCMeta):
                     "Adjust your configuration for the provider.%s"
                     % (url, msg_types))
             else:
-                # how could be None or any other non-False bool(False)
-                assert (needs_authentication is None)
                 # So we didn't know if authentication necessary, and it
                 # seems to be necessary, so Let's ask the user to setup
                 # authentication mechanism for this website

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -137,7 +137,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
         if authenticator:
             needs_authentication = authenticator.requires_authentication
         else:
-            needs_authentication = self.credential is None
+            needs_authentication = self.credential
         attempt, incomplete_attempt = 0, 0
         result = None
         while True:
@@ -242,7 +242,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                     auth_types=supported_auth_types,
                     new_provider=False)
         else:  # None or False
-            if not needs_authentication:
+            if needs_authentication is False:
                 # those urls must or should NOT require authentication
                 # but we got denied
                 raise DownloadError(
@@ -251,6 +251,8 @@ class BaseDownloader(object, metaclass=ABCMeta):
                     "Adjust your configuration for the provider.%s"
                     % (url, msg_types))
             else:
+                # how could be None or any other non-False bool(False)
+                assert (needs_authentication is None)
                 # So we didn't know if authentication necessary, and it
                 # seems to be necessary, so Let's ask the user to setup
                 # authentication mechanism for this website

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -261,6 +261,10 @@ class CompositeCredential(Credential):
         for c in self._credentials[1:]:
             c.delete()
 
+    @property
+    def is_expired(self):
+        return any(c.is_expired for c in self._credentials)
+
     def __call__(self):
         """Obtain credentials from a keyring and if any is not known -- ask"""
         # Start from the tail until we have credentials set

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -258,8 +258,19 @@ class CompositeCredential(Credential):
     def enter_new(self):
         # should invalidate/remove all tail credentials to avoid failing attempts to login
         self._credentials[0].enter_new()
+        self.refresh()
+
+    def refresh(self):
+        """Re-establish "dependent" credentials
+
+        E.g. if code outside was reported that it expired somehow before known expiration datetime
+        """
         for c in self._credentials[1:]:
             c.delete()
+        # trigger re-establishing the chain
+        _ = self()
+        if self.is_expired:
+            raise RuntimeError("Credential %s expired right upon refresh: should have not happened")
 
     @property
     def is_expired(self):

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -211,7 +211,10 @@ class AWS_S3(Credential):
         if not exp:
             return False
         exp_epoch = iso8601_to_epoch(exp)
-        expire_in = (exp_epoch - time.time()) / 3600.
+        # -2 to artificially shorten duration of the allotment to avoid
+        # possible race conditions between us checking either it has
+        # already expired before submitting a request.
+        expire_in = (exp_epoch - time.time() - 2) / 3600.
 
         lgr.debug(
             ("Credential %s has expired %.2fh ago"

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -209,7 +209,7 @@ class AWS_S3(Credential):
     def is_expired(self):
         exp = self.get('expiration', None)
         if not exp:
-            return True
+            return False
         exp_epoch = iso8601_to_epoch(exp)
         expire_in = (exp_epoch - time.time()) / 3600.
 

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -208,11 +208,14 @@ class S3Downloader(BaseDownloader):
         bucket_name = self._parse_url(url, bucket_only=True)
         if allow_old and self._bucket:
             if self._bucket.name == bucket_name:
-                lgr.debug(
-                    "S3 session: Reusing previous connection to bucket %s",
-                    bucket_name
-                )
-                return True  # we used old
+                if self.credential and self.credential.is_expired:
+                    lgr.debug("S3 session: credential expired")
+                else:
+                    lgr.debug(
+                        "S3 session: Reusing previous connection to bucket %s",
+                        bucket_name
+                    )
+                    return True  # we used old
             else:
                 lgr.warning("No support yet for multiple buckets per S3Downloader")
 

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -30,7 +30,7 @@ from ..support.network import (
 from .base import Authenticator
 from .base import BaseDownloader, DownloaderSession
 from ..support.exceptions import (
-    AccessDeniedError,
+    AccessPermissionExpiredError,
     TargetFileAbsent,
 )
 from ..support.s3 import (
@@ -244,7 +244,7 @@ class S3Downloader(BaseDownloader):
             # Since likely things went bad if credential expired, just raise general
             # AccessDeniedError. Logic upstream should retry
             if self.credential and self.credential.is_expired:
-                raise AccessDeniedError(
+                raise AccessPermissionExpiredError(
                     "Failed to get a key likely due to expired key: %s"
                     % exc_str(e))
             raise TargetFileAbsent("S3 refused to provide the key for %s from url %s: %s"

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -13,11 +13,16 @@ import re
 
 from urllib.parse import urlsplit, unquote as urlunquote
 
-from ..utils import auto_repr
-from ..utils import assure_dict_from_str
+from ..utils import (
+    assure_dict_from_str,
+    auto_repr,
+)
 from ..dochelpers import borrowkwargs
-from ..support.network import get_url_straight_filename
-from ..support.network import rfc2822_to_epoch, iso8601_to_epoch
+from ..support.network import (
+    get_url_straight_filename,
+    iso8601_to_epoch,
+    rfc2822_to_epoch,
+)
 
 from .base import Authenticator
 from .base import BaseDownloader, DownloaderSession
@@ -25,8 +30,13 @@ from ..support.exceptions import (
     DownloadError,
     TargetFileAbsent,
 )
-from ..support.s3 import boto, S3ResponseError, OrdinaryCallingFormat
-from ..support.s3 import get_bucket
+from ..support.s3 import (
+    OrdinaryCallingFormat,
+    S3ResponseError,
+    try_multiple_dec_s3,
+    boto,
+    get_bucket,
+)
 from ..support.status import FileStatus
 
 import logging
@@ -219,7 +229,9 @@ class S3Downloader(BaseDownloader):
         assert(self._bucket.name == bucket_name)  # must be the same
 
         try:
-            key = self._bucket.get_key(url_filepath, version_id=params.get('versionId', None))
+            key = try_multiple_dec_s3(self._bucket.get_key)(
+                url_filepath, version_id=params.get('versionId', None)
+            )
         except S3ResponseError as e:
             raise TargetFileAbsent("S3 refused to provide the key for %s from url %s: %s"
                                 % (url_filepath, url, e))

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -217,7 +217,8 @@ class S3Downloader(BaseDownloader):
                 lgr.warning("No support yet for multiple buckets per S3Downloader")
 
         lgr.debug("S3 session: Reconnecting to the bucket")
-        self._bucket = self.authenticator.authenticate(bucket_name, self.credential)
+        self._bucket = try_multiple_dec_s3(self.authenticator.authenticate)(
+            bucket_name, self.credential)
         return False
 
     def get_downloader_session(self, url, **kwargs):

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -34,11 +34,12 @@ from ..support.exceptions import (
     TargetFileAbsent,
 )
 from ..support.s3 import (
+    Key,
     OrdinaryCallingFormat,
     S3ResponseError,
-    try_multiple_dec_s3,
     boto,
     get_bucket,
+    try_multiple_dec_s3,
 )
 from ..support.status import FileStatus
 
@@ -240,6 +241,100 @@ class S3Downloader(BaseDownloader):
             raise AccessPermissionExpiredError(
                 "Credential %s has expired" % self.credential)
 
+    def _get_key(self, key_name, version_id=None, headers=None):
+        try:
+            return self._bucket.get_key(key_name, version_id=version_id, headers=headers)
+        except S3ResponseError as e:
+            if e.status != 400:
+                raise  # we will not deal with those here
+            # e.g. 400 Bad request could happen due to timed out key.
+            # Since likely things went bad if credential expired, just raise general
+            # AccessDeniedError. Logic upstream should retry
+            self._check_credential()
+            lgr.debug("bucket.get_key (HEAD) failed with %s, trying GET request now",
+                      exc_str(e))
+            try:
+                return self._get_key_via_get(key_name, version_id=version_id, headers=headers)
+            except S3ResponseError:
+                # propagate S3 exceptions since they actually can provide the reason why we failed!
+                raise
+            except Exception as e2:
+                lgr.debug("We failed to get a key via HEAD due to %s and then via partial GET due to %s",
+                          e, e2)
+                # reraise original one
+                raise e
+
+    def _get_key_via_get(self, key_name, version_id=None, headers=None):
+        """Get key information via GET so we can get error_code if any
+
+        The problem with bucket.get_key is that it uses HEAD request.
+        With that request response header has only the status (e.g. 400)
+        but not a specific error_code.  That makes it impossible to properly
+        react on failed requests (wait? re-auth?).
+
+        Yarik found no easy way in boto to reissue the request with GET,
+        so this code is lobotomized version of _get_key_internal but with GET
+        instead of HEAD and thus providing body into error handling.
+        """
+        query_args_l = []
+        if version_id:
+            query_args_l.append('versionId=%s' % version_id)
+        query_args = '&'.join(query_args_l) or None
+        bucket = self._bucket
+        headers = headers or {}
+        headers['Range'] = 'bytes=0-0'
+        response = bucket.connection.make_request(
+            'GET',
+            bucket.name,
+            key_name,
+            headers=headers,
+            query_args=query_args)
+        body = response.read()
+        if response.status // 100 == 2:
+            # it was all good
+            k = bucket.key_class(bucket)
+            provider = bucket.connection.provider
+            k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
+            for field in Key.base_fields:
+                k.__dict__[field.lower().replace('-', '_')] = \
+                    response.getheader(field)
+            crange, crange_size = response.getheader('content-range'), None
+            if crange:
+                # should look like 'bytes 0-0/50993'
+                if not crange.startswith('bytes 0-0/'):
+                    # we will just spit out original exception and be done -- we have tried!
+                    raise ValueError("Got content-range %s which I do not know how to handle to "
+                                     "get the full size" % repr(crange))
+                crange_size = int(crange.split('/', 1)[-1])
+                k.size = crange_size
+            # the following machinations are a workaround to the fact that
+            # apache/fastcgi omits the content-length header on HEAD
+            # requests when the content-length is zero.
+            # See http://goo.gl/0Tdax for more details.
+            if response.status != 206:  # partial content
+                # assume full return of 0 bytes etc
+                clen_size = int(response.getheader('content-length'), 0)
+
+                if crange_size is not None:
+                    if crange_size != clen_size:
+                        raise ValueError(
+                            "We got content-length %d and size from content-range %d - they do "
+                            "not match", clen_size, crange_size)
+                k.size = clen_size
+            k.name = key_name
+            k.handle_version_headers(response)
+            k.handle_encryption_headers(response)
+            k.handle_restore_headers(response)
+            k.handle_storage_class_header(response)
+            k.handle_addl_headers(response.getheaders())
+            return k
+        else:
+            if response.status == 404:
+                return None
+            else:
+                raise bucket.connection.provider.storage_response_error(
+                    response.status, response.reason, body)
+
     def get_downloader_session(self, url, **kwargs):
         bucket_name, url_filepath, params = self._parse_url(url)
         if params:
@@ -250,14 +345,10 @@ class S3Downloader(BaseDownloader):
 
         self._check_credential()
         try:
-            key = try_multiple_dec_s3(self._bucket.get_key)(
+            key = try_multiple_dec_s3(self._get_key)(
                 url_filepath, version_id=params.get('versionId', None)
             )
         except S3ResponseError as e:
-            # e.g. 400 Bad request could happen due to timed out key.
-            # Since likely things went bad if credential expired, just raise general
-            # AccessDeniedError. Logic upstream should retry
-            self._check_credential()
             raise TargetFileAbsent("S3 refused to provide the key for %s from url %s: %s"
                                 % (url_filepath, url, e))
         if key is None:

--- a/datalad/downloaders/tests/test_credentials.py
+++ b/datalad/downloaders/tests/test_credentials.py
@@ -111,10 +111,9 @@ def test_composite_credential1():
     cred.enter_new()
     assert_equal(keyring.get('name', 'user'), 'user2')
     assert_equal(keyring.get('name', 'password'), 'password2')
-    assert_equal(keyring.get('name:1', 'user'), None)
-    assert_equal(keyring.get('name:1', 'password'), None)
-    # which would get reevaluated if requested
-    assert_equal(keyring.entries, {'name:1': {}, 'name': {'user': 'user2', 'password': 'password2'}})
+    # we immediately refresh all credentials in the chain
+    assert_equal(keyring.get('name:1', 'user'), 'user2_1')
+    assert_equal(keyring.get('name:1', 'password'), 'password2_2')
     assert_equal(cred(), {'user': 'user2_1', 'password': 'password2_2'})
 
 

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -167,3 +167,18 @@ def test_restricted_bucket_on_NDA():
         ("s3://NDAR_Central_4/submission_23075/dataset_description.json", 'DA041147', 'error'),
     ]:
         yield check_download_external_url, url, failed_str, success_str
+
+
+@use_cassette('test_download_multiple_NDA')
+@with_tempfile(mkdir=True)
+def test_download_multiple_NDA(outdir):
+    # This would smoke/integration test logic for composite credential testing expiration
+    # of the token while reusing session from first url on the 2nd one
+    urls = [
+        "s3://NDAR_Central_4/submission_23075/README",
+        "s3://NDAR_Central_4/submission_23075/dataset_description.json",
+    ]
+    providers = get_test_providers(urls[0], reload=True)  # to verify having credentials to access
+
+    for url in urls:
+        ret = providers.download(url, outdir)

--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -18,9 +18,11 @@ from ..providers import Providers  # to test against crcns
 from ...tests.utils import (
     assert_equal,
     assert_raises,
+    integration,
     skip_if_no_network,
     SkipTest,
     swallow_outputs,
+    turtle,
     use_cassette,
     with_tempfile,
     with_testsui,
@@ -182,3 +184,85 @@ def test_download_multiple_NDA(outdir):
 
     for url in urls:
         ret = providers.download(url, outdir)
+
+
+# not really to be ran as part of the tests since it does
+# largely nothing but wait for token to expire!
+# It is still faster than waiting for real case to crash
+@turtle  # over 900 sec since that is the min duration for token
+@integration
+@with_tempfile(mkdir=True)
+def _test_expiring_token(outdir):
+    url = "s3://datalad-test0-versioned/1version-removed-recreated.txt"
+    outpath = op.join(outdir, "output")
+    providers = get_test_providers(url, reload=True)
+    downloader = providers.get_provider(url).get_downloader(url)
+
+    from time import time, sleep
+    from datalad.downloaders.credentials import AWS_S3, CompositeCredential, UserPassword
+    from datalad.support.keyring_ import MemoryKeyring
+    from datalad.tests.utils import ok_file_has_content
+    credential = downloader.credential  # AWS_S3('datalad-test-s3')
+
+    # We will replace credential with a CompositeCredential which will
+    # mint new token after expiration
+    # crap -- duration must be no shorter than 900, i.e. 15 minutes --
+    # too long to wait for a test!
+    duration = 900
+
+    generated = []
+    def _gen_session_token(_, key_id=None, secret_id=None):
+        from boto.sts.connection import STSConnection
+        sts = STSConnection(aws_access_key_id=key_id,
+                            aws_secret_access_key=secret_id)
+        # Note: without force_new=True it will not re-request a token and would
+        # just return old one if not expired yet.  Testing below might fail
+        # if not entirely new
+        token = sts.get_session_token(duration=duration, force_new=True)
+        generated.append(token)
+        return dict(key_id=token.access_key, secret_id=token.secret_key,
+                    session=token.session_token,
+                    expiration=token.expiration)
+
+    class CustomS3(CompositeCredential):
+        _CREDENTIAL_CLASSES = (UserPassword, AWS_S3)
+        _CREDENTIAL_ADAPTERS = (_gen_session_token,)
+
+    keyring = MemoryKeyring()
+    downloader.credential = new_credential = CustomS3("testexpire", keyring=keyring)
+    # but reuse our existing credential for the first part:
+    downloader.credential._credentials[0] = credential
+
+    # now downloader must use the token generator
+    assert not generated  # since we have not called it yet
+
+    # do it twice so we reuse session and test that we do not
+    # re-mint a new token
+    t0 = time()  # not exactly when we generated, might be a bit racy?
+    for i in range(2):
+        downloader.download(url, outpath)
+        ok_file_has_content(outpath, "version1")
+        os.unlink(outpath)
+    # but we should have asked for a new token only once
+    assert len(generated) == 1
+    assert downloader.credential is new_credential  # we did not reset it
+
+    # sleep for a while and now do a number of downloads during which
+    # token should get refreshed etc
+
+    # -3 since we have offset -2 hardcoded to refresh a bit ahead of time
+    to_sleep = duration - (time() - t0) - 3
+    print("Sleeping for %d seconds. Token should expire at %s" %
+          (to_sleep, generated[0].expiration))
+    sleep(to_sleep)
+
+    for i in range(5):
+        # should have not been regenerated yet
+        # -2 is our hardcoded buffer
+        if time() - t0 < duration - 2:
+            assert len(generated) == 1
+        downloader.download(url, outpath)
+        ok_file_has_content(outpath, "version1")
+        os.unlink(outpath)
+        sleep(1)
+    assert len(generated) == 2

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1986,7 +1986,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                 raise AnnexBatchCommandError(
                     cmd="addurl",
                     msg="Adding url %s to file %s failed due to %s" % (url, file_, exc_str(exc)))
-            assert(out_json['command'] == 'addurl')
+            assert \
+                (out_json['command'] == 'addurl'), \
+                "no exception was raised and no 'command' in result out_json=%s" % str(out_json)
         if not out_json.get('success', False):
             raise (AnnexBatchCommandError if batch else CommandError)(
                     cmd="addurl",

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -423,6 +423,14 @@ class AnonymousAccessDeniedError(AccessDeniedError):
     pass
 
 
+class AccessPermissionExpiredError(AccessDeniedError):
+    """To raise when there is a belief that it is due to expiration of a credential
+
+    which we might possibly be able to refresh, like in the case of CompositeCredential
+    """
+    pass
+
+
 class AccessFailedError(DownloadError):
     pass
 

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -92,7 +92,6 @@ def try_multiple_dec_s3(func):
                 exceptions_filter=lambda e: e.status in (
                     307,  # MovedTemporarily -- DNS updates etc
                     400,  # Generic Bad Request -- we kept hitting it once in a while
-                    # 403,
                     503,  # Slow down -- too many requests, so perfect fit to sleep a bit
                     ),
                 logger=lgr.debug,

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -108,7 +108,7 @@ def get_bucket(conn, bucket_name):
         Name of the bucket to connect to
     """
     try:
-        return conn.get_bucket(bucket_name)
+        return try_multiple_dec_s3(conn.get_bucket)(bucket_name)
     except S3ResponseError as e:
         # can initially deny or error to connect to the specific bucket by name,
         # and we would need to list which buckets are available under following
@@ -127,14 +127,14 @@ def get_bucket(conn, bucket_name):
             # Could be just HEAD call boto issues is not allowed, and we should not
             # try to verify that bucket is "reachable".  Just carry on
             try:
-                return conn.get_bucket(bucket_name, validate=False)
+                return try_multiple_dec_s3(conn.get_bucket)(bucket_name, validate=False)
             except S3ResponseError as e2:
                 lgr.debug("Cannot access bucket %s even without validation: %s",
                           bucket_name, exc_str(e2))
                 _handle_exception(e, bucket_name)
 
         try:
-            all_buckets = conn.get_all_buckets()
+            all_buckets = try_multiple_dec_s3(conn.get_all_buckets)()
             all_bucket_names = [b.name for b in all_buckets]
             lgr.debug("Found following buckets %s", ', '.join(all_bucket_names))
             if bucket_name in all_bucket_names:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1981,7 +1981,7 @@ def try_multiple_dec(
     exceptions: Exception or tuple of Exceptions, optional
       Exception or a tuple of multiple exceptions, on which to retry
     exceptions_filter: callable, optional
-      If provided, this unction will be called with a caught exception
+      If provided, this function will be called with a caught exception
       instance.  If function returns True - we will re-try, if False - exception
       will be re-raised without retrying.
     logger: callable, optional


### PR DESCRIPTION
I think this is an alternative (as a better solution to the underlying issue) to the https://github.com/datalad/datalad/pull/4928 -- I kept hitting a `400` error from S3 while `addurls` ABCD.  I believe in the course of DANDI project we had similar occasions whenever S3 would fail with 400 without apparent reason: well, there are many reasons why 400 could be returned - https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList and some of them are "legit", i.e. retry probably should not 'fix' that.  But I do not want to sift through all of them ATM.  IMHO it would be perfectly fine to retry a few times.

I have also added other codes (with comments in the code) which I think are legit to retry with sleep upon hitting.

Also `@try_multiple_dec` was enhanced and refactored a little to make it more useful generally.

I will now do a rerun of `addurls` with this PR applied so I could see if I finally manage to complete the runs of `addurls` without crash.

TODOs
- [x] figure out why not "effective" for my use case
- test the code by mocking `.get_bucket` to raise an exception on first try so forcing a retry - I did come up with a test but it is only an integration test which has extended run time... was not sure if mocked up test would be more pain than gain since it is really to test interaction with S3.  So decided to not pursue that.