### PR TITLE
BF+RF: Consistent and more "thorough" handling of fake HOMEs (including Windows)

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -93,27 +93,32 @@ test.__test__ = False
 # To store settings which setup_package changes and teardown_package should return
 _test_states = {
     'loglevel': None,
-    'DATALAD_LOG_LEVEL': None,
+    'env': {},
 }
 
 
 def setup_package():
     import os
     from datalad import consts
-    _test_states['DATASETS_TOPURL_ENV'] = os.environ.get('DATALAD_DATASETS_TOPURL', None)
+
+    _test_states['env'] = {}
+
+    def set_envvar(v, val):
+        """Memoize and then set env var"""
+        _test_states['env'][v] = os.environ.get(v, None)
+        os.environ[v] = val
+
     _test_states['DATASETS_TOPURL'] = consts.DATASETS_TOPURL
-    os.environ['DATALAD_DATASETS_TOPURL'] = consts.DATASETS_TOPURL = 'http://datasets-tests.datalad.org/'
+    consts.DATASETS_TOPURL = 'http://datasets-tests.datalad.org/'
+    set_envvar('DATALAD_DATASETS_TOPURL', consts.DATASETS_TOPURL)
 
     from datalad.tests.utils import DEFAULT_BRANCH
-    _test_states["GIT_CONFIG_PARAMETERS"] = os.environ.get(
-        "GIT_CONFIG_PARAMETERS")
-    os.environ["GIT_CONFIG_PARAMETERS"] = "'init.defaultBranch={}'".format(
-        DEFAULT_BRANCH)
+    set_envvar("GIT_CONFIG_PARAMETERS", "'init.defaultBranch={}'".format(DEFAULT_BRANCH))
 
     # To overcome pybuild overriding HOME but us possibly wanting our
     # own HOME where we pre-setup git for testing (name, email)
     if 'GIT_HOME' in os.environ:
-        os.environ['HOME'] = os.environ['GIT_HOME']
+        set_envvar('HOME', os.environ['GIT_HOME'])
     else:
         # we setup our own new HOME, the BEST and HUGE one
         from datalad.utils import make_tempfile
@@ -121,10 +126,8 @@ def setup_package():
         # TODO: split into a function + context manager
         with make_tempfile(mkdir=True) as new_home:
             pass
-        _test_states['HOME_VARS'] = {}
         for v, val in get_home_envvars(new_home).items():
-            _test_states['HOME_VARS'][v] = os.environ.get(v)
-            os.environ[v] = val
+            set_envvar(v, val)
         if not os.path.exists(new_home):
             os.makedirs(new_home)
         with open(os.path.join(new_home, '.gitconfig'), 'w') as f:
@@ -162,8 +165,7 @@ def setup_package():
         lgr.setLevel(100)
 
         # And we should also set it within environ so underlying commands also stay silent
-        _test_states['DATALAD_LOG_LEVEL'] = DATALAD_LOG_LEVEL
-        os.environ['DATALAD_LOG_LEVEL'] = '100'
+        set_envvar('DATALAD_LOG_LEVEL', '100')
     else:
         # We are not overriding them, since explicitly were asked to have some log level
         _test_states['loglevel'] = None
@@ -220,10 +222,6 @@ def teardown_package():
     ui.set_backend(_test_states['ui_backend'])
     if _test_states['loglevel'] is not None:
         lgr.setLevel(_test_states['loglevel'])
-        if _test_states['DATALAD_LOG_LEVEL'] is None:
-            os.environ.pop('DATALAD_LOG_LEVEL')
-        else:
-            os.environ['DATALAD_LOG_LEVEL'] = _test_states['DATALAD_LOG_LEVEL']
 
     from datalad.tests import _TEMP_PATHS_GENERATED
     if len(_TEMP_PATHS_GENERATED):
@@ -234,18 +232,12 @@ def teardown_package():
     for path in _TEMP_PATHS_GENERATED:
         rmtemp(path, ignore_errors=True)
 
-    # restore all the home variables
-    for v, val in _test_states['HOME_VARS'].items():
+    # restore all the env variables
+    for v, val in _test_states['env'].items():
         if val is not None:
             os.environ[v] = val
         else:
             os.environ.pop(v)
-
-    git_config_params = _test_states["GIT_CONFIG_PARAMETERS"]
-    if git_config_params is None:
-        os.environ.pop("GIT_CONFIG_PARAMETERS")
-    else:
-        os.environ["GIT_CONFIG_PARAMETERS"] = git_config_params
 
     # Re-establish correct global config after changing $HOME.
     # Might be superfluous, since after teardown datalad.cfg shouldn't be
@@ -253,8 +245,6 @@ def teardown_package():
     # either way.
     cfg.reload(force=True)
 
