### PR TITLE
NF: add infrastructure for specialized indexers

### DIFF
--- a/datalad/metadata/indexers/base.py
+++ b/datalad/metadata/indexers/base.py
@@ -1,0 +1,38 @@
+""" Metadata indexer base class """
+
+from typing import Any, Dict, List, Union
+
+
+class MetadataIndexer(object):
+    """ Defines the indexer interface """
+    def __init__(self, metadata_format_name: str):
+        """
+        Create a metadata indexer
+
+        The format name is passed to the constructor to allow
+        a single indexer to process multiple extractor results
+        """
+        self.metadata_format_name = metadata_format_name
+
+    def create_index(self, metadata: Union[Dict, List]) -> Dict[str, Any]:
+        """
+        Create an index from metadata.
+
+        The input is a list or dictionary that contains metadata
+        in the format identified by metadata_format_name.
+
+        The output should be a set of key-value pairs that represent
+        the information stored in `metadata´.
+
+        Parameters
+        ----------
+        metadata : Dict or List
+          Metadata created by an extractor.
+
+        Returns
+        ----------
+        Dictionary:
+           key-value pairs representing the information in metadata.
+           values can be literals or lists of literals
+        """
+        raise NotImplementedError

--- a/datalad/metadata/indexers/base.py
+++ b/datalad/metadata/indexers/base.py
@@ -38,7 +38,7 @@ class MetadataIndexer(object):
           Metadata created by an extractor.
 
         Returns
-        ----------
+        -------
         dict:
            key-value pairs representing the information in metadata.
            values can be literals or lists of literals

--- a/datalad/metadata/indexers/base.py
+++ b/datalad/metadata/indexers/base.py
@@ -1,3 +1,11 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """ Metadata indexer base class """
 
 from typing import Any, Dict, List, Union

--- a/datalad/metadata/indexers/base.py
+++ b/datalad/metadata/indexers/base.py
@@ -39,7 +39,7 @@ class MetadataIndexer(object):
 
         Returns
         ----------
-        Dictionary:
+        dict:
            key-value pairs representing the information in metadata.
            values can be literals or lists of literals
         """

--- a/datalad/metadata/indexers/base.py
+++ b/datalad/metadata/indexers/base.py
@@ -7,11 +7,11 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """ Metadata indexer base class """
-
+import abc
 from typing import Any, Dict, List, Union
 
 
-class MetadataIndexer(object):
+class MetadataIndexer(metaclass=abc.ABCMeta):
     """ Defines the indexer interface """
     def __init__(self, metadata_format_name: str):
         """
@@ -22,6 +22,7 @@ class MetadataIndexer(object):
         """
         self.metadata_format_name = metadata_format_name
 
+    @abc.abstractmethod
     def create_index(self, metadata: Union[Dict, List]) -> Dict[str, Any]:
         """
         Create an index from metadata.

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -25,6 +25,8 @@ from os.path import normpath
 import sys
 from time import time
 
+from pkg_resources import EntryPoint, iter_entry_points
+
 from datalad import cfg
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
@@ -173,16 +175,48 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
             else:
                 yield key, v
 
