### PR TITLE
TST: addurls: Explicitly test --key with fake dates enabled

### DIFF
--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -782,8 +782,9 @@ class TestAddurls(object):
                            key=fmt, exclude_autometa="*")
 
     @with_tempfile(mkdir=True)
-    def check_addurls_from_key(self, key_arg, expected_backend, path):
-        ds = Dataset(path).create(force=True)
+    def check_addurls_from_key(self, key_arg, expected_backend, fake_dates,
+                               path):
+        ds = Dataset(path).create(force=True, fake_dates=fake_dates)
         if OLD_EXAMINEKEY and ds.repo.is_managed_branch():
             raise SkipTest("Adjusted branch functionality requires "
                            "more recent `git annex examinekey`")
@@ -804,10 +805,13 @@ class TestAddurls(object):
 
     def test_addurls_from_key(self):
         fn = self.check_addurls_from_key
-        yield fn, "MD5-s{size}--{md5sum}", "MD5"
-        yield fn, "MD5E-s{size}--{md5sum}.dat", "MD5E"
-        yield skip_key_tests(fn), "et:MD5-s{size}--{md5sum}", "MD5E"
-        yield skip_key_tests(fn), "et:MD5E-s{size}--{md5sum}.dat", "MD5"
+        for case in [
+                (fn, "MD5-s{size}--{md5sum}", "MD5"),
+                (fn, "MD5E-s{size}--{md5sum}.dat", "MD5E"),
+                (skip_key_tests(fn), "et:MD5-s{size}--{md5sum}", "MD5E"),
+                (skip_key_tests(fn), "et:MD5E-s{size}--{md5sum}.dat", "MD5")]:
+            yield case + (False,)
+            yield case + (True,)
 
     @with_tempfile(mkdir=True)
     def test_addurls_row_missing_key_fields(self, path):


### PR DESCRIPTION
The --key functionality added in 45915917f4 (NF: addurls: Support
creating content-less tree from known checksums, 2020-11-25) has two
code paths, batch and non-batch, because batch commands are avoided
when fake dates are enabled [1].  However, as pointed out by @mih in
gh-5163, the non-batch code path is not covered in the CI runs.

Extend test_addurls_from_key() to cover datasets create with
fake_dates=True.

[1] 4d7ada2675 (RF: annexrepo: Disable batching when fake dates are
    enabled, 2018-04-13)
