### PR TITLE
BF: Flooding INFO log with messages non-consequential to users

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -203,7 +203,9 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
                             indexer.name,
                             str(indexer.dist),
                             exc_str(e))
-        lgr.info('Falling back to standard indexer for metadata format: %s', metadata_format_name)
+        lgr.debug(
+            'Falling back to standard indexer for metadata format: %s',
+            metadata_format_name)
         return lambda metadata: _deep_kv('', metadata)
 
     if val2str:


### PR DESCRIPTION
Fixes #5349

Missing indexers are now reported on DEBUG level instead of INFO level. In addition,
each missing indexer is reported only once.

To support reduced reporting without changing the existing signatures too much and
without carrying unrelated objects into functions, the InstanceStorage class was created.
It provides singleton storage objects, addressed by their purpose, i.e. an entry in an
Enum, that exist for the duration of the datalad invocation, i.e. as long as the
current python process is executed.
