### PR TITLE
TST: appveyor: Improve error reporting of codecov.io download

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -294,7 +294,7 @@ after_test:
   - cmd: powershell Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
   - cmd: "set PATH=C:\\msys64\\usr\\bin;%PATH%"
   - cmd: bash codecov.sh -f "coverage.xml" -U "-s" -A "-s" 
-  - sh: bash <(curl -s https://codecov.io/bash)
+  - sh: bash <(curl -sfS https://codecov.io/bash)
 
 
 #on_success:


### PR DESCRIPTION
A recent AppVeyor run [*] failed with

    bash <(curl -s https://codecov.io/bash)
    /dev/fd/63: line 2: syntax error near unexpected token `<'
    /dev/fd/63: line 2: `<html><head>'
    Command exited with code 2

Presumably that was due to a transient connection error.  Extend the
curl call with -f so that the failure is mapped to a non-zero exit
rather than reporting HTML on stdout.  Also add -S so that a
meaningful error is shown on stderr:

    $ curl -sfS https://codecov.io/bashh
    curl: (22) The requested URL returned error: 404
    $ echo $?
    22

[*] https://ci.appveyor.com/project/mih/datalad/builds/37574008/job/ja1eg9dbv2jhwmfr

---

I've canceled all builds aside from the appveyor one.
