### PR TITLE
Fix path and URL handling in ORA remote and associated tests

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -69,6 +69,7 @@ from datalad.tests.utils import (
     with_tree,
     SkipTest,
 )
+from datalad.support.network import get_local_file_url
 from datalad.core.distributed.clone import (
     _get_installationpath_from_url,
     decode_source_spec,
@@ -895,7 +896,7 @@ def _postclonetest_prepare(lcl, storepath, link):
     # URL to use for upload. Point is, that this should be invalid for the clone
     # so that autoenable would fail. Therefore let it be based on a to be
     # deleted symlink
-    upl_url = "ria+{}".format(link.as_uri())
+    upl_url = "ria+{}".format(get_local_file_url(str(link)))
 
     for d in (ds, subds, subgit):
 
@@ -943,7 +944,7 @@ def test_ria_postclonecfg():
         id = _postclonetest_prepare(lcl, store)
 
         # test cloning via ria+file://
-        yield _test_ria_postclonecfg, Path(store).as_uri(), id
+        yield _test_ria_postclonecfg, get_local_file_url(store, compatibility='git'), id
 
         # Note: HTTP disabled for now. Requires proper implementation in ORA
         #       remote. See

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -48,6 +48,7 @@ from datalad.tests.utils import (
     integration,
     known_failure,
     known_failure_appveyor,
+    known_failure_windows,
     neq_,
     nok_,
     ok_,
@@ -928,7 +929,7 @@ def _postclonetest_prepare(lcl, storepath, link):
     return ds.id
 
 
-@known_failure_appveyor
+@known_failure_windows  # https://github.com/datalad/datalad/issues/5134
 @slow  # 14 sec on travis
 def test_ria_postclonecfg():
 

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -583,7 +583,8 @@ def handle_errors(func):
                 entry = "{time}: Error:\n{exc_str}\n" \
                         "".format(time=datetime.now(),
                                   exc_str=exc_str)
-                log_target = self.store_base_path / 'error_logs' / \
+                # ensure base path is platform path
+                log_target = Path(self.store_base_path) / 'error_logs' / \
                              "{dsid}.{uuid}.log".format(dsid=self.archive_id,
                                                         uuid=self.uuid)
                 self.io.write_file(log_target, entry, mode='a')
@@ -618,7 +619,7 @@ class RIARemote(SpecialRemote):
         # machine to SSH-log-in to access/store the data
         # subclass must set this
         self.storage_host = None
-        # must be absolute, and POSIX
+        # must be absolute, and POSIX (will be instance of PurePosixPath)
         # subclass must set this
         self.store_base_path = None
         # by default we can read and write
@@ -649,8 +650,9 @@ class RIARemote(SpecialRemote):
         isn't configured, sets the remote to read-only operation.
         """
 
+        # ensure base path is platform path
         dataset_tree_version_file = \
-            self.store_base_path / 'ria-layout-version'
+            Path(self.store_base_path) / 'ria-layout-version'
 
         # check dataset tree version
         try:
@@ -787,7 +789,8 @@ class RIARemote(SpecialRemote):
                     "No remote base path configured. "
                     "Specify `base-path` setting.")
 
-        self.store_base_path = Path(self.store_base_path)
+        # the base path is ultimately derived from a URL, always treat as POSIX
+        self.store_base_path = PurePosixPath(self.store_base_path)
         if not self.store_base_path.is_absolute():
             raise RIARemoteError(
                 'Non-absolute object tree base path configuration: %s'
@@ -839,10 +842,14 @@ class RIARemote(SpecialRemote):
         locations, etc.
         If this doesn't raise, the remote end should be fine to work with.
         """
+        # make sure the base path is a platform path when doing local IO
+        # the incoming Path object is a PurePosixPath
+        store_base_path = Path(self.store_base_path) \
+            if self._local_io else self.store_base_path
 
         # cache remote layout directories
         self.remote_git_dir, self.remote_archive_dir, self.remote_obj_dir = \
-            self.get_layout_locations(self.store_base_path, self.archive_id)
+            self.get_layout_locations(store_base_path, self.archive_id)
 
         read_only_msg = "Treating remote as read-only in order to" \
                         "prevent damage by putting things into an unknown " \


### PR DESCRIPTION
This fixes #5085 but it does not make the relevant test complete due to #5134. However, with these changes, I can manually create RIA siblings, push them, clone them, and get data from them -- on windows.

```
(base) C:\Users\mih\TMP>datalad create someds
[INFO] Creating a new annex repo at C:\Users\mih\TMP\someds
[INFO] Detected a filesystem without fifo support.
[INFO] Disabling ssh connection caching.
[INFO] Detected a crippled filesystem.
[INFO] Scanning for unlocked files (this may take some time)
[INFO] Entering an adjusted branch where files are unlocked as this filesystem does not support locked files.
[INFO] Switched to branch 'adjusted/master(unlocked)'
create(ok): C:\Users\mih\TMP\someds (dataset)

(base) C:\Users\mih\TMP>datalad -C someds create-sibling-ria -s store ria+file://C/Users/mih/TMP/RIA
[INFO] create siblings 'store' and 'store-storage' ...
[INFO] Fetching updates for Dataset("C:\Users\mih\TMP\someds")
[INFO] Configure additional publication dependency on "store-storage"
create-sibling-ria(ok): C:\Users\mih\TMP\someds (dataset)

(base) C:\Users\mih\TMP>echo 123 > someds\dummy.txt

(base) C:\Users\mih\TMP>datalad -C someds save
add(ok): dummy.txt (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  save (ok: 1)

(base) C:\Users\mih\TMP>datalad -C someds push --to store
copy(ok): dummy.txt (file) [to store-storage...]
publish(ok): . (dataset) [refs/heads/master->store:refs/heads/master [new branch]]
publish(ok): . (dataset) [refs/heads/git-annex->store:refs/heads/git-annex [new branch]]

(base) C:\Users\mih\TMP>cat someds\.datalad\config
[datalad "dataset"]
        id = 7b95bb8c-750f-4e2e-8e91-a083af8b2b13

(base) C:\Users\mih\TMP>datalad clone ria+file:///C/Users/mih/TMP/RIA#7b95bb8c-750f-4e2e-8e91-a083af8b2b13 from_ria
[INFO] Detected a filesystem without fifo support.
[INFO] Disabling ssh connection caching.
[INFO] Detected a crippled filesystem.
[INFO] Scanning for unlocked files (this may take some time)
[INFO] Entering an adjusted branch where files are unlocked as this filesystem does not support locked files.
[INFO] Switched to branch 'adjusted/master(unlocked)'
[INFO] Remote origin cannot currently be accessed.
[INFO] Configure additional publication dependency on "store-storage"
configure-sibling(ok): . (sibling)
install(ok): C:\Users\mih\TMP\from_ria (dataset)
action summary:
  configure-sibling (ok: 1)
  install (ok: 1)
```

at this point it requires a manual intervention that should not be necessary (#5134).

```
(base) C:\Users\mih\TMP>git -C from_ria annex enableremote store-storage
enableremote store-storage ok
(recording state in git...)
```

but afterwards we are in business

```
(base) C:\Users\mih\TMP>datalad -C from_ria get dummy.txt
get(ok): dummy.txt (file) [from store-storage...]

(base) C:\Users\mih\TMP>cat from_ria\dummy.txt
123
```
