### PR TITLE
Reduce number of commits when cloning into a dataset

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -308,6 +308,10 @@ class Clone(Interface):
             # -> make submodule
             for r in ds.save(
                     path,
+                    # Note, that here we know we don't save anything but a new
+                    # subdataset. Hence, don't go with default commit message,
+                    # but be more specific.
+                    message="[DATALAD] Added subdataset",
                     return_type='generator',
                     result_filter=None,
                     result_xfm=None,

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -306,7 +306,7 @@ class Clone(Interface):
         if ds is not None:
             # we created a dataset in another dataset
             # -> make submodule
-            save_results = []
+            actually_saved_subds = False
             for r in ds.save(
                     path,
                     # Note, that here we know we don't save anything but a new
@@ -317,37 +317,38 @@ class Clone(Interface):
                     result_filter=None,
                     result_xfm=None,
                     on_failure='ignore'):
-                save_results.append(r)
+                actually_saved_subds = actually_saved_subds or (
+                        r['action'] == 'save' and
+                        r['type'] == 'dataset' and
+                        r['refds'] == ds.path and
+                        r['status'] == 'ok')
                 yield r
 
             # Modify .gitmodules to contain originally given url. This is
             # particularly relevant for postclone routines on a later `get`
             # for that subdataset. See gh-5256.
-            if any(r['action'] == 'save' and r['type'] == 'dataset' and \
-                   r['refds'] == ds.path for r in save_results):
-                if r['status'] == 'ok':
-                    # New subdataset actually saved. Amend the modification
-                    # of .gitmodules. Note, that we didn't allow to deviate
-                    # from git default behavior WRT a submodule's name vs
-                    # its path when we made this a new subdataset.
-                    subds_name = path.relative_to(ds.pathobj)
-                    ds.repo.call_git(
-                        ['config',
-                         '--file',
-                         '.gitmodules',
-                         '--replace-all',
-                         'submodule.{}.{}'.format(subds_name,
-                                                  "datalad-url"),
-                         source]
-                    )
-                    yield from ds.save('.gitmodules',
-                                       amend=True, to_git=True)
-                else:
-                    # We didn't really commit. Yield and call `subdatasets`
-                    # in that case.
-                    yield r
-                    ds.subdatasets(path,
-                                   set_property=[("datalad-url", source)])
+            if actually_saved_subds:
+                # New subdataset actually saved. Amend the modification
+                # of .gitmodules. Note, that we didn't allow to deviate
+                # from git default behavior WRT a submodule's name vs
+                # its path when we made this a new subdataset.
+                subds_name = path.relative_to(ds.pathobj)
+                ds.repo.call_git(
+                    ['config',
+                     '--file',
+                     '.gitmodules',
+                     '--replace-all',
+                     'submodule.{}.{}'.format(subds_name,
+                                              "datalad-url"),
+                     source]
+                )
+                yield from ds.save('.gitmodules',
+                                   amend=True, to_git=True)
+            else:
+                # We didn't really commit. Just call `subdatasets`
+                # in that case to have the modification included in the
+                # post-clone state (whatever that may be).
+                ds.subdatasets(path, set_property=[("datalad-url", source)])
 
 
 def clone_dataset(

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -306,6 +306,7 @@ class Clone(Interface):
         if ds is not None:
             # we created a dataset in another dataset
             # -> make submodule
+            save_results = []
             for r in ds.save(
                     path,
                     # Note, that here we know we don't save anything but a new
@@ -316,40 +317,37 @@ class Clone(Interface):
                     result_filter=None,
                     result_xfm=None,
                     on_failure='ignore'):
-
-                # Modify .gitmodules to contain originally given url. This is
-                # particularly relevant for postclone routines on a later `get`
-                # for that subdataset. See gh-5256.
-                if r['action'] == 'save' and r['type'] == 'dataset':
-                    if r['status'] == 'ok':
-                        # New subdataset actually saved. Amend the modification
-                        # of .gitmodules. Note, that we didn't allow to deviate
-                        # from git default behavior WRT a submodule's name vs
-                        # its path when we made this a new subdataset.
-                        subds_name = path.relative_to(ds.pathobj)
-                        ds.repo.call_git(
-                            ['config',
-                             '--file',
-                             '.gitmodules',
-                             '--replace-all',
-                             'submodule.{}.{}'.format(subds_name,
-                                                      "datalad-url"),
-                             source]
-                        )
-                        yield from ds.save('.gitmodules',
-                                           amend=True, to_git=True)
-                        # We don't need to pollute outside world with two save
-                        # results, when the "real" result will be one commit.
-                        continue
-                    else:
-                        # We didn't really commit. Yield and call `subdatasets`
-                        # in that case.
-                        yield r
-                        ds.subdatasets(path,
-                                       set_property=[("datalad-url", source)])
-                        continue
-
+                save_results.append(r)
                 yield r
+
+            # Modify .gitmodules to contain originally given url. This is
+            # particularly relevant for postclone routines on a later `get`
+            # for that subdataset. See gh-5256.
+            if any(r['action'] == 'save' and r['type'] == 'dataset' and \
+                   r['refds'] == ds.path for r in save_results):
+                if r['status'] == 'ok':
+                    # New subdataset actually saved. Amend the modification
+                    # of .gitmodules. Note, that we didn't allow to deviate
+                    # from git default behavior WRT a submodule's name vs
+                    # its path when we made this a new subdataset.
+                    subds_name = path.relative_to(ds.pathobj)
+                    ds.repo.call_git(
+                        ['config',
+                         '--file',
+                         '.gitmodules',
+                         '--replace-all',
+                         'submodule.{}.{}'.format(subds_name,
+                                                  "datalad-url"),
+                         source]
+                    )
+                    yield from ds.save('.gitmodules',
+                                       amend=True, to_git=True)
+                else:
+                    # We didn't really commit. Yield and call `subdatasets`
+                    # in that case.
+                    yield r
+                    ds.subdatasets(path,
+                                   set_property=[("datalad-url", source)])
 
 
 def clone_dataset(

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -275,7 +275,9 @@ def test_clone_into_dataset(source_path, top_path):
     source = Dataset(source_path).create()
     ds = create(top_path)
     assert_repo_status(ds.path)
-    hexsha_before = ds.repo.get_hexsha()
+    # Note, we test against the produced history in DEFAULT_BRANCH, not what it
+    # turns into in an adjusted branch!
+    hexsha_before = ds.repo.get_hexsha(DEFAULT_BRANCH)
     subds = ds.clone(source, "sub",
                      result_xfm='datasets', return_type='item-or-list')
     ok_((subds.pathobj / '.git').is_dir())

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -275,7 +275,7 @@ def test_clone_into_dataset(source_path, top_path):
     source = Dataset(source_path).create()
     ds = create(top_path)
     assert_repo_status(ds.path)
-
+    hexsha_before = ds.repo.get_hexsha()
     subds = ds.clone(source, "sub",
                      result_xfm='datasets', return_type='item-or-list')
     ok_((subds.pathobj / '.git').is_dir())
@@ -289,6 +289,13 @@ def test_clone_into_dataset(source_path, top_path):
     sds = ds.subdatasets("sub")
     assert_result_count(sds, 1, action='subdataset')
     eq_(sds[0]['gitmodule_datalad-url'], source.path)
+    # Clone produced one commit including the addition to .gitmodule:
+    commits = list(ds.repo.get_branch_commits_(
+        branch=DEFAULT_BRANCH,
+        stop=hexsha_before
+    ))
+    assert_not_in(hexsha_before, commits)
+    eq_(len(commits), 1)
 
     # but we could also save while installing and there should be no side-effect
     # of saving any other changes if we state to not auto-save changes


### PR DESCRIPTION
When a dataset is cloned into another one as a subdataset, we record the originally given URL in `.gitmodules`. This used to be a dedicated commit in addition to the one adding the new dataset as a subdataset. The former is now amended to the latter.