### PR TITLE
Tst nometalad

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -13,7 +13,6 @@ jobs:
         extension: [
             datalad-neuroimaging,
             datalad-container,
-            datalad-metalad,
             datalad-crawler,
         ]
     steps:


### PR DESCRIPTION
This extension is undergoing a substantial change. There is no point
in testing it. Given that the list of tested extension here is
also an abitrary subset of existing extension, there is also little
point in changing the workflow to use the latest extension release.

Targeting `maint`, but needs pickup in `master` too.