### PR TITLE
RF: Remove GitRepo.pull()

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1925,59 +1925,6 @@ class GitRepo(CoreGitRepo):
             all_=all_,
             git_options=git_options)
 
-    # XXX Consider removing this method. It is only used in `update()`,
-    # where it could be easily replaced with fetch+merge
-    def pull(self, remote=None, refspec=None, git_options=None, **kwargs):
-        """Pulls changes from a remote.
-
-        Parameters
-        ----------
-        remote : str, optional
-          name of the remote to pull from. If no remote is given,
-          the remote tracking branch is used.
-        refspec : str, optional
-          refspec to fetch.
-        git_options : list, optional
-          Additional command line options for git-pull.
-        kwargs :
-          Deprecated. GitPython-style keyword argument for git-pull.
-          Will be appended to any git_options.
-        """
-        git_options = ensure_list(git_options)
-        if kwargs:
-            git_options.extend(to_options(**kwargs))
-
-        cmd = ['git'] + self._GIT_COMMON_OPTIONS
-        cmd.extend(['pull', '--progress'] + git_options)
-
-        if remote is None:
-            if refspec:
-                # conflicts with using tracking branch or fetch all remotes
-                # For now: Just fail.
-                # TODO: May be check whether it fits to tracking branch
-                raise ValueError(
-                    "refspec specified without a remote. ({})".format(refspec))
-            # No explicit remote to fetch.
-            # => get tracking branch:
-            tb_remote, refspec = self.get_tracking_branch()
-            if tb_remote is not None:
-                remote = tb_remote
-            else:
-                # No remote, no tracking branch
-                # => fail
-                raise ValueError("Neither a remote is specified to pull "
-                                 "from nor a tracking branch is set up.")
-
-        cmd.append(remote)
-        if refspec:
-            cmd += ensure_list(refspec)
-
-        self._maybe_open_ssh_connection(remote)
-        self._git_runner.run(
-            cmd,
-            protocol=StdOutCaptureWithGitProgress,
-        )
-
     def push(self, remote=None, refspec=None, all_remotes=False,
              all_=False, git_options=None, **kwargs):
         """Push changes to a remote (or all remotes).

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -521,43 +521,6 @@ def test_GitRepo_get_remote_url(path):
 
 @with_tempfile
 @with_tempfile
-@with_tempfile
-def test_GitRepo_pull(test_path, orig_path, clone_path):
-
-    veryorigin = GitRepo(test_path)
-    with open(op.join(test_path, 'some.txt'), 'w') as f:
-        f.write("New text file.")
-    veryorigin.add('some.txt')
-    veryorigin.commit("new file added.")
-
-    origin = GitRepo.clone(test_path, orig_path)
-    clone = GitRepo.clone(orig_path, clone_path)
-    filename = get_most_obscure_supported_name()
-
-    with open(op.join(orig_path, filename), 'w') as f:
-        f.write("New file.")
-    origin.add(filename)
-    origin.commit("new file added.")
-    clone.pull()
-    ok_(op.exists(op.join(clone_path, filename)))
-
-    # While at it, let's test _get_remotes_having_commit a bit
-    from datalad.distribution.get import _get_remotes_having_commit
-    clone.add_remote("very_origin", test_path)
-    clone.fetch("very_origin")
-    eq_(
-        _get_remotes_having_commit(clone, clone.get_hexsha()),
-        ['origin']
-    )
-    prev_commit = clone.get_hexsha('HEAD^')
-    eq_(
-        set(_get_remotes_having_commit(clone, prev_commit)),
-        {'origin', 'very_origin'}
-    )
-
-
-@with_tempfile
-@with_tempfile
 def test_GitRepo_fetch(orig_path, clone_path):
 
     origin = GitRepo(orig_path)
@@ -637,42 +600,6 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     # we actually fetched it:
     assert_in('ssh-remote/' + DEFAULT_BRANCH,
               repo.get_remote_branches())
-
-
-@skip_nomultiplex_ssh
-@with_tempfile
-@with_tempfile
-def test_GitRepo_ssh_pull(remote_path, repo_path):
-    from datalad import ssh_manager
-
-    remote_repo = GitRepo(remote_path, create=True)
-    url = _path2localsshurl(remote_path)
-    socket_path = op.join(str(ssh_manager.socket_dir),
-                          get_connection_hash('datalad-test', bundled=True))
-    repo = GitRepo(repo_path, create=True)
-    repo.add_remote("ssh-remote", url)
-
-    # modify remote:
-    remote_repo.checkout("ssh-test", ['-b'])
-    with open(op.join(remote_repo.path, "ssh_testfile.dat"), "w") as f:
-        f.write("whatever")
-    remote_repo.add("ssh_testfile.dat")
-    remote_repo.commit("ssh_testfile.dat added.")
-
-    # file is not locally known yet:
-    assert_not_in("ssh_testfile.dat", repo.get_indexed_files())
-
-    # pull changes:
-    repo.pull(remote="ssh-remote", refspec=remote_repo.get_active_branch())
-    assert_repo_status(repo.path, annex=False)
-
-    # the connection is known to the SSH manager, since fetch() requested it:
-    assert_in(socket_path, list(map(str, ssh_manager._connections)))
-    # and socket was created:
-    ok_(op.exists(socket_path))
-
-    # we actually pulled the changes
-    assert_in("ssh_testfile.dat", repo.get_indexed_files())
 
 
 @skip_nomultiplex_ssh


### PR DESCRIPTION
This method is used nowhere in the code, and its obsoleteness
was put in an issue more than a year ago.

Closes #4132
