### PR TITLE
TST: Add datalad-hirni extension

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -15,6 +15,7 @@ jobs:
             datalad-container,
             datalad-metalad,
             datalad-crawler,
+            datalad-hirni,
         ]
     steps:
     - name: Set up system
@@ -40,13 +41,18 @@ jobs:
     - name: Install ${{ matrix.extension }} extension
       run: |
         pip install https://github.com/datalad/${{ matrix.extension }}/archive/master.zip
+      if: matrix.extension != 'datalad-hirni'
+    - name: Install ${{ matrix.extension }} extension
+      run: |
+        pip install https://github.com/psychoinformatics-de/${{ matrix.extension }}/archive/master.zip
+      if: matrix.extension == 'datalad-hirni'
     - name: Install additional dependencies
       run: |
         pip install mock
       if: matrix.extension == 'datalad-crawler'
     - name: Install Singularity
       run: sudo eatmydata apt-get install singularity-container
-      if: matrix.extension == 'datalad-container'
+      if: matrix.extension == 'datalad-container' || matrix.extension == 'datalad-hirni'
     - name: WTF!?
       run: |
         datalad wtf


### PR DESCRIPTION
As suggested in PR #5479, test against datalad-hirni, which became more vital to do with metalad being gone from the list for now.