### PR TITLE
TST: test_direct_mode: Fix two name errors

### DIFF
--- a/datalad/tests/test_direct_mode.py
+++ b/datalad/tests/test_direct_mode.py
@@ -125,7 +125,7 @@ def test_direct_cfg(path1, path2):
     ar2sub1 = AnnexRepo(op.join(path2, 'sub1'))
     # but now let's convert that sub1 to direct mode
     assert not ar2sub1.is_direct_mode()
-    _set_direct_mode(arsub1, True)
+    _set_direct_mode(ar2sub1, True)
     assert ar2sub1.is_direct_mode()
     del ar2; del ar2sub1; AnnexRepo._unique_instances.clear()  # fight flyweight
 
@@ -134,6 +134,6 @@ def test_direct_cfg(path1, path2):
 
     # And what if we are trying to add pre-cloned repo in direct mode?
     ar2sub2 = AnnexRepo.clone(path1, op.join(path2, 'sub2'))
-    _set_direct_mode(arsub2, True)
+    _set_direct_mode(ar2sub2, True)
     del ar2sub2; AnnexRepo._unique_instances.clear()  # fight flyweight
     ar2.add('sub2')


### PR DESCRIPTION
Most of test_direct_mode() is no longer executed because it requires a
git-annex version that supports direct mode, and the version used for
most CI jobs does not.  test_direct_mode() failed in master's most
recent cron job with git-annex 7.20190708+git9-gfa3524b95-1~ndall+1
due to two undefined names [*].  These came from a faulty conversion
in 595443c5b6 (RF: Strip AnnexRepo._set_direct_mode() from class and
make test helper, 2020-09-06).

Note that this failure didn't have a chance to surface until
relatively recently because the job stalled before aafebc819a (TST:
test_annex_ssh: Extend skip to older git-annex versions, 2020-10-20)

[*] https://travis-ci.org/github/datalad/datalad/jobs/741950931

---

No time or effort should be spent on direct mode at this point, but this fix is simple enough and was the only thing besides the allowed failures job that prevented master's most recent Travis cron build from being green.