### PR TITLE
Merge branch 'maint' (sshconnector conflicts)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,12 @@ matrix:
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=not
+    - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
   - python: 3.6
     env:
     - DATALAD_REPO_VERSION=6
     - NOSE_SELECTION_OP=""
+    - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for NOSE.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LANG=bg_BG.UTF-8

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -517,8 +517,7 @@ class CreateSibling(Interface):
             sibling (re-)configured (thus implies 'reconfigure').
             `replace` could lead to data loss, so use with care.  To minimize
             possibility of data loss, in interactive mode DataLad will ask for
-            confirmation, but it would just issue a warning and proceed in
-            non-interactive mode.
+            confirmation, but it would raise an exception in non-interactive mode.
             """,),
         inherit=inherit_opt,
         shared=Parameter(

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -100,12 +100,18 @@ class CreateSiblingGithub(Interface):
             constraints=EnsureStr()),
         existing=Parameter(
             args=("--existing",),
-            constraints=EnsureChoice('skip', 'error', 'reconfigure'),
+            constraints=EnsureChoice('skip', 'error', 'reconfigure', 'replace'),
             metavar='MODE',
             doc="""desired behavior when already existing or configured
-            siblings are discovered. 'skip': ignore; 'error': fail immediately;
-            'reconfigure': use the existing repository and reconfigure the
-            local dataset to use it as a sibling""",),
+            siblings are discovered. In this case, a dataset can be skipped
+            ('skip'), the sibling configuration be updated ('reconfigure'),
+            or process interrupts with error ('error'). DANGER ZONE: If 'replace'
+            is used, an existing github repository will be irreversibly removed,
+            re-initialized, and the sibling (re-)configured (thus implies 'reconfigure').
+            `replace` could lead to data loss, so use with care.  To minimize
+            possibility of data loss, in interactive mode DataLad will ask for
+            confirmation, but it would raise an exception in non-interactive mode.
+            """,),
         github_login=Parameter(
             args=('--github-login',),
             constraints=EnsureStr() | EnsureNone(),

--- a/datalad/downloaders/configs/indi.cfg
+++ b/datalad/downloaders/configs/indi.cfg
@@ -2,7 +2,6 @@
 # see https://github.com/datalad/datalad/issues/322
 [provider:indi-s3]
 url_re = s3://fcp-indi($|/.*)
-credential = datalad-test-s3
 authentication_type = aws-s3
 
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -21,6 +21,7 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureListOf
 from datalad.support.constraints import EnsureStr
+from datalad.utils import on_windows
 
 dirs = AppDirs("datalad", "datalad.org")
 
@@ -267,6 +268,13 @@ definitions = {
                'title': "If set, pass this file as ssh's -i option."}),
         'destination': 'global',
         'default': None,
