### PR TITLE
run: Two --input/--output glob fixes

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -616,6 +616,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             expected_exit=rerun_info.get("exit", 0) if rerun_info else None)
 
 
+    # Re-glob to capture any new outputs.
+    if explicit or expand in ["outputs", "both"]:
+        outputs.expand(refresh=True)
+
     # amend commit message with `run` info:
     # - pwd if inside the dataset
     # - the command itself

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -349,12 +349,15 @@ def prepare_inputs(dset_path, inputs, extra_inputs=None):
     for gp in gps:
         for res in _install_and_reglob(dset_path, gp):
             yield res
-        for res in get(dataset=dset_path, path=gp.expand(), on_failure="ignore"):
-            if _is_nonexistent_path(res):
-                # MIH why just a warning if given inputs are not valid?
-                lgr.warning("Input does not exist: %s", res["path"])
-            else:
-                yield res
+        if gp.misses:
+            ds = Dataset(dset_path)
+            for miss in gp.misses:
+                yield get_status_dict(
+                    action="run", ds=ds, status="error",
+                    message=("Input did not match existing file: %s",
+                             miss))
+        yield from get(dataset=dset_path, path=gp.expand_strict(),
+                       on_failure="ignore")
 
 
 def _unlock_or_remove(dset_path, paths):
@@ -579,7 +582,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             if outputs:
                 for res in _install_and_reglob(ds_path, outputs):
                     yield res
-                for res in _unlock_or_remove(ds_path, outputs.expand()):
+                for res in _unlock_or_remove(ds_path, outputs.expand_strict()):
                     yield res
 
             if rerun_outputs is not None:
@@ -617,6 +620,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
 
     # Re-glob to capture any new outputs.
+    #
+    # TODO: If a warning or error is desired when an --output pattern doesn't
+    # have a match, this would be the spot to do it.
     if explicit or expand in ["outputs", "both"]:
         outputs.expand(refresh=True)
 
@@ -672,7 +678,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         message if message is not None else _format_cmd_shorty(cmd_expanded),
         '"{}"'.format(record_id) if use_sidecar else record)
 
-    outputs_to_save = outputs.expand() if explicit else None
+    outputs_to_save = outputs.expand_strict() if explicit else None
     if outputs_to_save is not None and use_sidecar:
         outputs_to_save.append(record_path)
     do_save = outputs_to_save is None or outputs_to_save

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -658,10 +658,6 @@ def test_run_inputs_outputs(src, path):
     ok_(ds.repo.file_has_content("input.dat"))
     ok_(ds.repo.file_has_content("extra-input.dat"))
 
-    with swallow_logs(new_level=logging.WARN) as cml:
-        ds.run("cd .> dummy", inputs=["not-there"])
-        assert_in("Input does not exist: ", cml.out)
-
     # Test different combinations of globs and explicit files.
     inputs = ["a.dat", "b.dat", "c.txt", "d.txt"]
     create_tree(ds.path, {i: i for i in inputs})
@@ -731,13 +727,6 @@ def test_run_inputs_outputs(src, path):
         # MIH doesn't yet understand how to port this
         with open(op.join(path, "a.dat")) as fh:
             eq_(fh.read(), " appended\n appended\n")
-
-    if not on_windows:
-        # see datalad#2606
-        with swallow_logs(new_level=logging.DEBUG) as cml:
-            with swallow_outputs():
-                ds.run("echo blah", outputs=["not-there"])
-                assert_in("Filtered out non-existing path: ", cml.out)
 
     ds.create('sub')
     ds.run("echo sub_orig >sub/subfile")

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -763,9 +763,10 @@ def test_run_inputs_outputs(src, path):
 
 
 @known_failure_windows
-@with_tempfile(mkdir=True)
+@with_tree({"foo": "foo"})
 def test_run_inputs_no_annex_repo(path):
-    ds = Dataset(path).create(annex=False)
+    ds = Dataset(path).create(annex=False, force=True)
+    ds.save()
     # Running --input in a plain Git repo doesn't fail.
     ds.run("cd .> dummy", inputs=["*"])
     ok_exists(op.join(ds.path, "dummy"))

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -754,7 +754,7 @@ def test_run_inputs_outputs(src, path):
     eq_(res["run_info"]['inputs'], ["a.dat"])
     eq_(res["run_info"]['outputs'], ["b.dat"])
 
