### PR TITLE
Leave a log trace which env vars are queried for credentials

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -48,7 +48,7 @@ class Keyring(object):
     def get(self, name, field):
         # consult environment, might be provided there and should take precedence
         env_var = ('DATALAD_%s_%s' % (name, field)).replace('-', '_')
-        lgr.log(5, 'Credentials lookup attempt %s', env_var)
+        lgr.log(5, 'Credentials lookup attempt via env var %s', env_var)
         if env_var in os.environ:
             return os.environ[env_var]
         return self._keyring.get_password(self._get_service_name(name), field)

--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -10,6 +10,8 @@
 """
 
 import os
+import logging
+lgr = logging.getLogger('datalad.support.keyring')
 
 
 class Keyring(object):
@@ -46,6 +48,7 @@ class Keyring(object):
     def get(self, name, field):
         # consult environment, might be provided there and should take precedence
         env_var = ('DATALAD_%s_%s' % (name, field)).replace('-', '_')
+        lgr.log(5, 'Credentials lookup attempt %s', env_var)
         if env_var in os.environ:
             return os.environ[env_var]
         return self._keyring.get_password(self._get_service_name(name), field)


### PR DESCRIPTION
Before one would need to spend 10-15min to discover how exactly this is
working. Now `--log-level 5` will give a hint:

```
[Level 5] Credentials lookup attempt DATALAD_webdav.4shared.com_password
[Level 5] Credentials lookup attempt DATALAD_webdav.4shared.com_user
```

Should not hurt anyone. Isn't beautiful either, but having to override
credentials is a relatively frequent task in development, but also in
environments without credentials stores (HPC...). Knowing the names of
the variables is key here.
