### PR TITLE
ENH: Report error messages from JSON records in str(CommandError)

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -60,6 +60,17 @@ class CommandError(RuntimeError):
         if self.stderr:
             to_str += " [err: '{}']".format(ensure_unicode(self.stderr).strip())
         if self.kwargs:
+            if 'stdout_json' in self.kwargs:
+                from datalad.utils import unique
+                json_errors = unique([
+                    '{}{}'.format(
+                        m['note'] if m.get('note') else m.get('error-messages'),
+                        m['error-messages'] if m.get('error-messages') else '')
+                    for m in self.kwargs['stdout_json']
+                    if m.get('error-messages') or m.get('note')
+                ])
+                if json_errors:
+                    to_str += " [errors from JSON records: {}]".format(json_errors)
             to_str += " [info keys: {}]".format(
                 ', '.join(self.kwargs.keys()))
         return to_str

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -61,14 +61,13 @@ class CommandError(RuntimeError):
             to_str += " [err: '{}']".format(ensure_unicode(self.stderr).strip())
         if self.kwargs:
             if 'stdout_json' in self.kwargs:
+                src_keys = ('note', 'error-messages')
                 from datalad.utils import unique
-                json_errors = unique([
-                    '{}{}'.format(
-                        m['note'] if m.get('note') else m.get('error-messages'),
-                        m['error-messages'] if m.get('error-messages') else '')
+                json_errors = unique(
+                    '; '.join(str(m[key]) for key in src_keys if m.get(key))
                     for m in self.kwargs['stdout_json']
-                    if m.get('error-messages') or m.get('note')
-                ])
+                    if any(m.get(k) for k in src_keys)
+                )
                 if json_errors:
                     to_str += " [errors from JSON records: {}]".format(json_errors)
             to_str += " [info keys: {}]".format(

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1417,6 +1417,18 @@ def test_annex_drop(src, dst):
     # too much arguments:
     assert_raises(CommandError, ar.drop, ['.'], options=['--all'])
 
+    (ar.pathobj / 'somefile.txt').write_text('this')
+    ar.save()
+    with assert_raises(CommandError) as e:
+        ar.drop('somefile.txt')
+    # CommandError has to pull the errors from the JSON record 'note'
+    assert_in('necessary copies', str(e.exception))
+
+    with assert_raises(CommandError) as e:
+        ar._call_annex_records(['fsck', '-N', '3'])
+    # CommandError has to pull the errors from the JSON record 'error-messages'
+    assert_in('1 of 3 trustworthy copies', str(e.exception))
+
 
 @with_tree({"a.txt": "a", "b.txt": "b", "c.py": "c", "d": "d"})
 def test_annex_get_annexed_files(path):
@@ -2140,10 +2152,13 @@ def test_annexjson_protocol(path):
         res = ar._call_annex(
             ['find', '.', 'error', '--json'],
             protocol=AnnexJsonProtocol)
-        # normal operation is not impaired
-        eq_(e.stdout_json, orig_j)
-        # we get a clue what went wrong
-        assert_in('error not found', e.stderr)
+    # normal operation is not impaired
+    eq_(e.exception.kwargs['stdout_json'], orig_j)
+    # we get a clue what went wrong
+    assert_in('error not found', e.exception.stderr)
+    # there should be no errors reported in an individual records
+    # hence also no pointless statement in the str()
+    assert_not_in('errors from JSON records', str(e.exception))
 
 
 # http://git-annex.branchable.com/bugs/cannot_commit___34__annex_add__34__ed_modified_file_which_switched_its_largefile_status_to_be_committed_to_git_now/#comment-bf70dd0071de1bfdae9fd4f736fd1ec


### PR DESCRIPTION
Not doing that leaves users largely clueless as to why a JSON-based annex
command might have failed, without interactively debugging it.

This change turn the previous

```
CommandError:
 '"git" "annex" "drop" "--json" "--json-error-messages" --" "test-annex.dat"'
 failed with exitcode 1 under C:\Users\...\datalad_temp_testrepo_08ix2heg
 [err: 'git-annex: drop: 1 failed']
 [info keys: stdout_json]
```

into

```
CommandError:
 '"git" "annex" "drop" "--json" "--json-error-messages" --" "test-annex.dat"'
 failed with exitcode 1 under C:\Users\...\datalad_temp_testrepo_08ix2heg
 [err: 'git-annex: drop: 1 failed']
 [errors from JSON records: [['git-annex: content is locked']]]
 [info keys: stdout_json]
```

The markup is a bit convoluted, but there could be any number of error messages
per result and also any number of results.

"Error" messages are taken from either/or 'note' or 'error-messages' fields.

Fixes gh-5281