### PR TITLE
RF: remove disable_logger in customremotes/datalad.py

### DIFF
--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -67,8 +67,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
         """
 
         try:
-            with disable_logger():
-                status = self._providers.get_status(url)
+            status = self._providers.get_status(url)
             size = str(status.size) if status.size is not None else 'UNKNOWN'
             resp = ["CHECKURL-CONTENTS", size] \
                 + ([status.filename] if status.filename else [])
@@ -97,8 +96,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
         for url in self.get_URLS(key):
             # somewhat duplicate of CHECKURL
             try:
-                with disable_logger():
-                    status = self._providers.get_status(url)
+                status = self._providers.get_status(url)
                 if status:  # TODO:  anything specific to check???
                     resp = "CHECKPRESENT-SUCCESS"
                     break


### PR DESCRIPTION
It was introduced in 15ecbb78a86f36b353e763273577dd369671e61b (`0.9.2~76^2~6`) as a part of https://github.com/datalad/datalad/pull/1870
with a purpose according to description of not pollutting stdout used by
special remote for communication.  BUT logs go to stderr and do not interfer
anyhow with the communication, so the reason for the change is not clear to me.

I have been trying to figure out why the heck I am still seeing failures after
https://github.com/datalad/datalad/pull/4931 .  I kept adding more logging but
nothing appeared in the logs!  I finally was brought to this piece of code,
thus the motivation and argumentation for the change.

Let's see -- if CI is happy, it means that my argumentation above that there should be no interference is correct and it should be safe to merge.