### PR TITLE
Test, documentation, fixes and public introduction of parse_gitconfig_dump()

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -79,8 +79,9 @@ def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
     dump : str
       Null-byte separated output
     cwd : path-like, optional
-      Use this path to convert relative paths for origin reports
-      into absolute paths
+      Use this absolute path to convert relative paths for origin reports
+      into absolute paths. By default, the process working directory
+      PWD is used.
     multi_value : bool, optional
       If True, report values from multiple specifications of the
       same key as a tuple of values assigned to this key. Otherwise,
@@ -89,6 +90,10 @@ def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
     Returns:
     --------
     dict, set
+      Configuration items are returned as key/value pairs in a dictionary.
+      The second tuple-item will be a set of path objects comprising all
+      source files, if origin information was included in the dump
+      (--show-origin). An empty set is returned otherwise.
     """
     dct = {}
     fileset = set()

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -425,7 +425,7 @@ class ConfigManager(object):
             encoding='utf-8',
         )
         store = {}
-        store['cfg'], store['files'] = _parse_gitconfig_dump(
+        store['cfg'], store['files'] = parse_gitconfig_dump(
             stdout, cwd=self._runner.cwd)
 
         # update stats of config files, they have just been discovered

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -31,7 +31,15 @@ from pathlib import Path
 import logging
 lgr = logging.getLogger('datalad.config')
 
-cfg_kv_regex = re.compile(r'(^[^\n]*)\n(.*)$', flags=re.MULTILINE | re.DOTALL)
+# git-config key syntax with a section and a subsection
+# see git-config(1) for syntax details
+cfg_k_regex = re.compile(r'([a-zA-Z0-9-.]+\.[^\0\n]+)$', flags=re.MULTILINE)
+# identical to the key regex, but with an additional group for a
+# value in a null-delimited git-config dump
+cfg_kv_regex = re.compile(
+    r'([a-zA-Z0-9-.]+\.[^\0\n]+)\n(.*)$',
+    flags=re.MULTILINE | re.DOTALL
+)
 cfg_section_regex = re.compile(r'(.*)\.[^.]+')
 cfg_sectionoption_regex = re.compile(r'(.*)\.([^.]+)')
 
@@ -74,6 +82,14 @@ def _where_reload(obj):
 def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
     """Parse a dump-string from `git config -z --list`
 
+    This parser has limited support for discarding unrelated output
+    that may contaminate the given dump. It does so performing a
+    relatively strict matching of configuration key syntax, and discarding
+    lines in the output that are not valid git-config keys.
+
+    There is also built-in support for parsing outputs generated
+    with --show-origin (see return value).
+
     Parameters
     ----------
     dump : str
@@ -98,25 +114,40 @@ def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
     dct = {}
     fileset = set()
     for line in dump.split('\0'):
-        if not line:
+        # line is a null-delimited chunk
+        k = None
+        # in anticipation of output contamination, process within a loop
+        # where we can reject non syntax compliant pieces
+        while line:
+            if line.startswith('file:'):
+                # origin line
+                fname = Path(line[5:])
+                if not fname.is_absolute():
+                    fname = Path(cwd) / fname if cwd else Path.cwd() / fname
+                fileset.add(fname)
+                break
+            if line.startswith('command line:'):
+                # no origin that we could as a pathobj
+                break
+            # try getting key/value pair from the present chunk
+            k, v = _gitcfg_rec_to_keyvalue(line)
+            if v or cfg_k_regex.match(k):
+                # if we have a value, we also must have a good key
+                # otherwise check the key
+                # we are done with this chunk when there is a good key
+                break
+            else:
+                # no value, no good key, this chunk is not usable as is
+                # reset the key to cleanly discard the entire chunk
+                # should it not contain anything usable
+                k = None
+            # discard the first line and start over
+            ignore, line = line.split('\n', maxsplit=1)
+            lgr.debug('Non-standard git-config output, ignoring: %s', ignore)
+        if not k:
+            # nothing else to log, all ignored dump was reported before
             continue
-        if line.startswith('file:'):
-            # origin line
-            fname = Path(line[5:])
-            if not fname.is_absolute():
-                fname = Path(cwd) / fname if cwd else Path.cwd() / fname
-            fileset.add(fname)
-            continue
-        if line.startswith('command line:'):
-            # nothing we could handle
-            continue
-        kv_match = cfg_kv_regex.match(line)
-        if kv_match:
-            k, v = kv_match.groups()
-        else:
-            # could be just a key without = value, which git treats as True
-            # if asked for a bool
-            k, v = line, None
+        # multi-value reporting
         present_v = dct.get(k, None)
         if present_v is None or not multi_value:
             dct[k] = v
@@ -127,8 +158,32 @@ def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
                 dct[k] = (present_v, v)
     return dct, fileset
 
+
 # keep alias with previous name for now
 _parse_gitconfig_dump = parse_gitconfig_dump
+
+
+def _gitcfg_rec_to_keyvalue(rec):
+    """Helper for parse_gitconfig_dump()
+
+    Parameters
+    ----------
+    rec: str
+      Key/value specification string
+
+    Returns
+    -------
+    str, str
+      Parsed key and value. Value could be None.
+    """
+    kv_match = cfg_kv_regex.match(rec)
+    if kv_match:
+        k, v = kv_match.groups()
+    else:
+        # could be just a key without = value, which git treats as True
+        # if asked for a bool
+        k, v = rec, None
+    return k, v
 
 
 def _update_from_env(store):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import logging
 lgr = logging.getLogger('datalad.config')
 