+    def get_indexer_for(metadata_format_name: str) -> callable:
+        indexer = (tuple(iter_entry_points('datalad.metadata.indexers', metadata_format_name)) or (None,))[0]
+        if isinstance(indexer, EntryPoint):
+            try:
+                indexer_object = indexer.load()(metadata_format_name)
+                return indexer_object.create_index
+            except Exception as e:
+                lgr.warning('Failed to load indexer %s: %s', indexer.name, exc_str(e))
+        return lambda metadata: _deep_kv('', metadata)
+
+    def _iterable_to_unicode_string(value, perform_operation):
+        if perform_operation:
+            if isinstance(value, (list, tuple)):
+                return u' '.join(_any2unicode(i) for i in value)
+            return _any2unicode(value)
+        return value
+
+    meta = meta or {}
     return {
-        k:
-        # turn lists into space-separated value strings
-            (u' '.join(_any2unicode(i) for i in v) if isinstance(v, (list, tuple)) else
-            # and the rest into unicode
-            _any2unicode(v)) if val2str else v
-        for k, v in _deep_kv('', meta or {})
-        # auto-exclude any key that is not a defined field in the schema (if there is
-        # a schema
-        if schema is None or k in schema
+        # Collect all meta-items which have a non-dict value type and where
+        # the key not absent in a given schema.
+        **{
+            key: _iterable_to_unicode_string(value, val2str)
+            for key, value in filter(lambda kv: not isinstance(kv[1], dict), meta.items())
+            if schema is None or key in schema
+        },
+
+        # Collect all meta-items which have a dict value type and where
+        # the key is neither 'datalad_unique_content_properties' nor absent
+        # in a given schema.
+        # These values are considered as metadata, the keys are considered to
+        # be the name of the extractor, i.e. the metadata_format_name, that created
+        # the metadata.
+        **{
+            metadata_format_name + '.' + sub_key: _iterable_to_unicode_string(sub_key_value, val2str)
+            for metadata_format_name, metadata_content in filter(
+                lambda kv: isinstance(kv[1], dict) and kv[0] != 'datalad_unique_content_properties',
+                meta.items()
+            )
+            for sub_key, sub_key_value in get_indexer_for(metadata_format_name)(metadata_content)
+            if schema is None or metadata_format_name + '.' + sub_key in schema
+        }
     }
 
 

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -176,8 +176,8 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
     def get_indexer(metadata_format_name: str) -> callable:
         from pkg_resources import EntryPoint, iter_entry_points
 
-        # Use the first returned entry point, if any, because there should be
-        # at most one indexer for ``metadata_format_name´´.
+        # Use the first returned entry point, if any, because there can at most be
+        # one indexer for ``metadata_format_name´´.
         indexer = (tuple(iter_entry_points('datalad.metadata.indexers', metadata_format_name)) or (None,))[0]
         if isinstance(indexer, EntryPoint):
             try:
@@ -185,6 +185,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
                 return indexer_object.create_index
             except Exception as e:
                 lgr.warning('Failed to load indexer %s: %s', indexer.name, exc_str(e))
+        lgr.info('Falling back to standard indexer for metadata format: %s', metadata_format_name)
         return lambda metadata: _deep_kv('', metadata)
 
     if val2str:
