### PR TITLE
BF: All params in ORA's response to LISTCONFIGS

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -631,6 +631,8 @@ class RIARemote(SpecialRemote):
         if hasattr(self, 'configs'):
             # introduced in annexremote 1.4.2 to support LISTCONFIGS
             self.configs['url'] = "RIA store to use"
+            self.configs['archive-id'] = "Dataset ID. Should be set " \
+                                         "automatically by datalad"
         # machine to SSH-log-in to access/store the data
         # subclass must set this
         self.storage_host = None


### PR DESCRIPTION
Used to be optional, but recent git-annex will not accept parameters to
initremote that are not listed in its response to LISTCONFIGS if there
was a response to begin with.
