### PR TITLE
downloader: handle non-utf8 files being downloaded

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -27,7 +27,6 @@ from ..ui import ui
 from ..utils import (
     auto_repr,
     ensure_unicode,
-    read_file_ensure_unicode,
     unlink,
 )
 from ..dochelpers import exc_str
@@ -368,7 +367,10 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 % self.authenticator
 
             if file_:
-                content = read_file_ensure_unicode(file_)
+                # just read bytes and pass to check_for_auth_failure which
+                # will then encode regex into bytes (assuming utf-8 though)
+                with open(file_, 'rb') as fp:
+                    content = fp.read(self._DOWNLOAD_SIZE_TO_VERIFY_AUTH)
             else:
                 assert(content is not None)
 

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -26,6 +26,8 @@ from .. import cfg
 from ..ui import ui
 from ..utils import (
     auto_repr,
+    ensure_unicode,
+    read_file_ensure_unicode,
     unlink,
 )
 from ..dochelpers import exc_str
@@ -366,8 +368,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 % self.authenticator
 
             if file_:
-                with open(file_) as fp:
-                    content = fp.read(self._DOWNLOAD_SIZE_TO_VERIFY_AUTH)
+                content = read_file_ensure_unicode(file_)
             else:
                 assert(content is not None)
 
@@ -574,7 +575,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
 
             # now that we know size based on encoded content, let's decode into string type
             if isinstance(content, bytes) and decode:
-                content = content.decode()
+                content = ensure_unicode(content)
             # downloaded_size = os.stat(temp_filepath).st_size
 
             self._verify_download(url, downloaded_size, target_size, None, content=content)

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -217,6 +217,11 @@ class HTTPBaseAuthenticator(Authenticator):
             # verify that we actually logged in
             for failure_re in self.failure_re:
                 if content_is_bytes:
+                    # content could be not in utf-8. But I do not think that
+                    # it is worth ATM messing around with guessing encoding
+                    # of the content to figure out what to encode it into
+                    # since typically returned "auth failed" should be in
+                    # utf-8 or plain ascii
                     failure_re = ensure_bytes(failure_re)
                 if re.search(failure_re, content):
                     raise AccessDeniedError(

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -138,7 +138,7 @@ class S3DownloaderSession(DownloaderSession):
             # see http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
             self.key.get_contents_to_file(f, **kwargs)
         else:
-            return self.key.get_contents_as_string(encoding='utf-8', **kwargs)
+            return self.key.get_contents_as_string(encoding=None, **kwargs)
 
 
 @auto_repr

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -780,6 +780,7 @@ def ensure_unicode(s, encoding=None, confidence=None):
                     "confidence. Highest confidence was %s for %s"
                     % (denc_confidence, denc)
                 )
+            lgr.log(5, "Auto-detected encoding to be %s", denc)
             return s.decode(denc)
         else:
             raise ValueError(
@@ -2089,6 +2090,13 @@ def open_r_encdetect(fname, readahead=1000):
               fname,
               enc.get('confidence', 'unknown'))
     return io.open(fname, encoding=denc)
+
+
+def read_file_ensure_unicode(fname):
+    """A helper to read file passing content via ensure_unicode"""
+    with open(fname, 'rb') as f:
+        content = f.read()
+    return ensure_unicode(content)
 
 
 def read_csv_lines(fname, dialect=None, readahead=16384, **kwargs):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2092,11 +2092,17 @@ def open_r_encdetect(fname, readahead=1000):
     return io.open(fname, encoding=denc)
 
 
-def read_file_ensure_unicode(fname):
-    """A helper to read file passing content via ensure_unicode"""
+def read_file(fname, decode=True):
+    """A helper to read file passing content via ensure_unicode
+
+    Parameters
+    ----------
+    decode: bool, optional
+      if False, no ensure_unicode and file content returned as bytes
+    """
     with open(fname, 'rb') as f:
         content = f.read()
-    return ensure_unicode(content)
+    return ensure_unicode(content) if decode else content
 
 
 def read_csv_lines(fname, dialect=None, readahead=16384, **kwargs):


### PR DESCRIPTION
Some downloaders need to read-in the actual downloaded content to see if it may be a "login error" message since portals do not return a proper 403 etc.  If content is not utf8 - it was causing a puke (#4951) .

This is likely a tip of an iceberg and there could be more of places in datalad where we read some content assuming it to be utf-8, whenever it is not.  Introduced here `read_file` (I am ok to rename if desired, initially `read_file_ensure_unicode` - generalized into one to use without decoding as well) would be of help.  May be you know a better way? but I thought it would be nice to centralize all such logic on encoding discovery via `ensure_unicode` which we do use already quite a bit throughout the code.

edit 1 after more pushes: One functionality change/fix is for S3 downloader is to not try to decode content (when no file is provided) to stay consistent with http downloader which uses BytesIO and just returns its content.  It is up for outside logic on either to decode it ATM, although generally downloaders should respect content-type/encoding header fields and act appropriately (which AFIAK they don't do ATM) but that is outside of the scope of this BF PR.