### PR TITLE
TST: Stop using file:// URLs in test repo annex setup

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -147,21 +147,6 @@ def setup_package():
 """)
         _TEMP_PATHS_GENERATED.append(new_home)
 
-    # in order to avoid having to fiddle with rather uncommon
-    # file:// URLs in the tests, have a standard HTTP server
-    # that serves an 'httpserve' directory in the test HOME
-    # the URL will be available from datalad.test_http_server.url
-    from datalad.tests.utils import HTTPPath
-    import tempfile
-    global test_http_server
-    serve_path = tempfile.mkdtemp(
-        dir=cfg.get("datalad.tests.temp.dir"),
-        prefix='httpserve',
-    )
-    test_http_server = HTTPPath(serve_path)
-    test_http_server.start()
-    _TEMP_PATHS_GENERATED.append(serve_path)
-
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153
     cfg.reload(force=True)
@@ -224,6 +209,21 @@ def setup_package():
         lgr.debug("Pre-populating testrepos")
         from datalad.tests.utils import with_testrepos
         with_testrepos()(lambda repo: 1)()
+
+    # in order to avoid having to fiddle with rather uncommon
+    # file:// URLs in the tests, have a standard HTTP server
+    # that serves an 'httpserve' directory in the test HOME
+    # the URL will be available from datalad.test_http_server.url
+    from datalad.tests.utils import HTTPPath
+    import tempfile
+    global test_http_server
+    serve_path = tempfile.mkdtemp(
+        dir=cfg.get("datalad.tests.temp.dir"),
+        prefix='httpserve',
+    )
+    test_http_server = HTTPPath(serve_path)
+    test_http_server.start()
+    _TEMP_PATHS_GENERATED.append(serve_path)
 
 
 def teardown_package():


### PR DESCRIPTION
git-annex is having issues with those:
https://github.com/datalad/datalad/issues/5277

But even if that is fixed, it is still suboptimal to use a URL scheme as
primary testing target that not only needs to be specifically enabled
first, but is also explicitly advised against.

From https://git-annex.branchable.com/git-annex:

> List of URL schemes that git-annex is allowed to download content from. The default is "http https ftp".
> Think very carefully before changing this; there are security implications. For example, if it's changed to allow "file" URLs, then anyone who can get a commit into your git-annex repository could git-annex addurl a pointer to a private file located outside that repository, possibly causing it to be copied into your repository and transferred on to other remotes, exposing its content.

This change introduces a global HTTP server `datalad.test_http_server`
that is persistently available at test runtime. It could be used to
replace all usage of file:// URLs with http:// URLs. However, in the
scope of this change, only git-annex related usage is modified, but
the use of file:// URLs for Git (submodules) is kept. Argueably, those
are more relevant in practice.
