### PR TITLE
annexrepo.whereis: Implement batch=True

### DIFF
--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -466,9 +466,8 @@ class TestAddArchiveOptions():
 
         # previous state of things:
         prev_files = list(find_files('.*', self.annex.path))
-        with assert_raises(Exception), \
-                swallow_logs():
-            self.annex.whereis(key1, key=True, output='full')
+        assert_equal(self.annex.whereis(key1, key=True, output='full'), {})
+
         commits_prior = list(self.annex.get_branch_commits_('git-annex'))
         add_archive_content('1.tar', annex=self.annex, strip_leading_dirs=True, delete_after=True)
         commits_after = list(self.annex.get_branch_commits_('git-annex'))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2284,8 +2284,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                                     for x in ('description', 'here', 'urls')
                                     }
                    for remote in j.get('whereis')}
-        if WEB_SPECIAL_REMOTE_UUID in remotes:
-            assert(remotes[WEB_SPECIAL_REMOTE_UUID]['description'] == 'web')
         return remotes
 
     # TODO: reconsider having any magic at all and maybe just return a list/dict always

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2279,7 +2279,6 @@ class AnnexRepo(GitRepo, RepoInterface):
     def _whereis_json_to_dict(self, j):
         """Convert json record returned by annex whereis --json to our dict representation for it
         """
-        assert (j.get('success', True) is True)
         # process 'whereis' containing list of remotes
         remotes = {remote['uuid']: {x: remote.get(x, None)
                                     for x in ('description', 'here', 'urls')

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2283,7 +2283,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         remotes = {remote['uuid']: {x: remote.get(x, None)
                                     for x in ('description', 'here', 'urls')
                                     }
-                   for remote in j.get('whereis')}
+                   for remote in j['whereis']}
         return remotes
 
     # TODO: reconsider having any magic at all and maybe just return a list/dict always

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2515,3 +2515,18 @@ def test_call_annex(path):
         ar._call_annex(['not-an-annex-command'])
     except CommandError as e:
         assert_in('Invalid argument', e.stderr)
+
+
+@with_tempfile
+def test_whereis_zero_copies(path):
+    repo = AnnexRepo(path, create=True)
+    (repo.pathobj / "foo").write_text("foo")
+    repo.save()
+    repo.drop(["foo"], options=["--force"])
+
+    for output in "full", "uuids", "descriptions":
+        res = repo.whereis(files=["foo"], output=output)
+        if output == "full":
+            assert_equal(res["foo"], {})
+        else:
+            assert_equal(res, [[]])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -404,6 +404,7 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     eq_(lfull[non_web_remote]['urls'], [])
     assert_not_in('uuid', lfull[WEB_SPECIAL_REMOTE_UUID])  # no uuid in the records
     eq_(lfull[WEB_SPECIAL_REMOTE_UUID]['urls'], [testurl])
+    assert_equal(lfull[WEB_SPECIAL_REMOTE_UUID]['description'], 'web')
 
     # --all and --key are incompatible
     assert_raises(CommandError, ar.whereis, [], options='--all', output='full', key=True)


### PR DESCRIPTION
This series fills in the `batch=True` functionality of `AnnexRepo.whereis`, replacing the noop to-do warning from when the `batch` parameter was introduced in v0.3 (2016).

Note that this PR's base is master, but the branch is on top of maint.  That is so that the bug fix in the first commit can be merged to maint (if desired).

Closes #5457.