### PR TITLE
RM: remove _license_info and use in customremotes/main.py

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -40,30 +40,6 @@ from ..utils import (
 from ..dochelpers import exc_str
 
 
-def _license_info():
-    return """\
-Copyright (c) 2013-2019 DataLad developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-"""
-
-
 class ArgumentParserDisableAbbrev(argparse.ArgumentParser):
     # Don't accept abbreviations for long options. This kludge was originally
     # added at a time when our minimum required Python version was below 3.5,

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -57,7 +57,7 @@ def setup_parser(backend):
     helpers.parser_add_common_opt(
         parser,
         'version',
-        version='datalad %s\n\n%s' % (m__version__,))
+        version='datalad %s' % m__version__)
     if __debug__:
         parser.add_argument(
             '--dbg', action='store_true', dest='common_debug',

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -18,7 +18,6 @@ from .. import __doc__ as m__doc__, __version__ as m__version__
 from ..log import lgr
 
 from ..cmdline import helpers
-from ..cmdline.main import _license_info
 
 from ..utils import setup_exceptionhook
 from ..ui import ui
@@ -58,7 +57,7 @@ def setup_parser(backend):
     helpers.parser_add_common_opt(
         parser,
         'version',
-        version='datalad %s\n\n%s' % (m__version__, _license_info()))
+        version='datalad %s\n\n%s' % (m__version__,))
     if __debug__:
         parser.add_argument(
             '--dbg', action='store_true', dest='common_debug',


### PR DESCRIPTION
we stopped showing license for --version output for the main process,
but still were showing it for special remotes.  I see no reason for
the difference and maintaining another place where we would need to
tune up copyright years, so just removing it altogether
