### PR TITLE
update: support `reset --hard` action

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -24,6 +24,9 @@ from datalad.api import (
     update,
     remove,
 )
+from datalad.distribution.update import (
+    _process_how_args,
+)
 from datalad.utils import (
     knows_annex,
     rmtree,
@@ -47,6 +50,7 @@ from datalad.tests.utils import (
     maybe_adjust_repo,
     ok_file_has_content,
     assert_status,
+    assert_raises,
     assert_repo_status,
     assert_result_count,
     assert_in_results,
@@ -924,3 +928,34 @@ def test_update_adjusted_incompatible_with_ff_only(path):
     assert_in_results(
         ds_clone.update(on_failure="ignore"),
         action="update", status="ok")
+
+
+def test_process_how_args():
+    # --merge maps onto --how values. It has no equivalent of --how-subds,
+    # --which just gets set to --how's value when unspecified.
+    eq_(_process_how_args(merge=False, how=None, how_subds=None),
+        (None, None))
+    eq_(_process_how_args(merge=True, how=None, how_subds=None),
+        ("merge", "merge"))
+    eq_(_process_how_args(merge="any", how=None, how_subds=None),
+        ("merge", "merge"))
+    eq_(_process_how_args(merge="ff-only", how=None, how_subds=None),
+        ("ff-only", "ff-only"))
+
+    # Values other than the default --merge=False can not be mixed with
+    # non-default how values.
+    with assert_raises(ValueError):
+        _process_how_args(merge=True, how="merge", how_subds=None)
+    with assert_raises(ValueError):
+        _process_how_args(merge=True, how=None, how_subds="merge")
+
+    # --how-subds inherits the value of --how...
+    eq_(_process_how_args(merge=False, how="fetch", how_subds=None),
+        (None, None))
+    eq_(_process_how_args(merge=False, how="merge", how_subds=None),
+        ("merge", "merge"))
+    eq_(_process_how_args(merge=False, how="ff-only", how_subds=None),
+        ("ff-only", "ff-only"))
+    # ... unless --how-subds is explicitly specified.
+    eq_(_process_how_args(merge=False, how="merge", how_subds="fetch"),
+        ("merge", None))

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -907,3 +907,20 @@ def test_update_follow_parentds_lazy_other_branch(path):
         ds_clone.update(follow="parentds-lazy", merge="ff-only",
                         recursive=True)
         ok_(op.lexists(str(ds_clone.pathobj / "sub" / "foo")))
+
+
+@with_tempfile(mkdir=True)
+def test_update_adjusted_incompatible_with_ff_only(path):
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       recursive=True, result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+
+    assert_in_results(
+        ds_clone.update(merge="ff-only", on_failure="ignore"),
+        action="update", status="impossible")
+    assert_in_results(
+        ds_clone.update(on_failure="ignore"),
+        action="update", status="ok")

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -59,6 +59,7 @@ from datalad.tests.utils import (
     SkipTest,
     slow,
     known_failure_windows,
+    neq_,
 )
 from datalad import cfg as dl_cfg
 
@@ -928,6 +929,100 @@ def test_update_adjusted_incompatible_with_ff_only(path):
     assert_in_results(
         ds_clone.update(on_failure="ignore"),
         action="update", status="ok")
+
+
+@slow  # ~10s
+@skip_if_adjusted_branch
+@with_tempfile(mkdir=True)
+def check_update_how_subds_different(follow, path):
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    ds_src_sub = ds_src.create("sub")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       recursive=True, result_xfm="datasets")
+    (ds_clone.pathobj / "foo").write_text("foo")
+    ds_clone.save()
+    ds_clone_sub = Dataset(ds_clone.pathobj / "sub")
+
+    (ds_src_sub.pathobj / "bar").write_text("bar")
+    ds_src.save(recursive=True)
+
+    # Add unrecorded state to make --follow=sibling/parentds differ.
+    (ds_src_sub.pathobj / "baz").write_text("baz")
+    ds_src_sub.save()
+
+    ds_clone_repo = ds_clone.repo
+    ds_clone_hexsha_pre = ds_clone_repo.get_hexsha()
+
+    ds_clone_sub_repo = ds_clone_sub.repo
+    ds_clone_sub_branch_pre = ds_clone_sub_repo.get_active_branch()
+
+    res = ds_clone.update(follow=follow, how="merge", how_subds="reset",
+                          recursive=True)
+
+    assert_result_count(res, 1, action="merge", status="ok",
+                        path=ds_clone.path)
+    assert_result_count(res, 1, action="update.reset", status="ok",
+                        path=ds_clone_sub.path)
+
+    ds_clone_hexsha_post = ds_clone_repo.get_hexsha()
+    neq_(ds_clone_hexsha_pre, ds_clone_hexsha_post)
+    neq_(ds_src.repo.get_hexsha(), ds_clone_hexsha_post)
+    ok_(ds_clone_repo.is_ancestor(ds_clone_hexsha_pre, ds_clone_hexsha_post))
+
+    eq_(ds_clone_sub.repo.get_hexsha(),
+        ds_src_sub.repo.get_hexsha(None if follow == "sibling" else "HEAD~"))
+    ds_clone_sub_branch_post = ds_clone_sub_repo.get_active_branch()
+    eq_(ds_clone_sub_branch_pre, ds_clone_sub_branch_post)
+
+
+def test_update_how_subds_different():
+    yield check_update_how_subds_different, "sibling"
+    yield check_update_how_subds_different, "parentds"
+
+
+@slow  # ~15s
+@skip_if_adjusted_branch
+@with_tempfile(mkdir=True)
+def test_update_reset_dirty(path):
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    ds_src_s1 = ds_src.create("s1")
+    ds_src_s2 = ds_src.create("s2")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       recursive=True, result_xfm="datasets")
+
+    (ds_src_s1.pathobj / "foo").write_text("foo")
+    (ds_src_s2.pathobj / "bar").write_text("bar")
+    ds_src.save(recursive=True)
+
+    ds_clone_s1 = Dataset(ds_clone.pathobj / "s1")
+    ds_clone_s2 = Dataset(ds_clone.pathobj / "s2")
+    (ds_clone_s1.pathobj / "dirt").write_text("")
+
+    res = ds_clone.update(follow="sibling", how="reset", recursive=True,
+                          on_failure="ignore")
+
+    assert_result_count(res, 1, path=ds_clone.path,
+                        action=f"update.reset", status="error")
+    assert_result_count(res, 1, path=ds_clone_s1.path,
+                        action=f"update.reset", status="error")
+    assert_result_count(res, 1, path=ds_clone_s2.path,
+                        action=f"update.reset", status="ok")
+
+    # s2 was reset...
+    eq_(ds_src_s2.repo.get_hexsha(), ds_clone_s2.repo.get_hexsha())
+    # ... but s1 and the top-level dataset stayed behind due to the dirty tree.
+    eq_(ds_src.repo.get_hexsha("HEAD~"), ds_clone.repo.get_hexsha())
+    eq_(ds_src_s1.repo.get_hexsha("HEAD~"), ds_clone_s1.repo.get_hexsha())
+
+    assert_repo_status(ds_clone.path,
+                       modified=[ds_clone_s1.repo.path,
+                                 ds_clone_s2.repo.path])
 
 
 def test_process_how_args():

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -437,14 +437,16 @@ def _annex_plain_merge(repo, _, target, opts=None):
     yield from _plain_merge(repo, _, target, opts=opts)
     # Note: Avoid repo.merge_annex() so we don't needlessly create synced/
     # branches.
