### PR TITLE
BF: filter out Nones while estimating total size to download + safeguard dict access

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1488,7 +1488,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             files=files_arg,
             jobs=jobs,
             progress=True,
-            total_nbytes=sum(expected_downloads.values()),
+            # filter(bool,   to avoid trying to add up None's when size is not known
+            total_nbytes=sum(filter(bool, expected_downloads.values())),
         )
         results_list = list(results)
         # TODO:  should we here compare fetch_files against result_list
@@ -3508,15 +3509,15 @@ class AnnexJsonProtocol(WitlessProtocol):
                     # do not crash if no command is reported
                     label=j['action'].get('command', '').capitalize(),
                     unit=' Bytes',
-                    total=float(j['total-size']),
+                    total=float(j.get('total-size', None)),
                     noninteractive_level=5,
                 )
                 self._pbars.add(pbar_id)
             log_progress(
                 lgr.info,
                 pbar_id,
-                j['percent-progress'],
-                update=float(j['byte-progress']),
+                j.get('percent-progress', 0),
+                update=float(j.get('byte-progress', 0)),
                 noninteractive_level=5,
             )
             # do not let progress reports leak into the return value

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3509,7 +3509,7 @@ class AnnexJsonProtocol(WitlessProtocol):
                     # do not crash if no command is reported
                     label=j['action'].get('command', '').capitalize(),
                     unit=' Bytes',
-                    total=float(j.get('total-size', None)),
+                    total=float(j.get('total-size', 0)),
                     noninteractive_level=5,
                 )
                 self._pbars.add(pbar_id)


### PR DESCRIPTION
Key might be relaxed, so there would be no size information.  Example could be found in
https://github.com/datalad-datasets/machinelearning-books
dataset for  H.DaumeIII-A_Course_in_Machine_Learning.pdf  file

Closes #5266

Might not be the best (re)solution but should make code more robust even if total progress indicator would no longer report correct total whenever it is not known.

Also fixed up that https://github.com/datalad-datasets/machinelearning-books dataset for `G.James_D.Witten_T.Hastie_R.Tibshirani-An_Introduction_to_Statistical_Learning_with_Applications_in_R.pdf` file URL for which no longer worked, so updated to new one.  