### PR TITLE
Tell git-annex to go through datalad-sshrun

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -148,6 +148,11 @@ def setup_package():
     # from new $HOME (see gh-4153
     cfg.reload(force=True)
 
+    from datalad.interface.common_cfg import compute_cfg_defaults
+    compute_cfg_defaults()
+    # datalad.locations.sockets has likely changed. Discard any cached values.
+    ssh_manager._socket_dir = None
+
     # To overcome pybuild by default defining http{,s}_proxy we would need
     # to define them to e.g. empty value so it wouldn't bother touching them.
     # But then haskell libraries do not digest empty value nicely, so we just
@@ -250,6 +255,10 @@ def teardown_package():
     # needed. However, maintaining a consistent state seems a good thing
     # either way.
     cfg.reload(force=True)
+
+    from datalad.interface.common_cfg import compute_cfg_defaults
+    compute_cfg_defaults()
+    ssh_manager._socket_dir = None
 
     consts.DATASETS_TOPURL = _test_states['DATASETS_TOPURL']
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -570,6 +570,7 @@ class GitRunnerBase(object):
         if 'GIT_SSH_COMMAND' not in git_env:
             git_env['GIT_SSH_COMMAND'] = GIT_SSH_COMMAND
             git_env['GIT_SSH_VARIANT'] = 'ssh'
+        git_env['GIT_ANNEX_USE_GIT_SSH'] = '1'
 
         # We are parsing error messages and hints. For those to work more
         # reliably we are doomed to sacrifice i18n effort of git, and enforce

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -48,7 +48,7 @@ definitions = {
                'title': 'Cache directory',
                'text': 'Where should datalad cache files?'}),
         'destination': 'global',
