### PR TITLE
RF: Strip `AnnotatePaths` from `create_sibling()`

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -49,7 +49,6 @@ from datalad.distribution.dataset import (
     resolve_path,
     require_dataset,
 )
-from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.base import (
     build_doc,
     Interface,
@@ -92,6 +91,7 @@ from datalad.utils import (
     ensure_list,
     quote_cmdlinearg,
 )
+from datalad.core.local.diff import diff_dataset
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 
@@ -645,51 +645,69 @@ class CreateSibling(Interface):
         # parse the base dataset to find all subdatasets that need processing
         #
         to_process = []
-        for ap in AnnotatePaths.__call__(
-                dataset=refds_path,
-                # only a single path!
-                path=refds_path,
-                recursive=recursive,
-                recursion_limit=recursion_limit,
+        cand_ds = [
+            Dataset(r['path'])
+            for r in diff_dataset(
+                ds,
+                fr=since,
+                to=None,
+                # make explicit, but doesn't matter, no recursion in diff()
+                constant_refs=True,
+                # contrain to the paths of all locally existing subdatasets
+                path=[
+                    sds['path']
+                    for sds in ds.subdatasets(
+                        recursive=recursive,
+                        recursion_limit=recursion_limit,
+                        fulfilled=True,
+                        result_renderer=None)
+                ],
+                # save cycles, we are only looking for datasets
+                annex=None,
+                untracked='no',
+                # recursion was done faster by subdatasets()
+                recursive=False,
+                # save cycles, we are only looking for datasets
+                eval_file_type=False,
+            )
+            if r.get('type') == 'dataset' and r.get('state', None) != 'clean'
+        ]
+        # check remotes setup
+        for d in cand_ds if since else ([ds] + cand_ds):
+            d_repo = d.repo
+            if d_repo is None:
+                continue
+            checkds_remotes = d.repo.get_remotes()
+            res = dict(
                 action='create_sibling',
-                # both next should not happen anyways
-                unavailable_path_status='impossible',
-                nondataset_path_status='error',
-                modified=since,
-                return_type='generator',
-                on_failure='ignore'):
-            if ap.get('status', None):
-                # this is done
-                yield ap
-                continue
-            if ap.get('type', None) != 'dataset' or ap.get('state', None) == 'absent':
-                # this can happen when there is `since`, but we have no
-                # use for anything but datasets here
-                continue
-            checkds_remotes = Dataset(ap['path']).repo.get_remotes() \
-                if ap.get('state', None) != 'absent' \
-                else []
+                path=d.path,
+                type='dataset',
+            )
+
             if publish_depends:
                 # make sure dependencies are valid
                 # TODO: inherit -- we might want to automagically create
                 # those dependents as well???
-                unknown_deps = set(ensure_list(publish_depends)).difference(checkds_remotes)
+                unknown_deps = set(ensure_list(publish_depends)).difference(
+                    checkds_remotes)
                 if unknown_deps:
-                    ap['status'] = 'error'
-                    ap['message'] = (
-                        'unknown sibling(s) specified as publication dependency: %s',
-                        unknown_deps)
-                    yield ap
+                    yield dict(
+                        res,
+                        status='error',
+                        message=('unknown sibling(s) specified as publication '
+                                 'dependency: %s', unknown_deps),
+                    )
                     continue
             if name in checkds_remotes and existing in ('error', 'skip'):
-                ap['status'] = 'error' if existing == 'error' else 'notneeded'
-                ap['message'] = (
-                    "sibling '%s' already configured (specify alternative name, or force "
-                    "reconfiguration via --existing",
-                    name)
-                yield ap
+                yield dict(
+                    res,
+                    status='error' if existing == 'error' else 'notneeded',
+                    message=(
+                        "sibling '%s' already configured (specify alternative "
+                        "name, or force reconfiguration via --existing", name),
+                )
                 continue
-            to_process.append(ap)
+            to_process.append(res)
 
         if not to_process:
             # we ruled out all possibilities

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -567,6 +567,7 @@ def test_publish_depends(
         on_failure='ignore')
     assert_result_count(
         res, 1,
+        path=source.path,
         status='error',
         message=(
             'unknown sibling(s) specified as publication dependency: %s',


### PR DESCRIPTION
Use a 2-stage approach (subdatasets(recursive) + diff()) to avoid the
runtime cost of a full diff(recursive).

Ping gh-3368