### PR TITLE
RF: remove hardcoded mapping to jobs=0 in get._recursive_install_subds_underneath

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -512,9 +512,6 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                  refds_path=None, description=None, jobs=None, producer_only=False):
     if isinstance(recursion_limit, int) and recursion_limit <= 0:
         return
-    if jobs == "auto":
-        # be safe -- there might be ssh logins etc. So no parallel
-        jobs = 0
     # install using helper that give some flexibility regarding where to
     # get the module from
 


### PR DESCRIPTION
I am trying to assess feasibility for using parallelization "by default" by having

    [datalad "runtime"]
    max-jobs = 6
    max-annex-jobs = 6

in my ~/.gitconfig.  To my surprise this had  no effect on  datalad install -r ///openneuro
so I had to dig this hardcoded mapping out, which is done before we consult configuration
for datalad.runtime.max-jobs within parallel.py .  Looking at git log, I had this hardcoded
from the beginning (of adding parallelization to get) and probably never re-considered even
after we added safety measures to ssh connector which now would lock to prevent multiple
password prompts -- an issue which should be resolved at that level and not here for "auto".