### PR TITLE
BF: need to eval debian_installer call, and now we have --sudo option to allow sudo ops

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -250,8 +250,8 @@ install:
   - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
-  - cmd: IF DEFINED INSTALL_GITANNEX python datalad_installer.py %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && python datalad_installer.py ${INSTALL_GITANNEX}"
+  - cmd: IF DEFINED INSTALL_GITANNEX python datalad_installer.py --sudo ok %INSTALL_GITANNEX%
+  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && python datalad_installer.py --sudo ok ${INSTALL_GITANNEX}"
   # TODO remove when datalad-installer can handle this
   - cmd: tools\ci\appveyor_install_git-annex.bat
 

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install git-annex
       run: |
         wget -O datalad_installer.py https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py
-        python3 datalad_installer.py -E new.env git-annex -m ${{ matrix.install_scenario }}
+        python3 datalad_installer.py --sudo ok -E new.env git-annex -m ${{ matrix.install_scenario }}
         . new.env
         echo "PATH=$PATH" >> "$GITHUB_ENV"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,7 @@ before_install:
   - if [[ "${_DL_TMPDIR:-}" =~ .*/nfsmount ]]; then echo "mkdir $_DL_TMPDIR"; mkdir -p "$_DL_TMPDIR" "${_DL_TMPDIR}_"; echo "/tmp/nfsmount_ localhost(rw)" | sudo bash -c 'cat - > /etc/exports'; sudo apt-get install -y nfs-kernel-server; sudo exportfs -a; sudo mount -t nfs localhost:/tmp/nfsmount_ /tmp/nfsmount; fi
   # Install git-annex
   - wget -O datalad_installer.py https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py
-  - python3 datalad_installer.py -E new.env ${_DL_ANNEX_INSTALL_SCENARIO}
+  - eval python3 datalad_installer.py --sudo ok -E new.env ${_DL_ANNEX_INSTALL_SCENARIO}
   - source new.env && cat new.env >> ~/.bashrc
   - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then source tools/ci/install-upstream-git.sh; fi
   - if [ ! -z "${_DL_MIN_GIT:-}" ]; then tools/ci/install-minimum-git.sh; fi


### PR DESCRIPTION
Without --sudo ok  it now will ask user to confirm sudo operations by default.
We do have 1 matrix run which installs a .deb so it would need sudo.

Without eval it is impossible to pass  -e  options like I needed in a
https://github.com/datalad/datalad/pull/5442  so I decided to just have it
by default here

OSX tune up might have not been needed -- did not check. but better be safe than sorry ;)

PS resubmitting now against `maint`