### PR TITLE
TST/Win: enable removal of long paths on windows via path prefix

### DIFF
--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -456,6 +456,12 @@ def rmtree(path, chmod_files='auto', children_only=False, *args, **kwargs):
         return
     if not (os.path.islink(path) or not os.path.isdir(path)):
         rotree(path, ro=False, chmod_files=chmod_files)
+        if on_windows:
+            # shutil fails to remove paths that exceed 260 characters on Windows machines
+            # that did not enable long path support. A workaround to remove long paths
+            # anyway is to preprend \\?\ to the path.
+            # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces
+            path = r'\\?\ '.strip() + path
         _rmtree(path, *args, **kwargs)
     else:
         # just remove the symlink


### PR DESCRIPTION
shutils ``rmtree()`` [fails to remove file paths that exceed the 260 character limit](https://stackoverflow.com/questions/1365797/python-long-filename-support-broken-in-windows). This led to a testfailure in the removal phase of a temporary annex repo with sha256 backend (see https://github.com/datalad/datalad/pull/5199#issuecomment-737902114).

This change preprends paths under Windows with the magic prefix ``\\?\`` to hopefully enable the removal regardless of path length:
https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces
