### PR TITLE
Text2git: Largefiles = nothing rules for common textfiles if on Windows

### DIFF
--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -2,6 +2,7 @@
 
 import sys
 import os.path as op
+import platform
 
 from datalad.distribution.dataset import require_dataset
 
@@ -10,12 +11,78 @@ ds = require_dataset(
     check_installed=True,
     purpose='configuration')
 
-annex_largefiles = '((mimeencoding=binary)and(largerthan=0))'
-attrs = ds.repo.get_gitattributes('*')
-if not attrs.get('*', {}).get(
-        'annex.largefiles', None) == annex_largefiles:
-    ds.repo.set_gitattributes([
-        ('*', {'annex.largefiles': annex_largefiles})])
+if platform.system().lower() == 'windows':
+    # mimeencoding isn't functional under Windows yet (see #3360), this adds
+    # common extensions of text files by hand
+    force_in_git = [
+        '*.txt',
+        '*.json*',
+        '*.log',
+        '*.tsv',
+        '*.csv',
+        '*html',
+        '*.css',
+        '*.xml',
+        '*.rss',
+        '*.md',
+        '*.markdown',
+        '*.rmd',
+        '*.rst',
+        '*.rest',
+        '*.yml',
+        '*.toml',
+        '*.adoc',
+        '*.asc',
+        '*.tex',
+        '*.sty',
+        '*.bib',
+        '*.cls',
+        '*.aux',
+        '*.bst',
+        '*.clo',
+        '*.ini',
+        '*.cfg',
+        '*.cgi',
+        '*.py',
+        '*.pyx',
+        '*.go',
+        '*.java',
+        '.*js',
+        '*.sh',
+        '*.bash',
+        '*.zsh',
+        '*.pl',
+        '*.R',
+        '*.jl',
+        '*.ipynb'
+        '*.m',
+        '*.matlab',
+        '*awk',
+        '*.bat',
+        '*.cmd',
+        '*.cake',
+        '*.cmake',
+        'Makefile',
+        '*.c++',
+        '*.cpp',
+        '*.h',
+        '*.hh',
+        '*.inc',
+        '*.cp',
+        '*.cu',
+        '*.emacs',
+        '*.emacs.desktop'
+    ]
+    ds.repo.set_gitattributes(
+        [(p, {'annex.largefiles': 'nothing'}) for p in force_in_git])
+else:
+    annex_largefiles = '((mimeencoding=binary)and(largerthan=0))'
+
+    attrs = ds.repo.get_gitattributes('*')
+    if not attrs.get('*', {}).get(
+            'annex.largefiles', None) == annex_largefiles:
+        ds.repo.set_gitattributes([
+            ('*', {'annex.largefiles': annex_largefiles})])
 
 git_attributes_file = op.join(ds.path, '.gitattributes')
 ds.save(


### PR DESCRIPTION
This adds a workaround for #3360. Its fairly naive, and I'm happy to hear suggestions how to approach it in a more clever way. But it works like this (tested on our windows machine).

Instead of applying the mimenecoding based configuration of text2git, this writes a bunch of largefiles = nothing rules for common textfile extensions if ``text2git`` is used on Windows.

Downsides:
- every extension would need to be specified
- Datasets aren't portable to Windows if created on a non-Windows machine (but this was true before this change, anyway)

Todo:
- does this need a test?
- are there other common text file extensions I have missed?