### PR TITLE
BF: AnnexJsonProtocol - memoize the last line which failed to json load

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -22,8 +22,9 @@ if not __debug__:
 # For reproducible demos/tests
 import os
 _seed = os.environ.get('DATALAD_SEED', None)
-if _seed:
+if _seed is not None:
     import random
+    _seed = int(_seed)
     random.seed(_seed)
 
 import atexit

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3455,7 +3455,7 @@ class AnnexJsonProtocol(WitlessProtocol):
                         # it is the last line and fails to parse -- it can/likely
                         # to happen that it was not a complete line and that buffer
                         # got filled up/provided before the end of line.
-                        # So - memoize it and pass to the next call
+                        # Store it so that it can be prepended to data in the next call.
                         self._unprocessed = line
                         break
                     # TODO turn this into an error result, or put the exception

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3410,6 +3410,7 @@ class AnnexJsonProtocol(WitlessProtocol):
         super().__init__(done_future)
         self._global_pbar_id = 'annexprogress-{}'.format(id(self))
         self.total_nbytes = total_nbytes
+        self._remainder = None
 
     def connection_made(self, transport):
         super().connection_made(transport)
@@ -3435,17 +3436,30 @@ class AnnexJsonProtocol(WitlessProtocol):
             # let the base class decide what to do with it
             super().pipe_data_received(fd, data)
             return
+        if self._remainder:
+            data = self._remainder + data
+            self._remainder = None
         # this is where the JSON records come in
         # json_loads() is already logging any error, which is OK, because
         # under no circumstances we would expect broken JSON
-        for line in data.splitlines():
+        lines = data.splitlines()
+        for iline, line in enumerate(lines):
             try:
                 j = json_loads(line)
-            except Exception:
-                # TODO turn this into an error result, or put the exception
-                # onto the result future -- needs more thought
+            except Exception as exc:
                 if line.strip():
                     # do not complain on empty lines
+                    if iline == len(lines) - 1 and not data.endswith(os.linesep.encode()):
+                        lgr.debug("Caught %s while trying to parse JSON line %s which might "
+                                  "be not yet a full line", exc, line)
+                        # it is the last line and fails to parse -- it can/likely
+                        # to happen that it was not a complete line and that buffer
+                        # got filled up/provided before the end of line.
+                        # So - memoize it and pass to the next call
+                        self._remainder = line
+                        break
+                    # TODO turn this into an error result, or put the exception
+                    # onto the result future -- needs more thought
                     lgr.error('Received undecodable JSON output: %s', data)
                 continue
             self._proc_json_record(j)
@@ -3579,6 +3593,11 @@ class AnnexJsonProtocol(WitlessProtocol):
                 pbar_id,
                 'Finished',
                 noninteractive_level=5,
+            )
+        if self._remainder:
+            lgr.error(
+                "%d bytes of received undecodable JSON output remain: %s",
+                len(self._remainder), self._remainder
             )
         super().process_exited()
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3460,7 +3460,7 @@ class AnnexJsonProtocol(WitlessProtocol):
                         break
                     # TODO turn this into an error result, or put the exception
                     # onto the result future -- needs more thought
-                    lgr.error('Received undecodable JSON output: %s', data)
+                    lgr.error('Received undecodable JSON output: %s', line)
                 continue
             self._proc_json_record(j)
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2201,18 +2201,15 @@ def test_annexjson_protocol(path):
 
 @with_tempfile
 def test_annexjson_protocol_long(path):
