### PR TITLE
gitrepo: call_git*(read_only=True) follow-up

### DIFF
--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -203,7 +203,8 @@ def test_create_sub(path):
         'submodule.some/what/deeper.datalad-id={}'.format(
             subds.id),
         list(ds.repo.call_git_items_(['config', '--file', '.gitmodules',
-                                      '--list']))
+                                      '--list'],
+                                     read_only=True))
     )
 
     # subdataset is known to superdataset:

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -226,7 +226,7 @@ def test_subsuperdataset_save(path):
     # now we will lobotomize that sub3 so git would fail if any query is performed.
     (sub3.pathobj / '.git' / 'config').chmod(0o000)
     try:
-        sub3.repo.call_git(['ls-files'])
+        sub3.repo.call_git(['ls-files'], read_only=True)
         raise SkipTest
     except CommandError:
         # desired outcome

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -69,7 +69,8 @@ def test_initremote(store_path, store_url, ds_path):
     #   - url
     #   - common_init_opts
     #   - archive_id (which equals ds id)
-    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'])
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'],
+                                  read_only=True)
     assert_in("url={}".format(url), remote_log)
     [assert_in(c, remote_log) for c in common_init_opts]
     assert_in("archive-id={}".format(ds.id), remote_log)

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -120,7 +120,8 @@ def _test_initremote_basic(host, ds_path, store, link):
     #   - url
     #   - common_init_opts
     #   - archive_id (which equals ds id)
-    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'])
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'],
+                                  read_only=True)
     assert_in("url={}".format(url), remote_log)
     [assert_in(c, remote_log) for c in common_init_opts]
     assert_in("archive-id={}".format(ds.id), remote_log)
@@ -143,7 +144,8 @@ def _test_initremote_basic(host, ds_path, store, link):
         #   - common_init_opts
         #   - archive_id (which equals ds id)
         remote_log = ds.repo.call_git(['cat-file', 'blob',
-                                       'git-annex:remote.log'])
+                                       'git-annex:remote.log'],
+                                      read_only=True)
         assert_in("url={}".format(new_url), remote_log)
         [assert_in(c, remote_log) for c in common_init_opts]
         assert_in("archive-id={}".format(ds.id), remote_log)
@@ -203,7 +205,8 @@ def _test_initremote_rewrite(host, ds_path, store):
     #   - rewritten url
     #   - common_init_opts
     #   - archive_id (which equals ds id)
-    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'])
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'],
+                                  read_only=True)
     assert_in("url={}".format(replacement), remote_log)
     [assert_in(c, remote_log) for c in common_init_opts]
     assert_in("archive-id={}".format(ds.id), remote_log)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -577,7 +577,7 @@ def test_merge_conflict_in_subdataset_only(path):
     assert_repo_status(ds_clone_sub_noconflict.path)
     # ... but the one with the conflict leaves it for the caller to handle.
     ok_(ds_clone_sub_conflict.repo.call_git(
-        ["ls-files", "--unmerged", "--", "foo"]).strip())
+        ["ls-files", "--unmerged", "--", "foo"], read_only=True).strip())
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -354,7 +354,8 @@ def _choose_merge_target(repo, branch, remote, cfg_remote):
         # branch.*.merge value, but that assumes a value for remote.*.fetch.
         merge_target = repo.call_git_oneline(
             ["rev-parse", "--symbolic-full-name", "--abbrev-ref=strict",
-             "@{upstream}"])
+             "@{upstream}"],
+            read_only=True)
     elif branch:
         remote_branch = "{}/{}".format(remote, branch)
         if repo.commit_exists(remote_branch):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2131,13 +2131,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         expect_fail : bool, optional
           A non-zero exit is expected and should not be elevated above the
           DEBUG level.
-        read_only : bool, optional
-          By setting this to True, the caller indicates that the command does
-          not write to the repository, which lets this function skip some
-          operations that are necessary only for commands the modify the
-          repository. Beware that even commands that are conceptually
-          read-only, such as `git-status` and `git-diff`, may refresh and write
-          the index.
 
         Returns
         -------
@@ -2214,6 +2207,13 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         expect_fail : bool, optional
           A non-zero exit is expected and should not be elevated above the
           DEBUG level.
