### PR TITLE
Bring create-sibling-github to the modern age 

### DIFF
--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -174,7 +174,8 @@ class CreateSiblingGithub(Interface):
             dataset, check_installed=True, purpose='create GitHub sibling')
 
         res_kwargs = dict(
-            action='create_sibling_github',
+            action='create_sibling_github [dry-run]' if dryrun else
+            'create_sibling_github',
             logger=lgr,
             refds=ds.path,
         )
@@ -249,7 +250,6 @@ class CreateSiblingGithub(Interface):
                 status='ok',
                 url=url,
                 preexisted=existed,
-                dry_run=dryrun,
                 **res_kwargs)
 
         # TODO let submodule URLs point to GitHub (optional)

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -14,8 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import re
-
-from os.path import relpath
+import warnings
 
 from datalad.interface.base import (
     build_doc,
@@ -171,6 +170,15 @@ class CreateSiblingGithub(Interface):
             private=False,
             dryrun=False,
             dry_run=False):
+        if dryrun and not dry_run:
+            # the old one is used, and not in agreement with the new one
+            warnings.warn(
+                "datalad-create-sibling-github's `dryrun` option is "
+                "deprecated and will be removed in a future release, "
+                "use the renamed `dry_run/--dry-run` option instead.",
+                DeprecationWarning)
+            dry_run = dryrun
+
         # this is an absolute leaf package, import locally to avoid
         # unnecessary dependencies
         from datalad.support.github_ import _make_github_repos_
