### PR TITLE
TST: utils: Adjust get_ssh_port() for dropped Runner import

### DIFF
--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -98,6 +98,8 @@ from . import _TEMP_PATHS_GENERATED
 from datalad.cmd import (
     GitWitlessRunner,
     KillOutput,
+    StdOutErrCapture,
+    WitlessRunner,
 )
 
 # temp paths used by clones
@@ -1939,8 +1941,11 @@ def get_ssh_port(host):
     SkipTest if port cannot be found.
     """
     out = ''
+    runner = WitlessRunner()
     try:
-        out, err = Runner()(["ssh", "-G", host])
+        res = runner.run(["ssh", "-G", host], protocol=StdOutErrCapture)
+        out = res["stdout"]
+        err = res["stderr"]
     except Exception as exc:
         err = str(exc)
 


### PR DESCRIPTION
a7ecad3af8 (RF: old-Runner test usage reduction, 2020-10-08) dropped
the Runner() import, but it is still used in get_ssh_port().  Use
WitlessRunner() there too.

Fixes #5249.
