### PR TITLE
NF: Add alias argument to create_sibling_ria

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -104,6 +104,11 @@
             "affiliation": "Maze Therapeutics, South San Francisco, CA, United States",
             "name": "Nichols, B. Nolan",
             "orcid": "0000-0003-1099-3328"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research (PIK) e. V.",
+            "name": "Mika Pflüger",
+            "orcid": "0000-0002-7814-8916"
         }
     ],
     "grants": [

--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -10,6 +10,11 @@
 
 """
 
+import logging
+
+
+lgr = logging.getLogger('datalad.customremotes.ria_utils')
+
 
 class UnknownLayoutVersion(Exception):
     pass
@@ -209,4 +214,8 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=No
     if alias:
         alias_dir = base_path / "alias"
         io.mkdir(alias_dir)
-        io.symlink(dsgit_dir, alias_dir / alias)
+        try:
+            io.symlink(dsgit_dir, alias_dir / alias)
+        except FileExistsError:
+            lgr.warning("Alias %r already exists in the RIA store, not adding an "
+                        "alias.", alias)

--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -208,6 +208,5 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=No
     io.write_file(version_file, obj_version)
     if alias:
         alias_dir = base_path / "alias"
-        if not io.exists(alias_dir):
-            io.mkdir(alias_dir)
+        io.mkdir(alias_dir)
         io.symlink(dsgit_dir, alias_dir / alias)

--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -151,7 +151,7 @@ def create_store(io, base_path, version):
     io.write_file(version_file, version)
 
 
-def create_ds_in_store(io, base_path, dsid, obj_version, store_version):
+def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=None):
     """Helper to create a dataset in a RIA store
 
     Note, that this is meant as an internal helper and part of intermediate
@@ -171,6 +171,8 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version):
       layout version of the store (dataset tree)
     obj_version: str
       layout version of the dataset itself (object tree)
+    alias: str, optional
+      alias for the dataset in the store
     """
 
     # TODO: Note for RF'ing, that this is about setting up a valid target
@@ -204,3 +206,8 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version):
     io.mkdir(archive_dir)
     io.mkdir(dsobj_dir)
     io.write_file(version_file, obj_version)
+    if alias:
+        alias_dir = base_path / "alias"
+        if not io.exists(alias_dir):
+            io.mkdir(alias_dir)
+        io.symlink(dsgit_dir, alias_dir / alias)

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -179,6 +179,14 @@ class CreateSiblingRia(Interface):
             a storage sibling is created, this setting is ignored, and
             the primary sibling name is used.""",
             constraints=EnsureStr() | EnsureNone()),
+        alias=Parameter(
+            args=('--alias',),
+            metavar='ALIAS',
+            doc="""Alias for the dataset in the RIA store.
+            Add the necessary symlink so that this dataset can be cloned from the RIA
+            store using the given ALIAS instead of its ID.
+            With `recursive=True`, only the top dataset will be aliased.""",
+            constraints=EnsureStr() | EnsureNone()),
         post_update_hook=Parameter(
             args=("--post-update-hook",),
             doc="""Enable git's default post-update-hook for the created
@@ -246,6 +254,7 @@ class CreateSiblingRia(Interface):
                  name,
                  dataset=None,
                  storage_name=None,
+                 alias=None,
                  post_update_hook=False,
                  shared=None,
                  group=None,
@@ -396,6 +405,7 @@ class CreateSiblingRia(Interface):
             name,
             storage_sibling,
             storage_name,
+            alias,
             existing,
             shared,
             group,
@@ -419,6 +429,7 @@ class CreateSiblingRia(Interface):
                     name,
                     storage_sibling,
                     storage_name,
+                    None,  # subdatasets can't have the same alias as the parent
                     existing,
                     shared,
                     group,
@@ -434,6 +445,7 @@ def _create_sibling_ria(
         name,
         storage_sibling,
         storage_name,
+        alias,
         existing,
         shared,
         group,
@@ -548,7 +560,7 @@ def _create_sibling_ria(
             " and '{}'".format(storage_name) if storage_name else '',
         ))
     create_ds_in_store(SSHRemoteIO(ssh_host) if ssh_host else LocalIO(),
-                       base_path, ds.id, '2', '1')
+                       base_path, ds.id, '2', '1', alias)
     if storage_sibling:
         # we are using the main `name`, if the only thing we are creating
         # is the storage sibling

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -2,6 +2,7 @@ from annexremote import SpecialRemote
 from annexremote import RemoteError
 from annexremote import ProtocolError
 
+import os
 from pathlib import (
     Path,
     PurePosixPath
@@ -91,6 +92,9 @@ class IOBase(object):
     def mkdir(self, path):
         raise NotImplementedError
 
+    def symlink(self, target, link_name):
+        raise NotImplementedError
+
     def put(self, src, dst, progress_cb):
         raise NotImplementedError
 
@@ -167,6 +171,9 @@ class LocalIO(IOBase):
             parents=True,
             exist_ok=True,
         )
+
+    def symlink(self, target, link_name):
+        os.symlink(target, link_name)
 
     def put(self, src, dst, progress_cb):
         shutil.copy(
@@ -418,6 +425,9 @@ class SSHRemoteIO(IOBase):
 
     def mkdir(self, path):
         self._run('mkdir -p {}'.format(sh_quote(str(path))))
+
+    def symlink(self, target, link_name):
+        self._run('ln -s {} {}'.format(sh_quote(str(target)), sh_quote(str(link_name))))
 
     def put(self, src, dst, progress_cb):
         self.ssh.put(str(src), str(dst))

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -258,6 +258,7 @@ def test_create_push_url(detection_path, ds_path, store_path):
         ds.repo.call_annex(['copy', '.', '--to', 'datastore-storage'])
 
 
+@skip_if_on_windows
 @skip_wo_symlink_capability
 @with_tempfile
 @with_tempfile

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -27,6 +27,7 @@ from datalad.tests.utils import (
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_ssh,
+    skip_wo_symlink_capability,
     slow,
     swallow_logs,
     turtle,
@@ -174,6 +175,7 @@ def test_initremote_basic():
     yield _test_initremote_basic, None
 
 
+@skip_wo_symlink_capability
 @known_failure_windows  # see gh-4469
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
### Overview

Add an argument to create_sibling_ria to add an alias symlink to the RIA store to refer to this dataset.

### TODO

* [x] Integration test using create_sibling_ria directly
* [x] add to `.zenodo.json`

### Comment

Would be great to know if the way I'm adding this functionality looks sane, it is the first time I touch the datalad code.