### PR TITLE
ENH: Make --version output just version, and CMD --version output module and its version

### DIFF
--- a/datalad/cmdline/common_args.py
+++ b/datalad/cmdline/common_args.py
@@ -26,6 +26,8 @@ help = (
                  the use of a pager for displaying the help message""")
 )
 
+# note: no longer used by the main `datalad` entry point, but could still
+# be used by downstream software, so was left in place
 version = (
     'version', ('--version',),
     dict(action='version',

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -16,6 +16,7 @@ import os
 import re
 import sys
 import gzip
+import warnings
 from tempfile import NamedTemporaryFile
 from textwrap import wrap
 
@@ -132,6 +133,55 @@ class LogLevelAction(argparse.Action):
 #        i = 1
 
 
+def parser_add_version_opt(parser, mod_name, include_name=False, delay=False):
+    """Setup --version option
+
+    Parameters
+    ----------
+    parser:
+    mod_name: str, optional
+    include_name: bool, optional
+    delay: bool, optional
+      If set to True, no action is taken immediately, and rather
+      we assign the function which would print the version. Necessary for
+      early pre-parsing of the cmdline
+    """
+
+    def print_version():
+        mod = sys.modules.get(mod_name, None)
+        version = getattr(mod, '__version__', None)
+        if version is None:
+            # Let's use the standard Python mechanism if underlying module
+            # did not provide __version__
+            try:
+                import pkg_resources
+                version = pkg_resources.get_distribution(mod_name).version
+            except:
+                version = "unknown"
+        if include_name:
+            print("%s %s" % (mod_name, version))
+        else:
+            print(version)
+        sys.exit(0)
+
+    class versionAction(argparse.Action):
+        def __call__(self, parser, args, values, option_string=None):
+            if delay:
+                setattr(args, self.dest, print_version)
+            else:
+                print_version()
+
+    parser.add_argument(
+        "--version",
+        nargs=0,
+        action=versionAction,
+        help=(
+            "show the program's version"
+            if not mod_name
+            else "show the module and its version which provides the command")
+    )
+
+
 def parser_add_common_opt(parser, opt, names=None, **kwargs):
     from . import common_args
     opt_tmpl = getattr(common_args, opt)
@@ -143,14 +193,15 @@ def parser_add_common_opt(parser, opt, names=None, **kwargs):
         parser.add_argument(*names, **opt_kwargs)
 
 
-def parser_add_common_options(parser, version):
+def parser_add_common_options(parser, version=None):
     parser_add_common_opt(parser, 'log_level')
     parser_add_common_opt(parser, 'pbs_runner')
     parser_add_common_opt(parser, 'change_path')
-    parser_add_common_opt(
-        parser,
-        'version',
-        version=f'datalad {version}\n')
+    if version is not None:
+        warnings.warn("Passing 'version' to parser_add_common_options is deprecated "
+                      "and will be removed in a future release.",
+                      DeprecationWarning)
+    parser_add_version_opt(parser, 'datalad', include_name=False, delay=True)
     if __debug__:
         parser.add_argument(
             '--dbg', action='store_true', dest='common_debug',

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -198,7 +198,8 @@ def parser_add_common_options(parser, version=None):
     parser_add_common_opt(parser, 'pbs_runner')
     parser_add_common_opt(parser, 'change_path')
     if version is not None:
-        warnings.warn("Passing 'version' to parser_add_common_options is deprecated "
+        warnings.warn("Passing 'version' to parser_add_common_options "
+                      "no longer has an effect "
                       "and will be removed in a future release.",
                       DeprecationWarning)
     parser_add_version_opt(parser, 'datalad', include_name=False, delay=True)

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -202,7 +202,7 @@ def parser_add_common_options(parser, version=None):
                       "no longer has an effect "
                       "and will be removed in a future release.",
                       DeprecationWarning)
-    parser_add_version_opt(parser, 'datalad', include_name=False, delay=True)
+    parser_add_version_opt(parser, 'datalad', include_name=True, delay=True)
     if __debug__:
         parser.add_argument(
             '--dbg', action='store_true', dest='common_debug',

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -99,7 +99,7 @@ def setup_parser(
         formatter_class=formatter_class,
         add_help=False)
     # common options
-    helpers.parser_add_common_options(parser, datalad.__version__)
+    helpers.parser_add_common_options(parser)
     # yoh: atm we only dump to console.  Might adopt the same separation later on
     #      and for consistency will call it --verbose-level as well for now
     # log-level is set via common_opts ATM
@@ -122,6 +122,9 @@ def setup_parser(
     try:
         parsed_args, unparsed_args = parser._parse_known_args(
             cmdlineargs[1:], argparse.Namespace())
+        # before anything handle possible datalad --version
+        if not unparsed_args and getattr(parsed_args, 'version', None):
+            parsed_args.version()  # will exit with 0
         if not (completing or unparsed_args):
             fail_handler(parser, msg="too few arguments", exit_code=2)
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
@@ -220,6 +223,10 @@ def setup_parser(
             helpers.parser_add_common_opt(subparser, 'help')
             # let module configure the parser
             _intf.setup_parser(subparser)
+
+            # and we would add custom handler for --version
+            helpers.parser_add_version_opt(subparser, _intf.__module__.split('.', 1)[0], include_name=True)
+
             # logger for command
 
             # configure 'run' function for this command

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -35,17 +35,18 @@ from datalad.utils import (
     Path,
 )
 from datalad.tests.utils import (
-    on_windows,
-    with_tempfile,
+    SkipTest,
     assert_equal,
+    assert_in,
+    assert_not_in,
     assert_raises,
+    assert_re_in,
+    eq_,
     in_,
     ok_startswith,
-    assert_in,
-    assert_re_in,
-    assert_not_in,
+    on_windows,
     slow,
-    SkipTest,
+    with_tempfile,
 )
 
 
@@ -86,16 +87,23 @@ def run_main(args, exit_code=0, expect_stderr=False):
 
 # TODO: switch to stdout for --version output
 def test_version():
+    # we just get a version if not asking for a version of some command
     stdout, stderr = run_main(['--version'], expect_stderr=True)
+    eq_(stdout.rstrip(), datalad.__version__)
 
-    # and output should contain our version, copyright, license
-
-    # https://hg.python.org/cpython/file/default/Doc/whatsnew/3.4.rst#l1952
-    out = stdout if sys.version_info >= (3, 4) else stderr
-    ok_startswith(out, 'datalad %s\n' % datalad.__version__)
+    stdout, stderr = run_main(['clone', '--version'], expect_stderr=True)
+    ok_startswith(stdout, 'datalad %s\n' % datalad.__version__)
     # since https://github.com/datalad/datalad/pull/2733 no license in --version
-    assert_not_in("Copyright", out)
-    assert_not_in("Permission is hereby granted", out)
+    assert_not_in("Copyright", stdout)
+    assert_not_in("Permission is hereby granted", stdout)
+
+    try:
+        import datalad_container
+    except ImportError:
+        pass  # not installed, cannot test with extension
+    else:
+        stdout, stderr = run_main(['containers-list', '--version'], expect_stderr=True)
+        eq_(stdout, 'datalad_container %s\n' % datalad_container.__version__)
 
 
 def test_help_np():
@@ -215,7 +223,13 @@ def test_script_shims():
 
         # and let's check that it is our script
         out = runner.run([script, '--version'], protocol=StdOutErrCapture)
-        version = (out['stdout'] + out['stderr']).splitlines()[0].split(' ', 1)[1]
+        version = out['stdout'].rstrip()
+        if script != 'datalad':
+            # datalad --version  would return only version now, but all the `datalad CMD` and
+            # other entry points will still announce their origin, so we would need to strip
+            # it away
+            mod, version = version.split(' ', 1)
+            assert_equal(mod, 'datalad')
         # we can get git and non git .dev version... so for now
         # relax
         get_numeric_portion = lambda v: [x for x in v.split('.') if x.isdigit()]

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -89,7 +89,7 @@ def run_main(args, exit_code=0, expect_stderr=False):
 def test_version():
     # we just get a version if not asking for a version of some command
     stdout, stderr = run_main(['--version'], expect_stderr=True)
-    eq_(stdout.rstrip(), datalad.__version__)
+    eq_(stdout.rstrip(), "datalad %s" % datalad.__version__)
 
     stdout, stderr = run_main(['clone', '--version'], expect_stderr=True)
     ok_startswith(stdout, 'datalad %s\n' % datalad.__version__)
@@ -224,12 +224,8 @@ def test_script_shims():
         # and let's check that it is our script
         out = runner.run([script, '--version'], protocol=StdOutErrCapture)
         version = out['stdout'].rstrip()
-        if script != 'datalad':
-            # datalad --version  would return only version now, but all the `datalad CMD` and
-            # other entry points will still announce their origin, so we would need to strip
-            # it away
-            mod, version = version.split(' ', 1)
-            assert_equal(mod, 'datalad')
+        mod, version = version.split(' ', 1)
+        assert_equal(mod, 'datalad')
         # we can get git and non git .dev version... so for now
         # relax
         get_numeric_portion = lambda v: [x for x in v.split('.') if x.isdigit()]

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -54,10 +54,7 @@ def setup_parser(backend):
     # common options
     helpers.parser_add_common_opt(parser, 'help')
     helpers.parser_add_common_opt(parser, 'log_level')
-    helpers.parser_add_common_opt(
-        parser,
-        'version',
-        version='datalad %s' % m__version__)
+    helpers.parser_add_version_opt(parser, 'datalad', include_name=True)
     if __debug__:
         parser.add_argument(
             '--dbg', action='store_true', dest='common_debug',

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -235,7 +235,7 @@ def check_call_from_parser_pos_arg_underscore(how):
             return pos_arg
 
     parser = argparse.ArgumentParser()
-    parser_add_common_options(parser, version="v1")
+    parser_add_common_options(parser)
     Cmd.setup_parser(parser)
     args = parser.parse_args(["val"])
     eq_(Cmd.call_from_parser(args),


### PR DESCRIPTION
I might have went a little too wild, but I felt that having clean output
of datalad --version is nice -- it could facilitate use by scripts since
would no longer need parsing etc (but also might break them now).

So here is how it would look now with these changes:

	$> datalad --version
	0.14.1.dev129

	$> datalad install --version
	datalad 0.14.1.dev129

	$> datalad containers-list --version
	datalad_container 1.1.2

	$> git-annex-remote-datalad --version
	datalad 0.14.1.dev129

Closes #5527

edit: a side effect, it also addresses #3067 which was worked around via adding `--` to separate out command for `datalad run`. Now would even work in the `datalad run whatever --version` without `--`