### PR TITLE
BF: always save run sidecar files 

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -686,6 +686,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         '"{}"'.format(record_id) if use_sidecar else record)
 
     outputs_to_save = outputs.expand() if explicit else None
+    if outputs_to_save is not None and use_sidecar:
+        outputs_to_save.append(record_path)
     do_save = outputs_to_save is None or outputs_to_save
     if not rerun_info and cmd_exitcode:
         if do_save:

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -210,6 +210,18 @@ def test_sidecar(path):
     assert_in('"cmd":', last_commit_msg(ds.repo))
 
 
+    # make sure sidecar file is committed when explicitly specifiying outputs
+    ds.run("cd .> dummy4",
+           outputs=["dummy4"],
+           sidecar=True,
+           explicit=True,
+           message="sidecar + specified outputs")
+    assert_not_in('"cmd":', last_commit_msg(ds.repo))
+    assert_repo_status(ds.path)
+
+
+
+
 @with_tree(tree={"to_remove": "abc"})
 def test_run_save_deletion(path):
     ds = Dataset(path).create(force=True)


### PR DESCRIPTION
Fix a bug in `datalad-run`, where sidecar files weren't saved, when outputs are specified w/ `--explicit`.
A caller of `run` can't know the to be saved path and shouldn't need to care for a builtin feature to be functional. Can't see an argument why this wouldn't be a bug.