### PR TITLE
DOC: download-url: Add examples of path's trailing slash behavior

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -98,6 +98,13 @@ class DownloadURL(Interface):
              code_py="download_url(urls='s3://bucket/file2.dat', message='added a file', path='myfile.dat')",
              code_cmd="""datalad download-url -m 'added a file' -O myfile.dat \\
                          s3://bucket/file2.dat"""),
+        dict(text="Append a trailing slash to the target path "
+                  "to download into a specified directory",
+             code_py="download_url(['http://example.com/file.dat'], path='data/')",
+             code_cmd="datalad download-url --path=data/ http://example.com/file.dat"),
+        dict(text="Leave off the trailing slash to download into a regular file",
+             code_py="download_url(['http://example.com/file.dat'], path='data')",
+             code_cmd="datalad download-url --path=data http://example.com/file.dat"),
     ]
 
     @staticmethod


### PR DESCRIPTION
Since de9d692318 (ENH: download_url: Use trailing separator to signal
directory target, 2019-11-01), the path value is treated as a
directory if a trailing separator is given and as a regular file
otherwise.  --path's description mentions this, but the behavior can
be surprising/confusing, so add examples to highlight the behavior.

Closes #5528.

---

The example section in `datalad download-url --help` now includes

```
Append a trailing slash to the target path to download into a
specified directory::

   % datalad download-url --path=data/ http://example.com/file.dat

Leave off the trailing slash to download into a regular file::

   % datalad download-url --path=data http://example.com/file.dat
```

The Python help now includes

```
    Append a trailing slash to the target path to download into a
    specified directory::

       > download_url(['http://example.com/file.dat'], path='data/')

    Leave off the trailing slash to download into a regular file::

       > download_url(['http://example.com/file.dat'], path='data')
```

cc: @manuelakuhn