### PR TITLE
TST: ria: Work around new git-annex check

### DIFF
--- a/datalad/distributed/tests/test_ria_git_remote.py
+++ b/datalad/distributed/tests/test_ria_git_remote.py
@@ -64,7 +64,7 @@ def _test_bare_git_version_1(host, dspath, store):
     populate_dataset(ds)
     ds.save()
 
-    bare_repo_path, _, _ = get_layout_locations(1, store, ds.id)
+    bare_repo_path, _, objdir = get_layout_locations(1, store, ds.id)
     # Use git to make sure the remote end is what git thinks a bare clone of it
     # should look like
     subprocess.run(['git', 'clone', '--bare',
@@ -84,6 +84,9 @@ def _test_bare_git_version_1(host, dspath, store):
     # set up the dataset location, too.
     # Note: Dataset layout version 1 (dirhash lower):
     create_ds_in_store(io, store, ds.id, '1', '1')
+    # Avoid triggering a git-annex safety check. See gh-5253.
+    assert objdir.is_absolute()
+    io.remove_dir(objdir)
 
     # Now, let's have the bare repo as a git remote and use it with annex
     git_url = "ssh://{host}{path}".format(host=host, path=bare_repo_path) \
@@ -169,7 +172,7 @@ def _test_bare_git_version_2(host, dspath, store):
     populate_dataset(ds)
     ds.save()
 
-    bare_repo_path, _, _ = get_layout_locations(1, store, ds.id)
+    bare_repo_path, _, objdir = get_layout_locations(1, store, ds.id)
     # Use git to make sure the remote end is what git thinks a bare clone of it
     # should look like
     subprocess.run(['git', 'clone', '--bare',
@@ -189,6 +192,9 @@ def _test_bare_git_version_2(host, dspath, store):
     # set up the dataset location, too.
     # Note: Dataset layout version 2 (dirhash mixed):
     create_ds_in_store(io, store, ds.id, '2', '1')
+    # Avoid triggering a git-annex safety check. See gh-5253.
+    assert objdir.is_absolute()
+    io.remove_dir(objdir)
 
     # Now, let's have the bare repo as a git remote
     git_url = "ssh://{host}{path}".format(host=host, path=bare_repo_path) \


### PR DESCRIPTION
test_ria_git_remote.test_bare_git_version_{1,2} create a store with a
dataset and check git-annex operation with both the git remote and ora
special remote.  As of git-annex's 75acf5f44 (improve some edge cases
around partial initialization, 2020-12-14) [1], the operations with
the git remote fail because git-annex has a safety check that aborts
when it encounters a repo that has an annex/objects/ directory but no
annex.version or annex.uuid configuration.

The annex/objects/ directory is created by create_ds_in_store().  This
works fine in the context of the create-sibling-ria command: the git
remote has annex-ignore set to true as the intention is for git-annex
to only operate with the store via the ora special remote.  The above
tests, on the other hand, explicitly check git-annex operation on the
git remote.

The git-annex safety check, then, appears to be colliding with a
test-specific detail and shouldn't be an issue with real usage via the
ora special remote.  Given this, update these tests to remove the
annex/objects/ directory after they call create_ds_in_store().

[1] https://git-annex.branchable.com/todo/avoid_autoinit_when_git-annex_branch_already_exists/

Fixes #5253.

---

I'm not too confident about my conclusion that this shouldn't affect normal operation.  What do you think, @bpoldrack?