### PR TITLE
Nf json ld search

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -257,12 +257,20 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
             # Handle the @list node of JSON-LD here
             new_key_name = dict_or_list_or_value.get('@id', 'list')
             for index, element in enumerate(dict_or_list_or_value['@list']):
-                yield from _deep_kv(basekey + f".{new_key_name}[{index}]", element)
+                yield from _deep_kv(
+                    basekey
+                    + ".{new_key_name}[{index}]".format(
+                        new_key_name=new_key_name,
+                        index=index),
+                    element)
 
         if '@graph' in dict_or_list_or_value:
             # Handle the @graph node of JSON-LD here
             for index, element in enumerate(dict_or_list_or_value['@graph']):
-                yield from _deep_kv(basekey + f".graph[{index}]", element)
+                yield from _deep_kv(
+                    basekey
+                    + ".graph[{index}]".format(index=index),
+                    element)
 
         if "@type" in dict_or_list_or_value:
             key = _encode_key(dict_or_list_or_value['@type'])

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -234,6 +234,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
 
         """
         if dict_or_list_or_value is None:
+            yield basekey, None
             return
 
         # Special treatment of studyminimeta. This should really be done in an object associated with studyminimeta,
@@ -248,7 +249,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
 
         if isinstance(dict_or_list_or_value, list):
             for index, element in enumerate(dict_or_list_or_value):
-                yield from _deep_kv(basekey + f"[{index}]", element)
+                yield basekey, dict_or_list_or_value
             return
 
         # We know that dict_or_list_or_value is a dict now.
@@ -272,7 +273,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
             )
 
         for k, v in dict_or_list_or_value.items():
-            if k in ('@type', '@list', '@graph', 'datalad_unique_content_properties'):
+            if k in ('@type', '@list', '@graph', '@context', 'datalad_unique_content_properties'):
                 continue
             key = _encode_key(k)
             new_basekey = u'{}.{}'.format(basekey, key) if basekey else u'{}'.format(key)
@@ -938,7 +939,6 @@ class _EGrepCSSearch(_Search):
         # After #2156 datasets may not necessarily carry all
         # keys in the "unique" summary
         lgr.warning('In this search mode, the reported list of metadata keys may be incomplete')
-
 
     def _get_keys(self, mode=None):
         """Return keys and their statistics if mode != 'name'."""

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -661,7 +661,7 @@ def _test_ds_studyminimeta_show_keys_full_with_searcher(ds, search_class, mode):
 
         searcher = search_class(ds)
         searcher.show_keys(mode=mode)
-        out_lines = [line for line in cmo.out.split(os.linesep) if line]
+        out_lines = [line for line in cmo.out.splitlines() if line]
 
     key_lines = [key_line for key_line in out_lines if not key_line.startswith(' ')]
     if issubclass(search_class, _BlobSearch):

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -358,3 +358,265 @@ def test_meta2autofield_dict():
             'extr1': {'prop1': 'value'}}),
         {'extr1.prop1': 'value'}
     )
+
+
+def test_meta2autofield_jsonld_graph():
+    """ check proper handling of JSON-LD @graph nodes """
+    # Just a test that we would obtain the value stored for that extractor
+    # instead of what unique values it already had (whatever that means)
+    eq_(
+        _meta2autofield_dict({"r": {"@graph": ["a", "b", "c"]}}),
+        {'r.graph[0]': 'a', 'r.graph[1]': 'b', 'r.graph[2]': 'c'}
+    )
+
+
+def test_meta2autofield_jsonld_list():
+    """ check proper handling of JSON-LD @list nodes """
+    # Just a test that we would obtain the value stored for that extractor
+    # instead of what unique values it already had (whatever that means)
+    eq_(
+        _meta2autofield_dict({"r": {"@list": ["a", "b", "c"]}}),
+        {'r.list[0]': 'a', 'r.list[1]': 'b', 'r.list[2]': 'c'}
+    )
+
+
+_mocked_studyminimeta_jsonld = {
+    "@context": {
+        "@vocab": "http://schema.org/"
+    },
+    "@graph": [
+        {
+            "@id": "#study",
+            "@type": "CreativeWork",
+            "name": "Eine Studie",
+            "abstract": "a short description of the study",
+            "accountablePerson": "a@example.com",
+            "keywords": [
+                "k1",
+                "k2"
+            ],
+            "dateCreated": "01.01.2020",
+            "description": "end_date: 02.02.2020",
+            "contributor": [
+                {
+                    "@id": "https://schema.datalad.org/person#a@example.com"
+                },
+                {
+                    "@id": "https://schema.datalad.org/person#b@example.com"
+                }
+            ],
+            "funder": [
+                {
+                    "@id": "https://schema.datalad.org/organization#DFG",
+                    "@type": "Organization",
+                    "name": "DFG"
+                },
+                {
+                    "@id": "https://schema.datalad.org/organization#NHO",
+                    "@type": "Organization",
+                    "name": "NHO"
+                }
+            ]
+        },
+        {
+            "@id": "https://schema.datalad.org/datalad_dataset#id-0000--0000",
+            "@type": "Dataset",
+            "version": "a02312398324778972389472834",
+            "name": "Datenddaslk",
+            "url": "http://dlksdfs.comom.com",
+            "description": "Ein paar Daten, die ich mal gesammelt habe. Ein paar Daten, die ich mal gesammelt habe.",
+            "keywords": [
+                "d_k1",
+                "d_k2",
+                "d_k3"
+            ],
+            "author": [
+                {
+                    "@id": "https://schema.datalad.org/person#a@example.com"
+                },
+                {
+                    "@id": "https://schema.datalad.org/person#b@example.com"
+                }
+            ],
+            "hasPart": {
+                "@id": "#standards",
+                "@type": "DefinedTermSet",
+                "hasDefinedTerm": [
+                    {
+                        "@id": "https://schema.datalad.org/standard#dicom",
+                        "@type": "DefinedTerm",
+                        "termCode": "dicom"
+                    },
+                    {
+                        "@id": "https://schema.datalad.org/standard#ebdsi",
+                        "@type": "DefinedTerm",
+                        "termCode": "ebdsi"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "#personList",
+            "@list": [
+                {
+                    "@id": "https://schema.datalad.org/person#a@example.com",
+                    "@type": "Person",
+                    "email": "a@example.com",
+                    "name": "Prof. Dr.  Alex Meyer",
+                    "givenName": "Alex",
+                    "familyName": "Meyer",
+                    "sameAs": "0000-0001-0002-0033",
+                    "honorificSuffix": "Prof. Dr.",
+                    "affiliation": "Big Old University",
+                    "contactPoint": {
+                        "@id": "#contactPoint(a@example.com)",
+                        "@type": "ContactPoint",
+                        "description": "Corner broadway and main"
+                    }
+                },
+                {
+                    "@id": "https://schema.datalad.org/person#b@example.com",
+                    "@type": "Person",
+                    "email": "b@example.com",
+                    "name": "MD  Bernd Muller",
+                    "givenName": "Bernd",
+                    "familyName": "Muller",
+                    "sameAs": "0000-0001-0002-0034",
+                    "honorificSuffix": "MD",
+                    "affiliation": "RRU-SSLT",
+                    "contactPoint": {
+                        "@id": "#contactPoint(b@example.com)",
+                        "@type": "ContactPoint",
+                        "description": "central plaza"
+                    }
+                }
+            ]
+        },
+        {
+            "@id": "#publicationList",
+            "@list": [
+                {
+                    "@id": "#publication[0]",
+                    "@type": "ScholarlyArticle",
+                    "headline": "Publication Numero Unos",
+                    "datePublished": 2001,
+                    "author": [
+                        {
+                            "@id": "https://schema.datalad.org/person#a@example.com"
+                        },
+                        {
+                            "@id": "https://schema.datalad.org/person#b@example.com"
+                        }
+                    ],
+                    "publisher": {
+                        "@id": "https://schema.datalad.org/publisher#Renato",
+                        "@type": "Organization",
+                        "name": "Renato"
+                    },
+                    "isPartOf": {
+                        "@id": "#issue(4)",
+                        "@type": "PublicationIssue",
+                        "issueNumber": 4,
+                        "isPartOf": {
+                            "@id": "#volume(30)",
+                            "@type": "PublicationVolume",
+                            "volumeNumber": 30
+                        }
+                    }
+                },
+                {
+                    "@id": "#publication[1]",
+                    "@type": "ScholarlyArticle",
+                    "headline": "Publication Numero Dos",
+                    "datePublished": 2002,
+                    "author": [
+                        {
+                            "@id": "https://schema.datalad.org/person#a@example.com"
+                        },
+                        {
+                            "@id": "https://schema.datalad.org/person#b@example.com"
+                        }
+                    ],
+                    "publisher": {
+                        "@id": "https://schema.datalad.org/publisher#Vorndran",
+                        "@type": "Organization",
+                        "name": "Vorndran"
+                    },
+                    "isPartOf": {
+                        "@id": "#volume(400)",
+                        "@type": "PublicationVolume",
+                        "volumeNumber": 400
+                    }
+                },
+                {
+                    "@id": "#publication[2]",
+                    "@type": "ScholarlyArticle",
+                    "headline": "Publication Numero Tres",
+                    "datePublished": 2003,
+                    "author": [
+                        {
+                            "@id": "https://schema.datalad.org/person#a@example.com"
+                        },
+                        {
+                            "@id": "https://schema.datalad.org/person#b@example.com"
+                        }
+                    ],
+                    "publisher": {
+                        "@id": "https://schema.datalad.org/publisher#Eisenberg",
+                        "@type": "Organization",
+                        "name": "Eisenberg"
+                    },
+                    "isPartOf": {
+                        "@id": "#issue(500)",
+                        "@type": "PublicationIssue",
+                        "issueNumber": 500
+                    }
+                },
+                {
+                    "@id": "#publication[3]",
+                    "@type": "ScholarlyArticle",
+                    "headline": "Publication Numero Quatro",
+                    "datePublished": 2004,
+                    "author": [
+                        {
+                            "@id": "https://schema.datalad.org/person#a@example.com"
+                        },
+                        {
+                            "@id": "https://schema.datalad.org/person#b@example.com"
+                        }
+                    ],
+                    "publisher": {
+                        "@id": "https://schema.datalad.org/publisher#Killian-Tumler",
+                        "@type": "Organization",
+                        "name": "Killian-Tumler"
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+
+def test_meta2autofield_studyminimeta():
+    """ check proper handling of JSON-LD @list nodes """
+    # Just a test that we would obtain the value stored for that extractor
+    # instead of what unique values it already had (whatever that means)
+    eq_(
+        _meta2autofield_dict({"metalad_studyminimeta": _mocked_studyminimeta_jsonld}),
+        {
+            'metalad_studyminimeta.dataset.author': 'Prof. Dr.  Alex Meyer, MD  Bernd Muller',
+            'metalad_studyminimeta.dataset.name': 'Datenddaslk',
+            'metalad_studyminimeta.dataset.location': 'http://dlksdfs.comom.com',
+            'metalad_studyminimeta.dataset.description': 'Ein paar Daten, die ich mal gesammelt habe. Ein paar Daten, die ich mal gesammelt habe.',
+            'metalad_studyminimeta.dataset.keywords': 'd_k1, d_k2, d_k3',
+            'metalad_studyminimeta.dataset.standards': 'dicom, ebdsi',
+            'metalad_studyminimeta.person.email': 'a@example.com, b@example.com',
+            'metalad_studyminimeta.person.name': 'Prof. Dr.  Alex Meyer, MD  Bernd Muller',
+            'metalad_studyminimeta.name': 'Eine Studie',
+            'metalad_studyminimeta.accountable_person': 'Prof. Dr.  Alex Meyer',
+            'metalad_studyminimeta.contributor': 'Prof. Dr.  Alex Meyer, MD  Bernd Muller',
+            'metalad_studyminimeta.publication.author': 'Prof. Dr.  Alex Meyer, MD  Bernd Muller',
+            'metalad_studyminimeta.publication.title': 'Publication Numero Quatro',
+            'metalad_studyminimeta.publication.year': '2004', 'metalad_studyminimeta.keywords': 'k1, k2'
+        }
+    )


### PR DESCRIPTION
These changes modify the automated index creation from metadata objects to be able to create indices from JSON-LD objects, e.g. process @graph and @list. In addition, this PR adds a dedicated JSON-LD converter for studyminimeta-metadata objects (this converted should be moved to a different place later, cf. issue https://github.com/datalad/datalad/issues/4944)

The change will increase the number of key-value pairs that are searchable, i.e. the list that emitted by the command "datalad search --show-keys name" is longer.

In order to properly separate key-name spaces in woosh search, key names have been amended with an index notation. This allows separating the subtrees contained in a list-like metadata-objects. For example, the following keys will be printed by "datalad search --show-keys name", if the metalad_core extractor was executed:

```
 . . .
metalad_core.graph[0].agent.email
metalad_core.graph[0].agent.id
metalad_core.graph[0].agent.name
 . . .
``` 

A follow up to this commit would be to add a mechanism to register extractor-specific index creation and use this mechanism, instead of hard-coded branches, to perform extractor-specific index creation (see also issue: https://github.com/datalad/datalad/issues/4944)
