### PR TITLE
TST: test commit body in the default branch

### DIFF
--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -46,6 +46,7 @@ from datalad.tests.utils import (
     swallow_logs,
     with_tempfile,
     with_tree,
+    DEFAULT_BRANCH,
 )
 from datalad.utils import get_tempfile_kwargs, rmtemp
 from datalad import cfg as dl_cfg
@@ -446,7 +447,7 @@ class TestAddurls(object):
         # message record
         json_file = op.relpath(self.json_file, ds.path)
         ds.addurls(json_file, "{url}", "{name}")
-        ok_startswith(ds.repo.format_commit('%b'), f"url_file='{json_file}'")
+        ok_startswith(ds.repo.format_commit('%b', DEFAULT_BRANCH), f"url_file='{json_file}'")
         filenames = ["a", "b", "c"]
         for fname in filenames:
             ok_exists(op.join(ds.path, fname))


### PR DESCRIPTION
This is a left-over from #5202 that does not apply to maint (https://github.com/datalad/datalad/pull/5202#discussion_r535426621).
The change proposed here fixes one assertion of the test (the changes proposed in #5202 should fix the remaining failure). Instead of testing the commit body of the most recent commit, it tests the most recent commit on the ``DEFAULT_BRANCH`` to make the test pass also in repos that are in adjusted(unlocked) mode.