### PR TITLE
Add python interpreter path to cfgs

### DIFF
--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Procedure to configure additional metadata types
 
 Additional arguments: <metadata type label> [...]

--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Procedure to configure additional metadata types
 
 Additional arguments: <metadata type label> [...]

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Procedure to configure Git annex to add text files directly to Git"""
 
 import sys

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Procedure to configure Git annex to add text files directly to Git"""
 
 import sys

--- a/datalad/resources/procedures/cfg_yoda.py
+++ b/datalad/resources/procedures/cfg_yoda.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Procedure to apply YODA-compatible default setup to a dataset
 
 This procedure assumes a clean dataset that was just created by

--- a/datalad/resources/procedures/cfg_yoda.py
+++ b/datalad/resources/procedures/cfg_yoda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Procedure to apply YODA-compatible default setup to a dataset
 
 This procedure assumes a clean dataset that was just created by


### PR DESCRIPTION
There might be an issue with the server I'm using, but I have been getting the following error when trying to create a datalad dataset with -c text2git. Using datalad 0.14.0

```
(base) [xcpdev@cubic-login1 production]$ datalad create -c text2git -c yoda --description "${PROJECTNAME}" . 
[INFO   ] Creating a new annex repo at /cbica/projects/xcpDev/testproj/production 
[INFO   ] Scanning for unlocked files (this may take some time) 
[INFO   ] Running procedure cfg_text2git 
[INFO   ] == Command start (output follows) ===== 
/cbica/projects/xcpDev/testproj/miniconda3/lib/python3.8/site-packages/datalad/resources/procedures/cfg_text2git.py: line 1: Procedure to configure Git annex to add text files directly to Git: command not found
import: unable to open X server `' @ error/import.c/ImportImageCommand/369.
import: unable to open X server `' @ error/import.c/ImportImageCommand/369.
/cbica/projects/xcpDev/testproj/miniconda3/lib/python3.8/site-packages/datalad/resources/procedures/cfg_text2git.py: line 6: from: command not found
/cbica/projects/xcpDev/testproj/miniconda3/lib/python3.8/site-packages/datalad/resources/procedures/cfg_text2git.py: line 8: syntax error near unexpected token `('
/cbica/projects/xcpDev/testproj/miniconda3/lib/python3.8/site-packages/datalad/resources/procedures/cfg_text2git.py: line 8: `ds = require_dataset('
[INFO   ] == Command exit (modification check follows) ===== 
CommandError: '/cbica/projects/xcpDev/testproj/miniconda3/lib/python3.8/site-packages/datalad/resources/procedures/cfg_text2git.py /cbica/projects/xcpDev/testproj/production ' failed with exitcode 2 under /cbica/projects/xcpDev/testproj/production
```

This fixes the issue for me, but please let me know if there is something I can configure so this isn't necessary.