### PR TITLE
DOC: Include information on subdataset clone sources in `get` docs

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -151,6 +151,9 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     first, and duplicate URLs are stripped, while preserving the first item in the
     candidate list.
 
+    More information on this feature can be found at
+    http://handbook.datalad.org/r.html?clone-priority
+
     Parameters
     ----------
     ds : Dataset

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -148,7 +148,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     is the configured remote name.
 
     Lastly, all candidates are sorted according to their cost (lower values
-    first, and duplicate URLs are stripped, while preserving the first item in the
+    first), and duplicate URLs are stripped, while preserving the first item in the
     candidate list.
 
     More information on this feature can be found at
@@ -735,7 +735,7 @@ class Get(Interface):
     is the configured remote name.
 
     Lastly, all candidates are sorted according to their cost (lower values
-    first, and duplicate URLs are stripped, while preserving the first item in the
+    first), and duplicate URLs are stripped, while preserving the first item in the
     candidate list.
 
     .. note::


### PR DESCRIPTION
So far this information is only available in the docstring of an
internal helper, and in the handbook

http://handbook.datalad.org/en/latest/beyond_basics/101-148-clonepriority.html

However, it is an important piece of info that should be easily
accessible, especially when the `get` of a subdataset has just failed.
This specific use case also motivates, in part, the placement of this
information in the `get` documentation.

I will cancel travis and appveyor due to the nature of the diff.