### PR TITLE
MNT: Don't call get_interface_groups with include_plugins=True

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -21,7 +21,7 @@ def _command_summary():
     from datalad.interface.base import get_interface_groups
     from datalad.interface.base import load_interface
 
-    groups = get_interface_groups(include_plugins=True)
+    groups = get_interface_groups()
     grp_short_descriptions = defaultdict(list)
     for group, _, specs in sorted(groups, key=lambda x: x[1]):
         for spec in specs:

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -134,7 +134,7 @@ def setup_parser(
         need_single_subparser = False
         unparsed_args = cmdlineargs[1:]  # referenced before assignment otherwise
 
-    interface_groups = get_interface_groups(include_plugins=True)
+    interface_groups = get_interface_groups()
 
     # First unparsed could be either unknown option to top level "datalad"
     # or a command. Among unknown could be --help/--help-np which would

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -190,7 +190,7 @@ class Dataset(object, metaclass=PathBasedFlyweight):
             from datalad.interface.base import (
                 get_interface_groups, get_api_name, load_interface
             )
-            groups = get_interface_groups(True)
+            groups = get_interface_groups()
             for group, _, interfaces in groups:
                 for intfspec in interfaces:
                     # lgr.log(5, "Considering interface %s", intfspec)

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -65,20 +65,6 @@ definitions = {
         'destination': 'global',
         'default_fn': lambda: opj(dirs.user_cache_dir, 'sockets'),
     },
-    'datalad.locations.system-plugins': {
-        'ui': ('question', {
-               'title': 'System plugin directory',
-               'text': 'Where should datalad search for system plugins?'}),
-        'destination': 'global',
-        'default_fn': lambda: opj(dirs.site_config_dir, 'plugins'),
-    },
-    'datalad.locations.user-plugins': {
-        'ui': ('question', {
-               'title': 'User plugin directory',
-               'text': 'Where should datalad search for user plugins?'}),
-        'destination': 'global',
-        'default_fn': lambda: opj(dirs.user_config_dir, 'plugins'),
-    },
     'datalad.locations.system-procedures': {
         'ui': ('question', {
                'title': 'System procedure directory',


### PR DESCRIPTION
Calling get_interface_groups() with include_plugins=True was marked as
deprecated in gh-5554.

Update: And also remove `datalad.locations.{system,user}-plugins` options.