### PR TITLE
BF: Unlock used to pass resolved paths to status

### DIFF
--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -242,3 +242,11 @@ def test_unlock_cant_unlock(path):
             action="unlock",
             status=status,
             path=str(ds.pathobj / f))
+
+
+@with_tree(tree={'subdir': {'sub': {}}})
+def test_unlock_gh_5456(path):
+    path = Path(path)
+    unrelated_super = Dataset(path).create(annex=False, force=True)
+    ds = Dataset(path / 'subdir' / 'sub').create()
+    ds.unlock('.')


### PR DESCRIPTION
This destroys the logic within status that is based on "raw" input. In the particular case triggering this PR, `status` wouldn't realize the original call was passing `.` as the `path` argument.

Closes #5456