### PR TITLE
ENH: appveyor -- use newer git-annex + try to re-enable codecov submission

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,11 @@ image:
 build: false
 
 environment:
-  PYTHON: "C:\\Python35"
-  PYTHON_VERSION: "3.5.2"
-  PYTHON_ARCH: "32"
   MINICONDA: C:\Miniconda35
   DATALAD_TESTS_SSH: 1
 
   matrix:
+    # each matrix run comes with about 150s of setup overhead
     - KNOWN_FAILURES: true
       TEST_SELECTION: datalad.plugin
     - TEST_SELECTION: datalad.core
@@ -28,7 +26,6 @@ init:
   # alter machine PATH setting to have git-core tools and SSH installation
   # accessible even when SSHing into localhost (see gh-3683)
   - ps: '[System.Environment]::SetEnvironmentVariable("PATH", "$env:Path;C:\Program Files\Git\mingw64\libexec\git-core;C:\projects\datalad\resources\OpenSSH-Win32", [System.EnvironmentVariableTarget]::Machine)'
-  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
   # this will display login RDP info for the build VM, but if the build VM should block
   # see on_finish below instead
   #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
@@ -37,8 +34,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  #- "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib pytest pandas"
-  - "conda create -q -n test-environment python=%PYTHON_VERSION%"
+  - "conda create -q -n test-environment"
   - activate test-environment
   - mkdir resources
   # define test host alias

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 build: false
 
 environment:
-  MINICONDA: C:\Miniconda35
+  MINICONDA: C:\Miniconda37
   DATALAD_TESTS_SSH: 1
 
   # each matrix run comes with about 150s of setup overhead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,11 @@
+image:
+  - Visual Studio 2019
+
 build: false
 
 environment:
   PYTHON: "C:\\Python35"
-  PYTHON_VERSION: "3.5.1"
+  PYTHON_VERSION: "3.5.2"
   PYTHON_ARCH: "32"
   MINICONDA: C:\Miniconda35
   DATALAD_TESTS_SSH: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,21 @@
 build: false
 
 environment:
+  PYTHON: "C:\\Python35"
+  PYTHON_VERSION: "3.5.1"
+  PYTHON_ARCH: "32"
+  MINICONDA: C:\Miniconda35
+  DATALAD_TESTS_SSH: 1
+
   matrix:
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
-      DATALAD_TESTS_SSH: 1
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
-      DATALAD_TESTS_SSH: 1
-      DATALAD_REPO_VERSION: 6
+    - KNOWN_FAILURES: true
+      TEST_SELECTION: datalad.plugin
+    - TEST_SELECTION: datalad.core
+    - TEST_SELECTION: datalad.local datalad.distributed
+
+matrix:
+  allow_failures:
+    - KNOWN_FAILURES: true
 
 cache:
   # cache the pip cache
@@ -90,20 +93,22 @@ test_script:
   - git annex version
   # first sign of life
   - datalad wtf
+  # perform selected tests for this matrix run
+  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad %TEST_SELECTION%
   # and now this... [keep appending tests that should work!!]
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.core datalad.local datalad.distributed datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui
-  # one call per datalad component for now -- to better see what is being tested
-  # remaining fails: test_archives.test_basic_scenario test_datalad.test_basic_scenario_local_url
-  #- python -m nose -s -v -A "not (turtle)" datalad.customremotes
-  # remaining fails: test_http
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3
-  # remaining fails: extractors.tests.test_base test_aggregation test_base  datalad.metadata.extractors.tests.test_datacite_xml
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822
-  # remaining fails: test_addurls test_export_archive test_plugins"
-  # additional tests need module `dateutil`!!
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates
-  # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
-  - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner
+  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.core datalad.local datalad.distributed datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui
+  # # one call per datalad component for now -- to better see what is being tested
+  # # remaining fails: test_archives.test_basic_scenario test_datalad.test_basic_scenario_local_url
+  # #- python -m nose -s -v -A "not (turtle)" datalad.customremotes
+  # # remaining fails: test_http
+  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3
+  # # remaining fails: extractors.tests.test_base test_aggregation test_base  datalad.metadata.extractors.tests.test_datacite_xml
+  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822
+  # # remaining fails: test_addurls test_export_archive test_plugins"
+  # # additional tests need module `dateutil`!!
+  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates
+  # # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
+  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner
  
   # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
   - python -m coverage xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ install:
   # datalad-extensions built version with fixed up special remotes handling
   - appveyor DownloadFile http://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20201007+git171-g7e24b2587_x64.exe -FileName resources\git-annex-installer.exe
   # extract git annex into the system Git installation path
