### PR TITLE
NF: create-sibling-ria --storage-sibling only

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -195,9 +195,9 @@ class CreateSiblingRia(Interface):
             sibling are created ([CMD: on CMD][PY: True|'on' PY]).
             Alternatively, creation of the storage sibling can be disabled
             ([CMD: off CMD][PY: False|'off' PY]), or a storage sibling
-            is created only and no Git sibling
+            created only and no Git sibling
             ([CMD: only CMD][PY: 'only' PY]). In the latter mode, no Git
-            installation is required that the target host."""),
+            installation is required on the target host."""),
         existing=Parameter(
             args=("--existing",),
             constraints=EnsureChoice(

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -163,7 +163,9 @@ class CreateSiblingRia(Interface):
             metavar="NAME",
             doc="""Name of the storage sibling (git-annex special remote).
             Must not be identical to the sibling name. If not specified,
-            defaults to the sibling name plus '-storage' suffix.""",
+            defaults to the sibling name plus '-storage' suffix. If only
+            a storage sibling is created, this setting is ignored, and
+            the primary sibling name is used.""",
             constraints=EnsureStr() | EnsureNone()),
         post_update_hook=Parameter(
             args=("--post-update-hook",),
@@ -185,10 +187,17 @@ class CreateSiblingRia(Interface):
             crucial when [CMD: --shared=group CMD][PY: shared="group" PY]""",
             constraints=EnsureStr() | EnsureNone()),
         storage_sibling=Parameter(
-            args=("--no-storage-sibling",),
+            args=("--storage-sibling",),
             dest='storage_sibling',
-            doc="""Flag to disable establishing a storage sibling.""",
-            action="store_false"),
+            metavar='MODE',
+            constraints=EnsureChoice('only') | EnsureBool() | EnsureNone(),
+            doc="""By default, an ORA storage sibling and a Git repository
+            sibling are created ([CMD: on CMD][PY: True|'on' PY]).
+            Alternatively, creation of the storage sibling can be disabled
+            ([CMD: off CMD][PY: False|'off' PY]), or a storage sibling
+            is created only and no Git sibling
+            ([CMD: only CMD][PY: 'only' PY]). In the latter mode, no Git
+            installation is required that the target host."""),
         existing=Parameter(
             args=("--existing",),
             constraints=EnsureChoice(
@@ -209,6 +218,12 @@ class CreateSiblingRia(Interface):
                 'trust', 'semitrust', 'untrust') | EnsureNone(),
             doc="""specify a trust level for the storage sibling. If not
             specified, the default git-annex trust level is used.""",),
+        disable_storage__=Parameter(
+            args=("--no-storage-sibling",),
+            dest='disable_storage__',
+            doc="""This option is deprecated. Use '--storage-sibling off'
+            instead.""",
+            action="store_false"),
     )
 
     @staticmethod
@@ -225,8 +240,24 @@ class CreateSiblingRia(Interface):
                  existing='error',
                  trust_level=None,
                  recursive=False,
-                 recursion_limit=None
+                 recursion_limit=None,
+                 disable_storage__=None,
                  ):
+        if disable_storage__ is not None:
+            import warnings
+            warnings.warn("datalad-create-sibling-ria --no-storage-sibling "
+                          "is deprecated, use --storage-sibling off instead.",
+                          DeprecationWarning)
+            # recode to new setup
+            disable_storage__ = None
+            storage_sibling = False
+
+        if storage_sibling == 'only' and storage_name:
+            lgr.warning(
+                "Sibling name will be used for storage sibling in "
+                "storage-sibling-only mode, but a storage sibling name "
+                "was provided"
+            )
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='create sibling RIA')
@@ -483,15 +514,22 @@ def _create_sibling_ria(
                 )
                 return
 
-    lgr.info("create sibling{} '{}'{} ...".format(
-        's' if storage_name else '',
-        name,
-        " and '{}'".format(storage_name) if storage_name else '',
-    ))
+    if storage_sibling == 'only':
+        lgr.info("create storage sibling '{}' ...".format(name))
+    else:
+        lgr.info("create sibling{} '{}'{} ...".format(
+            's' if storage_name else '',
+            name,
+            " and '{}'".format(storage_name) if storage_name else '',
+        ))
     create_ds_in_store(SSHRemoteIO(ssh_host) if ssh_host else LocalIO(),
                        base_path, ds.id, '2', '1')
     if storage_sibling:
