### PR TITLE
BF: workarounds to tests on Windows

### DIFF
--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -165,7 +165,7 @@ def test_basic_scenario(d, d2):
 )
 def test_annex_get_from_subdir(topdir):
     from datalad.api import add_archive_content
-    annex = AnnexRepo(topdir, init=True)
+    annex = AnnexRepo(topdir, backend='MD5E', init=True)
     annex.add('a.tar.gz')
     annex.commit()
     add_archive_content('a.tar.gz', annex=annex, delete=True)

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -81,7 +81,7 @@ from datalad import cfg as dl_cfg
 @with_tempfile()
 def test_basic_scenario(d, d2):
     fn_archive, fn_extracted = fn_archive_obscure_ext, fn_archive_obscure
-    annex = AnnexRepo(d, runner=_get_custom_runner(d))
+    annex = AnnexRepo(d, backend='MD5E', runner=_get_custom_runner(d))
     annex.init_remote(
         ARCHIVES_SPECIAL_REMOTE,
         ['encryption=none', 'type=external', 'externaltype=%s' % ARCHIVES_SPECIAL_REMOTE,

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -33,6 +33,7 @@ from ...tests.utils import (
     assert_equal,
     assert_false,
     assert_is_instance,
+    assert_not_equal,
     assert_not_in,
     assert_true,
     chpwd,
@@ -322,7 +323,11 @@ def test_link_file_load(tempfile):
             # despite copystat mtime is not copied. TODO
             #        st.st_mtime)
 
-    if on_linux or on_osx:
+    # TODO: fix up the test to not rely on OS assumptions but rather
+    # first sense filesystem about linking support.
+    # For Yarik's Windows 10 VM test was failing under assumption that
+    # linking is not supported at all, but I guess it does.
+    if True:  # on_linux or on_osx:
         # above call should result in the hardlink
         assert_equal(inode(tempfile), inode(tempfile2))
         assert_equal(stats(tempfile), stats(tempfile2))
@@ -336,8 +341,8 @@ def test_link_file_load(tempfile):
                 link_file_load(tempfile, tempfile2)  # should still work
                 ok_("failed (TEST), copying file" in cm.out)
 
-    # should be a copy (either originally for windows, or after mocked call)
-    ok_(inode(tempfile) != inode(tempfile2))
+        # should be a copy (after mocked call)
+        assert_not_equal(inode(tempfile), inode(tempfile2))
     with open(tempfile2, 'r') as f:
         assert_equal(f.read(), "LOAD")
     assert_equal(stats(tempfile, times=False), stats(tempfile2, times=False))

--- a/tools/which.py
+++ b/tools/which.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import os
+import os.path as op
+import sys
+import subprocess
+
+if __name__ == '__main__':
+    cmd = sys.argv[1]
+    extra = sys.argv[2:]
+    for path in os.environ['PATH'].split(os.pathsep):
+        for ext in '', '.exe', '.bat', '.com':
+            exe = op.join(path, cmd + ext)
+            # print(exe)
+            if op.lexists(exe):
+                if extra:
+                    r = subprocess.run([exe] + extra, capture_output=True, check=True)
+                    print(exe, r.returncode == 0 and "ok" or "failed")
+                    for o in "stdout", "stderr":
+                        out = getattr(r, o)
+                        if out:
+                            print(f'{o}:')
+                            print(out.decode())
+                else:
+                    print(exe)


### PR DESCRIPTION
No real fixes since should be done either on git-annex level (misbehaving locking when path is too long) or us RFing tests to rely on capabilities of the TMPDIR instead of `if on_windows`, so might even start failing where was working before.

BUT with today's git-annex (soon to be built on CRON job, will upload to packages/ tomorrow) `datalad/customremotes/tests/test_archives.py` tests all pass for me on windows VM.

also I gift you the mighty `which.py` which you might love in a moment of despair.