### PR TITLE
BF: annexjson2result() could not handle file=null results

### DIFF
--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -224,7 +224,7 @@ def annexjson2result(d, ds, **kwargs):
     res['status'] = 'ok' if d.get('success', False) is True else 'error'
     # we cannot rely on any of these to be available as the feed from
     # git annex (or its wrapper) is not always homogeneous
-    if 'file' in d:
+    if d.get('file'):
         res['path'] = str(ds.pathobj / PurePosixPath(d['file']))
     if 'command' in d:
         res['action'] = d['command']

--- a/datalad/interface/tests/test_results.py
+++ b/datalad/interface/tests/test_results.py
@@ -1,0 +1,46 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Result utility tests
+
+"""
+
+from datalad.interface.results import (
+    annexjson2result,
+)
+from datalad.distribution.dataset import Dataset
+
+from datalad.tests.utils import (
+    eq_,
+    with_tempfile,
+)
+
+
+@ with_tempfile
+def test_annexjson2result(dspath):
+    # no explicit success means 'error'
+    eq_(annexjson2result(dict(), None),
+        dict(status='error'))
+    # unrecognized -> error
+    eq_(annexjson2result(dict(success='random'), None),
+        dict(status='error'))
+    # success is possible ;-)
+    eq_(annexjson2result(dict(success=True), None),
+        dict(status='ok'))
+
+    # path handling
+    # needs a dataset
+    ds = Dataset(dspath)
+    eq_(annexjson2result(dict(file='file1'), ds),
+        dict(status='error',
+             path=str(ds.pathobj / 'file1')))
+    # on all platforms, paths are reported in platform conventions
+    # although git-annex reports in posix
+    eq_(annexjson2result(dict(file='dir1/file1'), ds),
+        dict(status='error',
+             path=str(ds.pathobj / 'dir1' / 'file1')))


### PR DESCRIPTION
In this case, there should be no 'path' property at all.

Established a place to have any tests for the result utility code.
Far from being comprehensive...

Closes #5490
