### PR TITLE
ENH: introduce use of @deprecated from deprecated

### DIFF
--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -32,6 +32,7 @@ from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 from ..dochelpers import exc_str
 from datalad.utils import (
+    deprecated,
     ensure_unicode,
     getargspec,
     Path,
@@ -518,11 +519,10 @@ class AnnexCustomRemote(object):
 
         self.heavydebug("Got %d URL(s) for key %s", nurls, key)
 
+
+    @deprecated(version="0.14.0", reason="Optimization: use a generator gen_URLS")
     def get_URLS(self, key):
         """Gets URL(s) associated with a Key.
-
-        Use a generator gen_URLS where possible.
-        This one should be deprecated in 0.15.
         """
         return list(self.gen_URLS(key))
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -77,6 +77,7 @@ import datalad.utils as ut
 from ..utils import *
 from datalad.utils import (
     Path,
+    deprecated,
     ensure_unicode,
 )
 
@@ -852,6 +853,7 @@ def known_failure_v6_or_later(func):
 known_failure_v6 = known_failure_v6_or_later
 
 
+@deprecated(version="0.12.0", reason="Direct mode support is deprecated")
 def known_failure_direct_mode(func):
     """DEPRECATED.  Stop using.  Does nothing
 
@@ -860,15 +862,6 @@ def known_failure_direct_mode(func):
     If datalad.repo.direct is set to True behaves like `known_failure`.
     Otherwise the original (undecorated) function is returned.
     """
-    # TODO: consider adopting   nibabel/deprecated.py  nibabel/deprecator.py
-    # mechanism to consistently deprecate functionality and ensure they are
-    # displayed.
-    # Since 2.7 Deprecation warnings aren't displayed by default
-    # and thus kinda pointless to issue a warning here, so we will just log
-    msg = "Direct mode support is deprecated, so no point in using " \
-          "@known_failure_direct_mode for %r since glorious future " \
-          "DataLad 0.12" % func.__name__
-    lgr.warning(msg)
     return func
 
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -38,6 +38,9 @@ from time import sleep
 import inspect
 from itertools import tee
 
+# Centralize the choice of @deprecated decorator
+from deprecated.sphinx import deprecated
+
 import os.path as op
 from os.path import sep as dirsep
 from os.path import commonprefix

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requires = {
         'appdirs',
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
+        'deprecated',
         'distro; python_version >= "3.8"',
         'iso8601',
         'humanize',


### PR DESCRIPTION
If we decide to proceed forward with smth like that

- [ ] provide `@deprecated` support for `Parameter`
- [ ] add `sphinx.versionadded` and `sphinx.versionchanged` from deprecated