### PR TITLE
BF/Win: Use windows own concept of HOME

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -506,8 +506,9 @@ def test_installationpath_from_url():
 def test_expanduser(srcpath, destpath):
     src = Dataset(Path(srcpath) / 'src').create()
     dest = Dataset(Path(destpath) / 'dest').create()
-
-    with chpwd(destpath), patch.dict('os.environ', {'HOME': srcpath}):
+   
+    with chpwd(destpath), patch.dict('os.environ', {'USERPROFILE' if on_windows else 
+                                                    'HOME': srcpath}):
         res = clone(op.join('~', 'src'), 'dest', result_xfm=None, return_type='list',
                     on_failure='ignore')
         assert_result_count(res, 1)


### PR DESCRIPTION
This should fix a test failure that surfaced in #5196 and in @mih's new appveyor setup builds.
On Windows, instead of using ``HOME``, its equivalent ``USERPROFILE`` should be patched. ([list of env vars under windows](https://docs.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables)).
On my windows computer, this change makes the test pass.