### PR TITLE
TST: test_push_recursive: Make rest of test work on adjusted branch

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -311,11 +311,6 @@ def test_push_recursive(
     assert_in_results(
         res, status='notneeded', refspec=DEFAULT_REFSPEC)
 
-    if top.repo.is_managed_branch():
-        raise SkipTest(
-            'Save/status of subdataset with managed branches is an still '
-            'unresolved issue')
-
     # now annex a file in subsub
     test_copy_file = subsub.pathobj / 'test_mod_annex_file'
     test_copy_file.write_text("Heavy stuff.")
@@ -350,7 +345,7 @@ def test_push_recursive(
     top.save(sub.pathobj, message='annexadd', recursive=True)
     top.save(subnoannex.pathobj, message='gitadd', recursive=True)
     # now only publish the latter one
-    res = top.push(to="target", since='HEAD~1', recursive=True)
+    res = top.push(to="target", since=DEFAULT_BRANCH + '~1', recursive=True)
     # nothing copied, no reports on the other modification
     assert_not_in_results(res, action='copy')
     assert_not_in_results(res, path=sub.path)


### PR DESCRIPTION
test_push_recursive() aborts midway through due to unresolved
save/status issues with adjusted branches.  While there are those (and
they've at least been partially addressed on master with gh-5241), the
only change needed to make this test pass for me on maint under
tools/eval_under_testloopfs is switching a --since value away from
using "HEAD" (which is of course off-by-one on a synced adjusted
branch).
