### PR TITLE
datalad/install.py: neurodebian-devel: If git-annex-standalone is not installed, install it

### DIFF
--- a/datalad/install.py
+++ b/datalad/install.py
@@ -193,8 +193,7 @@ class GitAnnexInstaller:
                 current_annex_version = line.split()[1]
             prev = line
         assert devel_annex_version is not None, "Could not find devel annex version"
-        assert current_annex_version is not None, "Could not find current annex version"
-        if (
+        if current_annex_version is None or (
             subprocess.run(
                 [
                     "dpkg",


### PR DESCRIPTION
Fixes #5231.