### PR TITLE
BF: indi-s3 credentials

### DIFF
--- a/datalad/downloaders/configs/indi.cfg
+++ b/datalad/downloaders/configs/indi.cfg
@@ -2,7 +2,6 @@
 # see https://github.com/datalad/datalad/issues/322
 [provider:indi-s3]
 url_re = s3://fcp-indi($|/.*)
-credential = datalad-test-s3
 authentication_type = aws-s3
 
 


### PR DESCRIPTION
The `datalad-test-s3` credentials are configured as the default for indi-s3, which prevents the ability to connect anonymously. This change fixes #5038 

