### PR TITLE
Stop using .gitattributes for annex.largefiles config

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -41,6 +41,7 @@ from datalad.utils import (
     getpwd,
     ensure_list,
     get_dataset_root,
+    Path,
 )
 
 from datalad.distribution.dataset import (
@@ -54,7 +55,6 @@ from datalad.distribution.dataset import (
 
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
-import datalad.utils as ut
 
 
 __docformat__ = 'restructuredtext'
@@ -305,11 +305,11 @@ class Create(Interface):
             op.normpath(op.join(str(path), os.pardir)))
         if parentds_path:
             prepo = GitRepo(parentds_path)
-            parentds_path = ut.Path(parentds_path)
+            parentds_path = Path(parentds_path)
             # we cannot get away with a simple
             # GitRepo.get_content_info(), as we need to detect
             # uninstalled/added subdatasets too
-            check_path = ut.Path(path)
+            check_path = Path(path)
             pstatus = prepo.status(
                 untracked='no',
                 # limit query to target path for a potentially massive speed-up
@@ -385,7 +385,7 @@ class Create(Interface):
                 git_opts=initopts,
                 fake_dates=fake_dates)
             # place a .noannex file to indicate annex to leave this repo alone
-            stamp_path = ut.Path(tbrepo.path) / '.noannex'
+            stamp_path = Path(tbrepo.path) / '.noannex'
             stamp_path.touch()
             add_to_git[stamp_path] = {
                 'type': 'file',

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -69,7 +69,7 @@ def test_status_basics(path, linkpath, otherdir):
     eq_(stat, ds.status(result_renderer=None))
     assert_status('ok', stat)
     # we have a bunch of reports (be vague to be robust to future changes
-    assert len(stat) > 2
+    assert len(stat) > 1
     # check the composition
     for s in stat:
         eq_(s['status'], 'ok')


### PR DESCRIPTION
Only the test commit is concerned with the change that motivated this PR (incomplete still, but I had to stop for now -- still not fully comprehending the necessary expression). The rest are minor, but nevertheless useful RFs.

ATM (at least), it seems that this approach is also slightly faster than the `.gitattributes` creation and addition to Git (~4-5% of the total `create` runtime on my system)

TODO:
- [ ] Address `datalad.metadata.create-aggregate-annex-limit`

Ref #5383 