### PR TITLE
TST: no_annex: Avoid racy failure on adjusted branches

### DIFF
--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -191,13 +191,30 @@ def test_no_annex(path):
     # add inannex pre configuration
     ds.save(opj('code', 'inannex'))
     no_annex(pattern=['code/**', 'README'], dataset=ds.path)
+
+    inannex = (ds.pathobj / 'code' / 'inannex')
+    # Ensure that notinannex's mtime is as recent or newer than .git/index's so
+    # that, on an adjusted branch, the clean filter runs on the next save. This
+    # avoids a racy failure of the managed-branch assert_repo_status check
+    # below.
+    inannex.touch()
+
     # add inannex and README post configuration
     ds.save([opj('code', 'notinannex'), 'README'])
-    assert_repo_status(ds.path)
-    # one is annex'ed, the other is not, despite no change in add call
-    # importantly, also .gitattribute is not annexed
-    eq_([opj('code', 'inannex')],
-        [str(Path(p)) for p in ds.repo.get_annexed_files()])
+
+    if ds.repo.is_managed_branch():
+        # For unlocked files, if .gitattributes is configured so that a file
+        # should go to git, an annexed file will switch to be tracked by git
+        # the next time the clean filter runs on it.
+        #
+        # https://git-annex.branchable.com/forum/one-off_unlocked_annex_files_that_go_against_large/
+        assert_repo_status(ds.path, modified=[inannex])
+    else:
+        assert_repo_status(ds.path)
+        # one is annex'ed, the other is not, despite no change in add call
+        # importantly, also .gitattribute is not annexed
+        eq_([opj('code', 'inannex')],
+            [str(Path(p)) for p in ds.repo.get_annexed_files()])
 
 
 _ds_template = {


### PR DESCRIPTION
test_no_annex() has started to fail frequently on the CrippledFS runs.
I can trigger it with `tools/eval_under_testloopfs` locally.

The underlying issue is that if a file is added to the annex but the
annex.largefiles configuration would send it to git, that file will be
sent to git the next time the clean filter runs on it.  In the context
of this test, the test failure is sporadic because the clean filter
runs on the file ("code/inannex") only when its mtime matches
.git/index's.

I don't know why the above failure has started to happen much more
frequently, and, as mentioned in the git-annex link below, I'm not
sure what expectations here should be.

Avoid the intermittent failure by forcing the mtimes to be the same,
and updating the assertion to expect a dirty tree.  That should lead
to a reliable outcome, and, if git-annex's behavior changes here, a
test failure will let us know.

Re: #5300
https://git-annex.branchable.com/forum/one-off_unlocked_annex_files_that_go_against_large/
