### PR TITLE
removing asyncio.set_event_loop(None) call (reseting asyncio)

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -381,8 +381,6 @@ class WitlessRunner(object):
                 )
             )
         finally:
-            # be kind to callers and leave asyncio as we found it
-            asyncio.set_event_loop(None)
             # terminate the event loop, cannot be undone, hence we start a fresh
             # one each time (see BlockingIOError notes above)
             event_loop.close()


### PR DESCRIPTION
Fixes #5313 in case you consider it as an issue.

I'm not sure about my changes, but from my observation calling `asyncio.set_event_loop(None)` prevents from leaving "asyncio as we found it". Removing the line works at least for the example provided in the issue