### PR TITLE
addurls --key: Use newer examinekey to support adjusted branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
   # specific version mih uses to debug on real win10 box
   #- appveyor DownloadFile http://store.datalad.org/git-annex/windows/git-annex_8.20200309.exe -FileName resources\git-annex-installer.exe
   # datalad-extensions built version with fixed up special remotes handling
-  - appveyor DownloadFile http://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20201007+git171-g7e24b2587_x64.exe -FileName resources\git-annex-installer.exe
+  - appveyor DownloadFile http://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20201127+git11-g3be9dc6e1_x64.exe -FileName resources\git-annex-installer.exe
   # extract git annex into the system Git installation path
   - 7z x -aoa -o"C:\\Program Files\Git" resources\git-annex-installer.exe
   # info on how python is ticking

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,11 @@ environment:
     # older, but essential functionality
     - TEST_SELECTION: datalad.cmdline datalad.distribution datalad.interface datalad.support datalad.ui datalad.downloaders.tests.test_credentials datalad.downloaders.tests.test_providers datalad.downloaders.tests.test_s3 datalad.tests.test_api datalad.tests.test_constraints datalad.tests.test_dochelpers
     # assorted other tests
-    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives
+    - TEST_SELECTION: datalad.metadata.tests.test_search datalad.metadata.tests.test_extract_metadata datalad.metadata.extractors.tests.test_frictionless_datapackage datalad.metadata.extractors.tests.test_rfc822 datalad.tests.test_utils datalad.tests.test_base datalad.tests.test_installed datalad.tests.test_interface datalad.tests.test_misc datalad.tests.test_s3 datalad.tests.test_testrepos datalad.tests.test_utils_testrepos datalad.tests.test_archives datalad.plugin
     # also execute tests that probably still not run, but it will be
     # easier to pick the working one from the log
     - KNOWN2FAIL: 1
-      TEST_SELECTION: datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.plugin datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
+      TEST_SELECTION: datalad.customremotes datalad.downloaders.tests.test_http datalad.metadata.extractors.tests.test_base datalad.metadata.test_aggregation datalad.metadata.test_base datalad.metadata.extractors.tests.test_datacite_xml datalad.tests.test__main__ datalad.tests.test_cmd datalad.tests.test_log datalad.tests.test_protocols datalad.tests.test_auto datalad.tests.test_tests_utils
  
 matrix:
   allow_failures:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -716,9 +716,9 @@ class RegisterUrl(object):
             self.registerurl(key, row["url"])
             res = self.fromkey(key, filename)
         except CommandError as exc:
-                yield dict(self._err_res,
-                           path=row["filename_abs"],
-                           message=exc_str(exc))
+            yield dict(self._err_res,
+                       path=row["filename_abs"],
+                       message=exc_str(exc))
         else:
             yield dict(
                 annexjson2result(res, self.ds, type="file", logger=lgr),

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1090,19 +1090,17 @@ class Addurls(Interface):
 
         ds = require_dataset(dataset, check_installed=False)
         repo = ds.repo
+        st_dict = get_status_dict(action="addurls", ds=ds)
         if repo and not isinstance(repo, AnnexRepo):
-            yield get_status_dict(action="addurls",
-                                  ds=ds,
-                                  status="error",
-                                  message="not an annex repo")
+            yield dict(st_dict, status="error", message="not an annex repo")
             return
 
         if key and key.startswith("et:") and \
            external_versions["cmd:annex"] < "8.20201116":
-            yield get_status_dict(
-                action="addurls", ds=ds, status="error",
-                message=("et: prefix of `key` option requires "
-                         "git-annex 8.20201116 or later"))
+            yield dict(st_dict,
+                       status="error",
+                       message=("et: prefix of `key` option requires "
+                                "git-annex 8.20201116 or later"))
             return
 
         if url_file != "-":
@@ -1129,28 +1127,21 @@ class Addurls(Interface):
                                          dry_run,
                                          missing_value)
             except (ValueError, RequestException) as exc:
-                yield get_status_dict(action="addurls",
-                                      ds=ds,
-                                      status="error",
-                                      message=exc_str(exc))
+                yield dict(st_dict, status="error", message=exc_str(exc))
                 return
         finally:
             if fd is not sys.stdin:
                 fd.close()
 
         if not rows:
-            yield get_status_dict(action="addurls",
-                                  ds=ds,
-                                  status="notneeded",
-                                  message="No rows to process")
+            yield dict(st_dict, status="notneeded",
+                       message="No rows to process")
             return
 
         if len(rows) != len(set(row["filename"] for row in rows)):
-            yield get_status_dict(action="addurls",
-                                  ds=ds,
-                                  status="error",
-                                  message=("There are file name collisions; "
-                                           "consider using {_repindex}"))
+            yield dict(st_dict, status="error",
+                       message=("There are file name collisions; "
+                                "consider using {_repindex}"))
             return
 
         if dry_run:
@@ -1165,10 +1156,7 @@ class Addurls(Interface):
                     lgr.info("Metadata: %s",
                              sorted(u"{}={}".format(k, v)
                                     for k, v in row["meta_args"].items()))
-            yield get_status_dict(action="addurls",
-                                  ds=ds,
-                                  status="ok",
-                                  message="dry-run finished")
+            yield dict(st_dict, status="ok", message="dry-run finished")
             return
 
         if not repo:

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -720,10 +720,10 @@ class RegisterUrl(object):
                        path=row["filename_abs"],
                        message=exc_str(exc))
         else:
