### PR TITLE
MNT: update-contributors.yml: Avoid deprecated set-env

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -70,10 +70,10 @@ jobs:
              git commit -a -m "Automated deployment to update contributors $(date '+%Y-%m-%d')"
              git push origin "${BRANCH_FROM}"
           fi
-          echo "::set-env name=OPEN_PULL_REQUEST::${OPEN_PULL_REQUEST}"
-          echo "::set-env name=PULL_REQUEST_FROM_BRANCH::${BRANCH_FROM}"
-          echo "::set-env name=PULL_REQUEST_TITLE::[tributors] ${BRANCH_FROM}"
-          echo "::set-env name=PULL_REQUEST_BODY::Tributors update automated pull request."
+          echo "OPEN_PULL_REQUEST=${OPEN_PULL_REQUEST}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_FROM_BRANCH=${BRANCH_FROM}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_TITLE=[tributors] ${BRANCH_FROM}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_BODY=Tributors update automated pull request." >> $GITHUB_ENV
 
       - name: Open Pull Request
         uses: vsoch/pull-request-action@1.0.6


### PR DESCRIPTION
The last allcontributors-auto-detect build [1] failed with

    The `set-env` command is disabled. Please upgrade to using
    Environment Files or opt into unsecure command execution by
    setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable
    to `true`. For more information see:
    https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Switch to using environment files.

[1] https://github.com/datalad/datalad/actions/runs/391938310
