### PR TITLE
RF: test that ex-plugins have "dataset" as the first posarg

### DIFF
--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -53,13 +53,10 @@ def _test_consistent_order_of_args(intf, spec_posargs):
             'ExportArchive',
             'ExportToFigshare',
             'ExtractMetadata'):
-        # MIH I was never sure what this test enforces and it takes
-        # me ages each time to try to wrap my head around it
-        # I am confident that I do not want to change the API of this
-        # command now that it is a command and no longer a plugin
-        # hence this exception
-        # MIH: Also adding all ex-plugins that are "wrong" but should
-        # stay the same
+        if intf.__name__ != 'ExtractMetadata':
+            # ex-plugins had 'dataset' as the first positional argument
+            # and ExtractMetadata has 'types' as the first positional arg
+            eq_(args[0], 'dataset')
         eq_(spec_posargs, spec_posargs)
         return
 


### PR DESCRIPTION
echoing the meetup discussion

I took liberty of removing MIH comment, but we could bring it back if so desired