### PR TITLE
ENH(DX): Make DATALAD_LOG_OUTPUTS trigger logging of swallowed ouputs as well

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1237,6 +1237,16 @@ def swallow_outputs():
             self._err.close()
             out_name = self._out.name
             err_name = self._err.name
+            from datalad import cfg
+            if cfg.getbool('datalad.log', 'outputs', default=False) \
+                    and lgr.getEffectiveLevel() <= logging.DEBUG:
+                for s, sname in ((self.out, 'stdout'),
+                                 (self.err, 'stderr')):
+                    if s:
+                        pref = os.linesep + "| "
+                        lgr.debug("Swallowed %s:%s%s", sname, pref, s.replace(os.linesep, pref))
+                    else:
+                        lgr.debug("Nothing was swallowed for %s", sname)
             del self._out
             del self._err
             gc.collect()


### PR DESCRIPTION
We use swallow_outputs across many tests. Total swallow forbids figuring out what
has possibly gone wrong.  DATALAD_LOG_OUTPUTS is typically used for debugging
of problems and I thought that it would make sense to apply also to swallow_outputs,
instead of inventing a new config setting like DATALAD_UNSWALLOW_OUTPUTS and
or alike
