### PR TITLE
DOC: Reference handbook documentation in add_readme

### DIFF
--- a/datalad/plugin/add_readme.py
+++ b/datalad/plugin/add_readme.py
@@ -129,7 +129,7 @@ class AddReadme(Interface):
 This is a DataLad dataset{id}.
 
 For more information on DataLad and on how to work with its datasets,
-see the DataLad documentation at: http://docs.datalad.org
+see the DataLad documentation at: http://handbook.datalad.org
 """.format(
             title='Dataset "{}"'.format(meta['title']) if 'title' in meta else 'About this dataset',
             metainfo=metainfo,

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -236,7 +236,7 @@ PDDL
 This is a DataLad dataset (id: {id}).
 
 For more information on DataLad and on how to work with its datasets,
-see the DataLad documentation at: http://docs.datalad.org
+see the DataLad documentation at: http://handbook.datalad.org
 """.format(
     id=ds.id))
 


### PR DESCRIPTION
I saw that hirni uses ``add_readme.py`` to populate studydatasets with a placeholder README (within ``cfg_hirni``). This change makes the README reference the handbook as documentation instead of docs.datalad.org.
