### PR TITLE
RF: lower level for maint clear/refres log_progress from ConsoleLog

### DIFF
--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -72,12 +72,12 @@ class ConsoleLog(object):
 
     def message(self, msg, cr='\n'):
         from datalad.log import log_progress
-        log_progress(lgr.info, None, 'Clear progress bars', maint='clear',
+        log_progress(lgr.debug, None, 'Clear progress bars', maint='clear',
                      noninteractive_level=5)
         self.out.write(msg)
         if cr:
             self.out.write(cr)
-        log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh',
+        log_progress(lgr.debug, None, 'Refresh progress bars', maint='refresh',
                      noninteractive_level=5)
 
     def error(self, error):


### PR DESCRIPTION
I am not sure if that would not caused some undesired side-effects -- may be
lgr.info was under implicit assumption that all other log_progress are at lgr.info
level (or below).  But the reason why I am looking it is that in
https://github.com/dandi/dandisets/blob/master/tools/backups2datalad.py
we use datalad and have "our own" logger.  In interactive run I do see
those messages in the log (not progress bars I think) intermixed with dedicated
logger of that script, e.g.

    2020-10-28T11:04:02-0400 [INFO    ] backups2datalad.py Asset /sub-Templeton/sub-Templeton_ses-Templeton-032415_ecephys.nwb metadata unchanged; not taking any further action
    2020-10-28T11:04:02-0400 [INFO    ] datalad.ui.dialog Clear progress bars
    nothing to save, working tree clean
    2020-10-28T11:04:02-0400 [INFO    ] datalad.ui.dialog Refresh progress bars
    2020-10-28T11:04:02-0400 [INFO    ] datalad.ui.dialog Clear progress bars
    nothing to save, working tree clean
    2020-10-28T11:04:02-0400 [INFO    ] datalad.ui.dialog Refresh progress bars
    2020-10-28T11:04:02-0400 [INFO    ] backups2datalad.py No changes made to repository; deleting logfile
    2020-10-28T11:04:02-0400 [INFO    ] backups2datalad.py Syncing Dandiset 000042
    2020-10-28T11:04:03-0400 [INFO    ] dandi Traversing remote dandisets (000042) recursively
    2020-10-28T11:04:03-0400 [INFO    ] backups2datalad.py Updating metadata file
    2020-10-28T11:04:03-0400 [INFO    ] datalad.ui.dialog Clear progress bars
    nothing to save, working tree clean
    2020-10-28T11:04:03-0400 [INFO    ] datalad.ui.dialog Refresh progress bars
    2020-10-28T11:04:03-0400 [INFO    ] datalad.ui.dialog Clear progress bars
    nothing to save, working tree clean
    2020-10-28T11:04:03-0400 [INFO    ] datalad.ui.dialog Refresh progress bars
    2020-10-28T11:04:03-0400 [INFO    ] backups2datalad.py No changes made to repository; deleting logfile

so at large they provide no relevant information and just pollute the display.
May be an alternative solution is to hardcode to log any "maint" messages at
the non-interactive level (set to 5)?

PS ATM positioned against master since I do not know if would cause side-effects