### PR TITLE
ENH: cmdline: Use pydoc pager for --help

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -40,7 +40,8 @@ class HelpAction(argparse.Action):
         # It is important since we do discover all subcommands from entry
         # points at run time and thus any static manpage would like be out of
         # date
-        if is_interactive() \
+        interactive = is_interactive()
+        if interactive \
                 and option_string == '--help' \
                 and ' ' in parser.prog:  # subcommand
             try:
@@ -107,7 +108,11 @@ class HelpAction(argparse.Action):
         # usage is on the same line
         helpstr = re.sub(r'^usage:', 'Usage:', helpstr)
 
-        print(helpstr)
+        if interactive and option_string == '--help':
+            import pydoc
+            pydoc.pager(helpstr)
+        else:
+            print(helpstr)
         sys.exit(0)
 
 


### PR DESCRIPTION
The argument for -h/--help/--help-np is wired up with a custom
argparse.Action class, HelpAction.  For an interactive call with
--help and a subcommand, this class looks for a corresponding manpage
file and tries to shell out to man(1), falling back to printing the
help string.

This means that for several common install scenarios, output isn't
displayed with a pager, and there is no distinction between --help and
--help-np.  Given that the help text of most subcommands probably
exceeds common terminal heights, callers need to either scroll up or
do something like `datalad <subcommand> --help | less`.

Make a pager available in these situations by using pydoc.pager() to
display the --help output.  Two notes:

  * guarding the use of pydoc.pager() with datalad's is_interactive()
    isn't essential because pydoc.pager() avoids using a pager when it
    detects a non-interactive environment.  However, these interactive
    checks aren't identical, so it probably makes sense to honor a
    "no" from is_interactive().

  * pydoc.pager() will enter the pager even if the number of lines
    doesn't exceed the current terminal height.  Given the length of
    the output for most subcommands, checking this ourselves (and
    worrying about platform-specific details) before calling
    pydoc.pager() probably isn't worth it.

---

I've had a draft for this around for a while and thought about it again as I was typing `datalad siblings --help | less`.  Given the last point in the commit message, I'm not sure if others will think this is a good change.  Thoughts?
