### PR TITLE
BF: Treat git-mv'ed annexed files like untracked content

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -905,5 +905,5 @@ def test_save_git_mv_fixup(path):
     eq_(WitlessRunner(cwd=ds.path).run(
         ["cat", "foo"], protocol=StdOutCapture)['stdout'],
         "foocontent")
-    # FIXME: But only the deletion was saved.
+    # all clean
     assert_repo_status(ds.path)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -907,3 +907,23 @@ def test_save_git_mv_fixup(path):
         "foocontent")
     # all clean
     assert_repo_status(ds.path)
+
+
+@with_tempfile
+def test_save_staged_nonannex_goes_to_annex(path):
+    # Due to the `git mv` workaround above, staged paths are reset, so `datalad
+    # save` will send a file to the annex despite an explicit `git add` before.
+    ds = Dataset(path).create()
+    repo = ds.repo
+    foo = (ds.pathobj / "foo")
+    foo.write_text("content")
+    repo.call_git(["add", "foo"])
+    assert_repo_status(ds.path, added=[foo])
+
+    assert_not_in("backend",
+                  repo.get_content_annexinfo(paths=[foo])[foo])
+
+    ds.save()
+    assert_repo_status(ds.path)
+    assert_in("backend",
+              repo.get_content_annexinfo(paths=[foo])[foo])

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -815,8 +815,7 @@ def test_rerun_explicit(path):
     # But checking out a new HEAD can fail when there are modifications.
     ds.repo.checkout(DEFAULT_BRANCH)
     ok_(ds.repo.dirty)
-    ds.repo.add(["to_modify"], git=True)
-    ds.save()
+    ds.save(path=["to_modify"], to_git=True)
     assert_false(ds.repo.dirty)
     with open(op.join(ds.path, "to_modify"), "a") as ofh:
         ofh.write("more")

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -4041,7 +4041,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             else:
                 need_partial_commit = True
         if unstage:
-            self.call_git(['restore', '--staged'], files=unstage)
+            # keep compat with older Git versions for now
+            #self.call_git(['restore', '--staged'], files=unstage)
+            self.call_git(['reset', 'HEAD'], files=unstage)
 
         # remove first, because removal of a subds would cause a
         # modification of .gitmodules to be added to the todo list


### PR DESCRIPTION
`git-mv` stages the move, and our handling of such a change causes
a potential fix-up of an annex symlink to happen outside and after
our change analysis. This change unstages such paths and
re-categorizes such a modification as an untracked addition. This
essentially removes the special case and fixes gh-4967