### PR TITLE
Make `--output-format default` accessible

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -121,15 +121,17 @@ def setup_parser(
         variables in the process environment.""")
     parser.add_argument(
         '-f', '--output-format', dest='common_output_format',
-        default='default',
+        default='tailored',
         type=ensure_unicode,
         metavar="{default,json,json_pp,tailored,'<template>'}",
-        help="""select format for returned command results. 'default' give one line
+        help="""select format for returned command results. 'tailored'
+        enables a command-specific rendering style that is typically
+        tailored to human consumption, if there is one for a specific
+        command, or otherwise falls back on the the 'default' output
+        format (this is the standard behavior); 'default' give one line
         per result reporting action, status, path and an optional message;
         'json' renders a JSON object with all properties for each result (one per
-        line); 'json_pp' pretty-prints JSON spanning multiple lines; 'tailored'
-        enables a command-specific rendering style that is typically
-        tailored to human consumption (no result output otherwise),
+        line); 'json_pp' pretty-prints JSON spanning multiple lines;
         '<template>' reports any value(s) of any result properties in any format
         indicated by the template (e.g. '{path}'; compare with JSON
         output for all key-value choices). The template syntax follows the Python

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -765,7 +765,7 @@ class Interface(object):
             # allow commands to override the default, unless something other than
             # default is requested
             kwargs['result_renderer'] = \
-                args.common_output_format if args.common_output_format != 'default' \
+                args.common_output_format if args.common_output_format != 'tailored' \
                 else getattr(cls, 'result_renderer', args.common_output_format)
             if '{' in args.common_output_format:
                 # stupid hack, could and should become more powerful


### PR DESCRIPTION
Running something like `datalad -f default status` does not actually
switch to the standard result renderer, because we use the "tailored"
one by default. As pointed out in #2481 this not only conflates two
different meanings of *default*, but also doesn't really make sense.

From my POV the implementation really wants `"tailored"` to be the default
mode, and not the "default" renderer to be enabled by default.

Instead of getting creative with new synonyms for these terms, I went
for the minimal change that achieves the desired result (make it
possible to have a command with a custom result renderer run with the
standard one instead).

I switch the default value of `common_output_format` to `"tailored"`,
which already is the effective default behavior. This makes a
specification of an alternative `"default"` value actually switch the
renderer to the default one.

One could argue that `"default"` would be better named `"standard"`
(renderer), but I will not walk on this battle field ;-)

Closes #2481