-    repo.call_annex(["merge"])
+    yield _try_command(
+        {"action": "update.annex_merge", "message": "Merged annex branch"},
+        repo.call_annex, ["merge"])
 
 
 def _annex_sync(repo, remote, _target, opts=None):
-    repo.call_annex(
-        ['sync', '--no-push', '--pull', '--no-commit', '--no-content', remote]
-    )
-    return []
+    yield _try_command(
+        {"action": "update.annex_sync", "message": "Ran git-annex-sync"},
+        repo.call_annex,
+        ['sync', '--no-push', '--pull', '--no-commit', '--no-content', remote])
 
 
 def _reobtain(ds, update_fn):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -92,8 +92,12 @@ class Update(Interface):
             constraints=EnsureStr() | EnsureNone()),
         sibling=Parameter(
             args=("-s", "--sibling",),
-            doc="""name of the sibling to update from. If no sibling
-            is given, updates from all siblings are obtained.""",
+            doc="""name of the sibling to update from. When unspecified,
+            updates from all siblings are fetched. If there is more than one
+            sibling and changes will be brought into the working tree (as
+            requested via [CMD: --merge CMD][PY: `merge` PY]), a sibling will
+            be chosen based on the configured remote for the current
+            branch.""",
             constraints=EnsureStr() | EnsureNone()),
         dataset=Parameter(
             args=("-d", "--dataset"),
@@ -108,12 +112,9 @@ class Update(Interface):
             const="any",
             nargs="?",
             constraints=EnsureBool() | EnsureChoice("any", "ff-only"),
-            doc="""merge obtained changes from the sibling. If a sibling is not
-            explicitly given and there is only a single known sibling, that
-            sibling is used. Otherwise, an unspecified sibling defaults to the
-            configured remote for the current branch. By default, changes are
-            fetched from the sibling but not merged into the current branch.
-            With [CMD: --merge or --merge=any CMD][PY: merge=True or
+            doc="""merge obtained changes from the sibling. By default, changes
+            are fetched from the sibling but not merged into the current
+            branch. With [CMD: --merge or --merge=any CMD][PY: merge=True or
             merge="any" PY], the changes will be merged into the current
             branch. A value of 'ff-only' restricts the allowed merges to
             fast-forwards."""),

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -409,7 +409,7 @@ class Update(Interface):
                     path)
             if refds in update_failures:
                 lgr.warning("Not saving because top-level dataset %s "
-                            "had a update failure in subdataset",
+                            "had an update failure in subdataset",
                             refds.path)
             else:
                 save_paths = [p for p in save_paths if p != refds.path]


### PR DESCRIPTION
This is a work-in-progress series that extends `update` with the `reset --hard` functionality proposed in gh-5498.  It needs more tests, at the very least.  I'd be interesed in feedback on the names, the addition of two options, and keeping `--merge` around.
