### PR TITLE
AnnexJsonProtocol progress bar fixes

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3468,6 +3468,19 @@ class AnnexJsonProtocol(WitlessProtocol):
         target = action.get('file') or action.get('key')
         if target:
             label += " " + target
+
+        if label:
+            from datalad.ui import utils as ui_utils
+            # Reserving 55 characters for the progress bar is based
+            # approximately off what used to be done in the now-removed
+            # (948ccf3e18) ProcessAnnexProgressIndicators.
+            max_label_width = ui_utils.get_console_width() - 55
+            if max_label_width < 0:
+                # We're squeezed. Just show bar.
+                label = ""
+            elif len(label) > max_label_width:
+                mid = max_label_width // 2
+                label = label[:mid] + " .. " + label[-mid:]
         return label
 
     def _proc_json_record(self, j):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3453,20 +3453,21 @@ class AnnexJsonProtocol(WitlessProtocol):
     def _proc_json_record(self, j):
         # check for progress reports and act on them immediately
         # but only if there is something to build a progress report from
-        if 'action' in j and 'byte-progress' in j:
-            for err_msg in j['action'].pop('error-messages', []):
+        action = j.get('action')
+        if action and 'byte-progress' in j:
+            for err_msg in action.pop('error-messages', []):
                 lgr.error(err_msg)
             # use the action report to build a stable progress bar ID
             pbar_id = 'annexprogress-{}-{}'.format(
                 id(self),
-                hash(frozenset(j['action'])))
+                hash(frozenset(action)))
             if pbar_id in self._pbars and \
                     j.get('byte-progress', None) == j.get('total-size', None):
                 # take a known pbar down, completion or broken report
                 log_progress(
                     lgr.info,
                     pbar_id,
-                    'Finished annex action: {}'.format(j['action']),
+                    'Finished annex action: {}'.format(action),
                     noninteractive_level=5,
                 )
                 self._pbars.discard(pbar_id)
@@ -3480,9 +3481,9 @@ class AnnexJsonProtocol(WitlessProtocol):
                 log_progress(
                     lgr.info,
                     pbar_id,
-                    'Start annex action: {}'.format(j['action']),
+                    'Start annex action: {}'.format(action),
                     # do not crash if no command is reported
-                    label=j['action'].get('command', '').capitalize(),
+                    label=action.get('command', '').capitalize(),
                     unit=' Bytes',
                     total=float(j.get('total-size', 0)),
                     noninteractive_level=5,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3464,7 +3464,11 @@ class AnnexJsonProtocol(WitlessProtocol):
 
     def _get_pbar_label(self, action):
         # do not crash if no command is reported
-        return action.get('command', '').capitalize()
+        label = action.get('command', '').capitalize()
+        target = action.get('file') or action.get('key')
+        if target:
+            label += " " + target
+        return label
 
     def _proc_json_record(self, j):
         # check for progress reports and act on them immediately

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3454,9 +3454,11 @@ class AnnexJsonProtocol(WitlessProtocol):
         # check for progress reports and act on them immediately
         # but only if there is something to build a progress report from
         action = j.get('action')
-        if action and 'byte-progress' in j:
+        if action:
             for err_msg in action.pop('error-messages', []):
                 lgr.error(err_msg)
+
+        if action and 'byte-progress' in j:
             # use the action report to build a stable progress bar ID
             pbar_id = 'annexprogress-{}-{}'.format(
                 id(self),


### PR DESCRIPTION
This series makes two changes to AnnexJsonProtocol:

  * corrects a bug in the progress bar ID calculation that resulted in using the same ID across concurrent operations on different files

  * adds the file name to the progress bar

Together these fix gh-5419.
