### PR TITLE
ENH: Show info on credential setup in wtf()

### DIFF
--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -24,6 +24,7 @@ from datalad.utils import (
     ensure_unicode,
     getpwd,
     unlink,
+    Path,
 )
 from datalad.dochelpers import exc_str
 from datalad.support.external_versions import external_versions
@@ -261,6 +262,32 @@ def _describe_location(res):
     }
 
 
+def _describe_credentials():
+    import keyring
+    from keyring.util import platform_
+
+    def describe_keyring_backend(be):
+        be_repr = repr(be)
+        return be.name if 'object at 0' in be_repr else be_repr.strip('<>')
+
+    # might later add information on non-keyring credentials gh-4981
+    props = {}
+
+    active_keyring = keyring.get_keyring()
+    krp = {
+        'config_file': Path(platform_.config_root(), 'keyringrc.cfg'),
+        'data_root': platform_.data_root(),
+        'active_backends': [
+            describe_keyring_backend(be)
+            for be in getattr(active_keyring, 'backends', [active_keyring])
+        ],
+    }
+    props.update(
+        keyring=krp,
+    )
+    return props
+
+
 # Actuall callables for WTF. If None -- should be bound later since depend on
 # the context
 SECTION_CALLABLES = {
@@ -275,6 +302,7 @@ SECTION_CALLABLES = {
     'metadata_extractors': _describe_metadata_extractors,
     'dependencies': _describe_dependencies,
     'dataset': None,
+    'credentials': _describe_credentials,
 }
 
 


### PR DESCRIPTION
Would look something like this (paths truncated):

```
 % datalad wtf -S credentials
 # WTF
 ## credentials
   - keyring:
     - active_backends:
       - SecretService Keyring
       - PlaintextKeyring with no encyption v.1.0 at ...keyring_pass.cfg
     - config_file: ....config/python_keyring/keyringrc.cfg
     - data_root: ....local/share/python_keyring
```

If got tired of looking up the code snippets in the keyring docs to
run when switching machines, and discovering the left-overs of previous
configuration attempts.

Related to gh-4981
