### PR TITLE
rerun: Adjusted branch tweaks

### DIFF
--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -215,6 +215,16 @@ class Rerun(Interface):
                 message='cannot rerun command, nothing recorded')
             return
 
+        # ATTN: Use get_corresponding_branch() rather than is_managed_branch()
+        # for compatibility with a plain GitRepo.
+        if (onto is not None or branch is not None) and \
+           ds_repo.get_corresponding_branch():
+            yield get_status_dict(
+                "run", ds=ds, status="impossible",
+                message=("--%s is incompatible with adjusted branch",
+                         "branch" if onto is None else "onto"))
+            return
+
         if branch and branch in ds_repo.get_branches():
             yield get_status_dict(
                 "run", ds=ds, status="error",

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -122,13 +122,13 @@ def test_rerun(path, nodspath):
         f.write("foo")
     ds.save("nonrun-file")
     # Now rerun the buried command.
-    ds.rerun(revision="HEAD~", message="rerun buried")
+    ds.rerun(revision=DEFAULT_BRANCH + "~", message="rerun buried")
     eq_('xxx\n', open(probe_path).read())
     # Also check that the messasge override worked.
     eq_(last_commit_msg(ds.repo).splitlines()[0],
         "[DATALAD RUNCMD] rerun buried")
     # Or a range of commits, skipping non-run commits.
-    ds.rerun(since="HEAD~3")
+    ds.rerun(since=DEFAULT_BRANCH + "~3")
     eq_('xxxxx\n', open(probe_path).read())
     # Or --since= to run all reachable commits.
     ds.rerun(since="")
@@ -447,7 +447,7 @@ def test_rerun_outofdate_tree(path):
     ds.remove("foo")
     # Now rerunning should fail because foo no longer exists.
     with swallow_outputs():
-        assert_raises(CommandError, ds.rerun, revision="HEAD~")
+        assert_raises(CommandError, ds.rerun, revision=DEFAULT_BRANCH + "~")
 
 
 @known_failure_windows
@@ -694,7 +694,7 @@ def test_run_inputs_outputs(src, path):
     ds.save()
     ds.repo.copy_to(["after-dot-run"], remote="origin")
     ds.repo.drop(["after-dot-run"], options=["--force"])
-    ds.rerun("HEAD^")
+    ds.rerun(DEFAULT_BRANCH + "^")
     ds.repo.file_has_content("after-dot-run")
 
     # --output will unlock files that are present.

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -255,11 +255,11 @@ def test_rerun_chain(path):
         commits.append(ds.repo.get_hexsha())
         ds.rerun()
         _, info = get_run_info(ds, ds.repo.format_commit("%B"))
-        assert info["chain"] == commits
+        eq_(info["chain"], commits)
 
     ds.rerun(revision="first-run")
     _, info = get_run_info(ds, ds.repo.format_commit("%B"))
-    assert info["chain"] == commits[:1]
+    eq_(info["chain"], commits[:1])
 
 
 @known_failure_windows

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -712,12 +712,11 @@ def test_run_inputs_outputs(src, path):
             eq_(fh.read(), " appended\n" )
 
     # --input can be combined with --output.
-    ds.repo.call_git(["reset", "--hard", "HEAD~2"])
     ds.run("echo ' appended' >>a.dat", inputs=["a.dat"], outputs=["a.dat"])
     if not on_windows:
         # MIH doesn't yet understand how to port this
         with open(op.join(path, "a.dat")) as fh:
-            eq_(fh.read(), "a.dat appended\n")
+            eq_(fh.read(), " appended\n appended\n")
 
     if not on_windows:
         # see datalad#2606

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -251,10 +251,10 @@ def test_rerun_chain(path):
 
     with swallow_outputs():
         ds.run('echo x$(cat grows) > grows')
-    ds.repo.tag("first-run")
+    ds.repo.tag("first-run", commit=DEFAULT_BRANCH)
 
     for _ in range(3):
-        commits.append(ds.repo.get_hexsha())
+        commits.append(ds.repo.get_hexsha(DEFAULT_BRANCH))
         ds.rerun()
         _, info = get_run_info(ds, last_commit_msg(ds.repo))
         eq_(info["chain"], commits)
@@ -455,10 +455,10 @@ def test_rerun_outofdate_tree(path):
 def test_rerun_ambiguous_revision_file(path):
     ds = Dataset(path).create()
     ds.run('echo ambig > ambig')
-    ds.repo.tag("ambig")
+    ds.repo.tag("ambig", commit=DEFAULT_BRANCH)
     # Don't fail when "ambig" refers to both a file and revision.
     ds.rerun(since="", revision="ambig")
-    eq_(len(ds.repo.get_revisions()),
+    eq_(len(ds.repo.get_revisions(DEFAULT_BRANCH)),
         len(ds.repo.get_revisions("ambig")))
 
 
@@ -562,7 +562,7 @@ def test_rerun_script(path):
     # a run record sidecar file was added with the last commit
     assert(any(d['path'].startswith(op.join(ds.path, '.datalad', 'runinfo'))
                for d in ds.rerun(report=True, return_type='item-or-list')['diff']))
-    bar_hexsha = ds.repo.get_hexsha()
+    bar_hexsha = ds.repo.get_hexsha(DEFAULT_BRANCH)
 
     script_file = op.join(path, "commands.sh")
 
@@ -777,7 +777,7 @@ def test_rerun_explicit(path):
     ds.run("echo o >> foo", explicit=True, outputs=["foo"])
     with open(op.join(ds.path, "foo")) as ifh:
         orig_content = ifh.read()
-        orig_head = ds.repo.get_hexsha()
+        orig_head = ds.repo.get_hexsha(DEFAULT_BRANCH)
 
     # Explicit rerun is allowed in a dirty tree.
     ok_(ds.repo.dirty)

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -455,8 +455,8 @@ def test_rerun_ambiguous_revision_file(path):
     ds.run('echo ambig > ambig')
     ds.repo.tag("ambig")
     # Don't fail when "ambig" refers to both a file and revision.
-    ds.rerun(since="", revision="ambig", branch="rerun")
-    eq_(len(ds.repo.get_revisions("rerun")),
+    ds.rerun(since="", revision="ambig")
+    eq_(len(ds.repo.get_revisions()),
         len(ds.repo.get_revisions("ambig")))
 
 

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -71,6 +71,8 @@ from datalad.tests.utils import (
     known_failure_windows,
     known_failure_githubci_win,
     slow,
+    skip_if_adjusted_branch,
+    SkipTest,
 )
 
 from datalad.core.local.tests.test_run import last_commit_msg
@@ -170,6 +172,11 @@ def test_rerun_empty_branch(path):
 @with_tempfile(mkdir=True)
 def test_rerun_onto(path):
     ds = Dataset(path).create()
+    if ds.repo.is_managed_branch():
+        assert_status('impossible',
+                      ds.rerun(onto="triggers-abort", on_failure="ignore"))
+        raise SkipTest("Test incompatible with adjusted branch")
+
     # Make sure we have more than one commit. The one commit case is checked
     # elsewhere.
     ds.repo.commit(msg="noop commit", options=["--allow-empty"])
@@ -264,10 +271,14 @@ def test_rerun_chain(path):
     eq_(info["chain"], commits[:1])
 
 
-@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_just_one_commit(path):
     ds = Dataset(path).create()
+    if ds.repo.is_managed_branch():
+        assert_status('impossible',
+                      ds.rerun(branch="triggers-abort", on_failure="ignore"))
+        raise SkipTest("Test incompatible with adjusted branch")
+
     ds.repo.checkout("orph", options=["--orphan"])
     ds.repo.call_git(["reset", "--hard"])
     ds.repo.config.reload()
@@ -340,10 +351,13 @@ def test_run_failure(path):
     assert_false(op.exists(msgfile))
 
 
-@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_branch(path):
     ds = Dataset(path).create()
+    if ds.repo.is_managed_branch():
+        assert_status('impossible',
+                      ds.rerun(branch="triggers-abort", on_failure="ignore"))
+        raise SkipTest("Test incompatible with adjusted branch")
 
     ds.repo.tag("prerun")
 
@@ -390,7 +404,7 @@ def test_rerun_branch(path):
                   ds.rerun, since="prerun", branch="rerun2")
 
 
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_cherry_pick(path):
     ds = Dataset(path).create()
@@ -406,7 +420,7 @@ def test_rerun_cherry_pick(path):
         assert_in_results(results, status='ok', rerun_action=action)
 
 
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_invalid_merge_run_commit(path):
     ds = Dataset(path).create()
@@ -769,7 +783,7 @@ def test_run_inputs_no_annex_repo(path):
     ds.rerun()
 
 
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tree(tree={"to_modify": "to_modify"})
 def test_rerun_explicit(path):
     ds = Dataset(path).create(force=True)

--- a/datalad/interface/tests/test_rerun_merges.py
+++ b/datalad/interface/tests/test_rerun_merges.py
@@ -18,10 +18,10 @@ from datalad.tests.utils import (
     assert_false,
     DEFAULT_BRANCH,
     eq_,
-    known_failure_windows,
     neq_,
     ok_,
     slow,
+    skip_if_adjusted_branch,
     with_tempfile,
 )
 
@@ -41,7 +41,7 @@ from datalad.tests.utils import (
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_fastforwardable(path):
     ds = Dataset(path).create()
@@ -86,7 +86,7 @@ def test_rerun_fastforwardable(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_fastforwardable_mutator(path):
     ds = Dataset(path).create()
@@ -123,7 +123,7 @@ def test_rerun_fastforwardable_mutator(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_left_right_runs(path):
     ds = Dataset(path).create()
@@ -177,7 +177,7 @@ def test_rerun_left_right_runs(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_run_left_mutator_right(path):
     ds = Dataset(path).create()
@@ -207,7 +207,7 @@ def test_rerun_run_left_mutator_right(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_nonrun_left_run_right(path):
     ds = Dataset(path).create()
@@ -266,7 +266,7 @@ def test_rerun_nonrun_left_run_right(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_run_left_nonrun_right(path):
     ds = Dataset(path).create()
@@ -318,7 +318,7 @@ def test_rerun_run_left_nonrun_right(path):
 
 
 # @slow  # ~5sec on Yarik's laptop
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_mutator_left_nonrun_right(path):
     ds = Dataset(path).create()
@@ -351,7 +351,7 @@ def test_rerun_mutator_left_nonrun_right(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_mutator_stem_nonrun_merges(path):
     ds = Dataset(path).create()
@@ -413,7 +413,7 @@ def test_rerun_mutator_stem_nonrun_merges(path):
 
 
 # @slow  # ~4.5sec
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_exclude_side(path):
     ds = Dataset(path).create()
@@ -445,7 +445,7 @@ def test_rerun_exclude_side(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_run_left_nonrun_right(path):
     ds = Dataset(path).create()
@@ -493,7 +493,7 @@ def test_rerun_unrelated_run_left_nonrun_right(path):
 
 
 # @slow  # ~3.5sec on Yarik's laptop
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_mutator_left_nonrun_right(path):
     ds = Dataset(path).create()
@@ -522,7 +522,7 @@ def test_rerun_unrelated_mutator_left_nonrun_right(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_nonrun_left_run_right(path):
     ds = Dataset(path).create()
@@ -576,7 +576,7 @@ def test_rerun_unrelated_nonrun_left_run_right(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_nonrun_left_mutator_right(path):
     ds = Dataset(path).create()
@@ -618,7 +618,7 @@ def test_rerun_unrelated_nonrun_left_mutator_right(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_multifork(path):
     ds = Dataset(path).create()
@@ -697,7 +697,7 @@ def test_rerun_multifork(path):
 
 
 @slow
-@known_failure_windows
+@skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_octopus(path):
     ds = Dataset(path).create()


### PR DESCRIPTION
This series was prompted by gh-4335.  It tweaks `rerun` and several tests in test_rerun.py to be compatible with adjusted branches in scenarios that don't involve `--onto` and `--branch`.  The remaining scenarios are skipped, and `rerun` now aborts with an informative message.

test_rerun.py no longer shows any failures when I execute it under `tools/eval_under_testloopfs`.
