### PR TITLE
TST: appveyor: Move plugin tests back to known failures block

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,11 @@ environment:
     # older, but essential functionality
     - TEST_SELECTION: datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3 datalad.tests.test_api datalad.tests.test_constraints datalad.tests.test_dochelpers
     # assorted other tests
-    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.plugin
+    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives
     # also execute tests that probably still not run, but it will be
     # easier to pick the working one from the log
     - KNOWN2FAIL: 1
-      TEST_SELECTION: datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
+      TEST_SELECTION: datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.plugin datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
  
 matrix:
   allow_failures:


### PR DESCRIPTION
On maint, all of the plugin tests are now passing on appveyor
(gh-5202), so 7d01545eb1 moved the plugin tests out of the known
failures block.  Unfortunately tests for master's `addurls --key`
feature bring things back to a failing state (gh-5213).

Until this is resolved, move the plugin tests back to the known
failures block in master's appveyor.yml so that every appveyor run
doesn't need to be checked manually.

[ci skip]

---

cc @adswa 

Sorry for partially undoing your hard work, Adina :<