### PR TITLE
RF: cmd - reuse asyncio loop if there is one, start/close new one otherwise

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -359,6 +359,8 @@ class WitlessRunner(object):
         # this is how ipython does it
         try:
             event_loop = asyncio.get_event_loop()
+            if event_loop.is_closed():
+                raise RuntimeError("the loop was closed - use our own")
             new_loop = False
         except RuntimeError:
             new_loop = True

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -165,7 +165,12 @@ def test_asyncio_loop_noninterference1(path1, path2):
 import asyncio
 asyncio.get_event_loop()
 import datalad.api as datalad
-datalad.clone(path='{path2}', source="{path1}")
-asyncio.get_event_loop()
+ds = datalad.clone(path='{path2}', source="{path1}")
+loop = asyncio.get_event_loop()
+assert loop
+# simulate outside process closing the loop
+loop.close()
+# and us still doing ok
+ds.status()
 """)
     Runner().run([sys.executable, str(reproducer)])  # if Error -- the test failed


### PR DESCRIPTION
If BlockingIOError remains an issue, this change might have it resurfaced in
those use cases where datalad is used within some other asyncio app/script.
But at least it seems to mitigate current complete inability to use datalad
within asyncio scripts such as the minimal one provided by @djarecka:

    import asyncio
    asyncio.get_event_loop()
    import datalad.api as datalad
    datalad.clone(path='/tmp/afni', source="https://github.com/afni/afni_data.git")
    asyncio.get_event_loop()

Was not sure if not too radical for `maint` but let me know ;)

Alternative to #5314 

TODOs (if we decide that it is a way forward):
- [x] code in above code snippet as a unittest

<details>
<summary>FWIW -- benchmarks are suggesting some speedups</summary> 

```shell
       before           after         ratio
     [6945d71d]       [7c34a334]
     <bm/merge-target>       <bm/pr>   
       1.23±0.01s       1.12±0.01s     0.91  api.supers.time_createadd
       1.23±0.01s       1.09±0.02s    ~0.89  api.supers.time_createadd_to_dataset
           failed           failed      n/a  api.supers.time_diff
           failed           failed      n/a  api.supers.time_diff_recursive
       5.93±0.01s       5.56±0.01s     0.94  api.supers.time_installr
          232±7ms          215±5ms     0.92  api.supers.time_ls
       2.20±0.06s       2.01±0.02s     0.91  api.supers.time_ls_recursive
       2.34±0.06s       2.19±0.02s     0.94  api.supers.time_ls_recursive_long_all
           failed           failed      n/a  api.supers.time_remove
       1.13±0.02s       1.07±0.01s     0.94  api.supers.time_status
       2.08±0.05s       2.09±0.01s     1.01  api.supers.time_status_recursive
          101±4ms         95.6±5ms     0.94  api.supers.time_subdatasets
          357±6ms          347±9ms     0.97  api.supers.time_subdatasets_recursive
          102±3ms       94.5±0.9ms     0.92  api.supers.time_subdatasets_recursive_first
       3.99±0.07s       3.79±0.01s     0.95  api.supers.time_uninstall
         642±20ms         599±10ms     0.93  api.testds.time_create_test_dataset1
       3.74±0.09s       3.65±0.02s     0.98  api.testds.time_create_test_dataset2x2
         970±40ms         957±30ms     0.99  core.startup.time_help_np
          158±3ms          154±2ms     0.97  core.startup.time_import
          586±7ms         585±10ms     1.00  core.startup.time_import_api
      2.86±0.05ms       2.49±0.2ms    ~0.87  core.witlessrunner.time_echo
      3.27±0.05ms       2.91±0.1ms    ~0.89  core.witlessrunner.time_echo_gitrunner
      3.52±0.05ms       3.00±0.1ms    ~0.85  core.witlessrunner.time_echo_gitrunner_fullcapture
         486±10ms         480±20ms     0.99  plugins.addurls.addurls1.time_addurls('*')
       2.10±0.01s       2.02±0.02s     0.96  plugins.addurls.addurls1.time_addurls(None)
       16.5±0.9ms       15.6±0.5ms     0.95  repo.gitrepo.time_get_content_info
      7.63±0.08ms      7.55±0.06ms     0.99  support.path.get_parent_paths.time_allsubmods_toplevel
      7.07±0.09ms         7.51±1ms     1.06  support.path.get_parent_paths.time_allsubmods_toplevel_only
          391±6ns          360±3ns     0.92  support.path.get_parent_paths.time_no_submods
       6.03±0.4ms      6.06±0.07ms     1.01  support.path.get_parent_paths.time_one_submod_subdir
      6.08±0.07ms       5.95±0.2ms     0.98  support.path.get_parent_paths.time_one_submod_toplevel
        29.5±0.3s        27.9±0.3s     0.94  usecases.study_forrest.time_make_studyforrest_mockup
```
</details>