### PR TITLE
Tollerate %xx in filenames

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -837,6 +837,7 @@ def get_allargs_as_kwargs(call, args, kwargs):
     argspec = getargspec(call)
     defaults = argspec.defaults
     nargs = len(argspec.args)
+    defaults = defaults or []  # ensure it is a list and not None
     assert (nargs >= len(defaults))
     # map any args to their name
     argmap = list(zip(argspec.args[:len(args)], args))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -579,8 +579,12 @@ def _process_results(
                 msgargs = msg[1:]
                 msg = msg[0]
             if 'path' in res:
+                path = res['path']
+                if msgargs:
+                    # we will pass the msg for %-polation, so % should be doubled
+                    path = path.replace('%', '%%')
                 msg = '{} [{}({})]'.format(
-                    msg, res['action'], res['path'])
+                    msg, res['action'], path)
             if msgargs:
                 # support string expansion of logging to avoid runtime cost
                 try:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -583,7 +583,13 @@ def _process_results(
                     msg, res['action'], res['path'])
             if msgargs:
                 # support string expansion of logging to avoid runtime cost
-                res_lgr(msg, *msgargs)
+                try:
+                    res_lgr(msg, *msgargs)
+                except TypeError as exc:
+                    raise TypeError(
+                        "Failed to render %r with %r from %r: %s"
+                        % (msg, msgargs, res, exc_str(exc))
+                    )
             else:
                 res_lgr(msg)
 

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -341,7 +341,7 @@ class ExtractedArchive(object):
 
         It does not actually extract any archive
         """
-        return opj(self.path, urlunquote(afile))
+        return opj(self.path, afile)
 
     def get_extracted_files(self):
         """Generator to provide filenames which are available under extracted archive

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -222,11 +222,11 @@ def test_with_tempfile_specified_prefix(d1):
 @known_failure_githubci_win
 def test_get_most_obscure_supported_name():
     n = get_most_obscure_supported_name()
-    if platform.system() in ('Linux', 'Darwin'):
-        eq_(n, OBSCURE_PREFIX + OBSCURE_FILENAMES[1])
-    else:
-        # ATM no one else is as good
-        ok_(n in OBSCURE_PREFIX + OBSCURE_FILENAMES[2:])
+    ok_startswith(n, OBSCURE_PREFIX)
+    ok_(len(OBSCURE_FILENAMES) > 1)
+    # from more complex to simpler ones
+    ok_(len(OBSCURE_FILENAMES[0]) > len(OBSCURE_FILENAMES[-1]))
+    print(repr(n))
 
 
 def test_keeptemp_via_env_variable():

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1472,7 +1472,7 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     TODO: we might want to use it as a function where we would provide tdir
     """
     # we need separate good_base so we do not breed leading/trailing spaces
-    initial = good = OBSCURE_PREFIX + 'a'  # everyone should support that!
+    initial = good = 'a'  # everyone should support that!
     system = platform.system()
 
     OBSCURE_FILENAMES = []
@@ -1490,12 +1490,13 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     # incrementally build up the most obscure filename from parts
     for part in OBSCURE_FILENAME_PARTS:
         candidate = good + part
-        if good_filename(candidate):
+        if good_filename(OBSCURE_PREFIX + candidate):
             good = candidate
 
     # now we will compose some candidates with trailing spaces - trickier ones first
     # so we break the loop as soon as we get it
     for candidate in [' ' + good + ' ', ' ' + good, good + ' ', good]:
+        candidate = OBSCURE_PREFIX + candidate
         # if on_windows and filename.rstrip() != filename:
         #     continue
         if good_filename(candidate):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1440,7 +1440,7 @@ def with_parametric_batch(t):
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
 # Those will be tried to be added to the base name if filesystem allows
 OBSCURE_FILENAME_PARTS = ['/', '|', ';', '&',
-                          # TODO: add '%b5',
+                          '%b5',
                           ' ']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1497,8 +1497,8 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     # so we break the loop as soon as we get it
     for candidate in [' ' + good + ' ', ' ' + good, good + ' ', good]:
         candidate = OBSCURE_PREFIX + candidate
-        # if on_windows and filename.rstrip() != filename:
-        #     continue
+        if on_windows and candidate.rstrip() != candidate:
+            continue
         if good_filename(candidate):
             good = candidate
             break

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1438,21 +1438,12 @@ def with_parametric_batch(t):
 # List of most obscure filenames which might or not be supported by different
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
-OBSCURE_FILENAMES = (
-    u" \"';a&b/&c `| ",  # shouldn't be supported anywhere I guess due to /
-    u" \"';a&b&c `| ",
-    u" \"';abc `| ",
-    u" \"';abc | ",
-    u" \"';abc ",
-    u" ;abc ",
-    u" ;abc",
-    u" ab c ",
-    u" ab c",
-    u"ac",
-    u" ab .datc ",
-    u"ab .datc ",  # they all should at least support spaces and dots
-)
+# Those will be tried to be added to the base name if filesystem allows
+OBSCURE_FILENAME_PARTS = ['/', '|', ';', '&',
+                          # TODO: add '%b5',
+                          ' ']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
+
 # OSX is exciting -- some I guess FS might be encoding differently from decoding
 # so Й might get recoded
 # (ref: https://github.com/datalad/datalad/pull/1921#issuecomment-385809366)
@@ -1463,35 +1454,65 @@ if sys.getfilesystemencoding().lower() == 'utf-8':
     if on_windows:
         # TODO: really figure out unicode handling on windows
         UNICODE_FILENAME = ''
-    # Prepend the list with unicode names first
-    OBSCURE_FILENAMES = tuple(
-        f.replace(u'c', u'c' + UNICODE_FILENAME) for f in OBSCURE_FILENAMES
-    ) + OBSCURE_FILENAMES
+    if UNICODE_FILENAME:
+        OBSCURE_FILENAME_PARTS.append(UNICODE_FILENAME)
+# simple extension to finish it up
+OBSCURE_FILENAME_PARTS.append('.datc')
 
 
 @with_tempfile(mkdir=True)
-def get_most_obscure_supported_name(tdir):
+def get_most_obscure_supported_name(tdir, return_candidates=False):
     """Return the most obscure filename that the filesystem would support under TEMPDIR
 
