### PR TITLE
ENH: add shellcheck run on shell scripts which ATM are shellcheck kosher

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,7 +15,7 @@ jobs:
         sudo apt-get install shellcheck
     - name: Run shellcheck
       run: |
-      shellcheck \
+        shellcheck \
           tools/bisect-git-annex.scripts/bisect-git-annex-lock.sh \
           tools/ci/install-annex.sh \
           tools/ci/install-minimum-git.sh \

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,6 +13,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install shellcheck
+    - uses: actions/checkout@v1
     - name: Run shellcheck
       run: |
         shellcheck \

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run shellcheck
       run: |
+        # I: running only on a subset of scripts which are shellcheck clean ATM
         shellcheck \
           tools/bisect-git-annex.scripts/bisect-git-annex-lock.sh \
           tools/ci/install-annex.sh \

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: Shellcheck on scripts
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up system
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install shellcheck
+    - name: Run shellcheck
+      run: |
+      shellcheck \
+          tools/bisect-git-annex.scripts/bisect-git-annex-lock.sh \
+          tools/ci/install-annex.sh \
+          tools/ci/install-minimum-git.sh \
+          tools/ci/prep-travis-devel-annex.sh \
+          tools/ci/prep-travis-forssh.sh


### PR DESCRIPTION
I find `shellcheck` really handy!

I thought to make this workflow conditioned on changes to those files, but IMHO too much hassle for what it is worth since shellcheck run should be quite fast