### PR TITLE
interface: Include message in json{,_pp} output

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -632,7 +632,7 @@ def _process_results(
         elif result_renderer in ('json', 'json_pp'):
             ui.message(json.dumps(
                 {k: v for k, v in res.items()
-                 if k not in ('message', 'logger')},
+                 if k not in ('logger')},
                 sort_keys=True,
                 indent=2 if result_renderer.endswith('_pp') else None,
                 default=str))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -635,7 +635,7 @@ def _process_results(
                  if k not in ('message', 'logger')},
                 sort_keys=True,
                 indent=2 if result_renderer.endswith('_pp') else None,
-                default=lambda x: str(x)))
+                default=str))
         elif result_renderer in ('tailored', 'default'):
             if hasattr(cmd_class, 'custom_result_renderer'):
                 cmd_class.custom_result_renderer(res, **allkwargs)


### PR DESCRIPTION
When rendering results as json, the message and logger fields are
dropped.  Information about the logger seems unlikely to be useful,
but filtering out the message can lose information that's not
available elsewhere, particularly for commands that put a caught
exception in the message field of status=error results.

The message has been filtered out since result handling was introduced
in v0.6.0.  2747ed1928 (RF: Centralize logging in result evaluation,
2017-03-02) doesn't give an explicit reason for this, but it's likely
because the message can be a `(<format string>, <value>, ...)` tuple,
and those values aren't necessarily JSON serializable.  However, this
should no longer be an issue as of v0.11.0 because json.dumps() is
called with a default=str.

Retain the message in the json rendering to avoid losing information.

At least in the case of exceptions, another option would be to update
these commands to use a field that isn't dropped.  get_status_dict()
recently gained an 'exception' keyword, which it formats as the
'exception_traceback' field, so this approach is already used to some
degree.  Aside from backward compatibility concerns, the problem with
using a different field is that then callers using the default
renderer do not see the information.

Re: https://github.com/datalad/datalad/pull/5517#discussion_r599140556
