### PR TITLE
ENH: Allow experimenting with interactive commit-message entry

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -406,6 +406,15 @@ definitions = {
         'default': 'auto',
         'type': EnsureChoice('on', 'off', 'auto'),
     },
+    'datalad.save.no-message': {
+        'ui': ('question', {
+            'title': 'Commit message handling',
+            'text': 'When no commit message was provided: '
+                    'attempt to obtain one interactively (interactive); '
+                    'or use a generic commit message (generic)'}),
+        'default': 'generic',
+        'type': EnsureChoice('interactive', 'generic'),
+    },
     'datalad.install.inherit-local-origin': {
         'ui': ('question', {
             'title': 'Inherit local origin of dataset source',

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -411,7 +411,9 @@ definitions = {
             'title': 'Commit message handling',
             'text': 'When no commit message was provided: '
                     'attempt to obtain one interactively (interactive); '
-                    'or use a generic commit message (generic)'}),
+                    'or use a generic commit message (generic). '
+                    'NOTE: The interactive option is experimental. The '
+                    'behavior may change in backwards-incompatible ways.'}),
         'default': 'generic',
         'type': EnsureChoice('interactive', 'generic'),
     },


### PR DESCRIPTION
Concept: Run a follow-up `git commit --amend` in a runner session that doesn't capture any output, hence can drive any editor properly. This approach allows us to maintain any error message inspection, because these commit calls are unchanged. The interactive edit is a pure add-one, that is only attempted if anyhow possible. It should also not fail in ways that it would not have failed in the previous commit call.

Based on the feedback in gh-4121, the default (non-interactive) behavior
is unchanged. Trigger the interactive behavior via:

`datalad -c datalad.save.no-message=interactive save`

Fixes gh-5004

The primary purpose of this change is to allow enabling in dev environments, in order to get practical experience with the interactive behavior in various scenarios (simple one-dataset save, up to complex hierarchical operations). The current concept on how to deal with these is datalad/datalad-revolution#71 (which should see practical validation, which is prepared with this change). In any other scenario or deployment, this should be a no-op.