### PR TITLE
BF: Prevent a sibling URL from being added when there is none

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -421,7 +421,7 @@ def _configure_remote(
     if name != 'here':
         # do all configure steps that are not meaningful for the 'here' sibling
         # AKA the local repo
-        if name not in known_remotes:
+        if name not in known_remotes and url:
             # this remote is fresh: make it known
             # just minimalistic name and URL, the rest is coming from `configure`
             ds.repo.add_remote(name, url)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -370,4 +370,23 @@ def test_sibling_path_is_posix(basedir, otherpath):
     # path URL should come out POSIX as if `git clone` had configured it for origin
     # https://github.com/datalad/datalad/issues/3972
     eq_(res['url'], Path(otherpath).as_posix())
-     
+
+
+@with_tempfile()
+def test_bf3733(path):
+    ds = create(path)
+    # call siblings configure for an unknown sibling without a URL
+    # doesn't work, but also doesn't crash
+    assert_result_count(
+        ds.siblings(
+            'configure',
+            name='imaginary',
+            publish_depends='doesntmatter',
+            url=None,
+            on_failure='ignore'),
+        1,
+        status='error',
+        action="configure-sibling",
+        name="imaginary",
+        path=ds.path,
+    )


### PR DESCRIPTION
Turns:

```
$> datalad siblings -s github --publish-depends githubobjects configure
[ERROR  ] expected str, bytes or os.PathLike object, not NoneType [subprocess.py:_execute_child:1453] (TypeError)
```

into

```
% datalad -f json siblings -s github --publish-depends githubobjects configure
{"action": "configure-sibling", "name": "github", "path": "/tmp/gintest", "refds": "/tmp/gintest", "status": "error", "type": "sibling"}
```

However, the default result renderer does not care about such error
results and produces no output. But at least it doesn't crash anymore.

With the default `datalad.log.result-level=info` there is at least an
INFO log message with the error.

However, in general I'd say we discontinue the custom result renderer of
`siblings()` -- it is cryptic without providing a benefit.

Fixes gh-3733