### PR TITLE
ENH: Amending commits

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -1034,3 +1034,18 @@ def test_save_amend(dspath):
     # comitter changed:
     eq_(ds.repo.format_commit("%cn"), "Hopefully Different")
     eq_(ds.repo.format_commit("%ce"), "hope.diff@example.com")
+
+
+    # amend commit with no parent:
+    rmtree(dspath)
+    ds = Dataset(dspath).create()
+    branch = ds.repo.get_corresponding_branch()
+    # test pointless if we start with more than one commit
+    eq_(len(list(ds.repo.get_branch_commits_(branch))),
+        1)
+    last_sha = ds.repo.get_hexsha(branch)
+
+    ds.save(message="new initial commit", amend=True)
+    assert_repo_status(ds.repo)
+    assert_not_in(last_sha, ds.repo.get_branch_commits_(branch))
+    eq_(ds.repo.format_commit("%B").strip(), "new initial commit")

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -33,8 +33,10 @@ from datalad.tests.utils import (
     known_failure_appveyor,
     known_failure_windows,
     maybe_adjust_repo,
+    neq_,
     OBSCURE_FILENAME,
     ok_,
+    patch,
     SkipTest,
     skip_wo_symlink_capability,
     swallow_outputs,
@@ -889,3 +891,146 @@ def test_save_diff_ignore_submodules_config(path):
     # Saving a subdataset doesn't fail when diff.ignoreSubmodules=all.
     ds.save()
     assert_repo_status(ds.path)
+
+
+@with_tree(tree={'somefile': 'file content',
+                 'subds': {'file_in_sub': 'other'}})
+def test_save_amend(dspath):
+
+    dspath = Path(dspath)
+    file_in_super = dspath / 'somefile'
+    file_in_sub = dspath / 'subds' / 'file_in_sub'
+
+    # test on a hierarchy including a plain git repo:
+    ds = Dataset(dspath).create(force=True, no_annex=True)
+    subds = ds.create('subds', force=True)
+
+    # in an annex repo the branch we are interested in might not be the active
+    # branch (adjusted):
+    sub_branch = subds.repo.get_corresponding_branch()
+
+    ds.save(recursive=True)
+    assert_repo_status(ds.repo)
+
+    # amend in subdataset w/ new message; otherwise empty:
+    last_sha = subds.repo.get_hexsha(sub_branch)
+    subds.save(message="new message in sub", amend=True)
+    # we did in fact commit something:
+    neq_(last_sha, subds.repo.get_hexsha(sub_branch))
+    # repo is clean:
+    assert_repo_status(subds.repo)
+    # message is correct:
+    eq_(subds.repo.format_commit("%B", sub_branch).strip(),
+        "new message in sub")
+    # actually replaced the previous commit:
+    assert_not_in(last_sha, subds.repo.get_branch_commits_(sub_branch))
+
+
+    # amend in subdataset w/o new message
+    if not subds.repo.is_managed_branch():
+        subds.unlock('file_in_sub')
+    file_in_sub.write_text("modified again")
+    last_sha = subds.repo.get_hexsha(sub_branch)
+    subds.save(amend=True)
+    neq_(last_sha, subds.repo.get_hexsha(sub_branch))
+    assert_repo_status(subds.repo)
+    # message unchanged:
+    eq_(subds.repo.format_commit("%B", sub_branch).strip(),
+        "new message in sub")
+    # actually replaced the previous commit:
+    assert_not_in(last_sha, subds.repo.get_branch_commits_(sub_branch))
+
+
+    # amend in superdataset non-recursive
+    file_in_super.write_text("changed content")
+    if not subds.repo.is_managed_branch():
+        subds.unlock('file_in_sub')
+    file_in_sub.write_text("modified once again")
+    last_sha = ds.repo.get_hexsha()
+    last_sha_sub = subds.repo.get_hexsha(sub_branch)
+    ds.save(message="new message in super", amend=True)
+    neq_(last_sha, ds.repo.get_hexsha())
+    eq_(ds.repo.format_commit("%B").strip(), "new message in super")
+    assert_not_in(last_sha, ds.repo.get_branch_commits_())
+    # we didn't mess with the subds:
+    assert_repo_status(ds.repo, modified=["subds"])
+    eq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
+    eq_(subds.repo.format_commit("%B", sub_branch).strip(),
+        "new message in sub")
+
+
+    # amend recursively - unchanged message(s):
+    file_in_super.write_text("changed content again")
+    last_sha = ds.repo.get_hexsha()
+    last_sha_sub = subds.repo.get_hexsha(sub_branch)
+    ds.save(amend=True, recursive=True)
+    # super:
+    assert_repo_status(ds.repo)
+    neq_(last_sha, ds.repo.get_hexsha())
+    assert_not_in(last_sha, ds.repo.get_branch_commits_())
+    eq_(ds.repo.format_commit("%B").strip(), "new message in super")
+    # sub:
+    assert_repo_status(subds.repo)
+    neq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
+    assert_not_in(last_sha_sub, subds.repo.get_branch_commits_(sub_branch))
+    eq_(subds.repo.format_commit("%B", sub_branch).strip(),
+        "new message in sub")
+
+
+    # amend modifications recursively - new message:
+    file_in_super.write_text("changed content completely")
+    if not subds.repo.is_managed_branch():
+        subds.unlock('file_in_sub')
+    file_in_sub.write_text("new content")
+    last_sha = subds.repo.get_hexsha()
+    last_sha_sub = subds.repo.get_hexsha(sub_branch)
+    ds.save(message="recursive amend", amend=True, recursive=True)
+    # super:
+    assert_repo_status(ds.repo)
+    neq_(last_sha, ds.repo.get_hexsha())
+    assert_not_in(last_sha, ds.repo.get_branch_commits_())
+    eq_(ds.repo.format_commit("%B").strip(), "recursive amend")
+    # sub:
+    assert_repo_status(subds.repo)
+    neq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
+    assert_not_in(last_sha_sub, subds.repo.get_branch_commits_(sub_branch))
+    eq_(subds.repo.format_commit("%B", sub_branch).strip(), "recursive amend")
+
+    # amend recursively - new message only:
+    last_sha = subds.repo.get_hexsha()
+    last_sha_sub = subds.repo.get_hexsha(sub_branch)
+    ds.save(message="second recursive amend", amend=True, recursive=True)
+    # super:
+    assert_repo_status(ds.repo)
+    neq_(last_sha, ds.repo.get_hexsha())
+    assert_not_in(last_sha, ds.repo.get_branch_commits_())
+    eq_(ds.repo.format_commit("%B").strip(), "second recursive amend")
+    # sub:
+    assert_repo_status(subds.repo)
+    neq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
+    assert_not_in(last_sha_sub, subds.repo.get_branch_commits_(sub_branch))
+    eq_(subds.repo.format_commit("%B", sub_branch).strip(),
+        "second recursive amend")
+
+
+    # amend with different identity:
+    orig_author = ds.repo.format_commit("%an")
+    orig_email = ds.repo.format_commit("%ae")
+    orig_date = ds.repo.format_commit("%ad")
+    orig_committer = ds.repo.format_commit("%cn")
+    orig_committer_mail = ds.repo.format_commit("%ce")
+    eq_(orig_author, orig_committer)
+    eq_(orig_email, orig_committer_mail)
+    with patch.dict('os.environ',
+                    {'GIT_COMMITTER_NAME': 'Hopefully Different',
+                     'GIT_COMMITTER_EMAIL': 'hope.diff@example.com'}):
+
+        ds.config.reload(force=True)
+        ds.save(amend=True, message="amend with hope")
+    # author was kept:
+    eq_(orig_author, ds.repo.format_commit("%an"))
+    eq_(orig_email, ds.repo.format_commit("%ae"))
+    eq_(orig_date, ds.repo.format_commit("%ad"))
+    # comitter changed:
+    eq_(ds.repo.format_commit("%cn"), "Hopefully Different")
+    eq_(ds.repo.format_commit("%ce"), "hope.diff@example.com")

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -904,15 +904,18 @@ def test_save_amend(dspath):
     # test on a hierarchy including a plain git repo:
     ds = Dataset(dspath).create(force=True, no_annex=True)
     subds = ds.create('subds', force=True)
+    ds.save(recursive=True)
+    assert_repo_status(ds.repo)
+
+    # recursive and amend are mutually exclusive:
+    for d in (ds, subds):
+        assert_raises(ValueError, d.save, recursive=True, amend=True)
 
     # in an annex repo the branch we are interested in might not be the active
     # branch (adjusted):
     sub_branch = subds.repo.get_corresponding_branch()
 
-    ds.save(recursive=True)
-    assert_repo_status(ds.repo)
-
-    # amend in subdataset w/ new message; otherwise empty:
+    # amend in subdataset w/ new message; otherwise empty amendment:
     last_sha = subds.repo.get_hexsha(sub_branch)
     subds.save(message="new message in sub", amend=True)
     # we did in fact commit something:
@@ -925,8 +928,7 @@ def test_save_amend(dspath):
     # actually replaced the previous commit:
     assert_not_in(last_sha, subds.repo.get_branch_commits_(sub_branch))
 
-
-    # amend in subdataset w/o new message
+    # amend modifications in subdataset w/o new message
     if not subds.repo.is_managed_branch():
         subds.unlock('file_in_sub')
     file_in_sub.write_text("modified again")
@@ -940,15 +942,27 @@ def test_save_amend(dspath):
     # actually replaced the previous commit:
     assert_not_in(last_sha, subds.repo.get_branch_commits_(sub_branch))
 
+    # save --amend with nothing to amend with:
+    res = subds.save(amend=True)
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, status='notneeded', action='save')
 
