### PR TITLE
interface: Allow positional arguments with underscores 

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -22,6 +22,7 @@ from textwrap import wrap
 from ..cmd import WitlessRunner as Runner
 from ..log import is_interactive
 from ..utils import (
+    ensure_unicode,
     getpwd,
     unlink,
 )
@@ -140,6 +141,73 @@ def parser_add_common_opt(parser, opt, names=None, **kwargs):
         parser.add_argument(*opt_tmpl[1], **opt_kwargs)
     else:
         parser.add_argument(*names, **opt_kwargs)
+
+
+def parser_add_common_options(parser, version):
+    parser_add_common_opt(parser, 'log_level')
+    parser_add_common_opt(parser, 'pbs_runner')
+    parser_add_common_opt(parser, 'change_path')
+    parser_add_common_opt(
+        parser,
+        'version',
+        version=f'datalad {version}\n')
+    if __debug__:
+        parser.add_argument(
+            '--dbg', action='store_true', dest='common_debug',
+            help="enter Python debugger when uncaught exception happens")
+        parser.add_argument(
+            '--idbg', action='store_true', dest='common_idebug',
+            help="enter IPython debugger when uncaught exception happens")
+    parser.add_argument(
+        '-c', action='append', dest='cfg_overrides', metavar='KEY=VALUE',
+        help="""configuration variable setting. Overrides any configuration
+        read from a file, but is potentially overridden itself by configuration
+        variables in the process environment.""")
+    parser.add_argument(
+        '-f', '--output-format', dest='common_output_format',
+        default='default',
+        type=ensure_unicode,
+        metavar="{default,json,json_pp,tailored,'<template>'}",
+        help="""select format for returned command results. 'default' give one line
+        per result reporting action, status, path and an optional message;
+        'json' renders a JSON object with all properties for each result (one per
+        line); 'json_pp' pretty-prints JSON spanning multiple lines; 'tailored'
+        enables a command-specific rendering style that is typically
+        tailored to human consumption (no result output otherwise),
+        '<template>' reports any value(s) of any result properties in any format
+        indicated by the template (e.g. '{path}'; compare with JSON
+        output for all key-value choices). The template syntax follows the Python
+        "format() language". It is possible to report individual
+        dictionary values, e.g. '{metadata[name]}'. If a 2nd-level key contains
+        a colon, e.g. 'music:Genre', ':' must be substituted by '#' in the template,
+        like so: '{metadata[music#Genre]}'.""")
+    parser.add_argument(
+        '--report-status', dest='common_report_status',
+        choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],
+        help="""constrain command result report to records matching the given
+        status. 'success' is a synonym for 'ok' OR 'notneeded', 'failure' stands
+        for 'impossible' OR 'error'.""")
+    parser.add_argument(
+        '--report-type', dest='common_report_type',
+        choices=['dataset', 'file'],
+        action='append',
+        help="""constrain command result report to records matching the given
+        type. Can be given more than once to match multiple types.""")
+    parser.add_argument(
+        '--on-failure', dest='common_on_failure',
+        choices=['ignore', 'continue', 'stop'],
+        # no default: better be configure per-command
+        help="""when an operation fails: 'ignore' and continue with remaining
+        operations, the error is logged but does not lead to a non-zero exit code
+        of the command; 'continue' works like 'ignore', but an error causes a
+        non-zero exit code; 'stop' halts on first failure and yields non-zero exit
+        code. A failure is any result with status 'impossible' or 'error'.""")
+    parser.add_argument(
+        '--cmd', dest='_', action='store_true',
+        help="""syntactical helper that can be used to end the list of global
+        command line options before the subcommand label. Options taking
+        an arbitrary number of arguments may require to be followed by a single
+        --cmd in order to enable identification of the subcommand.""")
 
 
 def strip_arg_from_argv(args, value, opt_names):

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -32,7 +32,6 @@ from datalad.support.exceptions import CommandError
 from .helpers import strip_arg_from_argv
 from ..utils import (
     chpwd,
-    ensure_unicode,
     get_suggestions_msg,
     on_msys_tainted_paths,
     setup_exceptionhook,
@@ -100,71 +99,7 @@ def setup_parser(
         formatter_class=formatter_class,
         add_help=False)
     # common options
-    helpers.parser_add_common_opt(parser, 'log_level')
-    helpers.parser_add_common_opt(parser, 'pbs_runner')
-    helpers.parser_add_common_opt(parser, 'change_path')
-    helpers.parser_add_common_opt(
-        parser,
-        'version',
-        version='datalad %s\n' % datalad.__version__)
-    if __debug__:
-        parser.add_argument(
-            '--dbg', action='store_true', dest='common_debug',
-            help="enter Python debugger when uncaught exception happens")
-        parser.add_argument(
-            '--idbg', action='store_true', dest='common_idebug',
-            help="enter IPython debugger when uncaught exception happens")
-    parser.add_argument(
-        '-c', action='append', dest='cfg_overrides', metavar='KEY=VALUE',
-        help="""configuration variable setting. Overrides any configuration
-        read from a file, but is potentially overridden itself by configuration
-        variables in the process environment.""")
-    parser.add_argument(
-        '-f', '--output-format', dest='common_output_format',
-        default='default',
-        type=ensure_unicode,
-        metavar="{default,json,json_pp,tailored,'<template>'}",
-        help="""select format for returned command results. 'default' give one line
-        per result reporting action, status, path and an optional message;
-        'json' renders a JSON object with all properties for each result (one per
-        line); 'json_pp' pretty-prints JSON spanning multiple lines; 'tailored'
-        enables a command-specific rendering style that is typically
-        tailored to human consumption (no result output otherwise),
-        '<template>' reports any value(s) of any result properties in any format
-        indicated by the template (e.g. '{path}'; compare with JSON
-        output for all key-value choices). The template syntax follows the Python
-        "format() language". It is possible to report individual
-        dictionary values, e.g. '{metadata[name]}'. If a 2nd-level key contains
-        a colon, e.g. 'music:Genre', ':' must be substituted by '#' in the template,
-        like so: '{metadata[music#Genre]}'.""")
-    parser.add_argument(
-        '--report-status', dest='common_report_status',
-        choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],
-        help="""constrain command result report to records matching the given
-        status. 'success' is a synonym for 'ok' OR 'notneeded', 'failure' stands
-        for 'impossible' OR 'error'.""")
-    parser.add_argument(
-        '--report-type', dest='common_report_type',
-        choices=['dataset', 'file'],
-        action='append',
-        help="""constrain command result report to records matching the given
-        type. Can be given more than once to match multiple types.""")
-    parser.add_argument(
-        '--on-failure', dest='common_on_failure',
-        choices=['ignore', 'continue', 'stop'],
-        # no default: better be configure per-command
-        help="""when an operation fails: 'ignore' and continue with remaining
-        operations, the error is logged but does not lead to a non-zero exit code
-        of the command; 'continue' works like 'ignore', but an error causes a
-        non-zero exit code; 'stop' halts on first failure and yields non-zero exit
-        code. A failure is any result with status 'impossible' or 'error'.""")
-    parser.add_argument(
-        '--cmd', dest='_', action='store_true',
-        help="""syntactical helper that can be used to end the list of global
-        command line options before the subcommand label. Options taking
-        an arbitrary number of arguments may require to be followed by a single
-        --cmd in order to enable identification of the subcommand.""")
-
+    helpers.parser_add_common_options(parser, datalad.__version__)
     # yoh: atm we only dump to console.  Might adopt the same separation later on
     #      and for consistency will call it --verbose-level as well for now
     # log-level is set via common_opts ATM

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -354,12 +354,12 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     # get the signature
     ndefaults = 0
     args, varargs, varkw, defaults = getargspec(func)
