### PR TITLE
TST: Test uuids to exist before comparison

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -197,6 +197,7 @@ def test_clone_simple_local(src, path):
         # no content was installed:
         ok_(not ds.repo.file_has_content('test-annex.dat'))
         uuid_before = ds.repo.uuid
+        ok_(uuid_before)  # make sure we actually have an uuid
         eq_(ds.repo.get_description(), 'mydummy')
 
     # installing it again, shouldn't matter:
@@ -207,6 +208,7 @@ def test_clone_simple_local(src, path):
     ok_(ds.is_installed())
     if isinstance(origin.repo, AnnexRepo):
         eq_(uuid_before, ds.repo.uuid)
+
 
 
 # AssertionError: unexpected content of state "deleted": [WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/datalad_temp_gzegy3hf/testrepo--basic--r1/test-annex.dat')] != []

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -229,6 +229,7 @@ def test_install_simple_local(src, path):
         # no content was installed:
         ok_(not ds.repo.file_has_content('test-annex.dat'))
         uuid_before = ds.repo.uuid
+        ok_(uuid_before)  # we actually have an uuid
         eq_(ds.repo.get_description(), 'mydummy')
 
     # installing it again, shouldn't matter:


### PR DESCRIPTION
In some cases a few test runs end up comparing uuids that fail to exist in the first place, leading to a comparison that evaluates to `None == None`. Make the assumption that there actually is an uuid explicit in order to fail in the spot where it's going wrong rather than a much less telling point later on.

- Closes #4621
