### PR TITLE
BF: UI - .error also should go through .message to handle pbars

### DIFF
--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -81,7 +81,7 @@ class ConsoleLog(object):
                      noninteractive_level=5)
 
     def error(self, error):
-        self.out.write("ERROR: %s\n" % error)
+        self.message("ERROR: %s" % error)
 
     def get_progressbar(self, *args, **kwargs):
         """Return a progressbar.  See e.g. `tqdmProgressBar` about the interface


### PR DESCRIPTION
Otherwise might interfere with progress bars

I have not "observed" wrong behavior but change looks logical to me.  