### PR TITLE
TST: Disable tests involving the /// dataset on windows

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -111,6 +111,7 @@ def test_invalid_args(path, otherpath, alienpath):
     assert_status('error', ds_target.clone(ds.path, path=alienpath, on_failure='ignore'))
 
 
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @integration
 @skip_if_no_network
 @use_cassette('test_install_crcns')
@@ -130,7 +131,7 @@ def test_clone_crcns(tdir, ds_path):
     assert_in(crcns.path, ds.subdatasets(result_xfm='paths'))
 
 
-@known_failure_appveyor
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @integration
 @skip_if_no_network
 @use_cassette('test_install_crcns')
@@ -217,6 +218,7 @@ def test_clone_dataset_from_just_source(url, path):
 # test fails randomly, likely a bug in one of the employed test helpers
 # https://github.com/datalad/datalad/pull/3966#issuecomment-571267932
 @known_failure
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @with_tree(tree={
     'ds': {'test.txt': 'some'},
     })
@@ -405,6 +407,7 @@ def test_clone_isnt_a_smartass(origin_path, path):
     eq_(cloned.subdatasets(), [])
 
 
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @with_tempfile(mkdir=True)
 def test_clone_report_permission_issue(tdir):
     pdir = Path(tdir) / 'protected'
@@ -431,8 +434,7 @@ def test_clone_report_permission_issue(tdir):
         )
 
 
-# Started to hang on appveyor.
-@known_failure_appveyor  #FIXME - hangs
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @skip_if_no_network
 @with_tempfile
 def test_autoenabled_remote_msg(path):

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -176,7 +176,7 @@ def test_invalid_args(path):
 #    assert_in(crcns.path, ds.get_subdatasets(absolute=True))
 
 
-@known_failure_appveyor
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @skip_if_no_network
 @use_cassette('test_install_crcns')
 @with_tree(tree={'sub': {}})
@@ -288,6 +288,7 @@ def test_install_dataset_from_just_source_via_path(url, path):
     assert_in('INFO.txt', ds.repo.get_indexed_files())
 
 
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @with_tree(tree={
     'ds': {'test.txt': 'some'},
     })
@@ -436,7 +437,7 @@ def test_install_into_dataset(source, top_path):
 
 
 @slow   # 15sec on Yarik's laptop
-@known_failure_windows  #FIXME
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @usecase  # 39.3074s
 @skip_if_no_network
 @use_cassette('test_install_crcns')
@@ -879,6 +880,7 @@ def test_install_subds_from_another_remote(topdir):
 
 # Takes > 2 sec
 # Do not use cassette
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @skip_if_no_network
 @with_tempfile
 def check_datasets_datalad_org(suffix, tdir):

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -473,6 +473,7 @@ def test_remove_nowhining(path):
 
 
 @usecase
+@skip_if_on_windows # https://github.com/datalad/datalad/issues/5097
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 @use_cassette('test_remove_recursive_2')


### PR DESCRIPTION
It contains a directory `con/` which prevents cloning on windows:
https://github.com/datalad/datalad/issues/5097

