### PR TITLE
ENH(UX,DX): raise RuntimeError if PATH env var is not set

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -514,6 +514,8 @@ class GitRunnerBase(object):
         if found.  If it is empty (but not None), we do nothing
         """
         if GitRunnerBase._GIT_PATH is None:
+            if not os.environ.get('PATH', None):
+                raise RuntimeError("PATH environment variable is either undefined or set empty.")
             from distutils.spawn import find_executable
             # with all the nesting of config and this runner, cannot use our
             # cfg here, so will resort to dark magic of environment options


### PR DESCRIPTION
I think it is very reasonable to require for it to be set across all OSes
(IIRC).  Even though we would set PATH to point to the location where we find
git-annex using `distutils.spawn.find_executable`, I think it just buries the
issue of inadequate environment, and IMHO it is better to error out with a
clear message right away.

This should prevent needing to troubleshoot odd execution errors such as
in the case of https://github.com/datalad/datalad/issues/5546 .