### PR TITLE
RF(TST): invoke setup-docker-ssh without explicit --from

### DIFF
--- a/tools/ci/prep-travis-forssh.sh
+++ b/tools/ci/prep-travis-forssh.sh
@@ -33,8 +33,7 @@ ssh-keygen -f /tmp/dl-test-ssh-id -N ""
 curl -fSsL \
      https://raw.githubusercontent.com/datalad-tester/docker-ssh-target/master/setup \
      >setup-docker-ssh
-sh setup-docker-ssh --key=/tmp/dl-test-ssh-id.pub -2 \
-   --from=dataladtester/docker-ssh-target:latest
+sh setup-docker-ssh --key=/tmp/dl-test-ssh-id.pub -2
 
 until nc -vz localhost 42241 && nc -vz localhost 42242
 do sleep 1


### PR DESCRIPTION
This should make it first download our tarball export of the docker container
and load it, thus avoiding docker pull AFAIK

Corresponding changes were directly pushed to https://github.com/datalad-tester/docker-ssh-target and mirror of that repository with the actual tarball was shared at http://datasets.datalad.org/?dir=/datalad/docker-ssh-target from which now `setup` script would fetch the tarball

If works, Closes #5288 , and similar changes (just removing `--from`) should be introduced in other CI setups