### PR TITLE
BF: drop: Adjust annex's "use --force" message to avoid confusion

### DIFF
--- a/datalad/distribution/drop.py
+++ b/datalad/distribution/drop.py
@@ -101,6 +101,12 @@ def _drop_files(ds, paths, check, noannex_iserror=False, **kwargs):
         success = success_status_map[res['status']]
         respath_by_status[success] = \
             respath_by_status.get(success, []) + [res['path']]
+        if res["status"] == "error" and res["action"] == "drop":
+            msg = res["message"]
+            if isinstance(msg, str) and "Use --force to" in msg:
+                # Avoid confusing datalad-drop callers with git-annex-drop's
+                # suggestion to use --force.
+                res["message"] = msg.replace("--force", "--nocheck")
         yield res
     # report on things requested that annex was silent about
     for r in results_from_annex_noinfo(

--- a/datalad/distribution/tests/test_drop.py
+++ b/datalad/distribution/tests/test_drop.py
@@ -1,0 +1,29 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test drop command
+"""
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.exceptions import IncompleteResultsError
+from datalad.tests.utils import (
+    assert_status,
+    assert_in,
+    assert_raises,
+    with_tree,
+)
+
+
+@with_tree({"foo": "foo"})
+def test_drop_file_need_nocheck(path):
+    ds = Dataset(path).create(force=True)
+    ds.save()
+    with assert_raises(IncompleteResultsError) as cme:
+        ds.drop("foo")
+    # The --force suggestion from git-annex-drop is translated to --nocheck.
+    assert_in("--nocheck", str(cme.exception))
+    assert_status("ok", ds.drop("foo", check=False, on_failure="ignore"))


### PR DESCRIPTION
Calling `datalad drop` on a file that has too few copies will
confusingly propagate a message from `git annex drop` suggesting to
use --force, an option `datalad drop` does not have.  Replace --force
with --nocheck.

The new message may still be confusing to Python callers of drop()
because it suggests --nocheck rather than check=False, but that's not
a problem unique to this spot and is preferable to reporting the
completely wrong option.

Fixes #5135.
