### PR TITLE
ENH: make it possible to debug batched annex

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -43,6 +43,7 @@ from .utils import (
     assure_bytes,
     assure_unicode,
     auto_repr,
+    ensure_unicode,
     generate_file_chunks,
     get_tempfile_kwargs,
     split_cmdline,
@@ -1317,12 +1318,14 @@ class BatchedCommand(SafeDelCloseMixin):
           None otherwise
         """
         ret = None
+        process = self._process
         if self._stderr_out:
             # close possibly still open fd
+            lgr.debug(
+                "Closing stderr of %s", process)
             os.fdopen(self._stderr_out).close()
             self._stderr_out = None
-        if self._process:
-            process = self._process
+        if process:
             lgr.debug(
                 "Closing stdin of %s and waiting process to finish", process)
             process.stdin.close()
@@ -1330,10 +1333,29 @@ class BatchedCommand(SafeDelCloseMixin):
             process.wait()
             self._process = None
             lgr.debug("Process %s has finished", process)
+
+        # It is hard to debug when something is going wrong. Hopefully logging stderr
+        # if generally asked might be of help
+        if lgr.isEnabledFor(5):
+            from . import cfg
+            log_stderr = cfg.getbool('datalad.log', 'outputs', default=False)
+        else:
+            log_stderr = False
+
         if self._stderr_out_fname and os.path.exists(self._stderr_out_fname):
-            if return_stderr:
+            if return_stderr or log_stderr:
                 with open(self._stderr_out_fname, 'r') as f:
-                    ret = f.read()
+                    stderr = f.read()
+            if return_stderr:
+                ret = stderr
+            if log_stderr:
+                # only the last 100 lines
+                stderr = ensure_unicode(stderr)
+                stderr = stderr.splitlines()
+                lgr.log(5, "stderr had %d lines. Last lines (up to 100) were:", len(stderr))
+                for l in stderr[-100:]:
+                    lgr.log(5, "stderr| %s ", l)
+
             # remove the file where we kept dumping stderr
             unlink(self._stderr_out_fname)
             self._stderr_out_fname = None

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -1349,12 +1349,11 @@ class BatchedCommand(SafeDelCloseMixin):
             if return_stderr:
                 ret = stderr
             if log_stderr:
-                # only the last 100 lines
                 stderr = ensure_unicode(stderr)
                 stderr = stderr.splitlines()
-                lgr.log(5, "stderr had %d lines. Last lines (up to 100) were:", len(stderr))
-                for l in stderr[-100:]:
-                    lgr.log(5, "stderr| %s ", l)
+                lgr.log(5, "stderr of %s had %d lines:", process.pid, len(stderr))
+                for l in stderr:
+                    lgr.log(5, "| " + l)
 
             # remove the file where we kept dumping stderr
             unlink(self._stderr_out_fname)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3772,7 +3772,8 @@ class BatchedAnnex(BatchedCommand):
             annex_cmd + \
             (annex_options if annex_options else []) + \
             (['--json', '--json-error-messages'] if json else []) + \
-            ['--batch']  # , '--debug']
+            ['--batch'] + \
+            (['--debug'] if lgr.getEffectiveLevel() <= 8 else [])
         output_proc = \
             output_proc if output_proc else readline_json if json else None
         super(BatchedAnnex, self).__init__(


### PR DESCRIPTION
- add `--debug` option to `annex CMD --batch` invocation when level <= 8, analogously to what we do in main AnnexRepo "good old runner"
- incorporate and supersede #4925 - log all stderr lines if logging of outputs was requested and log level <= 5
  - 100 is just often is not enough to troubleshoot some issue which has happened some time before (crash of special remote etc) the batch process actually finished

I hope these two changes would make debugging of annex and started by it external remotes more manageable.  ATM it is either pain or just impossible.