+    Parameters
+    ----------
+    return_candidates: bool, optional
+      if True, return a tuple of (good, candidates) where candidates are "partially"
+      sorted from trickiest considered
     TODO: we might want to use it as a function where we would provide tdir
     """
-    for filename in OBSCURE_FILENAMES:
-        filename = OBSCURE_PREFIX + filename
-        if on_windows and filename.rstrip() != filename:
-            continue
+    # we need separate good_base so we do not breed leading/trailing spaces
+    initial = good = OBSCURE_PREFIX + 'a'  # everyone should support that!
+    system = platform.system()
+
+    OBSCURE_FILENAMES = []
+    def good_filename(filename):
+        OBSCURE_FILENAMES.append(candidate)
         try:
             with open(opj(tdir, filename), 'w') as f:
                 f.write("TEST LOAD")
-            return filename  # it will get removed as a part of wiping up the directory
+            return True
         except:
             lgr.debug("Filename %r is not supported on %s under %s",
-                      filename, platform.system(), tdir)
-            pass
-    raise RuntimeError("Could not create any of the files under %s among %s"
+                      filename, system, tdir)
+            return False
+
+    # incrementally build up the most obscure filename from parts
+    for part in OBSCURE_FILENAME_PARTS:
+        candidate = good + part
+        if good_filename(candidate):
+            good = candidate
+
+    # now we will compose some candidates with trailing spaces - trickier ones first
+    # so we break the loop as soon as we get it
+    for candidate in [' ' + good + ' ', ' ' + good, good + ' ', good]:
+        # if on_windows and filename.rstrip() != filename:
+        #     continue
+        if good_filename(candidate):
+            good = candidate
+            break
+
+    if good == initial:
+        raise RuntimeError("Could not create any of the files under %s among %s"
                        % (tdir, OBSCURE_FILENAMES))
+    lgr.debug("Tested %d obscure filename candidates. The winner: %r", len(OBSCURE_FILENAMES), good)
+    if return_candidates:
+        return good, OBSCURE_FILENAMES[::-1]
+    else:
+        return good
 
 
-OBSCURE_FILENAME = get_most_obscure_supported_name()
+OBSCURE_FILENAME, OBSCURE_FILENAMES = get_most_obscure_supported_name(return_candidates=True)
 
 
 @optional_args


### PR DESCRIPTION
To address #4950 , but also introducing `%b4` into an obscure filename used by tests. Sits on top of #4949 .  The actual fix in the last commit in the series was trivial and to the one of the most ancient pieces of code in the archive (current commit is f080379e8ae6faf61c0927662940399be9aa5543 ).  Let's now just see if tests pass to signal that there were no some hidden assumption somewhere ;-)