### PR TITLE
BF+TST: Robustify default_result_renderer()

### DIFF
--- a/datalad/core/local/tests/test_results.py
+++ b/datalad/core/local/tests/test_results.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test result handling"""
+
+from datalad.utils import (
+    on_windows,
+)
+from datalad.tests.utils import (
+    assert_in,
+    swallow_outputs,
+)
+from datalad.interface.utils import (
+    default_result_renderer,
+)
+
+
+def test_default_result_renderer():
+    # a bunch of bad cases of results
+    testcases = [
+        # an empty result will surface
+        ({}, ['<action-unspecified>(<status-unspecified>)']),
+        # non-standard status makes it out again
+        (dict(status='funky'), ['<action-unspecified>(funky)']),
+        # just an action result is enough to get some output
+        (dict(action='funky'), ['funky(<status-unspecified>)']),
+        # a plain path produces output, although
+        (dict(path='funky'), ['<action-unspecified>(<status-unspecified>): funky']),
+        # plain type makes it through
+        (dict(type='funky'),
+         ['<action-unspecified>(<status-unspecified>): (funky)']),
+        # plain message makes it through
+        (dict(message='funky'),
+         ['<action-unspecified>(<status-unspecified>): [funky]']),
+    ]
+    if on_windows:
+        testcases.extend([
+            # if relpath'ing is not possible, takes the path verbatim
+            (dict(path='C:\\funky', refds='D:\\medina'),
+             ['<action-unspecified>(<status-unspecified>): C:\\funky']),
+        ])
+    else:
+        testcases.extend([
+            (dict(path='/funky/cold/medina', refds='/funky'),
+             ['<action-unspecified>(<status-unspecified>): cold/medina']),
+        ])
+    for result, contenttests in testcases:
+        with swallow_outputs() as cmo:
+            default_result_renderer(result)
+            for ctest in contenttests:
+                assert_in(ctest, cmo.out)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -500,19 +500,27 @@ def eval_results(func):
 def default_result_renderer(res):
     if res.get('status', None) != 'notneeded':
         path = res.get('path', None)
-        path = ' {}'.format(path) if path else ''
+        if path and res.get('refds'):
+            try:
+                path = relpath(path, res['refds'])
+            except ValueError:
+                # can happen, e.g., on windows with paths from different
+                # drives. just go with the original path in this case
+                pass
         ui.message('{action}({status}):{path}{type}{msg}'.format(
-                action=ac.color_word(res['action'], ac.BOLD),
-                status=ac.color_status(res['status']),
-                path=relpath(path, res['refds']) if path and res.get('refds') else path,
-                type=' ({})'.format(
-                        ac.color_word(res['type'], ac.MAGENTA)
-                ) if 'type' in res else '',
-                msg=' [{}]'.format(
-                        res['message'][0] % res['message'][1:]
-                        if isinstance(res['message'], tuple) else res[
-                            'message'])
-                if res.get('message', None) else ''))
+            action=ac.color_word(
+                res.get('action', '<action-unspecified>'),
+                ac.BOLD),
+            status=ac.color_status(res.get('status', '<status-unspecified>')),
+            path=' {}'.format(path) if path else '',
+            type=' ({})'.format(
+                ac.color_word(res['type'], ac.MAGENTA)
+            ) if 'type' in res else '',
+            msg=' [{}]'.format(
+                res['message'][0] % res['message'][1:]
+                if isinstance(res['message'], tuple) else res[
+                    'message'])
+            if res.get('message', None) else ''))
 
 
 def _display_suppressed_message(nsimilar, ndisplayed, last_ts, final=False):


### PR DESCRIPTION
Changes:

- avoid spurious whitespace when results carry no path
- prevent crash when path relpath'ing is not possible (fixes gh-5116)
- make missing `action` and `status` declarations more obvious in the
  output (before it was just `None`)
- add test to verify a bunch of corner cases

Once released with 0.13.6, this could bring piece to the win2019 tests of datalad-osf @adswa 