### PR TITLE
log: Add target name filters to ProgressHandler

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -555,6 +555,7 @@ class LoggerHelper(object):
         #  logging.Formatter('%(asctime)-15s %(levelname)-6s %(message)s'))
         if is_interactive():
             phandler = ProgressHandler(other_handler=loghandler)
+            phandler.filters.extend(loghandler.filters)
             self.lgr.addHandler(phandler)
         else:
             loghandler.addFilter(partial(filter_noninteractive_progress,

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -122,7 +122,7 @@ def check_filters(name):
         lgr3.info('log3')
         assert_in('log1', cml.out)
         assert_in('log2', cml.out)
-        assert 'log3' not in cml.out
+        assert_not_in('log3', cml.out)
 
 
 def test_filters():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1401,10 +1401,7 @@ def swallow_logs(new_level=None, file_=None, name='datalad'):
     # we want to log levelname so we could test against it
     swallow_handler.setFormatter(
         logging.Formatter('[%(levelname)s] %(message)s'))
-    # Inherit filters
-    from datalad.log import ProgressHandler
-    swallow_handler.filters = sum([h.filters for h in old_handlers
-                                   if not isinstance(h, ProgressHandler)],
+    swallow_handler.filters = sum([h.filters for h in old_handlers],
                                   [])
     lgr.handlers = [swallow_handler]
     if old_level < logging.DEBUG:  # so if HEAVYDEBUG etc -- show them!


### PR DESCRIPTION
get_initialized_logger() used to add two handlers to the logger for
interactive calls:

  * a plain log handler with a filter to remove dlm_progress records
  * a ProgressHandler with a filter to keep dlm_progress records

Since 8f776d396e (ENH: make ProgressHandler emit via default handler
if not a progress record, 2020-10-12), only ProgressHandler is added
as a handler, and its .emit() relays non-dlm_progress records to the
plain handler.

This change causes `test_log.test_filters` to fail when executed with
--nocapture:

    AssertionError: 'log3' unexpectedly found in
    '[DEBUG] log1\n[INFO] log2\n[INFO] log3\n

The non-test aspect to the failure is that the target name filter that
is added to the plain logger isn't honored in the new arrangement.
Fix that by adding those filters to ProgressHandler's (currently
empty) .filters.

An additional issue is that swallow_logs() discards filters from
ProgressHandler when setting up its custom handler.  That made sense
before 8f776d396e, when ProgressHandler had a filter that only kept
dlm_progress records, but it doesn't work if ProgressHandler is used
as the primary handler that relays to the plain one.

Re: #5402
