### PR TITLE
save: Fix handling of explicit paths for nested new subdatasets

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -244,14 +244,22 @@ class Save(Interface):
             for superds, subdss in edges.items():
                 superds_status = paths_by_ds.get(superds, {})
                 for subds in subdss:
-                    # TODO actually start from an entry that may already
-                    # exist in the status record
-                    superds_status[ut.Path(subds)] = dict(
-                        # shot from the hip, some status config
-                        # to trigger this specific super/sub
-                        # relation to be saved
-                        state='untracked',
-                        type='dataset')
+                    subds_path = ut.Path(subds)
+                    sub_status = superds_status.get(subds_path, {})
+                    if not (sub_status.get("state") == "untracked" and
+                            sub_status.get("type") == "directory"):
+                        # ^ If the subdataset is already untracked directory,
+                        # let it go through the normal "add submodules"
+                        # handling of repo.save_().
+
+                        # TODO actually start from an entry that may already
+                        # exist in the status record
+                        superds_status[subds_path] = dict(
+                            # shot from the hip, some status config
+                            # to trigger this specific super/sub
+                            # relation to be saved
+                            state='untracked',
+                            type='dataset')
                 paths_by_ds[superds] = superds_status
 
         # TODO parallelize, whenever we have multiple subdataset of a single

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -834,3 +834,14 @@ def test_save_dotfiles():
     for git in [True, False, None]:
         for save_path in [None, "nodot-subdir"]:
             yield check_save_dotfiles, git, save_path
+
+
+@with_tempfile
+def test_save_nested_subs_explicit_paths(path):
+    ds = Dataset(path).create()
+    spaths = [Path("s1"), Path("s1", "s2"), Path("s1", "s2", "s3")]
+    for spath in spaths:
+        Dataset(ds.pathobj / spath).create()
+    ds.save(path=spaths)
+    eq_(set(ds.subdatasets(recursive=True, result_xfm="relpaths")),
+        set(map(str, spaths)))


### PR DESCRIPTION
After collecting the status information, save() adds a status record
for any subdatasets between the reference dataset and the target
dataset.  Here's an example that shows when these extra records are
needed:

    $ datalad create
    $ datalad create -d. a
    $ datalad create -d. a/b

During the last step, create() calls save() with "a/b" as the path.
After save() collects the status() information in paths_by_ds, the
value looks like this:

    {'{top}/a': {PosixPath('{top}/a/b'): {'state': 'untracked',
                                          'type': 'directory'}}}

Before calling GitRepo.save_(), save() adds another record for "a":

    {'{top}': {PosixPath('{top}/a'): {'state': 'untracked',
                                      'type': 'dataset'}},
     '{top}/a': {PosixPath('{top}/a/b'): {'state': 'untracked',
                                          'type': 'directory'}}}

If it didn't tack on the first entry, "a" would be left modified in
the top-level dataset.

This handling, however, interferes with explicitly adding new nested
subdatasets, as in the example from gh-5021:

    $ datalad create
    $ datalad create a
    $ datalad create a/b
    $ datalad save -d. a a/b

For the last step, the status information is originally

    {'{top}': {PosixPath('{top}/a'): {'state': 'untracked',
                                      'type': 'directory'}},
     '{top}/a': {PosixPath('{top}/a/b'): {'state': 'untracked',
                                          'type': 'directory'}}}

The handling described above results in save() effectively switching
the type of "a" to "dataset":

    {'{top}': {PosixPath('{top}/a'): {'state': 'untracked',
                                      'type': 'dataset'}},
     '{top}/a': {PosixPath('{top}/a/b'): {'state': 'untracked',
                                          'type': 'directory'}}}

When GitRepo.save_() receives status information, it doesn't properly
register the submodule: it feeds the dataset to `git add` rather than
to `git submodule add` because, as far as it can tell, "a" is an
existing submodule.

To avoid this issue, stop save() from overriding the status
information for records that have a type of "directory" and status of
"untracked", letting GitRepo.save_() treat these paths in the same way
as other unregistered submodules.

Note that this fix is only relevant when the intermediate subdatasets
are explicitly passed.  For example, dropping "a" from the last
command above (i.e. `datalad save -d. a/b`) would still result in the
state reported in gh-5021.  One way to address that would be to update
GitRepo.save_() to send "type=dataset state=untracked" records down
the same code path as "type=directory state=untracked", but hold off
on that because in some cases it would cost additional (and
unnecessary) get_content_info() calls.

Fixes #5021.
