### PR TITLE
More windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ test_script:
   # first sign of life
   - datalad wtf
   # and now this... [keep appending tests that should work!!]
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.core datalad.local datalad.distributed datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui
+  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.tests datalad.core datalad.local datalad.distributed datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui
   # one call per datalad component for now -- to better see what is being tested
   # remaining fails: test_archives.test_basic_scenario test_datalad.test_basic_scenario_local_url
   #- python -m nose -s -v -A "not (turtle)" datalad.customremotes
@@ -94,8 +94,6 @@ test_script:
   # remaining fails: test_addurls test_export_archive test_plugins"
   # additional tests need module `dateutil`!!
   - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates
-  # remaining fails: test_cmd test_protocols test_auto
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad  datalad.tests.test_tests_utils datalad.tests.test__main__ datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner datalad.tests.test_log
  
   # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
   - python -m coverage xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,8 +94,8 @@ test_script:
   # remaining fails: test_addurls test_export_archive test_plugins"
   # additional tests need module `dateutil`!!
   - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates
-  # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner
+  # remaining fails: test_cmd test_protocols test_auto
+  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad  datalad.tests.test_tests_utils datalad.tests.test__main__ datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner datalad.tests.test_log
  
   # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
   - python -m coverage xml

--- a/datalad/tests/test__main__.py
+++ b/datalad/tests/test__main__.py
@@ -15,6 +15,7 @@ from tempfile import NamedTemporaryFile
 from datalad.tests.utils import (
     assert_equal,
     assert_raises,
+    skip_if_on_windows,
 )
 
 from .. import __main__, __version__
@@ -36,7 +37,8 @@ def test_main_version(stdout):
     assert_equal(stdout.getvalue().rstrip(), "datalad %s" % __version__)
 
 
-@known_failure_githubci_win
+# automagic IO is not supported on windows
+@skip_if_on_windows
 @patch.object(AutomagicIO, 'activate')
 @patch('sys.stdout', new_callable=StringIO)
 def test_main_run_a_script(stdout, mock_activate):

--- a/datalad/tests/test_auto.py
+++ b/datalad/tests/test_auto.py
@@ -112,6 +112,7 @@ def test_proxying_open_testrepobased(repo):
 
 
 # TODO: RF to allow for quick testing of various scenarios/backends without duplication
+@known_failure_windows
 @with_tempfile(mkdir=True)
 def _test_proxying_open(generate_load, verify_load, repo):
     annex = AnnexRepo(repo, create=True)
@@ -181,6 +182,7 @@ def _test_proxying_open(generate_load, verify_load, repo):
             assert_true(annex2.file_has_content(fpath2_2))
 
 
+@known_failure_windows
 def test_proxying_open_h5py():
     def generate_hdf5(f):
         with h5py.File(f, "w") as f:
@@ -197,7 +199,7 @@ def test_proxying_open_h5py():
     yield _test_proxying_open, generate_hdf5, verify_hdf5
 
 
-@known_failure_githubci_win
+@known_failure_windows
 def test_proxying_open_regular():
     def generate_dat(f):
         with open(f, "w") as f:
@@ -210,7 +212,7 @@ def test_proxying_open_regular():
     yield _test_proxying_open, generate_dat, verify_dat
 
 
-@known_failure_githubci_win
+@known_failure_windows
 def test_proxying_io_open_regular():
 
     def generate_dat(f):
@@ -224,7 +226,7 @@ def test_proxying_io_open_regular():
     yield _test_proxying_open, generate_dat, verify_dat
 
 
-@known_failure_githubci_win
+@known_failure_windows
 def test_proxying_lzma_LZMAFile():
     def generate_dat(f):
         with LZMAFile(f, "w") as f:
@@ -237,6 +239,7 @@ def test_proxying_lzma_LZMAFile():
     yield _test_proxying_open, generate_dat, verify_dat
 
 
+@known_failure_windows
 def test_proxying_open_nibabel():
     if not nib:
         raise SkipTest("No nibabel found")
@@ -258,7 +261,7 @@ def test_proxying_open_nibabel():
     yield _test_proxying_open, generate_nii, verify_nii
 
 
