### PR TITLE
TST: clone: Ensure valid identity when patching HOME

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -573,6 +573,13 @@ def test_expanduser(srcpath, destpath):
     src = Dataset(Path(srcpath) / 'src').create()
     dest = Dataset(Path(destpath) / 'dest').create()
 
+    # We switch away from home set up in datalad.setup_package(), so make sure
+    # we have a valid identity.
+    with open(op.join(srcpath, ".gitconfig"), "w") as fh:
+        fh.write("[user]\n"
+                 "name = DataLad oooooTester\n"
+                 "email = test@example.com\n")
+
     with chpwd(destpath), patch.dict('os.environ', get_home_envvars(srcpath)):
         res = clone(op.join('~', 'src'), 'dest', result_xfm=None, return_type='list',
                     on_failure='ignore')


### PR DESCRIPTION
test_expanduser() is failing in the Conda build for 14.1 with

    fatal: unable to auto-detect email address (got 'conda@9bc15aa8a5d2.(none)')

It's not clear why this issue has only just shown up, but
test_expanduser() can't rely on user.name and user.email being set
because it switches away from the test home set up by
datalad.setup_package().  Set up user.name and user.email in the new
home to ensure that there is a usable identity.

Re: https://github.com/conda-forge/datalad-feedstock/pull/55

---

- [x] check whether patch resolves Conda build failure