### PR TITLE
ENH: create-sibling: Make default sibling choice more accessible

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -636,7 +636,7 @@ class CreateSibling(Interface):
 
         if not name:
             name = sibling_ri.hostname if ssh_sibling else "local"
-            lgr.debug(
+            lgr.info(
                 "No sibling name given. Using %s'%s' as sibling name",
                 "URL hostname " if ssh_sibling else "",
                 name)
@@ -708,6 +708,7 @@ class CreateSibling(Interface):
             if name in checkds_remotes and existing in ('error', 'skip'):
                 yield dict(
                     res,
+                    sibling_name=name,
                     status='error' if existing == 'error' else 'notneeded',
                     message=(
                         "sibling '%s' already configured (specify alternative "
@@ -785,6 +786,7 @@ class CreateSibling(Interface):
                 annex_groupwanted,
                 inherit
             )
+            currentds_ap["sibling_name"] = name
             if not path:
                 # nothing new was created
                 # TODO is 'notneeded' appropriate in this case?

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -37,6 +37,7 @@ from datalad.tests.utils import (
     assert_dict_equal,
     assert_false,
     assert_in,
+    assert_in_results,
     assert_no_errors_logged,
     assert_not_equal,
     assert_not_in,
@@ -542,7 +543,7 @@ def check_replace_and_relative_sshpath(use_ssh, src_path, dst_path):
     create_tree(ds.path, {'sub.dat': 'lots of data'})
     ds.save('sub.dat')
     try:
-        ds.create_sibling(url, ui=True)
+        res = ds.create_sibling(url, ui=True)
     except UnicodeDecodeError:
         if sys.version_info < (3, 7):
             # observed test failing on ubuntu 18.04 with python 3.6
@@ -550,7 +551,7 @@ def check_replace_and_relative_sshpath(use_ssh, src_path, dst_path):
             # We will just skip this tricky one
             raise SkipTest("Known failure")
         raise
-
+    assert_in_results(res, action="create_sibling", sibling_name=sibname)
     published = ds.publish(to=sibname, transfer_data='all')
     assert_result_count(published, 1, path=opj(ds.path, 'sub.dat'))
     # verify that hook runs and there is nothing in stderr


### PR DESCRIPTION
When --name isn't specified, create-sibling will use the hostname for
an SSH URL and "local" for a local path.  At the default logging
level, however, the caller isn't told what the selected name is.  And,
for scripting purposes, the name can't be easily determined because
it's not available in the result record.

Promote the debug-level message about the default sibling name to an
info-level message, and add a "sibling_name" field to the result
record.

Closes #1986.