### PR TITLE
Don't hard code "origin" as remote name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,12 +226,13 @@ before_install:
   - if [[ "${_DL_TMPDIR:-}" =~ .*/sym\ link ]]; then echo "Symlinking $_DL_TMPDIR"; ln -s /tmp "$_DL_TMPDIR"; fi
   - if [[ "${_DL_TMPDIR:-}" =~ .*/d\ i\ r ]]; then echo "mkdir $_DL_TMPDIR"; mkdir -p "$_DL_TMPDIR"; fi
   - if [[ "${_DL_TMPDIR:-}" =~ .*/nfsmount ]]; then echo "mkdir $_DL_TMPDIR"; mkdir -p "$_DL_TMPDIR" "${_DL_TMPDIR}_"; echo "/tmp/nfsmount_ localhost(rw)" | sudo bash -c 'cat - > /etc/exports'; sudo apt-get install -y nfs-kernel-server; sudo exportfs -a; sudo mount -t nfs localhost:/tmp/nfsmount_ /tmp/nfsmount; fi
+  # Maybe build install custom git.
+  - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then source tools/ci/install-upstream-git.sh; fi
+  - if [ ! -z "${_DL_MIN_GIT:-}" ]; then tools/ci/install-minimum-git.sh; fi
   # Install git-annex
   - wget -O datalad_installer.py https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py
   - eval python3 datalad_installer.py --sudo ok -E new.env ${_DL_ANNEX_INSTALL_SCENARIO}
   - source new.env && cat new.env >> ~/.bashrc
-  - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then source tools/ci/install-upstream-git.sh; fi
-  - if [ ! -z "${_DL_MIN_GIT:-}" ]; then tools/ci/install-minimum-git.sh; fi
   - pip install --upgrade pip
 
 install:

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -119,8 +119,13 @@ def setup_package():
     consts.DATASETS_TOPURL = 'http://datasets-tests.datalad.org/'
     set_envvar('DATALAD_DATASETS_TOPURL', consts.DATASETS_TOPURL)
 
-    from datalad.tests.utils import DEFAULT_BRANCH
-    set_envvar("GIT_CONFIG_PARAMETERS", "'init.defaultBranch={}'".format(DEFAULT_BRANCH))
+    from datalad.tests.utils import (
+        DEFAULT_BRANCH,
+        DEFAULT_REMOTE,
+    )
+    set_envvar("GIT_CONFIG_PARAMETERS",
+               "'init.defaultBranch={}' 'clone.defaultRemoteName={}'"
+               .format(DEFAULT_BRANCH, DEFAULT_REMOTE))
 
     # To overcome pybuild overriding HOME but us possibly wanting our
     # own HOME where we pre-setup git for testing (name, email)

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -29,6 +29,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     eq_,
     known_failure_githubci_osx,
     known_failure_githubci_win,
@@ -619,7 +620,7 @@ def test_gh1811(srcpath, clonepath):
     (clone.pathobj / 'somemore').write_text('somemore')
     clone.save()
     clone.repo.call_git(['checkout', 'HEAD~1'])