-            yield dict(
-                annexjson2result(res, self.ds, type="file", logger=lgr),
-                message="registered URL",
-                action="addurls")
+            res = annexjson2result(res, self.ds, type="file", logger=lgr)
+            if not res.get("message"):
+                res["message"] = "registered URL"
+            yield res
 
 
 # Note: If any other modules end up needing these batch operations, this should

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -836,9 +836,10 @@ def _add_urls(rows, ds, repo, ifexists=None, options=None,
             assert not repo.always_commit
             for a in repo.set_metadata_(filename, add=meta):
                 res = annexjson2result(a, ds, type="file", logger=lgr)
-                # Don't show all added metadata for the file because that
-                # could quickly flood the output.
-                del res["message"]
+                if res["status"] == "ok":
+                    # Don't show all added metadata for the file because that
+                    # could quickly flood the output.
+                    del res["message"]
                 yield res
 
 

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1095,9 +1095,11 @@ class Addurls(Interface):
 
         if key and key.startswith("et:") and \
            external_versions["cmd:annex"] < "8.20201116":
-            lgr.warning("et: prefix of `key` option requires "
-                        "git-annex 8.20201116 or later. Ignoring.")
-            key = None
+            yield get_status_dict(
+                action="addurls", ds=ds, status="error",
+                message=("et: prefix of `key` option requires "
+                         "git-annex 8.20201116 or later"))
+            return
 
         if url_file != "-":
             url_file = str(resolve_path(url_file, dataset))

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1084,7 +1084,6 @@ class Addurls(Interface):
         from requests.exceptions import RequestException
 
         from datalad.distribution.dataset import Dataset, require_dataset
-        from datalad.interface.results import get_status_dict
         from datalad.support.annexrepo import AnnexRepo
 
         lgr = logging.getLogger("datalad.plugin.addurls")

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -685,9 +685,11 @@ class RegisterUrl(object):
         self._err_res = get_status_dict(action="addurls", ds=self.ds,
                                         type="file", status="error")
 
-    def examinekey(self, parsed_key, filename):
-        opts = ["--migrate-to-backend=" + parsed_key["target_backend"],
-                "--filename=" + filename, parsed_key["key"]]
+    def examinekey(self, parsed_key, filename, migrate=False):
+        opts = []
+        if migrate:
+            opts.append("--migrate-to-backend=" + parsed_key["target_backend"])
+        opts.extend(["--filename=" + filename, parsed_key["key"]])
         return self.repo._run_annex_command_json("examinekey", opts=opts)[0]
 
     def fromkey(self, key, filename):
@@ -702,7 +704,7 @@ class RegisterUrl(object):
         try:
             parsed_key = row["key"]
             if "target_backend" in parsed_key:
-                ek_info = self.examinekey(parsed_key, filename)
+                ek_info = self.examinekey(parsed_key, filename, migrate=True)
                 if ek_info:
                     key = ek_info["key"]
                 else:
@@ -749,8 +751,11 @@ class BatchedRegisterUrl(RegisterUrl):
             self._batch_commands[command] = bcmd
         return bcmd(batch_input)
 
-    def examinekey(self, parsed_key, filename):
-        opts = ["--migrate-to-backend=" + parsed_key["target_backend"]]
+    def examinekey(self, parsed_key, filename, migrate=False):
+        if migrate:
+            opts = ["--migrate-to-backend=" + parsed_key["target_backend"]]
+        else:
+            opts = None
         return self._batch("examinekey", (parsed_key["key"], filename),
                            json=True, batch_options=opts)
 

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -812,6 +812,9 @@ class TestAddurls(object):
     @with_tempfile(mkdir=True)
     def test_addurls_row_missing_key_fields(self, path):
         ds = Dataset(path).create(force=True)
+        if OLD_EXAMINEKEY and ds.repo.is_managed_branch():
+            raise SkipTest("Adjusted branch functionality requires "
+                           "more recent `git annex examinekey`")
         data = self.data.copy()
         for row in data:
             if row["name"] == "b":

--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import (
     ok_exists,
     ok_startswith,
     skip_if,
+    SkipTest,
     swallow_logs,
     with_tempfile,
     with_tree,
@@ -407,8 +408,9 @@ def test_addurls_dry_run(path):
                   cml.out)
 
 
+OLD_EXAMINEKEY = external_versions["cmd:annex"] < "8.20201116"
 skip_key_tests = skip_if(
-    external_versions["cmd:annex"] < "8.20201116",
+    OLD_EXAMINEKEY,
     "git-annex version does not support `examinekey --migrate-to-backend`")
 
 
@@ -782,6 +784,9 @@ class TestAddurls(object):
     @with_tempfile(mkdir=True)
     def check_addurls_from_key(self, key_arg, expected_backend, path):
         ds = Dataset(path).create(force=True)
+        if OLD_EXAMINEKEY and ds.repo.is_managed_branch():
+            raise SkipTest("Adjusted branch functionality requires "
+                           "more recent `git annex examinekey`")
         ds.addurls(self.json_file, "{url}", "{name}", exclude_autometa="*",
                    key=key_arg)
         repo = ds.repo


### PR DESCRIPTION
This series addresses the `addurls --key` issues described in gh-5213.  It uses `git annex examinekey`s recently added `objectpointer` field, which means that `addurls --key` isn't supported on adjusted branches with git-annex versions below 8.20201116 (which includes AppVeyor).

I tested this via `tools/eval_under_testloopfs`; under that, the addurls tests related to `--key` fail before this series.

cc @adswa
