### PR TITLE
OPT: Avoid unconditional string expansion in log messages

### DIFF
--- a/datalad/__main__.py
+++ b/datalad/__main__.py
@@ -93,7 +93,7 @@ def main(argv=None):
         runctx(code, globs, globs)
         # TODO: see if we could hide our presence from the final tracebacks if execution fails
     except IOError as err:
-        lgr.error("Cannot run file %r because: %s" % (sys.argv[0], err))
+        lgr.error("Cannot run file %r because: %s", sys.argv[0], err)
         sys.exit(1)
     except SystemExit:
         pass

--- a/datalad/auto.py
+++ b/datalad/auto.py
@@ -303,7 +303,7 @@ class AutomagicIO(object):
             # wrong or being undesired. Nested invokation could happen
             # caused by independent pieces of code, e.g. user code
             # that invokes our own metadata handling.
-            lgr.debug("%s already active. No action taken" % self)
+            lgr.debug("%s already active. No action taken", self)
             return
         # overloads
         builtins.open = self._proxy_open

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -177,7 +177,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
             # The way we log is to stay consistent with Runner.
             # TODO: later we might just log in a single entry, without
             # fd_name prefix
-            lgr.log(5, "%s| %s " % (fd_name, log_data))
+            lgr.log(5, "%s| %s ", fd_name, log_data)
 
     def connection_made(self, transport):
         self.transport = transport
@@ -705,8 +705,8 @@ class BatchedCommand(SafeDelCloseMixin):
         self._stderr_out_fname = None
 
     def _initialize(self):
-        lgr.debug("Initiating a new process for %s" % repr(self))
-        lgr.log(5, "Command: %s" % self.cmd)
+        lgr.debug("Initiating a new process for %s", repr(self))
+        lgr.log(5, "Command: %s", self.cmd)
         # according to the internet wisdom there is no easy way with subprocess
         # while avoid deadlocks etc.  We would need to start a thread/subprocess
         # to timeout etc
@@ -783,7 +783,7 @@ class BatchedCommand(SafeDelCloseMixin):
             self._initialize()
 
         entry = arg + '\n'
-        lgr.log(5, "Sending %r to batched command %s" % (entry, self))
+        lgr.log(5, "Sending %r to batched command %s", entry, self)
         # apparently communicate is just a one time show
         # stdout, stderr = self._process.communicate(entry)
         # according to the internet wisdom there is no easy way with subprocess
@@ -803,7 +803,7 @@ class BatchedCommand(SafeDelCloseMixin):
             if not process.stdout.closed else None
         if stderr:
             lgr.warning("Received output in stderr: %r", stderr)