+        read_only : bool, optional
+          By setting this to True, the caller indicates that the command does
+          not write to the repository, which lets this function skip some
+          operations that are necessary only for commands the modify the
+          repository. Beware that even commands that are conceptually
+          read-only, such as `git-status` and `git-diff`, may refresh and write
+          the index.
 
         Returns
         -------

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2759,7 +2759,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             return {}
         # pull out file content
         out = self.call_git(
-            ['config', '-z', '-l', '--file', '.gitmodules'])
+            ['config', '-z', '-l', '--file', '.gitmodules'],
+            read_only=True)
         # abuse our config parser
         # disable multi-value report, because we could not deal with them
         # anyways, and they should not appear in a normal .gitmodules file
@@ -3219,7 +3220,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # simplify work with the result
         attributes = {p: {} for p in path}
         attr = []
-        for item in self.call_git_items_(cmd, files=path, sep='\0'):
+        for item in self.call_git_items_(cmd, files=path, sep='\0',
+                                         read_only=True):
             attr.append(item)
             if len(attr) < 3:
                 continue
@@ -3404,7 +3406,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             stdout = self.call_git(
                 cmd,
                 files=path_strs,
-                expect_fail=True)
+                expect_fail=True,
+                read_only=True)
         except CommandError as exc:
             if "fatal: Not a valid object name" in exc.stderr:
                 raise InvalidGitReferenceError(ref)
@@ -3662,7 +3665,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                         ['ls-files', '-z', '-m'],
                         # low-level code cannot handle pathobjs
                         files=[str(p) for p in paths] if paths else None,
-                        sep='\0')
+                        sep='\0',
+                        read_only=True)
                     if p)
                 _cache[key] = modified
         else:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2117,28 +2117,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         Internal helper to the call_git*() methods.
 
-        Parameters
-        ----------
-        args : list of str
-          Arguments to pass to `git`.
-        files : list of str, optional
-          File arguments to pass to `git`. The advantage of passing these here
-          rather than as part of `args` is that the call will be split into
-          multiple calls to avoid exceeding the maximum command line length.
-        expect_stderr : bool, optional
-          Standard error is expected and should not be elevated above the DEBUG
-          level.
-        expect_fail : bool, optional
-          A non-zero exit is expected and should not be elevated above the
-          DEBUG level.
-
-        Returns
-        -------
-        stdout, stderr
-
-        Raises
-        ------
-        CommandError if the call exits with a non-zero status.
+        The parameters, return value, and raised exceptions match those
+        documented for `call_git`.
         """
         runner = self._git_runner
         stderr_log_level = {True: 5, False: 11}[expect_stderr]
@@ -2235,17 +2215,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         Parameters
         ----------
-        args : list of str
-          Arguments to pass to `git`.
-        files : list of str, optional
-          File arguments to pass to `git`. The advantage of passing these here
-          rather than as part of `args` is that the call will be split into
-          multiple calls to avoid exceeding the maximum command line length.
-        expect_stderr : bool, optional
-          Standard error is expected and should not be elevated above the DEBUG
-          level.
         sep : str, optional
           Split the output by `str.split(sep)` rather than `str.splitlines`.
+
+        All other parameters match those described for `call_git`.
 
         Returns
         -------
@@ -2262,17 +2235,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     def call_git_oneline(self, args, files=None, expect_stderr=False, read_only=False):
         """Call git for a single line of output.
 
-        Parameters
-        ----------
-        args : list of str
-          Arguments to pass to `git`.
-        files : list of str, optional
-          File arguments to pass to `git`. The advantage of passing these here
-          rather than as part of `args` is that the call will be split into
-          multiple calls to avoid exceeding the maximum command line length.
-        expect_stderr : bool, optional
-          Standard error is expected and should not be elevated above the DEBUG
-          level.
+        All other parameters match those described for `call_git`.
 
         Raises
         ------