-    res = clone.push(to='origin', on_failure='ignore')
+    res = clone.push(to=DEFAULT_REMOTE, on_failure='ignore')
     assert_result_count(res, 1)
     assert_result_count(
         res, 1,

--- a/datalad/distributed/tests/test_ria.py
+++ b/datalad/distributed/tests/test_ria.py
@@ -9,6 +9,7 @@ from datalad.tests.utils import (
     assert_equal,
     assert_result_count,
     assert_true,
+    DEFAULT_REMOTE,
     has_symlink_capability,
     skip_if,
     skip_if_on_windows,
@@ -70,7 +71,7 @@ def test_ephemeral(ds_path, store_path, clone_path):
         assert_result_count(res, 1, success=True, file=file_testsub.as_posix())
 
         # push back git history
-        eph_clone.publish(to="origin", transfer_data="none")
+        eph_clone.publish(to=DEFAULT_REMOTE, transfer_data="none")
 
         # get an update in origin
         ds.update(merge=True, reobtain_data=True)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -44,6 +44,7 @@ from datalad.tests.utils import (
     assert_repo_status,
     assert_result_count,
     assert_message,
+    DEFAULT_REMOTE,
     serve_path_via_http,
     skip_if_adjusted_branch,
     skip_ssh,
@@ -103,20 +104,20 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     # own location default remote for current branch
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path)),
-        [dict(cost=500, name='origin', url=ds_subpath)])
+        [dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=sshurl)),
-        [dict(cost=500, name='origin', url=ds_subpath),
-         dict(cost=600, name='origin', url=sshurl)])
+        [dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+         dict(cost=600, name=DEFAULT_REMOTE, url=sshurl)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=httpurl)),
-        [dict(cost=500, name='origin', url=ds_subpath),
-         dict(cost=600, name='origin', url=httpurl)])
+        [dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+         dict(cost=600, name=DEFAULT_REMOTE, url=httpurl)])
 
     # make sure it does meaningful things in an actual clone with an actual
     # record of a subdataset
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            dict(cost=500, name='origin', url=ds_subpath),
+            dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
     ])
 
     # check that a configured remote WITHOUT the desired submodule commit
@@ -125,7 +126,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
                    result_renderer='disabled')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            dict(cost=500, name='origin', url=ds_subpath),
+            dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
     ])
     # inject a source URL config, should alter the result accordingly
     with patch.dict(
@@ -133,7 +134,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'youredead'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(cost=500, name='origin', url=ds_subpath),
+                dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
                 dict(cost=700, name='bang', url='youredead', from_config=True),
         ])
     # we can alter the cost by given the name a two-digit prefix
@@ -143,7 +144,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
                 dict(cost=400, name='bang', url='youredead', from_config=True),