-    # We install subdatasets to fully resolve globs.
+    # We uninstall subdatasets to fully resolve globs.
     ds.uninstall("s0")
     assert_false(Dataset(op.join(path, "s0")).is_installed())
     ds.run("echo {inputs} >globbed-subds", inputs=["s0/s1_*/s2/*.dat"])

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -128,18 +128,21 @@ class GlobbedPaths(object):
             Run glob regardless of whether there are cached values. This is
             useful if there may have been changes on the file system.
         """
+        if refresh:
+            self._cache = {}
+
         maybe_dot = self._maybe_dot if dot else []
         if not self._patterns:
             return maybe_dot + []
 
-        if refresh or "expanded" not in self._cache:
+        if "expanded" not in self._cache:
             paths = self._expand_globs()
             self._cache["expanded"] = paths
         else:
             paths = self._cache["expanded"]
 
         if full:
-            if refresh or "expanded_full" not in self._cache:
+            if "expanded_full" not in self._cache:
                 paths = [op.join(self.pwd, p) for p in paths]
                 self._cache["expanded_full"] = paths
             else:

--- a/datalad/support/globbedpaths.py
+++ b/datalad/support/globbedpaths.py
@@ -54,7 +54,7 @@ class GlobbedPaths(object):
         self._cache = {}
 
     def __bool__(self):
-        return bool(self._maybe_dot or self.expand())
+        return bool(self._maybe_dot or self._patterns)
 
     @staticmethod
     @lru_cache()

--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -48,7 +48,6 @@ def test_globbedpaths_get_sub_patterns():
         eq_(gp._get_sub_patterns(pat), expected)
 
 
-@known_failure_windows
 @with_tree(tree={"1.txt": "",
                  "2.dat": "",
                  "3.txt": "",
@@ -64,9 +63,12 @@ def test_globbedpaths(path):
             (["*.txt", "*.dat"], {"1.txt", "2.dat", u"bβ.dat", "3.txt"}),
             ([dotdir + "*.txt", "*.dat"],
              {dotdir + "1.txt", "2.dat", u"bβ.dat", dotdir + "3.txt"}),
-            (["subdir/*.txt"], {"subdir/1.txt", "subdir/2.txt"}),
-            ([dotdir + "subdir/*.txt"],
-             {dotdir + p for p in ["subdir/1.txt", "subdir/2.txt"]}),
+            ([op.join("subdir", "*.txt")],
+             {op.join("subdir", "1.txt"), op.join("subdir", "2.txt")}),
+            (["subdir" + op.sep], {"subdir" + op.sep}),
+            ([dotdir + op.join("subdir", "*.txt")],
+             {dotdir + op.join(*ps)
+              for ps in [("subdir", "1.txt"), ("subdir", "2.txt")]}),
             (["*.txt"], {"1.txt", "3.txt"})]:
         gp = GlobbedPaths(patterns, pwd=path)
         eq_(set(gp.expand()), expected)

--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -83,7 +83,8 @@ def test_globbedpaths(path):
             ([pardir + "*.txt"], {pardir + p for p in ["1.txt", "3.txt"]}),
             ([dotdir + pardir + "*.txt"],
              {dotdir + pardir + p for p in ["1.txt", "3.txt"]}),
-            (["subdir/"], {"subdir/"})]:
+            # Patterns that don't match are retained by default.
+            (["amiss"], {"amiss"})]:
         gp = GlobbedPaths(patterns, pwd=subdir_path)
         eq_(set(gp.expand()), expected)
         eq_(set(gp.expand(full=True)),


### PR DESCRIPTION
This series fixes two glob-related issues with run:

  * Output patterns are now re-globbed to capture changes when needed (first commit).

    #3448

  * If an input glob doesn't match, an error result is now returned (last commit).

    #5583

The commits in between are mostly focused on preparing the `GlobbedPaths` helper and tests for the last commit.