@@ -2291,17 +2254,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     def call_git_success(self, args, files=None, expect_stderr=False, read_only=False):
         """Call git and return true if the call exit code of 0.
 
-        Parameters
-        ----------
-        args : list of str
-          Arguments to pass to `git`.
-        files : list of str, optional
-          File arguments to pass to `git`. The advantage of passing these here
-          rather than as part of `args` is that the call will be split into
-          multiple calls to avoid exceeding the maximum command line length.
-        expect_stderr : bool, optional
-          Standard error is expected and should not be elevated above the DEBUG
-          level.
+        All parameters match those described for `call_git`.
 
         Returns
         -------

--- a/datalad/support/repodates.py
+++ b/datalad/support/repodates.py
@@ -43,7 +43,8 @@ def _cat_blob(repo, obj, bad_ok=False):
         kwds = {}
 
     try:
-        out_cat = repo.call_git(["cat-file", "blob", obj], **kwds)
+        out_cat = repo.call_git(["cat-file", "blob", obj], read_only=True,
+                                **kwds)
     except CommandError as exc:
         if bad_ok and "bad file" in exc.stderr:
             out_cat = None
@@ -68,7 +69,8 @@ def branch_blobs(repo, branch):
     """
     # Note: This might be nicer with rev-list's --filter and
     # --filter-print-omitted, but those aren't available until Git v2.16.
-    lines = repo.call_git_items_(["rev-list", "--objects"] + [branch])
+    lines = repo.call_git_items_(["rev-list", "--objects"] + [branch],
+                                 read_only=True)
     # Trees and blobs have an associated path printed.
     objects = (ln.split() for ln in lines)
     blob_trees = [obj for obj in objects if len(obj) == 2]
@@ -108,7 +110,7 @@ def branch_blobs_in_tree(repo, branch):
     """
     seen_blobs = set()
     lines = list(repo.call_git_items_(["ls-tree", "-z", "-r", branch],
-                                      sep="\0"))
+                                      sep="\0", read_only=True))
     if lines:
         num_lines = len(lines)
         log_progress(lgr.info,

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2071,7 +2071,7 @@ def test_fake_dates(path):
     for commit in ar.get_branch_commits_("git-annex"):
         eq_(timestamp, int(ar.format_commit('%ct', commit)))
     assert_in("timestamp={}s".format(timestamp),
-              ar.call_git(["cat-file", "blob", "git-annex:uuid.log"]))
+              ar.call_git(["cat-file", "blob", "git-annex:uuid.log"], read_only=True))
 
 
 # to prevent regression

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1662,22 +1662,23 @@ def test_gitrepo_call_git_methods(path):
                             expect_fail=expect_fail)
             check("fatal: bad source", cml.out)
 
-    eq_(list(gr.call_git_items_(["ls-files"])),
+    eq_(list(gr.call_git_items_(["ls-files"], read_only=True)),
         ["bar", "foo.txt"])
-    eq_(list(gr.call_git_items_(["ls-files", "-z"], sep="\0")),
+    eq_(list(gr.call_git_items_(["ls-files", "-z"], sep="\0", read_only=True)),
         # Note: The custom separator has trailing empty item, but this is an
         # arbitrary command with unknown output it isn't safe to trim it.
         ["bar", "foo.txt", ""])
 
     with assert_raises(AssertionError):
-        gr.call_git_oneline(["ls-files"])
+        gr.call_git_oneline(["ls-files"], read_only=True)
 
-    eq_(gr.call_git_oneline(["ls-files"], files=["bar"]),
+    eq_(gr.call_git_oneline(["ls-files"], files=["bar"], read_only=True),
         "bar")
 
-    ok_(gr.call_git_success(["rev-parse", "HEAD^{commit}"]))
+    ok_(gr.call_git_success(["rev-parse", "HEAD^{commit}"], read_only=True))
     with swallow_logs(new_level=logging.DEBUG) as cml:
-        assert_false(gr.call_git_success(["rev-parse", "HEAD^{blob}"]))
+        assert_false(gr.call_git_success(["rev-parse", "HEAD^{blob}"],
+                                         read_only=True))
         assert_not_in("expected blob type", cml.out)
 
 

--- a/datalad/support/tests/test_repodates.py
+++ b/datalad/support/tests/test_repodates.py
@@ -36,7 +36,7 @@ def test_check_dates(path):
             # We can't use ar.get_tags because that returns the commit's hexsha,
             # not the tag's, and ar.get_hexsha is limited to commit objects.
             return ar.call_git_oneline(
-                ["rev-parse", "refs/tags/{}".format(tag)])
+                ["rev-parse", "refs/tags/{}".format(tag)], read_only=True)
 
         ar.add("foo")
         ar.commit("add foo")


### PR DESCRIPTION
Move the description of the `read_only` parameter to `call_git`, avoid some repetition across `_call_git` and the `call_git*` docstrings, and use `read_only=True` more.