-        lgr.log(5, "Received output: %r" % stdout)
+        lgr.log(5, "Received output: %r", stdout)
         return stdout
 
     def close(self, return_stderr=False):

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -188,7 +188,7 @@ queue
 """ % locals())
         f.close()
         Runner().run(['condor_submit', f.name])
-        lgr.info("Scheduled execution via %s.  Logs will be stored under %s" % (pbs, logs))
+        lgr.info("Scheduled execution via %s.  Logs will be stored under %s", pbs, logs)
     finally:
         unlink(f.name)
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -503,7 +503,7 @@ def main(args=None):
                 ret = cmdlineargs.func(cmdlineargs)
             except InsufficientArgumentsError as exc:
                 # if the func reports inappropriate usage, give help output
-                lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
+                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
                 cmdlineargs.subparser.print_usage(sys.stderr)
                 sys.exit(2)
             except IncompleteResultsError as exc:
@@ -534,7 +534,7 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
-                lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
+                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
                 sys.exit(1)
     else:
         # just let argparser spit out its error, since there is smth wrong

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -247,7 +247,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         #  might be way too many?
         #  only if just archive portion of url is given or the one pointing
         #  to specific file?
-        lgr.debug("Current directory: %s, url: %s" % (os.getcwd(), url))
+        lgr.debug("Current directory: %s, url: %s", os.getcwd(), url)
         akey, afile, attrs = self._parse_url(url)
         size = attrs.get('size', None)
 
@@ -299,7 +299,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         # we could even store the filename within archive
         # Otherwise it is unrealistic to even require to recompute key if we
         # knew the backend etc
-        lgr.debug("VERIFYING key %s" % key)
+        lgr.debug("VERIFYING key %s", key)
         # The same content could be available from multiple locations within the same
         # archive, so let's not ask it twice since here we don't care about "afile"
         for akey, _ in self._gen_akey_afiles(key, unique_akeys=True):

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -375,10 +375,10 @@ class AnnexCustomRemote(object):
     def req_CLAIMURL(self, url):
         scheme = urlparse(url).scheme
         if scheme in self.SUPPORTED_SCHEMES:
-            self.debug("Claiming url %r", url)
+            self.debug("Claiming url %r" % url)
             self.send("CLAIMURL-SUCCESS")
         else:
-            self.debug("Not claiming url %s", url)
+            self.debug("Not claiming url %s" % url)
             self.send("CLAIMURL-FAILURE")
 
     # TODO: we should unify what to be overriden and some will provide CHECKURL
@@ -390,7 +390,7 @@ class AnnexCustomRemote(object):
                 self._transfer(cmd, key, file)
             except Exception as exc:
                 self.send(
-                    "TRANSFER-FAILURE %s %s %s", cmd, key, exc_str(exc)
+                    "TRANSFER-FAILURE %s %s %s" % (cmd, key, exc_str(exc))
                 )
         else:
             self.send_unsupported(

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -204,7 +204,7 @@ class AnnexCustomRemote(object):
             self.fout.write(msg + "\n")  # .encode())
             self.fout.flush()
         except IOError as exc:
-            lgr.debug("Failed to send due to %s" % str(exc))
+            lgr.debug("Failed to send due to %s", exc)
             if exc.errno == errno.EPIPE:
                 self.stop()
             else:
@@ -323,7 +323,7 @@ class AnnexCustomRemote(object):
                 self.error("Problem processing %r with parameters %r: %r"
                            % (req, req_load, exc_str(e)))
                 from traceback import format_exc
-                lgr.error("Caught exception detail: %s" % format_exc())
+                lgr.error("Caught exception detail: %s", format_exc())
 
     def req_INITREMOTE(self, *args):
         """Initialize this remote. Provides high level abstraction.
@@ -375,22 +375,22 @@ class AnnexCustomRemote(object):
     def req_CLAIMURL(self, url):
         scheme = urlparse(url).scheme
         if scheme in self.SUPPORTED_SCHEMES:
-            self.debug("Claiming url %r" % url)
+            self.debug("Claiming url %r", url)
             self.send("CLAIMURL-SUCCESS")
         else:
-            self.debug("Not claiming url %s" % url)
+            self.debug("Not claiming url %s", url)
             self.send("CLAIMURL-FAILURE")
 
     # TODO: we should unify what to be overriden and some will provide CHECKURL
 
     def req_TRANSFER(self, cmd, key, file):
         if cmd in ("RETRIEVE",):