-        'default': dirs.user_cache_dir,
+        'default_fn': lambda: dirs.user_cache_dir,
     },
     'datalad.locations.default-dataset': {
         'ui': ('question', {
@@ -56,42 +56,42 @@ definitions = {
                'text': 'Where should datalad should look for (or install) a '
                        'default dataset?'}),
         'destination': 'global',
-        'default': opj(expanduser('~'), 'datalad'),
+        'default_fn': lambda: opj(expanduser('~'), 'datalad'),
     },
     'datalad.locations.sockets': {
         'ui': ('question', {
                'title': 'Socket directory',
                'text': 'Where should datalad store socket files?'}),
         'destination': 'global',
-        'default': opj(dirs.user_cache_dir, 'sockets'),
+        'default_fn': lambda: opj(dirs.user_cache_dir, 'sockets'),
     },
     'datalad.locations.system-plugins': {
         'ui': ('question', {
                'title': 'System plugin directory',
                'text': 'Where should datalad search for system plugins?'}),
         'destination': 'global',
-        'default': opj(dirs.site_config_dir, 'plugins'),
+        'default_fn': lambda: opj(dirs.site_config_dir, 'plugins'),
     },
     'datalad.locations.user-plugins': {
         'ui': ('question', {
                'title': 'User plugin directory',
                'text': 'Where should datalad search for user plugins?'}),
         'destination': 'global',
-        'default': opj(dirs.user_config_dir, 'plugins'),
+        'default_fn': lambda: opj(dirs.user_config_dir, 'plugins'),
     },
     'datalad.locations.system-procedures': {
         'ui': ('question', {
                'title': 'System procedure directory',
                'text': 'Where should datalad search for system procedures?'}),
         'destination': 'global',
-        'default': opj(dirs.site_config_dir, 'procedures'),
+        'default_fn': lambda: opj(dirs.site_config_dir, 'procedures'),
     },
     'datalad.locations.user-procedures': {
         'ui': ('question', {
                'title': 'User procedure directory',
                'text': 'Where should datalad search for user procedures?'}),
         'destination': 'global',
-        'default': opj(dirs.user_config_dir, 'procedures'),
+        'default_fn': lambda: opj(dirs.user_config_dir, 'procedures'),
     },
     'datalad.locations.extra-procedures': {
         'ui': ('question', {
@@ -182,7 +182,7 @@ definitions = {
         'ui': ('question', {
                'title': 'Create a temporary directory at location specified by this flag. It is used by tests to create a temporary git directory while testing git annex archives etc'}),
         'type': EnsureStr(),
-        'default': environ.get('TMPDIR'),
+        'default_fn': lambda: environ.get('TMPDIR'),
     },
     'datalad.tests.temp.keep': {
         'ui': ('yesno', {
@@ -213,7 +213,7 @@ definitions = {
             'title': 'Cache directory for tests',
             'text': 'Where should datalad cache test files?'}),
         'destination': 'global',
-        'default': opj(dirs.user_cache_dir, 'tests')
+        'default_fn': lambda: opj(dirs.user_cache_dir, 'tests')
     },
     'datalad.log.level': {
         'ui': ('question', {
@@ -428,3 +428,18 @@ definitions = {
         'type': EnsureBool(),
     },
 }
+
+
+def compute_cfg_defaults():
+    """Compute dynamic defaults for configuration options.
+
+    These are options that depend on things like $HOME that change under our
+    testing setup.
+    """
+    for key, value in definitions.items():
+        def_fn = value.get("default_fn")
+        if def_fn:
+            value['default'] = def_fn()
+
+
+compute_cfg_defaults()

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1369,6 +1369,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     msg="Remote is not known. Known are: %s"
                     % (self.get_remotes(),)
                 )
+            self._maybe_open_ssh_connection(remote)
             options += ['--from', remote]
 
         # analyze provided files to decide which actually are needed to be
@@ -2811,6 +2812,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         if len(copy_files) != len(files):
             lgr.debug("Actually copying %d files", len(copy_files))
 
+        self._maybe_open_ssh_connection(remote)
         annex_options = ['--to=%s' % remote]
         if options:
             annex_options.extend(split_cmdline(options))

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1199,6 +1199,11 @@ def test_annex_ssh(topdir):
     ar.commit("add files")
 
     ar.copy_to(["foo"], remote="ssh-remote-1")
+    # copy_to() opens it if needed.
+    #
+    # Note: This isn't racy because datalad-sshrun should not close this itself
+    # because the connection was either already open before this test or
+    # copy_to(), not the underlying git-annex/datalad-sshrun call, opens it.
     ok_(exists(socket_1))
 
     # add another remote:
@@ -1213,6 +1218,8 @@ def test_annex_ssh(topdir):
         ok_(not exists(socket_2))
 
     # copy to the new remote:
+    #
+    # Same racy note as the copy_to() call above.
     ar.copy_to(["foo"], remote="ssh-remote-2")
 
     if not exists(socket_2):  # pragma: no cover

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1167,10 +1167,6 @@ def test_annex_ssh(topdir):
     remote_1_path = rm1.path
     remote_2_path = rm2.path
 
-    # Clear instances so that __init__() is invoked and
-    # _set_shared_connection() the next time AnnexRepo is called.
-    AnnexRepo._unique_instances.clear()
-
     from datalad import ssh_manager
 
     # check whether we are the first to use these sockets:
@@ -1188,12 +1184,8 @@ def test_annex_ssh(topdir):
     gr.add_remote("ssh-remote-1", "ssh://datalad-test" + remote_1_path)
 
     ar = AnnexRepo(repo_path, create=False)
-    ok_(any(hash_1 in opt for opt in ar._annex_common_options))
-    ok_(all(hash_2 not in opt for opt in ar._annex_common_options))
 
-    # connection to 'datalad-test' should be known to ssh manager:
-    assert_in(socket_1, list(map(str, ssh_manager._connections)))
-    # but socket was not touched:
+    # socket was not touched:
     if datalad_test_was_open:
         ok_(exists(socket_1))
     else:
@@ -1212,11 +1204,7 @@ def test_annex_ssh(topdir):
     # add another remote:
     ar.add_remote('ssh-remote-2', "ssh://datalad-test2" + remote_2_path)
 
-    # now, this connection was requested:
-    assert_in(socket_2, list(map(str, ssh_manager._connections)))
-    ok_(any(hash_1 in opt for opt in ar._annex_common_options))
-    ok_(any(hash_2 in opt for opt in ar._annex_common_options))
-    # but socket was not touched:
+    # socket was not touched:
     if datalad_test2_was_open:
         # FIXME: occasionally(?) fails in V6:
         if not ar.supports_unlocked_pointers:


### PR DESCRIPTION
This series addresses gh-5382.  The first commit fixes a test bug that was revealed by the `datalad-sshrun` switch, the second does the actual switch, and the rest are non-essential tweaks on top.
