### PR TITLE
BF: RIA cloning

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -933,9 +933,6 @@ def postclonecfg_annexdataset(ds, reckless, description=None):
     yield from configure_origins(ds, ds)
 
 
-_handle_possible_annex_dataset = postclonecfg_annexdataset
-
-
 def configure_origins(cfgds, probeds, label=None):
     """Configure any discoverable local dataset 'origin' sibling as a remote
 

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1019,7 +1019,9 @@ def test_ria_postclone_noannex(dspath, storepath, clonepath):
     rmtree(str(annex))
     assert_false(annex.exists())
 
-    clone(lcl_url + '#{}'.format(ds.id), clonepath)
+    clone_url = get_local_file_url(str(storepath), compatibility='git') + \
+                '#{}'.format(ds.id)
+    clone("ria+{}".format(clone_url), clonepath)
 
     # no need to test the cloning itself - we do that over and over in here
 

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -26,6 +26,7 @@ from datalad.utils import (
     chpwd,
     Path,
     on_windows,
+    rmtree
 )
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.gitrepo import GitRepo
@@ -959,7 +960,8 @@ def test_ria_postclonecfg():
         id = _postclonetest_prepare(lcl, store)
 
         # test cloning via ria+file://
-        yield _test_ria_postclonecfg, get_local_file_url(store, compatibility='git'), id
+        yield _test_ria_postclonecfg, \
+              get_local_file_url(store, compatibility='git'), id
 
         # Note: HTTP disabled for now. Requires proper implementation in ORA
         #       remote. See
@@ -972,6 +974,57 @@ def test_ria_postclonecfg():
         # test cloning via ria+ssh://
         yield skip_ssh(_test_ria_postclonecfg), \
             "ssh://datalad-test:{}".format(Path(store).as_posix()), id
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile
+@with_tempfile
+def test_ria_postclone_noannex(dspath, storepath, clonepath):
+
+    # Test for gh-5186: Cloning from local FS, shouldn't lead to annex
+    # initializing origin.
+
+    dspath = Path(dspath)
+    storepath = Path(storepath)
+    clonepath = Path(clonepath)
+
+    from datalad.customremotes.ria_utils import (
+        create_store,
+        create_ds_in_store,
+        get_layout_locations
+    )
+    from datalad.distributed.ora_remote import (
+        LocalIO,
+    )
+
+
+
+    # First create a dataset in a RIA store the standard way
+    somefile = dspath / 'a_file.txt'
+    somefile.write_text('irrelevant')
+    ds = Dataset(dspath).create(force=True)
+
+    io = LocalIO()
+    create_store(io, storepath, '1')
+    lcl_url = "ria+{}".format(get_local_file_url(str(storepath)))
+    create_ds_in_store(io, storepath, ds.id, '2', '1')
+    ds.create_sibling_ria(lcl_url, "store")
+    ds.push('.', to='store')
+
+
+    # now, remove annex/ tree from store in order to see, that clone
+    # doesn't cause annex to recreate it.
+    store_loc, _, _ = get_layout_locations(1, storepath, ds.id)
+    annex = store_loc / 'annex'
+    rmtree(str(annex))
+    assert_false(annex.exists())
+
+    clone(lcl_url + '#{}'.format(ds.id), clonepath)
+
+    # no need to test the cloning itself - we do that over and over in here
+
+    # bare repo in store still has no local annex:
+    assert_false(annex.exists())
 
 
 @slow  # 17sec on Yarik's laptop

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -14,12 +14,6 @@ __docformat__ = 'restructuredtext'
 
 import warnings
 
-from datalad.core.distributed.clone import (
-    Clone,
-    _get_installationpath_from_url,
-    _handle_possible_annex_dataset,
-    _get_tracking_source,
-)
 
 warnings.warn("datalad.distribution.clone is obsolete. "
               "Use datalad.core.distributed.clone module instead",


### PR DESCRIPTION
Fixes #5186 


Sits on top of PR #5254 due to #5253, which is not the same but a somewhat related issue.

Despite @mih's hesitance, I'd like to support RIA stores without any ORA remote. Since an ID based structure for standard, bare annex repos is perfectly valid and requires all the same stuff (URL resolution for example). In such a case this fix would not fix but sabotage the intended behavior. With that in mind, this one-liner is a function, that can be enhanced to first query the store for a to be introduced dataset level layout, that would disable the `annex-ignore` setting.