### PR TITLE
BF: push - do not call localsync unless annex

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -632,7 +632,11 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
                 "Sync local annex branch from pushurl after remote "
                 'availability update.')
         repo.call_git(fetch_cmd)
-        repo.localsync(target)
+        # If no CommandError was raised, it means that remote has git-annex
+        # but local repo might not be an annex yet. Since there is nothing to "sync"
+        # from us, we just skip localsync without mutating repo into an AnnexRepo
+        if is_annex_repo:
+            repo.localsync(target)
     except CommandError as e:
         # it is OK if the remote doesn't have a git-annex branch yet
         # (e.g. fresh repo)

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -378,9 +378,7 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
-          done_fetch=None, got_path_arg=False):
-    if not done_fetch:
-        done_fetch = set()
+          got_path_arg=False):
     force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
@@ -546,8 +544,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     # we know what to push and where, now dependency processing first
     for r in publish_depends:
         # simply make a call to this function again, all the same, but
-        # target is different, pass done_fetch to avoid duplicate
-        # and expensive calls to git-fetch
+        # target is different
         yield from _push(
             dspath,
             content,
@@ -558,7 +555,6 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             jobs,
             res_kwargs.copy(),
             pbars,
-            done_fetch=None,
             got_path_arg=got_path_arg,
         )
 

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -245,9 +245,9 @@ def test_push():
 @with_tempfile
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-@with_tempfile(mkdir=True)
-@with_tempfile(mkdir=True)
-@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True, suffix='sub')
+@with_tempfile(mkdir=True, suffix='subnoannex')
+@with_tempfile(mkdir=True, suffix='subsub')
 def test_push_recursive(
         origin_path, src_path, dst_top, dst_sub, dst_subnoannex, dst_subsub):
     # dataset with two submodules and one subsubmodule
@@ -372,6 +372,14 @@ def test_push_recursive(
         assert_in_results(
             res, status='notneeded', type='dataset', path=d.path,
             refspec=DEFAULT_REFSPEC)
+
+    # if noannex target gets some annex, we still should not fail to push
+    target_subnoannex.call_git(['annex', 'init'])
+    # just to ensure that we do need something to push
+    (subnoannex.pathobj / "newfile").write_text("content")
+    subnoannex.save()
+    res = subnoannex.push(to="target")
+    assert_in_results(res, status='ok', type='dataset')
 
 
 @slow  # 12sec on Yarik's laptop


### PR DESCRIPTION
Discovered by chance while troubleshooting failing
https://github.com/datalad/datalad/pull/5022
which due to "out of order" completion of get swapped datasets between
noannex and annexed.  Was fund to debug (so added descriptive temp dirs suffixes) .... heh ;)

While at it spotted unused kwarg in `_push`.  Removed - no need to keep and must not break anything
