### PR TITLE
BF: in a new process, test first if we can run any command, and if not - old ways

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -273,7 +273,7 @@ class WitlessRunner(object):
     # new loop instantiation in a child process
     # https://bugs.python.org/issue21998
     _loop_pid = None
-    _loop_need_new = False
+    _loop_need_new = None
 
     def __init__(self, cwd=None, env=None):
         """
@@ -365,51 +365,16 @@ class WitlessRunner(object):
         # with our own event loop management
         # this is how ipython does it
         try:
-            pid = os.getpid()
-            is_new_proc = WitlessRunner._loop_pid is None or WitlessRunner._loop_pid != pid
-            if WitlessRunner._loop_need_new and not is_new_proc:
-                raise RuntimeError("we know we need a new loop")
+            is_new_proc = self._check_if_new_proc()
             event_loop = asyncio.get_event_loop()
             if is_new_proc:
-                WitlessRunner._loop_pid = pid
-                # We need to check if we can any command
-                try:
-                    event_loop.run_until_complete(
-                        run_async_cmd(
-                            event_loop,
-                            [sys.executable, "--version"],
-                            protocol,
-                            stdin,
-                            protocol_kwargs=kwargs,
-                            cwd=cwd,
-                            env=env,
-                        )
-                    )
-                    WitlessRunner._loop_need_new = False
-                except OSError as e:
-                    # due to https://bugs.python.org/issue21998
-                    # exhibits in https://github.com/ReproNim/testkraken/issues/95
-                    lgr.debug("It seems we need a new loop when running our commands: %s", exc_str(e))
-                    WitlessRunner._loop_need_new = True
-                    raise RuntimeError("the loop is not reusable")
+                self._check_if_loop_usable(event_loop, stdin)
             if event_loop.is_closed():
                 raise RuntimeError("the loop was closed - use our own")
             new_loop = False
         except RuntimeError:
+            event_loop = self._get_new_event_loop()
             new_loop = True
-            # start a new event loop, which we will close again further down
-            # if this is not done events like this will occur
-            #   BlockingIOError: [Errno 11] Resource temporarily unavailable
-            #   Exception ignored when trying to write to the signal wakeup fd:
-            # It is unclear to me why it happens when reusing an event looped
-            # that it stopped from time to time, but starting fresh and doing
-            # a full termination seems to address the issue
-            if sys.platform == "win32":
-                # use special event loop that supports subprocesses on windows
-                event_loop = asyncio.ProactorEventLoop()
-            else:
-                event_loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(event_loop)
         try:
             # include the subprocess manager in the asyncio event loop
             results = event_loop.run_until_complete(
@@ -450,6 +415,72 @@ class WitlessRunner(object):
         # denoise, must be zero at this point
         results.pop('code', None)
         return results
+
+    @classmethod
+    def _check_if_new_proc(cls):
+        """Check if WitlessRunner is used under a new PID
+
+        Raises
+        ------
+        RuntimeError
+          If it is not a new proc and we already know that we need a new loop
+          in this pid
+        """
+        pid = os.getpid()
+        is_new_proc = cls._loop_pid is None or cls._loop_pid != pid
+        if is_new_proc:
+            # We need to check if we can run any command smoothly
+            cls._loop_pid = pid
+            cls._loop_need_new = None
+        elif cls._loop_need_new:
+            raise RuntimeError("we know we need a new loop")
+        return is_new_proc
+
+    @classmethod
+    def _check_if_loop_usable(cls, event_loop, stdin):
+        """Check if given event_loop could run a simple command
+
+        Sets _loop_need_new variable to a bool depending on what it finds
+
+        Raises
+        ------
+        RuntimeError
+          If loop is not reusable
+        """
+        # We need to check if we can run any command smoothly
+        try:
+            event_loop.run_until_complete(
+                run_async_cmd(
+                    event_loop,
+                    [sys.executable, "--version"],  # fast! 0.004 sec and to be ran once per process
+                    KillOutput,
+                    stdin,
+                )
+            )
+            cls._loop_need_new = False
+        except OSError as e:
+            # due to https://bugs.python.org/issue21998
+            # exhibits in https://github.com/ReproNim/testkraken/issues/95
+            lgr.debug("It seems we need a new loop when running our commands: %s", exc_str(e))
+            cls._loop_need_new = True
+            raise RuntimeError("the loop is not reusable")
+
+    @staticmethod
+    def _get_new_event_loop():
+        # start a new event loop, which we will close again further down
+        # if this is not done events like this will occur
+        #   BlockingIOError: [Errno 11] Resource temporarily unavailable
+        #   Exception ignored when trying to write to the signal wakeup fd:
+        # It is unclear to me why it happens when reusing an event looped
+        # that it stopped from time to time, but starting fresh and doing
+        # a full termination seems to address the issue
+        if sys.platform == "win32":
+            # use special event loop that supports subprocesses on windows
+            event_loop = asyncio.ProactorEventLoop()
+        else:
+            event_loop = asyncio.SelectorEventLoop()
+        asyncio.set_event_loop(event_loop)
+        return event_loop
 
 
 class GitRunnerBase(object):

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -420,6 +420,15 @@ class WitlessRunner(object):
     def _check_if_new_proc(cls):
         """Check if WitlessRunner is used under a new PID
 