-    # amend in superdataset non-recursive
+    # amend in superdataset w/ new message; otherwise empty amendment:
+    last_sha = ds.repo.get_hexsha()
+    ds.save(message="new message in super", amend=True)
+    neq_(last_sha, ds.repo.get_hexsha())
+    assert_repo_status(subds.repo)
+    eq_(ds.repo.format_commit("%B").strip(), "new message in super")
+    assert_not_in(last_sha, ds.repo.get_branch_commits_())
+
+    # amend modifications in superdataset w/o new message
     file_in_super.write_text("changed content")
     if not subds.repo.is_managed_branch():
         subds.unlock('file_in_sub')
     file_in_sub.write_text("modified once again")
     last_sha = ds.repo.get_hexsha()
     last_sha_sub = subds.repo.get_hexsha(sub_branch)
-    ds.save(message="new message in super", amend=True)
+    ds.save(amend=True)
     neq_(last_sha, ds.repo.get_hexsha())
     eq_(ds.repo.format_commit("%B").strip(), "new message in super")
     assert_not_in(last_sha, ds.repo.get_branch_commits_())
@@ -958,60 +972,17 @@ def test_save_amend(dspath):
     eq_(subds.repo.format_commit("%B", sub_branch).strip(),
         "new message in sub")
 
-
-    # amend recursively - unchanged message(s):
-    file_in_super.write_text("changed content again")
+    # save --amend with nothing to amend with:
     last_sha = ds.repo.get_hexsha()