@@ -199,7 +200,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
     meta = meta or {}
     return {
         # Collect all meta-items which have a non-dict value type and where
-        # the key not absent in a given schema.
+        # the key is not absent in a given schema.
         **{
             key: _val2str_helper(value)
             for key, value in filter(lambda kv: not isinstance(kv[1], dict), meta.items())
@@ -209,7 +210,7 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
         # Collect all meta-items which have a dict value type and where
         # the key is neither 'datalad_unique_content_properties' nor absent
         # in a given schema.
-        # These values are considered as metadata, the keys are considered to
+        # These values are considered to be metadata, the keys are considered to
         # be the name of the extractor, i.e. the metadata_format_name, that created
         # the metadata.
         **{

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -52,6 +52,8 @@ from ..search import (
     _meta2autofield_dict,
 )
 
+from ..indexers.base import MetadataIndexer
+
 
 @with_testsui(interactive=False)
 @with_tempfile(mkdir=True)
@@ -365,9 +367,9 @@ def test_meta2autofield_dict():
 
 def test_external_indexer():
     """ check that external indexer are called """
-    class MockedIndexer:
+    class MockedIndexer(MetadataIndexer):
         def __init__(self, metadata_format_name: str):
-            pass
+            super().__init__(metadata_format_name)
 
         def create_index(self, metadata):
             yield from {

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -18,6 +18,9 @@ from os.path import (
     dirname,
     join as opj,
 )
+
+from pkg_resources import EntryPoint
+
 from datalad.api import Dataset
 from datalad.utils import (
     chpwd,
@@ -362,8 +365,6 @@ def test_meta2autofield_dict():
 
 def test_external_indexer():
     """ check that external indexer are called """
-    from pkg_resources import EntryPoint
-
     class MockedIndexer:
         def __init__(self, metadata_format_name: str):
             pass
@@ -384,7 +385,7 @@ def test_external_indexer():
     def _mocked_iter_entry_points(group, metadata):
         yield MockedEntryPoint()
 
-    with patch('datalad.metadata.search.iter_entry_points',
+    with patch('pkg_resources.iter_entry_points',
                MagicMock(side_effect=_mocked_iter_entry_points)):
         index = _meta2autofield_dict({
             'datalad_unique_content_properties': {
@@ -408,8 +409,6 @@ def test_external_indexer():
 
 def test_faulty_external_indexer():
     """ check that generic indexer is called on external indexer faults """
-    from pkg_resources import EntryPoint
-
     class MockedEntryPoint(EntryPoint):
         def __init__(self):
             self.name = 'MockedEntryPoint'
@@ -420,7 +419,7 @@ def test_faulty_external_indexer():
     def _mocked_iter_entry_points(group, metadata):
         yield MockedEntryPoint()
 
-    with patch('datalad.metadata.search.iter_entry_points',
+    with patch('pkg_resources.iter_entry_points',
                MagicMock(side_effect=_mocked_iter_entry_points)):
         index = _meta2autofield_dict({
             'datalad_unique_content_properties': {

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -414,6 +414,7 @@ def test_faulty_external_indexer():
     class MockedEntryPoint(EntryPoint):
         def __init__(self):
             self.name = 'MockedEntryPoint'
+            self.dist = 'Mock Distribution 1.1'
 
         def load(self, *args):
             raise Exception('Mocked indexer error')
@@ -423,6 +424,43 @@ def test_faulty_external_indexer():
 
     with patch('pkg_resources.iter_entry_points',
                MagicMock(side_effect=_mocked_iter_entry_points)):
+
+        index = _meta2autofield_dict({
+            'datalad_unique_content_properties': {
+                'extr1': {
+                    "prop1": "v1"
+                }
+            },
+            'extr1': {
+                'prop1': 'value'
+            }
+        })
+
+    eq_(
+        index,
+        {
+            'extr1.prop1': 'value'
+        }
+    )
+
+
+def test_multiple_entry_points():
+    """ check that generic indexer is called if multiple indexers exist for the same name """
+    class MockedEntryPoint(EntryPoint):
+        def __init__(self):
+            self.name = 'MockedEntryPoint'
+            self.dist = 'Mock Distribution 1.1'
+
+        def load(self, *args):
+            return 'Loaded MockedEntryPoint'
+
+    def _mocked_iter_entry_points(group, metadata):
+        yield MockedEntryPoint()
+        yield MockedEntryPoint()
+
+    with patch('pkg_resources.iter_entry_points',
+               MagicMock(side_effect=_mocked_iter_entry_points)):
+
         index = _meta2autofield_dict({
             'datalad_unique_content_properties': {
                 'extr1': {

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -199,12 +199,12 @@ def _describe_extensions():
     return infos
 
 
-def _describe_metadata_extractors():
+def _describe_metadata_elements(group):
     infos = {}
     from pkg_resources import iter_entry_points
     from importlib import import_module
 
-    for e in iter_entry_points('datalad.metadata.extractors'):
+    for e in iter_entry_points(group):
         info = {}
         infos[e.name] = info
         try:
@@ -272,7 +272,8 @@ SECTION_CALLABLES = {
     'configuration': None,
     'location': None,
     'extensions': _describe_extensions,
-    'metadata_extractors': _describe_metadata_extractors,
+    'metadata_extractors': lambda: _describe_metadata_elements('datalad.metadata.extractors'),
+    'metadata_indexers': lambda: _describe_metadata_elements('datalad.metadata.indexers'),
     'dependencies': _describe_dependencies,
     'dataset': None,
 }

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -206,9 +206,10 @@ def _describe_metadata_elements(group):
 
     for e in iter_entry_points(group):
         info = {}
-        infos[e.name] = info
+        infos['%s (%s)' % (e.name, str(e.dist))] = info
         try:
             info['module'] = e.module_name
+            info['distribution'] = str(e.dist)
             mod = import_module(e.module_name, package='datalad')
             info['version'] = getattr(mod, '__version__', None)
             e.load()


### PR DESCRIPTION
This PR introduces an infrastructure for specialized indexers, which means indexers, that are specifically built to generate an index from metadata of a given format (the metadata format name is the same as the name of the extractor that generated the metadata). If datalad search needs to build an index for metadata it will now check whether a matching specialized indexer is installed. If a matching indexer is found, it will be called to generate the index, i.e. the set of key-value pairs that represents the metadata in the search context (this is done for all four search modes, i.e.: autofield, blobtext, egrep, and egrepcs).

If no specialized indexer is found for a metadata-format, the generic indexer that was used before will be used for this format.

This PR closes issue #4944 
