### PR TITLE
RM: remove url from GitRepo.__init__ -- was deprecated in 0.5.0

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -380,7 +380,6 @@ class Create(Interface):
             lgr.info("Creating a new git repo at %s", tbds.path)
             tbrepo = GitRepo(
                 tbds.path,
-                url=None,
                 create=True,
                 create_sanity_checks=False,
                 git_opts=initopts,
@@ -396,7 +395,6 @@ class Create(Interface):
             lgr.info("Creating a new annex repo at %s", tbds.path)
             tbrepo = AnnexRepo(
                 tbds.path,
-                url=None,
                 create=True,
                 create_sanity_checks=False,
                 # do not set backend here, to avoid a dedicated commit

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -137,7 +137,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     # reasons
     _ALLOW_LOCAL_URLS = False
 
-    def __init__(self, path, url=None, runner=None,
+    def __init__(self, path, runner=None,
                  backend=None, always_commit=True,
                  create=True, create_sanity_checks=True,
                  init=False, batch_size=None, version=None, description=None,
@@ -154,10 +154,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         path: str
           Path to git-annex repository. In case it's not an absolute path, it's
           relative to PWD
-        url: str, optional
-          url to the to-be-cloned repository. Requires valid git url
-          according to
-          http://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS .
         runner: Runner, optional
           Provide a Runner in case AnnexRepo shall not create it's own.
           This is especially needed in case of desired dry runs.
@@ -193,7 +189,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # scope.
         do_init = False
         super(AnnexRepo, self).__init__(
-            path, url, runner=runner,
+            path, runner=runner,
             create=create, create_sanity_checks=create_sanity_checks,
             repo=repo, git_opts=git_opts, fake_dates=fake_dates)
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -77,7 +77,6 @@ from datalad.utils import (
 from .external_versions import external_versions
 from .exceptions import (
     CommandError,
-    DeprecatedError,
     FileNotInRepositoryError,
     GitIgnoreError,
     InvalidGitReferenceError,
@@ -828,7 +827,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                # override path since there is no need ATM for such details
                path="datalad",
                description="DataLad - Data management and distribution platform")
-    def __init__(self, path, url=None, runner=None, create=True,
+    def __init__(self, path, runner=None, create=True,
                  git_opts=None, repo=None, fake_dates=False,
                  create_sanity_checks=True,
                  **kwargs):
@@ -841,11 +840,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         path: str
           path to the git repository; In case it's not an absolute path,
           it's relative to PWD
-        url: str, optional
-          DEPRECATED -- use .clone() class method
-          url to the to-be-cloned repository. Requires a valid git url
-          according to:
-          http://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS .
         create: bool, optional
           if true, creates a git repository at `path` if there is none. Also
           creates `path`, if it doesn't exist.
@@ -919,13 +913,6 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             if not _valid_repo:
                 raise InvalidGitRepositoryError(path)
         # END Repo validity test
-
-        if url is not None:
-            raise DeprecatedError(
-                new=".clone() class method",
-                version="0.5.0",
-                msg="RF: url passed to init()"
-            )
 
         # So that we "share" control paths with git/git-annex
         if ssh_manager:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -70,7 +70,6 @@ from datalad.support.gitrepo import (
 )
 from datalad.support.exceptions import (
     CommandError,
-    DeprecatedError,
     FileNotInRepositoryError,
     InvalidGitRepositoryError,
     PathKnownToRepositoryError,
@@ -1241,8 +1240,6 @@ def test_optimized_cloning(path):
     from datalad.support.network import get_local_file_url
     clonepath = op.join(path, 'clone')
     for src in (originpath, get_local_file_url(originpath, compatibility='git')):
-        # deprecated
-        assert_raises(DeprecatedError, GitRepo, url=src, path=clonepath)
         clone = GitRepo.clone(url=src, path=clonepath, create=True)
         clone_inodes = _get_inodes(clone)
         eq_(origin_inodes, clone_inodes, msg='with src={}'.format(src))


### PR DESCRIPTION
Note: no other uses of DeprecatedError exception ATM
