### PR TITLE
Win/BF: don't invoke 'git-annex' but 'git annex'

### DIFF
--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -424,7 +424,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         def progress_indicators(l):
             self.info("PROGRESS-JSON: " + l.rstrip(os.linesep))
 
-        self.runner(["git-annex", "get",
+        self.runner(["git", "annex", "get",
                      "--json", "--json-progress",
                      "--key", akey
                      ],

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -652,7 +652,7 @@ class AnnexCustomRemote(object):
         # TODO: should actually be implemented by AnnexRepo
         #       Command is available in annex >= 20140410
         (out, err) = \
-            self.runner(['git-annex', 'contentlocation', key], cwd=self.path)
+            self.runner(['git', 'annex', 'contentlocation', key], cwd=self.path)
         # TODO: it would exit with non-0 if key is not present locally.
         # we need to catch and throw our exception
         return opj(self.path, out.rstrip(os.linesep))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1036,7 +1036,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         if git_options:
             cmd_list = ['git'] + git_options + ['annex']
         else:
-            cmd_list = ['git-annex']
+            # Note: On Windows machines, for a yet unclear reason, git-annex may
+            # not be found as an executable. This is mitigated (again, for an
+            # unclear reason) by seperating the invocation into "git annex". See
+            # https://github.com/datalad/datalad/issues/4892 for original issue.
+            cmd_list = ['git', 'annex']
         if jobs:
             annex_options += ['-J%d' % jobs]
 

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -267,7 +267,7 @@ def test_runner_failure(dir_):
     from ..support.annexrepo import AnnexRepo
     repo = AnnexRepo(dir_, create=True)
     runner = Runner()
-    failing_cmd = ['git-annex', 'add', 'notexistent.dat']
+    failing_cmd = ['git', 'annex', 'add', 'notexistent.dat']
 
     with assert_raises(CommandError) as cme, \
          swallow_logs() as cml:


### PR DESCRIPTION
On a Windows machine, while ``git-annex`` and ``git annex`` invocations work fine from an Anaconda prompt, a "git-annex" command invoked via ``run_annex_command`` fails to find the git-annex executable.
When using 'git annex', though, commands seem to work just fine. This change fixes #4892. I lack an in-depth understanding of why that is, yet, but I also figured that this change doesn't do harm to anything else.
