### PR TITLE
gitrepo: Direct files to git with annex.gitaddtoannex

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1230,9 +1230,9 @@ class GitRepo(CoreGitRepo):
         try:
             # without --verbose git 2.9.3  add does not return anything
             add_out = self._call_git(
-                # Set annex.largefiles to prevent storing files in
+                # Set annex.gitaddtoannex to prevent storing files in
                 # annex with a v6+ annex repo.
-                ['-c', 'annex.largefiles=nothing', 'add'] +
+                ['-c', 'annex.gitaddtoannex=false', 'add'] +
                 ensure_list(git_options) +
                 to_options(update=update) + ['--verbose'],
                 files=files,

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1673,7 +1673,8 @@ def test_GitRepo_get_revisions(path):
     eq_(gr.get_revisions(DEFAULT_BRANCH + ".."), [])
 
 
-@with_tree({"foo": "foo"})
+@with_tree({"foo": "foo",
+            ".gitattributes": "* annex.largefiles=anything"})
 def test_gitrepo_add_to_git_with_annex_v7(path):
     from datalad.support.annexrepo import AnnexRepo
     ar = AnnexRepo(path, create=True, version=7)


### PR DESCRIPTION
* Update `GitRepo.add_` to use `annex.gitaddtoannex` instead of `annex.largefiles` to direct files to Git.  See the message of second commit for the background.

* Update the associated regression test for a change in git-annex's behavior.
