### PR TITLE
RF: customremotes: Remove unused _get_key_path() method

### DIFF
--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -258,7 +258,6 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
             # Extract via cache only if size is not yet known
             if size is None:
                 # if for testing we want to force getting the archive extracted
-                # _ = self.cache.assure_extracted(self._get_key_path(akey)) # TEMP
                 efile = self.cache[akey_path].get_extracted_filename(afile)
                 efile = ensure_bytes(efile)
 

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -662,16 +662,6 @@ class AnnexCustomRemote(object):
         """
         return list(self.gen_URLS(key))
 
-    def _get_key_path(self, key):
-        """Return path to the KEY file
-        """
-        # TODO: should actually be implemented by AnnexRepo
-        #       Command is available in annex >= 20140410
-        out = self.repo.call_git(['git', 'annex', 'contentlocation', key])
-        # TODO: it would exit with non-0 if key is not present locally.
-        # we need to catch and throw our exception
-        return opj(self.path, out.rstrip(os.linesep))
-
     # TODO: test on annex'es generated with those new options e.g.-c annex.tune.objecthash1=true
     #def get_GETCONFIG SETCONFIG  SETCREDS  GETCREDS  GETUUID  GETGITDIR  SETWANTED  GETWANTED
     #SETSTATE GETSTATE SETURLPRESENT  SETURLMISSING


### PR DESCRIPTION
309878904 (RF: Replace old-style custom runner calls in customremotes,
2020-11-11) switched _get_key_path() over to using repo.call_git(),
but it left 'git' in the arguments, leading to a broken 'git git annex
...' call.

Rather than fix the call, just drop AnnexCustomRemote._get_key_path()
because it hasn't had a caller in the code base since 096e2f3ec
(NF+RF: really sketchy initial interface/add_archive_content.py +
swarms of tunes around, 2015-11-09).

---

Sorry, I missed this when reviewing gh-5142.  Spotted it today when thinking about gh-5161 (and gh-4406).
