### PR TITLE
DOC: search: Fix an invalid escape sequence

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -1146,7 +1146,7 @@ class Search(Interface):
       indexed datasets) which either have a field starting with "age" or
       "gender"::
 
-        % datalad search --mode autofield --show-keys name '\.age' '\.gender'
+        % datalad search --mode autofield --show-keys name '\\.age' '\\.gender'
 
       Fuzzy search for datasets with an author that is specified in a particular
       metadata field::


### PR DESCRIPTION
0cd1635c05 (MNT: Avoid invalid escape sequences in strings,
2019-05-17) did a tree-wide clean up to avoid "DeprecationWarning:
invalid escape sequence" warnings, but another case was introduced
since then.
