### PR TITLE
TST: Stop using file:// URLs in test repo annex setup

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -92,6 +92,8 @@ _test_states = {
     'HOME': None,
 }
 
+# handle to an HTTP server instance that is used as part of the tests
+test_http_server = None
 
 def setup_package():
     import os
@@ -127,6 +129,21 @@ def setup_package():
 	email = test@example.com
 """)
         _TEMP_PATHS_GENERATED.append(new_home)
+
+    # in order to avoid having to fiddle with rather uncommon
+    # file:// URLs in the tests, have a standard HTTP server
+    # that serves an 'httpserve' directory in the test HOME
+    # the URL will be available from datalad.test_http_server.url
+    from datalad.tests.utils import HTTPPath
+    import tempfile
+    global test_http_server
+    serve_path = tempfile.mkdtemp(
+        dir=cfg.get("datalad.tests.temp.dir"),
+        prefix='httpserve',
+    )
+    test_http_server = HTTPPath(serve_path)
+    test_http_server.start()
+    _TEMP_PATHS_GENERATED.append(serve_path)
 
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153
@@ -217,6 +234,9 @@ def teardown_package():
             os.environ.pop('DATALAD_LOG_LEVEL')
         else:
             os.environ['DATALAD_LOG_LEVEL'] = _test_states['DATALAD_LOG_LEVEL']
+
+    if test_http_server:
+        test_http_server.stop()
 
     from datalad.tests import _TEMP_PATHS_GENERATED
     if len(_TEMP_PATHS_GENERATED):


### PR DESCRIPTION
git-annex is having issues with those:
https://github.com/datalad/datalad/issues/5277

But even if that is fixed, it is still suboptimal to use a URL scheme as
primary testing target that not only needs to be specifically enabled
first, but is also explicitly advised against.

From https://git-annex.branchable.com/git-annex:

> List of URL schemes that git-annex is allowed to download content from. The default is "http https ftp".
> Think very carefully before changing this; there are security implications. For example, if it's changed to allow "file" URLs, then anyone who can get a commit into your git-annex repository could git-annex addurl a pointer to a private file located outside that repository, possibly causing it to be copied into your repository and transferred on to other remotes, exposing its content.

This change introduces a global HTTP server `datalad.test_http_server`
that is persistently available at test runtime. It could be used to
replace all usage of file:// URLs with http:// URLs. However, in the
scope of this change, only git-annex related usage is modified, but
the use of file:// URLs for Git (submodules) is kept. Argueably, those
are more relevant in practice.