-  - 7z x -o"C:\\Program Files\Git" resources\git-annex-installer.exe
+  - 7z x -aoa -o"C:\\Program Files\Git" resources\git-annex-installer.exe
   # info on how python is ticking
   - python -c "import sys; print(sys.path)"
   # cannot do full, e.g. because libxmp is N/A, causes unguarded ERRORs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,10 @@ test_script:
   # perform selected tests for this matrix run
   - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad %TEST_SELECTION%
   # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
-  - python -m coverage xml
+  # crashes with:
+  #     from _sqlite3 import *
+  # ImportError: DLL load failed: %1 is not a valid Win32 application
+  #- python -m coverage xml
 
 #after_test:
 #  - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,9 @@ install:
   # latest version
   #- appveyor DownloadFile https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe -FileName resources\git-annex-installer.exe
   # specific version mih uses to debug on real win10 box
-  - appveyor DownloadFile http://store.datalad.org/git-annex/windows/git-annex_8.20200309.exe -FileName resources\git-annex-installer.exe
+  #- appveyor DownloadFile http://store.datalad.org/git-annex/windows/git-annex_8.20200309.exe -FileName resources\git-annex-installer.exe
+  # datalad-extensions built version with fixed up special remotes handling
+  - appveyor DownloadFile http://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20201007+git171-g7e24b2587_x64.exe -FileName resources\git-annex-installer.exe
   # extract git annex into the system Git installation path
   - 7z x -o"C:\\Program Files\Git" resources\git-annex-installer.exe
   # info on how python is ticking

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,22 @@ environment:
   MINICONDA: C:\Miniconda35
   DATALAD_TESTS_SSH: 1
 
+  # each matrix run comes with about 150s of setup overhead
   matrix:
-    # each matrix run comes with about 150s of setup overhead
-    - KNOWN_FAILURES: true
-      TEST_SELECTION: datalad.plugin
-    - TEST_SELECTION: datalad.core
-    - TEST_SELECTION: datalad.local datalad.distributed
-
+    # more modern functionality
+    - TEST_SELECTION: datalad.core datalad.local datalad.distributed datalad.tests.test_witless_runner datalad.tests.test_config
+    # older, but essential functionality
+    - TEST_SELECTION: datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3 datalad.tests.test_api datalad.tests.test_constraints datalad.tests.test_dochelpers 
+    # assorted other tests
+    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives
+    # also execute tests that probably still not run, but it will be
+    # easier to pick the working one from the log
+    - KNOWN2FAIL: 1
+      TEST_SELECTION: datalad.plugin datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
+ 
 matrix:
   allow_failures:
-    - KNOWN_FAILURES: true
+    - KNOWN2FAIL: 1
 
 cache:
   # cache the pip cache
@@ -94,21 +100,6 @@ test_script:
   - datalad wtf
   # perform selected tests for this matrix run
   - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad %TEST_SELECTION%
