### PR TITLE
ENH: addurl - store original urlfile, not resolved full path

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -924,7 +924,7 @@ class Addurls(Interface):
 
 url_file='{}'
 url_format='{}'
-filename_format='{}'""".format(url_file, url_format, filename_format)
+filename_format='{}'""".format(urlfile, url_format, filename_format)
 
         if files_to_add:
             meta_rows = [r for r in rows if r["filename_abs"] in files_to_add and r["meta_args"]]

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -41,6 +41,7 @@ from datalad.tests.utils import (
     HTTPPath,
     known_failure_githubci_win,
     ok_exists,
+    ok_startswith,
     swallow_logs,
     with_tempfile,
     with_tree,
@@ -438,8 +439,13 @@ class TestAddurls(object):
 
         n_annex_commits = get_annex_commit_counts()
 
-        ds.addurls(self.json_file, "{url}", "{name}")
-
+        # Meanwhile also test that we can specify path relative
+        # to the top of the dataset, as we generally treat paths in
+        # Python API, and it will be the one saved in commit
+        # message record
+        json_file = op.relpath(self.json_file, ds.path)
+        ds.addurls(json_file, "{url}", "{name}")
+        ok_startswith(ds.repo.format_commit('%b'), f"url_file='{json_file}'")
         filenames = ["a", "b", "c"]
         for fname in filenames:
             ok_exists(op.join(ds.path, fname))


### PR DESCRIPTION
Rationale - to make commit message "portable" happen someone needs to
redo it. Ideally the urlfile should be either "-" or relative within dataset
path.  I decided to not inforce it but merely store the original specification
of the user.

Also decided to just adjust/reuse existing test to not add more time to setup
a dedicated one

NB positioned against master since changes the record/behavior, unless there is consensus that it is appropriate for `maint` ;)