-        lgr.debug('init special remote {}'.format(storage_name))
+        # we are using the main `name`, if the only thing we are creating
+        # is the storage sibling
+        srname = name if storage_sibling == 'only' else storage_name
+
+        lgr.debug('init special remote {}'.format(srname))
         special_remote_options = [
             'type=external',
             'externaltype=ora',
@@ -500,7 +538,7 @@ def _create_sibling_ria(
             'url={}'.format(url)]
         try:
             ds.repo.init_remote(
-                storage_name,
+                srname,
                 options=special_remote_options)
         except CommandError as e:
             if existing == 'reconfigure' \
@@ -510,14 +548,14 @@ def _create_sibling_ria(
                 lgr.debug(
                     "special remote '%s' already exists. "
                     "Run enableremote instead.",
-                    storage_name)
+                    srname)
                 # TODO: Use AnnexRepo.enable_remote (which needs to get
                 #       `options` first)
                 cmd = [
                     'git',
                     'annex',
                     'enableremote',
-                    storage_name] + special_remote_options
+                    srname] + special_remote_options
                 subprocess.run(cmd, cwd=quote_cmdlinearg(ds.repo.path))
             else:
                 yield get_status_dict(
@@ -529,9 +567,18 @@ def _create_sibling_ria(
                 return
 
         if trust_level:
-            ds.repo.call_git(['annex', trust_level, storage_name])
+            ds.repo.call_git(['annex', trust_level, srname])
         # get uuid for use in bare repo's config
-        uuid = ds.config.get("remote.{}.annex-uuid".format(storage_name))
+        uuid = ds.config.get("remote.{}.annex-uuid".format(srname))
+
+    if storage_sibling == 'only':
+        # we can stop here, the rest of the function is about setting up
+        # the git remote part of the sibling
+        yield get_status_dict(
+            status='ok',
+            **res_kwargs,
+        )
+        return
 
     # 2. create a bare repository in-store:
 

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -267,6 +267,17 @@ class CreateSiblingRia(Interface):
             logger=lgr,
         )
 
+        # parse target URL
+        try:
+            ssh_host, base_path, rewritten_url = verify_ria_url(url, ds.config)
+        except ValueError as e:
+            yield get_status_dict(
+                status='error',
+                message=str(e),
+                **res_kwargs
+            )
+            return
+
         if ds.repo.get_hexsha() is None or ds.id is None:
             raise RuntimeError(
                 "Repository at {} is not a DataLad dataset, "
@@ -359,16 +370,6 @@ class CreateSiblingRia(Interface):
         # reduced to single instance, since rewriting url based on config could
         # be different for subdatasets.
 
-        # parse target URL
-        try:
-            ssh_host, base_path, rewritten_url = verify_ria_url(url, ds.config)
-        except ValueError as e:
-            yield get_status_dict(
-                status='error',
-                message=str(e),
-                **res_kwargs
-            )
-            return
         create_store(SSHRemoteIO(ssh_host) if ssh_host else LocalIO(),
                      Path(base_path),
                      '1')

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -183,6 +183,7 @@ def test_create_simple():
     yield skip_if_on_windows(skip_ssh(_test_create_store)), 'datalad-test'
 
 
+@skip_if_on_windows  # ORA remote is incompatible with windows clients
 @with_tempfile
 @with_tree({'ds': {'file1.txt': 'some'}})
 def test_storage_only(base_path, ds_path):

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -20,6 +20,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_repo_status,
     assert_result_count,
+    assert_status,
     chpwd,
     eq_,
     skip_if_on_windows,
@@ -30,6 +31,7 @@ from datalad.tests.utils import (
 )
 from datalad.utils import Path
 from functools import wraps
+from datalad.support.network import get_local_file_url
 
 
 def with_store_insteadof(func):
@@ -37,7 +39,7 @@ def with_store_insteadof(func):
 
     @wraps(func)
     @attr('with_config')
-    def  _wrap_with_store_insteadof(*args, **kwargs):
+    def _wrap_with_store_insteadof(*args, **kwargs):
         host = args[0]
         base_path = args[1]
         try:
@@ -53,7 +55,7 @@ def with_store_insteadof(func):
                                    host=host if host else '',
                                    path=base_path),
                          where='global', reload=True)
