### PR TITLE
Make benchmark workflow fail if a benchmark slowed down too much

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,3 +39,6 @@ jobs:
       run: |
         # Invocation from tools/ci/benchmark-travis-pr.sh for convenience
         asv compare refs/bm/merge-target refs/bm/pr
+    - name: Fail if any benchmarks have slowed down too much
+      run: |
+        ! asv compare --factor 1.2 --split refs/bm/merge-target refs/bm/pr | grep -q "got worse"


### PR DESCRIPTION
As requested [here](https://github.com/con/fscacher/pull/16#issuecomment-729761695).