### PR TITLE
BF: get: Fix recent regression in error propagation

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -710,10 +710,17 @@ def _get_targetpaths(ds, content, refds_path, source, jobs):
             yield r
         return
     respath_by_status = {}
-    for res in ds_repo.get(
+    try:
+        results = ds_repo.get(
             content,
             options=['--from=%s' % source] if source else [],
-            jobs=jobs):
+            jobs=jobs)
+    except CommandError as exc:
+        results = exc.kwargs.get("stdout_json")
+        if not results:
+            raise
+
+    for res in results:
         res = annexjson2result(res, ds, type='file', logger=lgr,
                                refds=refds_path)
         success = success_status_map[res['status']]

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -683,3 +683,14 @@ def test_get_subdataset_direct_fetch(path):
                         action="install", type="dataset", status="error")
     assert_result_count(res, 1,
                         action="install", type="dataset", status="ok")
+
+
+@with_tempfile()
+def test_get_relays_command_errors(path):
+    ds = Dataset(path).create()
+    (ds.pathobj / "foo").write_text("foo")
+    ds.save()
+    ds.drop("foo", check=False)
+    assert_result_count(
+        ds.get("foo", on_failure="ignore", result_renderer=None),
+        1, action="get", type="file", status="error")


### PR DESCRIPTION
As of 46d78a8353 (2020-11-18), AnnexRepo.get() uses
_call_annex_records(), which unlike _run_annex_command_json(), raises
a CommandError when git-annex exits with a non-zero status (gh-5163).
Update `datalad get` to catch the exception, extract the json records,
and yield them as results.

Thanks to @adswa for the test case.

Fixes #5260.
