### PR TITLE
ENH: datalad.locations.extra-procedures to provide extra location(s) for procedures

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -86,6 +86,12 @@ definitions = {
         'destination': 'global',
         'default': opj(dirs.user_config_dir, 'procedures'),
     },
+    'datalad.locations.extra-procedures': {
+        'ui': ('question', {
+            'title': 'Extra procedure directory',
+            'text': 'Where should datalad search for some additional procedures?'}),
+        'destination': 'global',
+    },
     'datalad.locations.dataset-procedures': {
         'ui': ('question', {
                'title': 'Dataset procedure directory',

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -96,21 +96,20 @@ def _get_proc_config(name, ds=None):
 
 
 def _get_procedure_implementation(name='*', ds=None):
-    """get potential procedure path and configuration
+    """get potential procedures: path, name, configuration, and a help message
 
-    Order of consideration is user-level, system-level, extra locations, dataset,
-    datalad extensions, datalad. First one found according to this order is the
-    one to be returned. Therefore local definitions/configurations take
+    The order of consideration is user-level, system-level, extra locations, dataset,
+    datalad extensions, datalad. Therefore local definitions/configurations take
     precedence over ones, that come from outside (via a datalad-extension or a
     dataset with its .datalad/config). If a dataset had precedence (as it was
     before), the addition (or just an update) of a (sub-)dataset would otherwise
-    surprisingly cause you do execute code different from what you defined
+    surprisingly cause you to execute code different from what you defined
     within ~/.gitconfig or your local repository's .git/config.
     So, local definitions take precedence over remote ones and more specific
     ones over more general ones.
 
-    Returns
-    -------
+    Yields
+    ------
     tuple
       path, name, format string, help message
     """

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -98,7 +98,7 @@ def _get_proc_config(name, ds=None):
 def _get_procedure_implementation(name='*', ds=None):
     """get potential procedure path and configuration
 
-    Order of consideration is user-level, system-level, dataset,
+    Order of consideration is user-level, system-level, extra locations, dataset,
     datalad extensions, datalad. First one found according to this order is the
     one to be returned. Therefore local definitions/configurations take
     precedence over ones, that come from outside (via a datalad-extension or a
@@ -119,7 +119,8 @@ def _get_procedure_implementation(name='*', ds=None):
 
     # 1. check system and user account for procedure
     for loc in (cfg.obtain('datalad.locations.user-procedures'),
-                cfg.obtain('datalad.locations.system-procedures')):
+                cfg.obtain('datalad.locations.system-procedures'),
+                cfg.get('datalad.locations.extra-procedures', get_all=True)):
         for dir in ensure_list(loc):
             for m, n in _get_file_match(dir, name):
                 yield (m, n,) + _get_proc_config(n)

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -25,21 +25,23 @@ from datalad.utils import (
     swallow_outputs,
 )
 from datalad.tests.utils import (
-    eq_,
-    ok_file_has_content,
-    with_tree,
-    with_tempfile,
-    assert_raises,
-    assert_repo_status,
-    assert_true,
+    OBSCURE_FILENAME,
     assert_false,
     assert_in_results,
     assert_not_in_results,
-    skip_if,
-    OBSCURE_FILENAME,
-    on_windows,
+    assert_raises,
+    assert_repo_status,
+    assert_result_count,
+    assert_true,
+    eq_,
     known_failure_windows,
+    ok_file_has_content,
+    on_windows,
+    patch_config,
+    skip_if,
     skip_if_on_windows,
+    with_tempfile,
+    with_tree,
 )
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import (
@@ -87,7 +89,12 @@ from datalad.api import save, Dataset
 with open(op.join(sys.argv[1], 'fromproc.txt'), 'w') as f:
     f.write('hello\\n')
 save(dataset=Dataset(sys.argv[1]), path='fromproc.txt')
-"""}})
+"""},
+    'cfg_yoda.sh': """\
+#!/bin/bash
+echo "I am never to be ran but could be discovered"
+exit 1
+"""})
 @with_tempfile
 def test_procedure_discovery(path, super_path):
     with chpwd(path):
@@ -97,17 +104,44 @@ def test_procedure_discovery(path, super_path):
         ps = run_procedure(discover=True)
         # there are a few procedures coming with datalad, needs to find them
         assert_true(len(ps) > 2)
-        # we get three essential properties
-        eq_(
-            sum(['procedure_type' in p and
-                 'procedure_callfmt' in p and
-                 'path' in p
-                 for p in ps]),
-            len(ps))
+        # we get essential properties
+        _check_procedure_properties(ps)
 
     # set up dataset with registered procedure (c&p from test_basics):
     ds = Dataset(path).create(force=True)
+    # extra check: must not pick up cfg_yoda.sh in top directory
     ds.run_procedure('cfg_yoda')
+
+    # path to a procedure which is not under any "standard" location but
+    # present in the dataset
+    code_dir_procedure_path = op.join(ds.path, 'code', 'datalad_test_proc.py')
+    top_dir_procedure_path = op.join(ds.path, 'cfg_yoda.sh')
+
+    # run discovery on the dataset:
+    ps = ds.run_procedure(discover=True)
+    # it should not be found magically by default
+    assert_not_in_results(ps, path=code_dir_procedure_path)
+    assert_not_in_results(ps, path=top_dir_procedure_path)
+
+    with patch_config({'datalad.locations.extra-procedures': op.join(ds.path, 'code')}):
+        # run discovery on the dataset:
+        ps = ds.run_procedure(discover=True)
+        # still needs to find procedures coming with datalad
+        assert_true(len(ps) > 3)
+        # and procedure under the path we specified
+        assert_result_count(ps, 1, path=code_dir_procedure_path)
+        assert_not_in_results(ps, path=top_dir_procedure_path)
+
+    # multiple extra locations
+    with patch_config({'datalad.locations.extra-procedures': [op.join(ds.path, 'code'), ds.path]}):
+        # run discovery on the dataset:
+        ps = ds.run_procedure(discover=True)
+        # still needs to find procedures coming with datalad
+        assert_true(len(ps) > 4)
+        # and procedure under the path we specified
+        assert_result_count(ps, 1, path=code_dir_procedure_path)
+        assert_result_count(ps, 1, path=top_dir_procedure_path)
+
     # configure dataset to look for procedures in its code folder
     ds.config.add(
         'datalad.locations.dataset-procedures',
@@ -121,14 +155,10 @@ def test_procedure_discovery(path, super_path):
     # still needs to find procedures coming with datalad
     assert_true(len(ps) > 2)
     # we get three essential properties
-    eq_(
-        sum(['procedure_type' in p and
-             'procedure_callfmt' in p and
-             'path' in p
-             for p in ps]),
-        len(ps))
+    _check_procedure_properties(ps)
     # dataset's procedure needs to be in the results
-    assert_in_results(ps, path=op.join(ds.path, 'code', 'datalad_test_proc.py'))
+    # and only a single one
+    assert_result_count(ps, 1, path=code_dir_procedure_path)
     # a subdir shouldn't be considered a procedure just because it's "executable"
     assert_not_in_results(ps, path=op.join(ds.path, 'code', 'testdir'))
 
@@ -141,13 +171,7 @@ def test_procedure_discovery(path, super_path):
     ps = super.run_procedure(discover=True)
     # still needs to find procedures coming with datalad
     assert_true(len(ps) > 2)
-    # we get three essential properties
-    eq_(
-        sum(['procedure_type' in p and
-             'procedure_callfmt' in p and
-             'path' in p
-             for p in ps]),
-        len(ps))
+    _check_procedure_properties(ps)
     # dataset's procedure needs to be in the results
     assert_in_results(ps, path=op.join(super.path, 'sub', 'code',
                                        'datalad_test_proc.py'))
@@ -175,6 +199,16 @@ def test_procedure_discovery(path, super_path):
             path=op.join(super.path, 'sub', 'code',
                          'unknwon_broken_link'),
             state='absent')
+
+
+def _check_procedure_properties(ps):
+    """a common check that we get three essential properties"""
+    eq_(
+        sum(['procedure_type' in p and
+             'procedure_callfmt' in p and
+             'path' in p
+             for p in ps]),
+        len(ps))
 
 
 @skip_if(cond=on_windows and dl_cfg.obtain("datalad.repo.version") < 6)


### PR DESCRIPTION
This could be useful to point to extra locations for procedures which might
reside in some subdataset, or an alternative to system/user-wide locations.
E.g. it provides a solution IMHO to https://github.com/datalad/datalad/issues/4802 (alternative to #4803) which avoids need for some new semantic of --dataset in "create" command, thus keeping it possible to do

  datalad -c datalad.locations.extra-procedures=$PWD/procedures create  -d . -c mine sub/

as well as

  datalad -c datalad.locations.extra-procedures=$PWD/procedures create  -d ^ -c mine sub/

if current dataset is a subdataset within hierarchy.  Or point that location to any other arbitrary location (within subdataset, directory, anywhere).
Some inconvenience for use through Python API, for which I filed
https://github.com/datalad/datalad/issues/5155

TODOs
- [x] follow up commit since I believe a docstring needs further unrelated tune up