### PR TITLE
BF: Save and restore existing asyncio event-loop

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -463,6 +463,13 @@ class WitlessRunner(object):
             cwd=cwd,
         )
 
+        # rescue any event-loop to be able to reassign after we are done
+        # with our own event loop management
+        # this is how ipython does it
+        try:
+            old_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            old_loop = None
         # start a new event loop, which we will close again further down
         # if this is not done events like this will occur
         #   BlockingIOError: [Errno 11] Resource temporarily unavailable
@@ -476,21 +483,25 @@ class WitlessRunner(object):
         else:
             event_loop = asyncio.SelectorEventLoop()
         asyncio.set_event_loop(event_loop)
-        # include the subprocess manager in the asyncio event loop
-        results = event_loop.run_until_complete(
-            run_async_cmd(
-                event_loop,
-                cmd,
-                protocol,
-                stdin,
-                protocol_kwargs=kwargs,
-                cwd=cwd,
-                env=env,
+        try:
+            # include the subprocess manager in the asyncio event loop
+            results = event_loop.run_until_complete(
+                run_async_cmd(
+                    event_loop,
+                    cmd,
+                    protocol,
+                    stdin,
+                    protocol_kwargs=kwargs,
+                    cwd=cwd,
+                    env=env,
+                )
             )
-        )
-        # terminate the event loop, cannot be undone, hence we start a fresh
-        # one each time (see BlockingIOError notes above)
-        event_loop.close()
+            # terminate the event loop, cannot be undone, hence we start a fresh
+            # one each time (see BlockingIOError notes above)
+            event_loop.close()
+        finally:
+            # be kind to callers and leave asyncio as we found it
+            asyncio.set_event_loop(old_loop)
 
         # log before any exception is raised
         lgr.log(8, "Finished running %r with status %s", cmd, results['code'])


### PR DESCRIPTION
This approach is copied from IPython. It prevents the crash reported in
gh-5064 by not leaving behind a closed event-loop, but rather any
previously existing one, or `None`.

Fixes gh-5064

