### PR TITLE
run: Don't remove leading empty directory when removing outputs

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -395,6 +395,9 @@ def _unlock_or_remove(dset_path, paths):
 
     if existing:
         remove = Remove()
+        # Note: If Unlock() is given a directory (including a subdataset) as a
+        # path, files without content present won't be reported, so those cases
+        # aren't being covered by the "remove if not present" logic below.
         for res in Unlock()(dataset=dset_path, path=existing,
                             on_failure="ignore"):
             if res["status"] == "impossible":

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -412,10 +412,10 @@ def _unlock_or_remove(dset_path, paths):
             try:
                 os.unlink(res["path"])
             except OSError as exc:
-                yield dict(res, action="run-remove", status="error",
+                yield dict(res, action="run.remove", status="error",
                            message=("Removing file failed: %s", exc_str(exc)))
             else:
-                yield dict(res, action="run-remove", status="ok",
+                yield dict(res, action="run.remove", status="ok",
                            message="Removed file")
 
 

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -16,6 +16,7 @@ import json
 import warnings
 
 from argparse import REMAINDER
+import os
 import os.path as op
 from os.path import join as opj
 from os.path import normpath
@@ -25,7 +26,7 @@ from tempfile import mkdtemp
 from datalad.core.local.save import Save
 from datalad.distribution.get import Get
 from datalad.distribution.install import Install
-from datalad.distribution.remove import Remove
+from datalad.dochelpers import exc_str
 from datalad.interface.unlock import Unlock
 
 from datalad.interface.base import Interface
@@ -394,20 +395,28 @@ def _unlock_or_remove(dset_path, paths):
             lgr.debug("Filtered out non-existing path: %s", path)
 
     if existing:
-        remove = Remove()
+        notpresent_results = []
         # Note: If Unlock() is given a directory (including a subdataset) as a
         # path, files without content present won't be reported, so those cases
         # aren't being covered by the "remove if not present" logic below.
         for res in Unlock()(dataset=dset_path, path=existing,
                             on_failure="ignore"):
-            if res["status"] == "impossible":
-                if "cannot unlock" in res["message"]:
-                    for rem_res in remove(dataset=dset_path,
-                                          path=res["path"],
-                                          check=False, save=False):
-                        yield rem_res
-                    continue
+            if res["status"] == "impossible" and res["type"] == "file" \
+               and "cannot unlock" in res["message"]:
+                notpresent_results.append(res)
+                continue
             yield res
+        # Avoid `datalad remove` because it calls git-rm underneath, which will
+        # remove leading directories if no other files remain. See gh-5486.
+        for res in notpresent_results:
+            try:
+                os.unlink(res["path"])
+            except OSError as exc:
+                yield dict(res, action="run-remove", status="error",
+                           message=("Removing file failed: %s", exc_str(exc)))
+            else:
+                yield dict(res, action="run-remove", status="ok",
+                           message="Removed file")
 
 
 def normalize_command(command):

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -548,3 +548,33 @@ def test_run_path_semantics(path):
         run("cd .> five", dataset=ds0)
     ok_exists(op.join(ds0.path, "five"))
     assert_repo_status(ds0.path)
+
+
+@with_tempfile(mkdir=True)
+def test_run_remove_keeps_leading_directory(path):
+    ds = Dataset(op.join(path, "ds")).create()
+    repo = ds.repo
+
+    (ds.pathobj / "d").mkdir()
+    output = (ds.pathobj / "d" / "foo")
+    output.write_text("foo")
+    ds.save()
+
+    output_rel = str(output.relative_to(ds.pathobj))
+    repo.drop(output_rel, options=["--force"])
+
+    assert_in_results(
+        ds.run("cd .> {}".format(output_rel), outputs=[output_rel],
+               result_renderer=None),
+        action="run-remove", status="ok")
+
+    assert_repo_status(ds.path)
+
+    # Remove still gets saved() if command doesn't generate the output (just as
+    # it would if git-rm were used instead of unlink).
+    repo.drop(output_rel, options=["--force"])
+    assert_in_results(
+        ds.run("cd .> something-else", outputs=[output_rel],
+               result_renderer=None),
+        action="run-remove", status="ok")
+    assert_repo_status(ds.path)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -566,7 +566,7 @@ def test_run_remove_keeps_leading_directory(path):
     assert_in_results(
         ds.run("cd .> {}".format(output_rel), outputs=[output_rel],
                result_renderer=None),
-        action="run-remove", status="ok")
+        action="run.remove", status="ok")
 
     assert_repo_status(ds.path)
 
@@ -576,5 +576,5 @@ def test_run_remove_keeps_leading_directory(path):
     assert_in_results(
         ds.run("cd .> something-else", outputs=[output_rel],
                result_renderer=None),
-        action="run-remove", status="ok")
+        action="run.remove", status="ok")
     assert_repo_status(ds.path)


### PR DESCRIPTION
If outputs aren't present (and thus can't be unlocked), run() removes
them so that the command doesn't need to provide special handling of
annex links.  This is done with `datalad remove`, which calls git-rm
underneath. `git rm path/to/file` deletes the leading directories when
they are otherwise empty.

That behavior can be surprising for commands that don't ensure
outputs' directories exist.  Instead unlink the file directly so
leading empty directories stick around.  Unlike git-rm, this doesn't
remove the file from the index, but the end result is the same after
the save (even if the command ends up not recreating the output).

Note, however, that ideally commands should be written to not assume
that the output directory exists in HEAD's tree.  This makes them
better suited to be used outside the context of the current tree
(e.g., `rerun --onto`), where an output's directory of course may be
pruned because the checked out tree doesn't include any tracked files
under an output's directory.

Closes #5486.

---

Opened against master due to the result record changes.