-    last_sha_sub = subds.repo.get_hexsha(sub_branch)
-    ds.save(amend=True, recursive=True)
-    # super:
-    assert_repo_status(ds.repo)
-    neq_(last_sha, ds.repo.get_hexsha())
-    assert_not_in(last_sha, ds.repo.get_branch_commits_())
-    eq_(ds.repo.format_commit("%B").strip(), "new message in super")
-    # sub:
-    assert_repo_status(subds.repo)
-    neq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
-    assert_not_in(last_sha_sub, subds.repo.get_branch_commits_(sub_branch))
+    res = ds.save(amend=True)
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, status='notneeded', action='save')
+    eq_(last_sha, ds.repo.get_hexsha())
+    # we didn't mess with the subds:
+    assert_repo_status(ds.repo, modified=["subds"])
+    eq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
     eq_(subds.repo.format_commit("%B", sub_branch).strip(),
         "new message in sub")
-
-
-    # amend modifications recursively - new message:
-    file_in_super.write_text("changed content completely")
-    if not subds.repo.is_managed_branch():
-        subds.unlock('file_in_sub')
-    file_in_sub.write_text("new content")
-    last_sha = subds.repo.get_hexsha()
-    last_sha_sub = subds.repo.get_hexsha(sub_branch)
-    ds.save(message="recursive amend", amend=True, recursive=True)
-    # super:
-    assert_repo_status(ds.repo)
-    neq_(last_sha, ds.repo.get_hexsha())
-    assert_not_in(last_sha, ds.repo.get_branch_commits_())
-    eq_(ds.repo.format_commit("%B").strip(), "recursive amend")
-    # sub:
-    assert_repo_status(subds.repo)
-    neq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
-    assert_not_in(last_sha_sub, subds.repo.get_branch_commits_(sub_branch))
-    eq_(subds.repo.format_commit("%B", sub_branch).strip(), "recursive amend")
-
-    # amend recursively - new message only:
-    last_sha = subds.repo.get_hexsha()
-    last_sha_sub = subds.repo.get_hexsha(sub_branch)
-    ds.save(message="second recursive amend", amend=True, recursive=True)
-    # super:
-    assert_repo_status(ds.repo)
-    neq_(last_sha, ds.repo.get_hexsha())
-    assert_not_in(last_sha, ds.repo.get_branch_commits_())
-    eq_(ds.repo.format_commit("%B").strip(), "second recursive amend")
-    # sub:
-    assert_repo_status(subds.repo)
-    neq_(last_sha_sub, subds.repo.get_hexsha(sub_branch))
-    assert_not_in(last_sha_sub, subds.repo.get_branch_commits_(sub_branch))
-    eq_(subds.repo.format_commit("%B", sub_branch).strip(),
-        "second recursive amend")
-
 
     # amend with different identity:
     orig_author = ds.repo.format_commit("%an")