+    defaults = defaults or tuple()
     if add_args:
         add_argnames = sorted(add_args.keys())
         args.extend(add_argnames)
         defaults = defaults + tuple(add_args[k] for k in add_argnames)
-    if defaults is not None:
-        ndefaults = len(defaults)
+    ndefaults = len(defaults)
     # start documentation with what the callable brings with it
     doc = prefix if prefix else u''
     if len(args) > 1:

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -664,11 +664,12 @@ class Interface(object):
         args, varargs, varkw, defaults = getargspec(cls.__call__)
         if defaults is not None:
             ndefaults = len(defaults)
+        default_offset = ndefaults - len(args)
         for i, arg in enumerate(args):
             if not is_api_arg(arg):
                 continue
             param = cls._params_[arg]
-            defaults_idx = ndefaults - len(args) + i
+            defaults_idx = default_offset + i
             cmd_args = param.cmd_args
             if cmd_args == tuple():
                 # explicitly provided an empty sequence of argument names

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -662,7 +662,7 @@ class Interface(object):
         # get the signature
         ndefaults = 0
         args, varargs, varkw, defaults = getargspec(cls.__call__)
-        if not defaults is None:
+        if defaults is not None:
             ndefaults = len(defaults)
         for i, arg in enumerate(args):
             if not is_api_arg(arg):

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -41,6 +41,10 @@ def _args(**kwargs):
     return Namespace(
         # ATM duplicates definitions done by cmdline.main and
         # required by code logic to be defined. (should they?)
+        #
+        # TODO: The common options are now added by
+        # cmdline.helpers.parser_add_common_options(), which can be reused by
+        # tests.
         **updated(
             dict(
                 common_output_format="default"

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -32,6 +32,7 @@ from ..base import (
     nadict,
     nagen,
     NA_STRING,
+    update_docstring_with_parameters,
 )
 from argparse import Namespace
 
@@ -190,3 +191,19 @@ def test_status_custom_summary_no_repeats(path):
         protocol=StdOutCapture)
     out_lines = out['stdout'].splitlines()
     eq_(len(out_lines), len(set(out_lines)))
+
+
+def test_update_docstring_with_parameters_no_kwds():
+    from datalad.support.param import Parameter
+
+    def fn(pos0):
+        "fn doc"
+
+    assert_not_in("3", fn.__doc__)
+    # Call doesn't crash when there are no keyword arguments.
+    update_docstring_with_parameters(
+        fn,
+        dict(pos0=Parameter(doc="pos0 param doc"),
+             pos1=Parameter(doc="pos1 param doc")),
+        add_args={"pos1": 3})
+    assert_in("3", fn.__doc__)

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -13,7 +13,6 @@
 import unittest.mock as mock
 from datalad.tests.utils import *
 from datalad.utils import (
-    swallow_outputs,
     updated,
 )
 from datalad.cmd import (

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -11,7 +11,14 @@
 """
 
 import unittest.mock as mock
-from datalad.tests.utils import *
+from datalad.tests.utils import (
+    assert_in,
+    assert_not_in,
+    eq_,
+    ok_,
+    patch_config,
+    with_tempfile,
+)
 from datalad.utils import (
     updated,
 )

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1027,7 +1027,7 @@ class Addurls(Interface):
             it ends with ".tsv". Otherwise, treat it as a CSV file.""",
             constraints=EnsureChoice(*INPUT_TYPES)),
         exclude_autometa=Parameter(
-            args=("-x", "--exclude_autometa"),
+            args=("-x", "--exclude-autometa"),
             metavar="REGEXP",
             doc="""By default, metadata field=value pairs are constructed with
             each column in `URL-FILE`, excluding any single column that is

--- a/datalad/plugin/addurls.py
+++ b/datalad/plugin/addurls.py
@@ -1123,7 +1123,9 @@ class Addurls(Interface):
                  message=None, dry_run=False, fast=False, ifexists=None,
                  missing_value=None, save=True, version_urls=False,
                  cfg_proc=None, jobs=None, drop_after=False):
-        # Temporarily work around gh-2269.
+        # This was to work around gh-2269. That's fixed, but changing the
+        # positional argument names now would cause breakage for any callers
+        # that used these arguments as keyword arguments.
         url_file = urlfile
         url_format, filename_format = urlformat, filenameformat
 


### PR DESCRIPTION
This series updates the argument parsing logic so that parameter names for positional options can use underscores.  The third commit contains a fix for a type bug that I ran into while testing this.  The last commit contains the main fix.

Closes #2269.

cc @christian-monch
