### PR TITLE
Skip two tests on windows (github CI in particular for one)

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -30,6 +30,7 @@ from datalad.tests.utils import (
     DEFAULT_BRANCH,
     eq_,
     known_failure_githubci_osx,
+    known_failure_githubci_win,
     neq_,
     ok_,
     ok_file_has_content,
@@ -847,6 +848,7 @@ def test_push_matching(path):
         ds.repo.get_hexsha(DEFAULT_BRANCH))
 
 
+@known_failure_githubci_win  # https://github.com/datalad/datalad/issues/5271
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/tests/test_install.py
+++ b/datalad/tests/test_install.py
@@ -2,10 +2,16 @@ import os.path
 from pathlib import Path
 import subprocess
 import sys
-from .utils import assert_in, turtle, with_tempfile
+from .utils import (
+    assert_in,
+    skip_if_on_windows,
+    turtle,
+    with_tempfile,
+)
 
 
 @turtle
+@skip_if_on_windows  # all development for this functionality is moving to datalad-installer
 @with_tempfile(mkdir=True)
 def test_install_miniconda(tmpdir):
     miniconda_path = os.path.join(tmpdir, "conda")


### PR DESCRIPTION
to finally establish a green baseline in datalad/git-annex builds on windows (master is the only one red ATM)

ref: #5271 