### PR TITLE
BF: add a non-interactive mode also to progress bar wrappers

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -368,7 +368,8 @@ def with_result_progress(fn, label="Total", unit=" Files", log_filter=None):
         label = base_label
         log_progress(lgr.info, pid,
                      "%s: starting", label,
-                     total=len(items), label=label, unit=unit)
+                     total=len(items), label=label, unit=unit,
+                     noninteractive_level=5)
 
         for res in fn(items, *args, **kwargs):
             if not (log_filter and not log_filter(res)):
@@ -386,9 +387,11 @@ def with_result_progress(fn, label="Total", unit=" Files", log_filter=None):
                     pid,
                     "%s: processed result%s", base_label,
                     " for " + res["path"] if "path" in res else "",
-                    label=label, update=1, increment=True)
+                    label=label, update=1, increment=True,
+                    noninteractive_level=5)
             yield res
-        log_progress(lgr.info, pid, "%s: done", base_label)
+        log_progress(lgr.info, pid, "%s: done", base_label,
+                     noninteractive_level=5)
 
     def _wrap_with_result_progress(items, *args, **kwargs):
         return list(_wrap_with_result_progress_(items, *args, **kwargs))
@@ -421,7 +424,8 @@ def with_progress(items, lgrcall=None, label="Total", unit=" Files"):
     label = base_label
     log_progress(lgrcall, pid,
                  "%s: starting", label,
-                 total=len(items), label=label, unit=unit)
+                 total=len(items), label=label, unit=unit,
+                 noninteractive_level=5)
 
     for item in items:
         # Since we state "processed", and actual processing might be happening
@@ -431,8 +435,9 @@ def with_progress(items, lgrcall=None, label="Total", unit=" Files"):
             lgrcall,
             pid,
             "%s: processed", base_label,
-            label=label, update=1, increment=True)
-    log_progress(lgr.info, pid, "%s: done", base_label)
+            label=label, update=1, increment=True,
+            noninteractive_level=5)
+    log_progress(lgr.info, pid, "%s: done", base_label, noninteractive_level=5)
 
 
 class LoggerHelper(object):

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -530,7 +530,8 @@ class ProducerConsumerProgressLog(ProducerConsumer):
         log_progress(lgr_.info, pid,
                      "%s: starting", self.label,
                      # will become known only later total=len(items),
-                     label=self.label, unit=" " + self.unit)
+                     label=self.label, unit=" " + self.unit,
+                     noninteractive_level=5)
         counts = defaultdict(int)
         total_announced = None  # self.total
         for res in super().__iter__():
@@ -545,7 +546,8 @@ class ProducerConsumerProgressLog(ProducerConsumer):
                     total=self.total,
                     # unfortunately of no effect, so we cannot inform that more items to come
                     # unit=("+" if not it.finished else "") + " " + unit,
-                    update=0  # not None, so it does not stop
+                    update=0,  # not None, so it does not stop
+                    noninteractive_level=5
                 )
                 total_announced = self.total
 
@@ -567,9 +569,11 @@ class ProducerConsumerProgressLog(ProducerConsumer):
                     pid,
                     "%s: processed result%s", self.label,
                     " for " + res["path"] if "path" in res else "",
-                    label=label, update=1, increment=True)
+                    label=label, update=1, increment=True,
+                    noninteractive_level=5)
             yield res
-        log_progress(lgr_.info, pid, "%s: done", self.label)
+        log_progress(lgr_.info, pid, "%s: done", self.label,
+                     noninteractive_level=5)
 
 
 class _FinalShutdown(Exception):


### PR DESCRIPTION
Building the handbook based on the current master currently intersperses command outputs with the wrappers of progress bars (``[INFO] Total: starting``, ``[INFO] Total: processed result for ...`` and ``[INFO] Total: done``).

Here is an example:

```
$ datalad download-url http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf \
  --dataset . \
  -m "add beginners guide on bash" \
  -O books/bash_guide.pdf
[INFO] Downloading 'http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf' into '/home/me/dl-101/DataLad-101/books/bash_guide.pdf' 
download_url(ok): /home/me/dl-101/DataLad-101/books/bash_guide.pdf (file)
[INFO] Total: starting 
[INFO]  
add(ok): books/bash_guide.pdf (file)
[INFO] Total: processed result for /home/me/dl-101/DataLad-101 
save(ok): . (dataset)
[INFO] Total: done 
action summary:
  add (ok: 1)
  download_url (ok: 1)
  save (ok: 1)
```

This change adds the ``noninteractive_level`` argument of ``log_progress`` where it is yet missing, mirroring fde05f8f0.