### PR TITLE
BF: Just use -m coverage instead of some debian specific python*-coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
     # running on Travis.
     - NOSE_SELECTION="integration or usecase or slow or network"
     - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
-    # Special settings/helper for combined coverage from special remotes execution
-    - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python

--- a/tools/coverage-bin/datalad
+++ b/tools/coverage-bin/datalad
@@ -10,9 +10,7 @@ curbin=$(which "$bin")
 curdatalad=$(which datalad)
 curdir=$(dirname $curdatalad)
 
-
-COVERAGE=${COVERAGE:-python-coverage}
-COVERAGE_RUN="`which $COVERAGE` run"
+COVERAGE_RUN="-m coverage run"
 
 export PATH=${PATH//$curdir:/}
 newdatalad=$(which datalad)


### PR DESCRIPTION
That should bring back coverage reporting from nested special remotes of datalad,
and avoid requirement of setting a special COVERAGE env var

Closes #4956 .