### PR TITLE
assert_not_in_results: Make failure message more helpful 

### DIFF
--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1385,6 +1385,7 @@ def assert_in_results(results, **kwargs):
     for r in ensure_list(results):
         if all(k in r and r[k] == v for k, v in kwargs.items()):
             found = True
+            break
     if not found:
         raise AssertionError(
             "Desired result\n{}\nnot found among\n{}"

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1378,25 +1378,31 @@ def assert_result_count(results, n, **kwargs):
                 _format_res(results)))
 
 
-def assert_in_results(results, **kwargs):
-    """Verify that the particular combination of keys and values is found in
-    one of the results"""
+def _check_results_in(should_contain, results, **kwargs):
     found = False
     for r in ensure_list(results):
         if all(k in r and r[k] == v for k, v in kwargs.items()):
             found = True
             break
-    if not found:
-        raise AssertionError(
-            "Desired result\n{}\nnot found among\n{}"
-            .format(_format_res(kwargs), _format_res(results)))
+    if found ^ should_contain:
+        if should_contain:
+            msg = "Desired result\n{}\nnot found among\n{}"
+        else:
+            msg = "Result\n{}\nunexpectedly found among\n{}"
+        raise AssertionError(msg.format(_format_res(kwargs),
+                                        _format_res(results)))
+
+
+def assert_in_results(results, **kwargs):
+    """Verify that the particular combination of keys and values is found in
+    one of the results"""
+    _check_results_in(True, results, **kwargs)
 
 
 def assert_not_in_results(results, **kwargs):
     """Verify that the particular combination of keys and values is not in any
     of the results"""
-    for r in ensure_list(results):
-        assert any(k not in r or r[k] != v for k, v in kwargs.items())
+    _check_results_in(False, results, **kwargs)
 
 
 def assert_result_values_equal(results, prop, values):


### PR DESCRIPTION
When writing a test recently, I noticed that the error message for `assert_not_in_results` is empty.  This PR makes it more like `assert_in_results`:

```
AssertionError: Result
  {
   "action": "unlock",
   "path": "/tmp/datalad_temp_tree_test_unlock_directory9n0g56ut/dir/b"
  }
unexpectedly found among
  [
   {
    "action": "unlock",
    "path": "/tmp/datalad_temp_tree_test_unlock_directory9n0g56ut/dir/b",
    "refds": "/tmp/datalad_temp_tree_test_unlock_directory9n0g56ut",
    "status": "ok",
    "type": "file"
   }
  ]
```
