### PR TITLE
OPT: gen_URLS (to replace get_URLS) - query schemes in order of prior "successes"

### DIFF
--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -153,7 +153,10 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         Made "generators all the way" as an exercise but also to delay any
         checks etc until really necessary.
         """
-        urls = self.get_URLS(key)
+        # we will need all URLs anyways later on ATM, so lets list() them
+        # Anyways here we have a single scheme (archive) so there is not
+        # much optimization possible
+        urls = list(self.gen_URLS(key))
 
         akey_afiles = [
             self._parse_url(url)[:2]  # skip size

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -38,7 +38,6 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
         # about.  So for a key we might get back multiple URLs and as a
         # heuristic let's use the most recently asked one
 
-        self._last_url = None  # for heuristic to choose among multiple URLs
         self._providers = Providers.from_config_files()
 
     #
@@ -144,11 +143,6 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
         # TODO: We might want that one to be a generator so we do not bother requesting
         # all possible urls at once from annex.
         urls = self.get_URLS(key)
-
-        if self._last_url in urls:
-            # place it first among candidates... some kind of a heuristic
-            urls.pop(self._last_url)
-            urls = [self._last_url] + urls
 
         # TODO: priorities etc depending on previous experience or settings
 

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -92,7 +92,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
         """
         lgr.debug("VERIFYING key %s" % key)
         resp = None
-        for url in self.get_URLS(key):
+        for url in self.gen_URLS(key):
             # somewhat duplicate of CHECKURL
             try:
                 status = self._providers.get_status(url)
@@ -142,11 +142,12 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
 
         # TODO: We might want that one to be a generator so we do not bother requesting
         # all possible urls at once from annex.
-        urls = self.get_URLS(key)
+        urls = []
 
         # TODO: priorities etc depending on previous experience or settings
 
-        for url in urls:
+        for url in self.gen_URLS(key):
+            urls.append(url)
             try:
                 downloaded_path = self._providers.download(
                     url, path=path, overwrite=True


### PR DESCRIPTION
Ref: #4954 

I do  not think it would be of tremendous performance boost (since most of the time is likely to be spent in interaction with external resources) but it can cut interactions between git-annex and `datalad` special remote significantly, and will pollute log less.

I think the change is quite straightforward and I would not mind to rebase it against `maint`, but I am also ok to keep it in master.