@@ -1035,8 +1006,7 @@ def test_save_amend(dspath):
     eq_(ds.repo.format_commit("%cn"), "Hopefully Different")
     eq_(ds.repo.format_commit("%ce"), "hope.diff@example.com")
 
-
-    # edge case: amend empty commit with no parent:
+    # corner case: amend empty commit with no parent:
     rmtree(str(dspath))
     # When adjusted branch is enforced by git-annex detecting a crippled FS,
     # git-annex produces an empty commit before switching to adjusted branch:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3356,15 +3356,14 @@ class AnnexRepo(GitRepo, RepoInterface):
             old_sha = self.get_hexsha(corresponding_branch)
 
             org_commit_pointer = corresponding_branch + "~1"
-            author_name = self.format_commit("%an", org_commit_pointer)
-            author_email = self.format_commit("%ae", org_commit_pointer)
-            author_date = self.format_commit("%ad", org_commit_pointer)
-            old_parent = self.format_commit("%P", org_commit_pointer)
+            author_name, author_email, author_date, \
+            old_parent, old_message = self.format_commit(
+                "%an%x00%ae%x00%ad%x00%P%x00%B", org_commit_pointer).split('\0')
             new_env = (self._git_runner.env
                        if self._git_runner.env else os.environ).copy()
             # `message` might be empty - we need to take it from the to be
             # amended commit in that case:
-            msg = message or self.format_commit("%B", org_commit_pointer)
+            msg = message or old_message
             new_env.update({
                 'GIT_AUTHOR_NAME': author_name,
                 'GIT_AUTHOR_EMAIL': author_email,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3350,6 +3350,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
             adjusted_branch = self.get_active_branch()
             corresponding_branch = self.get_corresponding_branch()
+            old_sha = self.get_hexsha(corresponding_branch)
 
             org_commit_pointer = corresponding_branch + "~1"
             author_name = self.format_commit("%an", org_commit_pointer)
@@ -3376,8 +3377,10 @@ class AnnexRepo(GitRepo, RepoInterface):
                                     read_only=False)
             new_sha = out.strip()
 
-            self.update_ref("refs/heads/" + corresponding_branch, new_sha)
-            self.update_ref("refs/basis/" + adjusted_branch, new_sha)
+            self.update_ref("refs/heads/" + corresponding_branch,
+                            new_sha, old_sha)
+            self.update_ref("refs/basis/" + adjusted_branch,
+                            new_sha, old_sha)
             self.localsync(managed_only=True)
 
     def localsync(self, remote=None, managed_only=False):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3356,7 +3356,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             author_name = self.format_commit("%an", org_commit_pointer)
             author_email = self.format_commit("%ae", org_commit_pointer)
             author_date = self.format_commit("%ad", org_commit_pointer)
-
+            old_parent = self.format_commit("%P", org_commit_pointer)
             new_env = (self._git_runner.env
                        if self._git_runner.env else os.environ).copy()
             # `message` might be empty - we need to take it from the to be
@@ -3369,12 +3369,12 @@ class AnnexRepo(GitRepo, RepoInterface):
             })
             # TODO: What about fake_dates in this context?
             #       ATM this is applied on top by _call_git().
-            out, _ = self._call_git(["commit-tree",
-                                     corresponding_branch + "^{tree}",
-                                     "-p", corresponding_branch + "~2",
-                                     "-m", msg],
-                                    env=new_env,
-                                    read_only=False)
+            commit_cmd = ["commit-tree",
+                          corresponding_branch + "^{tree}",
+                          "-m", msg]
+            if old_parent:
+                commit_cmd.extend(["-p", old_parent])
+            out, _ = self._call_git(commit_cmd, env=new_env, read_only=False)
             new_sha = out.strip()
 
             self.update_ref("refs/heads/" + corresponding_branch,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3327,13 +3327,15 @@ class AnnexRepo(GitRepo, RepoInterface):
                     if 'error-messages' in r else None,
                     logger=lgr)
 