-    return  _wrap_with_store_insteadof
+    return _wrap_with_store_insteadof
 
 
 @with_tempfile
@@ -67,6 +69,14 @@ def test_invalid_calls(path):
     # same name for git- and special remote:
     assert_raises(ValueError, ds.create_sibling_ria, 'ria+file:///some/where',
                   name='some', storage_name='some')
+
+    # missing ria+ URL prefix
+    assert_result_count(
+        ds.create_sibling_ria(
+            'file:///some/where', name='some', on_failure='ignore'),
+        1,
+        status='error',
+    )
 
 
 @skip_if_on_windows  # running into short path issues; same as gh-4131
@@ -110,7 +120,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     assert_in("uuid = {}".format(super_uuid), content)
 
     # implicit test of success by ria-installing from store:
-    ds.publish(to="datastore", transfer_data='all')
+    ds.push(to="datastore")
     with chpwd(clone_path):
         if host:
             # note, we are not using the "test-store"-label here
@@ -172,5 +182,57 @@ def test_create_simple():
     # TODO: Skipped due to gh-4436
     yield skip_if_on_windows(skip_ssh(_test_create_store)), 'datalad-test'
 
+
+@with_tempfile
+@with_tree({'ds': {'file1.txt': 'some'}})
+def test_storage_only(base_path, ds_path):
+    store_url = 'ria+' + get_local_file_url(base_path)
+
+    ds = Dataset(ds_path).create(force=True)
+    ds.save(recursive=True)
+    assert_repo_status(ds.path)
+
+    res = ds.create_sibling_ria(store_url, "datastore", storage_sibling='only')
+    assert_result_count(res, 1, status='ok', action='create-sibling-ria')
+    eq_(len(res), 1)
+
+    # the storage sibling uses the main name, not -storage
+    siblings = ds.siblings(result_renderer=None)
+    eq_({'datastore', 'here'},
+        {s['name'] for s in siblings})
+
+    # smoke test that we can push to it
+    res = ds.push(to='datastore')
+    assert_status('ok', res)
+    assert_result_count(res, 1, action='copy')
+
+
+@with_tempfile
+@with_tempfile
+@with_tree({'ds': {'file1.txt': 'some'}})
+def test_no_storage(store1, store2, ds_path):
+    store1_url = 'ria+' + get_local_file_url(store1)
+    store2_url = 'ria+' + get_local_file_url(store2)
+
+    ds = Dataset(ds_path).create(force=True)
+    ds.save(recursive=True)
+    assert_repo_status(ds.path)
+
+    res = ds.create_sibling_ria(store1_url, "datastore1", storage_sibling=False)
+    assert_result_count(res, 1, status='ok', action='create-sibling-ria')
+    eq_({'datastore1', 'here'},
+        {s['name'] for s in ds.siblings(result_renderer=None)})
+
+    # deprecated way of disabling storage still works
+    res = ds.create_sibling_ria(store2_url, "datastore2", disable_storage__=True)
+    assert_result_count(res, 1, status='ok', action='create-sibling-ria')
+    eq_({'datastore2', 'datastore1', 'here'},
+        {s['name'] for s in ds.siblings(result_renderer=None)})
+
+    # smoke test that we can push to it
+    res = ds.push(to='datastore1')
+    assert_status('ok', res)
+    # but nothing was copied, because there is no storage sibling
+    assert_result_count(res, 0, action='copy')
 
 # TODO: explicit naming of special remote


### PR DESCRIPTION
- add support for `storage_sibling='only'` which triggers the mode
  desired in gh-5077

- add an additional parameter `disable_storage__=None` which is
  used as a destination for the previous `--no-storage-sibling` cmdline
  option. Whenever it is used, as deprecation warning is issued

- introduce `--storage-sibling {on|off|only}` cmdline argument handling.
  This opens up straightforward handling of further storage sibling
  modes (different special remote types/configs) in the future -- in
  contrast to an alternative approach along the lines of a dedicated off
  switch for the repository sibling part.

From the perspective of the cmdline interface this deprecates
`--no-storage-sibling` in favor of `--storage-sibling`.

From the perspective of the Python API, an additional argument value of
`storage_sibling` is recognized.

Fixes gh-5077

TODO:

- [x] Obtain feedback from OP
- [x] Add test