### PR TITLE
Reduce usage of mktemp()

### DIFF
--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -137,7 +137,6 @@ class ArchivesCache(object):
     # IDEA: extract under .git/annex/tmp so later on annex unused could clean it
     #       all up
     def __init__(self, toppath=None, persistent=False):
-
         self._toppath = toppath
         if toppath:
             path = opj(toppath, ARCHIVES_TEMP_DIR)
@@ -146,10 +145,30 @@ class ArchivesCache(object):
                 lgr.debug("For non-persistent archives using %s suffix for path %s",
                           tempsuffix, path)
                 path += tempsuffix
+            # TODO: begging for a race condition
+            if not exists(path):
+                lgr.debug("Initiating clean cache for the archives under %s",
+                          self.path)
+                try:
+                    self._made_path = True
+                    os.makedirs(path)
+                    lgr.debug("Cache initialized")
+                except Exception:
+                    lgr.error("Failed to initialize cached under %s", path)
+                    raise
+            else:
+                lgr.debug(
+                    "Not initiating existing cache for the archives under %s",
+                    self.path)
+                self._made_path = False
         else:
             if persistent:
-                raise ValueError("%s cannot be persistent since no toppath was provided" % self)
-            path = tempfile.mktemp(**get_tempfile_kwargs())
+                raise ValueError(
+                    "%s cannot be persistent, because no toppath was provided"
+                    % self)
+            path = tempfile.mkdtemp(**get_tempfile_kwargs())
+            self._made_path = True
+
         self._path = path
         self.persistent = persistent
         # TODO?  ensure that it is absent or we should allow for it to persist a bit?

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -148,7 +148,7 @@ class ArchivesCache(object):
             # TODO: begging for a race condition
             if not exists(path):
                 lgr.debug("Initiating clean cache for the archives under %s",
-                          self.path)
+                          path)
                 try:
                     self._made_path = True
                     os.makedirs(path)
@@ -159,7 +159,7 @@ class ArchivesCache(object):
             else:
                 lgr.debug(
                     "Not initiating existing cache for the archives under %s",
-                    self.path)
+                    path)
                 self._made_path = False
         else:
             if persistent:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1790,6 +1790,9 @@ def make_tempfile(content=None, wrapped=None, **tkwargs):
 
     filename = {False: tempfile.mktemp,
                 True: tempfile.mkdtemp}[mkdir](**tkwargs_)
+    # MIH: not clear to me why we need to perform this (possibly expensive)
+    # resolve. It was already part of the original implementation
+    # 008d9ab8cc3e0170c0a9b8479e80dee9ffe6eb7f
     filename = Path(filename).resolve()
 
     if content:
@@ -1811,6 +1814,8 @@ def make_tempfile(content=None, wrapped=None, **tkwargs):
         # glob here for all files with the same name (-suffix)
         # would be useful whenever we requested .img filename,
         # and function creates .hdr as well
+        # MIH: this is undocumented behavior, and undesired in the general
+        # case. it should be made conditional and explicit
         lsuffix = len(tkwargs_.get('suffix', ''))
         filename_ = lsuffix and filename[:-lsuffix] or filename
         filenames = glob.glob(filename_ + '*')

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1801,8 +1801,10 @@ def make_tempfile(content=None, wrapped=None, **tkwargs):
     filename = str(filename)
 
     if __debug__:
-        # TODO mkdir
-        lgr.debug('Created temporary thing named %s"', filename)
+        lgr.debug(
+            'Created temporary %s named %s',
+            'directory' if mkdir else 'file',
+            filename)
     try:
         yield filename
     finally:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1321,11 +1321,11 @@ def swallow_logs(new_level=None, file_=None, name='datalad'):
         def __init__(self):
             if file_ is None:
                 kw = get_tempfile_kwargs({}, prefix="logs")
-                out_file = tempfile.mktemp(**kw)
+                self._out = NamedTemporaryFile(mode='a', delete=False, **kw)
             else:
                 out_file = file_
-            # PY3 requires clearly one or another.  race condition possible
-            self._out = open(out_file, 'a')
+                # PY3 requires clearly one or another.  race condition possible
+                self._out = open(out_file, 'a')
             self._final_out = None
 
         def _read(self, h):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -19,6 +19,7 @@ import shutil
 import os
 import sys
 import tempfile
+from tempfile import NamedTemporaryFile
 import platform
 import gc
 import glob
@@ -1219,8 +1220,8 @@ def swallow_outputs():
         def __init__(self):
             kw = get_tempfile_kwargs({}, prefix="outputs")
 
-            self._out = open(tempfile.mktemp(**kw), 'w')
-            self._err = open(tempfile.mktemp(**kw), 'w')
+            self._out = NamedTemporaryFile(delete=False, mode='w', **kw)
+            self._err = NamedTemporaryFile(delete=False, mode='w', **kw)
 
         def _read(self, h):
             with open(h.name) as f:


### PR DESCRIPTION
Inspired by #5507 this aimed to removed the usage of `mktemp()`, deprecated since Python 2.3 (or in other words: deprecated already before any of this code was writen).

While this PR removed some cases, in others things are too intertwined to anyhow consider the necessary effort justifiable for inclusion in `maint`.

Fixing a bunch of log message calls with needless unconditional string formatting on the side, and complaining about the general behavior of `make_tempfile()`, too. The `resolve()` done in there could be one of the reasons for slowed performance of the test battery -- it is executed *a lot* and resolve can be slow, depending on the file system conditions.