### PR TITLE
RM: install - remove --nosave/save=False

### DIFF
--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -19,7 +19,6 @@ from datalad.interface.common_opts import (
     recursion_limit,
     location_description,
     jobs_opt,
-    nosave_opt,
     reckless_opt,
 )
 from datalad.interface.results import (
@@ -158,7 +157,6 @@ class Install(Interface):
         description=location_description,
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
-        save=nosave_opt,
         reckless=reckless_opt,
         jobs=jobs_opt,
     )
@@ -174,7 +172,6 @@ class Install(Interface):
             description=None,
             recursive=False,
             recursion_limit=None,
-            save=True,
             reckless=None,
             jobs="auto"):
 
@@ -238,7 +235,6 @@ class Install(Interface):
                 for r in Install.__call__(
                         source=s,
                         description=description,
-                        save=save,
                         # we need to disable error handling in order to have it done at
                         # the very top, otherwise we are not able to order a global
                         # "ignore-and-keep-going"

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -410,7 +410,7 @@ def test_install_into_dataset(source, top_path):
     ds = create(top_path)
     assert_repo_status(ds.path)
 
-    subds = ds.install("sub", source=source, save=False)
+    subds = ds.install("sub", source=source)
     ok_(isdir(opj(subds.path, '.git')))
     ok_(subds.is_installed())
     assert_in('sub', ds.subdatasets(result_xfm='relpaths'))


### PR DESCRIPTION
As it is of no effect for awhile -- I have not done investigation when it
started to be of no effect, but it was reported on the matrix forum that
it has no effect in 0.13.5-0.13.7

Since 0.14.0 seems to be not "revolutionary" enough , and option is of no effect, I think it would be ok to just kill it