### PR TITLE
BF: make ORA aware of sameas

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -777,6 +777,8 @@ class RIARemote(SpecialRemote):
         # try loading all needed info from (git) config
         name = self.annex.getconfig('name')
         if not name:
+            name = self.annex.getconfig('sameas-name')
+        if not name:
             raise RIARemoteError(
                 "Cannot determine special remote name, got: {}".format(
                     repr(name)))

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -145,6 +145,17 @@ def _test_initremote_basic(host, ds_path, store, link):
         [assert_in(c, remote_log) for c in common_init_opts]
         assert_in("archive-id={}".format(ds.id), remote_log)
 
+    # we can deal with --sameas, which leads to a special remote not having a
+    # 'name' property, but only a 'sameas-name'. See gh-4259
+    try:
+        ds.repo.init_remote('ora2',
+                            options=init_opts + ['--sameas', 'ria-remote'])
+    except CommandError as e:
+        if 'Invalid option `--sameas' in e.stderr:
+            # annex too old - doesn't know --sameas
+            pass
+        else:
+            raise 
     # TODO: - check output of failures to verify it's failing the right way
     #       - might require to run initremote directly to get the output
 


### PR DESCRIPTION
Special remotes being set up via --sameas don't have a 'name' config to
query but only a 'sameas-name'.

(Closes #4259)

