### PR TITLE
Fix recent test_copy_file_prevent_dotgit_placement failure

### DIFF
--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -227,7 +227,12 @@ class CopyFile(Interface):
         if not specs_from:
             raise ValueError("Neither `paths` nor `specs_from` given.")
 
-        if not target_dir and ds:
+        if target_dir:
+            if ".git" in target_dir.parts:
+                raise ValueError(
+                    "Target directory should not contain a .git directory: {}"
+                    .format(target_dir))
+        elif ds:
             # no specific target set, but we have to write into a dataset,
             # and one was given. It seems to make sense to use this dataset
             # as a target. it is already to reference for any path resolution.

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -337,6 +337,6 @@ def test_copy_file_prevent_dotgit_placement(srcpath, destpath):
     assert_in_results(
         dest.copy_file(
             [sub.pathobj / '.git' / 'config',
-             dest.pathobj / 'some', '.git'], on_failure='ignore'),
+             dest.pathobj / 'some' / '.git'], on_failure='ignore'),
         status='impossible',
         action='copy_file')

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -340,3 +340,10 @@ def test_copy_file_prevent_dotgit_placement(srcpath, destpath):
              dest.pathobj / 'some' / '.git'], on_failure='ignore'),
         status='impossible',
         action='copy_file')
+
+    # The last path above wasn't treated as a target directory because it
+    # wasn't an existing directory. We also guard against a '.git' in the
+    # target directory code path, though the handling is different.
+    with assert_raises(ValueError):
+        dest.copy_file([sub.pathobj / '.git' / 'config',
+                        dest.pathobj / '.git'])

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3440,6 +3440,14 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             inf = {}
             props = props_re.match(line)
             if not props:
+                # Kludge: Filter out paths starting with .git/ to work around
+                # an `ls-files -o` bug that was fixed in Git 2.25.
+                #
+                # TODO: Drop this condition when GIT_MIN_VERSION is at least
+                # 2.25.
+                if line.startswith(".git/"):
+                    lgr.debug("Filtering out .git/ file: %s", line)
+                    continue
                 # not known to Git, but Git always reports POSIX
                 path = ut.PurePosixPath(line)
                 inf['gitshasum'] = None

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -14,6 +14,7 @@ import datalad.utils as ut
 from datalad.tests.utils import (
     assert_dict_equal,
     assert_equal,
+    assert_false,
     assert_in,
     assert_not_in,
     assert_raises,
@@ -271,3 +272,11 @@ def test_info_path_inside_submodule(path):
     cinfo = ds.repo.get_content_info(
         ref="HEAD", paths=[foo.relative_to(ds.pathobj)])
     assert_in("gitshasum", cinfo[subds.pathobj])
+
+
+@with_tempfile
+def test_get_content_info_dotgit(path):
+    ds = Dataset(path).create()
+    # Files in .git/ won't be reported, though this takes a kludge on our side
+    # before Git 2.25.
+    assert_false(ds.repo.get_content_info(paths=[op.join(".git", "config")]))


### PR DESCRIPTION
This last commit in this series fixes the git-version-dependent `test_copy_file_prevent_dotgit_placement` failure reported in gh-5248.  The first three commits are changes related to `copy-file`s `.git/` guards.