-@known_failure_githubci_win
+@known_failure_windows
 def test_proxying_os_stat():
     from os.path import exists
     def generate_dat(f):

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -23,6 +23,7 @@ from datalad.tests.utils import (
     assert_is,
     assert_raises,
     eq_,
+    known_failure_appveyor,
     known_failure_githubci_win,
     lgr,
     OBSCURE_FILENAME,
@@ -77,6 +78,9 @@ def test_runner_dry(tempfile):
     assert_equal("args=('foo', 'bar')", dry[1]['command'][1])
 
 
+# UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 10:
+# character maps to <undefined>
+@known_failure_appveyor
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner(tempfile):
@@ -282,6 +286,9 @@ def test_runner_failure(dir_):
     assert_equal(1, cme.exception.code)
 
 
+# UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 1:
+# invalid continuation byte
+@known_failure_appveyor
 @with_tempfile(mkdir=True)
 def test_runner_failure_unicode(path):
     # Avoid OBSCURE_FILENAME in hopes of windows-compatibility (gh-2929).

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -44,10 +44,14 @@ from ..cmd import (
 )
 from datalad.support.exceptions import CommandError
 from datalad.support.protocol import DryRunProtocol
-from datalad.utils import split_cmdline
+from datalad.utils import (
+    split_cmdline,
+    quote_cmdlinearg,
+)
 
 
-@known_failure_githubci_win
+# runner protocol implementation is not compatible with windows
+@skip_if_on_windows
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner_dry(tempfile):
@@ -73,7 +77,6 @@ def test_runner_dry(tempfile):
     assert_equal("args=('foo', 'bar')", dry[1]['command'][1])
 
 
-@known_failure_githubci_win
 @assert_cwd_unchanged
 @with_tempfile
 def test_runner(tempfile):
@@ -81,7 +84,7 @@ def test_runner(tempfile):
     # test non-dry command call
     runner = Runner()
     content = 'Testing äöü東 real run'
-    cmd = 'echo %s > %r' % (content, tempfile)
+    cmd = 'echo %s > %s' % (content, quote_cmdlinearg(tempfile))
     ret = runner.run(cmd)
     assert_equal(ret, ('', ''))  # no out or err
     ok_file_has_content(tempfile, content, strip=True)
@@ -152,7 +155,8 @@ def test_runner_instance_callable_wet():
     eq_(ret, os.path.join('foo', 'bar'))
 
 
-@known_failure_githubci_win
+# runner logging implementation is not compatible with windows
+@skip_if_on_windows
 def test_runner_log_stderr():
 
     runner = Runner(log_outputs=True)
@@ -178,6 +182,8 @@ def test_runner_log_stderr():
                           "stderr| stderr-Message should not be logged")
 
 
+# runner logging implementation is not compatible with windows
+@skip_if_on_windows
 @known_failure_githubci_win
 def test_runner_log_stdout():
     # TODO: no idea of how to check correct logging via any kind of
@@ -331,7 +337,10 @@ def test_runner_stdin(path):
         assert_in("whatever", cmo.out)
 
 