-                dict(cost=500, name='origin', url=ds_subpath),
+                dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
         ])
     # verify template instantiation works
     with patch.dict(
@@ -151,7 +152,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'pre-{id}-post'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(cost=500, name='origin', url=ds_subpath),
+                dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
                 dict(cost=700, name='bang', url='pre-{}-post'.format(sub.id),
                      from_config=True),
         ])

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -61,6 +61,7 @@ from datalad.tests.utils import (
     assert_status,
     assert_in_results,
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     ok_startswith,
     serve_path_via_http,
     swallow_logs,
@@ -893,7 +894,8 @@ def check_datasets_datalad_org(suffix, tdir):
     # Apparently things can break, especially with introduction of the
     # smart HTTP backend for apache2 etc
     ds = install(tdir, source='///dicoms/dartmouth-phantoms/bids_test6-PD+T2w' + suffix)
-    eq_(ds.config.get('remote.origin.annex-ignore', None), None)
+    eq_(ds.config.get(f'remote.{DEFAULT_REMOTE}.annex-ignore', None),
+        None)
     # assert_result_count and not just assert_status since for some reason on
     # Windows we get two records due to a duplicate attempt (as res[1]) to get it
     # again, which is reported as "notneeded".  For the purpose of this test

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import (
     assert_status,
     create_tree,
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     eq_,
     known_failure_appveyor,
     known_failure_windows,
@@ -163,7 +164,7 @@ def test_publish_simple(origin, src_path, dst_path):
     source = install(src_path, source=origin, recursive=True)
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
-    source.repo.remove_remote("origin")
+    source.repo.remove_remote(DEFAULT_REMOTE)
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
@@ -222,7 +223,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
     source = install(src_path, source=origin, recursive=True)
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
-    source.repo.remove_remote("origin")
+    source.repo.remove_remote(DEFAULT_REMOTE)
 
     # create plain git at target:
     target = GitRepo(dst_path, create=True)
@@ -735,7 +736,7 @@ def test_gh1811(srcpath, clonepath):
     (clone.pathobj / 'somemore').write_text('somemore')
     clone.save()
     clone.repo.call_git(['checkout', 'HEAD~1'])
-    res = clone.publish(to='origin', on_failure='ignore')
+    res = clone.publish(to=DEFAULT_REMOTE, on_failure='ignore')
     assert_result_count(res, 1)
     assert_result_count(
         res, 1,
@@ -751,12 +752,12 @@ def test_publish_no_fetch_refspec_configured(path):
     GitWitlessRunner(cwd=str(path)).run(
         ["git", "init", "--bare", "empty-remote"])
     ds = Dataset(path / "ds").create()
-    ds.repo.add_remote("origin", str(ds.pathobj.parent / "empty-remote"))
+    ds.repo.add_remote(DEFAULT_REMOTE, str(ds.pathobj.parent / "empty-remote"))
     # Mimic a situation that can happen with an LFS remote. See gh-4199.
-    ds.repo.config.unset("remote.origin.fetch", where="local")
+    ds.repo.config.unset(f"remote.{DEFAULT_REMOTE}.fetch", where="local")
     (ds.repo.pathobj / "foo").write_text("a")
     ds.save()
-    ds.publish(to="origin")
+    ds.publish(to=DEFAULT_REMOTE)
 
 
 @known_failure_windows

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -162,7 +162,7 @@ def test_publish_simple(origin, src_path, dst_path):
 
     # prepare src
     source = install(src_path, source=origin, recursive=True)
-    # forget we cloned it (provide no 'origin' anymore), which should lead to
+    # forget we cloned it by removing remote, which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote(DEFAULT_REMOTE)
 
@@ -221,7 +221,7 @@ def test_publish_plain_git(origin, src_path, dst_path):
 
     # prepare src
     source = install(src_path, source=origin, recursive=True)
-    # forget we cloned it (provide no 'origin' anymore), which should lead to
+    # forget we cloned it by removing remote, which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote(DEFAULT_REMOTE)
 

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -49,6 +49,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_in_results,
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     skip_if_adjusted_branch,
     SkipTest,
     slow,
@@ -69,7 +70,7 @@ def test_update_simple(origin, src_path, dst_path):
     source = install(src_path, source=origin, recursive=True)
     # forget we cloned it (provide no 'origin' anymore), which should lead to
     # setting tracking branch to target:
-    source.repo.remove_remote("origin")
+    source.repo.remove_remote(DEFAULT_REMOTE)
 
     # dataset without sibling will not need updates
     assert_status('notneeded', source.update())
@@ -101,7 +102,8 @@ def test_update_simple(origin, src_path, dst_path):
     assert_not_in("update.txt",
                   dest.repo.get_files(dest.repo.get_active_branch()))
     # modification is known to branch origin/<default branch>
-    assert_in("update.txt", dest.repo.get_files("origin/" + DEFAULT_BRANCH))
+    assert_in("update.txt",
+              dest.repo.get_files(DEFAULT_REMOTE + "/" + DEFAULT_BRANCH))
 
     # merge:
     assert_status('ok', dest.update(merge=True))
@@ -273,7 +275,7 @@ def test_newthings_coming_down(originpath, destpath):
         source=originpath, path=destpath,
         result_xfm='datasets', return_type='item-or-list')
     assert_is_instance(ds.repo, GitRepo)
-    assert_in('origin', ds.repo.get_remotes())
+    assert_in(DEFAULT_REMOTE, ds.repo.get_remotes())
     # turn origin into an annex
     origin = AnnexRepo(originpath, create=True)
     # clone doesn't know yet

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -32,6 +32,7 @@ from datalad.support.gitrepo import (
     GitRepo,
 )
 from datalad.support.annexrepo import AnnexRepo
+from datalad.support.external_versions import external_versions
 from datalad.tests.utils import (
     with_tempfile,
     assert_in,
@@ -691,6 +692,12 @@ def test_merge_follow_parentds_subdataset_adjusted_warning(path):
 @skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def check_merge_follow_parentds_subdataset_detached(on_adjusted, path):
+    if on_adjusted and DEFAULT_REMOTE != "origin" and \
+       external_versions['cmd:annex'] <= "8.20210330":
+        raise SkipTest(
+            "'git annex init' with adjusted branch currently fails "
+            "due to hard-coded 'origin'")
+
     # Note: For the adjusted case, this is not much more than a smoke test that
     # on an adjusted branch we fail sensibly. The resulting state is not easy
     # to reason about nor desirable.

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -69,7 +69,7 @@ def test_update_simple(origin, src_path, dst_path):
 
     # prepare src
     source = install(src_path, source=origin, recursive=True)
-    # forget we cloned it (provide no 'origin' anymore), which should lead to
+    # forget we cloned it by removing remote, which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote(DEFAULT_REMOTE)
 
@@ -91,7 +91,7 @@ def test_update_simple(origin, src_path, dst_path):
     assert_status('ok', dest.update())
     assert_repo_status(dst_path)
 
-    # modify origin:
+    # modify remote:
     with open(opj(src_path, "update.txt"), "w") as f:
         f.write("Additional content")
     source.save(path="update.txt", message="Added update.txt")
@@ -102,7 +102,7 @@ def test_update_simple(origin, src_path, dst_path):
     # modification is not known to active branch:
     assert_not_in("update.txt",
                   dest.repo.get_files(dest.repo.get_active_branch()))
-    # modification is known to branch origin/<default branch>
+    # modification is known to branch <default remote>/<default branch>
     assert_in("update.txt",
               dest.repo.get_files(DEFAULT_REMOTE + "/" + DEFAULT_BRANCH))
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -423,7 +423,10 @@ definitions = {
                     "clone source is configured as an 'origin-2' remote "
                     "to make its annex automatically available. The process "
                     "is repeated recursively for any further qualifying "
-                    "'origin' dataset thereof."}),
+                    "'origin' dataset thereof."
+                    "Note that if clone.defaultRemoteName is configured "
+                    "to use a name other than 'origin', that name will be "
+                    "used instead."}),
         'default': True,
         'type': EnsureBool(),
     },

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -59,6 +59,7 @@ from datalad.tests.utils import (
     ok_file_under_git,
     create_tree,
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     eq_,
     neq_,
     assert_status,
@@ -667,7 +668,7 @@ def test_run_inputs_outputs(src, path):
     create_tree(ds.path, {i: i for i in inputs})
 
     ds.save()
-    ds.repo.copy_to(inputs, remote="origin")
+    ds.repo.copy_to(inputs, remote=DEFAULT_REMOTE)
     ds.repo.drop(inputs, options=["--force"])
 
     test_cases = [(["*.dat"], ["a.dat", "b.dat"]),
@@ -687,7 +688,7 @@ def test_run_inputs_outputs(src, path):
     create_tree(ds.path, {"subdir": {"a": "subdir a",
                                      "b": "subdir b"}})
     ds.save("subdir")
-    ds.repo.copy_to(["subdir/a", "subdir/b"], remote="origin")
+    ds.repo.copy_to(["subdir/a", "subdir/b"], remote=DEFAULT_REMOTE)
     ds.repo.drop("subdir", options=["--force"])
     ds.run("cd .> subdir-dummy", inputs=[op.join(ds.path, "subdir")])
     ok_(all(ds.repo.file_has_content(op.join("subdir", f)) for f in ["a", "b"]))
@@ -706,7 +707,7 @@ def test_run_inputs_outputs(src, path):
     # time of the run.
     create_tree(ds.path, {"after-dot-run": "after-dot-run content"})
     ds.save()
-    ds.repo.copy_to(["after-dot-run"], remote="origin")
+    ds.repo.copy_to(["after-dot-run"], remote=DEFAULT_REMOTE)
     ds.repo.drop(["after-dot-run"], options=["--force"])
     ds.rerun(DEFAULT_BRANCH + "^")
     ds.repo.file_has_content("after-dot-run")

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -73,6 +73,7 @@ from datalad.tests.utils import (
     assert_true,
     create_tree,
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     eq_,
     find_files,
     get_most_obscure_supported_name,
@@ -1160,10 +1161,10 @@ def test_annex_ssh(topdir):
     topdir = Path(topdir)
     rm1 = AnnexRepo(topdir / "remote1", create=True)
     rm2 = AnnexRepo.clone(rm1.path, str(topdir / "remote2"))
-    rm2.remove_remote("origin")
+    rm2.remove_remote(DEFAULT_REMOTE)
 
     main_tmp = AnnexRepo.clone(rm1.path, str(topdir / "main"))
-    main_tmp.remove_remote("origin")
+    main_tmp.remove_remote(DEFAULT_REMOTE)
     repo_path = main_tmp.path
     del main_tmp
     remote_1_path = rm1.path
@@ -1504,7 +1505,7 @@ def test_is_available(batch, p):
     assert is_available(fname) is True
 
     # known remote but doesn't have it
-    assert is_available(fname, remote='origin') is False
+    assert is_available(fname, remote=DEFAULT_REMOTE) is False
     # it is on the 'web'
     assert is_available(fname, remote='web') is True
     # not effective somehow :-/  may be the process already running or smth
@@ -1922,7 +1923,7 @@ def test_wanted(path):
     GitRepo.clone(ar.path, ar1_path)
     ar1 = AnnexRepo(ar1_path, init=False)
     eq_(ar1.get_preferred_content('wanted'), None)
-    eq_(ar1.get_preferred_content('wanted', 'origin'), v)
+    eq_(ar1.get_preferred_content('wanted', DEFAULT_REMOTE), v)
     ar1.set_preferred_content('wanted', expr='standard')
     eq_(ar1.get_preferred_content('wanted'), 'standard')
 
@@ -2065,7 +2066,8 @@ def test_AnnexRepo_get_tracking_branch(src_path, path):
     ar = AnnexRepo.clone(src_path, path)
 
     # we want the relation to original branch, e.g. in v6+ adjusted branch
-    eq_(('origin', 'refs/heads/' + DEFAULT_BRANCH), ar.get_tracking_branch())
+    eq_((DEFAULT_REMOTE, 'refs/heads/' + DEFAULT_BRANCH),
+        ar.get_tracking_branch())
 
 
 @skip_if_adjusted_branch
@@ -2097,7 +2099,7 @@ def test_is_special(path):
     ok_(rem.is_special_annex_remote("imspecial"))
 
     ar = AnnexRepo.clone(rem.path, op.join(path, "main"))
-    assert_false(ar.is_special_annex_remote("origin"))
+    assert_false(ar.is_special_annex_remote(DEFAULT_REMOTE))
 
     assert_false(ar.is_special_annex_remote("imspecial",
                                             check_if_known=False))
@@ -2105,9 +2107,9 @@ def test_is_special(path):
     ok_(ar.is_special_annex_remote("imspecial"))
 
     # With a mis-configured remote, give warning and return false.
-    ar.config.unset("remote.origin.url", where="local")
+    ar.config.unset(f"remote.{DEFAULT_REMOTE}.url", where="local")
     with swallow_logs(new_level=logging.WARNING) as cml:
-        assert_false(ar.is_special_annex_remote("origin"))
+        assert_false(ar.is_special_annex_remote(DEFAULT_REMOTE))
         cml.assert_logged(msg=".*no URL.*", level="WARNING", regex=True)
 
 
@@ -2411,7 +2413,7 @@ def test_ro_operations(path):
     # progress forward original repo and fetch (but nothing else) it into repo2
     repo.add('file2')
     repo.commit()
-    repo2.fetch('origin')
+    repo2.fetch(DEFAULT_REMOTE)
 
     # Assure that regardless of umask everyone could read it all
     run(['chmod', '-R', 'a+rX', repo2.path])

--- a/datalad/tests/test_testrepos.py
+++ b/datalad/tests/test_testrepos.py
@@ -13,6 +13,7 @@ import os
 from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import usecase
 from datalad.tests.utils import (
+    DEFAULT_REMOTE,
     ok_,
     with_testrepos,
     with_tempfile,
@@ -33,8 +34,8 @@ def test_having_annex(path):
     #ok_('git-annex' in branches, msg="Didn't find git-annex among %s" % branches)
     # look for it among remote refs
     refs = repo.get_remote_branches()
-    ok_('origin/git-annex' in refs, msg="Didn't find git-annex among refs %s"
-                                        % refs)
+    ok_(DEFAULT_REMOTE +'/git-annex' in refs,
+        msg="Didn't find git-annex among refs %s" % refs)
 
 @with_testrepos(flavors=['network'])
 def test_point_to_github(url):

--- a/datalad/tests/test_utils_cached_dataset.py
+++ b/datalad/tests/test_utils_cached_dataset.py
@@ -25,6 +25,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_result_count,
     assert_true,
+    DEFAULT_REMOTE,
     known_failure_windows,
     skip_if_no_network,
     with_tempfile
@@ -174,10 +175,10 @@ def test_cached_dataset(cache_dir):
             # it's a clone in a temp. location, not within the cache
             assert_not_in(cache_dir, ds.pathobj.parents)
             assert_result_count(ds.siblings(), 1, type="sibling",
-                                name="origin",
+                                name=DEFAULT_REMOTE,
                                 url=str(cache_dir / name_in_cache))
             here = ds.config.get("annex.uuid")
-            origin = ds.config.get("remote.origin.annex-uuid")
+            origin = ds.config.get(f"remote.{DEFAULT_REMOTE}.annex-uuid")
             where = ds.repo.whereis(str(annexed_file))
             assert_not_in(here, where)
             assert_not_in(origin, where)
@@ -191,10 +192,10 @@ def test_cached_dataset(cache_dir):
             # it's a clone in a temp. location, not within the cache
             assert_not_in(cache_dir, ds.pathobj.parents)
             assert_result_count(ds.siblings(), 1, type="sibling",
-                                name="origin",
+                                name=DEFAULT_REMOTE,
                                 url=str(cache_dir / name_in_cache))
             here = ds.config.get("annex.uuid")
-            origin = ds.config.get("remote.origin.annex-uuid")
+            origin = ds.config.get(f"remote.{DEFAULT_REMOTE}.annex-uuid")
             where = ds.repo.whereis(str(annexed_file))
             assert_in(here, where)
             assert_in(origin, where)
@@ -208,13 +209,13 @@ def test_cached_dataset(cache_dir):
             # it's a clone in a temp. location, not within the cache
             assert_not_in(cache_dir, ds.pathobj.parents)
             assert_result_count(ds.siblings(), 1, type="sibling",
-                                name="origin",
+                                name=DEFAULT_REMOTE,
                                 url=str(cache_dir / name_in_cache))
             # origin is the same cached dataset, that got this content in
             # decorated_test2 before. Should still be there. But "here" we
             # didn't request it
             here = ds.config.get("annex.uuid")
-            origin = ds.config.get("remote.origin.annex-uuid")
+            origin = ds.config.get(f"remote.{DEFAULT_REMOTE}.annex-uuid")
             where = ds.repo.whereis(str(annexed_file))
             assert_not_in(here, where)
             assert_in(origin, where)
@@ -229,13 +230,13 @@ def test_cached_dataset(cache_dir):
             # it's a clone in a temp. location, not within the cache
             assert_not_in(cache_dir, ds.pathobj.parents)
             assert_result_count(ds.siblings(), 1, type="sibling",
-                                name="origin",
+                                name=DEFAULT_REMOTE,
                                 url=str(cache_dir / name_in_cache))
             # origin is the same cached dataset, that got this content in
             # decorated_test2 before. Should still be there. But "here" we
             # didn't request it
             here = ds.config.get("annex.uuid")
-            origin = ds.config.get("remote.origin.annex-uuid")
+            origin = ds.config.get(f"remote.{DEFAULT_REMOTE}.annex-uuid")
             where = ds.repo.whereis(str(annexed_file))
             assert_not_in(here, where)
             assert_in(origin, where)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -116,7 +116,12 @@ if external_versions["cmd:git"] >= "2.28":
 else:
     DEFAULT_BRANCH = "master"
 
-DEFAULT_REMOTE = "origin"
+if external_versions["cmd:git"] >= "2.30.0":
+    # The specific value here doesn't matter, but it should not be the default
+    # from any Git version to test that we work with custom values.
+    DEFAULT_REMOTE = "dl-test-remote"  # Set by setup_package().
+else:
+    DEFAULT_REMOTE = "origin"
 
 # additional shortcuts
 neq_ = assert_not_equal

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -116,6 +116,8 @@ if external_versions["cmd:git"] >= "2.28":
 else:
     DEFAULT_BRANCH = "master"
 
+DEFAULT_REMOTE = "origin"
+
 # additional shortcuts
 neq_ = assert_not_equal
 nok_ = assert_false

--- a/datalad/tests/utils_cached_dataset.py
+++ b/datalad/tests/utils_cached_dataset.py
@@ -13,7 +13,10 @@ from datalad.utils import (
     rmtree
 )
 from datalad.support.annexrepo import AnnexRepo
-from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import (
+    DEFAULT_REMOTE,
+    with_tempfile,
+)
 
 
 DATALAD_TESTS_CACHE = cfg.obtain("datalad.tests.cache")
@@ -111,7 +114,7 @@ def get_cached_dataset(url, version=None, keys=None):
     # things. It's about datasets used in the tests - they shouldn't change too
     # frequently.
     elif any('uptodate' not in c['operations']
-             for c in ds.repo.fetch('origin')):
+             for c in ds.repo.fetch(DEFAULT_REMOTE)):
         rmtree(ds.path)
         ds = Clone()(url, ds.pathobj)
 
@@ -178,7 +181,7 @@ def cached_dataset(f, url=None, version=None, paths=None):
                 # translate to keys.
                 keys = clone_ds.repo.get_file_key(paths)
                 ds.repo.get(keys, key=True)
-                clone_ds.repo.fsck(remote='origin', fast=True)
+                clone_ds.repo.fsck(remote=DEFAULT_REMOTE, fast=True)
 
             clone_ds.get(paths)
         return f(*(arg[:-1] + (clone_ds,)), **kw)

--- a/tools/ci/install-minimum-git.sh
+++ b/tools/ci/install-minimum-git.sh
@@ -13,5 +13,5 @@ target_dir="$PWD/git-src"
 git clone https://github.com/git/git "$target_dir"
 cd "$target_dir"
 git checkout "refs/tags/v$MIN_VERSION"
-make --jobs
+make --jobs 2
 ./git version

--- a/tools/ci/install-upstream-git.sh
+++ b/tools/ci/install-upstream-git.sh
@@ -5,7 +5,7 @@ git clone https://github.com/git/git "$target_dir"
 (
     cd "$target_dir"
     git checkout origin/master
-    make --jobs
+    make --jobs 2
 )
 export PATH="$target_dir/bin-wrappers/:$PATH"
 git version


### PR DESCRIPTION
`datalad clone` and test code assume that the remote name is "origin".  Even though `datalad clone` doesn't expose the `--origin` option of `git clone`, this assumption is no longer safe because, as of Git 2.30, the default remote name for clones can be configured via `clone.defaultRemoteName`.

This is a work-in-progress series for addressing that.

---

- [x] Drop tip commits after confirming tests pass with custom `clone.defaultRemoteName` value.

  I've executed only a subset of tests locally, so there are probably still failures to address.

  Update: ~Need to fix git build first.~
  https://travis-ci.com/github/datalad/datalad/builds/223108958#L1661

  Passed: https://travis-ci.com/github/datalad/datalad/builds/223218195

- [x] Deal with adjusted branches failing with a remote name other than "origin".

  See
  https://git-annex.branchable.com/bugs/crippledfs__58___annex-init_crash_when_remote_name_is/

  The main solution here is probably just to not set the custom value for systems that default to adjusted branches, waiting for an upstream fix.

  Update: Fixed upstream in git-annex by e1a9b79fa (fix hardcoded origin name in checkAdjustedClone, 2021-04-14).

- [x] Adjust nearby comments and docstrings to avoid 'origin'.

  The changes so far are almost all code changes.

- [x] Double check that we should stick with `datalad.get.subdataset-source-candidate-200origin`.

...


