### PR TITLE
BF+OPT: addurls - avoid resources (processes) exhaustion in case of having large number of subdatasets

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 from functools import partial
+import inspect
 import logging
 import os
 import sys
@@ -341,7 +342,7 @@ def with_result_progress(fn, label="Total", unit=" Files"):
     pid = str(fn)
     base_label = label
 
-    def wrapped(items, **kwargs):
+    def _wrap_with_result_progress_(items, **kwargs):
         counts = defaultdict(int)
 
         label = base_label
@@ -349,7 +350,6 @@ def with_result_progress(fn, label="Total", unit=" Files"):
                      "%s: starting", label,
                      total=len(items), label=label, unit=unit)
 
-        results = []
         for res in fn(items, **kwargs):
             counts[res["status"]] += 1
             count_strs = (count_str(*args)
@@ -366,10 +366,15 @@ def with_result_progress(fn, label="Total", unit=" Files"):
                 "%s: processed result%s", base_label,
                 " for " + res["path"] if "path" in res else "",
                 label=label, update=1, increment=True)
-            results.append(res)
+            yield res
         log_progress(lgr.info, pid, "%s: done", base_label)
-        return results
-    return wrapped
+
+    def _wrap_with_result_progress(items, **kwargs):
+        return list(_wrap_with_result_progress_(items, **kwargs))
+
+    return _wrap_with_result_progress_ \
+        if inspect.isgeneratorfunction(fn) \
+        else _wrap_with_result_progress
 
 
 class LoggerHelper(object):

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -923,7 +923,7 @@ class Addurls(Interface):
 
             files_to_add.update(ds_files_to_add)
             # stop all batched processes etc before considering next dataset
-            ds.repo.precommit()
+            repo.precommit()
 
         msg = message or """\
 [DATALAD] add files from URLs

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -896,7 +896,7 @@ class Addurls(Interface):
                 files_to_add.add(r["path"])
             yield r
 
-            msg = message or """\
+        msg = message or """\
 [DATALAD] add files from URLs
 
 url_file='{}'

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -854,20 +854,6 @@ class Addurls(Interface):
                                    return_type='generator'):
                     yield r
 
-        for row in rows:
-            # Add additional information that we'll need for various
-            # operations.
-            filename_abs = os.path.join(ds.path, row["filename"])
-            if row["subpath"]:
-                ds_current = Dataset(os.path.join(ds.path,
-                                                  row["subpath"]))
-            else:
-                ds_current = ds
-            ds_filename = os.path.relpath(filename_abs, ds_current.path)
-            row.update({"filename_abs": filename_abs,
-                        "ds": ds_current,
-                        "ds_filename": ds_filename})
-
         if version_urls:
             num_urls = len(rows)
             log_progress(lgr.info, "addurls_versionurls",
@@ -889,6 +875,20 @@ class Addurls(Interface):
                              "Versioned result for %s: %s", url, row["url"],
                              update=1, increment=True)
             log_progress(lgr.info, "addurls_versionurls", "Finished versioning URLs")
+
+        for row in rows:
+            # Add additional information that we'll need for various
+            # operations.
+            filename_abs = os.path.join(ds.path, row["filename"])
+            if row["subpath"]:
+                ds_current = Dataset(os.path.join(ds.path,
+                                                  row["subpath"]))
+            else:
+                ds_current = ds
+            ds_filename = os.path.relpath(filename_abs, ds_current.path)
+            row.update({"filename_abs": filename_abs,
+                        "ds": ds_current,
+                        "ds_filename": ds_filename})
 
         files_to_add = set()
         for r in add_urls(rows, ifexists=ifexists, options=annex_options):

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -888,7 +888,9 @@ class Addurls(Interface):
         # batched annex process per each subdataset, which might be infeasible
         # in any use-case with a considerable number of subdatasets.
         # TODO: logical spot for parallel run across (sub)datasets
-        for subpath, ds_rows in itertools.groupby(rows, itemgetter("subpath")):
+        get_subpath = itemgetter("subpath")
+        for subpath, ds_rows in itertools.groupby(
+                sorted(rows, key=get_subpath), get_subpath):
             # Serialize the ds_rows since we will use it multiple times and
             # add_urls expects a container to run len() on
             ds_rows = tuple(ds_rows)

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -888,9 +888,13 @@ class Addurls(Interface):
         # batched annex process per each subdataset, which might be infeasible
         # in any use-case with a considerable number of subdatasets.
         # TODO: logical spot for parallel run across (sub)datasets
-        get_subpath = itemgetter("subpath")
+
+        def keyfn(d):
+            # The top-level dataset has a subpath of None.
+            return d.get("subpath") or ""
+
         for subpath, ds_rows in itertools.groupby(
-                sorted(rows, key=get_subpath), get_subpath):
+                sorted(rows, key=keyfn), keyfn):
             # Serialize the ds_rows since we will use it multiple times and
             # add_urls expects a container to run len() on
             ds_rows = tuple(ds_rows)

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test logging facilities """
 
