### PR TITLE
OPT: Speed up _check_git_annex_version()

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -47,7 +47,6 @@ from datalad.utils import (
     assure_list,
     auto_repr,
     ensure_list,
-    get_linux_distribution,
     on_windows,
     partition,
     Path,
@@ -555,15 +554,8 @@ class AnnexRepo(GitRepo, RepoInterface):
     def _check_git_annex_version(cls):
         ver = external_versions['cmd:annex']
         # in case it is missing
-        msg = "Visit http://git-annex.branchable.com/install/"
-        # we might be able to do better
-        try:
-            linux_distribution_name = get_linux_distribution()[0]
-            if linux_distribution_name in {'debian', 'ubuntu'}:
-                msg = "Install  git-annex-standalone  from NeuroDebian " \
-                      "(http://neuro.debian.net)"
-        except:  # pragma: no cover
-            pass
+        msg = "Visit http://handbook.datalad.org/r.html?install " \
+              "for instructions on how to install DataLad and git-annex."
 
         exc_kwargs = dict(
             name="git-annex",

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1547,7 +1547,7 @@ def test_annex_version_handling_bad_git_annex(path):
             AnnexRepo(path)
         linux_distribution_name = get_linux_distribution()[0]
         if linux_distribution_name == 'debian':
-            assert_in("http://neuro.debian.net", str(cme.exception))
+            assert_in("handbook.datalad.org", str(cme.exception))
         eq_(AnnexRepo.git_annex_version, None)
 
     with set_annex_version('6.20160505'):


### PR DESCRIPTION
It removes a programmatic assesment of the platform in order to
build a targeted message to be displayed whenever git-annex
cannot be found.

Now the message is generic and saved 1.5s for a wide range of
datalad command executed on the cmdline.

For example, a `datalad create` on Debian drops from 2.5s to 800ms.

now:
```
(datalad3-dev) mih@meiner /tmp % time datalad create s1
[INFO   ] Creating a new annex repo at /tmp/s1 
[INFO   ] Scanning for unlocked files (this may take some time) 
create(ok): /tmp/s1 (dataset)
datalad create s1  0.59s user 0.27s system 104% cpu 0.833 total

(datalad3-dev) mih@meiner /tmp/s1 (git)-[master] % touch this
(datalad3-dev) mih@meiner /tmp/s1 (git)-[master] % time datalad save
add(ok): this (file)                                                                                                                       
save(ok): . (dataset)                                                                                                                      
action summary:                                                                                                                            
  add (ok: 1)
  save (ok: 1)
datalad save  0.50s user 0.17s system 98% cpu 0.677 total

(datalad3-dev) mih@meiner /tmp/s1 (git)-[master] % time datalad status --annex
1 annex'd file (0.0 B recorded total size)
nothing to save, working tree clean
datalad status --annex  0.32s user 0.09s system 102% cpu 0.403 total
```

before:
```
(datalad3-dev) mih@meiner /tmp % time datalad create s2
[INFO   ] Creating a new annex repo at /tmp/s2 
[INFO   ] Scanning for unlocked files (this may take some time) 
create(ok): /tmp/s2 (dataset)
datalad create s2  2.02s user 0.34s system 98% cpu 2.413 total

(datalad3-dev) mih@meiner /tmp/s2 (git)-[master] % time datalad save
add(ok): this (file)                                                                                                                       
save(ok): . (dataset)                                                                                                                      
action summary:                                                                                                                            
  add (ok: 1)
  save (ok: 1)
datalad save  2.04s user 0.31s system 92% cpu 2.531 total

(datalad3-dev) mih@meiner /tmp/s2 (git)-[master] % time datalad status --annex
1 annex'd file (0.0 B recorded total size)
nothing to save, working tree clean
datalad status --annex  1.88s user 0.20s system 100% cpu 2.059 total
```


Fixes #5317