-    # Inform about the seed here and use dedicated RNG so we are not
-    # effected by any other use of random before this test
-    seed = _seed if _seed is not None else random.randint(0, 1000)
-    # Inform for ease of debugging.
-    # TODO: if other test like this appears, craft @with_rng helper
-    print("RNG seed: %s" % seed)
-    rng = random.Random(seed)
     records = [
-        {('field%d' % f): ("a" * rng.randint(0, 5000))
-             for f in range(rng.randint(1, 100))
-         }
-        for i in range(10)
+        {"k": "v" * 20},
+        # Value based off of
+        # Lib.asyncio.unix_events._UnixReadPipeTransport.max_size.
+        {"k": "v" * 256 * 1024},
+        # and tiny ones in between should not be lost
+        {"k": "v"},
+        # even a much larger one - we should handle as well
+        {"k": "v" * 256 * 1024 * 5},
     ]
     with open(path, 'w') as f:
         for record in records:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -10,13 +10,16 @@
 
 """
 
-from datalad.tests.utils import known_failure_v6
-
+import gc
+import json
 import logging
+import os
+import random
+import re
+import sys
+
 from functools import partial
 from glob import glob
-import os
-import re
 from os import mkdir
 from os.path import (
     join as opj,
@@ -27,14 +30,16 @@ from os.path import (
     exists,
 )
 from shutil import copyfile
-from datalad.tests.utils import assert_not_is_instance
-
 
 from urllib.parse import urljoin
 from urllib.parse import urlsplit
 
 from unittest.mock import patch
-import gc
+
+from datalad import (
+    cfg as dl_cfg,
+    _seed,
+)
 
 from datalad.cmd import (
     GitWitlessRunner,
@@ -62,6 +67,7 @@ from datalad.tests.utils import (
     assert_is_instance,
     assert_not_equal,
     assert_not_in,
+    assert_not_is_instance,
     assert_raises,
     assert_re_in,
     assert_repo_status,
@@ -114,7 +120,6 @@ from datalad.support.exceptions import (
 )
 
 from datalad.support.gitrepo import GitRepo
-from datalad import cfg as dl_cfg
 
 # imports from same module:
 from datalad.support.annexrepo import (
@@ -2193,6 +2198,60 @@ def test_annexjson_protocol(path):
     # hence also no pointless statement in the str()
     assert_not_in('errors from JSON records', str(e.exception))
 
+
+@with_tempfile
+def test_annexjson_protocol_long(path):
+    # Inform about the seed here and use dedicated RNG so we are not
+    # effected by any other use of random before this test
+    seed = _seed if _seed is not None else random.randint(0, 1000)
+    # Inform for ease of debugging.
+    # TODO: if other test like this appears, craft @with_rng helper
+    print("RNG seed: %s" % seed)
+    rng = random.Random(seed)
+    records = [
+        {('field%d' % f): ("a" * rng.randint(0, 5000))
+             for f in range(rng.randint(1, 100))
+         }
+        for i in range(10)
+    ]
+    with open(path, 'w') as f:
+        for record in records:
+            print("print(%r);" % json.dumps(record), file=f)
+    runner = GitWitlessRunner()
+    res = runner.run(
+        [sys.executable, path],
+        protocol=AnnexJsonProtocol
+    )
+    eq_(res['stdout'], '')
+    eq_(res['stderr'], '')
+    eq_(res['stdout_json'], records)
+
+
+def test_annexjson_protocol_incorrect():
+    yield check_annexjson_protocol_incorrect, ''
+    yield check_annexjson_protocol_incorrect, ', end=""'
+
+
+@with_tempfile
+def check_annexjson_protocol_incorrect(print_opt, path):
+    # Test that we still log some incorrectly formed JSON record
+    bad_json = '{"I": "am wrong,}'
+    with open(path, 'w') as f:
+        print("print(%r%s);" % (bad_json, print_opt), file=f)
+    runner = GitWitlessRunner()
+    with swallow_logs(new_level=logging.ERROR) as cml:
+        res = runner.run(
+            [sys.executable, path],
+            protocol=AnnexJsonProtocol
+        )
+        cml.assert_logged(
+            msg=".*[rR]eceived undecodable JSON output",
+            level="ERROR",
+            regex=True)
+    # only error logged and nothing returned
+    eq_(res['stdout'], '')
+    eq_(res['stderr'], '')
+    eq_(res['stdout_json'], [])
 
 # see https://github.com/datalad/datalad/pull/5400 for troubleshooting
 # for stalling with unlock=False, and then with unlock=True it took >= 300 sec


### PR DESCRIPTION
Protocol's buffer could get filled up before the entire json line is
actually received, so the AnnexJsonProtocol could then receive only a
part of it, and fail to parse such a partial json entry.

The patch is a bit overdone: in principle I think

    not data.endswith(os.linesep.encode())

condition could be dropped, but I think it should not hurt since we are not
expecting new lines in the output within records, thus if the trailing symbol
in the entire data is a newline, it would mean that we did read the entire line
and thus we should not try to join it with the next one.

I am not sure if similar "I care about lines" behavior is relevant to other
WitlessProtocols and might need to be adjusted similarly.

Closes #5393

TODO:
- [x] test (just feed with some large and short json records interleaved and see if all good)

individual commits (adjusted more while crafting the tests) might have more information.