### PR TITLE
Runner -- shot of mercy

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -30,9 +30,9 @@ from datalad.support.gitrepo import (
 )
 from datalad.cmd import (
     CommandError,
-    GitRunner,
+    GitWitlessRunner,
     StdOutCapture,
-    WitlessRunner,
+    StdOutErrCapture,
 )
 from datalad.distributed.ora_remote import (
     LocalIO,
@@ -673,7 +673,7 @@ def postclonecfg_ria(ds, props):
             #       to work and would read from stdin. Make sure we know this
             #       works for required git versions and on all platforms.
             with make_tempfile(content=config_content) as cfg_file:
-                runner = WitlessRunner(env=GitRunner.get_git_environ_adjusted())
+                runner = GitWitlessRunner()
                 try:
                     result = runner.run(
                         ['git', 'config', '-f', cfg_file,
@@ -803,7 +803,6 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
                     # the path
                     # Note, that w/o support for bare repos in GitRepo we also
                     # can't use ConfigManager ATM.
-                    from datalad.cmd import GitWitlessRunner, StdOutErrCapture
                     gc_response = GitWitlessRunner(
                         cwd=origin_git_path,
                     ).run(['git', 'config', '--local', '--get', 'core.bare'],

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -30,7 +30,10 @@ from datalad.utils import (
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
-from datalad.cmd import WitlessRunner as Runner
+from datalad.cmd import (
+    GitWitlessRunner,
+    WitlessRunner as Runner,
+)
 from datalad.tests.utils import (
     assert_false,
     assert_in,
@@ -1081,7 +1084,6 @@ def test_ephemeral(origin_path, bare_path,
     eq_(res, [origin.config.get("annex.uuid")])
 
     # 4. ephemeral clone from a bare repo
-    from datalad.cmd import GitWitlessRunner
     runner = GitWitlessRunner()
     runner.run(['git', 'clone', '--bare', origin_path, bare_path])
     runner.run(['git', 'annex', 'init'], cwd=bare_path)

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -21,7 +21,10 @@ from datalad.support.exceptions import (
 )
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
-from datalad.cmd import GitRunner
+from datalad.cmd import (
+    GitWitlessRunner,
+    StdOutCapture,
+)
 from datalad.utils import (
     Path,
     on_windows,
@@ -61,8 +64,10 @@ def test_magic_number():
     # commit
     # given the level of dark magic, we better test whether this stays
     # constant across Git versions (it should!)
-    out, err = GitRunner().run('cd ./ | git hash-object --stdin -t tree')
-    eq_(out.strip(), PRE_INIT_COMMIT_SHA)
+    out = GitWitlessRunner().run(
+        ['git', 'hash-object', '-t', 'tree', '/dev/null'],
+        protocol=StdOutCapture)
+    eq_(out['stdout'].strip(), PRE_INIT_COMMIT_SHA)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -65,7 +65,7 @@ def test_magic_number():
     # given the level of dark magic, we better test whether this stays
     # constant across Git versions (it should!)
     out = GitWitlessRunner().run(
-        ['git', 'hash-object', '-t', 'tree', '/dev/null'],
+        'cd ./ | git hash-object --stdin -t tree',
         protocol=StdOutCapture)
     eq_(out['stdout'].strip(), PRE_INIT_COMMIT_SHA)
 

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -207,16 +207,19 @@ class LocalIO(IOBase):
             # no archive, not file
             return False
         loc = str(file_path)
-        from datalad.cmd import Runner
-        runner = Runner()
+        from datalad.cmd import (
+            StdOutErrCapture,
+            WitlessRunner,
+        )
+        runner = WitlessRunner()
         # query 7z for the specific object location, keeps the output
         # lean, even for big archives
-        out, err = runner(
+        out = runner.run(
             ['7z', 'l', str(archive_path),
              loc],
-            log_stdout=True,
+            protocol=StdOutErrCapture,
         )
-        return loc in out
+        return loc in out['stdout']
 
     def read_file(self, file_path):
 

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -49,6 +49,9 @@ from datalad.customremotes.ria_utils import (
     create_ds_in_store,
     get_layout_locations
 )
+from datalad.cmd import (
+    GitWitlessRunner,
+)
 
 
 # Note, that exceptions to test for are generally CommandError since we are
@@ -385,11 +388,6 @@ def test_version_check():
 @with_tempfile
 @with_tempfile
 def _test_gitannex(host, store, dspath):
-
-    from datalad.cmd import (
-        GitRunner,
-        WitlessRunner
-    )
     store = Path(store)
 
     dspath = Path(dspath)
@@ -435,7 +433,7 @@ def _test_gitannex(host, store, dspath):
     # run git-annex-testremote
     # note, that we don't want to capture output. If something goes wrong we
     # want to see it in test build's output log.
-    WitlessRunner(cwd=dspath, env=GitRunner.get_git_environ_adjusted()).run(
+    GitWitlessRunner(cwd=dspath).run(
         ['git', 'annex', 'testremote', 'store']
     )
 

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -30,7 +30,8 @@ from datalad.ui import ui
 
 from datalad.cmd import (
     CommandError,
-    Runner,
+    StdOutErrCapture,
+    WitlessRunner,
 )
 from datalad.consts import (
     TIMESTAMP_FMT,
@@ -96,8 +97,15 @@ from datalad.utils import (
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 
 
-class _RunnerAdapter(Runner):
+class _RunnerAdapter(WitlessRunner):
     """An adapter to use interchanegably with SSH connection"""
+
+    def __call__(self, cmd):
+        # all commands used in here are plain strings
+        out = self.run(
+            ['sh', '-c', cmd] if isinstance(cmd, str) else cmd,
+            protocol=StdOutErrCapture)
+        return out['stdout'], out['stderr']
 
     def get_git_version(self):
         return external_versions['cmd:git']

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -101,10 +101,7 @@ class _RunnerAdapter(WitlessRunner):
     """An adapter to use interchanegably with SSH connection"""
 
     def __call__(self, cmd):
-        # all commands used in here are plain strings
-        out = self.run(
-            ['sh', '-c', cmd] if isinstance(cmd, str) else cmd,
-            protocol=StdOutErrCapture)
+        out = self.run(cmd, protocol=StdOutErrCapture)
         return out['stdout'], out['stderr']
 
     def get_git_version(self):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -32,6 +32,7 @@ from datalad.utils import (
     Path,
     _path_,
 )
+from datalad.cmd import GitWitlessRunner
 from datalad.tests.utils import (
     assert_false as nok_,
     assert_false,
@@ -742,10 +743,10 @@ def test_gh1811(srcpath, clonepath):
 
 @with_tempfile(mkdir=True)
 def test_publish_no_fetch_refspec_configured(path):
-    from datalad.cmd import GitRunner
 
     path = Path(path)
-    GitRunner(cwd=str(path)).run(["git", "init", "--bare", "empty-remote"])
+    GitWitlessRunner(cwd=str(path)).run(
+        ["git", "init", "--bare", "empty-remote"])
     ds = Dataset(path / "ds").create()
     ds.repo.add_remote("origin", str(ds.pathobj.parent / "empty-remote"))
     # Mimic a situation that can happen with an LFS remote. See gh-4199.

--- a/datalad/interface/diff.py
+++ b/datalad/interface/diff.py
@@ -36,7 +36,10 @@ from datalad.support.exceptions import CommandError
 from datalad.support.param import Parameter
 from datalad.interface.common_opts import recursion_flag
 from datalad.interface.common_opts import recursion_limit
-from datalad.cmd import GitRunner
+from datalad.cmd import (
+    StdOutErrCapture,
+    GitWitlessRunner,
+)
 
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
@@ -91,14 +94,8 @@ def _get_untracked_content(dspath, report_untracked, paths=None):
            # fully untracked dirs as such, the rest as files
            '--untracked={}'.format(report_untracked)]
     try:
-        stdout, stderr = GitRunner(cwd=dspath).run(
-            cmd,
-            log_stderr=True,
-            log_stdout=True,
-            log_online=False,
-            expect_stderr=False,
-            shell=False,
-            expect_fail=True)
+        stdout = GitWitlessRunner(cwd=dspath).run(
+            cmd, protocol=StdOutErrCapture)['stdout']
     except CommandError as e:
         # TODO should we catch any and handle them in here?
         raise e
@@ -154,14 +151,8 @@ def _parse_git_diff(dspath, diff_thingie=None, paths=None,
         cmd.extend(ap['path'] for ap in paths if ap.get('raw_input', False))
 
     try:
-        stdout, stderr = GitRunner(cwd=dspath).run(
-            cmd,
-            log_stderr=True,
-            log_stdout=True,
-            log_online=False,
-            expect_stderr=False,
-            shell=False,
-            expect_fail=True)
+        stdout = GitWitlessRunner(cwd=dspath).run(
+            cmd, protocol=StdOutErrCapture)['stdout']
     except CommandError as e:
         if 'bad revision' in e.stderr:
             yield dict(

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -16,6 +16,10 @@ from datalad.utils import (
     swallow_outputs,
     updated,
 )
+from datalad.cmd import (
+    StdOutCapture,
+    WitlessRunner,
+)
 
 from ..base import (
     Interface,
@@ -159,7 +163,6 @@ def test_nadict():
 @with_tempfile(mkdir=True)
 def test_status_custom_summary_no_repeats(path):
     from datalad.api import Dataset
-    from datalad.cmd import Runner
     from datalad.core.local.status import Status
 
     # This regression test depends on the command having a custom summary
@@ -176,7 +179,8 @@ def test_status_custom_summary_no_repeats(path):
     (ds.pathobj / "foo").write_text("foo content")
     ds.save()
 
-    out, _ = Runner(cwd=path).run(
-        ["datalad", "--output-format=tailored", "status", "--annex"])
-    out_lines = out.splitlines()
+    out = WitlessRunner(cwd=path).run(
+        ["datalad", "--output-format=tailored", "status", "--annex"],
+        protocol=StdOutCapture)
+    out_lines = out['stdout'].splitlines()
     eq_(len(out_lines), len(set(out_lines)))

--- a/datalad/interface/tests/test_diff.py
+++ b/datalad/interface/tests/test_diff.py
@@ -14,7 +14,10 @@ __docformat__ = 'restructuredtext'
 
 
 from os.path import join as opj
-from datalad.cmd import GitRunner
+from datalad.cmd import (
+    GitWitlessRunner,
+    StdOutCapture,
+)
 from datalad.distribution.dataset import Dataset
 from datalad.api import diff
 from datalad.interface.diff import _parse_git_diff
@@ -46,8 +49,10 @@ def test_magic_number():
     # commit
     # given the level of dark magic, we better test whether this stays
     # constant across Git versions (it should!)
-    out, err = GitRunner().run('git hash-object -t tree /dev/null')
-    eq_(out.strip(), PRE_INIT_COMMIT_SHA)
+    out = GitWitlessRunner().run(
+        ['git', 'hash-object', '-t', 'tree', '/dev/null'],
+        protocol=StdOutCapture)
+    eq_(out['stdout'].strip(), PRE_INIT_COMMIT_SHA)
 
 
 @known_failure_githubci_win

--- a/datalad/interface/tests/test_ls_webui.py
+++ b/datalad/interface/tests/test_ls_webui.py
@@ -40,7 +40,7 @@ from datalad.utils import (
     swallow_outputs,
     _path_,
 )
-from datalad.cmd import Runner
+from datalad.cmd import WitlessRunner
 
 
 def test_machinesize():
@@ -192,7 +192,8 @@ def test_ls_json(topdir, topurl):
     # register "external" submodule  by installing and uninstalling it
     ext_url = topurl + '/dir/subgit/.git'
     # need to make it installable via http
-    Runner()('git update-server-info', cwd=opj(topdir, 'dir', 'subgit'))
+    WitlessRunner(cwd=opj(topdir, 'dir', 'subgit')).run(
+        ['git', 'update-server-info'])
     ds.install(opj('dir', 'subgit_ext'), source=ext_url)
     ds.uninstall(opj('dir', 'subgit_ext'))
     meta_dir = opj('.git', 'datalad', 'metadata')

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -15,7 +15,10 @@ __docformat__ = 'restructuredtext'
 import os.path as op
 import sys
 
-from datalad.cmd import Runner
+from datalad.cmd import (
+    WitlessRunner,
+    KillOutput,
+)
 from datalad.utils import (
     chpwd,
     quote_cmdlinearg,
@@ -299,11 +302,15 @@ def test_quoting(path):
         with assert_raises(CommandError):
             ds.run_procedure(spec=["just2args", "still-one arg"])
 
-        runner = Runner(cwd=ds.path)
+        runner = WitlessRunner(cwd=ds.path)
         runner.run(
-            "datalad run-procedure just2args \"with ' sing\" 'with \" doub'")
+            ['sh', '-c',
+             "datalad run-procedure just2args \"with ' sing\" 'with \" doub'"],
+            protocol=KillOutput)
         with assert_raises(CommandError):
-            runner.run("datalad run-procedure just2args 'still-one arg'")
+            runner.run(
+                ['sh', '-c', "datalad run-procedure just2args 'still-one arg'"],
+            protocol=KillOutput)
 
 
 @skip_if_on_windows

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -304,13 +304,12 @@ def test_quoting(path):
 
         runner = WitlessRunner(cwd=ds.path)
         runner.run(
-            ['sh', '-c',
-             "datalad run-procedure just2args \"with ' sing\" 'with \" doub'"],
+            "datalad run-procedure just2args \"with ' sing\" 'with \" doub'",
             protocol=KillOutput)
         with assert_raises(CommandError):
             runner.run(
-                ['sh', '-c', "datalad run-procedure just2args 'still-one arg'"],
-            protocol=KillOutput)
+                "datalad run-procedure just2args 'still-one arg'",
+                protocol=KillOutput)
 
 
 @skip_if_on_windows

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 from io import StringIO
 
 from datalad.api import addurls, Dataset, subdatasets
-from datalad.cmd import Runner
+from datalad.cmd import WitlessRunner
 from datalad.consts import WEB_SPECIAL_REMOTE_UUID
 import datalad.plugin.addurls as au
 from datalad.support.exceptions import IncompleteResultsError
@@ -715,7 +715,7 @@ class TestAddurls(object):
         # The previous test checks all the cases, but it overrides sys.stdin.
         # Do a simple check that's closer to a command line call.
         Dataset(path).create(force=True)
-        runner = Runner(cwd=path)
+        runner = WitlessRunner(cwd=path)
         with open(self.json_file) as jfh:
             runner.run(["datalad", "addurls", '-', '{url}', '{name}'],
                        stdin=jfh)

--- a/datalad/plugin/wtf.py
+++ b/datalad/plugin/wtf.py
@@ -90,18 +90,22 @@ def _describe_datalad():
 
 
 def _describe_annex():
-    from datalad.cmd import GitRunner
+    from datalad.cmd import (
+        GitWitlessRunner,
+        StdOutErrCapture,
+    )
 
-    runner = GitRunner()
+    runner = GitWitlessRunner()
     try:
-        out, err = runner.run(['git', 'annex', 'version'])
+        out = runner.run(
+            ['git', 'annex', 'version'], protocol=StdOutErrCapture)
     except CommandError as e:
         return dict(
             version='not available',
             message=exc_str(e),
         )
     info = {}
-    for line in out.split(os.linesep):
+    for line in out['stdout'].split(os.linesep):
         key = line.split(':')[0]
         if not key:
             continue

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -61,10 +61,11 @@ from datalad.log import log_progress
 from datalad.support.json_py import json_loads
 from datalad.cmd import (
     BatchedCommand,
-    GitRunner,
+    GitWitlessRunner,
     # KillOutput,
     run_gitcommand_on_file_list_chunks,
     SafeDelCloseMixin,
+    StdOutErrCapture,
     WitlessProtocol,
 )
 
@@ -606,12 +607,13 @@ class AnnexRepo(GitRepo, RepoInterface):
           upgradable -> list of upgradable versions (int)
         """
         if cls.repository_versions is None:
-            from datalad.cmd import Runner
             key_remap = {
                 "supported repository versions": "supported",
                 "upgrade supported from repository versions": "upgradable"}
-            out, _ = Runner().run(["git", "annex", "version"])
-            kvs = (ln.split(":", 1) for ln in out.splitlines())
+            out = GitWitlessRunner().run(
+                ["git", "annex", "version"],
+                protocol=StdOutErrCapture)
+            kvs = (ln.split(":", 1) for ln in out['stdout'].splitlines())
             cls.repository_versions = {
                 key_remap[k]: list(map(int, v.strip().split()))
                 for k, v in kvs if k in key_remap}

--- a/datalad/support/archive_utils_7z.py
+++ b/datalad/support/archive_utils_7z.py
@@ -55,10 +55,7 @@ def decompress_file(archive, dir_):
     if len(suffixes) > 1 and suffixes[-2] == '.tar':
         # we have a compressed tar file that needs to be fed through the
         # decompressor first
-        cmd = [
-            'sh', '-c',
-            '7z x {} -so | 7z x -si -ttar'.format(quote_cmdlinearg(archive)),
-        ]
+        cmd = '7z x {} -so | 7z x -si -ttar'.format(quote_cmdlinearg(archive))
     else:
         # fire and forget
         cmd = ['7z', 'x', archive]
@@ -90,13 +87,10 @@ def compress_files(files, archive, path=None, overwrite=True):
             )
     suffixes = _normalize_fname_suffixes(apath.suffixes)
     if len(suffixes) > 1 and suffixes[-2] == '.tar':
-        cmd = [
-            'sh', '-c',
-            '7z u .tar -so -- {} | 7z u -si -- {}'.format(
-                join_cmdline(files),
-                quote_cmdlinearg(str(apath)),
-            ),
-        ]
+        cmd = '7z u .tar -so -- {} | 7z u -si -- {}'.format(
+            join_cmdline(files),
+            quote_cmdlinearg(str(apath)),
+        )
     else:
         cmd = ['7z', 'u', str(apath), '--'] + files
     runner.run(cmd, protocol=KillOutput)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1319,12 +1319,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             cmd.extend(git_options)
         cmd += ["rev-parse", "--show-toplevel"]
         try:
-            toppath, err = GitRunner().run(
-                cmd,
-                cwd=path,
-                log_stdout=True, log_stderr=True,
-                expect_fail=True, expect_stderr=True)
-            toppath = toppath.rstrip('\n\r')
+            out = GitWitlessRunner(cwd=path).run(
+                cmd, protocol=StdOutErrCapture)
+            toppath = out['stdout'].rstrip('\n\r')
         except CommandError:
             return None
         except OSError:

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -39,7 +39,11 @@ from datalad.utils import (
     ensure_list,
     on_windows,
 )
-from datalad.cmd import Runner
+from datalad.cmd import (
+    NoCapture,
+    StdOutErrCapture,
+    WitlessRunner,
+)
 
 lgr = logging.getLogger('datalad.support.sshconnector')
 
@@ -183,24 +187,18 @@ class SSHConnection(object):
         ssh_cmd += [self.sshri.as_str()] \
             + [cmd]
 
-        kwargs = dict(
-            log_stdout=log_output, log_stderr=log_output,
-            log_online=not log_output
-        )
-
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True
-        return self.runner.run(
+        out = self.runner.run(
             ssh_cmd,
-            expect_fail=True,
-            expect_stderr=True,
-            stdin=stdin,
-            **kwargs)
+            protocol=StdOutErrCapture if log_output else NoCapture,
+            stdin=stdin)
+        return out['stdout'], out['stderr']
 
     @property
     def runner(self):
         if self._runner is None:
-            self._runner = Runner()
+            self._runner = WitlessRunner()
         return self._runner
 
     def is_open(self):
@@ -219,7 +217,11 @@ class SSHConnection(object):
             # "Master is running" and that is normal, not worthy warning about
             # etc -- we are doing the check here for successful operation
             with tempfile.TemporaryFile() as tempf:
-                out, err = self.runner.run(cmd, stdin=tempf, expect_stderr=True)
+                self.runner.run(
+                    cmd,
+                    # do not leak output
+                    protocol=StdOutErrCapture,
+                    stdin=tempf)
             res = True
         except CommandError as e:
             if e.code != 255:
@@ -299,7 +301,7 @@ class SSHConnection(object):
         cmd = ["ssh", "-O", "stop"] + self._ssh_args + [self.sshri.as_str()]
         lgr.debug("Closing %s by calling %s", self, cmd)
         try:
-            self.runner.run(cmd, expect_stderr=True, expect_fail=True)
+            self.runner.run(cmd, protocol=StdOutErrCapture)
         except CommandError as e:
             lgr.debug("Failed to run close command")
             if self.ctrl_path.exists():
@@ -355,7 +357,8 @@ class SSHConnection(object):
             self.sshri.hostname,
             _quote_filename_for_scp(destination),
         )]
-        return self.runner.run(scp_cmd)
+        out = self.runner.run(scp_cmd, protocol=StdOutErrCapture)
+        return out['stdout'], out['stderr']
 
     def get(self, source, destination, recursive=False, preserve_attrs=False):
         """Copies source file/folder from remote to a local destination.
@@ -391,7 +394,8 @@ class SSHConnection(object):
                     for s in ensure_list(source)]
         # add destination path
         scp_cmd += [destination]
-        return self.runner.run(scp_cmd)
+        out = self.runner.run(scp_cmd, protocol=StdOutErrCapture)
+        return out['stdout'], out['stderr']
 
     def get_annex_installdir(self):
         key = 'installdir:annex'

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1532,8 +1532,8 @@ def test_duecredit(path):
 
     # and now enable DUECREDIT - output could come to stderr
     env['DUECREDIT_ENABLE'] = '1'
-    out, err = run(cmd, env=env)
-    outs = out + err
+    out = run(cmd, env=env, protocol=StdOutErrCapture)
+    outs = ''.join(out.values())
 
     if external_versions['duecredit']:
         assert_in(test_string, outs)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -21,7 +21,11 @@ import sys
 
 
 from datalad import get_encoding_info
-from datalad.cmd import Runner
+from datalad.cmd import (
+    StdOutCapture,
+    StdOutErrCapture,
+    WitlessRunner,
+)
 
 from datalad.utils import (
     chpwd,
@@ -287,9 +291,9 @@ def test_GitRepo_get_indexed_files(src, path):
     gr = GitRepo.clone(src, path)
     idx_list = gr.get_indexed_files()
 
-    runner = Runner()
-    out = runner(['git', 'ls-files'], cwd=path)
-    out_list = list(filter(bool, out[0].split('\n')))
+    runner = WitlessRunner(cwd=path)
+    out = runner.run(['git', 'ls-files'], protocol=StdOutCapture)
+    out_list = list(filter(bool, out['stdout'].split('\n')))
 
     for item in idx_list:
         assert_in(item, out_list, "%s not found in output of git ls-files in %s" % (item, path))
@@ -1504,7 +1508,7 @@ def test_fake_dates(path):
 @with_tempfile(mkdir=True)
 def test_duecredit(path):
     # Just to check that no obvious side-effects
-    run = Runner(cwd=path).run
+    run = WitlessRunner(cwd=path).run
     cmd = [
         sys.executable, "-c",
         "from datalad.support.gitrepo import GitRepo; GitRepo(%r, create=True)" % path
@@ -1520,15 +1524,15 @@ def test_duecredit(path):
     # cwd is not matching possibly present PWD env variable
     env.pop('PWD', None)
 
-    out, err = run(cmd, env=env, expect_stderr=True)
-    outs = out + err  # Let's not depend on where duecredit decides to spit out
+    out = run(cmd, env=env, protocol=StdOutErrCapture)
+    outs = ''.join(out.values()) # Let's not depend on where duecredit decides to spit out
     # All quiet
     test_string = 'Data management and distribution platform'
     assert_not_in(test_string, outs)
 
     # and now enable DUECREDIT - output could come to stderr
     env['DUECREDIT_ENABLE'] = '1'
-    out, err = run(cmd, env=env, expect_stderr=True)
+    out, err = run(cmd, env=env)
     outs = out + err
 
     if external_versions['duecredit']:

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -14,7 +14,10 @@ from datalad.tests.utils import assert_raises, assert_equal
 from unittest.mock import patch
 
 from datalad.api import sshrun
-from datalad.cmd import Runner
+from datalad.cmd import (
+    StdOutCapture,
+    WitlessRunner,
+)
 from datalad.cmdline.main import main
 
 from datalad.tests.utils import skip_if_on_windows
@@ -47,12 +50,14 @@ def test_no_stdin_swallow(fname):
     # will relay actual exit code on CommandError
     cmd = ['datalad', 'sshrun', 'datalad-test', 'cat']
 
-    out, err = Runner().run(cmd, stdin=open(fname))
-    assert_equal(out.rstrip(), '123magic')
+    out = WitlessRunner().run(
+        cmd, stdin=open(fname), protocol=StdOutCapture)
+    assert_equal(out['stdout'].rstrip(), '123magic')
 
     # test with -n switch now, which we could place even at the end
-    out, err = Runner().run(cmd + ['-n'], stdin=open(fname))
-    assert_equal(out, '')
+    out = WitlessRunner().run(
+        cmd + ['-n'], stdin=open(fname), protocol=StdOutCapture)
+    assert_equal(out['stdout'], '')
 
 
 @skip_if_on_windows
@@ -60,8 +65,8 @@ def test_no_stdin_swallow(fname):
 @with_tempfile(suffix="1 space", content="magic")
 def test_fancy_quotes(f):
     cmd = ['datalad', 'sshrun', 'datalad-test', """'cat '"'"'%s'"'"''""" % f]
-    out, err = Runner().run(cmd)
-    assert_equal(out, 'magic')
+    out = WitlessRunner().run(cmd, protocol=StdOutCapture)
+    assert_equal(out['stdout'], 'magic')
 
 
 @skip_if_on_windows

--- a/datalad/tests/test_installed.py
+++ b/datalad/tests/test_installed.py
@@ -16,19 +16,26 @@ from datalad.tests.utils import (
     assert_cwd_unchanged,
 )
 
-from datalad.cmd import Runner
+from datalad.cmd import (
+    StdOutErrCapture,
+    WitlessRunner,
+)
 from datalad.support.exceptions import CommandError
 
+
 def check_run_and_get_output(cmd):
-    runner = Runner()
+    runner = WitlessRunner()
     try:
         # suppress log output happen it was set to high values
         with patch.dict('os.environ', {'DATALAD_LOG_LEVEL': 'WARN'}):
-            output = runner.run(["datalad", "--help"])
+            output = runner.run(
+                ["datalad", "--help"],
+                protocol=StdOutErrCapture)
     except CommandError as e:
         raise AssertionError("'datalad --help' failed to start normally. "
                              "Exited with %d and output %s" % (e.code, (e.stdout, e.stderr)))
-    return output
+    return output['stdout'], output['stderr']
+
 
 @assert_cwd_unchanged
 def test_run_datalad_help():

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -17,7 +17,10 @@ from datalad.tests.utils import (
     with_testrepos,
     with_tempfile,
 )
-from datalad.cmd import Runner
+from datalad.cmd import (
+    StdOutErrCapture,
+    WitlessRunner,
+)
 from .utils_testdatasets import make_studyforrest_mockup
 
 
@@ -42,8 +45,8 @@ def test_point_to_github(url):
 @with_tempfile
 def test_clone(src, tempdir):
     # Verify that all our repos are clonable
-    r = Runner()
-    output = r.run(["git" , "clone", src, tempdir], log_online=True)
+    r = WitlessRunner()
+    output = r.run(["git" , "clone", src, tempdir], protocol=StdOutErrCapture)
     #status, output = getstatusoutput("git clone %(src)s %(tempdir)s" % locals())
     ok_(os.path.exists(os.path.join(tempdir, ".git")))
     # TODO: requires network for sure! ;)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -111,6 +111,7 @@ from .utils import (
     ok_file_has_content,
     ok_generator,
     ok_startswith,
+    on_travis,
     probe_known_failure,
     skip_if,
     skip_if_no_module,
@@ -1320,7 +1321,17 @@ def test_is_interactive(fout):
     # happen, also test the core protocols
     # (we can only be interactive in a runner, if the test execution
     # itself happens in an interactive environment)
-    for proto, interactive in ((NoCapture, is_interactive()),
+    for proto, interactive in ((NoCapture,
+                                # It is unclear why (on travis only) a child
+                                # process can report to be interactive
+                                # whenever the parent process is not.
+                                # Maintain this test exception until
+                                # someone can provide insight. The point of
+                                # this test is to ensure that NoCapture
+                                # in an interactive parent also keeps the
+                                # child interactive, so this oddity is not
+                                # relevant.
+                                True if on_travis else is_interactive()),
                                (KillOutput, False),
                                (StdOutErrCapture, False),
                                (GitProgress, False),

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -59,6 +59,7 @@ from datalad.utils import (
     import_module_from_file,
     import_modules,
     is_explicit_path,
+    is_interactive,
     join_cmdline,
     knows_annex,
     line_profile,
@@ -1283,12 +1284,22 @@ def test_never_fail():
 def test_is_interactive(fout):
     # must not fail if one of the streams is no longer open:
     # https://github.com/datalad/datalad/issues/3267
-    from ..cmd import Runner
+    from datalad.cmd import (
+        KillOutput,
+        NoCapture,
+        StdOutErrCapture,
+        WitlessRunner,
+    )
+    from datalad.support.gitrepo import GitProgress
+    from datalad.support.annexrepo import (
+        AnnexInitOutput,
+        AnnexJsonProtocol,
+    )
 
     bools = ["False", "True"]
 
     def get_interactive(py_pre="", **run_kwargs):
-        out, err = Runner().run(
+        out = WitlessRunner().run(
             [sys.executable,
              "-c",
              py_pre +
@@ -1305,8 +1316,19 @@ def test_is_interactive(fout):
         assert_in(out, bools)
         return bool(bools.index(out))
 
-    # we never request for pty in our Runner, so can't be interactive
-    eq_(get_interactive(), False)
+    # verify that NoCapture can make fully interactive execution
+    # happen, also test the core protocols
+    # (we can only be interactive in a runner, if the test execution
+    # itself happens in an interactive environment)
+    for proto, interactive in ((NoCapture, is_interactive()),
+                               (KillOutput, False),
+                               (StdOutErrCapture, False),
+                               (GitProgress, False),
+                               (AnnexInitOutput, False),
+                               (AnnexJsonProtocol, False)):
+        eq_(get_interactive(protocol=proto),
+            interactive,
+            msg='{} -> {}'.format(str(proto), interactive))
     # and it must not crash if smth is closed
     for o in ('stderr', 'stdin', 'stdout'):
         eq_(get_interactive("import sys; sys.%s.close(); " % o), False)

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -45,7 +45,7 @@ def py2cmd(code):
 def test_runner(tempfile):
     runner = Runner()
     content = 'Testing äöü東 real run'
-    cmd = ['sh', '-c', 'echo %s > %r' % (content, tempfile)]
+    cmd = 'echo %s > %r' % (content, tempfile)
     res = runner.run(cmd)
     # no capture of any kind, by default
     ok_(not res['stdout'])

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -27,7 +27,10 @@ from datalad.cmd import (
     WitlessRunner as Runner,
     StdOutCapture,
 )
-from datalad.utils import Path
+from datalad.utils import (
+    on_windows,
+    Path,
+)
 from datalad.support.exceptions import CommandError
 
 
@@ -44,8 +47,8 @@ def py2cmd(code):
 @with_tempfile
 def test_runner(tempfile):
     runner = Runner()
-    content = 'Testing äöü東 real run'
-    cmd = 'echo %s > %r' % (content, tempfile)
+    content = 'Testing real run' if on_windows else 'Testing äöü東 real run' 
+    cmd = 'echo %s > %s' % (content, tempfile)
     res = runner.run(cmd)
     # no capture of any kind, by default
     ok_(not res['stdout'])

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -80,7 +80,6 @@ from datalad.utils import (
     ensure_unicode,
 )
 
-from ..cmd import Runner
 from .. import utils
 from ..support.exceptions import (
     CommandError,
@@ -96,6 +95,10 @@ from ..consts import (
     ARCHIVES_TEMP_DIR,
 )
 from . import _TEMP_PATHS_GENERATED
+from datalad.cmd import (
+    GitWitlessRunner,
+    KillOutput,
+)
 
 # temp paths used by clones
 _TEMP_PATHS_CLONES = set()
@@ -928,12 +931,10 @@ def _get_resolved_flavors(flavors):
 
 
 def clone_url(url):
-    # delay import of our code until needed for certain
-    from ..cmd import Runner
-    runner = Runner()
+    runner = GitWitlessRunner()
     tdir = tempfile.mkdtemp(**get_tempfile_kwargs(
         {'dir': dl_cfg.get("datalad.tests.temp.dir")}, prefix='clone_url'))
-    _ = runner(["git", "clone", url, tdir], expect_stderr=True)
+    runner.run(["git", "clone", url, tdir], protocol=KillOutput)
     if GitRepo(tdir).is_with_annex():
         AnnexRepo(tdir, init=True)
     _TEMP_PATHS_CLONES.add(tdir)


### PR DESCRIPTION
All Runner code is now hanging on a thin thread. The remaining connections are:

- `GitRepo._run_git_custom_command` is still on life support but already brain dead
- `run` still uses `Runner` -> #5002
- [x] `create_sibling` has a fancy `Runner` adaptor class that adds a few functions that partially duplicate functionality in `SSHConnection` and want to become command abstractions (although that effort #4068 died a lonely death, @bpoldrack )

Significant changes:
- WitlessRunner now supports shell-based execution https://github.com/datalad/datalad/pull/4996/commits/df4f782bd8a30693cb5a28665ad4e41eb82c9907
