### PR TITLE
exceptions: Restore CLI rendering of CommandError subclasses

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1304,7 +1304,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             if remote not in self.get_remotes():
                 raise RemoteNotAvailableError(
                     remote=remote,
-                    cmd="get",
+                    cmd="annex get",
                     msg="Remote is not known. Known are: %s"
                     % (self.get_remotes(),)
                 )

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -294,16 +294,6 @@ class RemoteNotAvailableError(CommandError):
     where 'MyRemote' doesn't exist.
     """
 
-    # TODO: Raise this from GitRepo. Currently depends on method:
-    # Either it's a direct git call
-    #   => CommandError and stderr:
-    #       fatal: 'notthere' does not appear to be a git repository
-    #       fatal: Could not read from remote repository.
-    # or it's a GitPython call
-    #   => ValueError "Remote named 'NotExistingRemote' didn't exist"
-    # and another one:
-    #   see GitRepo.remove_remote()
-
     def __init__(self, remote, **kwargs):
         """
 

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -35,11 +35,13 @@ class CommandError(RuntimeError):
             quote_cmdlinearg,
         )
         to_str = "{}: ".format(self.__class__.__name__)
-        if self.cmd:
+        cmd = self.cmd
+        if cmd:
             to_str += "'{}'".format(
                 # go for a compact, normal looking, properly quoted
-                # command rendering
-                ' '.join(quote_cmdlinearg(c) for c in ensure_list(self.cmd))
+                # command rendering if the command is in list form
+                ' '.join(quote_cmdlinearg(c) for c in cmd)
+                if isinstance(cmd, list) else cmd
             )
         if self.code:
             to_str += " failed with exitcode {}".format(self.code)


### PR DESCRIPTION
I misspelled a remote name when calling `datalad get --source` and saw this message, which by itself I'd take to mean a remote named 'annex get' is not available.

```
RemoteNotAvailableError: ''annex get''
```

That's a regression that came with v0.13.0 and affects all `CommandError` subclasses.  The final commit of this series restores the display to

```
Remote 'DO-NOT-EXIST' is not available. Command failed:
RemoteNotAvailableError: 'annex get'
```

The three commits before that are cleanup commits in surrounding areas, and any of them can safely be dropped.