-    def _save_post(self, message, status, partial_commit, amend=False):
+    def _save_post(self, message, status, partial_commit,
+                   amend=False, allow_empty=False):
 
         if amend and self.is_managed_branch() and \
                 self.format_commit("%B").strip() == "git-annex adjusted branch":
             # We must not directly amend on an adjusted branch, but fix it
             # up after the fact. That is if HEAD is a git-annex commit.
             # Otherwise we still can amend-commit normally.
+            # Note, that this may involve creating an empty commit first.
             amend = False
             adjust_amend = True
         else:
@@ -3341,7 +3343,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # first do standard GitRepo business
         super(AnnexRepo, self)._save_post(
-            message, status, partial_commit, amend, allow_empty=adjust_amend)
+            message, status, partial_commit, amend,
+            allow_empty=allow_empty or adjust_amend)
         # then sync potential managed branches
         self.localsync(managed_only=True)
         if adjust_amend:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3370,8 +3370,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 'GIT_AUTHOR_EMAIL': author_email,
                 'GIT_AUTHOR_DATE': author_date
             })
-            # TODO: What about fake_dates in this context?
-            #       ATM this is applied on top by _call_git().
             commit_cmd = ["commit-tree",
                           corresponding_branch + "^{tree}",
                           "-m", msg]

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -4135,7 +4135,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                                 else tuple())}):
                 yield r
 
-        self._save_post(message, status, need_partial_commit, amend=amend)
+        # Note, that allow_empty is always ok when we amend. Required when we
+        # amend an empty commit while the amendment is empty, too (though
+        # possibly different message). If an empty commit was okay before, it's
+        # okay now.
+        self._save_post(message, status, need_partial_commit, amend=amend,
+                        allow_empty=amend)
         # TODO yield result for commit, prev helper checked hexsha pre
         # and post...
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1676,11 +1676,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         orig_msg = msg
         if not msg:
-            if '--amend' in options and '--no-edit' not in options:
-                # don't overwrite old commit message with our default message
-                # by default, but re-use old one. In other words: Make --no-edit
-                # the default:
-                options += ["--no-edit"]
+            if '--amend' in options:
+                if '--no-edit' not in options:
+                    # don't overwrite old commit message with our default
+                    # message by default, but re-use old one. In other words:
+                    # Make --no-edit the default:
+                    options += ["--no-edit"]
             else:
                 msg = 'Recorded changes'
                 _datalad_msg = True

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2129,9 +2129,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         cmd = self._git_cmd_prefix + args
 
-        env = None
         if not read_only and self.fake_dates_enabled:
-            env = self.add_fake_dates(runner.env)
+            env = self.add_fake_dates(env if env else runner.env)
 
         protocol = StdOutErrCapture
         out = err = None

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -40,6 +40,7 @@ from datalad.tests.utils import (
     assert_false,
     assert_in,
     assert_in_results,
+    assert_not_equal,
     assert_not_in,
     assert_raises,
     assert_repo_status,
@@ -315,6 +316,24 @@ def test_GitRepo_commit(path):
     # commit with empty message:
     gr.commit()
     assert_repo_status(gr)
+    assert_equal(gr.format_commit("%B").strip(), "[DATALAD] Recorded changes")
+
+    # amend commit:
+    assert_equal(len(list(gr.get_branch_commits_())), 2)
+    last_sha = gr.get_hexsha()
+    with open(op.join(path, filename), 'w') as f:
+        f.write("changed again")
+    gr.add(filename)
+    gr.commit("amend message", options=to_options(amend=True))
+    assert_repo_status(gr)
+    assert_equal(gr.format_commit("%B").strip(), "amend message")
+    assert_not_equal(last_sha, gr.get_hexsha())
+    assert_equal(len(list(gr.get_branch_commits_())), 2)
+    # amend w/o message maintains previous one:
+    gr.commit(options=to_options(amend=True))
+    assert_repo_status(gr)
+    assert_equal(len(list(gr.get_branch_commits_())), 2)
+    assert_equal(gr.format_commit("%B").strip(), "amend message")
 
     # nothing to commit doesn't raise by default:
     gr.commit()


### PR DESCRIPTION
Looking into a resolution of #3244 (and subsequently #5412).

Introducing `--amend` for `save`. By default this keeps the previous commit message if none was passed to save. `--amend` can not be applied recursively for now (see #5455 ).

- minor fix: `GitRepo._call_git` didn't respect its `env` parameter
- minor fix: `save` exited zero w/o a result when called on empty repo (no commit or empty commit only). Now: either `notneeded`     or proceeds in case of `--amend`.
- minor enh: `GitRepo.update_ref` now optionally takes `oldvalue` parameter
