### PR TITLE
BF(DIRTY): ensure that we never allow for gc to run detached

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -581,6 +581,18 @@ class GitWitlessRunner(WitlessRunner, GitRunnerBase):
         return results
 
 
+    def run(self, cmd, **kwargs):
+        """Execute a command and communicate with it.
+
+        TODO
+        """
+        assert isinstance(cmd, list), "we do not do strings here"
+        assert cmd[0] == 'git'
+        # We need to ensure that git does not engage gc in the background
+        cmd_ = [cmd[0], '-c', 'gc.autodetach=0'] + cmd[1:]
+        return super().run(cmd_, **kwargs)
+
+
 def readline_rstripped(stdout):
     #return iter(stdout.readline, b'').next().rstrip()
     return stdout.readline().rstrip()

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -580,7 +580,7 @@ def test_cfg_originorigin(path):
     with chpwd(path), swallow_logs(new_level=logging.DEBUG) as cml:
         clone_lev3 = clone('clone_lev2', 'clone_lev3')
         # we called git-annex-init; see gh-4367:
-        cml.assert_logged(msg=r"[^[]*Async run \[('git', 'annex'|'git-annex'), "
+        cml.assert_logged(msg=r"[^[]*Async run \[('git', '-c', 'gc.autodetach=0', 'annex'|'git-annex'), "
                               r"'init'",
                           match=False,
                           level='DEBUG')

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -58,14 +58,18 @@ from datalad.api import (
 )
 
 
-def test_magic_number():
+@with_tempfile(mkdir=True)
+def test_magic_number(path):
     # we hard code the magic SHA1 that represents the state of a Git repo
     # prior to the first commit -- used to diff from scratch to a specific
     # commit
     # given the level of dark magic, we better test whether this stays
     # constant across Git versions (it should!)
-    out = GitWitlessRunner().run(
-        'cd ./ | git hash-object --stdin -t tree',
+    runner = GitWitlessRunner(cwd=path)
+    runner.run(['git', 'init'])
+    runner.run(['git', 'commit', '--allow-empty', '-m', 'empty'])
+    out = runner.run(
+        ['git', 'show', '--pretty=format:%T'],
         protocol=StdOutCapture)
     eq_(out['stdout'].strip(), PRE_INIT_COMMIT_SHA)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2745,8 +2745,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     def gc(self, allow_background=False, auto=False):
         """Perform house keeping (garbage collection, repacking)"""
         cmd_options = []
-        if not allow_background:
-            cmd_options += ['-c', 'gc.autodetach=0']
+        if allow_background:
+            raise NotImplementedError("no longer supported")
         cmd_options += ['gc', '--aggressive']
         if auto:
             cmd_options += ['--auto']

--- a/tools/copy_urls_from_datalad.py
+++ b/tools/copy_urls_from_datalad.py
@@ -58,4 +58,4 @@ if __name__ == '__main__':
                 "registerurl", '-c', 'annex.alwayscommit=false', k, url])
     # to cause annex to commit all the changes
     annex.call_annex(["merge"])
-    annex.gc(allow_background=False)
+    annex.gc()


### PR DESCRIPTION
Otherwise subsequent  git  command invocation might fail to find
objects etc, as Adina has found in her example on her laptop:

	#!/usr/bin/sh

	set -e -x

	datalad create ima
	cd ima
	datalad download-url \
		 --archive \
		 --message "Download Imagenette dataset" \
		 'https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-160.tgz'

	cd ../
	datalad create -c text2git -c yoda ml
	cd ml

	mkdir -p data
	datalad clone -d . ../ima data/raw

leading to errors like

	CommandError: 'git clone --progress ../ima /tmp/ml/data/raw' failed with exitcode 128 [err: 'Cloning into '/tmp/ml/data/raw'...
	fatal: failed to copy file to '/tmp/ml/data/raw/.git/objects/2f/f2467efde6304a84a1a2f52eee3f5a5fa5448d': No such file or directory']]

We have numerous spots were we invoke git without some centralization and
common place is the GitWitlessRunner.  That is why in this DIRTY hack I just
overloaded `run` to ensure us passing that configuration setting to git, since
AFAIK it cannot be passed through env var (or am I wrong?)

Since we would be always passing it, I have effectively "disabled"
background gc in GitRepo.gc used in a single script among tools

@adswa - does this diff help (or did you use `maint`?)

