### PR TITLE
Audit get_annexed_files use

### DIFF
--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -125,7 +125,8 @@ def _test_create_store(host, base_path, ds_path, clone_path):
         assert installed_ds.is_installed()
         assert_repo_status(installed_ds.repo)
         eq_(installed_ds.id, ds.id)
-        assert_in(op.join('ds', 'file1.txt'),
+        # Note: get_annexed_files() always reports POSIX paths.
+        assert_in('ds/file1.txt',
                   installed_ds.repo.get_annexed_files())
         assert_result_count(installed_ds.get(op.join('ds', 'file1.txt')),
                             1,

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -309,9 +309,7 @@ def test_install_dataladri(src, topurl, path):
     ok_file_has_content(opj(path, 'test.txt'), 'some')
 
 
-# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:338
 @slow   # 46sec on Yarik's laptop and tripped Travis CI
-@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local', 'local-url', 'network'])
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -350,8 +350,9 @@ def test_install_recursive(src, path_nr, path_r):
         ok_(subds.is_installed(),
             "Not installed: %s" % (subds,))
         # no content was installed:
-        ok_(not any(subds.repo.file_has_content(
-            subds.repo.get_annexed_files())))
+        ainfo = subds.repo.get_content_annexinfo(init=None,
+                                                 eval_availability=True)
+        assert_false(any(st["has_content"] for st in ainfo.values()))
     # no unfulfilled subdatasets:
     ok_(top_ds.subdatasets(recursive=True, fulfilled=False) == [])
 
@@ -384,12 +385,18 @@ def test_install_recursive_with_data(src, path):
     eq_(res[0]['path'], path)
     top_ds = YieldDatasets()(res[0])
     ok_(top_ds.is_installed())
+
+    def all_have_content(repo):
+        ainfo = repo.get_content_annexinfo(init=None, eval_availability=True)
+        return all(st["has_content"] for st in ainfo.values())
+
     if isinstance(top_ds.repo, AnnexRepo):
-        ok_(all(top_ds.repo.file_has_content(top_ds.repo.get_annexed_files())))
+        ok_(all_have_content(top_ds.repo))
+
     for subds in top_ds.subdatasets(recursive=True, result_xfm='datasets'):
         ok_(subds.is_installed(), "Not installed: %s" % (subds,))
         if isinstance(subds.repo, AnnexRepo):
-            ok_(all(subds.repo.file_has_content(subds.repo.get_annexed_files())))
+            ok_(all_have_content(subds.repo))
 
 
 # https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:555
@@ -741,7 +748,9 @@ def test_install_noautoget_data(src, path):
     # there should only be datasets in the list of installed items,
     # and none of those should have any data for their annexed files yet
     for ds in cdss:
-        assert_false(any(ds.repo.file_has_content(ds.repo.get_annexed_files())))
+        ainfo = ds.repo.get_content_annexinfo(init=None,
+                                              eval_availability=True)
+        assert_false(any(st["has_content"] for st in ainfo.values()))
 
 
 @with_tempfile

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -203,14 +203,16 @@ def test_uninstall_subdataset(src, dst):
         ok_(subds.is_installed())
 
         repo = subds.repo
-        annexed_files = repo.get_annexed_files()
-        repo.get(annexed_files)
+
+        annexed_files = repo.get_content_annexinfo(init=None)
+        repo.get([str(f) for f in annexed_files])
 
         # drop data of subds:
         res = ds.drop(path=subds.path, result_xfm='paths')
-
-        ok_(all([opj(subds.path, f) in res for f in annexed_files]))
-        ok_(all([not i for i in repo.file_has_content(annexed_files)]))
+        ok_(all(str(f) in res for f in annexed_files))
+        ainfo = repo.get_content_annexinfo(paths=annexed_files,
+                                           eval_availability=True)
+        ok_(all(not st["has_content"] for st in ainfo.values()))
         # subdataset is still known
         assert_in(subds.path, ds.subdatasets(result_xfm='paths'))
 

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -202,14 +202,15 @@ def test_uninstall_subdataset(src, dst):
     for subds in ds.subdatasets(result_xfm='datasets'):
         ok_(subds.is_installed())
 
-        annexed_files = subds.repo.get_annexed_files()
-        subds.repo.get(annexed_files)
+        repo = subds.repo
+        annexed_files = repo.get_annexed_files()
+        repo.get(annexed_files)
 
         # drop data of subds:
         res = ds.drop(path=subds.path, result_xfm='paths')
 
         ok_(all([opj(subds.path, f) in res for f in annexed_files]))
-        ok_(all([not i for i in subds.repo.file_has_content(annexed_files)]))
+        ok_(all([not i for i in repo.file_has_content(annexed_files)]))
         # subdataset is still known
         assert_in(subds.path, ds.subdatasets(result_xfm='paths'))
 

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -190,8 +190,6 @@ def test_uninstall_git_file(path):
     eq_(res, ['INFO.txt'])
 
 
-# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:509
-@known_failure_windows
 @with_testrepos('submodule_annex', flavors=['local'])
 @with_tempfile(mkdir=True)
 def test_uninstall_subdataset(src, dst):

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -404,7 +404,6 @@ def test_update_volatile_subds(originpath, otherpath, destpath):
     assert_repo_status(ds.path)
 
 
-@known_failure_windows  #FIXME
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_reobtain_data(originpath, destpath):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -407,15 +407,17 @@ def _annex_sync(repo, remote, _target, merge_opts=None):
 def _reobtain(ds, merge_fn):
     def wrapped(*args, **kwargs):
         repo = ds.repo
+        repo_pathobj = repo.pathobj
 
         lgr.info("Applying updates to %s", ds)
         # get all annexed files that have data present
         lgr.info('Recording file content availability '
                  'to re-obtain updated files later on')
-        ds_path = ds.path
-        present_files = [
-            opj(ds_path, p)
-            for p in repo.get_annexed_files(with_content_only=True)]
+        ainfo = repo.get_content_annexinfo(
+            init=None, eval_availability=True)
+        # Recode paths for ds.get() call.
+        present_files = [str(ds.pathobj / f.relative_to(repo_pathobj))
+                         for f, st in ainfo.items() if st["has_content"]]
 
         yield from merge_fn(*args, **kwargs)
 

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -18,10 +18,12 @@ from datalad.distribution.dataset import Dataset
 
 from datalad.tests.utils import (
     assert_dict_equal,
+    assert_false,
     assert_not_in,
     assert_repo_status,
     assert_result_count,
     assert_status,
+    assert_true,
     eq_,
     known_failure_githubci_win,
     skip_if_on_windows,
@@ -211,14 +213,17 @@ def test_aggregate_with_unavailable_objects_from_subds(path, target):
     clone = Dataset(opj(super.path, "base"))
     assert_repo_status(clone.path)
     objpath = opj('.datalad', 'metadata', 'objects')
-    objs = [o for o in sorted(clone.repo.get_annexed_files(with_content_only=False)) if o.startswith(objpath)]
+    objs = clone.repo.get_content_annexinfo(paths=[objpath], init=None,
+                                            eval_availability=True)
     eq_(len(objs), 6)
-    eq_(all(clone.repo.file_has_content(objs)), False)
+    assert_false(any(st["has_content"] for st in objs.values()))
 
     # now aggregate should get those metadata objects
     super.aggregate_metadata(recursive=True, update_mode='all',
                              force_extraction=False)
-    eq_(all(clone.repo.file_has_content(objs)), True)
+    objs_after = clone.repo.get_content_annexinfo(
+        paths=objs, init=None, eval_availability=True)
+    assert_true(all(st["has_content"] for st in objs_after.values()))
 
 
 # this is for gh-1987

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2565,7 +2565,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         Returns
         -------
-        A list of file names
+        A list of POSIX file names
         """
         if not patterns:
             args = [] if with_content_only else ['--include', "*"]

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1218,12 +1218,12 @@ def test_annex_ssh(topdir):
 def test_annex_remove(path):
     repo = AnnexRepo(path, create=False)
 
-    file_list = repo.get_annexed_files()
+    file_list = list(repo.get_content_annexinfo(init=None))
     assert len(file_list) >= 1
     # remove a single file
-    out = repo.remove(file_list[0])
-    assert_not_in(file_list[0], repo.get_annexed_files())
-    eq_(out[0], file_list[0])
+    out = repo.remove(str(file_list[0]))
+    assert_not_in(file_list[0], repo.get_content_annexinfo(init=None))
+    eq_(out[0], str(file_list[0].relative_to(repo.pathobj)))
 
     with open(opj(repo.path, "rm-test.dat"), "w") as f:
         f.write("whatever")


### PR DESCRIPTION
As discussed in [gh-5202][1], a good number of ``get_annexed_files`` call sites (all but one in test code) don't account for the returned paths being POSIX paths.  This series hopefully addresses all of the problematic spots.

Here are the potentially affected tests.  I haven't yet tried to remove any of the skip windows decorators.  I think most if not all of them will still fail on windows because of `with_testrepos` or other issues.  @adswa, when you have a chance, would you mind testing these on your windows machine?


- `test_aggregate_with_unavailable_objects_from_subds`
- `test_annex_remove`
- `test_create_simple`
- `test_install_noautoget_data`
- `test_install_recursive_with_data`
- `test_install_recursive`
- `test_reobtain_data`
- `test_uninstall_subdataset`

[1]: https://github.com/datalad/datalad/pull/5202#discussion_r536199209
