### PR TITLE
Audit incorrect assert_raises use

### DIFF
--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -101,8 +101,8 @@ def test_basics(path, nodspath):
         # provoke command failure
         with assert_raises(CommandError) as cme:
             ds.run('7i3amhmuch9invalid')
-            # let's not speculate that the exit code is always 127
-            ok_(cme.code > 0)
+        # let's not speculate that the exit code is always 127
+        ok_(cme.exception.code > 0)
         eq_(last_state, ds.repo.get_hexsha())
         # now one that must work
         res = ds.run('cd .> empty', message='TEST')

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -58,15 +58,9 @@ def check_basic_scenario(url, d):
     eq_(len(whereis2), 1)  # datalad
 
     # if we provide some bogus address which we can't access, we shouldn't pollute output
-    with swallow_outputs() as cmo, swallow_logs() as cml:
-        with assert_raises(CommandError) as cme:
-            annex.add_urls([url + '_bogus'])
-            assert_in('addurl: 1 failed', cme.stderr)
-        # assert_equal(cml.out, '')
-        err, out = cmo.err, cmo.out
-    assert_equal(out, '')
-    assert_equal(err, '')
-    # and there should be nothing more
+    with assert_raises(CommandError) as cme:
+        annex.add_urls([url + '_bogus'])
+    assert_in('addurl: 1 failed', cme.exception.stderr)
 
 
 # unfortunately with_tree etc decorators aren't generators friendly thus

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2152,23 +2152,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         if backend:
             options.extend(('--backend', backend))
 
-        self._call_annex(
+        return self._call_annex_records(
             ['addurl'] + options + urls,
             git_options=git_options,
-            # In general, don't capture stderr, since download progress
-            # provided by wget uses stderr. But when git-annex runs
-            # with --debug on verbose log-levels, this would leak tons of
-            # output instead of going through normal logging. In that case,
-            # capture stderr and expense of progress reporting (where beauty
-            # is of lower priority).
-            protocol=StdOutErrCapture
-            if lgr.getEffectiveLevel() <= 8 else StdOutCapture
-        )
-
-        # currently simulating similar return value, assuming success
-        # for all files:
-        # TODO: Make return values consistent across both *Repo classes!
-        return [{u'file': f, u'success': True} for f in urls]
+            progress=True)
 
     @normalize_path
     def rm_url(self, file_, url):


### PR DESCRIPTION
In gh-5333, @mih fixed a case where an assertion was made in the `assert_raises` context, leading to it having no effect.  This series is the result of a wider audit, but I only found two other cases.  The first one (in `datalad.customremotes.tests.test_datalad`) is a bit more involved, and the proposed fix makes changes to master-specific non-test code.  The second one (in `datalad.core.local.tests.test_run`) is a simple fix.  As with the case in gh-5333, both these assertions were silent failures.
