### PR TITLE
ENH(UX): set "smoothing=0" for any progress bar with "total" in its label

### DIFF
--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -258,6 +258,10 @@ try:
                      unit_scale=True, total=total, file=out,
                      leave=leave,
                      ))
+            if label and 'total' in label.lower() and 'smoothing' not in self._pbar_params:
+                # ad-hoc: All tqdm totals will report total mean, and not some
+                # momentary speed
+                self._pbar_params['smoothing'] = 0
             self._pbar = None
 
         def _create(self, initial=0):


### PR DESCRIPTION
Original odd experience was reported in https://github.com/datalad/datalad/pull/5421#issuecomment-784316274 and it was
due to interplay of two factors:

1 - Total is updated only after git-annex verifies the checksum.

Total progress bar is updated only upon the final "ok" from git-annex
that we got the file.  That also involves validation of the checksum by
git-annex. So, even though file is finished downloading, and its progress bar
disappeared, Total would not be updated until that file is "ok"ed by annex.
That takes time, so perceptually to the user  (me) it was odd that Total shows
only some little total although a good number of files already "downloaded"

Good news: since Joey implemented "on the fly" checksumming (at least for
built in "special remotes") -- with e.g. `8.20210223+git1-g33af7d193-1~ndall+1` (*)
experience is much better since there is no delay from progressbar disappearing
and the final message arriving and thus Total gets updated.

2 - Default tqdm setting is not good for "rare" updates

See `smoothing` at https://github.com/tqdm/tqdm . Default `0.3` is a
compromise between providing user with smth between "momentary" and
"mean" speed.  When Total is updated only once a minute, that leads to
"current" speed being indeed quite low if most of the time there were no
progress at all ;)

Since "smoothing" is ATM quit specific to tqdm and we have quite a number of
subclasses from ProgressBarBase  I decided to just go for an ad-hoc solution
here and make any progress bar which has "total" in its label to use
smoothing=0, i.e. to report the mean.

Altogether with a new git-annex and this total smoothing of 0, Total looks
quite decent now ;)

Closes #5434

*: reminder - installation of a bleeding edge build of git-annex on debians is as difficult as `datalad-installer git-annex -m datalad/git-annex` now (you would need hub.oauthtoken though in your git config)