+import inspect
 import logging
 import os.path
 from os.path import exists
@@ -21,6 +22,7 @@ from datalad.log import (
     LoggerHelper,
     log_progress,
     TraceBack,
+    with_result_progress,
 )
 from datalad import cfg as dl_cfg
 from datalad.support.constraints import EnsureBool
@@ -34,6 +36,7 @@ from datalad.tests.utils import (
     known_failure_githubci_win,
     ok_,
     ok_endswith,
+    ok_generator,
     swallow_logs,
     with_tempfile,
 )
@@ -180,3 +183,39 @@ def test_log_progress_noninteractive_filter():
         for present in ["Start", "THERE0", "THERE1", "Done"]:
             assert_in(present, cml.out)
         assert_not_in("NOT", cml.out)
+
+
+def test_with_result_progress_generator():
+    # Tests ability for the decorator to decorate a regular function
+    # or a generator function (then it returns a generator function)
+
+    @with_result_progress
+    def func(l):
+        return l
+
+    generated = []
+    @with_result_progress
+    def gen(l):
+        for i in l:
+            generated.append(i)
+            yield i
+
+    recs = [{'status': 'ok', 'unrelated': i} for i in range(2)]
+    # still works for a func and returns provided list
+    ok_(not inspect.isgeneratorfunction(func))
+    assert_equal(func(recs), recs)
+
+    # generator should still yield and next iteration should only happen
+    # when requested
+    ok_(inspect.isgeneratorfunction(gen))
+    g = gen(recs)
+
+    ok_generator(g)
+    assert_equal(generated, [])  # nothing yet
+    assert_equal(next(g), recs[0])
+    assert_equal(generated, recs[:1])
+    assert_equal(next(g), recs[1])
+    assert_equal(generated, recs)
+
+    # just to make sure all good to redo
+    assert_equal(list(gen(recs)), recs)


### PR DESCRIPTION
Motivation: For ABCD, due to a vast number of subjects (`>1k`) and number of files per each (`>200`) it is desired to adhere to the same ideas as for HCP dataset and create a subdataset for each subject (at least in the `derivatives/*/*`) subfolders. Upon its analysis, `addurls` discovers which subdatasets,  creates (or warns about their existence, see #4968) them, and then proceeds with invoking `AnnexRepo.add_url_to_file` in a batched mode (which is good).  But then each such batched git-annex instantiates about 19 subprocesses (one of which is `git-remote-annex-datalad`) which leads to resources exhaustion, and at some point one of the batched processes doesn't start or perform as expected and the whole run collapses.

IMHO a "resolution" to this is quite straightforward -- group rows by their datasets, and issue `.precommit` when done with any particular to stop all the batched processes for that dataset.repo.  That is what is implemented in this PR.

I went a little further with OPT though after I noticed access to `.repo` per each row.  IIRC that operation is not "fast".  How much it is affecting overall runtime - in case of non `--fast`, any such penalty is probably negligible.  I do not know yet if there is any notable difference, but once again -- why to waste cycles.

Commit messages and comments in the code provide more argumentation and information. 
TODOs
- [x] see how it effects a real run on ABCD - verified that git/git-annex count stays close to "hard to spot" since processes are short lived (spotted that the datalad process itself is quite heavy - 4GB virtual/resident memory.  I guess all the datasets' instances, didn't investigate)
- [ ] decide on either to proceed fixing up progress indication here one way or another, or just move the entire BF against `master` with a more invasive RFing of addurls to avoid unnecessary duplicate actions across `add_urls` and `add_meta` subcalls
- [ ] may be add a unittest which would verify that no more than a single batched addurls exists any given point in time throughout addurls testing.