### PR TITLE
BF: ORA authenticated HTTP access

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -556,7 +556,7 @@ class HTTPRemoteIO(object):
         # to annexremote.dirhash from within IO classes
 
         url = self.base_url + "/annex/objects/" + str(key_path)
-        from datalad.utils import download_url
+        from datalad.support.network import download_url
         download_url(url, filename, overwrite=True)
 
 

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -556,15 +556,8 @@ class HTTPRemoteIO(object):
         # to annexremote.dirhash from within IO classes
 
         url = self.base_url + "/annex/objects/" + str(key_path)
-        response = requests.get(url, stream=True)
-
-        with open(filename, 'wb') as dst_file:
-            bytes_received = 0
-            for chunk in response.iter_content(chunk_size=self.buffer_size,
-                                               decode_unicode=False):
-                dst_file.write(chunk)
-                bytes_received += len(chunk)
-                progress_cb(bytes_received)
+        from datalad.utils import download_url
+        download_url(url, filename, overwrite=True)
 
 
 def handle_errors(func):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -1023,4 +1023,42 @@ def get_cached_url_content(url, name=None, fetcher=None, maxage=None):
         lgr.debug("stored result of request to '{}' in {}".format(url, doc_fname))
     return doc
 
+
+def download_url(url, dest=None, overwrite=False):
+    """Download a file from a URL
+
+    Supports and honors any DataLad "downloader/provider" configuration.
+
+    Parameters
+    ----------
+    url: str
+      Source URL to download from.
+    dest: Path-like or None
+      Destination file name (file must not exist), or name of a target
+      directory (must exists, and filename must be derivable from `url`).
+      If None, the downloaded content will be returned as a string.
+    overwrite: bool
+      Force overwriting an existing destination file.
+
+    Returns
+    -------
+    str
+      Path of the downloaded file, or URL content if `dest` is None.
+
+    Raises
+    ------
+    DownloadError
+      If `dest` already exists and is a file, or if `dest` is a directory
+      and no filename could be determined from `url`, or if no file was
+      found at the given `url`.
+    """
+    from datalad.downloaders.providers import Providers
+    providers = Providers.from_config_files()
+    # not returning anything: download() seems to just echo `dest`
+    if dest:
+        return providers.download(url, path=str(dest), overwrite=overwrite)
+    else:
+        return providers.fetch(url)
+
+
 lgr.log(5, "Done importing support.network")

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -1054,7 +1054,6 @@ def download_url(url, dest=None, overwrite=False):
     """
     from datalad.downloaders.providers import Providers
     providers = Providers.from_config_files()
-    # not returning anything: download() seems to just echo `dest`
     if dest:
         return providers.download(url, path=str(dest), overwrite=overwrite)
     else:


### PR DESCRIPTION
This sits on top of #5025 (to be able to make use of the `download_url()` helper), and replaces a custom HTTP GET that is unaware of error response codes (#4980) and necessary credentials (#5024).

ATM this solution is only working for `git annex get`, but not `datalad get`. No idea why.
https://github.com/datalad/datalad/issues/5024#issuecomment-707541179

Fixes #4980
Fixes #5024