### PR TITLE
NF: cfg_noannex procedure to convert annexed repo into the one without annex

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -168,11 +168,6 @@ class Create(Interface):
             doc="""enforce creation of a dataset in a non-empty directory""",
             action='store_true'),
         description=location_description,
-        no_annex=Parameter(
-            # hide this from the cmdline parser, replaced by `annex`
-            args=tuple(),
-            doc="""this option is deprecated, use `annex` instead""",
-            action='store_true'),
         annex=Parameter(
             args=("--no-annex",),
             dest='annex',
@@ -208,24 +203,10 @@ class Create(Interface):
             force=False,
             description=None,
             dataset=None,
-            no_annex=_NoAnnexDefault,
             annex=True,
             fake_dates=False,
             cfg_proc=None
     ):
-        # TODO: The current release of datalad-metalad (v0.2.1) still uses
-        # no_annex in its tests. Remove this compatibility kludge once a
-        # release is made, which will include 16a170e (2020-09-08).
-        if no_annex is not _NoAnnexDefault:
-            # the two mirror options do not agree and the deprecated one is
-            # not at default value
-            warnings.warn("datalad-create's `no_annex` option is deprecated "
-                          "and will be removed in a future release, "
-                          "use the reversed-sign `annex` option instead.",
-                          DeprecationWarning)
-            # honor the old option for now
-            annex = not no_annex
-
         # we only perform negative tests below
         no_annex = not annex
 

--- a/datalad/resources/procedures/cfg_noannex.py
+++ b/datalad/resources/procedures/cfg_noannex.py
@@ -1,0 +1,36 @@
+"""Procedure to uninit Git-annex (if initialized), and create/save .noannex file to prevent annex initialization
+
+If there are git-annex'ed files already, git annex uninit and this procedure will fail.
+
+"""
+
+import sys
+
+from datalad.distribution.dataset import require_dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad import lgr
+
+ds = require_dataset(
+    sys.argv[1],
+    check_installed=True,
+    purpose='configuration')
+
+if isinstance(ds.repo, AnnexRepo):
+    repo = ds.repo
+    # TODO: if procedures can have options -- add --force handling/passing
+    #
+    # annex uninit unlocks files for which there is content (nice) but just proceeds
+    # and leaves broken symlinks for files without content.  For the current purpose
+    # of this procedure we just prevent "uninit" of any annex with some files already
+    # annexed.
+    if any(repo.call_annex_items_(['whereis', '--all'])):
+        raise RuntimeError("Annex has some annexed files, unsafe")
+    # remove annex
+    repo.call_annex(['uninit'])
+
+noannex_file = ds.pathobj / ".noannex"
+if not noannex_file.exists():
+    lgr.info("Creating and committing a .noannex file")
+    noannex_file.touch()
+    ds.save(noannex_file,
+            message="Added .noannex to prevent accidental initialization of git-annex")

--- a/datalad/resources/procedures/cfg_noannex.py
+++ b/datalad/resources/procedures/cfg_noannex.py
@@ -4,33 +4,38 @@ If there are git-annex'ed files already, git annex uninit and this procedure wil
 
 """
 
-import sys
-
 from datalad.distribution.dataset import require_dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad import lgr
 
-ds = require_dataset(
-    sys.argv[1],
-    check_installed=True,
-    purpose='configuration')
 
-if isinstance(ds.repo, AnnexRepo):
-    repo = ds.repo
-    # TODO: if procedures can have options -- add --force handling/passing
-    #
-    # annex uninit unlocks files for which there is content (nice) but just proceeds
-    # and leaves broken symlinks for files without content.  For the current purpose
-    # of this procedure we just prevent "uninit" of any annex with some files already
-    # annexed.
-    if any(repo.call_annex_items_(['whereis', '--all'])):
-        raise RuntimeError("Annex has some annexed files, unsafe")
-    # remove annex
-    repo.call_annex(['uninit'])
+def no_annex(ds):
+    ds = require_dataset(
+        ds,
+        check_installed=True,
+        purpose='configuration')
 
-noannex_file = ds.pathobj / ".noannex"
-if not noannex_file.exists():
-    lgr.info("Creating and committing a .noannex file")
-    noannex_file.touch()
-    ds.save(noannex_file,
-            message="Added .noannex to prevent accidental initialization of git-annex")
+    if isinstance(ds.repo, AnnexRepo):
+        repo = ds.repo
+        # TODO: if procedures can have options -- add --force handling/passing
+        #
+        # annex uninit unlocks files for which there is content (nice) but just proceeds
+        # and leaves broken symlinks for files without content.  For the current purpose
+        # of this procedure we just prevent "uninit" of any annex with some files already
+        # annexed.
+        if any(repo.call_annex_items_(['whereis', '--all'])):
+            raise RuntimeError("Annex has some annexed files, unsafe")
+        # remove annex
+        repo.call_annex(['uninit'])
+
+    noannex_file = ds.pathobj / ".noannex"
+    if not noannex_file.exists():
+        lgr.info("Creating and committing a .noannex file")
+        noannex_file.touch()
+        ds.save(noannex_file,
+                message="Added .noannex to prevent accidental initialization of git-annex")
+
+
+if __name__ == '__main__':
+    import sys
+    no_annex(sys.argv[1])

--- a/datalad/resources/procedures/tests/test_noannex.py
+++ b/datalad/resources/procedures/tests/test_noannex.py
@@ -1,0 +1,56 @@
+#emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*- 
+#ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.gitrepo import GitRepo
+from datalad.tests.utils import with_tempfile, with_tree
+from datalad.support.exceptions import CommandError
+
+from nose.tools import (
+    assert_true,
+    assert_false,
+    assert_raises,
+)
+
+
+def check_noannex(ds):
+    assert_true(isinstance(ds.repo, GitRepo))
+    assert_true((ds.pathobj / ".noannex").exists())
+    assert_false((ds.pathobj / ".git" / "annex").exists())
+
+
+@with_tempfile(mkdir=True)
+def test_noannex_simple(path):
+    ds = Dataset(path).create()
+    assert_true(isinstance(ds.repo, AnnexRepo))
+    ds.run_procedure('cfg_noannex')  # we are killing annex while ds.repo
+    check_noannex(ds)
+
+
+@with_tree(tree={
+    'data': 'some'
+})
+def test_noannex_create_force(path):
+    ds = Dataset(path).create(force=True, cfg_proc='noannex')
+    check_noannex(ds)
+
+
+@with_tree(tree={
+    'data': 'some'
+})
+def test_noannex_fail_if_has_annexed(path):
+    ds = Dataset(path).create(force=True)
+    ds.save()
+    assert_true(isinstance(ds.repo, AnnexRepo))
+    # internally procedure raises RuntimeError, but since we run it via runner, we
+    # get CommandError here
+    with assert_raises(CommandError):
+        ds.run_procedure('cfg_noannex')  # we are killing annex while ds.repo


### PR DESCRIPTION
Initial motivation is to be able to use  `datalad create -c noannex` ,
in particular in the light of https://github.com/datalad/datalad/issues/5423
RFC.

Yes, we do have  --no-annex  option but it could not be applied "post-fact".
Also I like the consistency of having dataset configuration via  -c option
to create.

TODOs
- [x] seek initial feedback
- [x] test
- [x] also removed `no_annex` Python option for `create` which was deprecated as of 0.13.0 .
- possibly options? (--force, --ensure-content, ...?) -- decided not to bother for now (until a use case)