### PR TITLE
TST: Add skip_if_adjusted_branch decorator

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -35,6 +35,7 @@ from datalad.tests.utils import (
     ok_,
     ok_file_has_content,
     serve_path_via_http,
+    skip_if_adjusted_branch,
     skip_if_on_windows,
     skip_ssh,
     slow,
@@ -537,6 +538,7 @@ def test_gh1426(origin_path, target_path):
         target.get_hexsha(DEFAULT_BRANCH))
 
 
+@skip_if_adjusted_branch  # gh-4075
 @skip_if_on_windows  # create_sibling incompatible with win servers
 @skip_ssh
 @with_tree(tree={'1': '123'})
@@ -545,9 +547,6 @@ def test_gh1426(origin_path, target_path):
 def test_publish_target_url(src, desttop, desturl):
     # https://github.com/datalad/datalad/issues/1762
     ds = Dataset(src).create(force=True)
-    if ds.repo.is_managed_branch():
-        raise SkipTest(
-            'Skipped due to https://github.com/datalad/datalad/issues/4075')
     ds.save('1')
     ds.create_sibling('ssh://datalad-test:%s/subdir' % desttop,
                       name='target',
@@ -608,15 +607,13 @@ def test_gh1811(srcpath, clonepath):
     )
 
 
+# FIXME: on crippled FS post-update hook enabling via create-sibling doesn't
+# work ATM
+@skip_if_adjusted_branch
 @with_tempfile()
 @with_tempfile()
 def test_push_wanted(srcpath, dstpath):
     src = Dataset(srcpath).create()
-
-    if src.repo.is_managed_branch():
-        # on crippled FS post-update hook enabling via create-sibling doesn't
-        # work ATM
-        raise SkipTest("no create-sibling on crippled FS")
     (src.pathobj / 'data.0').write_text('0')
     (src.pathobj / 'secure.1').write_text('1')
     (src.pathobj / 'secure.2').write_text('2')
@@ -662,15 +659,14 @@ def test_push_wanted(srcpath, dstpath):
     eq_((dst.pathobj / 'secure.1').read_text(), '1')
 
 
+# FIXME: on crippled FS post-update hook enabling via create-sibling doesn't
+# work ATM
+@skip_if_adjusted_branch
 @slow  # 10sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_auto_data_transfer(path):
     path = Path(path)
     ds_a = Dataset(path / "a").create()
-    if ds_a.repo.is_managed_branch():
-        # on crippled FS post-update hook enabling via create-sibling doesn't
-        # work ATM
-        raise SkipTest("no create-sibling on crippled FS")
     (ds_a.pathobj / "foo.dat").write_text("foo")
     ds_a.save()
 
@@ -723,15 +719,14 @@ def test_auto_data_transfer(path):
         path=str(ds_a.pathobj / "bar.dat"))
 
 
+# FIXME: on crippled FS post-update hook enabling via create-sibling doesn't
+# work ATM
+@skip_if_adjusted_branch
 @slow  # 16sec on Yarik's laptop
 @with_tempfile(mkdir=True)
 def test_auto_if_wanted_data_transfer_path_restriction(path):
     path = Path(path)
     ds_a = Dataset(path / "a").create()