@@ -184,7 +192,7 @@ class CreateSiblingGithub(Interface):
             dataset, check_installed=True, purpose='create GitHub sibling')
 
         res_kwargs = dict(
-            action='create_sibling_github [dry-run]' if dryrun else
+            action='create_sibling_github [dry-run]' if dry_run else
             'create_sibling_github',
             logger=lgr,
             refds=ds.path,
@@ -226,7 +234,7 @@ class CreateSiblingGithub(Interface):
         # actually make it happen on GitHub
         for res in _make_github_repos_(
                 github_login, github_organization, filtered,
-                existing, access_protocol, private, dryrun):
+                existing, access_protocol, private, dry_run):
             # blend reported results with standard properties
             res = dict(
                 res,
@@ -239,7 +247,7 @@ class CreateSiblingGithub(Interface):
                 # something went wrong, do not proceed
                 continue
             # lastly configure the local datasets
-            if not dryrun:
+            if not dry_run:
                 extra_remote_vars = {
                     # first make sure that annex doesn't touch this one
                     # but respect any existing config

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -140,13 +140,18 @@ class CreateSiblingGithub(Interface):
             will be marked as private and only visible to those granted 
             access or by membership of a team/organization/etc.
             """),
-        dryrun=Parameter(
-            args=("--dryrun",),
+        dry_run=Parameter(
+            args=("--dry-run",),
             action="store_true",
             doc="""If this flag is set, no communication with GitHub is
             performed, and no repositories will be created. Instead
             would-be repository names are reported for all relevant datasets
             """),
+        dryrun=Parameter(
+            args=("--dryrun",),
+            action="store_true",
+            doc="""Deprecated. Use the renamed
+            [CMD: --dry-run CMD][PY: `dry_run` PY] parameter"""),
     )
 
     @staticmethod
@@ -164,7 +169,8 @@ class CreateSiblingGithub(Interface):
             access_protocol='https',
             publish_depends=None,
             private=False,
-            dryrun=False):
+            dryrun=False,
+            dry_run=False):
         # this is an absolute leaf package, import locally to avoid
         # unnecessary dependencies
         from datalad.support.github_ import _make_github_repos_

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -44,8 +44,8 @@ from datalad.distribution.siblings import Siblings
 lgr = logging.getLogger('datalad.distribution.create_sibling_github')
 
 
-def template_fx(path):
-    """Turn subdataset paths into Github compliant repository name suffixes
+def normalize_reponame(path):
+    """Turn name (e.g. path) into a Github compliant repository name
     """
     return re.sub(r'\s+', '_', re.sub(r'[/\\]+', '-', path))
 
@@ -169,6 +169,10 @@ class CreateSiblingGithub(Interface):
         # unnecessary dependencies
         from datalad.support.github_ import _make_github_repos_
 
+        if reponame != normalize_reponame(reponame):
+            raise ValueError('Invalid name for a GitHub project: {}'.format(
+                reponame))
+
         # what to operate on
         ds = require_dataset(
             dataset, check_installed=True, purpose='create GitHub sibling')
@@ -206,7 +210,7 @@ class CreateSiblingGithub(Interface):
             gh_reponame = reponame if d == ds else \
                 '{}-{}'.format(
                     reponame,
-                    template_fx(str(d.pathobj.relative_to(ds.pathobj))))
+                    normalize_reponame(str(d.pathobj.relative_to(ds.pathobj))))
             filtered.append((d, gh_reponame))
 
         if not filtered:

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -17,30 +17,30 @@ import re
 
 from os.path import relpath
 
-from ..interface.base import (
+from datalad.interface.base import (
     build_doc,
     Interface,
 )
-from ..interface.common_opts import (
+from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
     publish_depends,
 )
-from ..support.param import Parameter
-from ..support.constraints import (
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
     EnsureChoice,
     EnsureNone,
     EnsureStr,
 )
-from ..utils import (
+from datalad.utils import (
     ensure_list,
 )
-from .dataset import (
+from datalad.distribution.dataset import (
     datasetmethod,
     EnsureDataset,
     require_dataset,
 )
-from .siblings import Siblings
+from datalad.distribution.siblings import Siblings
 
 lgr = logging.getLogger('datalad.distribution.create_sibling_github')
 

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -44,9 +44,11 @@ from datalad.distribution.siblings import Siblings
 
 lgr = logging.getLogger('datalad.distribution.create_sibling_github')
 
-# presently only implemented method to turn subdataset paths into Github
-# compliant repository name suffixes
-template_fx = lambda x: re.sub(r'\s+', '_', re.sub(r'[/\\]+', '-', x))
+
+def template_fx(path):
+    """Turn subdataset paths into Github compliant repository name suffixes
+    """
+    return re.sub(r'\s+', '_', re.sub(r'[/\\]+', '-', path))
 
 
 @build_doc

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -197,15 +197,12 @@ class CreateSiblingGithub(Interface):
         filtered = []
         for d, mp in toprocess:
             if name in d.repo.get_remotes():
-                if existing == 'error':
-                    msg = '{} already has a configured sibling "{}"'.format(
-                        d, name)
-                    if dryrun:
-                        lgr.error(msg)
-                    else:
-                        raise ValueError(msg)
-                elif existing == 'skip':
-                    continue
+                yield get_status_dict(
+                    ds=d,
+                    status='error' if existing == 'error' else 'notneeded',
+                    message=('already has a configured sibling "%s"', name),
+                    **res_kwargs)
+                continue
             gh_reponame = '{}{}{}'.format(
                 reponame,
                 '-' if mp else '',

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -143,10 +143,10 @@ class CreateSiblingGithub(Interface):
         dry_run=Parameter(
             args=("--dry-run",),
             action="store_true",
-            doc="""If this flag is set, no communication with GitHub is
-            performed, and no repositories will be created. Instead
-            would-be repository names are reported for all relevant datasets
-            """),
+            doc="""If this flag is set, no repositories will be created.
+            Instead tests for name collisions with existing projects will be
+            performed, and would-be repository names are reported for all
+            relevant datasets"""),
         dryrun=Parameter(
             args=("--dryrun",),
             action="store_true",

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -221,6 +221,14 @@ class CreateSiblingGithub(Interface):
         for d, url, existed in _make_github_repos_(
                 github_login, github_organization, filtered,
                 existing, access_protocol, private, dryrun):
+            # report that we have created the project on github
+            yield get_status_dict(
+                ds=d,
+                status='ok',
+                url=url,
+                message=("project at %s", url),
+                preexisted=existed,
+                **res_kwargs)
             # lastly configure the local datasets
             if not dryrun:
                 extra_remote_vars = {
@@ -238,20 +246,14 @@ class CreateSiblingGithub(Interface):
                     var = 'remote.{}.{}'.format(name, var_name)
                     if var not in d.config:
                         d.config.add(var, var_value, where='local')
-                Siblings()(
+                yield from Siblings()(
                     'configure',
                     dataset=d,
                     name=name,
                     url=url,
                     recursive=False,
                     # TODO fetch=True, maybe only if one existed already
-                    publish_depends=publish_depends)
-            yield get_status_dict(
-                ds=d,
-                status='ok',
-                url=url,
-                message=("project at %s", url),
-                preexisted=existed,
-                **res_kwargs)
+                    publish_depends=publish_depends,
+                    result_renderer='disabled')
 
         # TODO let submodule URLs point to GitHub (optional)

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -250,6 +250,7 @@ class CreateSiblingGithub(Interface):
                 ds=d,
                 status='ok',
                 url=url,
+                message=("project at %s", url),
                 preexisted=existed,
                 **res_kwargs)
 

--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -181,7 +181,7 @@ class CreateSiblingGithub(Interface):
         )
         # gather datasets and essential info
         # dataset instance and mountpoint relative to the top
-        toprocess = [(ds, '')]
+        toprocess = [ds]
         if recursive:
             for sub in ds.subdatasets(
                     fulfilled=None,  # we want to report on missing dataset in here
@@ -191,11 +191,11 @@ class CreateSiblingGithub(Interface):
                 if not sub.is_installed():
                     lgr.info('Ignoring unavailable subdataset %s', sub)
                     continue
-                toprocess.append((sub, relpath(sub.path, start=ds.path)))
+                toprocess.append(sub)
 
         # check for existing remote configuration
         filtered = []
-        for d, mp in toprocess:
+        for d in toprocess:
             if name in d.repo.get_remotes():
                 yield get_status_dict(
                     ds=d,
@@ -203,10 +203,10 @@ class CreateSiblingGithub(Interface):
                     message=('already has a configured sibling "%s"', name),
                     **res_kwargs)
                 continue
-            gh_reponame = '{}{}{}'.format(
-                reponame,
-                '-' if mp else '',
-                template_fx(mp))
+            gh_reponame = reponame if d == ds else \
+                '{}-{}'.format(
+                    reponame,
+                    template_fx(str(d.pathobj.relative_to(ds.pathobj))))
             filtered.append((d, gh_reponame))
 
         if not filtered:

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -21,6 +21,7 @@ from datalad.tests.utils import (
     assert_equal,
     assert_false,
     assert_in,
+    assert_in_results,
     assert_not_in,
     assert_raises,
     assert_true,
@@ -92,19 +93,30 @@ def test_dont_trip_over_missing_subds(path):
     assert_not_in('github', ds1.repo.get_remotes())
     # fail on existing
     ds1.repo.add_remote('github', 'http://nothere')
-    assert_raises(ValueError,
-        ds1.create_sibling_github, 'bogus', recursive=True,
-        github_login='disabledloginfortesting')
-    # talk to github when existing is OK
-    assert_raises(gh.BadCredentialsException,
-        ds1.create_sibling_github, 'bogus', recursive=True,
-        github_login='disabledloginfortesting', existing='reconfigure')
-    # return happy emptiness when all is skipped
-    assert_equal(
+    assert_in_results(
         ds1.create_sibling_github(
             'bogus', recursive=True,
-            github_login='disabledloginfortesting', existing='skip'),
-        [])
+            github_login='disabledloginfortesting',
+            on_failure='ignore'),
+        status='error',
+        message=('already has a configured sibling "%s"', 'github'),
+    )
+    assert_in_results(
+        ds1.create_sibling_github(
+            'bogus', recursive=True,
+            github_login='disabledloginfortesting',
+            existing='reconfigure'),
+        status='notneeded',
+        message=('already has a configured sibling "%s"', 'github'),
+    )
+    assert_in_results(
+        ds1.create_sibling_github(
+            'bogus', recursive=True,
+            github_login='disabledloginfortesting',
+            existing='skip',),
+        status='notneeded',
+        message=('already has a configured sibling "%s"', 'github'),
+    )
 
 
 # Ran on Yarik's laptop, so would use his available token
@@ -171,18 +183,27 @@ def check_integration1(login, keyring,
             url_fmt = 'https://{login}@github.com/{organization}/{repo_name}.git'
         else:
             url_fmt = 'https://github.com/{login}/{repo_name}.git'
-        eq_(res, [(ds, url_fmt.format(**locals()), False)])
+        assert_in_results(
+            res,
+            path=ds.path,
+            url=url_fmt.format(**locals()),
+            preexisted=False)
 
         # but if we rerun - should kaboom since already has this sibling:
-        with assert_raises(ValueError) as cme:
-            ds.create_sibling_github(repo_name, **kwargs)
-        assert_in("already has a configured sibling", str(cme.exception))
+        assert_in_results(
+            ds.create_sibling_github(repo_name, on_failure='ignore', **kwargs),
+            message=('already has a configured sibling "%s"', 'github'),
+            status='error',
+        )
 
         # but we can give it a new name, but it should kaboom since the remote one
         # exists already
-        with assert_raises(ValueError) as cme:
-            ds.create_sibling_github(repo_name, name="github2", **kwargs)
-        assert_in("already exists on", str(cme.exception))
+        assert_in_results(
+            ds.create_sibling_github(repo_name, name="github2",
+                                     on_failure='ignore', **kwargs),
+            message=('repository "%s" already exists on Github', 'test_integration1'),
+            status='error',
+        )
         # we should not leave the broken sibling behind
         assert_not_in('github2', ds.repo.get_remotes())
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -650,7 +650,7 @@ class Interface(object):
     _interrupted_exit_code = 1
 
     _OLDSTYLE_COMMANDS = (
-        'AddArchiveContent', 'CrawlInit', 'Crawl', 'CreateSiblingGithub',
+        'AddArchiveContent', 'CrawlInit', 'Crawl',
         'CreateTestDataset', 'Export', 'Ls', 'SSHRun', 'Test')
 
     @classmethod


### PR DESCRIPTION
Primarly turns the command into a normal DataLad command that emits result records.  But it also changes a number of other small bits and pieces. I tried to keep the individual commits sensible and reasonably well described in their messages.

Fixes #5548