### PR TITLE
BF: Accept ria+https URLs in clone

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -628,8 +628,7 @@ def postclonecfg_ria(ds, props):
         # get that config file the same way:
         config_content = None
         scheme = props['giturl'].split(':', 1)[0]
-        if scheme == 'http':
-
+        if scheme in ['http', 'https']:
             try:
                 response = requests.get("{}{}config".format(
                     props['giturl'],


### PR DESCRIPTION
There's no actual handling of those URLs involved here. It's simply
passing it on to requests. Simply don't let clone swallow it.
