### PR TITLE
RF: Use datalad.locations.sockets as dedicated configuration

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -58,6 +58,13 @@ definitions = {
         'destination': 'global',
         'default': opj(expanduser('~'), 'datalad'),
     },
+    'datalad.locations.sockets': {
+        'ui': ('question', {
+               'title': 'Socket directory',
+               'text': 'Where should datalad store socket files?'}),
+        'destination': 'global',
+        'default': opj(dirs.user_cache_dir, 'sockets'),
+    },
     'datalad.locations.system-plugins': {
         'ui': ('question', {
                'title': 'System plugin directory',

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -688,8 +688,7 @@ class MultiplexSSHManager(BaseSSHManager):
         if self._socket_dir is not None:
             return
         from datalad import cfg
-        self._socket_dir = \
-            Path(cfg.obtain('datalad.locations.cache')) / 'sockets'
+        self._socket_dir = Path(cfg.obtain('datalad.locations.sockets'))
         self._socket_dir.mkdir(exist_ok=True, parents=True)
         try:
             os.chmod(str(self._socket_dir), 0o700)


### PR DESCRIPTION
Instead of putting sockets into the cache dir. This makes it possible to
place sockets specifically, rather than all cache content. This will
make it easier to workaround filesystem limitations (gh-4075), and
path length issues (gh-5232).

Keep default location unchanged `<cachedir>/sockets`

However, using this location seems suboptimal. $HOME (which contains `cachedir` typically), may be mounted from another machine. `/tmp` is much more commonly used for this on Linux (X Server, KDE, ...), and more likely to be a local drive.

Using this new config makes things work on OSX re pathlength https://ci.appveyor.com/project/mih/appveyor-datalad/builds/36771014/job/r7yif4oct81baee7