### PR TITLE
Don't leave failed clone behind

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -564,6 +564,15 @@ def clone_dataset(
                 message=str(e),
                 **result_props,
             )
+
+            # We were supposed to clone a particular version but failed to.
+            # This is particularly pointless in case of subdatasets and
+            # potentially fatal with current implementation of recursion.
+            # see gh-5387
+            lgr.debug("removing failed clone attempt at %s", dest_path)
+            # TODO stringification can be removed once pathlib compatible
+            # or if PY35 is no longer supported
+            rmtree(str(dest_path), children_only=dest_path_existed)
             return
 
     # perform any post-processing that needs to know details of the clone

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -569,7 +569,7 @@ def clone_dataset(
             # This is particularly pointless in case of subdatasets and
             # potentially fatal with current implementation of recursion.
             # see gh-5387
-            lgr.debug("removing failed clone attempt at %s", dest_path)
+            lgr.debug("Failed to checkout %s, removing this clone attempt at %s", checkout_gitsha, dest_path)
             # TODO stringification can be removed once pathlib compatible
             # or if PY35 is no longer supported
             rmtree(str(dest_path), children_only=dest_path_existed)


### PR DESCRIPTION
This is a to be discussed proposal.

The issue is that `clone` - if ordered to checkout a particular version and fails to find that commit - fails, but leaves the cloned repo as is. Arguably that might be okay-ish when called directly, but if `clone` is called from within `get` to retrieve a subdataset we get the wrong thing, leave it (modified) and in the recursive case even start to get its subdatasets.

This approach would always kill such a failed attempt. Probably needs a switch or config. The alternative to only let the caller do that seems rather difficult if I look into `get`.

What do you think, @datalad/developers?

Closes #5387 