### PR TITLE
RF: Stop using old-Runner in `run`

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -454,24 +454,16 @@ def format_command(dset, command, **kwds):
 
 
 def _execute_command(command, pwd, expected_exit=None):
-    from datalad.cmd import Runner
+    from datalad.cmd import WitlessRunner
 
     exc = None
     cmd_exitcode = None
-    runner = Runner(cwd=pwd)
+    runner = WitlessRunner(cwd=pwd)
     try:
         lgr.info("== Command start (output follows) =====")
         runner.run(
-            command,
-            # immediate output
-            log_online=True,
-            # not yet sure what we should do with the command output
-            # IMHO `run` itself should be very silent and let the command talk
-            log_stdout=False,
-            log_stderr=False,
-            expect_stderr=True,
-            expect_fail=True,
-            # TODO stdin
+            # command is always a string
+            command
         )
     except CommandError as e:
         # strip our own info from the exception. The original command output


### PR DESCRIPTION
Instead of switching to `subprocess.run()` (original plan), I still use a runner in order to retain the CommandError raise that might be important to consumers, and simultaneously avoid having to duplicate the CommandError construction logic.

This used to be part of #4996, but has been placed into a standalone PR due to the complications of https://github.com/datalad/datalad-container/pull/131 -- and caused by a no-log behavior of `run` introduced by this PR. Executed commands communicate directly with the terminal.