### PR TITLE
Avoid repo type assumptions to enable proper tracking branch detection (maint)

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1255,3 +1255,19 @@ def test_fetch_git_special_remote(url_path, url, path):
     ds_b = clone(ds_a.path, path / "other")
     ds_b.get("f1")
     ok_(ds_b.repo.file_has_content("f1"))
+
+
+@skip_if_no_network
+@with_tempfile(mkdir=True)
+def test_nonuniform_adjusted_subdataset(path):
+    # https://github.com/datalad/datalad/issues/5107
+    topds = Dataset(Path(path) / "top").create()
+    subds_url = 'git://github.com/datalad/testrepo--basic--r1'
+    if not topds.repo.is_managed_branch():
+        raise SkipTest(
+            "Test logic assumes default dataset state is adjusted")
+    topds.clone(
+        source='git://github.com/datalad/testrepo--basic--r1',
+        path='subds')
+    eq_(topds.subdatasets(return_type='item-or-list')['gitmodule_url'],
+        subds_url)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -100,6 +100,7 @@ from .repo import (
     RepoInterface,
     path_based_str_repr,
 )
+from datalad.core.local.repo import repo_from_path
 
 # shortcuts
 _curdirsep = curdir + sep
@@ -2837,7 +2838,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             cmd += ['-b', branch]
         if url is None:
             # repo must already exist locally
-            subm = GitRepo(op.join(self.path, path), create=False, init=False)
+            subm = repo_from_path(op.join(self.path, path))
             # check that it has a commit, and refuse
             # to operate on it otherwise, or we would get a bastard
             # submodule that cripples git operations
@@ -3115,7 +3116,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             (remote or None, refspec or None) of the tracking branch
         """
         if branch is None:
-            branch = self.get_active_branch()
+            branch = self.get_corresponding_branch() or self.get_active_branch()
             if branch is None:
                 return None, None
 


### PR DESCRIPTION
Force-treating a to-be-added submodule as a GitRepo prevented the
detection of a corresponding branch to the active branch, in order to
determine the true tracking branch. Which is necessary to discover
the effective clone URL from a repository (when it is in adjusted
mode).

This is an alternative to 901c8fd4eaf8070fa632f03d9428eceba3c0c97c but
reworked to be applicable to the 0.13 series.

Fixes gh-5107
