### PR TITLE
Revert "ENH: When closing batched processes avoid waiting forever"

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -359,6 +359,15 @@ definitions = {
         'type': EnsureChoice('all', 'success', 'failure', 'ok', 'notneeded', 'impossible', 'error'),
         'default': None,
     },
+    'datalad.runtime.stalled-external': {
+        'ui': ('question', {
+            'title': 'Behavior for handing external processes',
+            'text': 'What to do with external processes if they do not finish in some minimal reasonable time. '
+                    'If "abandon", datalad would proceed without waiting for external process to exit. '
+                    'ATM applies only to batched git-annex processes. Should be changed with caution.'}),
+        'type': EnsureChoice('wait', 'abandon'),
+        'default': 'wait',
+    },
     'datalad.search.indexercachesize': {
         'ui': ('question', {
                'title': 'Maximum cache size for search index (per process)',


### PR DESCRIPTION
This reverts commit 383819eafc77e604c9cea2977820dcd299ea2902.

That workaround, introduced in #4829, just hides away the problem, possibly
leading to data loss (e.g. batched process would not finish its processing by
then and we proceed to eg save or alike), and makes it hard to impossible to
spot/debug in real life cases where it manifests itself.

This is unlikely to fix the issue, but I want to see if it still
reproduces (I failed to reproduce it in the past 2 days).

More references:

- datalad issue https://github.com/datalad/datalad/issues/4998
- git-annex report https://git-annex.branchable.com/bugs/some_annex_addurl_--fast_--with-files_--json_--json-error-messages_--batch__do_not_quit/

I do not think of any reasonable "timeout" we could specify and be "correct", since in some cases (very large index) it could take awhile for e.g. `addurl --batch` to complete and I do not know how long exactly.  What we could do is to add some "activity indication", e.g. if it did not complete within X seconds, we bring up "progress bar like" information bar which would report PID of the batched child process, and may be its tree with CPU/IO  information. That would allow to ease troubleshooting, alert user about still ongoing (or stalled?) activity.  In interactive mode we could may be even add some shortcut (e.g. if Ctrl-C is pressed and thus we get an exception) to jump into pdb... just ideas

Conflicts:
	datalad/cmd.py - melded with added later logging of stderr
