### PR TITLE
run: Add dry run mode

### DIFF
--- a/.codespell-ignorelines
+++ b/.codespell-ignorelines
@@ -1,1 +1,2 @@
                 %%NAME\tthe name of the dataset, where slashes are replaced by
+               inputs=["fo*"], outputs=["b*r"])

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -30,6 +30,7 @@ from datalad.dochelpers import exc_str
 from datalad.interface.unlock import Unlock
 
 from datalad.interface.base import Interface
+from datalad.interface.utils import default_result_renderer
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
@@ -37,6 +38,7 @@ from datalad.interface.common_opts import save_message_opt
 
 from datalad.config import anything2bool
 
+import datalad.support.ansi_colors as ac
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureBool
@@ -49,6 +51,8 @@ from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
 from datalad.distribution.dataset import datasetmethod
+
+from datalad.ui import ui
 
 from datalad.utils import (
     chpwd,
@@ -171,6 +175,8 @@ class Run(Interface):
              'outfile.txt' 'code/script.sh'""")
     ]
 
+    result_renderer = "tailored"
+
     _params_ = dict(
         cmd=Parameter(
             args=("cmd",),
@@ -231,6 +237,13 @@ class Run(Interface):
             '.datalad/runinfo' directory (customizable via the
             'datalad.run.record-directory' configuration variable).""",
             constraints=EnsureNone() | EnsureBool()),
+        dry_run=Parameter(
+            # Leave out common -n short flag to avoid confusion with
+            # `containers-run [-n|--container-name]`.
+            args=("--dry-run",),
+            action="store_true",
+            doc="""Do not run the command; just display details about the
+            command execution."""),
     )
 
     @staticmethod
@@ -245,15 +258,53 @@ class Run(Interface):
             assume_ready=None,
             explicit=False,
             message=None,
-            sidecar=None):
+            sidecar=None,
+            dry_run=False):
         for r in run_command(cmd, dataset=dataset,
                              inputs=inputs, outputs=outputs,
                              expand=expand,
                              assume_ready=assume_ready,
                              explicit=explicit,
                              message=message,
-                             sidecar=sidecar):
+                             sidecar=sidecar,
+                             dry_run=dry_run):
             yield r
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        if kwargs.get("dry_run") and "dry_run_info" in res:
+            ui.message(ac.color_word("Dry run information", ac.MAGENTA))
+
+            def fmt_line(key, value, multiline=False):
+                return (" {key}:{sep}{value}"
+                        .format(key=ac.color_word(key, ac.BOLD),
+                                sep=os.linesep + "  " if multiline else " ",
+                                value=value))
+
+            dry_run_info = res["dry_run_info"]
+            lines = [fmt_line("location", dry_run_info["pwd_full"])]
+
+            # TODO: Inputs and outputs could be pretty long. These may be worth
+            # truncating.
+            inputs = dry_run_info["inputs"]
+            if inputs:
+                lines.append(fmt_line("expanded inputs", inputs,
+                                      multiline=True))
+            outputs = dry_run_info["outputs"]
+            if outputs:
+                lines.append(fmt_line("expanded outputs", outputs,
+                                      multiline=True))
+
+            cmd = res["run_info"]["cmd"]
+            cmd_expanded = dry_run_info["cmd_expanded"]
+            lines.append(fmt_line("command", cmd, multiline=True))
+            if cmd != cmd_expanded:
+                lines.append(fmt_line("expanded command", cmd_expanded,
+                                      multiline=True))
+
+            ui.message(os.linesep.join(lines))
+        else:
+            default_result_renderer(res)
 
 
 def get_command_pwds(dataset):
@@ -513,6 +564,7 @@ def _execute_command(command, pwd, expected_exit=None):
 
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 assume_ready=None, explicit=False, message=None, sidecar=None,
+                dry_run=False,
                 extra_info=None,
                 rerun_info=None,
                 extra_inputs=None,
@@ -598,7 +650,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     # ATTN: For correct path handling, all dataset commands call should be
     # unbound. They should (1) receive a string dataset argument, (2) receive
     # relative paths, and (3) happen within a chpwd(pwd) context.
