### PR TITLE
RF: radical - always reuse loop and if pid changes, establish a new one

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -359,6 +359,8 @@ class WitlessRunner(object):
         # this is how ipython does it
         try:
             event_loop = asyncio.get_event_loop()
+            if event_loop.is_closed():
+                raise RuntimeError("the loop was closed - use our own")
             new_loop = False
         except RuntimeError:
             new_loop = True

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -165,7 +165,12 @@ def test_asyncio_loop_noninterference1(path1, path2):
 import asyncio
 asyncio.get_event_loop()
 import datalad.api as datalad
-datalad.clone(path='{path2}', source="{path1}")
-asyncio.get_event_loop()
+ds = datalad.clone(path='{path2}', source="{path1}")
+loop = asyncio.get_event_loop()
+assert loop
+# simulate outside process closing the loop
+loop.close()
+# and us still doing ok
+ds.status()
 """)
     Runner().run([sys.executable, str(reproducer)])  # if Error -- the test failed


### PR DESCRIPTION
Sits on top of #5350 (wanted to keep it in the git history of struggle), but the actual change is only the 5f6fe634a863281742c0eb7d238c111da6e2e52e

    This might be incomplete solution since we might be "abandoning" original loop
    which is perfectly fine and was somehow tuned by some outside process.  Not
    yet sure what ramifications it would have

I have tested on @djarecka 's use case of testkraken and it works!  Let's see if CI picks up anything

edit -- I did test on `datalad.core.local.tests.test_run` and so no BlockingIOErrors