### PR TITLE
OPT+BF: annotate read_only git/annex invocations, thread lock read-write git/annex and git-config invocations

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1621,8 +1621,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # reports a type change as modified.
         modified = [
             f for f in self.call_git_items_(
-                ['diff-files', '--name-only', '-z'], sep='\0',
-                read_only=True)
+                ['diff', '--name-only', '-z'], sep='\0')
             if f] if pointers else []
         annex_res = fn(files, normalize_paths=False, batch=batch)
         return [bool(annex_res.get(f) and

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -859,7 +859,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         srs = {}
         try:
             for line in self.call_git_items_(
-                    ['cat-file', 'blob', 'git-annex:remote.log']):
+                    ['cat-file', 'blob', 'git-annex:remote.log'],
+                    check_fake_dates=False):
                 # be precise and split by spaces
                 fields = line.split(' ')
                 # special remote UUID
@@ -1620,7 +1621,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         # reports a type change as modified.
         modified = [
             f for f in self.call_git_items_(
-                ['diff', '--name-only', '-z'], sep='\0')
+                ['diff', '--name-only', '-z'], sep='\0',
+                check_fake_dates=False)
             if f] if pointers else []
         annex_res = fn(files, normalize_paths=False, batch=batch)
         return [bool(annex_res.get(f) and

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1621,7 +1621,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # reports a type change as modified.
         modified = [
             f for f in self.call_git_items_(
-                ['diff', '--name-only', '-z'], sep='\0',
+                ['diff-files', '--name-only', '-z'], sep='\0',
                 read_only=True)
             if f] if pointers else []
         annex_res = fn(files, normalize_paths=False, batch=batch)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -860,7 +860,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         try:
             for line in self.call_git_items_(
                     ['cat-file', 'blob', 'git-annex:remote.log'],
-                    check_fake_dates=False):
+                    read_only=True):
                 # be precise and split by spaces
                 fields = line.split(' ')
                 # special remote UUID
@@ -1622,7 +1622,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         modified = [
             f for f in self.call_git_items_(
                 ['diff', '--name-only', '-z'], sep='\0',
-                check_fake_dates=False)
+                read_only=True)
             if f] if pointers else []
         annex_res = fn(files, normalize_paths=False, batch=batch)
         return [bool(annex_res.get(f) and

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2209,11 +2209,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
           A non-zero exit is expected and should not be elevated above the
           DEBUG level.
         read_only : bool, optional
-          If set to True, we assume that command does not introduce changes to recorded
-          in git information (commits, heads, tags) and merely reads/outputs information
-          (note: git might still adjust caches and index).
-          If set to False, we would inspect if dates should be faked for dataset
-          commits and set up the Git environment to ensure that.
+          By setting this to True, the caller indicates that the command does
+          not write to the repository, which lets this function skip some
+          operations that are necessary only for commands the modify the
+          repository. Beware that even commands that are conceptually
+          read-only, such as `git-status` and `git-diff`, may refresh and write
+          the index.
 
         Returns
         -------

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2209,11 +2209,11 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
           A non-zero exit is expected and should not be elevated above the
           DEBUG level.
         read_only : bool, optional
-          If False (default), do not assume that command does not introduce changes and
-          is merely out read/output information.
-          E.g., if not read_only, we would inspect if dates should be faked for dataset
-          commits and set up the Git environment to ensure that. Must be
-          disabled for repository initialization.
+          If set to True, we assume that command does not introduce changes to recorded
+          in git information (commits, heads, tags) and merely reads/outputs information
+          (note: git might still adjust caches and index).
+          If set to False, we would inspect if dates should be faked for dataset
+          commits and set up the Git environment to ensure that.
 
         Returns
         -------

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2114,7 +2114,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                             log_stdout=True, log_stderr=True, log_online=False,
                             expect_stderr=True, cwd=None, env=None,
                             shell=None, expect_fail=False,
-                            read_only=True,
+                            read_only=False,
                             index_file=None,
                             updates_tree=False):
         """Allows for calling arbitrary commands.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2118,7 +2118,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                             log_stdout=True, log_stderr=True, log_online=False,
                             expect_stderr=True, cwd=None, env=None,
                             shell=None, expect_fail=False,
-                            read_only=False,
+                            check_fake_dates=False,
                             index_file=None,
                             updates_tree=False):
         """Allows for calling arbitrary commands.
@@ -2148,7 +2148,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         assert(cmd[0] == 'git')
         cmd = cmd[:1] + self._GIT_COMMON_OPTIONS + cmd[1:]
 
-        if not read_only and self.fake_dates_enabled:
+        if check_fake_dates and self.fake_dates_enabled:
             env = self.add_fake_dates(env)
 
         if index_file:


### PR DESCRIPTION
old description which got it going:  While looking at py-spy stack from long running status I noticed that majority
of time is spent on git config call, triggered by checking for fake dates
config setting. AFAIK for read-only operations, which cannot produce a commit,
it might benefit to skip that check. And _call_git already has that kwarg,
but it is not proxied by "higher-level" helpers.  To avoid breeding workarounds
(like the one RFed within this commit) I decided that we might benefit from
exposing that option in higher-level helpers as well. Then "read-only" invocations could set it to False and we might avoid needless  config read in some cases (I have not done any timing on any prototypical use case which might benefit from this, but I would assume that status or diff might).

What is in the PR
- RF to make possible to make "lean" `call_git` read only invocations which would not even read config since not needed
- BF add thread locking non-read-only invocations of git/annex -- in `GitRepo.call_git` and `ConfigManager._run`.  That closes #5131 .  Now you can really animate your terminals with something like `datalad install -r -J50 /// ` ;-)