### PR TITLE
config: Allow options to be set via DATALAD_CONFIG_OVERRIDES

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -125,11 +125,11 @@ def _update_from_env(store):
     overrides = {}
     dct = {}
     for k in os.environ:
-        if k == "DATALAD_CONFIG_OVERRIDES":
+        if k == "DATALAD_CONFIG_OVERRIDES_JSON":
             try:
                 overrides = json.loads(os.environ[k])
             except json.decoder.JSONDecodeError as exc:
-                lgr.warning("Failed to load DATALAD_CONFIG_OVERRIDES: %s",
+                lgr.warning("Failed to load DATALAD_CONFIG_OVERRIDES_JSON: %s",
                             exc)
         elif k.startswith('DATALAD_'):
             dct[k.replace('__', '-').replace('_', '.').lower()] = os.environ[k]

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -409,9 +409,9 @@ def test_name_with_underscore(path):
         with assert_raises(ValueError):
             ds.run_procedure(spec=["print_args"])
 
-    # But it can be set via DATALAD_CONFIG_OVERRIDES.
+    # But it can be set via DATALAD_CONFIG_OVERRIDES_JSON.
     with patch.dict("os.environ",
-                    {"DATALAD_CONFIG_OVERRIDES":
+                    {"DATALAD_CONFIG_OVERRIDES_JSON":
                      '{"datalad.procedures.print_args.call-format": '
                      '"python {script}"}'}):
         ds.config.reload()

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import os.path as op
 import sys
+from unittest.mock import patch
 
 from datalad.cmd import (
     WitlessRunner,
@@ -391,3 +392,27 @@ def test_text2git(path):
     # and trivial binaries - annexed
     for f in BINARY_FILES:
         assert_true(ds.repo.is_under_annex(f))
+
+
+@with_tree(tree={".datalad": {"procedures": {"print_args": """
+import sys
+print(sys.argv)
+"""}}})
+def test_name_with_underscore(path):
+    ds = Dataset(path).create(force=True)
+
+    # Procedure name with underscore can't be reached directly with a DATALAD_
+    # environment variable.
+    with patch.dict("os.environ",
+                    {"DATALAD_PROCEDURES_PRINT_ARGS_CALL__FORMAT":
+                     'python {script}'}):
+        with assert_raises(ValueError):
+            ds.run_procedure(spec=["print_args"])
+
+    # But it can be set via DATALAD_CONFIG_OVERRIDES.
+    with patch.dict("os.environ",
+                    {"DATALAD_CONFIG_OVERRIDES":
+                     '{"datalad.procedures.print_args.call-format": '
+                     '"python {script}"}'}):
+        ds.config.reload()
+        ds.run_procedure(spec=["print_args"])

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -373,29 +373,29 @@ def test_from_env_overrides():
         assert_not_in("datalad.FoO", cfg)
         assert_equal(cfg["datalad.foo"], "val")
 
-    # But they can be handled via DATALAD_CONFIG_OVERRIDES.
+    # But they can be handled via DATALAD_CONFIG_OVERRIDES_JSON.
     with patch.dict("os.environ",
-                    {"DATALAD_CONFIG_OVERRIDES": '{"datalad.FoO": "val"}'}):
+                    {"DATALAD_CONFIG_OVERRIDES_JSON": '{"datalad.FoO": "val"}'}):
         cfg.reload()
         assert_equal(cfg["datalad.FoO"], "val")
 
-    # DATALAD_CONFIG_OVERRIDES isn't limited to datalad variables.
+    # DATALAD_CONFIG_OVERRIDES_JSON isn't limited to datalad variables.
     with patch.dict("os.environ",
-                    {"DATALAD_CONFIG_OVERRIDES": '{"a.b.c": "val"}'}):
+                    {"DATALAD_CONFIG_OVERRIDES_JSON": '{"a.b.c": "val"}'}):
         cfg.reload()
         assert_equal(cfg["a.b.c"], "val")
 
     # Explicitly provided DATALAD_ variables take precedence over those in
-    # DATALAD_CONFIG_OVERRIDES.
+    # DATALAD_CONFIG_OVERRIDES_JSON.
     with patch.dict("os.environ",
-                    {"DATALAD_CONFIG_OVERRIDES": '{"datalad.foo": "val"}',
+                    {"DATALAD_CONFIG_OVERRIDES_JSON": '{"datalad.foo": "val"}',
                      "DATALAD_FOO": "val-direct"}):
         cfg.reload()
         assert_equal(cfg["datalad.foo"], "val-direct")
 
     # JSON decode errors don't lead to crash.
     with patch.dict("os.environ",
-                    {"DATALAD_CONFIG_OVERRIDES": '{'}):
+                    {"DATALAD_CONFIG_OVERRIDES_JSON": '{'}):
         with swallow_logs(logging.WARNING) as cml:
             cfg.reload()
         assert_in("Failed to load DATALAD_CONFIG_OVERRIDE", cml.out)
@@ -640,4 +640,3 @@ def test_external_modification(path):
     runner.run(['git', 'config', '--local', '--replace-all', key, '11'])
     config.reload()
     assert_equal(config[key], '11')
-

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -361,6 +361,46 @@ def test_from_env():
         assert_equal(cfg['datalad.crazy.override'], 'fromenv')
 
 
+def test_from_env_overrides():
+    cfg = ConfigManager()
+    assert_not_in("datalad.FoO", cfg)
+
+    # Some details, like case and underscores, cannot be handled by the direct
+    # environment variable mapping.
+    with patch.dict("os.environ",
+                    {"DATALAD_FOO": "val"}):
+        cfg.reload()
+        assert_not_in("datalad.FoO", cfg)
+        assert_equal(cfg["datalad.foo"], "val")
+
+    # But they can be handled via DATALAD_CONFIG_OVERRIDES.
+    with patch.dict("os.environ",
+                    {"DATALAD_CONFIG_OVERRIDES": '{"datalad.FoO": "val"}'}):
+        cfg.reload()
+        assert_equal(cfg["datalad.FoO"], "val")
+
+    # DATALAD_CONFIG_OVERRIDES isn't limited to datalad variables.
+    with patch.dict("os.environ",
+                    {"DATALAD_CONFIG_OVERRIDES": '{"a.b.c": "val"}'}):
+        cfg.reload()
+        assert_equal(cfg["a.b.c"], "val")
+
+    # Explicitly provided DATALAD_ variables take precedence over those in
+    # DATALAD_CONFIG_OVERRIDES.
+    with patch.dict("os.environ",
+                    {"DATALAD_CONFIG_OVERRIDES": '{"datalad.foo": "val"}',
+                     "DATALAD_FOO": "val-direct"}):
+        cfg.reload()
+        assert_equal(cfg["datalad.foo"], "val-direct")
+
+    # JSON decode errors don't lead to crash.
+    with patch.dict("os.environ",
+                    {"DATALAD_CONFIG_OVERRIDES": '{'}):
+        with swallow_logs(logging.WARNING) as cml:
+            cfg.reload()
+        assert_in("Failed to load DATALAD_CONFIG_OVERRIDE", cml.out)
+
+
 def test_overrides():
     cfg = ConfigManager()
     # any sensible (and also our CI) test environment(s) should have this

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -25,6 +25,12 @@ replacing any ``__`` (two underscores) with a hyphen, then any ``_``
 lower case. Values from environment variables take precedence over
 configuration file settings.
 
+In addition, the ``DATALAD_CONFIG_OVERRIDES`` environment variable can
+be set to a JSON record with configuration values.  This is
+particularly useful for options that aren't accessible through the
+naming scheme described above (e.g., an option name that includes an
+underscore).
+
 The following sections provide a (non-exhaustive) list of settings honored
 by datalad. They are categorized according to the scope they are typically
 associated with.

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -25,7 +25,7 @@ replacing any ``__`` (two underscores) with a hyphen, then any ``_``
 lower case. Values from environment variables take precedence over
 configuration file settings.
 
-In addition, the ``DATALAD_CONFIG_OVERRIDES`` environment variable can
+In addition, the ``DATALAD_CONFIG_OVERRIDES_JSON`` environment variable can
 be set to a JSON record with configuration values.  This is
 particularly useful for options that aren't accessible through the
 naming scheme described above (e.g., an option name that includes an


### PR DESCRIPTION
ConfigManager allows setting options via environment variables, where
the option name is constructed from the environment variable by
mapping two underscores to a hyphen and one underscore to a dot.  With
this system, some options aren't accessible.  Taking the example from
gh-5503: `datalad.procedure.NAME.call-format` cannot be set with
`DATALAD_PROCEDURE_NAME_CALL__FORMAT` when `NAME` (based on the
procedure file name) includes an underscore or an upper case
character.

Lift this restriction by adding support for a DATALAD_CONFIG_OVERRIDES
environment variable whose value is a JSON record with configuration
values.  These values have a precedence just below values set directly
via DATALAD_ environment variables.

Fixes gh-5503.

---

cc @bpoldrack

From the datalad standpoint, this is perhaps more of a feature than a fix, but I've decided to place this against maint so that the associated [datalad-hirni issue][1] can be resolved sooner.  Given that there's no change of behavior if `DATALAD_CONFIG_OVERRIDES` isn't set, it's unlikely to be problematic.  The one thing I can think of is if some third-party library has some custom handling of a `datalad.config.overrides` option and is relying it being accessible through the `DATALAD_CONFIG_OVERRIDES` environment variable, which seems very unlikely.

[1]: https://github.com/psychoinformatics-de/datalad-hirni/issues/177
