### PR TITLE
BF/RF: push - get diff depth-first not breadth-first

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -317,7 +317,7 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
             # TODO?: expose order as an option for diff and push
             # since in some cases breadth-first would be sufficient
             # and result in "taking action faster"
-            # reporting_order='breadth-first'
+            reporting_order='bottom-up'
     ):
         if res.get('action', None) != 'diff':
             # we don't care right now

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -314,10 +314,11 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
             recursion_limit=recursion_limit,
             # make it as fast as possible
             eval_file_type=False,
-            # we relay on all records of a dataset coming out
-            # in succession, with no interuption by records
-            # concerning subdataset content
-            reporting_order='breadth-first'):
+            # TODO?: expose order as an option for diff and push
+            # since in some cases breadth-first would be sufficient
+            # and result in "taking action faster"
+            # reporting_order='breadth-first'
+    ):
         if res.get('action', None) != 'diff':
             # we don't care right now
             continue
@@ -331,9 +332,9 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
                 'Cannot handle diff result without a parent dataset '
                 'property: {}'.format(res))
         if res.get('type', None) == 'dataset':
-            # a subdataset record in another data
+            # a subdataset record in another dataset
             # this could be here, because
-            # - this dataset with explicitely requested by path
+            # - this dataset was explicitly requested by path
             #   -> should get a dedicated dataset record -- even without recursion
             # - a path within an existing subdataset was given
             # - a path within an non-existing subdataset was given
@@ -386,7 +387,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
 
     res_kwargs.update(type='dataset', path=dspath)
 
-    # content will be unique for every push (even on the some dataset)
+    # content will be unique for every push (even on the same dataset)
     pbar_id = 'push-{}-{}'.format(target, id(content))
     # register for final orderly take down
     pbars[pbar_id] = ds

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -247,7 +247,7 @@ def test_push():
     yield check_push, True
 
 
-def check_datasets_order(res, order='depth-first'):
+def check_datasets_order(res, order='bottom-up'):
     """Check that all type=dataset records not violating the expected order
 
     it is somewhat weak test, i.e. records could be produced so we
@@ -260,9 +260,9 @@ def check_datasets_order(res, order='depth-first'):
         if r.get('type') != 'dataset':
             continue
         if prev and r['path'] != prev:
-            if order == 'depth-first':
+            if order == 'bottom-up':
                 assert_false(path_startswith(r['path'], prev))
-            elif order == 'breadth-first':
+            elif order == 'top-down':
                 assert_false(path_startswith(prev, r['path']))
             else:
                 raise ValueError(order)

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -186,18 +186,21 @@ def diff_dataset(
       Whether to perform file type discrimination between real symlinks
       and symlinks representing annex'ed files. This can be expensive
       in datasets with many files.
-    reporting_order : {'depth-first', 'breadth-first'}, optional
+    reporting_order : {'depth-first', 'breadth-first', 'bottom-up'}, optional
       By default, subdataset content records are reported after the record
       on the subdataset's submodule in a superdataset (depth-first).
       Alternatively, report all superdataset records first, before reporting
-      any subdataset content records (breadth-first).
+      any subdataset content records (breadth-first). Both 'depth-first'
+      and 'breadth-first' both report dataset content before considering
+      subdatasets. Alternative 'bottom-up' mode is similar to 'depth-first'
+      but dataset content is reported after reporting on subdatasets.
 
     Yields
     ------
     dict
       DataLad result records.
     """
-    if reporting_order not in ('depth-first', 'breadth-first'):
+    if reporting_order not in ('depth-first', 'breadth-first', 'bottom-up'):
         raise ValueError('Unknown reporting order: {}'.format(reporting_order))
 
     ds = require_dataset(
@@ -353,10 +356,10 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
             parentds=ds.path,
             status='ok',
         )
-        if order == 'depth-first':
-            ds_diffs.append(path_rec)
-        elif order == 'breadth-first':
+        if order in ('breadth-first', 'depth-first'):
             yield path_rec
+        elif order == 'bottom-up':
+            ds_diffs.append(path_rec)
         else:
             raise ValueError(order)
         # for a dataset we need to decide whether to dive in, or not
@@ -405,7 +408,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                     cache=cache,
                     order=order,
                 )
-                if order == 'depth-first':
+                if order in ('depth-first', 'bottom-up'):
                     yield from _diff_ds(*call_args, **call_kwargs)
                 elif order == 'breadth-first':
                     subds_diffcalls.append((call_args, call_kwargs))
@@ -415,7 +418,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                 raise RuntimeError(
                     "Unexpected subdataset state '{}'. That sucks!".format(
                         subds_state))
-    # deal with staged ds diffs (for depth-first)
+    # deal with staged ds diffs (for bottom-up)
     for rec in ds_diffs:
         yield rec
     # deal with staged subdataset diffs (for breadth-first)


### PR DESCRIPTION
Remote repositories must exist for push already, and might have hooks enabled to process the "clean" state of the repository. In hooks we deploy with web-ui e.g. we "aggregate" information about sizes within submodules.  For that to work correctly, submodules should be pushed first, and not after their "superdatasets".
    
No reason/use case comes to mind why we might want to push super datasets first (besides that they are more "readily" analyzable, so `push` might start pushing sooner), and original commit 9796a5ff seems to not state specific choice for the breadth-first behavior.

Closes #5410

TODOs:
- [x] do full tests sweep (here in this PR) to spot more side-effects
- ~~fix up the test (or code) which I marked to be skipped to do the sweep~~ magically "Fixed" itself and @yarikoptic wonders if may be related to git-annex version boost
- [x] if decided to proceed, add a dedicated test to establish this order
- [x] figure out proper naming... [see below](https://github.com/datalad/datalad/pull/5416#pullrequestreview-624688045)