### PR TITLE
update: Add minimal fetching --follow=parentds mode

### DIFF
--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-from os.path import lexists, join as opj
+from os.path import lexists
 import itertools
 
 from datalad.dochelpers import exc_str


### PR DESCRIPTION
update(..., recursive=True) calls git-fetch in every subdataset.  When
using follow=parentds to follow the commit registered in the parent
dataset, this can lead to many unneeded fetches, especially when only
a few subdatasets need to be updated.

Add another --follow value, "parentds-lazy", that is like "parent-ds"
but fetches only if the commit isn't already present and avoids
processing the dataset entirely if the registered commit is already
checked out.  Keep "parentds" around because, as mentioned in gh-4452,
the caller may still want to fetch from the sibling to, e.g., bring in
updates to the git-annex branch.

Note that in cases where the registered commit is already checked out
in a subdataset and the subdataset is unmodified, we could
conceptually skip descending into deeper subdatasets.  However, that
would require either extending subdatasets() or reworking/exposing
internal subdatasets() logic for update() to use.

Closes #4452.
Closes #4642.

---

```
$ time datalad update --recursive --follow=parentds
[...]
action summary:
  update (ok: 16)
datalad update --recursive --follow=parentds  1.22s user 0.75s system 57% cpu 3.428 total

$ time datalad update --recursive --follow=parentds-lazy
[...]
action summary:
  update (notneeded: 15, ok: 1)
datalad update --recursive --follow=parentds-lazy  0.66s user 0.15s system 93% cpu 0.859 total
```
