### PR TITLE
NF: Make multiplexed SSH connections an optional feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,12 @@ matrix:
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=not
+    - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
   - python: 3.5
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=""
+    - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for NOSE.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LANG=bg_BG.UTF-8

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -53,15 +53,8 @@ from datalad.utils import get_encoding_info, get_envvars_info, getpwd
 getpwd()
 
 lgr.log(5, "Instantiating ssh manager")
-from .support.sshconnector import (
-    MultiplexSSHManager,
-    NoMultiplexSSHManager,
-)
-ssh_manager = (
-    MultiplexSSHManager()
-    if cfg.obtain('datalad.ssh.multiplex-connections')
-    else NoMultiplexSSHManager()
-)
+from .support.sshconnector import SSHManager
+ssh_manager = SSHManager()
 atexit.register(ssh_manager.close, allow_fail=False)
 atexit.register(lgr.log, 5, "Exiting")
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -53,8 +53,15 @@ from datalad.utils import get_encoding_info, get_envvars_info, getpwd
 getpwd()
 
 lgr.log(5, "Instantiating ssh manager")
-from .support.sshconnector import SSHManager
-ssh_manager = SSHManager()
+from .support.sshconnector import (
+    MultiplexSSHManager,
+    NoMultiplexSSHManager,
+)
+ssh_manager = (
+    MultiplexSSHManager()
+    if cfg.obtain('datalad.ssh.multiplex-connections')
+    else NoMultiplexSSHManager()
+)
 atexit.register(ssh_manager.close, allow_fail=False)
 atexit.register(lgr.log, 5, "Exiting")
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -21,6 +21,7 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureListOf
 from datalad.support.constraints import EnsureStr
+from datalad.utils import on_windows
 
 dirs = AppDirs("datalad", "datalad.org")
 
@@ -267,6 +268,13 @@ definitions = {
                'title': "If set, pass this file as ssh's -i option."}),
         'destination': 'global',
         'default': None,
