### PR TITLE
Test against released metalad only

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -37,9 +37,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    # As metalad undergoes heavy rewriting, test released version in order to
+    # discover breakage done by datalad. We need to know when another extension
+    # cannot depend on both - current datalad and released metalad.
+    - name: Install datalad-metalad extension
+      run: |
+        pip install datalad-metalad
+      if: matrix.extension == 'datalad-metalad'
     - name: Install ${{ matrix.extension }} extension
       run: |
         pip install https://github.com/datalad/${{ matrix.extension }}/archive/master.zip
+      if: matrix.extension != 'datalad-metalad'
     - name: Install additional dependencies
       run: |
         pip install mock


### PR DESCRIPTION
Alternative proposal for #5479.

datalad-hirni depends on metalad. If we break released metalad in datalad core, I still need to know, as hirni then cannot use both - released metalad and newest datalad.