### PR TITLE
OPT: get_content_info: Speed up ls-files by dropping unneeded flags

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3436,13 +3436,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # --exclude-standard will make sure to honor and standard way
             # git can be instructed to ignore content, and will prevent
             # crap from contaminating untracked file reports
-            cmd = ['ls-files',
-                   '--stage', '-z', '-d', '-m', '--exclude-standard']
+            cmd = ['ls-files', '--stage', '-z']
             # untracked report mode, using labels from `git diff` option style
             if untracked == 'all':
-                cmd.append('-o')
+                cmd += ['--exclude-standard', '-o']
             elif untracked == 'normal':
-                cmd += ['-o', '--directory', '--no-empty-directory']
+                cmd += ['--exclude-standard', '-o', '--directory', '--no-empty-directory']
             elif untracked == 'no':
                 pass
             else:


### PR DESCRIPTION
GitRepo.get_content_info() calls ls-files with --modified and
--deleted.  When combined with --stage, those flags don't add any
information, just duplicate lines in the output.  In addition to
redundant processing, these flags result in a slower ls-files call
because the working tree needs to be considered.  Without --modified
and --deleted, the execution time of `ls-files --stage` is comparable
to that of `ls-tree -r`.

    $ git clone https://datasets.datalad.org/openneuro/.git .
    $ git version
    git version 2.29.0.311.g38ddec7408
    $ git status # warm cache

    $ multitime -n 5 -q git ls-files --stage
    ===> multitime results
    1: -q git ls-files --stage
                Mean        Std.Dev.    Min         Median      Max
    real        0.005       0.001       0.003       0.006       0.007
    user        0.001       0.002       0.000       0.000       0.005
    sys         0.004       0.002       0.000       0.006       0.006

    $ multitime -n 5 -q git ls-tree --long --full-tree -r HEAD
    ===> multitime results
    1: -q git ls-tree --long --full-tree -r HEAD
                Mean        Std.Dev.    Min         Median      Max
    real        0.007       0.002       0.004       0.007       0.010
    user        0.003       0.003       0.000       0.003       0.007
    sys         0.004       0.002       0.000       0.004       0.007

    $ multitime -n 5 -q git ls-files --stage --modified --deleted
    ===> multitime results
    1: -q git ls-files --stage --modified --deleted
                Mean        Std.Dev.    Min         Median      Max
    real        0.025       0.009       0.021       0.021       0.043
    user        0.017       0.007       0.010       0.016       0.031
    sys         0.008       0.003       0.004       0.008       0.012

Speed up get_content_info's ls-files call by dropping --modified and
--deleted.  While adjusting the ls-files arguments, also avoid
unnecessarily adding --exclude-standard when --others isn't specified.

Note that gh-5061 proposed making get_submodules_() pass ref="HEAD"
when it calls get_content_info() in order to trigger the faster
ls-tree code path, but, with the changes here, there's no notable
difference, at least in the openneuro clone above:

    $ python -m timeit -n 10 \
           -s "from datalad.support.gitrepo import GitRepo" \
           -s "gr = GitRepo('.')" \
           "list(gr.get_submodules_())"

    on master (f66dce7e5e):  10 loops, best of 5: 40.5 msec per loop
                   this PR:  10 loops, best of 5: 24.8 msec per loop
           with ref="HEAD":  10 loops, best of 5: 25.9 msec per loop
