### PR TITLE
Don't use old annex.backends option

### DIFF
--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -177,7 +177,7 @@ def test_create(probe, path):
     assert_repo_status(ds.path, annex=True)
 
     # check default backend
-    eq_(ds.config.get("annex.backends"), 'MD5E')
+    eq_(ds.config.get("annex.backend"), 'MD5E')
     if not ar.is_managed_branch():
         eq_(ds.config.get("core.sharedrepository"), '2')
     # check description in `info`

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -177,7 +177,10 @@ def test_create(probe, path):
     assert_repo_status(ds.path, annex=True)
 
     # check default backend
-    eq_(ds.config.get("annex.backend"), 'MD5E')
+    (ds.pathobj / "f1").write_text("1")
+    ds.save()
+    eq_(ds.repo.get_file_backend(["f1"]), ['MD5E'])
+
     if not ar.is_managed_branch():
         eq_(ds.config.get("core.sharedrepository"), '2')
     # check description in `info`

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -323,9 +323,6 @@ class AnnexRepo(GitRepo, RepoInterface):
           If persistent, would add/commit to .gitattributes. If not -- would
           set within .git/config
         """
-        # TODO: 'annex.backends' actually is a space separated list.
-        # Figure out, whether we want to allow for a list here or what to
-        # do, if there is sth in that setting already
         if persistent:
             # could be set in .gitattributes or $GIT_DIR/info/attributes
             if 'annex.backend' in self.get_gitattributes('.')['.']:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2689,6 +2689,19 @@ class AnnexRepo(GitRepo, RepoInterface):
     @property
     def default_backends(self):
         self.config.reload()
+        # TODO: Deprecate and remove this property? It's used in the tests and
+        # datalad-crawler.
+        #
+        # git-annex used to try the list of backends in annex.backends in
+        # order. Now it takes annex.backend if set, falling back to the first
+        # value of annex.backends. See 4c1e3210f (annex.backend is the new name
+        # for what was annex.backends, 2017-05-09).
+        backend = self.get_gitattributes('.')['.'].get(
+            'annex.backend',
+            self.config.get("annex.backend", default=None))
+        if backend:
+            return [backend]
+
         backends = self.config.get("annex.backends", default=None)
         if backends:
             return backends.split()

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -331,7 +331,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 )
             else:
                 lgr.debug("Setting annex backend to %s (persistently)", backend)
-                self.config.set('annex.backends', backend, where='local')
+                self.config.set('annex.backend', backend, where='local')
                 git_attributes_file = '.gitattributes'
                 self.set_gitattributes(
                     [('*', {'annex.backend': backend})],
@@ -345,7 +345,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     )
         else:
             lgr.debug("Setting annex backend to %s (in .git/config)", backend)
-            self.config.set('annex.backends', backend, where='local')
+            self.config.set('annex.backend', backend, where='local')
 
     @classmethod
     def _cleanup(cls, path, batched):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -331,7 +331,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 )
             else:
                 lgr.debug("Setting annex backend to %s (persistently)", backend)
-                self.config.set('annex.backend', backend, where='local')
                 git_attributes_file = '.gitattributes'
                 self.set_gitattributes(
                     [('*', {'annex.backend': backend})],

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1124,17 +1124,16 @@ def test_annexrepo_fake_dates_disables_batched(sitepath, siteurl, dst):
 
 @with_tempfile(mkdir=True)
 def test_annex_backends(path):
-    repo = AnnexRepo(path)
-    eq_(repo.default_backends, None)
+    path = Path(path)
+    repo_default = AnnexRepo(path / "r_default")
+    eq_(repo_default.default_backends, None)
 
-    rmtree(path)
-
-    repo = AnnexRepo(path, backend='MD5E')
-    eq_(repo.default_backends, ['MD5E'])
+    repo_kw = AnnexRepo(path / "repo_kw", backend='MD5E')
+    eq_(repo_kw.default_backends, ['MD5E'])
 
     # persists
-    repo = AnnexRepo(path)
-    eq_(repo.default_backends, ['MD5E'])
+    repo_kw = AnnexRepo(path / "repo_kw")
+    eq_(repo_kw.default_backends, ['MD5E'])
 
 
 @skip_nomultiplex_ssh  # too much of "multiplex" testing

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1135,6 +1135,10 @@ def test_annex_backends(path):
     repo_kw = AnnexRepo(path / "repo_kw")
     eq_(repo_kw.default_backends, ['MD5E'])
 
+    repo_config = AnnexRepo(path / "repo_config")
+    repo_config.config.set("annex.backend", "MD5E", reload=True)
+    eq_(repo_config.default_backends, ["MD5E"])
+
     repo_compat = AnnexRepo(path / "repo_compat")
     repo_compat.config.set("annex.backends", "MD5E WORM", reload=True)
     eq_(repo_compat.default_backends, ["MD5E", "WORM"])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1135,6 +1135,10 @@ def test_annex_backends(path):
     repo_kw = AnnexRepo(path / "repo_kw")
     eq_(repo_kw.default_backends, ['MD5E'])
 
+    repo_compat = AnnexRepo(path / "repo_compat")
+    repo_compat.config.set("annex.backends", "MD5E WORM", reload=True)
+    eq_(repo_compat.default_backends, ["MD5E", "WORM"])
+
 
 @skip_nomultiplex_ssh  # too much of "multiplex" testing
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,8 +10,6 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
-
 import logging
 from functools import partial
 from glob import glob


### PR DESCRIPTION
DataLad still uses the annex.backend**s** option, but since git-annex 6.20170510, annex.backend is the preferred name.  annex.backends was kept for compatibility and offers no additional functionality.  This series switches to using annex.backend.  It also changes `set_default_backend(..., persistent=True)` to no longer set a shadowed backend value in `.git/config`.
