### PR TITLE
WitlessRunner: Log current working directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -551,12 +551,6 @@ Refer datalad/config.py for information on how to add these environment variable
 - *DATALAD_DATASETS_TOPURL*:
   Used to point to an alternative location for `///` dataset. If running
   tests preferred to be set to http://datasets-tests.datalad.org
-- *DATALAD_LOG_CWD*:
-  Whether to log cwd where command to be executed
-- *DATALAD_LOG_ENV*:
-  If contains a digit (e.g. 1), would log entire environment passed into
-  the Runner.run's popen call.  Otherwise could be a comma separated list
-  of environment variables to log
 - *DATALAD_LOG_LEVEL*:
   Used for control the verbosity of logs printed to stdout while running datalad commands/debugging
 - *DATALAD_LOG_NAME*:
@@ -565,8 +559,6 @@ Refer datalad/config.py for information on how to add these environment variable
   Used to control either both stdout and stderr of external commands execution are logged in detail (at DEBUG level)
 - *DATALAD_LOG_PID*
   To instruct datalad to log PID of the process
-- *DATALAD_LOG_STDIN*:
-  Whether to log stdin for the command
 - *DATALAD_LOG_TARGET*
   Where to log: `stderr` (default), `stdout`, or another filename
 - *DATALAD_LOG_TIMESTAMP*:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -81,8 +81,6 @@ async def run_async_cmd(loop, cmd, protocol, stdin, protocol_kwargs=None,
       The nature of the return value is determined by the given
       protocol class.
     """
-    lgr.debug('Async run %s', cmd)
-
     if protocol_kwargs is None:
         protocol_kwargs = {}
     cmd_done = asyncio.Future(loop=loop)
@@ -376,6 +374,7 @@ class WitlessRunner(object):
             event_loop = self._get_new_event_loop()
             new_loop = True
         try:
+            lgr.debug('Async run:\n cwd=%s\n cmd=%s', cwd, cmd)
             # include the subprocess manager in the asyncio event loop
             results = event_loop.run_until_complete(
                 run_async_cmd(

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -625,8 +625,8 @@ def test_cfg_originorigin(path):
     with chpwd(path), swallow_logs(new_level=logging.DEBUG) as cml:
         clone_lev3 = clone('clone_lev2', 'clone_lev3')
         # we called git-annex-init; see gh-4367:
-        cml.assert_logged(msg=r"[^[]*Async run \[('git',.*'annex'|'git-annex'), "
-                              r"'init'",
+        cml.assert_logged(msg=r"[^[]*Async run:\n cwd=.*\n"
+                              r" cmd=\[('git',.*'annex'|'git-annex'), 'init'",
                           match=False,
                           level='DEBUG')
     assert_result_count(


### PR DESCRIPTION
This PR updates the runner's "Async run ..." debug-level logging messages to include current working directory (taking care of gh-5487, though not through the requested `DATALAD_LOG_CWD`) and removes `DATALAD_LOG` options that were only relevant for the old runner.