### PR TITLE
ENH: display datalad version in the first log message out there  when running in cmdline

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -38,6 +38,7 @@ from ..utils import (
     setup_exceptionhook,
 )
 from ..dochelpers import exc_str
+from ..version import __full_version__
 
 
 def _license_info():
@@ -212,8 +213,8 @@ def setup_parser(
             cmdlineargs[1:], argparse.Namespace())
         if not (completing or unparsed_args):
             fail_handler(parser, msg="too few arguments", exit_code=2)
-        lgr.debug("Command line args 1st pass. Parsed: %s Unparsed: %s",
-                  parsed_args, unparsed_args)
+        lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
+                  __full_version__, parsed_args, unparsed_args)
     except Exception as exc:
         lgr.debug("Early parsing failed with %s", exc_str(exc))
         need_single_subparser = False


### PR DESCRIPTION
I just embedded it into the message we already have for CLI parsing, because
that is effectively the first log line printed if log level is changed
(as most commonly done) via -l debug .

This should help to avoid possibly asking for WTF when we ourselfves or others provide at least this information "by default" along with `-l debug` output

Looks like
```
$> datalad -l 1 install -s /// /tmp/dddd
[DEBUG  ] Command line args 1st pass for DataLad 0.13.4.dev15-g84ba1-dirty. Parsed: Namespace() Unparsed: ['install', '-s', '///', '/tmp/dddd'] 
...
```