### PR TITLE
Use environment file instead of set-env

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install git-annex
       run: |
         eval source tools/ci/install-annex.sh ${{ matrix.install_scenario }}
-        echo "::set-env name=PATH::$PATH"
+        echo "PATH=$PATH" >> $GITHUB_ENV
 
     - name: Set up Python 3.6
       uses: actions/setup-python@v1

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install git-annex
       run: |
         eval source tools/ci/install-annex.sh ${{ matrix.install_scenario }}
-        echo "PATH=$PATH" >> $GITHUB_ENV
+        echo "PATH=$PATH" >> "$GITHUB_ENV"
 
     - name: Set up Python 3.6
       uses: actions/setup-python@v1


### PR DESCRIPTION
The set-env workflow command is deprecated in favor of environment files: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/