### PR TITLE
RF: AnnexRepo.get_file_key() as a compat-frontend for get_content_annexinfo()

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2732,10 +2732,13 @@ class AnnexRepo(GitRepo, RepoInterface):
             For each file in input list indicates the used backend by a str
             like "SHA256E" or "MD5".
         """
-
         return [
-            self.get_key_backend(self.get_file_key(f))
-            for f in files
+            r.get('backend')
+            for r in self.get_content_annexinfo(
+                # we provide records for files to inspect. this bypasses
+                # any internal git-calls to acquire status info
+                init={self.pathobj / fn: {} for fn in files},
+                eval_availability=False).values()
         ]
 
     @property

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -234,8 +234,7 @@ def test_AnnexRepo_get_file_key(src, annex_path):
     # should raise Exception; also test for polymorphism
     assert_raises(IOError, ar.get_file_key, "test.dat")
     assert_raises(FileNotInAnnexError, ar.get_file_key, "test.dat")
-    # exception no longer raised, would be expensive to query in addition
-    #assert_raises(FileInGitError, ar.get_file_key, "test.dat")
+    assert_raises(FileInGitError, ar.get_file_key, "test.dat")
 
     # filenotpresent.wtf doesn't even exist
     assert_raises(IOError, ar.get_file_key, "filenotpresent.wtf")

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -210,8 +210,6 @@ def test_AnnexRepo_is_direct_mode_gitrepo(path):
     assert_false(dm)
 
 
-# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789014#step:8:473
-@known_failure_windows
 @assert_cwd_unchanged
 @with_testrepos('.*annex.*', flavors=local_testrepo_flavors)
 @with_tempfile
@@ -236,7 +234,8 @@ def test_AnnexRepo_get_file_key(src, annex_path):
     # should raise Exception; also test for polymorphism
     assert_raises(IOError, ar.get_file_key, "test.dat")
     assert_raises(FileNotInAnnexError, ar.get_file_key, "test.dat")
-    assert_raises(FileInGitError, ar.get_file_key, "test.dat")
+    # exception no longer raised, would be expensive to query in addition
+    #assert_raises(FileInGitError, ar.get_file_key, "test.dat")
 
     # filenotpresent.wtf doesn't even exist
     assert_raises(IOError, ar.get_file_key, "filenotpresent.wtf")


### PR DESCRIPTION
The previous implementation did not work on windows, and the desired
information is readily provided by more commonly used methods.

Fixes gh-5068
