### PR TITLE
Make diffstatus decision making more accessible

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -221,21 +221,25 @@ def test_subsuperdataset_save(path):
     sub2 = parent.create(sub1.pathobj / 'sub2')
     sub3 = parent.create(sub2.pathobj / 'sub3')
     assert_repo_status(path)
-    # now we will lobotomize that sub2 so git would fail if any query is performed.
-    rmtree(str(sub3.pathobj / '.git' / 'objects'))
+    # now we will lobotomize that sub3 so git would fail if any query is performed.
+    (sub3.pathobj / '.git' / 'config').chmod(0o000)
+    try:
+        sub3.repo.call_git(['ls-files'])
+        raise SkipTest
+    except CommandError:
+        # desired outcome
+        pass
     # the call should proceed fine since neither should care about sub3
     # default is no recursion
     parent.save('sub1')
     sub1.save('sub2')
     assert_raises(CommandError, parent.save, 'sub1', recursive=True)
-    # and should fail if we request saving while in the parent directory
-    # but while not providing a dataset, since operation would run within
-    # pointed subdataset
-    with chpwd(sub1.path):
-        assert_raises(CommandError, save, 'sub2')
     # but should not fail in the top level superdataset
     with chpwd(parent.path):
         save('sub1')
+    # or in a subdataset above the problematic one
+    with chpwd(sub1.path):
+        save('sub2')
 
 
 @skip_wo_symlink_capability

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -234,7 +234,7 @@ def test_subsuperdataset_save(path):
     parent.save('sub1')
     sub1.save('sub2')
     assert_raises(CommandError, parent.save, 'sub1', recursive=True)
