### PR TITLE
RF/BF: report "impossible" upon get of a annexed file without git-annex branch

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -664,7 +664,7 @@ def _get_targetpaths(ds, content, refds_path, source, jobs):
     # needs to be an annex to get content
     if not isinstance(ds_repo, AnnexRepo):
         for r in results_from_paths(
-                content, status='notneeded',
+                content,
                 message="no dataset annex, content already present",
                 action='get',
                 type='file',

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -14,20 +14,21 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-from os.path import isdir
-from os.path import isabs
-from os.path import join as opj
-from os.path import relpath
-from os.path import abspath
-from os.path import normpath
 from datalad.utils import (
     ensure_list,
     with_pathsep as _with_sep,
     path_is_subpath,
     PurePosixPath,
 )
-from datalad.support.path import robust_abspath
-
+from datalad.support.path import (
+    exists,
+    isabs,
+    isdir,
+    join as opj,
+    normpath,
+    relpath,
+    robust_abspath,
+)
 from datalad.distribution.dataset import Dataset
 
 
@@ -91,7 +92,7 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
 
 
 def results_from_paths(paths, action=None, type=None, logger=None, refds=None,
-                       status=None, message=None):
+                       message=None):
     """
     Helper to yield analog result dicts for each path in a sequence.
 
@@ -107,9 +108,12 @@ def results_from_paths(paths, action=None, type=None, logger=None, refds=None,
 
     """
     for p in ensure_list(paths):
+        # TODO: notneeded vs impossible is incomplete solution here --
+        # would not work for unlocked files!
         yield get_status_dict(
             action, path=p, type=type, logger=logger, refds=refds,
-            status=status, message=(message, p) if '%s' in message else message)
+            status='notneeded' if exists(p) else 'impossible',
+            message=(message, p) if '%s' in message else message)
 
 
 def is_ok_dataset(r):


### PR DESCRIPTION
Solution here is incomplete (comment added) since it should consider git
link files in cases of unlocked (and edited here: and crippled fs) annexed files.  It would be more expensive AFAIK,
thus before even attempting to implement that, I have decided to provide the
fix which would work in 90% of the time first.

Specifically it would Closes #4510 if accepted ;)

Without the fix, asking get to get content for a broken symlink results in "ah
-- all is good -- you do not need it" behavior (similar to the slogan of the
local little town store "We do not have it - you do not need it!"), which is
IMHO plain incorrect:

	$> datalad -f json_pp get sub-01/anat/sub-01_inplaneT2.nii.gz
	{
	  "action": "get",
	  "path": "/tmp/ds000001/sub-01/anat/sub-01_inplaneT2.nii.gz",
	  "refds": "/tmp/ds000001",
	  "status": "notneeded",
	  "type": "file"
	}

with exit 0.  With the fix:

	$> datalad -f json_pp get sub-01/anat/sub-01_inplaneT2.nii.gz
	[WARNING] no dataset annex, content already present [get(/tmp/ds000001/sub-01/anat/sub-01_inplaneT2.nii.gz)]
	{
	  "action": "get",
	  "path": "/tmp/ds000001/sub-01/anat/sub-01_inplaneT2.nii.gz",
	  "refds": "/tmp/ds000001",
	  "status": "impossible",
	  "type": "file"
	}
	(dev3) 1 29415 ->1

exits with 1, and status "impossible" which is IMHO factually correct, and
WARNING message is actually informative.