-cfg_kv_regex = re.compile(r'(^.*)\n(.*)$', flags=re.MULTILINE)
+cfg_kv_regex = re.compile(r'(^[^\n]*)\n(.*)$', flags=re.MULTILINE | re.DOTALL)
 cfg_section_regex = re.compile(r'(.*)\.[^.]+')
 cfg_sectionoption_regex = re.compile(r'(.*)\.([^.]+)')
 

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -71,8 +71,7 @@ def _where_reload(obj):
     return obj
 
 
-# TODO document and make "public" (used in GitRepo too)
-def _parse_gitconfig_dump(dump, cwd=None, multi_value=True):
+def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
     """Parse a dump-string from `git config -z --list`
 
     Parameters
@@ -86,6 +85,10 @@ def _parse_gitconfig_dump(dump, cwd=None, multi_value=True):
       If True, report values from multiple specifications of the
       same key as a tuple of values assigned to this key. Otherwise,
       the last configuration is reported.
+
+    Returns:
+    --------
+    dict, set
     """
     dct = {}
     fileset = set()
@@ -118,6 +121,9 @@ def _parse_gitconfig_dump(dump, cwd=None, multi_value=True):
             else:
                 dct[k] = (present_v, v)
     return dct, fileset
+
+# keep alias with previous name for now
+_parse_gitconfig_dump = parse_gitconfig_dump
 
 
 def _update_from_env(store):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -53,7 +53,7 @@ from datalad.cmd import (
 )
 from datalad.config import (
     ConfigManager,
-    _parse_gitconfig_dump,
+    parse_gitconfig_dump,
     write_config_section,
 )
 
@@ -2760,7 +2760,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         # anyways, and they should not appear in a normal .gitmodules file
         # but could easily appear when duplicates are included. In this case,
         # we better not crash
-        db, _ = _parse_gitconfig_dump(out, cwd=self.path, multi_value=False)
+        db, _ = parse_gitconfig_dump(out, cwd=self.path, multi_value=False)
         mods = {}
         for k, v in db.items():
             if not k.startswith('submodule.'):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -105,8 +105,15 @@ def test_parse_gitconfig_dump():
     parsed, files = parse_gitconfig_dump(gitcfg_dump_w_origin, cwd='ROOT')
     assert_equal(
         files,
+        # the 'command line:' origin is ignored
         set((Path('ROOT/.git/config'), Path('/home/me/.gitconfig'))))
-    # important
+    assert_equal(gitcfg_parsetarget, parsed)
+
+    # now contaminate the output with a prepended error message
+    # https://github.com/datalad/datalad/issues/5502
+    # must work, but really needs the trailing newline
+    parsed, files = parse_gitconfig_dump(
+        "unfortunate stdout\non more lines\n" + gitcfg_dump_w_origin)
     assert_equal(gitcfg_parsetarget, parsed)
 
 

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -71,6 +71,16 @@ true\0just.a.key\0annex.version
 long\ntext with\nnewlines\0annex.something
 abcdef\0"""
 
+
+# include a "command line" origin
+gitcfg_dump_w_origin = """\
+file:.git/config\0core.withdot
+true\0file:.git/config\0just.a.key\0file:/home/me/.gitconfig\0annex.version
+8\0file:.git/config\0filter.with2dots.some
+long\ntext with\nnewlines\0file:.git/config\0command line:\0annex.something
+abcdef\0"""
+
+
 gitcfg_parsetarget = {
     'core.withdot': 'true',
     'just.a.key': None,
@@ -90,6 +100,13 @@ def test_parse_gitconfig_dump():
     # simple case, no origin info, clean output
     parsed, files = parse_gitconfig_dump(gitcfg_dump)
     assert_equal(files, set())
+    assert_equal(gitcfg_parsetarget, parsed)
+    # now with origin information in the dump
+    parsed, files = parse_gitconfig_dump(gitcfg_dump_w_origin, cwd='ROOT')
+    assert_equal(
+        files,
+        set((Path('ROOT/.git/config'), Path('/home/me/.gitconfig'))))
+    # important
     assert_equal(gitcfg_parsetarget, parsed)
 
 

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -40,6 +40,7 @@ from datalad.distribution.dataset import Dataset
 from datalad.api import create
 from datalad.config import (
     ConfigManager,
+    parse_gitconfig_dump,
     rewrite_url,
     write_config_section,
 )
@@ -63,10 +64,33 @@ myint = 3
 findme = 5.0
 """
 
+gitcfg_dump = """\
+core.withdot
+true\0just.a.key\0annex.version
+8\0filter.with2dots.some
+long\ntext with\nnewlines\0annex.something
+abcdef\0"""
+
+gitcfg_parsetarget = {
+    'core.withdot': 'true',
+    'just.a.key': None,
+    'annex.version': '8',
+    'filter.with2dots.some': 'long\ntext with\nnewlines',
+    'annex.something': 'abcdef',
+}
+
+
 _dataset_config_template = {
     'ds': {
         '.datalad': {
             'config': _config_file_content}}}
+
+
+def test_parse_gitconfig_dump():
+    # simple case, no origin info, clean output
+    parsed, files = parse_gitconfig_dump(gitcfg_dump)
+    assert_equal(files, set())
+    assert_equal(gitcfg_parsetarget, parsed)
 
 
 @with_tree(tree=_dataset_config_template)


### PR DESCRIPTION
This PR (in order of importance):

- fixes handling of multi-line values (all but the first line were ignored before)
- introduces a unit test for this function
- adds more documentation
- robustifies the parser to be able to work with contaminated output (fixes #5502)

Although this series slightly complicates the processing in this critical function, I do not observe a performance impact (see commit message).