### PR TITLE
TST/BF: enable overwriting downloads under Windows

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -475,7 +475,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 os.utime(temp_filepath, (time.time(), status.mtime))
 
             # place successfully downloaded over the filepath
-            os.rename(temp_filepath, filepath)
+            os.replace(temp_filepath, filepath)
 
             if stats:
                 stats.downloaded += 1

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -129,7 +129,6 @@ def test_process_www_authenticate():
                  [])
 
 
-@known_failure_githubci_win
 @with_tree(tree=[('file.dat', 'abc')])
 @serve_path_via_http
 def test_HTTPDownloader_basic(toppath, topurl):
@@ -808,7 +807,6 @@ def test_lorisadapter(d, keyring):
     assert_equal(content, "correct body")
 
 
-@known_failure_githubci_win
 @with_tree(tree=[('file.dat', 'abc')])
 @serve_path_via_http
 def test_download_url(toppath, topurl):


### PR DESCRIPTION
This PR aims to fix a test failure that surfaced when a re-download attempts to overwrite an existing file (https://github.com/datalad/datalad/pull/5199#issuecomment-737973537). On Windows systems, an ``os.rename()`` will always raise a FileExistsError
if the file exits, while on Unix systems the existing file is replaced silently if the user has permissions, see https://docs.python.org/3/library/os.html#os.rename.
``os.replace()`` appears to be a cross-platform compatible solution, but let's hope that this doesn't break something else - then I could just do it ``if on_windows``.