-            lgr.debug("%s key %s into/from %s" % (cmd, key, file))  # was INFO level
+            lgr.debug("%s key %s into/from %s", cmd, key, file)  # was INFO level
             try:
                 self._transfer(cmd, key, file)
             except Exception as exc:
                 self.send(
-                    "TRANSFER-FAILURE %s %s %s" % (cmd, key, exc_str(exc))
+                    "TRANSFER-FAILURE %s %s %s", cmd, key, exc_str(exc)
                 )
         else:
             self.send_unsupported(
@@ -543,7 +543,7 @@ def generate_uuids():
 def init_datalad_remote(repo, remote, encryption=None, autoenable=False, opts=[]):
     """Initialize datalad special remote"""
     from datalad.consts import DATALAD_SPECIAL_REMOTES_UUIDS
-    lgr.info("Initiating special remote %s" % remote)
+    lgr.info("Initiating special remote %s", remote)
     remote_opts = [
         'encryption=%s' % str(encryption).lower(),
         'type=external',

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -71,7 +71,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
             resp = ["CHECKURL-CONTENTS", size] \
                 + ([status.filename] if status.filename else [])
         except Exception as exc:
-            self.debug("Failed to check url %s: %s" % (url, exc_str(exc)))
+            self.debug("Failed to check url %s: %s", url, exc_str(exc))
             resp = ["CHECKURL-FAILURE"]
         self.send(*resp)
 
@@ -90,7 +90,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
             Indicates that it is not currently possible to verify if the key is
             present in the remote. (Perhaps the remote cannot be contacted.)
         """
-        lgr.debug("VERIFYING key %s" % key)
+        lgr.debug("VERIFYING key %s", key)
         resp = None
         for url in self.gen_URLS(key):
             # somewhat duplicate of CHECKURL
@@ -103,14 +103,14 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 # we can connect to that server but that specific url is N/A,
                 # probably check the connection etc
             except TargetFileAbsent as exc:
-                self.debug("Target url %s file seems to be missing: %s" % (url, exc_str(exc)))
+                self.debug("Target url %s file seems to be missing: %s", url, exc_str(exc))
                 if not resp:
                     # if it is already marked as UNKNOWN -- let it stay that way
                     # but if not -- we might as well say that we can no longer access it
                     resp = "CHECKPRESENT-FAILURE"
             except Exception as exc:
                 resp = "CHECKPRESENT-UNKNOWN"
-                self.debug("Failed to check status of url %s: %s" % (url, exc_str(exc)))
+                self.debug("Failed to check status of url %s: %s", url, exc_str(exc))
         if resp is None:
             resp = "CHECKPRESENT-UNKNOWN"
         self.send(resp, key)
@@ -152,7 +152,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 downloaded_path = self._providers.download(
                     url, path=path, overwrite=True
                 )
-                lgr.info("Successfully downloaded %s into %s" % (url, downloaded_path))
+                lgr.info("Successfully downloaded %s into %s", url, downloaded_path)
                 self.send('TRANSFER-SUCCESS', cmd, key)
                 return
             except Exception as exc:

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -71,7 +71,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
             resp = ["CHECKURL-CONTENTS", size] \
                 + ([status.filename] if status.filename else [])
         except Exception as exc:
-            self.debug("Failed to check url %s: %s", url, exc_str(exc))
+            self.debug("Failed to check url %s: %s" % (url, exc_str(exc)))
             resp = ["CHECKURL-FAILURE"]
         self.send(*resp)
 
@@ -103,14 +103,14 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 # we can connect to that server but that specific url is N/A,
                 # probably check the connection etc
             except TargetFileAbsent as exc:
-                self.debug("Target url %s file seems to be missing: %s", url, exc_str(exc))
+                self.debug("Target url %s file seems to be missing: %s" % (url, exc_str(exc)))
                 if not resp:
                     # if it is already marked as UNKNOWN -- let it stay that way
                     # but if not -- we might as well say that we can no longer access it
                     resp = "CHECKPRESENT-FAILURE"
             except Exception as exc:
                 resp = "CHECKPRESENT-UNKNOWN"
-                self.debug("Failed to check status of url %s: %s", url, exc_str(exc))
+                self.debug("Failed to check status of url %s: %s" % (url, exc_str(exc)))
         if resp is None:
             resp = "CHECKPRESENT-UNKNOWN"
         self.send(resp, key)

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -130,5 +130,5 @@ def main(args=None, backend=None):
         try:
             _main(args, backend)
         except Exception as exc:
-            lgr.error('%s (%s)' % (str(exc), exc.__class__.__name__))
+            lgr.error('%s (%s)', str(exc), exc.__class__.__name__)
             sys.exit(1)

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -797,7 +797,7 @@ class CreateSibling(Interface):
 
             # publish web-interface to root dataset on publication server
             if current_ds.path == refds_path and ui:
-                lgr.info("Uploading web interface to %s" % path)
+                lgr.info("Uploading web interface to %s", path)
                 try:
                     CreateSibling.upload_web_interface(path, shell, shared, ui)
                 except CommandError as e:

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -396,7 +396,7 @@ def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False
         # publishing of `remote` might depend on publishing other
         # remote(s) first:
         for d in publish_depends:
-            lgr.info("Publishing to configured dependency: '%s'" % d)
+            lgr.info("Publishing to configured dependency: '%s'", d)
             # call this again to take care of the dependency first,
             # but keep the paths the same, as the goal is to publish those
             # to the primary remote, and not anything elase to a dependency

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -552,7 +552,7 @@ def _configure_remote(
                     "Could not enable annex remote %s. This is expected if %s "
                     "is a pure Git remote, or happens if it is not accessible.",
                     name, name)
-                lgr.debug("Exception was: %s" % exc_str(exc))
+                lgr.debug("Exception was: %s", exc_str(exc))
 
             if as_common_datasrc:
                 ri = RI(url)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -210,7 +210,7 @@ class Update(Interface):
                 yield res
                 continue
             if not sibling_ and len(remotes) > 1 and merge:
-                lgr.debug("Found multiple siblings:\n%s" % remotes)
+                lgr.debug("Found multiple siblings:\n%s", remotes)
                 res['status'] = 'impossible'
                 res['message'] = "Multiple siblings, please specify from which to update."
                 yield res

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -165,7 +165,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                     used_old_session = self._establish_session(url, allow_old=allow_old_session)
                 if not allow_old_session:
                     assert(not used_old_session)
-                lgr.log(5, "Calling out into %s for %s" % (method, url))
+                lgr.log(5, "Calling out into %s for %s", method, url)
                 result = method(url, **kwargs)
                 # assume success if no puke etc
                 break

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -55,7 +55,7 @@ try:
     _FTP_SUPPORT = True
     requests_ftp.monkeypatch_session()
 except ImportError as e:
-    lgr.debug("Failed to import requests_ftp, thus no ftp support: %s" % exc_str(e))
+    lgr.debug("Failed to import requests_ftp, thus no ftp support: %s", exc_str(e))
     _FTP_SUPPORT = False
 
 if lgr.getEffectiveLevel() <= 1:

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -254,7 +254,7 @@ class Providers(object):
                 lgr.warning("Do not know how to treat section %s here" % section)
 
         # link credentials into providers
-        lgr.debug("Assigning credentials into %d providers" % len(providers))
+        lgr.debug("Assigning credentials into %d providers", len(providers))
         for provider in providers.values():
             if provider.credential:
                 if provider.credential not in credentials:
@@ -356,7 +356,7 @@ class Providers(object):
         # protocols
         scheme = Provider.get_scheme_from_url(url)
         if scheme not in self._default_providers:
-            lgr.debug("Initializing default provider for %s" % scheme)
+            lgr.debug("Initializing default provider for %s", scheme)
             self._default_providers[scheme] = Provider(name="", url_res=["%s://.*" % scheme])
         provider = self._default_providers[scheme]
         lgr.debug("No dedicated provider, returning default one for %s: %s",

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -432,7 +432,7 @@ class AddArchiveContent(Interface):
                             target_file_path_new = opj(p, fn_base + suf + ('.' if (fn_ext or ends_with_dot) else '') + fn_ext)
                             if not lexists(target_file_path_new):
                                 break
-                            lgr.debug("File %s already exists" % target_file_path_new)
+                            lgr.debug("File %s already exists", target_file_path_new)
                             i += 1
                             suf = '.%d' % i
                         target_file_path = target_file_path_new
@@ -496,7 +496,7 @@ class AddArchiveContent(Interface):
                 # force=True since some times might still be staged and fail
                 annex.remove(archive_rpath, force=True)
 
-            lgr.info("Finished adding %s: %s" % (archive, stats.as_str(mode='line')))
+            lgr.info("Finished adding %s: %s", archive, stats.as_str(mode='line'))
 
             if outside_stats:
                 outside_stats += stats

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -155,7 +155,7 @@ def load_interface(spec):
     if isinstance(spec[1], dict):
         intf = _load_plugin(spec[1]['file'], fail=False)
     else:
-        lgr.log(5, "Importing module %s " % spec[0])
+        lgr.log(5, "Importing module %s ", spec[0])
         try:
             mod = import_module(spec[0], package='datalad')
         except Exception as e:

--- a/datalad/interface/ls_webui.py
+++ b/datalad/interface/ls_webui.py
@@ -314,7 +314,7 @@ def fs_traverse(path, repo, parent=None,
         fs['nodes'] = children          # add children info to main fs dictionary
         if render:                      # render directory node at location(path)
             fs_render(fs, json=json, ds_path=basepath or path)
-            lgr.info('Directory: %s' % path)
+            lgr.info('Directory: %s', path)
 
     return fs
 
@@ -374,7 +374,7 @@ def ds_traverse(rootds, parent=None, json=None,
         time.localtime(getmtime(index_file))) if exists(index_file) else ''
 
     # render current dataset
-    lgr.info('Dataset: %s' % rootds.path)
+    lgr.info('Dataset: %s', rootds.path)
     fs_render(fs, json=json, ds_path=rootds.path)
     return fs
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -209,7 +209,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                               ' Initializing ...' % self.path)
                     do_init = True
             elif create:
-                lgr.debug('Initializing annex repository at %s...' % self.path)
+                lgr.debug('Initializing annex repository at %s...', self.path)
                 do_init = True
             else:
                 raise InvalidAnnexRepositoryError("No annex found at %s." % self.path)
@@ -3673,14 +3673,14 @@ def readlines_until_ok_or_failed(stdout, maxlines=100):
     """Read stdout until line ends with ok or failed"""
     out = ''
     i = 0
-    lgr.log(3, "Trying to receive from %s" % stdout)
+    lgr.log(3, "Trying to receive from %s", stdout)
     while not stdout.closed:
         i += 1
         if maxlines > 0 and i > maxlines:
             raise IOError("Expected no more than %d lines. So far received: %r" % (maxlines, out))
         lgr.log(2, "Expecting a line")
         line = stdout.readline()
-        lgr.log(2, "Received line %r" % line)
+        lgr.log(2, "Received line %r", line)
         out += line
         if re.match(r'^.*\b(failed|ok)$', line.rstrip()):
             break

--- a/datalad/support/archive_utils_patool.py
+++ b/datalad/support/archive_utils_patool.py
@@ -37,7 +37,7 @@ import patoolib.util
 # Seems have managed with swallow_outputs
 #
 # def _patool_log(level, msg):
-#     lgr.log(level, "patool: %s" % msg)
+#     lgr.log(level, "patool: %s", msg)
 #
 # def _patool_log_info(msg, *args, **kwargs):
 #     _patool_log(logging.DEBUG, msg)
@@ -87,7 +87,7 @@ def _patool_run(cmd, verbosity=0, **kwargs):
     except CommandError as e:
         return e.code
     except Exception as e:
-        lgr.error("While invoking runner caught unexpected exception: %s" % e)
+        lgr.error("While invoking runner caught unexpected exception: %s", e)
         return 100  # unknown beast
 patoolib.util.run = _patool_run
 
@@ -165,9 +165,9 @@ def decompress_file(archive, dir_):
                                   outdir=outdir,
                                   verbosity=100)
         if cmo.out:
-            lgr.debug("patool gave stdout:\n%s" % cmo.out)
+            lgr.debug("patool gave stdout:\n%s", cmo.out)
         if cmo.err:
-            lgr.debug("patool gave stderr:\n%s" % cmo.err)
+            lgr.debug("patool gave stderr:\n%s", cmo.err)
 
     # Note: (ben) Experienced issue, where extracted tarball
     # lacked execution bit of directories, leading to not being
@@ -210,6 +210,6 @@ def compress_files(files, archive, path=None, overwrite=True):
                                      [unixify_path(f) for f in files],
                                      verbosity=100)
         if cmo.out:
-            lgr.debug("patool gave stdout:\n%s" % cmo.out)
+            lgr.debug("patool gave stdout:\n%s", cmo.out)
         if cmo.err:
-            lgr.debug("patool gave stderr:\n%s" % cmo.err)
+            lgr.debug("patool gave stderr:\n%s", cmo.err)

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -82,7 +82,7 @@ def decompress_file(archive, dir_, leading_directories='strip'):
       and that leading directory will be removed.
     """
     if not exists(dir_):
-        lgr.debug("Creating directory %s to extract archive into" % dir_)
+        lgr.debug("Creating directory %s to extract archive into", dir_)
         os.makedirs(dir_)
 
     _decompress_file(archive, dir_)
@@ -92,7 +92,7 @@ def decompress_file(archive, dir_, leading_directories='strip'):
         if not len(files) and len(dirs) == 1:
             # move all the content under dirs[0] up 1 level
             widow_dir = opj(dir_, dirs[0])
-            lgr.debug("Moving content within %s upstairs" % widow_dir)
+            lgr.debug("Moving content within %s upstairs", widow_dir)
             subdir, subdirs_, files_ = next(os.walk(opj(dir_, dirs[0])))
             for f in subdirs_ + files_:
                 os.rename(opj(subdir, f), opj(dir_, f))
@@ -159,16 +159,16 @@ class ArchivesCache(object):
 
         # TODO: begging for a race condition
         if not exists(path):
-            lgr.debug("Initiating clean cache for the archives under %s" % self.path)
+            lgr.debug("Initiating clean cache for the archives under %s", self.path)
             try:
                 self._made_path = True
                 os.makedirs(path)
                 lgr.debug("Cache initialized")
             except Exception as e:
-                lgr.error("Failed to initialize cached under %s" % path)
+                lgr.error("Failed to initialize cached under %s", path)
                 raise
         else:
-            lgr.debug("Not initiating existing cache for the archives under %s" % self.path)
+            lgr.debug("Not initiating existing cache for the archives under %s", self.path)
             self._made_path = False
 
     @property
@@ -181,10 +181,10 @@ class ArchivesCache(object):
             del self._archives[aname]
         # Probably we should not rely on _made_path and not bother if persistent removing it
         # if ((not self.persistent) or force) and self._made_path:
-        #     lgr.debug("Removing the entire archives cache under %s" % self.path)
+        #     lgr.debug("Removing the entire archives cache under %s", self.path)
         #     rmtemp(self.path)
         if (not self.persistent) or force:
-            lgr.debug("Removing the entire archives cache under %s" % self.path)
+            lgr.debug("Removing the entire archives cache under %s", self.path)
             rmtemp(self.path)
 
     def _get_normalized_archive_path(self, archive):
@@ -408,7 +408,7 @@ class ExtractedArchive(object):
         self.assure_extracted()
         path = self.get_extracted_filename(afile)
         # TODO: make robust
-        lgr.log(2, "Verifying that %s exists" % abspath(path))
+        lgr.log(2, "Verifying that %s exists", abspath(path))
         assert exists(path), "%s must exist" % path
         return path
 

--- a/datalad/support/configparserinc.py
+++ b/datalad/support/configparserinc.py
@@ -112,7 +112,7 @@ class SafeConfigParserWithIncludes(SafeConfigParser):
                     else:
                             parser.read(resource)
             except UnicodeDecodeError as e:
-                    logSys.error("Error decoding config file '%s': %s" % (resource, e))
+                    logSys.error("Error decoding config file '%s': %s", resource, e)
                     return []
 
             resourceDir = os.path.dirname(resource)
@@ -143,7 +143,7 @@ class SafeConfigParserWithIncludes(SafeConfigParser):
                     filenames = [ filenames ]
             for filename in filenames:
                     fileNamesFull += SafeConfigParserWithIncludes.getIncludes(filename)
-            logSys.debug("Reading files: %s" % fileNamesFull)
+            logSys.debug("Reading files: %s", fileNamesFull)
             if sys.version_info >= (3,2):  # pragma: no cover
                     return SafeConfigParser.read(self, fileNamesFull, encoding='utf-8')
             else:

--- a/datalad/support/digests.py
+++ b/datalad/support/digests.py
@@ -59,7 +59,7 @@ class Digester(object):
         dict
           Keys are algorithm labels, and values are checksum strings
         """
-        lgr.debug("Estimating digests for %s" % fpath)
+        lgr.debug("Estimating digests for %s", fpath)
         digests = [x() for x in self._digest_funcs]
         with open(fpath, 'rb') as f:
             while True:

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -245,7 +245,7 @@ class ExternalVersions(object):
                         try:
                             module = __import__(modname)
                         except ImportError:
-                            lgr.debug("Module %s seems to be not present" % modname)
+                            lgr.debug("Module %s seems to be not present", modname)
                             return None
                         except Exception as exc:
                             lgr.warning("Failed to import module %s due to %s",

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1452,7 +1452,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
             # confirmed?
             # What's best in case of a list of files?
         except OSError as e:
-            lgr.error("add: %s" % e)
+            lgr.error("add: %s", e)
             raise
 
         # Make sure return value from GitRepo is consistent with AnnexRepo
@@ -1691,7 +1691,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         if index_file:
             env['GIT_INDEX_FILE'] = index_file
 
-        lgr.debug("Committing via direct call of git: %s" % cmd)
+        lgr.debug("Committing via direct call of git: %s", cmd)
 
         file_chunks = generate_file_chunks(files, cmd) if files else [[]]
 
@@ -4146,7 +4146,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                     if 'error-messages' in r else None,
                     logger=lgr)
         except OSError as e:
-            lgr.error("add: %s" % e)
+            lgr.error("add: %s", e)
             raise
 
     def _save_add_submodules(self, paths):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -334,7 +334,7 @@ def _guess_ri_cls(ri):
     # We assume that it is a URL and parse it. Depending on the result
     # we might decide that it was something else ;)
     fields = URL._pr_to_fields(urlparse(ri))
-    lgr.log(5, "Parsed ri %s into fields %s" % (ri, fields))
+    lgr.log(5, "Parsed ri %s into fields %s", ri, fields)
     type_ = 'url'
     # Special treatments
     # file:///path should stay file:
@@ -347,7 +347,7 @@ def _guess_ri_cls(ri):
         # dl+archive:... or just for ssh   hostname:path/p1
         elif '+' not in fields['scheme']:
             type_ = 'ssh'
-            lgr.log(5, "Assuming ssh style ri, adjusted: %s" % (fields,))
+            lgr.log(5, "Assuming ssh style ri, adjusted: %s", (fields,))
 
     if not fields['scheme'] and not fields['hostname']:
         parts = _split_colon(ri)
@@ -374,7 +374,7 @@ def _guess_ri_cls(ri):
 
     cls = TYPES[type_]
     # just parse the ri according to regex matchint ssh "ri" specs
-    lgr.log(5, "Detected %s ri" % type_)
+    lgr.log(5, "Detected %s ri", type_)
     return cls
 
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -347,7 +347,7 @@ def _guess_ri_cls(ri):
         # dl+archive:... or just for ssh   hostname:path/p1
         elif '+' not in fields['scheme']:
             type_ = 'ssh'
-            lgr.log(5, "Assuming ssh style ri, adjusted: %s", (fields,))
+            lgr.log(5, "Assuming ssh style ri, adjusted: %s", fields)
 
     if not fields['scheme'] and not fields['hostname']:
         parts = _split_colon(ri)

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -234,7 +234,7 @@ def prune_and_delete_bucket(bucket):
     #for key in b.list_versions(''):
     #    b.delete_key(key)
     bucket.delete()
-    lgr.info("Bucket %s was removed" % bucket.name)
+    lgr.info("Bucket %s was removed", bucket.name)
 
 
 def set_bucket_public_access_policy(bucket):
@@ -257,7 +257,7 @@ def gen_test_bucket(bucket_name):
     # assure we have none
     try:
         bucket = conn.get_bucket(bucket_name)
-        lgr.info("Deleting existing bucket %s" % bucket.name)
+        lgr.info("Deleting existing bucket %s", bucket.name)
         prune_and_delete_bucket(bucket)
     except:  # MIH: MemoryError?
         # so nothing to worry about
@@ -304,7 +304,7 @@ def _gen_bucket_test0(bucket_name="datalad-test0", versioned=True):
     bucket.delete_key(files(f))
     files.reset_version(f)
     files(f)
-    lgr.info("Bucket %s was generated and populated" % bucket_name)
+    lgr.info("Bucket %s was generated and populated", bucket_name)
 
     return bucket
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -482,7 +482,7 @@ class MultiplexSSHConnection(BaseSSHConnection):
             return False
         # check whether controlmaster is still running:
         cmd = ["ssh", "-O", "check"] + self._ssh_args + [self.sshri.as_str()]
-        lgr.debug("Checking %s by calling %s" % (self, cmd))
+        lgr.debug("Checking %s by calling %s", self, cmd)
         try:
             # expect_stderr since ssh would announce to stderr
             # "Master is running" and that is normal, not worthy warning about
@@ -791,7 +791,7 @@ class MultiplexSSHManager(BaseSSHManager):
                         and (not ctrl_paths
                              or self._connections[c].ctrl_path in ctrl_paths)]
             if to_close:
-                lgr.debug("Closing %d SSH connections..." % len(to_close))
+                lgr.debug("Closing %d SSH connections...", len(to_close))
             for cnct in to_close:
                 f = self._connections[cnct].close
                 if allow_fail:

--- a/datalad/support/third/nda_aws_token_generator.py
+++ b/datalad/support/third/nda_aws_token_generator.py
@@ -25,7 +25,7 @@ class NDATokenGenerator(object):
     def __init__(self, url):
         assert url is not None
         self.url = url
-        logging.debug('constructed with url %s' % url)
+        logging.debug('constructed with url %s', url)
 
     def generate_token(self, username, password):
         logging.info('request to generate AWS token')
@@ -40,11 +40,11 @@ class NDATokenGenerator(object):
         digest_bytes = hasher.digest()
         byte_string = binascii.hexlify(digest_bytes)
         output = byte_string.decode('utf-8')
-        logging.debug('encoded password hash: %s' % output)
+        logging.debug('encoded password hash: %s', output)
         return output
 
     def __construct_request_xml(self, username, encoded_password):
-        logging.debug('constructing request with %s - %s' % (username, encoded_password))
+        logging.debug('constructing request with %s - %s', username, encoded_password)
         soap_schema = self.__schemas['soap']
         datamanager_schema = self.__schemas['data']
 
@@ -69,7 +69,7 @@ class NDATokenGenerator(object):
         return etree.tostring(element)
 
     def __make_request(self, request_message):
-        logging.debug('making post request to %s' % self.url)
+        logging.debug('making post request to %s', self.url)
 
         headers = {
             'SOAPAction': '"generateToken"',
@@ -88,7 +88,7 @@ class NDATokenGenerator(object):
         error = tree.find('.//errorMessage')
         if error is not None:
             error_msg = error.text
-            logging.error('response had error message: %s' % error_msg)
+            logging.error('response had error message: %s', error_msg)
             raise Exception(error_msg)
         generated_token = tree[0][0]
         token_elements = [e.text for e in generated_token[0:4]]

--- a/datalad/support/vcr_.py
+++ b/datalad/support/vcr_.py
@@ -54,7 +54,7 @@ try:
           implementation but the one below)
         """
         path = _get_cassette_path(path)
-        lgr.debug("Using cassette %s" % path)
+        lgr.debug("Using cassette %s", path)
         if return_body is not None:
             my_vcr = _VCR(
                 before_record_response=lambda r: dict(r, body={'string': return_body.encode()}))

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -595,7 +595,7 @@ class SilentHTTPHandler(SimpleHTTPRequestHandler):
     def log_message(self, format, *args):
         if self._silent:
             return
-        lgr.debug("HTTP: " + format % args)
+        lgr.debug("HTTP: " + format, *args)
 
 
 def _multiproc_serve_path_via_http(hostname, path_to_serve_from, queue): # pragma: no cover
@@ -1100,7 +1100,7 @@ def with_testrepos(t, regex='.*', flavors='auto', skip=False, count=None):
                 break
             ntested += 1
             if __debug__:
-                lgr.debug('Running %s on %s' % (t.__name__, uri))
+                lgr.debug('Running %s on %s', t.__name__, uri)
             try:
                 t(*(arg + (uri,)), **kw)
             finally:

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -61,7 +61,7 @@ class _UI_Switcher(object):
 
     def set_backend(self, backend):
         if backend and (backend == self._backend):
-            lgr.debug("not changing backend since the same %s" % backend)
+            lgr.debug("not changing backend since the same %s", backend)
             return
         if backend is None:
             # Might be IPython
@@ -83,7 +83,7 @@ class _UI_Switcher(object):
             else:
                 backend = 'dialog' if is_interactive() else 'no-progress'
         self._ui = KNOWN_BACKENDS[backend]()
-        lgr.debug("UI set to %s" % self._ui)
+        lgr.debug("UI set to %s", self._ui)
         self._backend = backend
 
     @property

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -545,16 +545,16 @@ def rmtemp(f, *args, **kwargs):
     """
     if not os.environ.get('DATALAD_TESTS_TEMP_KEEP'):
         if not os.path.lexists(f):
-            lgr.debug("Path %s does not exist, so can't be removed" % f)
+            lgr.debug("Path %s does not exist, so can't be removed", f)
             return
-        lgr.log(5, "Removing temp file: %s" % f)
+        lgr.log(5, "Removing temp file: %s", f)
         # Can also be a directory
         if os.path.isdir(f):
             rmtree(f, *args, **kwargs)
         else:
             unlink(f)
     else:
-        lgr.info("Keeping temp file: %s" % f)
+        lgr.info("Keeping temp file: %s", f)
 
 
 def file_basename(name, return_ext=False):
@@ -1801,7 +1801,7 @@ def make_tempfile(content=None, wrapped=None, **tkwargs):
 
     if __debug__:
         # TODO mkdir
-        lgr.debug('Created temporary thing named %s"' % filename)
+        lgr.debug('Created temporary thing named %s"', filename)
     try:
         yield filename
     finally:


### PR DESCRIPTION
Use the loggers ability to delay expansion till a message is actually
being rendered.

Some messages are generated so frequently, it may even impact the performance.