### PR TITLE
NF: downloaders: Support downloading Docker registry blobs

### DIFF
--- a/datalad/downloaders/configs/dockerio.cfg
+++ b/datalad/downloaders/configs/dockerio.cfg
@@ -1,0 +1,3 @@
+[provider:dockerio]
+url_re = https://registry-1.docker.io/v2/.*
+authentication_type = bearer_token_anon

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -22,6 +22,7 @@ from .base import NoneAuthenticator, NotImplementedAuthenticator
 
 from .http import (
     HTMLFormAuthenticator,
+    HTTPAnonBearerTokenAuthenticator,
     HTTPAuthAuthenticator,
     HTTPBasicAuthAuthenticator,
     HTTPDigestAuthAuthenticator,
@@ -50,6 +51,7 @@ AUTHENTICATION_TYPES = {
     'http_basic_auth': HTTPBasicAuthAuthenticator,
     'http_digest_auth': HTTPDigestAuthAuthenticator,
     'bearer_token': HTTPBearerTokenAuthenticator,
+    'bearer_token_anon': HTTPAnonBearerTokenAuthenticator,
     'aws-s3': S3Authenticator,  # TODO: check if having '-' is kosher
     'nda-s3': S3Authenticator,
     'loris-token': HTTPBearerTokenAuthenticator,

--- a/datalad/downloaders/tests/test_docker_registry.py
+++ b/datalad/downloaders/tests/test_docker_registry.py
@@ -1,0 +1,47 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for the docker-registry:// downloader"""
+
+from datalad.distribution.dataset import Dataset
+from datalad.tests.utils import (
+    assert_in,
+    eq_,
+    integration,
+    patch_config,
+    skip_if_no_network,
+    slow,
+    with_tempfile,
+)
+
+
+@skip_if_no_network
+@slow  # ~7s
+@integration
+@with_tempfile(mkdir=True)
+def test_download_docker_blob(path):
+    from datalad.consts import (
+        DATALAD_SPECIAL_REMOTE,
+        DATALAD_SPECIAL_REMOTES_UUIDS,
+    )
+    from datalad.customremotes.base import init_datalad_remote
+
+    with patch_config({"datalad.repo.backend": "SHA256E"}):
+        ds = Dataset(path).create()
+    ds_repo = ds.repo
+    init_datalad_remote(ds_repo, DATALAD_SPECIAL_REMOTE)
+
+    id_ = "f0b02e9d092d905d0d87a8455a1ae3e9bb47b4aa3dc125125ca5cd10d6441c9f"
+    outfile = ds_repo.pathobj / "blob"
+    url = "https://registry-1.docker.io/v2/library/busybox/blobs/sha256:" + id_
+    ds.download_url(urls=[url], path=str(outfile))
+
+    annex_info = ds.repo.get_content_annexinfo(paths=[outfile], init=None)
+    eq_(id_, annex_info[outfile]["keyname"])
+    assert_in(DATALAD_SPECIAL_REMOTES_UUIDS[DATALAD_SPECIAL_REMOTE],
+              ds_repo.whereis([str(outfile)])[0])


### PR DESCRIPTION
An upcoming PR for datalad-container will add a skopeo/OCI-based
adapter for tracking images in a dataset (as an alternative to the
already available docker-save-based adapter).  When the source of the
image is Docker Hub, the layer blobs tracked in the dataset can be
reobtained via a query to the docker.io registry endpoint.

Add a docker-registry:// link type and wire up the datalad special
remote so that datalad-container can assign links to layers.

---

- [ ] Figure out if `HTTPBearerTokenAuthenticator` can be used rather than adding `HTTPAnonBearerTokenAuthenticator` class