-    if not inject:
+    if not (inject or dry_run):
         with chpwd(pwd):
             for res in prepare_inputs(
                     ds_path,
@@ -662,6 +714,16 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         run_info["dsid"] = ds.id
     if extra_info:
         run_info.update(extra_info)
+
+    if dry_run:
+        yield get_status_dict(
+            "run", ds=ds, status="ok", message="Dry run",
+            run_info=run_info,
+            dry_run_info=dict(cmd_expanded=cmd_expanded,
+                              pwd_full=pwd,
+                              inputs=inputs.expand(),
+                              outputs=outputs.expand()))
+        return
 
     if not inject:
         cmd_exitcode, exc = _execute_command(

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -732,7 +732,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
     if dry_run:
         yield get_status_dict(
-            "run", ds=ds, status="ok", message="Dry run",
+            "run [dry-run]", ds=ds, status="ok", message="Dry run",
             run_info=run_info,
             dry_run_info=dict(cmd_expanded=cmd_expanded,
                               pwd_full=pwd,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -243,7 +243,9 @@ class Run(Interface):
             args=("--dry-run",),
             action="store_true",
             doc="""Do not run the command; just display details about the
-            command execution."""),
+            command execution. Note that input and output globs underneath an
+            uninstalled dataset will be left unexpanded because no subdatasets
+            will be installed for a dry run."""),
     )
 
     @staticmethod

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -66,7 +66,6 @@ from datalad.tests.utils import (
     ok_,
     ok_exists,
     ok_file_has_content,
-    slow,
     swallow_logs,
     swallow_outputs,
     with_tempfile,

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -629,14 +629,14 @@ def test_dry_run(path):
     # that to the default renderer.
     with swallow_outputs() as cmo:
         with assert_raises(IncompleteResultsError):
-            ds.run("blah ", dry_run=True)
+            ds.run("blah ", dry_run="basic")
         assert_in("run(impossible)", cmo.out)
         assert_not_in("blah", cmo.out)
 
     ds.save()
 
     with swallow_outputs() as cmo:
-        ds.run("blah ", dry_run=True)
+        ds.run("blah ", dry_run="basic")
         assert_in("Dry run", cmo.out)
         assert_in("location", cmo.out)
         assert_in("blah", cmo.out)
@@ -644,7 +644,7 @@ def test_dry_run(path):
         assert_not_in("expanded outputs", cmo.out)
 
     with swallow_outputs() as cmo:
-        ds.run("blah {inputs} {outputs}", dry_run=True,
+        ds.run("blah {inputs} {outputs}", dry_run="basic",
                inputs=["fo*"], outputs=["b*r"])
         assert_in(
             'blah "foo" "bar"' if on_windows else "blah foo bar",
@@ -653,6 +653,13 @@ def test_dry_run(path):
         assert_in("['foo']", cmo.out)
         assert_in("expanded outputs", cmo.out)
         assert_in("['bar']", cmo.out)
+
+    # Just the command.
+    with swallow_outputs() as cmo:
+        ds.run("blah ", dry_run="command")
+        assert_not_in("Dry run", cmo.out)
+        assert_in("blah", cmo.out)
+        assert_not_in("inputs", cmo.out)
 
     # The output file wasn't unlocked.
     assert_repo_status(ds.path)
@@ -665,7 +672,7 @@ def test_dry_run(path):
 
     # If a subdataset is installed, it works as usual.
     with swallow_outputs() as cmo:
-        ds.run("blah {inputs}", dry_run=True, inputs=["sub/b*"])
+        ds.run("blah {inputs}", dry_run="basic", inputs=["sub/b*"])
         assert_in(
             'blah "sub\\baz"' if on_windows else 'blah sub/baz',
             cmo.out)
@@ -673,6 +680,6 @@ def test_dry_run(path):
     # However, a dry run will not do the install/reglob procedure.
     ds.uninstall("sub", check=False)
     with swallow_outputs() as cmo:
-        ds.run("blah {inputs}", dry_run=True, inputs=["sub/b*"])
+        ds.run("blah {inputs}", dry_run="basic", inputs=["sub/b*"])
         assert_in("sub/b*", cmo.out)
         assert_not_in("baz", cmo.out)


### PR DESCRIPTION
This PR implements the dry-run operation proposed in gh-5538 by adding a `--dry-run` flag to `run` along with a custom result renderer.  I went light on the reported details, but, if desired, I think it should be straightforward to extend this approach later with more information.

I decided to go with the name `--dry-run` because I think that's the most familiar/obvious name, though `--report` would align with `rerun`.  Also, `--report` might be a bit more natural if this option is later extended to take an optional value (e.g., to restrict or extend what is reported).

---

```
$ touch foo
$ datalad save

$ datalad run --dry-run -i 'fo*' -o out 'cat {inputs[0]} >{outputs[0]}'
Dry run information
 location: /tmp/dl-vaZ53PN
 expanded inputs:
  ['foo']
 expanded outputs:
  ['out']
 command:
  cat {inputs[0]} >{outputs[0]}
 expanded command:
  cat foo >out
```
