### PR TITLE
TST: announce known failure 7 tests on windows github or just generaly windows

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -49,6 +49,7 @@ from datalad.tests.utils import (
     integration,
     known_failure,
     known_failure_appveyor,
+    known_failure_githubci_win,
     known_failure_windows,
     neq_,
     nok_,
@@ -204,6 +205,8 @@ def test_clone_simple_local(src, path):
         eq_(uuid_before, ds.repo.uuid)
 
 
+# AssertionError: unexpected content of state "deleted": [WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/datalad_temp_gzegy3hf/testrepo--basic--r1/test-annex.dat')] != []
+@known_failure_githubci_win
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
 def test_clone_dataset_from_just_source(url, path):
@@ -976,6 +979,8 @@ def test_ria_postclonecfg():
             "ssh://datalad-test:{}".format(Path(store).as_posix()), id
 
 
+# fatal: Could not read from remote repository.
+@known_failure_githubci_win  # in datalad/git-annex as e.g. of 20201218
 @with_tempfile(mkdir=True)
 @with_tempfile
 @with_tempfile

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -13,6 +13,7 @@ from os.path import isabs
 
 from datalad.tests.utils import (
     eq_,
+    known_failure_githubci_win,
     with_tree,
 )
 from datalad.support.annexrepo import AnnexRepo
@@ -24,6 +25,8 @@ from ..base import (
 )
 
 
+# PermissionError: [WinError 32] The process cannot access the file because it is being used by another process:
+@known_failure_githubci_win
 @with_tree(tree={'file.dat': ''})
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -47,6 +47,7 @@ from datalad.tests.utils import (
     serve_path_via_http,
     slow,
     known_failure_windows,
+    known_failure_githubci_win,
 )
 from datalad.utils import (
     with_pathsep,
@@ -70,6 +71,8 @@ def _make_dataset_hierarchy(path):
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
 
+# AssertionError since does get extra record {'cost': 400, 'name': 'bang', 'url': 'youredead', 'from_config': True},
+@known_failure_githubci_win
 @with_tempfile
 @with_tempfile
 @with_tempfile

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -271,6 +271,7 @@ def test_install_dataset_from_instance(src, dst):
     assert_in('INFO.txt', clone.repo.get_indexed_files())
 
 
+@known_failure_githubci_win
 @with_testrepos(flavors=['network'])
 @with_tempfile
 def test_install_dataset_from_just_source_via_path(url, path):

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -97,7 +97,7 @@ def test_invalid_call(origin, tdir):
         type='dataset')
 
 
-@known_failure_appveyor
+@known_failure_windows
 @with_tempfile
 @with_tempfile
 def test_since_empty_and_unsupported(p1, p2):
@@ -757,7 +757,7 @@ def test_publish_no_fetch_refspec_configured(path):
     ds.publish(to="origin")
 
 
-@known_failure_appveyor
+@known_failure_windows
 @slow  # 14sec on Yarik's laptop
 @skip_ssh
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
... if already known to fail on appveyor, I just made it into known_failure_windows

These seems to be the only ones which are erroring or failing in a run against
fresh git annex within datalad/git-annex.  master has some of those and some additional
(would be in a follow up PR after this is merged), but here are the listings for the record

	$> grep '\(FAIL\|ERROR\): ' win-maint.txt | grep -e 'datalad\.' | awk '{print $2  $3;}' | sort | nl
		 1	ERROR:datalad.core.distributed.tests.test_clone.test_ria_postclone_noannex
		 2	ERROR:datalad.customremotes.tests.test_base.test_get_contentlocation
		 3	ERROR:datalad.distribution.tests.test_publish.test_publish_fetch_do_not_recurse_submodules
		 4	ERROR:datalad.distribution.tests.test_publish.test_since_empty_and_unsupported
		 5	FAIL:datalad.core.distributed.tests.test_clone.test_clone_dataset_from_just_source
		 6	FAIL:datalad.distribution.tests.test_get.test_get_flexible_source_candidates_for_submodule
		 7	FAIL:datalad.distribution.tests.test_install.test_install_dataset_from_just_source_via_path

	$> grep '\(FAIL\|ERROR\): ' win-master.txt | grep -e 'datalad\.' | awk '{print $2  $3;}' | sort | nl
		 1	ERROR:datalad.core.distributed.tests.test_clone.test_ria_postclone_noannex
		 2	ERROR:datalad.distributed.tests.test_create_sibling_ria.test_no_storage
		 3	ERROR:datalad.distribution.tests.test_publish.test_publish_fetch_do_not_recurse_submodules
		 4	ERROR:datalad.distribution.tests.test_publish.test_since_empty_and_unsupported
		 5	ERROR:datalad.tests.test_install.test_install_miniconda
		 6	FAIL:datalad.core.distributed.tests.test_clone.test_clone_dataset_from_just_source
		 7	FAIL:datalad.distribution.tests.test_install.test_install_dataset_from_just_source_via_path

git-annex 8.20201128-g231257da4
