### PR TITLE
RF: make external versions return UnknownVersion which compares False

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -38,6 +38,18 @@ class UnknownVersion:
             return 0
         raise TypeError("UNKNOWN version is not comparable")
 
+    def __eq__(self, other):
+        return other is self
+
+    def __ne__(self, other):
+        return other is not self
+
+    def __lt__(self, other):
+        return False
+
+    __gt__ = __lt__
+    # True only if the same, the rest -- False
+    __le__ = __ge__ = __eq__
 
 #
 # Custom handlers
@@ -238,7 +250,7 @@ class ExternalVersions(object):
                 except Exception as exc:
                     lgr.debug("Failed to deduce version of %s due to %s"
                               % (modname, exc_str(exc)))
-                    return None
+                    return UnknownVersion()
             else:
                 if module is None:
                     if modname not in sys.modules:

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -36,8 +36,10 @@ from datalad.tests.utils import (
     assert_greater_equal,
     assert_in,
     assert_not_in,
+    assert_not_equal,
     assert_raises,
     assert_true,
+    assert_false,
 )
 from datalad.tests.utils import SkipTest
 
@@ -76,8 +78,10 @@ def test_external_versions_basic():
     # And that thing is "True", i.e. present
     assert(ev['os'])
     # but not comparable with anything besides itself (was above)
-    assert_raises(TypeError, cmp, ev['os'], '0')
-    assert_raises(TypeError, assert_greater, ev['os'], '0')
+    assert_not_equal(ev['os'], '0')
+    assert_false(ev['os'] > '0')
+    assert_false(ev['os'] < '0')
+    assert_false(ev['os'] <= '0')
 
     return
     ## Code below is from original duecredit, and we don't care about


### PR DESCRIPTION
(unless the same) if external version cannot be deduced

Then such comparisons as  '0.1' < external_versions['blah'] < '0.2'
used in skip_if decorators would return False instead of just crashing.
This happens now e.g. due to
https://github.com/datalad/datalad/issues/5100
