### PR TITLE
DOC: Replace leftover 'datalad add' with 'datalad save'

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -123,7 +123,7 @@ class Run(Interface):
       Add a placeholder "name" with the value "joe"::
 
         % git config --file=.datalad/config datalad.run.substitutions.name joe
-        % datalad add -m "Configure name placeholder" .datalad/config
+        % datalad save -m "Configure name placeholder" .datalad/config
 
       Access the new placeholder in a command::
 

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -240,7 +240,7 @@ class AddArchiveContent(Interface):
         if archive in annex.untracked_files:
             raise RuntimeError(
                 "The archive is not under annex yet. You should run 'datalad "
-                "add {}' first".format(archive))
+                "save {}' first".format(archive))
 
         if not allow_dirty and annex.dirty:
             # already saved me once ;)

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -389,9 +389,9 @@ def test_add_archive_use_archive_dir(repo_path):
         with assert_raises(RuntimeError) as cmr:
             add_archive_content(archive_path)
         assert_re_in(
-            "You should run ['\"]datalad add 4u\\\\1\\.tar\\.gz['\"] first"
+            "You should run ['\"]datalad save 4u\\\\1\\.tar\\.gz['\"] first"
             if on_windows else
-            "You should run ['\"]datalad add 4u/1\\.tar\\.gz['\"] first",
+            "You should run ['\"]datalad save 4u/1\\.tar\\.gz['\"] first",
             str(cmr.exception), match=False
         )
         with swallow_outputs():


### PR DESCRIPTION
When 'datalad add' was deprecated, a few spots in the documentation
slipped past the tree-wide `s/add/save/` update.

(Aside from the changelog, it looks like the only remaining use of
'datalad add' is in a generated file,
docs/source/basics_nesteddatasets.rst.in.)