+    },
+    'datalad.ssh.multiplex-connections': {
+        'ui': ('question', {
+               'title': "Whether to use a single shared connection for multiple SSH processes aiming at the same target."}),
+        'destination': 'global',
+        'default': not on_windows,
+        'type': EnsureBool(),
     },
     'datalad.annex.retry': {
         'ui': ('question',

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -418,6 +418,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         remote_name: str
         url: str
         """
+        if not self.config.obtain('datalad.ssh.multiplex-connections'):
+            return
+
         from datalad.support.network import is_ssh
         # Note:
         #

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -924,7 +924,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         # So that we "share" control paths with git/git-annex
         if ssh_manager:
-            ssh_manager.assure_initialized()
+            ssh_manager.ensure_initialized()
 
         # note: we may also want to distinguish between a path to the worktree
         # and the actual repository

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -79,11 +79,10 @@ def get_connection_hash(hostname, port='', username='', identity_file='',
 
 
 @auto_repr
-class SSHConnection(object):
-    """Representation of a (shared) ssh connection.
+class BaseSSHConnection(object):
+    """Representation of an SSH connection.
     """
-
-    def __init__(self, ctrl_path, sshri, identity_file=None,
+    def __init__(self, sshri, identity_file=None,
                  use_remote_annex_bundle=True, force_ip=False):
         """Create a connection handler
 
@@ -91,8 +90,6 @@ class SSHConnection(object):
 
         Parameters
         ----------
-        ctrl_path: str
-          path to SSH controlmaster
         sshri: SSHRI
           SSH resource identifier (contains all connection-relevant info),
           or another resource identifier that can be converted into an SSHRI.
@@ -114,59 +111,37 @@ class SSHConnection(object):
                 "connections: {}".format(sshri))
         self.sshri = SSHRI(**{k: v for k, v in sshri.fields.items()
                               if k in ('username', 'hostname', 'port')})
-        # on windows cmd args lists are always converted into a string using appropriate
-        # quoting rules, on other platforms args lists are passed directly and we need
-        # to take care of quoting ourselves
-        ctrlpath_arg = "ControlPath={}".format(ctrl_path if on_windows else sh_quote(str(ctrl_path)))
-        self._ssh_args = ["-o", ctrlpath_arg]
-        self.ctrl_path = Path(ctrl_path)
-        if self.sshri.port:
-            self._ssh_args += ['-p', '{}'.format(self.sshri.port)]
-
+        # arguments only used for opening a connection
+        self._ssh_open_args = []
+        # arguments for annex ssh invocation
+        self._ssh_args = []
+        self._ssh_open_args.extend(
+            ['-p', '{}'.format(self.sshri.port)] if self.sshri.port else [])
         if force_ip:
-            self._ssh_args.append("-{}".format(force_ip))
-        self._identity_file = identity_file
-        self._use_remote_annex_bundle = use_remote_annex_bundle
+            self._ssh_open_args.append("-{}".format(force_ip))
+        if identity_file:
+            self._ssh_open_args.extend(["-i", identity_file])
 
+        self._use_remote_annex_bundle = use_remote_annex_bundle
         # essential properties of the remote system
         self._remote_props = {}
-        self._opened_by_us = False
 
     def __call__(self, cmd, options=None, stdin=None, log_output=True):
-        """Executes a command on the remote.
+        raise NotImplementedError
 
-        It is the callers responsibility to properly quote commands
-        for remote execution (e.g. filename with spaces of other special
-        characters). Use the `sh_quote()` from the module for this purpose.
+    def open(self):
+        raise NotImplementedError
 
-        Parameters
-        ----------
-        cmd: str
-          command to run on the remote
-        options : list of str, optional
-          Additional options to pass to the `-o` flag of `ssh`. Note: Many
-          (probably most) of the available configuration options should not be
-          set here because they can critically change the properties of the
-          connection. This exists to allow options like SendEnv to be set.
+    def close(self):
+        raise NotImplementedError
 
-        Returns
-        -------
-        tuple of str
-          stdout, stderr of the command run.
-        """
+    @property
+    def runner(self):
+        if self._runner is None:
+            self._runner = WitlessRunner()
+        return self._runner
 
-        # XXX: check for open socket once
-        #      and provide roll back if fails to run and was not explicitly
-        #      checked first
-        # MIH: this would mean that we would have to distinguish failure
-        #      of a payload command from failure of SSH itself. SSH however,
-        #      only distinguishes success and failure of the entire operation
-        #      Increase in fragility from introspection makes a potential
-        #      performance benefit a questionable improvement.
-        # make sure we have an open connection, will test if action is needed
-        # by itself
-        self.open()
-
+    def _adjust_cmd_for_bundle_execution(self, cmd):
         # locate annex and set the bundled vs. system Git machinery in motion
         if self._use_remote_annex_bundle:
             remote_annex_installdir = self.get_annex_installdir()
@@ -175,17 +150,21 @@ class SSHConnection(object):
                 cmd = '{}; {}'.format(
                     'export "PATH={}:$PATH"'.format(remote_annex_installdir),
                     cmd)
+        return cmd
+
+    def _exec_ssh(self, ssh_cmd, cmd, options=None, stdin=None, log_output=True):
+        cmd = self._adjust_cmd_for_bundle_execution(cmd)
+
+        for opt in options or []:
+            ssh_cmd.extend(["-o", opt])
 
         # build SSH call, feed remote command as a single last argument
         # whatever it contains will go to the remote machine for execution
         # we cannot perform any sort of escaping, because it will limit
         # what we can do on the remote, e.g. concatenate commands with '&&'
-        ssh_cmd = ["ssh"] + self._ssh_args
-        for opt in options or []:
-            ssh_cmd.extend(["-o", opt])
+        ssh_cmd += [self.sshri.as_str()] + [cmd]
 
-        ssh_cmd += [self.sshri.as_str()] \
-            + [cmd]
+        lgr.debug("%s is used to run %s", self, ssh_cmd)
 
         # TODO: pass expect parameters from above?
         # Hard to explain to toplevel users ... So for now, just set True
@@ -194,123 +173,6 @@ class SSHConnection(object):
             protocol=StdOutErrCapture if log_output else NoCapture,
             stdin=stdin)
         return out['stdout'], out['stderr']
-
-    @property
-    def runner(self):
-        if self._runner is None:
-            self._runner = WitlessRunner()
-        return self._runner
-
-    def is_open(self):
-        if not self.ctrl_path.exists():
-            lgr.log(
-                5,
-                "Not opening %s for checking since %s does not exist",
-                self, self.ctrl_path
-            )
-            return False
-        # check whether controlmaster is still running:
-        cmd = ["ssh", "-O", "check"] + self._ssh_args + [self.sshri.as_str()]
-        lgr.debug("Checking %s by calling %s" % (self, cmd))
-        try:
-            # expect_stderr since ssh would announce to stderr
-            # "Master is running" and that is normal, not worthy warning about
-            # etc -- we are doing the check here for successful operation
-            with tempfile.TemporaryFile() as tempf:
-                self.runner.run(
-                    cmd,
-                    # do not leak output
-                    protocol=StdOutErrCapture,
-                    stdin=tempf)
-            res = True
-        except CommandError as e:
-            if e.code != 255:
-                # this is not a normal SSH error, whine ...
-                raise e
-            # SSH died and left socket behind, or server closed connection
-            self.close()
-            res = False
-        lgr.debug(
-            "Check of %s has %s",
-            self,
-            {True: 'succeeded', False: 'failed'}[res])
-        return res
-
-    def open(self):
-        """Opens the connection.
-
-        In other words: Creates the SSH ControlMaster to be used by this
-        connection, if it is not there already.
-
-        Returns
-        -------
-        bool
-          True when SSH reports success opening the connection, False when
-          a ControlMaster for an open connection already exists.
-
-        Raises
-        ------
-        ConnectionOpenFailedError
-          When starting the SSH ControlMaster process failed.
-        """
-        # the socket should vanish almost instantly when the connection closes
-        # sending explicit 'check' commands to the control master is expensive
-        # (needs tempfile to shield stdin, Runner overhead, etc...)
-        # as we do not use any advanced features (forwarding, stop[ing the
-        # master without exiting) it should be relatively safe to just perform
-        # the much cheaper check of an existing control path
-        if self.ctrl_path.exists():
-            return False
-
-        # set control options
-        ctrl_options = ["-fN",
-                        "-o", "ControlMaster=auto",
-                        "-o", "ControlPersist=15m"] + self._ssh_args
-        if self._identity_file:
-            ctrl_options.extend(["-i", self._identity_file])
-        # create ssh control master command
-        cmd = ["ssh"] + ctrl_options + [self.sshri.as_str()]
-
-        # start control master:
-        lgr.debug("Opening %s by calling %s" % (self, cmd))
-        proc = Popen(cmd)
-        stdout, stderr = proc.communicate(input="\n")  # why the f.. this is necessary?
-
-        # wait till the command exits, connection is conclusively
-        # open or not at this point
-        exit_code = proc.wait()
-
-        if exit_code != 0:
-            raise ConnectionOpenFailedError(
-                cmd,
-                'Failed to open SSH connection (could not start ControlMaster process)',
-                exit_code,
-                stdout,
-                stderr,
-            )
-        self._opened_by_us = True
-        return True
-
-    def close(self):
-        """Closes the connection.
-        """
-        if not self._opened_by_us:
-            lgr.debug("Not closing %s since was not opened by itself", self)
-            return
-        # stop controlmaster:
-        cmd = ["ssh", "-O", "stop"] + self._ssh_args + [self.sshri.as_str()]
-        lgr.debug("Closing %s by calling %s", self, cmd)
-        try:
-            self.runner.run(cmd, protocol=StdOutErrCapture)
-        except CommandError as e:
-            lgr.debug("Failed to run close command")
-            if self.ctrl_path.exists():
-                lgr.debug("Removing existing control path %s", self.ctrl_path)
-                # socket need to go in any case
-                self.ctrl_path.unlink()
-            if e.code != 255:
-                # not a "normal" SSH error
-                raise e
 
     def _get_scp_command_spec(self, recursive, preserve_attrs):
         """Internal helper for SCP interface methods"""
@@ -454,7 +316,349 @@ class SSHConnection(object):
 
 
 @auto_repr
-class SSHManager(object):
+class NoMultiplexSSHConnection(BaseSSHConnection):
+    """Representation of an SSH connection.
+
+    The connection is opened for execution of a single process, and closed
+    as soon as the process end.
+    """
+    def __init__(self, sshri, **kwargs):
+        """Create a connection handler
+
+        The actual opening of the connection is performed on-demand.
+
+        Parameters
+        ----------
+        sshri: SSHRI
+          SSH resource identifier (contains all connection-relevant info),
+          or another resource identifier that can be converted into an SSHRI.
+        **kwargs
+          Pass on to BaseSSHConnection
+        """
+        super().__init__(sshri, **kwargs)
+        self._ssh_open_args += [
+            # we presently do not support any interactive authentication
+            # at the time of process execution
+            '-o', 'PasswordAuthentication=no',
+            '-o', 'KbdInteractiveAuthentication=no',
+        ]
+
+    def __call__(self, cmd, options=None, stdin=None, log_output=True):
+        """Executes a command on the remote.
+
+        It is the callers responsibility to properly quote commands
+        for remote execution (e.g. filename with spaces of other special
+        characters). Use the `sh_quote()` from the module for this purpose.
+
+        Parameters
+        ----------
+        cmd: str
+          command to run on the remote
+        options : list of str, optional
+          Additional options to pass to the `-o` flag of `ssh`. Note: Many
+          (probably most) of the available configuration options should not be
+          set here because they can critically change the properties of the
+          connection. This exists to allow options like SendEnv to be set.
+
+        Returns
+        -------
+        tuple of str
+          stdout, stderr of the command run.
+        """
+        # there is no dedicated "open" step, put all args together
+        ssh_cmd = ["ssh"] + self._ssh_open_args + self._ssh_args
+        return self._exec_ssh(
+            ssh_cmd,
+            cmd,
+            options=options,
+            stdin=stdin,
+            log_output=log_output)
+
+    def is_open(self):
+        return False
+
+    def open(self):
+        return False
+
+    def close(self):
+        # we perform blocking execution, we should not return from __call__ until
+        # the connection is already closed
+        pass
+
+
+@auto_repr
+class MultiplexSSHConnection(BaseSSHConnection):
+    """Representation of a (shared) ssh connection.
+    """
+    def __init__(self, ctrl_path, sshri, **kwargs):
+        """Create a connection handler
+
+        The actual opening of the connection is performed on-demand.
+
+        Parameters
+        ----------
+        ctrl_path: str
+          path to SSH controlmaster
+        sshri: SSHRI
+          SSH resource identifier (contains all connection-relevant info),
+          or another resource identifier that can be converted into an SSHRI.
+        **kwargs
+          Pass on to BaseSSHConnection
+        """
+        super().__init__(sshri, **kwargs)
+
+        # on windows cmd args lists are always converted into a string using appropriate
+        # quoting rules, on other platforms args lists are passed directly and we need
+        # to take care of quoting ourselves
+        ctrlpath_arg = "ControlPath={}".format(ctrl_path if on_windows else sh_quote(str(ctrl_path)))
+        self._ssh_args += ["-o", ctrlpath_arg]
+        self._ssh_open_args += [
+            "-fN",
+            "-o", "ControlMaster=auto",
+            "-o", "ControlPersist=15m",
+        ]
+        self.ctrl_path = Path(ctrl_path)
+        self._opened_by_us = False
+
+    def __call__(self, cmd, options=None, stdin=None, log_output=True):
+        """Executes a command on the remote.
+
+        It is the callers responsibility to properly quote commands
+        for remote execution (e.g. filename with spaces of other special
+        characters). Use the `sh_quote()` from the module for this purpose.
+
+        Parameters
+        ----------
+        cmd: str
+          command to run on the remote
+        options : list of str, optional
+          Additional options to pass to the `-o` flag of `ssh`. Note: Many
+          (probably most) of the available configuration options should not be
+          set here because they can critically change the properties of the
+          connection. This exists to allow options like SendEnv to be set.
+
+        Returns
+        -------
+        tuple of str
+          stdout, stderr of the command run.
+        """
+
+        # XXX: check for open socket once
+        #      and provide roll back if fails to run and was not explicitly
+        #      checked first
+        # MIH: this would mean that we would have to distinguish failure
+        #      of a payload command from failure of SSH itself. SSH however,
+        #      only distinguishes success and failure of the entire operation
+        #      Increase in fragility from introspection makes a potential
+        #      performance benefit a questionable improvement.
+        # make sure we have an open connection, will test if action is needed
+        # by itself
+        self.open()
+
+        ssh_cmd = ["ssh"] + self._ssh_args
+        return self._exec_ssh(
+            ssh_cmd,
+            cmd,
+            options=options,
+            stdin=stdin,
+            log_output=log_output)
+
+    def is_open(self):
+        if not self.ctrl_path.exists():
+            lgr.log(
+                5,
+                "Not opening %s for checking since %s does not exist",
+                self, self.ctrl_path
+            )
+            return False
+        # check whether controlmaster is still running:
+        cmd = ["ssh", "-O", "check"] + self._ssh_args + [self.sshri.as_str()]
+        lgr.debug("Checking %s by calling %s" % (self, cmd))
+        try:
+            # expect_stderr since ssh would announce to stderr
+            # "Master is running" and that is normal, not worthy warning about
+            # etc -- we are doing the check here for successful operation
+            with tempfile.TemporaryFile() as tempf:
+                self.runner.run(
+                    cmd,
+                    # do not leak output
+                    protocol=StdOutErrCapture,
+                    stdin=tempf)
+            res = True
+        except CommandError as e:
+            if e.code != 255:
+                # this is not a normal SSH error, whine ...
+                raise e
+            # SSH died and left socket behind, or server closed connection
+            self.close()
+            res = False
+        lgr.debug(
+            "Check of %s has %s",
+            self,
+            {True: 'succeeded', False: 'failed'}[res])
+        return res
+
+    def open(self):
+        """Opens the connection.
+
+        In other words: Creates the SSH ControlMaster to be used by this
+        connection, if it is not there already.
+
+        Returns
+        -------
+        bool
+          True when SSH reports success opening the connection, False when
+          a ControlMaster for an open connection already exists.
+
+        Raises
+        ------
+        ConnectionOpenFailedError
+          When starting the SSH ControlMaster process failed.
+        """
+        # the socket should vanish almost instantly when the connection closes
+        # sending explicit 'check' commands to the control master is expensive
+        # (needs tempfile to shield stdin, Runner overhead, etc...)
+        # as we do not use any advanced features (forwarding, stop[ing the
+        # master without exiting) it should be relatively safe to just perform
+        # the much cheaper check of an existing control path
+        if self.ctrl_path.exists():
+            return False
+
+        # create ssh control master command
+        cmd = ["ssh"] + self._ssh_open_args + self._ssh_args + [self.sshri.as_str()]
+
+        # start control master:
+        lgr.debug("Opening %s by calling %s", self, cmd)
+        proc = Popen(cmd)
+        stdout, stderr = proc.communicate(input="\n")  # why the f.. this is necessary?
+
+        # wait till the command exits, connection is conclusively
+        # open or not at this point
+        exit_code = proc.wait()
+
+        if exit_code != 0:
+            raise ConnectionOpenFailedError(
+                cmd,
+                'Failed to open SSH connection (could not start ControlMaster process)',
+                exit_code,
+                stdout,
+                stderr,
+            )
+        self._opened_by_us = True
+        return True
+
+    def close(self):
+        """Closes the connection.
+        """
+        if not self._opened_by_us:
+            lgr.debug("Not closing %s since was not opened by itself", self)
+            return
+        # stop controlmaster:
+        cmd = ["ssh", "-O", "stop"] + self._ssh_args + [self.sshri.as_str()]
+        lgr.debug("Closing %s by calling %s", self, cmd)
+        try:
+            self.runner.run(cmd, protocol=StdOutErrCapture)
+        except CommandError as e:
+            lgr.debug("Failed to run close command")
+            if self.ctrl_path.exists():
+                lgr.debug("Removing existing control path %s", self.ctrl_path)
+                # socket need to go in any case
+                self.ctrl_path.unlink()
+            if e.code != 255:
+                # not a "normal" SSH error
+                raise e
+
+
+@auto_repr
+class BaseSSHManager(object):
+    """Interface for an SSHManager
+    """
+    def ensure_initialized(self):
+        """Ensures that manager is initialized"""
+        pass
+
+    assure_initialized = ensure_initialized
+
+    def get_connection(self, url, use_remote_annex_bundle=True, force_ip=False):
+        """Get an SSH connection handler
+
+        Parameters
+        ----------
+        url: str
+          ssh url
+        force_ip : {False, 4, 6}
+          Force the use of IPv4 or IPv6 addresses.
+
+        Returns
+        -------
+        BaseSSHConnection
+        """
+        raise NotImplementedError
+
+    def _prep_connection_args(self, url):
+        # parse url:
+        from datalad.support.network import RI, is_ssh
+        if isinstance(url, RI):
+            sshri = url
+        else:
+            if ':' not in url and '/' not in url:
+                # it is just a hostname
+                lgr.debug("Assuming %r is just a hostname for ssh connection",
+                          url)
+                url += ':'
+            sshri = RI(url)
+
+        if not is_ssh(sshri):
+            raise ValueError("Unsupported SSH URL: '{0}', use "
+                             "ssh://host/path or host:path syntax".format(url))
+
+        from datalad import cfg
+        identity_file = cfg.get("datalad.ssh.identityfile")
+        return sshri, identity_file
+
+    def close(self, allow_fail=True):
+        """Closes all connections, known to this instance.
+
+        Parameters
+        ----------
+        allow_fail: bool, optional
+          If True, swallow exceptions which might be thrown during
+          connection.close, and just log them at DEBUG level
+        """
+        pass
+
+
+@auto_repr
+class NoMultiplexSSHManager(BaseSSHManager):
+    """Does not "manage" and just returns a new connection
+    """
+
+    def get_connection(self, url, use_remote_annex_bundle=True, force_ip=False):
+        """Get a singleton, representing a shared ssh connection to `url`
+
+        Parameters
+        ----------
+        url: str
+          ssh url
+        force_ip : {False, 4, 6}
+          Force the use of IPv4 or IPv6 addresses.
+
+        Returns
+        -------
+        SSHConnection
+        """
+        sshri, identity_file = self._prep_connection_args(url)
+
+        return NoMultiplexSSHConnection(
+            sshri,
+            identity_file=identity_file,
+            use_remote_annex_bundle=use_remote_annex_bundle,
+            force_ip=force_ip,
+        )
+
+
+@auto_repr
+class MultiplexSSHManager(BaseSSHManager):
     """Keeps ssh connections to share. Serves singleton representation
     per connection.
 
@@ -464,6 +668,7 @@ class SSHManager(object):
     """
 
     def __init__(self):
+        super().__init__()
         self._socket_dir = None
         self._connections = dict()
         # Initialization of prev_connections is happening during initial
@@ -471,23 +676,22 @@ class SSHManager(object):
         # to an empty list to fail if logic is violated
         self._prev_connections = None
         # and no explicit initialization in the constructor
-        # self.assure_initialized()
+        # self.ensure_initialized()
 
     @property
     def socket_dir(self):
         """Return socket_dir, and if was not defined before,
         and also pick up all previous connections (if any)
         """
-        self.assure_initialized()
+        self.ensure_initialized()
         return self._socket_dir
 
-    def assure_initialized(self):
+    def ensure_initialized(self):
         """Assures that manager is initialized - knows socket_dir, previous connections
         """
         if self._socket_dir is not None:
             return
-        from ..config import ConfigManager
-        cfg = ConfigManager()
+        from datalad import cfg
         self._socket_dir = \
             Path(cfg.obtain('datalad.locations.cache')) / 'sockets'
         self._socket_dir.mkdir(exist_ok=True, parents=True)
@@ -517,6 +721,7 @@ class SSHManager(object):
         lgr.log(5,
                 "Found %d previous connections",
                 len(self._prev_connections))
+    assure_initialized = ensure_initialized
 
     def get_connection(self, url, use_remote_annex_bundle=True, force_ip=False):
         """Get a singleton, representing a shared ssh connection to `url`
@@ -532,24 +737,7 @@ class SSHManager(object):
         -------
         SSHConnection
         """
-        # parse url:
-        from datalad.support.network import RI, is_ssh
-        if isinstance(url, RI):
-            sshri = url
-        else:
-            if ':' not in url and '/' not in url:
-                # it is just a hostname
-                lgr.debug("Assuming %r is just a hostname for ssh connection",
-                          url)
-                url += ':'
-            sshri = RI(url)
-
-        if not is_ssh(sshri):
-            raise ValueError("Unsupported SSH URL: '{0}', use "
-                             "ssh://host/path or host:path syntax".format(url))
-
-        from datalad import cfg
-        identity_file = cfg.get("datalad.ssh.identityfile")
+        sshri, identity_file = self._prep_connection_args(url)
 
         conhash = get_connection_hash(
             sshri.hostname,
@@ -566,7 +754,7 @@ class SSHManager(object):
         if ctrl_path in self._connections:
             return self._connections[ctrl_path]
         else:
-            c = SSHConnection(
+            c = MultiplexSSHConnection(
                 ctrl_path, sshri, identity_file=identity_file,
                 use_remote_annex_bundle=use_remote_annex_bundle,
                 force_ip=force_ip)
@@ -606,6 +794,17 @@ class SSHManager(object):
                         lgr.debug("Failed to close a connection: "
                                   "%s", exc_str(exc))
             self._connections = dict()
+
+
+# retain backward compat with 0.13.4 and earlier
+# should be ok since cfg already defined by the time this one is imported
+from .. import cfg
+if cfg.obtain('datalad.ssh.multiplex-connections'):
+    SSHManager = MultiplexSSHManager
+    SSHConnection = MultiplexSSHConnection
+else:
+    SSHManager = NoMultiplexSSHManager
+    SSHConnection = NoMultiplexSSHConnection
 
 
 def _quote_filename_for_scp(name):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -87,6 +87,7 @@ from datalad.tests.utils import (
     skip_if,
     skip_if_on_windows,
     skip_if_root,
+    skip_nomultiplex_ssh,
     skip_ssh,
     SkipTest,
     slow,
@@ -1116,7 +1117,7 @@ def test_annex_backends(path):
     eq_(repo.default_backends, ['MD5E'])
 
 
-@skip_ssh
+@skip_nomultiplex_ssh  # too much of "multiplex" testing
 @with_tempfile(mkdir=True)
 def test_annex_ssh(topdir):
     # On Xenial, this hangs with a recent git-annex. It bisects to git-annex's

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -55,6 +55,7 @@ from datalad.tests.utils import (
     ok_,
     skip_if_no_network,
     skip_if_on_windows,
+    skip_nomultiplex_ssh,
     skip_ssh,
     SkipTest,
     slow,
@@ -537,7 +538,7 @@ def _path2localsshurl(path):
 # broken,possibly due to a GitPy issue with windows sshurls
 # see https://github.com/datalad/datalad/pull/3638
 @skip_if_on_windows
-@skip_ssh
+@skip_nomultiplex_ssh
 @with_testrepos('.*basic.*', flavors=['local'])
 @with_tempfile
 def test_GitRepo_ssh_fetch(remote_path, repo_path):
@@ -571,7 +572,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 # broken,possibly due to a GitPy issue with windows sshurls
 # see https://github.com/datalad/datalad/pull/3638
 @skip_if_on_windows
-@skip_ssh
+@skip_nomultiplex_ssh
 @with_tempfile
 @with_tempfile
 def test_GitRepo_ssh_pull(remote_path, repo_path):
@@ -610,7 +611,7 @@ def test_GitRepo_ssh_pull(remote_path, repo_path):
 # broken,possibly due to a GitPy issue with windows sshurls
 # see https://github.com/datalad/datalad/pull/3638
 @skip_if_on_windows
-@skip_ssh
+@skip_nomultiplex_ssh
 @with_tempfile
 @with_tempfile
 def test_GitRepo_ssh_push(repo_path, remote_path):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -275,6 +275,25 @@ def skip_ssh(func):
     return  _wrap_skip_ssh
 
 
+def skip_nomultiplex_ssh(func):
+    """Skips SSH tests if default connection/manager does not support multiplexing
+
+    e.g. currently on windows or if set via datalad.ssh.multiplex-connections config variable
+    """
+
+    check_not_generatorfunction(func)
+    from ..support.sshconnector import MultiplexSSHManager, SSHManager
+
+    @wraps(func)
+    @attr('skip_nomultiplex_ssh')
+    @skip_ssh
+    def  _wrap_skip_nomultiplex_ssh(*args, **kwargs):
+        if SSHManager is not MultiplexSSHManager:
+            raise SkipTest("SSH without multiplexing is used")
+        return func(*args, **kwargs)
+    return  _wrap_skip_nomultiplex_ssh
+
+
 @optional_args
 def skip_v6_or_later(func, method='raise'):
     """Skip tests if v6 or later will be used as the default repo version.

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -81,7 +81,7 @@ class ConsoleLog(object):
                      noninteractive_level=5)
 
     def error(self, error):
-        self.out.write("ERROR: %s\n" % error)
+        self.message("ERROR: %s" % error)
 
     def get_progressbar(self, *args, **kwargs):
         """Return a progressbar.  See e.g. `tqdmProgressBar` about the interface


### PR DESCRIPTION
The non-trivial conflicts are between master's a575224599 (RF: SSH
connector code uses WitlessRunner instead of Runner, 2020-07-16) and
maint's c728888112 (Merge pull request #5042 from
mih/enh-sshnomultiplex, 2020-10-16).  Resolve these by taking the
changes from c728888112 and then reintegrating the
Runner->WitlessRunner changes.

---

I think I'll be satisfied that the conflict resolutions are okay after a successful test run, but of course anyone double checking them would be appreciated.
