### PR TITLE
WiP: trying to get a better status than just "untracked" for a subdataset

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -182,6 +182,10 @@ def path_is_under(values, path=None):
     return False
 
 
+# XXX YOH: from a cursory review seems like possibly an expensive function
+# whenever many paths were provided (e.g. via shell glob).
+# Might be worth testing on some usecase and py-spy'ing if notable portion
+# of time is spent.
 def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
                                       spec, includeds=None):
     """Discover the edges and nodes in a dataset tree to given target paths
@@ -200,7 +204,7 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
     spec : dict
       `content_by_ds`-style dictionary that will receive information about the
       discovered datasets. Specifically, for each discovered dataset there
-      will be in item with its path under the key (path) of the respective
+      will be an item with its path under the key (path) of the respective
       superdataset.
     includeds : sequence, optional
       Any paths given are treated as existing subdatasets, regardless of


### PR DESCRIPTION
In a very dirty state -- just want to do a quick sweep through the tests.
It does seem to address #5521 (runs for 0.9 sec instead of >4 minutes; edit: took 20 minutes on a cold `git`) with the same effect of accomplishing nothing.
Actually it even removes result record on `add(ok): psychoinformatics-de (file)` for intermediate dataset which is not really added anyhow (no changes) and reports only a correct `save (notneeded: 2)`

Edit: most likely it is a wrong place for the fix add it should be done in status, to return records for intermediate datasets if refds was provided