### PR TITLE
BF: Don't modify PATH if not necessary

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -1095,7 +1095,7 @@ class GitRunnerBase(object):
             # we only need to consider bundled git if it's actually different
             # from default. (see issue #5030)
             alongside = op.lexists(bundled_git_path) and \
-                        bundled_git_path != find_executable('git')
+                        bundled_git_path != op.realpath(find_executable('git'))
 
         return annex_path if alongside else ''
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -1091,7 +1091,12 @@ class GitRunnerBase(object):
             alongside = False
         else:
             annex_path = op.dirname(op.realpath(annex_fpath))
-            alongside = op.lexists(op.join(annex_path, 'git'))
+            bundled_git_path = op.join(annex_path, 'git')
+            # we only need to consider bundled git if it's actually different
+            # from default. (see issue #5030)
+            alongside = op.lexists(bundled_git_path) and \
+                        bundled_git_path != find_executable('git')
+
         return annex_path if alongside else ''
 
     @staticmethod


### PR DESCRIPTION
PATH modification in Runner classes is meant to make sure we use
bundled w/ annex git executable (except when instructed otherwise
by DATALAD_USE_DEFAULT_GIT). However, don't mess with PATH when
what we find to be bundled is the same thing that is found with
unmodified PATH anyway. This is particularly important when the
"bundeled" location is /usr/bin and we are running in a virtual
environment, leading to that PATH overruling the venv.

Closes #5030 and by extension #5024  (when combined with #5026)