-  # and now this... [keep appending tests that should work!!]
-  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.core datalad.local datalad.distributed datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui
-  # # one call per datalad component for now -- to better see what is being tested
-  # # remaining fails: test_archives.test_basic_scenario test_datalad.test_basic_scenario_local_url
-  # #- python -m nose -s -v -A "not (turtle)" datalad.customremotes
-  # # remaining fails: test_http
-  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3
-  # # remaining fails: extractors.tests.test_base test_aggregation test_base  datalad.metadata.extractors.tests.test_datacite_xml
-  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822
-  # # remaining fails: test_addurls test_export_archive test_plugins"
-  # # additional tests need module `dateutil`!!
-  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.plugin.tests.test_check_dates
-  # # remaining fails: test__main__ test_cmd test_log  test_protocols test_test_utils test_auto
-  # - python -m nose -s -v -A "not (turtle)" --with-cov --cover-package datalad datalad.tests.test_utils datalad.tests.test_api datalad.tests.test_base datalad.tests.test_config datalad.tests.test_constraints datalad.tests.test_dochelpers datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.tests.test_witless_runner
- 
   # prepare coverage.xml in a separate invocation.  If invoked directly with nose - do not include test_ files themselves
   - python -m coverage xml
 

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -50,6 +50,7 @@ from datalad.support.param import Parameter
 from datalad.support.network import (
     get_local_file_url,
     download_url,
+    is_url,
     URL,
     RI,
     DataLadRI,
@@ -395,7 +396,8 @@ def clone_dataset(
             for cand in candidate_sources:
                 src = cand['giturl']
                 if track_url == src \
-                        or get_local_file_url(track_url, compatibility='git') == src \
+                        or (not is_url(track_url)
+                            and get_local_file_url(track_url, compatibility='git') == src) \
                         or track_path == expanduser(src):
                     yield get_status_dict(
                         status='notneeded',

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -266,7 +266,8 @@ def test_status_symlinked_dir_within_repo(path):
         return ds.status(path=[bar_f], annex="availability",
                          on_failure="ignore", result_renderer=None)
 
-    if ds.repo.git_annex_version < "8.20200522":
+    if ds.repo.git_annex_version < "8.20200522" or on_windows:
+        # TODO: on windows even with a recent annex -- no CommandError is raised, TODO
         assert_result_count(call(), 0)
     else:
         # As of 2a8fdfc7d (Display a warning message when asked to operate on a

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -7,14 +7,18 @@ from datalad.customremotes.ria_utils import (
     create_ds_in_store,
     UnknownLayoutVersion
 )
-from datalad.utils import Path
+from datalad.utils import (
+    on_windows,
+    Path,
+)
 from datalad.tests.utils import (
     assert_equal,
     assert_raises,
     assert_true,
     rmtree,
     skip_ssh,
-    with_tempfile
+    with_tempfile,
+    SkipTest,
 )
 
 
@@ -56,6 +60,10 @@ def _test_setup_store(io_cls, io_args, store):
 def test_setup_store():
 
     yield _test_setup_store, LocalIO, []
+
+    if on_windows:
+        raise SkipTest('ora_remote.SSHRemoteIO stalls on Windows')
+
     yield skip_ssh(_test_setup_store), SSHRemoteIO, ['datalad-test']
 
 
@@ -109,4 +117,8 @@ def _test_setup_ds_in_store(io_cls, io_args, store):
 def test_setup_ds_in_store():
 
     yield _test_setup_ds_in_store, LocalIO, []
+
+    if on_windows:
+        raise SkipTest('ora_remote.SSHRemoteIO stalls on Windows')
+
     yield skip_ssh(_test_setup_ds_in_store), SSHRemoteIO, ['datalad-test']

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -687,6 +687,7 @@ def test_AnnexRepo_get_file_backend(src, dst):
     eq_(ar.get_file_backend('test-annex.dat'), 'SHA1')
 
 
+@known_failure_windows
 @with_tempfile
 def test_AnnexRepo_always_commit(path):
 

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -101,6 +101,7 @@ from .utils import (
     eq_,
     has_symlink_capability,
     known_failure,
+    known_failure_appveyor,
     known_failure_v6,
     known_failure_windows,
     nok_,
@@ -1169,6 +1170,10 @@ def test_dlabspath(path):
             eq_(dlabspath("./bu", norm=True), opj(d, "bu"))
 
 
+# OSError: [WinError 998] Invalid access to memory location:
+# '(originated from NtWow64ReadVirtualMemory64)'
+# But passes on a real win10 box -- might be server config issue
+@known_failure_appveyor
 @with_tree({'1': 'content', 'd': {'2': 'more'}})
 def test_get_open_files(p):
     pobj = Path(p)


### PR DESCRIPTION
TODOs:

- [x] Switch to win10-like test environment
- [x] Switch to PY37. @mih thinks there is no point in supporting outdated environment at this point. However PY38 is not fully functional on the current appveyor build image. So PY37
- [x] split into multiple test runs
- [x] also execute known2fail test modules in an allowed-failure test run, so we can detect improvements more easily and move tests into proper test runs accordingly
- [x] fixup testing
- [x] remove TEMP removing all other CIs
- [x] figure out or giveup (again) on codecov submission (@mih: I removed the blind re-enabling again, for now, did not work out)