### PR TITLE
Windows: Experiment with quoting

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -509,8 +509,10 @@ def test_installationpath_from_url():
 def test_expanduser(srcpath, destpath):
     src = Dataset(Path(srcpath) / 'src').create()
     dest = Dataset(Path(destpath) / 'dest').create()
-
-    with chpwd(destpath), patch.dict('os.environ', {'HOME': srcpath}):
+   
+    with chpwd(destpath), patch.dict('os.environ', {'USERPROFILE' if on_windows else 
+                                                    'HOME': srcpath}):
+        
         res = clone(op.join('~', 'src'), 'dest', result_xfm=None, return_type='list',
                     on_failure='ignore')
         assert_result_count(res, 1)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -512,7 +512,6 @@ def test_expanduser(srcpath, destpath):
    
     with chpwd(destpath), patch.dict('os.environ', {'USERPROFILE' if on_windows else 
                                                     'HOME': srcpath}):
-        
         res = clone(op.join('~', 'src'), 'dest', result_xfm=None, return_type='list',
                     on_failure='ignore')
         assert_result_count(res, 1)

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -27,6 +27,7 @@ from datalad.cmd import (
     WitlessRunner as Runner,
     StdOutErrCapture,
 )
+from datalad.distribution.create_sibling import _RunnerAdapter
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import urlquote
@@ -847,3 +848,15 @@ def test_non_master_branch(src_path, target_path):
         "other-sub")
     eq_(get_branch(Dataset(target_path / "b" / "sub-b").repo),
         DEFAULT_BRANCH)
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_preserve_attrs(src, dest):
+    create_tree(src, {"src": {"foo": {"bar": "This is test text."}}})
+    os.utime(opj(src, "src", "foo", "bar"), (1234567890, 1234567890))
+    _RunnerAdapter().put(opj(src, "src"), dest, recursive=True, preserve_attrs=True)
+    s = os.stat(opj(dest, "src", "foo", "bar"))
+    assert s.st_atime == 1234567890
+    assert s.st_mtime == 1234567890
+    with open(opj(dest, "src", "foo", "bar")) as fp:
+        assert fp.read() == "This is test text."

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2454,7 +2454,7 @@ def bytes2human(n, format='%(value).1f %(symbol)sB'):
 def quote_cmdlinearg(arg):
     """Perform platform-appropriate argument quoting"""
     # https://stackoverflow.com/a/15262019
-    return '"{}"'.format(
+    return '{}'.format(
         arg.replace('"', '""')
     ) if on_windows else shlex_quote(arg)
 


### PR DESCRIPTION
I gave up trying to understand how [(different things on) Windows interpret and escape quotes](https://stackoverflow.com/a/31413730), but  the error that surfaced in #5117, where the source and destination in a ``cp`` command got grouped into a single argument instead of two, is resolved by escaping a double quote with another double-quote (``""``) instead of two double-quotes (``"""``). Since Travis works again, I'm opening a PR just to see which things break with switching from triple double-quotes to double double-quotes.