-    if _test_states['DATASETS_TOPURL_ENV']:
-        os.environ['DATALAD_DATASETS_TOPURL'] = _test_states['DATASETS_TOPURL_ENV']
     consts.DATASETS_TOPURL = _test_states['DATASETS_TOPURL']
 
     from datalad.support.cookies import cookies_db

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -24,6 +24,7 @@ from datalad.api import (
 )
 from datalad.utils import (
     chpwd,
+    get_home_envvars,
     Path,
     on_windows,
     rmtree
@@ -525,7 +526,7 @@ def test_expanduser(srcpath, destpath):
     src = Dataset(Path(srcpath) / 'src').create()
     dest = Dataset(Path(destpath) / 'dest').create()
 
-    with chpwd(destpath), patch.dict('os.environ', {'HOME': srcpath}):
+    with chpwd(destpath), patch.dict('os.environ', get_home_envvars(srcpath)):
         res = clone(op.join('~', 'src'), 'dest', result_xfm=None, return_type='list',
                     on_failure='ignore')
         assert_result_count(res, 1)

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -10,6 +10,8 @@
 import os
 import os.path as op
 
+from datalad.utils import get_home_envvars
+
 from datalad.tests.utils import (
     assert_in,
     assert_raises,
@@ -72,7 +74,7 @@ def test_git_config_warning(path):
     if 'GIT_AUTHOR_NAME' in os.environ:
         raise SkipTest("Found existing explicit identity config")
     with chpwd(path), \
-            patch.dict('os.environ', {'HOME': path}), \
+            patch.dict('os.environ', get_home_envvars(path)), \
             swallow_logs(new_level=30) as cml:
         # no configs in that empty HOME
         from datalad.api import Dataset

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -509,7 +509,7 @@ def test_global_config():
 
     # from within tests, global config should be read from faked $HOME (see
     # setup_package)
-    glb_cfg_file = Path(os.environ['HOME']) / '.gitconfig'
+    glb_cfg_file = Path(os.path.expanduser('~')) / '.gitconfig'
     assert any(glb_cfg_file.samefile(Path(p)) for p in dl_cfg._cfgfiles)
     assert_equal(dl_cfg.get("user.name"), "DataLad Tester")
     assert_equal(dl_cfg.get("user.email"), "test@example.com")

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -31,6 +31,7 @@ from datalad.tests.utils import (
     with_tree,
 )
 from datalad.utils import (
+    get_home_envvars,
     swallow_logs,
     Path
 )
@@ -177,8 +178,9 @@ def test_something(path, new_home):
     # very carefully test non-local config
     # so carefully that even in case of bad weather Yarik doesn't find some
     # lame datalad unittest sections in his precious ~/.gitconfig
+    env = get_home_envvars(new_home)
     with patch.dict('os.environ',
-                    {'HOME': new_home, 'DATALAD_SNEAKY_ADDITION': 'ignore'}):
+                    dict(get_home_envvars(new_home), DATALAD_SNEAKY_ADDITION='ignore')):
         global_gitconfig = opj(new_home, '.gitconfig')
         assert(not exists(global_gitconfig))
         globalcfg = ConfigManager()

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -183,6 +183,27 @@ def not_supported_on_windows(msg=None):
                                   + (": %s" % msg if msg else ""))
 
 
+def get_home_envvars(new_home):
+    """Return dict with env variables to be adjusted for a new HOME
+
+    Only variables found in current os.environ are adjusted.
+
+    Parameters
+    ----------
+    new_home: str
+      New home path, in native to OS "schema"
+    """
+    environ = os.environ
+    out = {'HOME': new_home}
+    if on_windows:
+        # requires special handling, since it has a number of relevant variables
+        # and also Python changed its behavior and started to respect USERPROFILE only
+        # since python 3.8: https://bugs.python.org/issue36264
+        out['USERPROFILE'] = new_home
+        out['HOMEDRIVE'], out['HOMEPATH'] = op.splitdrive(new_home)
+    return {v: val for v, val in out.items() if v in os.environ}
+
+
 def shortened_repr(value, l=30):
     try:
         if hasattr(value, '__repr__') and (value.__repr__ is not object.__repr__):


### PR DESCRIPTION
Windows brings us many joys, including also having not just USERPROFILE but also HOMEDRIVE and HOMEPATH, so resetting USERPROFILE itself is not totally kosher alone.  Also, we could have PATH (e.g. in git shell) defined too even on Windows, so it is not sufficient to just reset USERPROFILE.

So in the first commit I have added a function to set only the variables known to current os.environ, and use of that one instead of hardcoded use of USERPROFILE vs HOME in test_clone seems to make that test pass for me for both py 3.7 and 3.8 on windows.  If confirmed that other Windows gurus are happy, then Closes #5338 (merge conflict will be minimal when merging into master for that test, didn't check overall though).   I have tuned up a few other tests where I found `HOME` to be used without paying due respect to glorious Windows land, so hopefully it would make it all a bit more consistent.

While at it I also made handling of memoized env variables in setup/teardown more consistent and concise. It is a separate commit, so if any objections -- could probably later do it against master