### PR TITLE
Adjust more tests to work on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,13 @@ environment:
     # more modern functionality
     - TEST_SELECTION: datalad.core datalad.local datalad.distributed datalad.tests.test_witless_runner datalad.tests.test_config
     # older, but essential functionality
-    - TEST_SELECTION: datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3 datalad.tests.test_api datalad.tests.test_constraints datalad.tests.test_dochelpers 
+    - TEST_SELECTION: datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3 datalad.tests.test_api datalad.tests.test_constraints datalad.tests.test_dochelpers
     # assorted other tests
-    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives
+    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.plugin
     # also execute tests that probably still not run, but it will be
     # easier to pick the working one from the log
     - KNOWN2FAIL: 1
-      TEST_SELECTION: datalad.plugin datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
+      TEST_SELECTION: datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
  
 matrix:
   allow_failures:

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -43,6 +43,7 @@ from datalad.tests.utils import (
     swallow_logs,
     with_tempfile,
     with_tree,
+    on_windows,
 )
 from datalad.utils import get_tempfile_kwargs, rmtemp
 from datalad import cfg as dl_cfg
@@ -444,9 +445,15 @@ class TestAddurls(object):
         # Ignore this check if we're faking dates because that disables
         # batch mode.
         if not dl_cfg.get('datalad.fake-dates'):
-            # We should have two new commits on the git-annex: one for the
-            # added urls and one for the added metadata.
-            eq_(n_annex_commits + 2, get_annex_commit_counts())
+            if not on_windows:
+                # We should have two new commits on the git-annex: one for the
+                # added urls and one for the added metadata.
+                eq_(n_annex_commits + 2, get_annex_commit_counts())
+            else:
+                # For unknown reasons (TODO/FIXME) the git-annex branch has
+                # two extra commits (the commit with three metadata changes 
+                # is represented as three individual commits)
+                eq_(n_annex_commits + 2 + 2, get_annex_commit_counts())
 
         # Add to already existing links, overwriting.
         with swallow_logs(new_level=logging.DEBUG) as cml:

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -253,14 +253,14 @@ def test_extract():
         filename_format="{age_group}//{now_dead}//{name}.csv")
 
     eq_(subpaths,
-        ["adult", "kid", "adult/no", "adult/yes", "kid/no"])
+        ["adult", "kid", op.join("adult", "no"), op.join("adult", "yes"), op.join("kid", "no")])
 
     eq_([d["url"] for d in info],
         ["will_1.com", "bob_2.com", "scott_1.com", "max_2.com"])
 
     eq_([d["filename"] for d in info],
-        ["kid/no/will.csv", "adult/yes/bob.csv",
-         "adult/no/scott.csv", "kid/no/max.csv"])
+        [op.join("kid", "no", "will.csv"), op.join("adult", "yes", "bob.csv"),
+         op.join("adult", "no", "scott.csv"), op.join("kid", "no", "max.csv")])
 
     expects = [{"name": "will", "age_group": "kid", "debut_season": "1",
                 "now_dead": "no"},
@@ -274,7 +274,7 @@ def test_extract():
         assert_dict_equal(d["meta_args"], expect)
 
     eq_([d["subpath"] for d in info],
-        ["kid/no", "adult/yes", "adult/no", "kid/no"])
+        [op.join("kid", "no"), op.join("adult", "yes"), op.join("adult", "no"), op.join("kid", "no")])
 
 
 def test_extract_disable_autometa():

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -444,16 +444,13 @@ class TestAddurls(object):
 
         # Ignore this check if we're faking dates because that disables
         # batch mode.
-        if not dl_cfg.get('datalad.fake-dates'):
-            if not on_windows:
-                # We should have two new commits on the git-annex: one for the
-                # added urls and one for the added metadata.
-                eq_(n_annex_commits + 2, get_annex_commit_counts())
-            else:
-                # For unknown reasons (TODO/FIXME) the git-annex branch has
-                # two extra commits (the commit with three metadata changes 
-                # is represented as three individual commits)
-                eq_(n_annex_commits + 2 + 2, get_annex_commit_counts())
+        # Also ignore if on Windows as it seems as if a git-annex bug 
+        # leads to separate meta data commits: 
+        # https://github.com/datalad/datalad/pull/5202#discussion_r535429704
+        if not (dl_cfg.get('datalad.fake-dates') or on_windows):
+            # We should have two new commits on the git-annex: one for the
+            # added urls and one for the added metadata.
+            eq_(n_annex_commits + 2, get_annex_commit_counts())
 
         # Add to already existing links, overwriting.
         with swallow_logs(new_level=logging.DEBUG) as cml:

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -24,6 +24,7 @@ from datalad.plugin.wtf import _HIDDEN
 from datalad.version import __version__
 
 from ..wtf import SECTION_CALLABLES
+from ...utils import Path
 
 from datalad.utils import assure_unicode
 from datalad.tests.utils import (
@@ -184,7 +185,7 @@ def test_no_annex(path):
     # one is annex'ed, the other is not, despite no change in add call
     # importantly, also .gitattribute is not annexed
     eq_([opj('code', 'inannex')],
-        ds.repo.get_annexed_files())
+        [str(Path(p)) for p in ds.repo.get_annexed_files()])
 
 
 _ds_template = {


### PR DESCRIPTION
Another set of Windows adjustments that should fix the failures that occurred in #5199.
I'm not convinced I did it in the most clever way, in particular, I used Path() to convert hardcoded Posix paths to something that fits to the given operating system. If there are better alternatives, please let me know :)