+    },
+    'datalad.ssh.multiplex-connections': {
+        'ui': ('question', {
+               'title': "Whether to use a single shared connection for multiple SSH processes aiming at the same target."}),
+        'destination': 'global',
+        'default': False if on_windows else True,
+        'type': EnsureBool(),
     },
     'datalad.annex.retry': {
         'ui': ('question',

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -273,7 +273,7 @@ definitions = {
         'ui': ('question', {
                'title': "Whether to use a single shared connection for multiple SSH processes aiming at the same target."}),
         'destination': 'global',
-        'default': False if on_windows else True,
+        'default': not on_windows,
         'type': EnsureBool(),
     },
     'datalad.annex.retry': {

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -413,6 +413,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         remote_name: str
         url: str
         """
+        if not self.config.obtain('datalad.ssh.multiplex-connections'):
+            return
+
         from datalad.support.network import is_ssh
         # Note:
         #

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -951,7 +951,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         # So that we "share" control paths with git/git-annex
         if ssh_manager:
-            ssh_manager.assure_initialized()
+            ssh_manager.ensure_initialized()
 
         # note: we may also want to distinguish between a path to the worktree
         # and the actual repository

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -116,7 +116,7 @@ class BaseSSHConnection(object):
         if force_ip:
             self._ssh_open_args.append("-{}".format(force_ip))
         if identity_file:
-            self._ssh_open_args.extend(["-i", self._identity_file])
+            self._ssh_open_args.extend(["-i", identity_file])
 
         self._use_remote_annex_bundle = use_remote_annex_bundle
         # essential properties of the remote system

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -165,6 +165,8 @@ class BaseSSHConnection(object):
             log_online=not log_output
         )
 
+        lgr.debug("%s is used to run %s", self, ssh_cmd)
+
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True
         return self.runner.run(
@@ -522,7 +524,7 @@ class MultiplexSSHConnection(BaseSSHConnection):
         cmd = ["ssh"] + self._ssh_open_args + self._ssh_args + [self.sshri.as_str()]
 
         # start control master:
-        lgr.debug("Opening %s by calling %s" % (self, cmd))
+        lgr.debug("Opening %s by calling %s", self, cmd)
         proc = Popen(cmd)
         stdout, stderr = proc.communicate(input="\n")  # why the f.. this is necessary?
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -691,8 +691,7 @@ class MultiplexSSHManager(BaseSSHManager):
         """
         if self._socket_dir is not None:
             return
-        from ..config import ConfigManager
-        cfg = ConfigManager()
+        from datalad import cfg
         self._socket_dir = \
             Path(cfg.obtain('datalad.locations.cache')) / 'sockets'
         self._socket_dir.mkdir(exist_ok=True, parents=True)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -314,7 +314,7 @@ class BaseSSHConnection(object):
 
 
 @auto_repr
-class SingleProcessSSHConnection(BaseSSHConnection):
+class NoMultiplexSSHConnection(BaseSSHConnection):
     """Representation of an SSH connection.
 
     The connection is opened for execution of a single process, and closed
@@ -649,7 +649,7 @@ class NoMultiplexSSHManager(BaseSSHManager):
         """
         sshri, identity_file = self._prep_connection_args(url)
 
-        return SingleProcessSSHConnection(
+        return NoMultiplexSSHConnection(
             sshri,
             identity_file=identity_file,
             use_remote_annex_bundle=use_remote_annex_bundle,
@@ -804,7 +804,7 @@ if cfg.obtain('datalad.ssh.multiplex-connections'):
     SSHConnection = MultiplexSSHConnection
 else:
     SSHManager = NoMultiplexSSHManager
-    SSHConnection = SingleProcessSSHConnection
+    SSHConnection = NoMultiplexSSHConnection
 
 
 def _quote_filename_for_scp(name):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -568,7 +568,7 @@ class BaseSSHManager(object):
     """Interface for an SSHManager
     """
     def ensure_initialized(self):
-        """Assures that manager is initialized"""
+        """Ensures that manager is initialized"""
         pass
 
     assure_initialized = ensure_initialized
@@ -624,14 +624,8 @@ class BaseSSHManager(object):
 
 @auto_repr
 class NoMultiplexSSHManager(BaseSSHManager):
+    """Does not "manage" and just returns a new connection
     """
-    """
-
-    def __init__(self):
-        super().__init__()
-
-    def ensure_initialized(self):
-        pass
 
     def get_connection(self, url, use_remote_annex_bundle=True, force_ip=False):
         """Get a singleton, representing a shared ssh connection to `url`

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -623,6 +623,41 @@ class BaseSSHManager(object):
 
 
 @auto_repr
+class NoMultiplexSSHManager(BaseSSHManager):
+    """
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def ensure_initialized(self):
+        pass
+
+    def get_connection(self, url, use_remote_annex_bundle=True, force_ip=False):
+        """Get a singleton, representing a shared ssh connection to `url`
+
+        Parameters
+        ----------
+        url: str
+          ssh url
+        force_ip : {False, 4, 6}
+          Force the use of IPv4 or IPv6 addresses.
+
+        Returns
+        -------
+        SSHConnection
+        """
+        sshri, identity_file = self._prep_connection_args(url)
+
+        return SingleProcessSSHConnection(
+            sshri,
+            identity_file=identity_file,
+            use_remote_annex_bundle=use_remote_annex_bundle,
+            force_ip=force_ip,
+        )
+
+
+@auto_repr
 class MultiplexSSHManager(BaseSSHManager):
     """Keeps ssh connections to share. Serves singleton representation
     per connection.
@@ -641,14 +676,14 @@ class MultiplexSSHManager(BaseSSHManager):
         # to an empty list to fail if logic is violated
         self._prev_connections = None
         # and no explicit initialization in the constructor
-        # self.assure_initialized()
+        # self.ensure_initialized()
 
     @property
     def socket_dir(self):
         """Return socket_dir, and if was not defined before,
         and also pick up all previous connections (if any)
         """
-        self.assure_initialized()
+        self.ensure_initialized()
         return self._socket_dir
 
     def ensure_initialized(self):

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -797,8 +797,14 @@ class MultiplexSSHManager(BaseSSHManager):
 
 
 # retain backward compat with 0.13.4 and earlier
-SSHManager = MultiplexSSHManager
-SSHConnection = MultiplexSSHConnection
+# should be ok since cfg already defined by the time this one is imported
+from .. import cfg
+if cfg.obtain('datalad.ssh.multiplex-connections'):
+    SSHManager = MultiplexSSHManager
+    SSHConnection = MultiplexSSHConnection
+else:
+    SSHManager = NoMultiplexSSHManager
+    SSHConnection = SingleProcessSSHConnection
 
 
 def _quote_filename_for_scp(name):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -88,6 +88,7 @@ from datalad.tests.utils import (
     skip_if,
     skip_if_on_windows,
     skip_if_root,
+    skip_nomultiplex_ssh,
     skip_ssh,
     SkipTest,
     slow,
@@ -1118,7 +1119,7 @@ def test_annex_backends(path):
     eq_(repo.default_backends, ['MD5E'])
 
 
-@skip_ssh
+@skip_nomultiplex_ssh  # too much of "multiplex" testing
 @with_tempfile(mkdir=True)
 def test_annex_ssh(topdir):
     # On Xenial, this hangs with a recent git-annex. It bisects to git-annex's

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -49,6 +49,7 @@ from datalad.tests.utils import (
     ok_,
     skip_if_no_network,
     skip_if_on_windows,
+    skip_nomultiplex_ssh,
     skip_ssh,
     SkipTest,
     slow,
@@ -531,7 +532,7 @@ def _path2localsshurl(path):
 # broken,possibly due to a GitPy issue with windows sshurls
 # see https://github.com/datalad/datalad/pull/3638
 @skip_if_on_windows
-@skip_ssh
+@skip_nomultiplex_ssh
 @with_testrepos('.*basic.*', flavors=['local'])
 @with_tempfile
 def test_GitRepo_ssh_fetch(remote_path, repo_path):
@@ -565,7 +566,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 # broken,possibly due to a GitPy issue with windows sshurls
 # see https://github.com/datalad/datalad/pull/3638
 @skip_if_on_windows
-@skip_ssh
+@skip_nomultiplex_ssh
 @with_tempfile
 @with_tempfile
 def test_GitRepo_ssh_pull(remote_path, repo_path):
@@ -604,7 +605,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
 # broken,possibly due to a GitPy issue with windows sshurls
 # see https://github.com/datalad/datalad/pull/3638
 @skip_if_on_windows
-@skip_ssh
+@skip_nomultiplex_ssh
 @with_tempfile
 @with_tempfile
 def test_GitRepo_ssh_push(repo_path, remote_path):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -272,6 +272,25 @@ def skip_ssh(func):
     return  _wrap_skip_ssh
 
 
+def skip_nomultiplex_ssh(func):
+    """Skips SSH tests if default connection/manager does not support multiplexing
+
+    e.g. currently on windows or if set via datalad.ssh.multiplex-connections config variable
+    """
+
+    check_not_generatorfunction(func)
+    from ..support.sshconnector import MultiplexSSHManager, SSHManager
+
+    @wraps(func)
+    @attr('skip_nomultiplex_ssh')
+    @skip_ssh
+    def  _wrap_skip_nomultiplex_ssh(*args, **kwargs):
+        if SSHManager is not MultiplexSSHManager:
+            raise SkipTest("SSH without multiplexing is used")
+        return func(*args, **kwargs)
+    return  _wrap_skip_nomultiplex_ssh
+
+
 @optional_args
 def skip_v6_or_later(func, method='raise'):
     """Skip tests if v6 or later will be used as the default repo version.


### PR DESCRIPTION
A new switch `datalad.ssh.multiplex-connections` is introduced (off by default on windows).

A leaner manager and a different SSHConnection object are used in the non-multiplexed mode.

Manager and Connection classes have been RF'ed substantially.

Also streamlined the handling of SSH args. Instead of keeping individual ones, let the constructor(s) lump them into categories "for opening" and "for any call". This seems to be sufficient.

ATM this is targeting `maint` to have a chance to get SSH cloning working on windows prior 0.14.0 (e.g. #5031). but the necessary changes are substantial. So this will have to be more than a "fix".

TODO
- [x] Verify that solution is working on a regular win10 box, not just tests.
- [x] Consider added a travis run that performs SSH tests (only) without connection multiplexing to disentangle windows issues from SSH issues.
  Related https://github.com/datalad/datalad/issues/4166

Fixes #2575
Fixes #5031 
