### PR TITLE
BF/RF: GitRepo.push -- push first refspec separately first for github (or if remote.{remote}.datalad-push-default-first is set)

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -412,7 +412,7 @@ class ConfigManager(object):
           `text`.
         """
         # do local import, as this module is import prominently and the
-        # could theroetically import all kind of weired things for type
+        # could theoretically import all kind of weired things for type
         # conversion
         from datalad.interface.common_cfg import definitions as cfg_defs
         # fetch what we know about this variable

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -218,11 +218,21 @@ class CreateSiblingGithub(Interface):
         # lastly configure the local datasets
         for d, url, existed in rinfo:
             if not dryrun:
-                # first make sure that annex doesn't touch this one
-                # but respect any existing config
-                ignore_var = 'remote.{}.annex-ignore'.format(name)
-                if not ignore_var in d.config:
-                    d.config.add(ignore_var, 'true', where='local')
+                extra_remote_vars = {
+                    # first make sure that annex doesn't touch this one
+                    # but respect any existing config
+                    'annex-ignore': 'true',
+                    # first push should separately push active branch first
+                    # to overcome github issue of choosing "default" branch
+                    # alphabetically if its name does not match the default
+                    # branch for the user (or organization) which now defaults
+                    # to "main"
+                    'datalad-push-default-first': 'true'
+                }
+                for var_name, var_value in extra_remote_vars.items():
+                    var = 'remote.{}.{}'.format(name, var_name)
+                    if var not in d.config:
+                        d.config.add(var, var_value, where='local')
                 Siblings()(
                     'configure',
                     dataset=d,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2422,7 +2422,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         refspec separately to possibly ensure that the first refspec is chosen
         by remote as the "default branch".
         See https://github.com/datalad/datalad/issues/4997
-        Upon succesfull push if this variable was set in the local git config,
+        Upon successful push if this variable was set in the local git config,
         we unset it, so subsequent pushes would proceed normally.
 
         Parameters
@@ -2468,7 +2468,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             )
         # note: above push_ should raise exception if errors out
         if cfg.get_from_source('local', cfg_push_var) is not None:
-            lgr.debug("Removing %s variable from local git config after succesfull push", cfg_push_var)
+            lgr.debug("Removing %s variable from local git config after successful push", cfg_push_var)
             cfg.unset(cfg_push_var, 'local')
         return push_res
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1716,3 +1716,52 @@ def test_protocols():
     # http is well tested already
     for proto in 'git', 'https':
         yield _test_protocols, proto
+
+
+@with_tempfile
+def test_gitrepo_push_default_first_kludge(path):
+    path = Path(path)
+    repo_a = GitRepo(path / "a", bare=True)
+    repo_b = GitRepo.clone(repo_a.path, str(path / "b"))
+
+    (repo_b.pathobj / "foo").write_text("foo")
+    repo_b.save()
+
+    # push() usually pushes all refspecs in one go.
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        res_oneshot = repo_b.push(remote="origin",
+                                  refspec=[DEFAULT_BRANCH + ":b-oneshot",
+                                           DEFAULT_BRANCH + ":a-oneshot",
+                                           DEFAULT_BRANCH + ":c-oneshot"])
+    cmds_oneshot = [ln for ln in cml.out.splitlines()
+                    if "cmd" in ln and "push" in ln and DEFAULT_BRANCH in ln]
+    eq_(len(cmds_oneshot), 1)
+    assert_in(":a-oneshot", cmds_oneshot[0])
+    assert_in(":b-oneshot", cmds_oneshot[0])
+    assert_in(":c-oneshot", cmds_oneshot[0])
+    eq_(len(res_oneshot), 3)
+
+    # But if datalad-push-default-first is set...
+    cfg_var = "remote.origin.datalad-push-default-first"
+    repo_b.config.set(cfg_var, "true", where="local")
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        res_twoshot = repo_b.push(remote="origin",
+                                  refspec=[DEFAULT_BRANCH + ":b-twoshot",
+                                           DEFAULT_BRANCH + ":a-twoshot",
+                                           DEFAULT_BRANCH + ":c-twoshot"])
+    cmds_twoshot = [ln for ln in cml.out.splitlines()
+                    if "cmd" in ln and "push" in ln and DEFAULT_BRANCH in ln]
+    # ... there are instead two git-push calls.
+    eq_(len(cmds_twoshot), 2)
+    # The first is for the first item of the refspec.
+    assert_in(":b-twoshot", cmds_twoshot[0])
+    assert_not_in(":b-twoshot", cmds_twoshot[1])
+    # The remaining items are in the second call.
+    assert_in(":a-twoshot", cmds_twoshot[1])
+    assert_in(":c-twoshot", cmds_twoshot[1])
+    assert_not_in(":c-twoshot", cmds_twoshot[0])
+    assert_not_in(":a-twoshot", cmds_twoshot[0])
+    # The result returned by push() has the same number of records, though.
+    eq_(len(res_twoshot), 3)
+    # The configuration variable is removed afterward.
+    assert_false(repo_b.config.get(cfg_var))


### PR DESCRIPTION
This is a central place for logic of pushing refspecs used by push and publish,
so I decided to fix in a single spot instead of duplicating logic or providing
yet another additional wrapper, and thus possibly of help to any other code which
uses .push().

Note:
- logic is in effect only if remote and refspecs are provided. So it will be
  of no effect if either of those not provided, but most likely there would be
  no relevant use case since it would require manual configuration first of the
  refspecs and default remote for a branch within config before submitting a push

Qs:
-  may be logic should move even deeper into  push_ generator?
-  ideas on how to establish testing for this, without interacting with github, since it seemed we encountered such behavior on pushing multiple refspecs at once only with github. ATM tested "manually" with both push and publish using reproducer in #4997
- [x] redo following the proposal in https://github.com/datalad/datalad/pull/5010#issuecomment-712997679 to explicitly annotate config while `create-sibling-github` to do separate initial push(es) only in that case (not always upon initial push).  I am not 100% satisfied in such approach since would make it github specific, and might be needed for other (gitlab?) if they start behaving the same way

Closes: #4997