+        Note that this is a function that is meant to be called from within a
+        particular context only. The RuntimeError is expected to be catched by
+        the caller and is meant to be more like a response message than an
+        exception.
+
+        Returns
+        -------
+        bool
+
         Raises
         ------
         RuntimeError
@@ -441,6 +450,11 @@ class WitlessRunner(object):
         """Check if given event_loop could run a simple command
 
         Sets _loop_need_new variable to a bool depending on what it finds
+
+        Note that this is a function that is meant to be called from within a
+        particular context only. The RuntimeError is expected to be catched by
+        the caller and is meant to be more like a response message than an
+        exception.
 
         Raises
         ------

--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -24,6 +24,7 @@ from datalad.tests.utils import (
     assert_greater_equal,
     assert_repo_status,
     assert_raises,
+    known_failure_osx,
     rmtree,
     on_windows,
     on_osx,
@@ -134,6 +135,7 @@ def test_creatsubdatasets(topds_path, n=2):
     assert_repo_status(ds.repo)
 
 
+@known_failure_osx  # https://github.com/datalad/datalad/issues/5309
 @skip_if(not ProducerConsumer._can_use_threads, msg="Test relies on having parallel execution")
 def test_gracefull_death():
 

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -200,7 +200,7 @@ def test_asyncio_forked(temp):
     if sys.version_info < (3, 8) and pid != 0:
         # for some reason it is crucial to sleep a little (but 0.001 is not enough)
         # in the master process with older pythons or it takes forever to make the child run
-        sleep(0.01)
+        sleep(0.1)
     try:
         runner.run([sys.executable, '--version'], protocol=StdOutCapture)
         if pid == 0:

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -197,6 +197,10 @@ def test_asyncio_forked(temp):
         # so we will just skip if no forking is possible
         raise SkipTest(f"Cannot fork: {exc}")
     # if does not fail (in original or in a fork) -- we are good
+    if sys.version_info < (3, 8) and pid != 0:
+        # for some reason it is crucial to sleep a little (but 0.001 is not enough)
+        # in the master process with older pythons or it takes forever to make the child run
+        sleep(0.01)
     try:
         runner.run([sys.executable, '--version'], protocol=StdOutCapture)
         if pid == 0:

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -28,6 +28,7 @@ from datalad.tests.utils import (
     OBSCURE_FILENAME,
     ok_,
     ok_file_has_content,
+    SkipTest,
     with_tempfile,
 )
 from datalad.cmd import (
@@ -189,7 +190,12 @@ def test_asyncio_forked(temp):
     temp = Path(temp)
     runner = Runner()
     import os
-    pid = os.fork()
+    try:
+        pid = os.fork()
+    except BaseException as exc:
+        # .fork availability is "Unix", and there are cases where it is "not supported"
+        # so we will just skip if no forking is possible
+        raise SkipTest(f"Cannot fork: {exc}")
     # if does not fail (in original or in a fork) -- we are good
     try:
         runner.run([sys.executable, '--version'], protocol=StdOutCapture)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -933,6 +933,19 @@ def known_failure_githubci_osx(func):
     return func
 
 
+def known_failure_osx(func):
+    """Test decorator for a known test failure on macOS
+    """
+    if on_osx:
+        @known_failure
+        @wraps(func)
+        @attr('known_failure_osx')
+        @attr('osx')
+        def dm_func(*args, **kwargs):
+            return func(*args, **kwargs)
+        return dm_func
+    return func
+
 # ### ###
 # END known failure decorators
 # ### ###


### PR DESCRIPTION
To overcome a problem with unruly super processes, ref: https://github.com/ReproNim/testkraken/issues/95 may be just on OSX.

We will track if we are trying to run in a new PID, and if new - we will first test if we can run a command in the default loop, if not -- we revert to "old ways" for that PID to start loop for each process

@djarecka please check if works for you.  Tried on OSX with 3.7  on testkraken -- seems to be "good as old" ;)

- [x] ideally needs a test

Also adds a known failure for parallel on osx, closes #5309

Checked on a local VM, it also seems to Closes #5362 (although I am not yet 100% sure why/how since we are not catching NotImplementedError ;))