### PR TITLE
BF: declare minimal version of fasteners to be 0.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requires = {
         'distro; python_version >= "3.8"',
         'iso8601',
         'humanize',
-        'fasteners',
+        'fasteners>=0.14',
         'patool>=1.7',
         'tqdm',
         'wrapt',


### PR DESCRIPTION
In master, 3ab5a14689d6575f841a05d450e2676e855d6035, added use of InterProcessLock
with providing our logger.  That feature was added only in 0.14 according to
https://github.com/harlowja/fasteners/blob/master/ChangeLog

and stable Debian (and NeuroDebian ATM) has only 0.12.0 which causes
errors.

We could have checked on version of fasteners and provided only if recent enough,
but for now (hoping that backport builds succeed) I am just establishing minimal
version
