### PR TITLE
BF: Sibling setup missed update-server-info

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -643,13 +643,12 @@ def _create_sibling_ria(
             disabled_hook.rename(enabled_hook)
         if group:
             # TODO; do we need a cwd here?
-            subprocess.run(chgrp_cmd, cwd=quote_cmdlinearg(ds.path))
+            subprocess.run(chgrp_cmd, cwd=ds.path)
         # finally update server
         if post_update_hook:
             # Conditional on post_update_hook, since one w/o the other doesn't
             # seem to make much sense.
-            subprocess.run("git update-server-info",
-                           cwd=quote_cmdlinearg(ds.path))
+            gr.call_git(["update-server-info"])
 
     # add a git remote to the bare repository
     # Note: needs annex-ignore! Otherwise we might push into dirhash

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -622,6 +622,14 @@ def _create_sibling_ria(
             # created for it, set its group to a desired one if was
             # provided with the same chgrp
             ssh(chgrp_cmd)
+
+        # finally update server
+        if post_update_hook:
+            # Conditional on post_update_hook, since one w/o the other doesn't
+            # seem to make much sense.
+            ssh('cd {rootdir} && git update-server-info'.format(
+                rootdir=quote_cmdlinearg(str(repo_path))
+            ))
     else:
         gr = GitRepo(repo_path, create=True, bare=True,
                      shared=shared if shared else None)
@@ -636,6 +644,12 @@ def _create_sibling_ria(
         if group:
             # TODO; do we need a cwd here?
             subprocess.run(chgrp_cmd, cwd=quote_cmdlinearg(ds.path))
+        # finally update server
+        if post_update_hook:
+            # Conditional on post_update_hook, since one w/o the other doesn't
+            # seem to make much sense.
+            subprocess.run("git update-server-info",
+                           cwd=quote_cmdlinearg(ds.path))
 
     # add a git remote to the bare repository
     # Note: needs annex-ignore! Otherwise we might push into dirhash

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -24,6 +24,7 @@ from datalad.tests.utils import (
     chpwd,
     eq_,
     known_failure_githubci_win,
+    ok_exists,
     skip_if_on_windows,
     skip_ssh,
     slow,
@@ -114,7 +115,7 @@ def _test_create_store(host, base_path, ds_path, clone_path):
 
     # check bare repo:
     git_config = Path(base_path) / ds.id[:3] / ds.id[3:] / 'config'
-    assert git_config.exists()
+    ok_exists(git_config)
     content = git_config.read_text()
     assert_in("[datalad \"ora-remote\"]", content)
     super_uuid = ds.config.get("remote.{}.annex-uuid".format('datastore-storage'))


### PR DESCRIPTION
create-sibling-ria missed out on calling `git update-server-info` after
setting up the remote repository. This would result in an unsuccessful
fetch at the end and would need a push to be fixed (since post update
hook is enabled).

Closes #5530

