### PR TITLE
test_annex_ssh: Extend skip to older git-annex versions

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1129,6 +1129,12 @@ def test_annex_ssh(topdir):
     if external_versions['cmd:system-ssh'] < '7.4' and \
        '7.20191230' < external_versions['cmd:annex'] <= '8.20200720.1':
         raise SkipTest("Test known to hang")
+    # And, since the switch to the Docker SSH target, our cron build with
+    # 7.20190708 stalls. 7.20190819 is the first known good version, but do a
+    # minimal skip up until the next release because we don't know that
+    # 7.20190730 stalls.
+    if external_versions['cmd:annex'] < '7.20190730':
+        raise SkipTest("Test known to hang")
 
     topdir = Path(topdir)
     rm1 = AnnexRepo(topdir / "remote1", create=True)


### PR DESCRIPTION
test_annex_ssh() does not stall with the git-annex version used in
regular Travis jobs (7.20190819).  test_annex_ssh(), among other
SSH-related tests, used to stall with newer git-annex versions.  This
appeared to have something to do with the old SSH version on Xenial,
and a workaround was applied on git-annex's end [1].  test_annex_ssh()
skips from 7.20191230 to 8.20200720.1 to avoid this stall.

However, test_annex_ssh() also stalls in the cron job that tests
against git-annex 7.20190708 [2].  The build succeeds if
test_annex_ssh() is skipped [3].  It looks like the stall started with
the switch to the Docker SSH target [4].

I cannot trigger this locally on a Debian Buster system with the
Docker SSH target, so perhaps there's an interaction with the Xenial
environment.  Until someone figures out what's going on (or more
likely the minimum git-annex version is bumped), skip test_annex_ssh()
if the version is before 7.20190730, the first release after
7.20190708.

[1] https://git-annex.branchable.com/bugs/SSH-based_git-annex-init_hang_on_older_systems___40__Xenial__44___Jessie__41__/
[2] https://travis-ci.org/github/datalad/datalad/builds/737211842
[3] https://travis-ci.org/github/datalad/datalad/builds/737503675
[4] before ssh switch:
    https://travis-ci.org/github/datalad/datalad/jobs/710531493
    after ssh switch:
    https://travis-ci.org/github/datalad/datalad/jobs/712705841

Closes #5050.

---

- [X] Drop temporary tip commit that tests deb-url cron build.
  https://travis-ci.org/github/datalad/datalad/builds/737529150