### PR TITLE
BF: use push_io to check ability to write

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1073,7 +1073,7 @@ class RIARemote(SpecialRemote):
             raise RIARemoteError("Remote is treated as read-only. "
                                  "Set 'ora-remote.<name>.force-write=true' to "
                                  "overrule this.")
-        if isinstance(self.io, HTTPRemoteIO):
+        if isinstance(self.push_io, HTTPRemoteIO):
             raise RIARemoteError("Write access via HTTP not implemented")
 
     @property


### PR DESCRIPTION
Still using `io` instead of `push_io` when checking for whether or not
we can write was an oversight when introducing push-url to ORA remote.

Closes #5471

