### PR TITLE
BF+OPT: config - compare full stat records, for "gone" files too, do not bother with 2 sec rule

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -342,15 +342,8 @@ class ConfigManager(object):
 
         # we have read files before
         # check if any file we read from has changed
-        current_time = time()
         curstats = self._get_stats(store)
-
-        # protect against low-res mtimes (FAT32 has 2s, EXT3 has 1s!)
-        # if mtime age is less than worst resolution assume modified.
-        # And since we are doing that -- do it first, in tests we would operate "quickly"
-        # so can decide quickly as well
-        return any(s.st_mtime - current_time <= 2.0 for s in curstats.values()) \
-               or any(curstats[f] != storestats[f] for f in store['files'])
+        return any(curstats[f] != storestats[f] for f in store['files'])
 
     def _reload(self, run_args):
         # query git-config

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -210,7 +210,7 @@ class ConfigManager(object):
             # track the files that jointly make up the config in this store
             files=set(),
             # and their modification times to be able to avoid needless unforced reloads
-            mtimes=None,
+            stats=None,
         )
         self._stores = dict(
             # populated with info from git
@@ -336,19 +336,21 @@ class ConfigManager(object):
         self._merged_store = merged
 
     def _need_reload(self, store):
-        if not store['mtimes']:
+        storestats = store['stats']
+        if not storestats:
             return True
+
         # we have read files before
         # check if any file we read from has changed
         current_time = time()
-        curmtimes = {c: c.stat().st_mtime for c in store['files'] if c.exists()}
-        if all(curmtimes[c] == store['mtimes'].get(c) and
-               # protect against low-res mtimes (FAT32 has 2s, EXT3 has 1s!)
-               # if mtime age is less than worst resolution assume modified
-               (current_time - curmtimes[c]) > 2.0
-               for c in curmtimes):
-            return False
-        return True
+        curstats = self._get_stats(store)
+
+        # protect against low-res mtimes (FAT32 has 2s, EXT3 has 1s!)
+        # if mtime age is less than worst resolution assume modified.
+        # And since we are doing that -- do it first, in tests we would operate "quickly"
+        # so can decide quickly as well
+        return any(s.st_mtime - current_time <= 2.0 for s in curstats.values()) \
+               or any(curstats[f] != storestats[f] for f in store['files'])
 
     def _reload(self, run_args):
         # query git-config
@@ -362,10 +364,14 @@ class ConfigManager(object):
         store['cfg'], store['files'] = _parse_gitconfig_dump(
             stdout, cwd=self._runner.cwd)
 
-        # update mtimes of config files, they have just been discovered
+        # update stats of config files, they have just been discovered
         # and should still exist
-        store['mtimes'] = {c: c.stat().st_mtime for c in store['files']}
+        store['stats'] = self._get_stats(store)
         return store
+
+    @staticmethod
+    def _get_stats(store):
+        return {f: f.stat() if f.exists() else None for f in store['files']}
 
     @_where_reload
     def obtain(self, var, default=None, dialog_type=None, valtype=None,


### PR DESCRIPTION
See individual commits for more details/reasoning.

If tests pass (I have not run them locally in full, only local interesting ones) -- I would consider myself done with it, although ideally at least the first commit (actual BF) should ideally be adopted for `maint` as well.

Closes #4644 
most likely it could also "close" #4363 but I failed to reproduce it locally even after reverting #4365 workaround.  Ideally someone might want to go through those explicit `.reload`s we have in the tests and kill them 