### PR TITLE
addurls: Support creating content-less tree from known checksums

### DIFF
--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -237,6 +237,8 @@ class AnnexKeyParser(object):
         self.regexp = re.compile(r"(?P<backend>[A-Z0-9]+)"
                                  r"(?:-[^-]+)?"
                                  r"--(?P<keyname>[^/\n]+)\Z")
+        self.empty = "".join(i[0]
+                             for i in string.Formatter().parse(format_string))
 
     def parse(self, row):
         """Format the key with the fields in `row` and parse it.
@@ -256,6 +258,12 @@ class AnnexKeyParser(object):
         except KeyError as exc:
             lgr.debug("Row missing fields for --key: %s",
                       exc_str(exc))
+            return {}
+
+        if key == self.empty:
+            lgr.debug("All fields in --key's value are empty in row: %s", row)
+            # We got the same string that'd we get if all the fields were
+            # empty, so this doesn't have a key.
             return {}
 
         match = self.regexp.match(key)

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1062,7 +1062,8 @@ class Addurls(Interface):
             for subpath in subpaths:
                 lgr.info("Would create a subdataset at %s", subpath)
             for row in rows:
-                lgr.info("Would download %s to %s",
+                lgr.info("Would %s %s to %s",
+                         "register" if row.get("key") else "download",
                          row["url"],
                          os.path.join(ds.path, row["filename"]))
                 if "meta_args" in row:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -31,7 +31,7 @@ from datalad.interface.common_opts import (
     jobs_opt,
     nosave_opt,
 )
-from datalad.support.exceptions import AnnexBatchCommandError
+from datalad.support.exceptions import CommandError
 from datalad.support.itertools import groupby_sorted
 from datalad.support.network import get_url_filename
 from datalad.support.path import split_ext
@@ -544,7 +544,7 @@ def _add_urls(rows, ds, repo, ifexists=None, options=None, drop_after=False):
         try:
             out_json = repo.add_url_to_file(filename, row["url"],
                                             batch=True, options=options)
-        except AnnexBatchCommandError as exc:
+        except CommandError as exc:
             yield get_status_dict(action="addurls",
                                   ds=ds,
                                   type="file",
@@ -570,7 +570,7 @@ def _add_urls(rows, ds, repo, ifexists=None, options=None, drop_after=False):
             try:
                 repo.drop_key(res_addurls['annexkey'], batch=True)
                 st_kwargs = dict(status="ok")
-            except (AssertionError, AnnexBatchCommandError) as exc:
+            except (AssertionError, CommandError) as exc:
                 st_kwargs = dict(message=exc_str(exc),
                                   status="error")
             yield get_status_dict(action="drop",

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -824,7 +824,8 @@ class Addurls(Interface):
         lgr = logging.getLogger("datalad.plugin.addurls")
 
         ds = require_dataset(dataset, check_installed=False)
-        if ds.repo and not isinstance(ds.repo, AnnexRepo):
+        repo = ds.repo
+        if repo and not isinstance(repo, AnnexRepo):
             yield get_status_dict(action="addurls",
                                   ds=ds,
                                   status="error",
@@ -895,7 +896,7 @@ class Addurls(Interface):
                                   message="dry-run finished")
             return
 
-        if not ds.repo:
+        if not repo:
             # Populate a new dataset with the URLs.
             yield from ds.create(
                 result_xfm=None,

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -817,7 +817,6 @@ class Addurls(Interface):
 
         from requests.exceptions import RequestException
 
-        from datalad.api import create
         from datalad.distribution.dataset import Dataset, require_dataset
         from datalad.interface.results import get_status_dict
         from datalad.support.annexrepo import AnnexRepo

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -428,8 +428,8 @@ class TestAddurls(object):
                     {"url": cls.url + "udir/b.dat",
                      "name": "b",
                      "subdir": "bar",
-                     "md5sum": "71dd3e865d708f8f8e971309096cd676",
-                     "size": "9"},
+                     "md5sum": "",
+                     "size": ""},
                     {"url": cls.url + "udir/c.dat",
                      "name": "c",
                      "subdir": "foo",
@@ -770,7 +770,7 @@ class TestAddurls(object):
                    key="MD5-s{size}--{md5sum}")
         repo = ds.repo
         repo_path = ds.repo.pathobj
-        paths = [repo_path / x for x in "abc"]
+        paths = [repo_path / x for x in "ac"]
 
         annexinfo = repo.get_content_annexinfo(eval_availability=True)
         for path in paths:
@@ -779,7 +779,7 @@ class TestAddurls(object):
             assert_false(pstat["has_content"])
 
         get_res = ds.get(paths, result_renderer=None, on_failure="ignore")
-        assert_result_count(get_res, 3, action="get", status="ok")
+        assert_result_count(get_res, 2, action="get", status="ok")
 
     @with_tempfile(mkdir=True)
     def test_addurls_row_missing_key_fields(self, path):

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -418,13 +418,18 @@ class TestAddurls(object):
         cls._hpath.start()
         cls.url = cls._hpath.url
 
+        cls.data = [{"url": cls.url + "udir/a.dat",
+                     "name": "a",
+                     "subdir": "foo"},
+                    {"url": cls.url + "udir/b.dat",
+                     "name": "b",
+                     "subdir": "bar"},
+                    {"url": cls.url + "udir/c.dat",
+                     "name": "c",
+                     "subdir": "foo"}]
         cls.json_file = tempfile.mktemp(suffix=".json", **mktmp_kws)
         with open(cls.json_file, "w") as jfh:
-            json.dump(
-                [{"url": cls.url + "udir/a.dat", "name": "a", "subdir": "foo"},
-                 {"url": cls.url + "udir/b.dat", "name": "b", "subdir": "bar"},
-                 {"url": cls.url + "udir/c.dat", "name": "c", "subdir": "foo"}],
-                jfh)
+            json.dump(cls.data, jfh)
 
     @classmethod
     def teardown_class(cls):

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -763,10 +763,14 @@ class TestAddurls(object):
     @with_tempfile(mkdir=True)
     def test_addurls_from_key_invalid_format(self, path):
         ds = Dataset(path).create(force=True)
-        with assert_raises(IncompleteResultsError):
-            ds.addurls(self.json_file, "{url}", "{name}",
-                       key="{name}-which-has-no-double-dash",
-                       exclude_autometa="*")
+        for fmt in ["{name}-which-has-no-double-dash",
+                    # Invalid hash length.
+                    "MD5-s{size}--{md5sum}a",
+                    # Invalid hash content.
+                    "MD5-s{size}--" + 32 * "q"]:
+            with assert_raises(IncompleteResultsError):
+                ds.addurls(self.json_file, "{url}", "{name}",
+                           key=fmt, exclude_autometa="*")
 
     @with_tempfile(mkdir=True)
     def check_addurls_from_key(self, key_arg, expected_backend, path):


### PR DESCRIPTION
This draft series extends `addurls` with a mode of operation along the lines of what was proposed in gh-5150: using keys specified by the caller, build the tree and register the associated URLs without downloading any content.
