### PR TITLE
Overhaul ORA remote's HTTP access to RIA stores

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -630,13 +630,12 @@ class HTTPRemoteIO(object):
     # NOTE: For now read-only. Not sure yet whether an IO class is the right
     # approach.
 
-    def __init__(self, ria_url, dsid, buffer_size=DEFAULT_BUFFER_SIZE):
-        assert ria_url.startswith("ria+http")
-        self.base_url = ria_url[4:]
-        if self.base_url[-1] == '/':
-            self.base_url = self.base_url[:-1]
+    def __init__(self, url, buffer_size=DEFAULT_BUFFER_SIZE):
+        if not url.startswith("http"):
+            raise RIARemoteError("Expected HTTP URL, but got {}".format(url))
 
-        self.base_url += "/" + dsid[:3] + '/' + dsid[3:]
+        self.store_url = url.rstrip('/')
+
         # make sure default is used when None was passed, too.
         self.buffer_size = buffer_size if buffer_size else DEFAULT_BUFFER_SIZE
 
@@ -644,17 +643,32 @@ class HTTPRemoteIO(object):
         # Note, that we need the path with hash dirs, since we don't have access
         # to annexremote.dirhash from within IO classes
 
-        url = self.base_url + "/annex/objects/" + str(key_path)
-        response = requests.head(url, allow_redirects=True)
-        return response.status_code == 200
+        return self.exists(key_path)
 
     def get(self, key_path, filename, progress_cb):
         # Note, that we need the path with hash dirs, since we don't have access
         # to annexremote.dirhash from within IO classes
 
-        url = self.base_url + "/annex/objects/" + str(key_path)
+        url = self.store_url + str(key_path)
         from datalad.support.network import download_url
         download_url(url, filename, overwrite=True)
+
+    def exists(self, path):
+        # use same signature as in SSH and Local IO, although validity is
+        # limited in case of HTTP.
+        url = self.store_url + path.as_posix()
+        try:
+            response = requests.head(url, allow_redirects=True)
+        except Exception as e:
+            raise RIARemoteError(str(e))
+
+        return response.status_code == 200
+
+    def read_file(self, file_path):
+
+        from datalad.support.network import download_url
+        content = download_url(self.store_url + file_path.as_posix())
+        return content
 
 
 def handle_errors(func):
@@ -1041,12 +1055,7 @@ class RIARemote(SpecialRemote):
                 # fall back on the UUID for the annex remote
                 self.archive_id = self.annex.getuuid()
 
-        if not isinstance(self.io, HTTPRemoteIO):
-            self.get_store()
-
-        # else:
-        # TODO: consistency with SSH and FILE behavior? In those cases we make
-        #       sure the store exists from within initremote
+        self.get_store()
 
         self.annex.setconfig('archive-id', self.archive_id)
         # make sure, we store the potentially rewritten URL
@@ -1103,9 +1112,18 @@ class RIARemote(SpecialRemote):
             if self._local_io():
                 self._io = LocalIO()
             elif self.ria_store_url.startswith("ria+http"):
-                self._io = HTTPRemoteIO(self.ria_store_url,
-                                        self.archive_id,
-                                        self.buffer_size)
+                # TODO: That construction of "http(s)://host/" should probably
+                #       be moved, so that we get that when we determine
+                #       self.storage_host. In other words: Get the parsed URL
+                #       instead and let HTTPRemoteIO + SSHRemoteIO deal with it
+                #       uniformly. Also: Don't forget about a possible port.
+
+                url_parts = self.ria_store_url[4:].split('/')
+                # we expect parts: ("http(s):", "", host:port, path)
+                self._io = HTTPRemoteIO(
+                    url_parts[0] + "//" + url_parts[2],
+                    self.buffer_size
+                )
             elif self.storage_host:
                 self._io = SSHRemoteIO(self.storage_host, self.buffer_size)
                 from atexit import register
@@ -1178,8 +1196,7 @@ class RIARemote(SpecialRemote):
         self.uuid = self.annex.getuuid()
         self._verify_config(gitdir)
 
-        if not isinstance(self.io, HTTPRemoteIO):
-            self.get_store()
+        self.get_store()
 
         # report active special remote configuration/status
         self.info = {
@@ -1235,12 +1252,6 @@ class RIARemote(SpecialRemote):
     @handle_errors
     def transfer_retrieve(self, key, filename):
 
-        if isinstance(self.io, HTTPRemoteIO):
-            self.io.get(PurePosixPath(self.annex.dirhash(key)) / key / key,
-                        filename,
-                        self.annex.progress)
-            return
-
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         abs_key_path = dsobj_dir / key_path
         # sadly we have no idea what type of source gave checkpresent->true
@@ -1259,10 +1270,6 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def checkpresent(self, key):
-
-        if isinstance(self.io, HTTPRemoteIO):
-            return self.io.checkpresent(
-                PurePosixPath(self.annex.dirhash(key)) / key / key)
 
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         abs_key_path = dsobj_dir / key_path

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -48,6 +48,20 @@ def test_initremote(store_path, store_url, ds_path):
     url = "ria+" + store_url
     init_opts = common_init_opts + ['url={}'.format(url)]
 
+    # fail when there's no RIA store at the destination
+    assert_raises(CommandError, ds.repo.init_remote, 'ora-remote',
+                  options=init_opts)
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ora-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+
+    # now make it a store
+    io = LocalIO()
+    create_store(io, store_path, '1')
+    create_ds_in_store(io, store_path, ds.id, '2', '1')
+
     # fails on non-RIA URL
     assert_raises(CommandError, ds.repo.init_remote, 'ora-remote',
                   options=common_init_opts + ['url={}'


### PR DESCRIPTION
Restructure ORA remote's `HTTPRemoteIO` to remove special cases in ORA's code, where HTTP is treated somewhat differrent than SSH or local access.
For RIA stores, this leads to the `ria-layout-version` files being required to be served as well (which technically wasn't the case before). It also means that the request URLs now use paths for annexed objects according to the specified layout, whereas before we'd always send the same request and it was up to the server to consider its layout and deliver the right thing.

HTTP stores are validated on `annex initremote`/`annex enableremote` the same way they are when using `ssh:` or `file:` scheme URLs. Therefore, autoenabling will fail under the same conditions, making `clone`'s reconfiguration business consistent across access methods.

Closes #5451 