-    # but should not fail in the top level superdataset
+    # and should not fail in the top level superdataset
     with chpwd(parent.path):
         save('sub1')
     # or in a subdataset above the problematic one

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3901,7 +3901,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         eval_submodule_state : {'commit', 'no', ...}
         """
         if against_commit:
-            # we can ignore any worktree modification report when
+            # we can ignore any worktree modification reported when
             # comparing against a commit
             modified_in_worktree = False
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3874,19 +3874,19 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         else:
             return status
 
-    def _diffstatus_get_state_props(self, to, f, from_state, to_state_r,
+    def _diffstatus_get_state_props(self, to, f, from_state, to_state,
                                     modified):
         props = None
         if not from_state:
             # this is new, or rather not known to the previous state
             props = dict(
-                state='added' if to_state_r['gitshasum'] else 'untracked',
+                state='added' if to_state['gitshasum'] else 'untracked',
             )
-            if 'type' in to_state_r:
-                props['type'] = to_state_r['type']
-        elif to_state_r['gitshasum'] == from_state['gitshasum'] and \
+            if 'type' in to_state:
+                props['type'] = to_state['type']
+        elif to_state['gitshasum'] == from_state['gitshasum'] and \
                 (modified is None or f not in modified):
-            if to_state_r['type'] != 'dataset':
+            if to_state['type'] != 'dataset':
                 # no change in git record, and no change on disk
                 props = dict(
                     # at this point we know that the reported object ids
@@ -3899,11 +3899,11 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                     state='clean'
                     if to is not None or (f.exists() or f.is_symlink())
                     else 'deleted',
-                    type=to_state_r['type'],
+                    type=to_state['type'],
                 )
             else:
                 # a dataset
-                props = dict(type=to_state_r['type'])
+                props = dict(type=to_state['type'])
                 if to is not None:
                     # we can only be confident without looking
                     # at the worktree, if we compare to a recorded
@@ -3912,7 +3912,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 else:
                     # report the shasum that we know, for further
                     # wrangling of subdatasets below
-                    props['gitshasum'] = to_state_r['gitshasum']
+                    props['gitshasum'] = to_state['gitshasum']
                     props['prev_gitshasum'] = from_state['gitshasum']
         else:
             # change in git record, or on disk
@@ -3925,14 +3925,14 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 f.is_symlink() else 'deleted',
                 # TODO record before and after state for diff-like use
                 # cases
-                type=to_state_r['type'],
+                type=to_state['type'],
             )
         state = props.get('state', None)
         if state in ('clean', 'added', 'modified'):
-            props['gitshasum'] = to_state_r['gitshasum']
-            if 'bytesize' in to_state_r:
+            props['gitshasum'] = to_state['gitshasum']
+            if 'bytesize' in to_state:
                 # if we got this cheap, report it
-                props['bytesize'] = to_state_r['bytesize']
+                props['bytesize'] = to_state['bytesize']
             elif state == 'clean' and 'bytesize' in from_state:
                 # no change, we can take this old size info
                 props['bytesize'] = from_state['bytesize']

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3796,7 +3796,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 to, f, from_state.get(f, None), to_state_r,
                 # if we compare against the worktree, report if
                 # path is reported as modified in it
-                to is None and f in modified)
+                to is None and f in modified,
+                eval_submodule_state)
             # potential early exit in "global" eval mode
             if eval_submodule_state == 'global' and \
                     props.get('state', None) not in ('clean', None):
@@ -3878,7 +3879,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             return status
 
     def _diffstatus_get_state_props(self, to, f, from_state, to_state,
-                                    modified_in_worktree):
+                                    modified_in_worktree, eval_submodule_state):
         props = {}
         if 'type' in to_state:
             props['type'] = to_state['type']
@@ -3894,10 +3895,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # this is new, or rather not known to the previous state
             state = 'added' if to_sha else 'untracked'
         elif to_sha == from_sha and not modified_in_worktree:
-            # something that is seemingly unmodified, base on the info
+            # something that is seemingly unmodified, based on the info
             # gathered so far
             if to_state['type'] == 'dataset':
-                if to is not None:
+                if to is not None or eval_submodule_state == 'commit':
                     # we compare against a recorded state, just based on
                     # the shas we can be confident, otherwise the state
                     # of a subdataset isn't fully known yet, because

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3882,15 +3882,18 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         props = {}
         if 'type' in to_state:
             props['type'] = to_state['type']
+
+        to_sha = to_state['gitshasum']
+        from_sha = from_state['gitshasum'] if from_state else None
+
         # determine the state of `f` from from_state and to_state records, if
         # it can be determined conclusively from it. If not, it will
         # stay None for now
         state = None
         if not from_state:
             # this is new, or rather not known to the previous state
-            state = 'added' if to_state['gitshasum'] else 'untracked'
-        elif to_state['gitshasum'] == from_state['gitshasum'] and \
-                not modified_in_worktree:
+            state = 'added' if to_sha else 'untracked'
+        elif to_sha == from_sha and not modified_in_worktree:
             # something that is seemingly unmodified, base on the info
             # gathered so far
             if to_state['type'] == 'dataset':
@@ -3931,7 +3934,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # assign present gitsha to any record
             # state==None can only happen for subdatasets that
             # already existed, so also assign a sha for them
-            props['gitshasum'] = to_state['gitshasum']
+            props['gitshasum'] = to_sha
             if 'bytesize' in to_state:
                 # if we got this cheap, report it
                 props['bytesize'] = to_state['bytesize']
@@ -3942,7 +3945,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # assign previous gitsha to any record
             # state==None can only happen for subdatasets that
             # already existed, so also assign a sha for them
-            props['prev_gitshasum'] = from_state['gitshasum']
+            props['prev_gitshasum'] = from_sha
         if state:
             # only report a state if we could determine any
             # outside code tests for existence of the property

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3880,6 +3880,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     def _diffstatus_get_state_props(self, to, f, from_state, to_state,
                                     modified_in_worktree):
         props = None
+        # each branch of the conditional must set props to a state dict
         if not from_state:
             # this is new, or rather not known to the previous state
             props = dict(
@@ -3907,16 +3908,16 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             else:
                 # a dataset
                 props = dict(type=to_state['type'])
-                if to is not None:
-                    # we can only be confident without looking
-                    # at the worktree, if we compare to a recorded
-                    # state
-                    props['state'] = 'clean'
-                else:
+                if to is None:
+                    # comparison against the worktree
                     # report the shasum that we know, for further
                     # wrangling of subdatasets below
                     props['gitshasum'] = to_state['gitshasum']
                     props['prev_gitshasum'] = from_state['gitshasum']
+                else:
+                    # we compare against a recorded state, just based on
+                    # the shas we can be confident
+                    props['state'] = 'clean'
         else:
             # change in git record, or on disk
             props = dict(


### PR DESCRIPTION
This is a key piece of decision making, but it is notoriously hard to read and not well designed (all blame on me). Here I am trying to dissect it and put it back together in a more accessible fashion.

The focus is on being more gentle to humans, but it should not suffer a performance-loss.

The diff will look like a rewrite, but I tried to make the individual commits tell a story.