### PR TITLE
DOC: Use SPDX License Identifiers/Expression for License metadata

### DIFF
--- a/datalad/metadata/extractors/tests/test_rfc822.py
+++ b/datalad/metadata/extractors/tests/test_rfc822.py
@@ -24,7 +24,7 @@ Description: Basic summary
  A text with arbitrary length and content that can span multiple
  .
  paragraphs (this is a new one)
-License: CC0
+License: CC0-1.0
  The person who associated a work with this deed has dedicated the work to the
  public domain by waiving all of his or her rights to the work worldwide under
  copyright law, including all related and neighboring rights, to the extent
@@ -57,7 +57,7 @@ def test_get_metadata(path):
   "homepage": "http://studyforrest.org",
   "issuetracker": "https://github.com/psychoinformatics-de/studyforrest-data-phase2/issues",
   "license": [
-    "CC0",
+    "CC0-1.0",
     "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.\\nYou can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission."
   ],
   "maintainer": [

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -215,7 +215,7 @@ Here is an example:
    A text with arbitrary length and content that can span multiple
    .
    paragraphs (this is a new one)
-  License: CC0
+  License: CC0-1.0
    The person who associated a work with this deed has dedicated the work to the
    public domain by waiving all of his or her rights to the work worldwide under
    copyright law, including all related and neighboring rights, to the extent
@@ -255,9 +255,11 @@ The following fields are supported:
   reports can be submitted.
 ``License``:
   A description of the license or terms of use for the dataset. The first
-  lines should contain a list of license labels (e.g. CC0, PPDL) for standard
-  licenses, if possible. Full license texts or term descriptions can be
-  included.
+  lines should be the SPDX License Identifier from the `SPDX License List <https://spdx.org/licenses/>`_
+  (e.g. "CC0-1.0" or "PPDL-1.0"). More complex licensing situation can be expressed
+  using
+  `SPDX License Expressions <https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/>`_.
+  Full license texts or term descriptions can be included.
 ``Maintainer``:
   Can be used in addition and analog to ``Author``, when authors (creators of
   the data) need to be distinguished from maintainers of the dataset.


### PR DESCRIPTION
This provides an unambiguous and machine readable way to reference licenses.

I am not sure if this way of specificaing the license is the right way (see https://github.com/datalad/datalad/issues/5496), but switching to SPDX is a quick win.