### PR TITLE
BF: RIA clone HTTP403 handling and support authenticated access

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -1023,4 +1023,42 @@ def get_cached_url_content(url, name=None, fetcher=None, maxage=None):
         lgr.debug("stored result of request to '{}' in {}".format(url, doc_fname))
     return doc
 
+
+def download_url(url, dest=None, overwrite=False):
+    """Download a file from a URL
+
+    Supports and honors any DataLad "downloader/provider" configuration.
+
+    Parameters
+    ----------
+    url: str
+      Source URL to download from.
+    dest: Path-like or None
+      Destination file name (file must not exist), or name of a target
+      directory (must exists, and filename must be derivable from `url`).
+      If None, the downloaded content will be returned as a string.
+    overwrite: bool
+      Force overwriting an existing destination file.
+
+    Returns
+    -------
+    str
+      Path of the downloaded file, or URL content if `dest` is None.
+
+    Raises
+    ------
+    DownloadError
+      If `dest` already exists and is a file, or if `dest` is a directory
+      and no filename could be determined from `url`, or if no file was
+      found at the given `url`.
+    """
+    from datalad.downloaders.providers import Providers
+    providers = Providers.from_config_files()
+    # not returning anything: download() seems to just echo `dest`
+    if dest:
+        return providers.download(url, path=str(dest), overwrite=overwrite)
+    else:
+        return providers.fetch(url)
+
+
 lgr.log(5, "Done importing support.network")


### PR DESCRIPTION
This PR essentially removes a custom HTTP GET request handling and uses a new (but pretty trivial) download helper.

Fixes gh-5023

... although it could be made better by supporting git-credentials as a credential sources in DataLad. This, however, would only make internal changes and no have consequences for the proposed change in `clone`.

A significant annoyance is that low-level code insists on reporting INFO level log messages that will no report URL to be downloaded to short-lived temporary files with cryptic names. But at least it is functioning properly for now.