### PR TITLE
ENH: more obscurity - add ', ", and {} to obscure filenames

### DIFF
--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -35,6 +35,7 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import NoDatasetFound
 from datalad.utils import (
+    guard_for_format,
     quote_cmdlinearg,
     split_cmdline,
 )
@@ -436,8 +437,8 @@ class RunProcedure(Interface):
                              "Missing 'execute' permissions?" % procedure_file)
 
         cmd = ex['template'].format(
-            script=quote_cmdlinearg(procedure_file),
-            ds=quote_cmdlinearg(ds.path) if ds else '',
+            script=guard_for_format(quote_cmdlinearg(procedure_file)),
+            ds=guard_for_format(quote_cmdlinearg(ds.path)) if ds else '',
             args=(u' '.join(quote_cmdlinearg(a) for a in args) if args else ''))
         lgr.info(u"Running procedure %s", name)
         lgr.debug(u'Full procedure command: %r', cmd)

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -797,7 +797,7 @@ def get_ds_aggregate_db_locations(ds, version='default', warn_absent=True):
             # caller had no specific idea what metadata version is needed/available
             # This dataset does not have aggregated metadata.  Does it have any
             # other version?
-            info_glob = op.join(ds.path, agginfo_relpath_template).format('*')
+            info_glob = op.join(ds.path, agginfo_relpath_template.format('*'))
             info_files = glob.glob(info_glob)
             msg = "Found no aggregated metadata info file %s." \
                   % info_fpath

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1439,7 +1439,7 @@ def with_parametric_batch(t):
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
 # Those will be tried to be added to the base name if filesystem allows
-OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}']
+OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}', "'", '"']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
 
 # OSX is exciting -- some I guess FS might be encoding differently from decoding

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1439,7 +1439,7 @@ def with_parametric_batch(t):
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
 # Those will be tried to be added to the base name if filesystem allows
-OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5']
+OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
 
 # OSX is exciting -- some I guess FS might be encoding differently from decoding

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1477,7 +1477,12 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     def good_filename(filename):
         OBSCURE_FILENAMES.append(candidate)
         try:
-            with open(opj(tdir, filename), 'w') as f:
+            # Windows seems to not tollerate trailing spaces and
+            # ATM we do not distinguish obscure filename and dirname.
+            # So here we will test for both - being able to create dir
+            # with obscure name and obscure filename under
+            os.mkdir(opj(tdir, filename))
+            with open(opj(tdir, filename, filename), 'w') as f:
                 f.write("TEST LOAD")
             return True
         except:
@@ -1488,8 +1493,6 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     # incrementally build up the most obscure filename from parts
     for part in OBSCURE_FILENAME_PARTS:
         candidate = good + part
-        if on_windows and candidate.rstrip() != candidate:
-            continue
         if good_filename(candidate):
             good = candidate
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1439,9 +1439,7 @@ def with_parametric_batch(t):
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
 # Those will be tried to be added to the base name if filesystem allows
-OBSCURE_FILENAME_PARTS = ['/', '|', ';', '&',
-                          '%b5',
-                          ' ']
+OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
 
 # OSX is exciting -- some I guess FS might be encoding differently from decoding
@@ -1456,8 +1454,8 @@ if sys.getfilesystemencoding().lower() == 'utf-8':
         UNICODE_FILENAME = ''
     if UNICODE_FILENAME:
         OBSCURE_FILENAME_PARTS.append(UNICODE_FILENAME)
-# simple extension to finish it up
-OBSCURE_FILENAME_PARTS.append('.datc')
+# space before extension, simple extension and trailing space to finish it up
+OBSCURE_FILENAME_PARTS += [' ', '.datc', ' ']
 
 
 @with_tempfile(mkdir=True)
@@ -1472,7 +1470,7 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     TODO: we might want to use it as a function where we would provide tdir
     """
     # we need separate good_base so we do not breed leading/trailing spaces
-    initial = good = 'a'  # everyone should support that!
+    initial = good = OBSCURE_PREFIX
     system = platform.system()
 
     OBSCURE_FILENAMES = []
@@ -1490,18 +1488,10 @@ def get_most_obscure_supported_name(tdir, return_candidates=False):
     # incrementally build up the most obscure filename from parts
     for part in OBSCURE_FILENAME_PARTS:
         candidate = good + part
-        if good_filename(OBSCURE_PREFIX + candidate):
-            good = candidate
-
-    # now we will compose some candidates with trailing spaces - trickier ones first
-    # so we break the loop as soon as we get it
-    for candidate in [' ' + good + ' ', ' ' + good, good + ' ', good]:
-        candidate = OBSCURE_PREFIX + candidate
         if on_windows and candidate.rstrip() != candidate:
             continue
         if good_filename(candidate):
             good = candidate
-            break
 
     if good == initial:
         raise RuntimeError("Could not create any of the files under %s among %s"

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2438,6 +2438,16 @@ def quote_cmdlinearg(arg):
     ) if on_windows else shlex_quote(arg)
 
 
+def guard_for_format(arg):
+    """Replace { and } with {{ and }}
+
+    To be used in cases if arg is not expected to have provided
+    by user .format() placeholders, but 'arg' might become a part
+    of a composite passed to .format(), e.g. via 'Run'
+    """
+    return arg.replace('{', '{{').replace('}', '}}')
+
+
 def split_cmdline(s):
     """Perform platform-appropriate command line splitting.
 


### PR DESCRIPTION
Also refactors a bit how obscure file name is generated so trailing white spaces are PARTS now thus code is simplified.
Also removed ad-hoc windows skipping of a name with trailing space -- testing now `mkdir` as well.  Let's see if that would allow those previously failing tests to pass and what would be the name on windows.

The most obscure filename one my laptop now is ``` "\';a&b&cΔЙקم๗あ `| ```.

I have done only a limited sweep over local tests.

note FTR: in conda python 3.5 I have two ria tests failing but it seems unrelated to this (`datalad/core/distributed/tests/test_push.py:test_ria_push datalad/core/distributed/tests/test_clone.py:test_ria_postclonecfg`)