-@known_failure_githubci_win
+# this test assumes that this source file is using the same
+# lineendings as are standard on the platform. While this is
+# common on *nix, it is a choice on windows
+@skip_if_on_windows
 def test_process_remaining_output():
     runner = Runner()
     out = u"""\

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -36,7 +36,10 @@ from datalad.tests.utils import (
     ok_endswith,
     swallow_logs,
     with_tempfile,
+    SkipTest,
 )
+from datalad.utils import on_windows
+
 
 # pretend we are in interactive mode so we could check if coloring is
 # disabled
@@ -158,6 +161,8 @@ def test_color_formatter():
                  name='some name'))
 
         cf = ColorFormatter(use_color=use_color)
+        if on_windows:
+            raise SkipTest('Unclear under which conditions coloring should work')
         (assert_in if use_color else assert_not_in)(colors.RESET_SEQ, cf.format(rec))
 
 

--- a/datalad/tests/test_protocols.py
+++ b/datalad/tests/test_protocols.py
@@ -26,7 +26,7 @@ from datalad.tests.utils import (
     assert_false,
     with_tempfile,
     swallow_logs,
-    known_failure_githubci_win,
+    known_failure_windows,
 )
 
 from ..support.protocol import (
@@ -40,7 +40,7 @@ from ..support.protocol import (
 from ..cmd import Runner
 
 
-@known_failure_githubci_win
+@known_failure_windows
 @with_tempfile
 def test_protocol_commons(protocol_file):
 
@@ -76,6 +76,7 @@ def test_protocol_commons(protocol_file):
         assert_equal(str_, read_str)
 
 
+@known_failure_windows
 @with_tempfile
 @with_tempfile
 def test_ExecutionTimeProtocol(path1, path2):
@@ -125,6 +126,7 @@ def test_ExecutionTimeProtocol(path1, path2):
     ok_(timer_protocol[2]['duration'] >= 0)
 
 
+@known_failure_windows
 @with_tempfile
 @with_tempfile
 def test_ExecutionTimeExternalsProtocol(path1, path2):
@@ -162,6 +164,7 @@ def test_ExecutionTimeExternalsProtocol(path1, path2):
     assert_equal(len(timer_protocol), 2)
 
 
+@known_failure_windows
 @with_tempfile
 def test_DryRunProtocol(path):
 
@@ -182,6 +185,7 @@ def test_DryRunProtocol(path):
     assert_equal(len(protocol), 2)
 
 
+@known_failure_windows
 @with_tempfile
 def test_DryRunExternalsProtocol(path):
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -607,7 +607,10 @@ def test_expandpath():
     eq_(expandpath("some", False), expandvars('some'))
     assert_true(isabs(expandpath('some')))
     # this may have to go because of platform issues
-    eq_(expandpath("$HOME"), expanduser('~'))
+    if not on_windows:
+        # expanduser is not influenced by our HOME setting adjustments
+        # for the tests on windows
+        eq_(expandpath("$HOME"), expanduser('~'))
 
 
 def test_is_explicit_path():
@@ -710,8 +713,7 @@ def test_get_timestamp_suffix():
     # we need to patch temporarily TZ
     with patch.dict('os.environ', {'TZ': 'GMT'}):
         # skynet DOB
-        target_ts = '1970-01-01T00:00:00-0000' \
-            if on_windows else '1970-01-01T00:00:00+0000'
+        target_ts = '1970-01-01T00:00:00+0000'
         assert_equal(get_timestamp_suffix(0), '-' + target_ts)
         assert_equal(get_timestamp_suffix(0, prefix="+"),
                      '+' + target_ts)
@@ -794,7 +796,7 @@ def test_as_unicode():
     assert_in("1 is not of any of known or provided", str(cme.exception))
 
 
-@known_failure_windows
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 def test_path_prefix(path):
     eq_(get_path_prefix('/d1/d2', '/d1/d2'), '')
@@ -862,7 +864,7 @@ def test_get_dataset_root(path):
         eq_(get_dataset_root(fname), os.curdir)
 
 
-@known_failure_windows
+@skip_if_on_windows
 def test_path_startswith():
     ok_(path_startswith('/a/b', '/a'))
     ok_(path_startswith('/a/b', '/a/b'))
@@ -878,7 +880,7 @@ def test_path_startswith():
     assert_raises(ValueError, path_startswith, '/a/b', 'a')
 
 
-@known_failure_windows
+@skip_if_on_windows
 def test_path_is_subpath():
     ok_(path_is_subpath('/a/b', '/a'))
     ok_(path_is_subpath('/a/b/c', '/a'))

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -15,6 +15,7 @@ import os
 import os.path as op
 import shutil
 import sys
+import time
 import logging
 from unittest.mock import patch
 import builtins
@@ -712,8 +713,12 @@ def test_path_():
 def test_get_timestamp_suffix():
     # we need to patch temporarily TZ
     with patch.dict('os.environ', {'TZ': 'GMT'}):
+        # figure out how GMT time zone suffix is represented
+        # could be +0 or -0, depending on platform
+        # just use whatever it is, not the subject of this test
+        tz_suffix = time.strftime('%z', time.gmtime(0))
         # skynet DOB
-        target_ts = '1970-01-01T00:00:00+0000'
+        target_ts = '1970-01-01T00:00:00' + tz_suffix
         assert_equal(get_timestamp_suffix(0), '-' + target_ts)
         assert_equal(get_timestamp_suffix(0, prefix="+"),
                      '+' + target_ts)

--- a/datalad/tests/test_utils_cached_dataset.py
+++ b/datalad/tests/test_utils_cached_dataset.py
@@ -25,6 +25,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_result_count,
     assert_true,
+    known_failure_windows,
     skip_if_no_network,
     with_tempfile
 )
@@ -152,6 +153,7 @@ def test_get_cached_dataset(cache_dir):
             assert_is(ds, ds2)
 
 
+@known_failure_windows
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_cached_dataset(cache_dir):
@@ -253,6 +255,7 @@ def test_cached_dataset(cache_dir):
         assert_not_equal(first_repopath, second_repopath)
 
 
+@known_failure_windows
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_cached_url(cache_dir):

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -960,10 +960,7 @@ def clone_url(url):
     return tdir
 
 
-if not on_windows:
-    local_testrepo_flavors = ['local'] # 'local-url'
-else:
-    local_testrepo_flavors = ['network-clone']
+local_testrepo_flavors = ['local'] # 'local-url'
 
 _TESTREPOS = None
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -707,10 +707,12 @@ def with_memory_keyring(t):
 def without_http_proxy(tfunc):
     """Decorator to remove http*_proxy env variables for the duration of the test
     """
-
+    
     @wraps(tfunc)
     @attr('without_http_proxy')
     def  _wrap_without_http_proxy(*args, **kwargs):
+        if on_windows:
+            raise SkipTest('Unclear why this is not working on windows')
         # Such tests don't require real network so if http_proxy settings were
         # provided, we remove them from the env for the duration of this run
         env = os.environ.copy()


### PR DESCRIPTION
This is an effort to enable more testing on windows. In particular the aim is to have some testing working with a windows datalad installation that a user following the handbook would have -- rather than just within the somewhat twister appveyor setup.

All changes are cross-verified manually on a win10 box with an installation as described in https://github.com/datalad-handbook/book/pull/588

- Remove testrepo setup special case on windows https://github.com/datalad/datalad/pull/5069#issuecomment-715013343
- run all `datalad.tests` tests, mark individual ones as failing or skip them, if there is no hope -- this will help further breakage from creeping in #5074 