### PR TITLE
TST: appveyor: Restore execution of modules that use with_testrepos

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -130,6 +130,7 @@ def test_clone_crcns(tdir, ds_path):
     assert_in(crcns.path, ds.subdatasets(result_xfm='paths'))
 
 
+@known_failure_appveyor
 @integration
 @skip_if_no_network
 @use_cassette('test_install_crcns')
@@ -926,6 +927,7 @@ def _postclonetest_prepare(lcl, storepath, link):
     return ds.id
 
 
+@known_failure_appveyor
 @slow  # 14 sec on travis
 def test_ria_postclonecfg():
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -74,6 +74,7 @@ from datalad.tests.utils import (
     usecase,
     get_datasets_topdir,
     SkipTest,
+    known_failure_appveyor,
     known_failure_windows,
     known_failure_githubci_win,
 )
@@ -175,6 +176,7 @@ def test_invalid_args(path):
 #    assert_in(crcns.path, ds.get_subdatasets(absolute=True))
 
 
+@known_failure_appveyor
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tree(tree={'sub': {}})

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import (
     create_tree,
     DEFAULT_BRANCH,
     eq_,
+    known_failure_appveyor,
     known_failure_windows,
     neq_,
     ok_,
@@ -96,6 +97,7 @@ def test_invalid_call(origin, tdir):
         type='dataset')
 
 
+@known_failure_appveyor
 @with_tempfile
 @with_tempfile
 def test_since_empty_and_unsupported(p1, p2):
@@ -755,6 +757,7 @@ def test_publish_no_fetch_refspec_configured(path):
     ds.publish(to="origin")
 
 
+@known_failure_appveyor
 @slow  # 14sec on Yarik's laptop
 @skip_ssh
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -976,7 +976,7 @@ def test_AnnexRepo_get_contentlocation():
         yield _test_AnnexRepo_get_contentlocation, batch
 
 
-@known_failure_githubci_win
+@known_failure_windows
 @with_tree(tree=(('about.txt', 'Lots of abouts'),
                  ('about2.txt', 'more abouts'),
                  ('about2_.txt', 'more abouts_'),

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1025,9 +1025,6 @@ def _get_testrepos_uris(regex, flavors):
     return uris
 
 
-# addurls with our generated file:// URLs doesn't work on appveyor
-# https://ci.appveyor.com/project/mih/datalad/builds/29841505/job/330rwn2a3cvtrakj
-@known_failure_appveyor
 @optional_args
 def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
     """Decorator to provide a local/remote test repository
@@ -1064,6 +1061,10 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
     @wraps(t)
     @attr('with_testrepos')
     def  _wrap_with_testrepos(*arg, **kw):
+        # addurls with our generated file:// URLs doesn't work on appveyor
+        # https://ci.appveyor.com/project/mih/datalad/builds/29841505/job/330rwn2a3cvtrakj
+        if 'APPVEYOR' in os.environ:
+            raise SkipTest("Testrepo setup is broken on AppVeyor")
         # TODO: would need to either avoid this "decorator" approach for
         # parametric tests or again aggregate failures like sweepargs does
         flavors_ = _get_resolved_flavors(flavors)


### PR DESCRIPTION
A good number of test modules no longer show up in the appveyor logs,
including those that test very basic and important functionality
(e.g., GitRepo, save, get, and clone).  It looks like these were lost
starting with gh-3975 (2020-01-02), in particular the last commit of
that series (715be1f786).

One change of that commit was to decorate with_testrepos() with
known_failure_appveyor().  (Before the series, the function returned
by with_testrepos() raised a SkipTest if on Windows.)  Based on
replacing the decorator with a plain SkipTest [*], it seems that any
module that uses with_testrepos() isn't executed on appveyor (for
reasons that I don't understand).

Drop the known_failure_appveyor() decorator and instead raise a
SkipTest if on appveyor to restore the execution of tests modules.

Closes #4411.

[*] https://ci.appveyor.com/project/mih/datalad/builds/35927969

---

- [x] Mark now-executed tests that are failing as known failures
      https://ci.appveyor.com/project/mih/datalad/builds/35928683