### PR TITLE
BF: log - accept non-str (but str()-able) instances

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -175,6 +175,11 @@ class ColorFormatter(logging.Formatter):
         # safety guard if None was provided
         if record.msg is None:
             record.msg = ""
+        else:
+            # to avoid our logger puking on receiving exception instances etc.
+            # .getMessage, used to interpolate it, would cast it to str anyways
+            # and thus not puke
+            record.msg = str(record.msg)
         if record.msg.startswith('| '):
             # If we already log smth which supposed to go without formatting, like
             # output for running a command, just return the message and be done

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -75,6 +75,14 @@ def test_logging_to_a_file(dst):
         regex += ' RSS/VMS: \S+/\S+( \S+)?\s*'
     regex += "(\s+\S+\s*)? " + msg
     assert_re_in(regex, line, match=True)
+
+    # Python's logger is ok (although not documented as supported) to accept
+    # non-string messages, which could be str()'ed.  We should not puke
+    msg2 = "Kenny is alive"
+    lgr.error(RuntimeError(msg2))
+    with open(dst) as f:
+        assert_in(msg2, f.read())
+
     # Close all handlers so windows is happy -- apparently not closed fast enough
     for handler in lgr.handlers:
         handler.close()


### PR DESCRIPTION
I have ran into a use case where external library logs an exception, but then
our logger starts puking.  Default formatter tollerates them just fine, so we
better do too.