-    if ds_a.repo.is_managed_branch():
-        # on crippled FS post-update hook enabling via create-sibling doesn't
-        # work ATM
-        raise SkipTest("no create-sibling on crippled FS")
     ds_a_sub0 = ds_a.create("sub0")
     ds_a_sub1 = ds_a.create("sub1")
 

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -12,7 +12,7 @@ from datalad.tests.utils import (
     assert_result_count,
     known_failure_windows,
     serve_path_via_http,
-    SkipTest,
+    skip_if_adjusted_branch,
     with_tempfile
 )
 from datalad.distributed.ora_remote import (
@@ -76,6 +76,11 @@ def test_initremote(store_path, store_url, ds_path):
     assert_in("archive-id={}".format(ds.id), remote_log)
 
 
+# TODO: on crippled FS copytree to populate store doesn't seem to work.
+#       Or may be it's just the serving via HTTP that doesn't work.
+#       Either way, after copytree and fsck, whereis doesn't report
+#       the store as an available source.
+@skip_if_adjusted_branch
 @known_failure_windows  # see gh-4469
 @with_tempfile(mkdir=True)
 @serve_path_via_http
@@ -85,13 +90,6 @@ def test_read_access(store_path, store_url, ds_path):
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
     ds.save()
-
-    if ds.repo.is_managed_branch():
-        # TODO: on crippled FS copytree to populate store doesn't seem to work.
-        #       Or may be it's just the serving via HTTP that doesn't work.
-        #       Either way, after copytree and fsck, whereis doesn't report
-        #       the store as an available source.
-        raise SkipTest("Skip on crippled FS")
 
     files = [Path('one.txt'), Path('subdir') / 'two']
     store_path = Path(store_path)

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -24,6 +24,7 @@ from datalad.tests.utils import (
     has_symlink_capability,
     SkipTest,
     known_failure_windows,
+    skip_if_adjusted_branch,
     skip_if_no_network,
     skip_ssh,
     slow,
@@ -387,6 +388,10 @@ def test_version_check():
     yield _test_version_check, None
 
 
+# git-annex-testremote is way too slow on crippled FS.
+# Use is_managed_branch() as a proxy and skip only here
+# instead of in a decorator
+@skip_if_adjusted_branch
 @known_failure_windows  # see gh-4469
 @with_tempfile
 @with_tempfile
@@ -397,12 +402,6 @@ def _test_gitannex(host, store, dspath):
     store = Path(store)
 
     ds = Dataset(dspath).create()
-
-    if ds.repo.is_managed_branch():
-        # git-annex-testremote is way too slow on crippled FS.
-        # Use is_managed_branch() as a proxy and skip only here
-        # instead of in a decorator
-        raise SkipTest("Test too slow on crippled FS")
 
     populate_dataset(ds)
     ds.save()

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -45,9 +45,9 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_message,
     serve_path_via_http,
+    skip_if_adjusted_branch,
     skip_ssh,
     skip_if_on_windows,
-    SkipTest,
     slow,
     known_failure_windows,
     known_failure_githubci_win,
@@ -643,6 +643,8 @@ def test_gh3356(src, path):
         action='status', has_content=True)
 
 
+# The setup here probably breaks down with adjusted branches.
+@skip_if_adjusted_branch
 @slow  # ~12s
 @skip_if_on_windows
 @skip_ssh
@@ -650,10 +652,6 @@ def test_gh3356(src, path):
 def test_get_subdataset_direct_fetch(path):
     path = Path(path)
     origin = Dataset(path / "origin").create()
-    if origin.repo.is_managed_branch():
-        # The setup here probably breaks down with adjusted branches.
-        raise SkipTest("Test assumes non-adjusted branches")
-
     for sub in ["s0", "s1"]:
         sds = origin.create(origin.pathobj / sub)
         sds.repo.commit(msg="another commit", options=["--allow-empty"])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -87,6 +87,7 @@ from datalad.tests.utils import (
     serve_path_via_http,
     set_annex_version,
     skip_if,
+    skip_if_adjusted_branch,
     skip_if_on_windows,
     skip_if_root,
     skip_nomultiplex_ssh,
@@ -2020,14 +2021,12 @@ def test_AnnexRepo_get_tracking_branch(path):
     eq_(('origin', 'refs/heads/' + DEFAULT_BRANCH), ar.get_tracking_branch())
 
 
+# Test needs repository with non-managed branch.
+@skip_if_adjusted_branch
 @with_testrepos('basic_annex', flavors=['clone'])
 def test_AnnexRepo_is_managed_branch(path):
 
     ar = AnnexRepo(path)
-
-    if ar.is_managed_branch():
-        raise SkipTest("Test needs repository with non-managed branch")
-
     if ar.supports_unlocked_pointers:
         ar.adjust()
         ok_(ar.is_managed_branch())


### PR DESCRIPTION
A repeated pattern in the tests is to create a dataset with a path
generated via with_{tree,tempfile} and then raise a SkipTest if the
dataset is on an adjusted branch.  Aside from being a bit harder to
grep for, a problem with this pattern is that it's wasteful.  A
dataset is created for each test, but the temporary directory's file
system isn't changing out from under us, so we can use the same answer
across tests.

Add a skip_if_adjusted_branch() decorator that caches the result,
paying the cost of an additional create() call for file systems that
do not default to adjusted branches.

Another advantage of this new decorator is that, when we realize a
test marked with skip_if_on_windows() actually failed due to more
general adjusted branch issues, we can simply switch the decorator.
