### PR TITLE
BF: interface: Restore result output fallback to "default"

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -766,7 +766,7 @@ class Interface(object):
             # default is requested
             kwargs['result_renderer'] = \
                 args.common_output_format if args.common_output_format != 'tailored' \
-                else getattr(cls, 'result_renderer', args.common_output_format)
+                else getattr(cls, 'result_renderer', 'default')
             if '{' in args.common_output_format:
                 # stupid hack, could and should become more powerful
                 kwargs['result_renderer'] = DefaultOutputRenderer(args.common_output_format)


### PR DESCRIPTION
When 7541eacd03 (Make `--output-format default` accessible,
2021-03-09) switched to using "tailored" as the default for
--output-format, commands without a custom renderer were
unintentionally silenced:

    $ datalad save foo
    # nothing
  
    vs
  
    $ datalad save foo
    add(ok): foo (file)
    save(ok): . (dataset)
    action summary:
      add (ok: 1)
      save (ok: 1)

Restore that output by falling back to "default" when the renderer
isn't specified via --output-format or the command class attribute.

Fixes #5476.