### PR TITLE
RF copy_file() with a cleaner (cached) Repo method access

### DIFF
--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -556,7 +556,6 @@ def _copy_file(src, dest, cache):
         for k, v in whereis.items()
         if v.get('urls', None)
     }
-
     if urls_by_sr:
         # some URLs are on record in the for this file
         # obtain information on special remotes
@@ -565,43 +564,13 @@ def _copy_file(src, dest, cache):
             src_srinfo = _extract_special_remote_info(src_repo)
             # put in cache
             src_repo_rec['srinfo'] = src_srinfo
-        # TODO generalize to more than one unique dest_repo
-        dest_srinfo = _extract_special_remote_info(dest_repo)
 
-        for src_rid, urls in urls_by_sr.items():
-            if not (src_rid == '00000000-0000-0000-0000-000000000001' or
-                    src_srinfo.get(src_rid, {}).get('externaltype', None) == 'datalad'):
-                # TODO generalize to any special remote
-                lgr.warning(
-                    'Ignore URL for presently unsupported special remote'
-                )
-                continue
-            if src_rid != '00000000-0000-0000-0000-000000000001' and \
-                    src_srinfo[src_rid] not in dest_srinfo.values():
-                # this is a special remote that the destination repo doesnt know
-                sri = src_srinfo[src_rid]
-                lgr.debug('Init additionally required special remote: %s', sri)
-                dest_repo.init_remote(
-                    # TODO what about a naming conflict across all dataset sources?
-                    sri['name'],
-                    ['{}={}'.format(k, v) for k, v in sri.items() if k != 'name'],
-                )
-                # must update special remote info for later matching
-                dest_srinfo = _extract_special_remote_info(dest_repo)
-            for url in urls:
-                lgr.debug('Register URL for key %s: %s', dest_key, url)
-                # TODO OPT: add .register_url(key, batched=False) to AnnexRepo
-                #  to speed up this step by batching.
-                dest_repo.call_annex(['registerurl', dest_key, url])
-            dest_rid = src_rid \
-                if src_rid == '00000000-0000-0000-0000-000000000001' \
-                else [
-                    k for k, v in dest_srinfo.items()
-                    if v['name'] == src_srinfo[src_rid]['name']
-                ].pop()
-            lgr.debug('Mark key %s as present for special remote: %s',
-                      dest_key, dest_rid)
-            dest_repo.call_annex(['setpresentkey', dest_key, dest_rid, '1'])
+        _register_urls(
+            dest_repo,
+            dest_key,
+            urls_by_sr,
+            src_srinfo,
+        )
 
     # TODO prevent copying .datalad of from other datasets?
     yield dict(
@@ -610,6 +579,55 @@ def _copy_file(src, dest, cache):
         message=dest,
         status='ok',
     )
+
+
+def _register_urls(repo, key, urls_by_sr, src_srinfo):
+    """Register URLs for a key in a repo based on special remote info
+
+    Parameters
+    ----------
+    repo : AnnexRepo
+    key : str
+    urls_by_sr : dict
+    src_srinfo : dict
+    """
+    # TODO generalize to more than one unique repo
+    dest_srinfo = _extract_special_remote_info(repo)
+
+    for src_rid, urls in urls_by_sr.items():
+        if not (src_rid == '00000000-0000-0000-0000-000000000001' or
+                src_srinfo.get(src_rid, {}).get('externaltype', None) == 'datalad'):
+            # TODO generalize to any special remote
+            lgr.warning(
+                'Ignore URL for presently unsupported special remote'
+            )
+            continue
+        if src_rid != '00000000-0000-0000-0000-000000000001' and \
+                src_srinfo[src_rid] not in dest_srinfo.values():
+            # this is a special remote that the destination repo doesnt know
+            sri = src_srinfo[src_rid]
+            lgr.debug('Init additionally required special remote: %s', sri)
+            repo.init_remote(
+                # TODO what about a naming conflict across all dataset sources?
+                sri['name'],
+                ['{}={}'.format(k, v) for k, v in sri.items() if k != 'name'],
+            )
+            # must update special remote info for later matching
+            dest_srinfo = _extract_special_remote_info(repo)
+        for url in urls:
+            lgr.debug('Register URL for key %s: %s', key, url)
+            # TODO OPT: add .register_url(key, batched=False) to AnnexRepo
+            #  to speed up this step by batching.
+            repo.call_annex(['registerurl', key, url])
+        dest_rid = src_rid \
+            if src_rid == '00000000-0000-0000-0000-000000000001' \
+            else [
+                k for k, v in dest_srinfo.items()
+                if v['name'] == src_srinfo[src_rid]['name']
+            ].pop()
+        lgr.debug('Mark key %s as present for special remote: %s',
+                  key, dest_rid)
+        repo.call_annex(['setpresentkey', key, dest_rid, '1'])
 
 
 def _replace_file(str_src, dest, str_dest, follow_symlinks):

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -427,6 +427,27 @@ def _get_repo_record(fpath, cache):
 
 
 def _copy_file(src, dest, cache):
+    """Transfer a single file from a source to a target dataset
+
+    Parameters
+    ----------
+    src : Path or str
+      Source file path
+    dest : Path or str
+      Destination file path
+    cache : dict
+      Repository lookup cache to be provided to _get_repo_record().
+      Each key is a directory, and each value is a dict with a 'repo'
+      key (value `None` if not within a dataset; or a *Repo() instance
+      of the containing repository), and a 'repo_root' key (`None`
+      if not within a dataset; or a `Path` instance with the unresolved
+      repository root path).
+
+    Yields
+    ------
+    dict
+      Result record.
+    """
     lgr.debug("Attempt to copy: %s -> %s", src, dest)
     str_src = str(src)
     str_dest = str(dest)
@@ -608,6 +629,29 @@ def _extract_special_remote_info(repo):
 
 
 def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
+    """Put a key into a target repository
+
+    Parameters
+    ----------
+    finfo : dict
+      Properties of the source file, as reported by get_content_annexinfo()
+    str_src : str
+      Source path as a plain str
+    dest : Path
+      Destination path
+    str_dest : str
+      Same as `dest`, but as a plain str
+    dest_repo_rec : dict
+      Repository lookup cache item. This function will add and query
+      a 'tmp' key to this record for a temp dir for copy operations
+      to be used for the destination repository.
+
+    Returns
+    -------
+    str or dict
+      If a str, the key was established and the key name is returned.
+      If a dict, an error occurred and an error result record is returned.
+    """
     dest_repo = dest_repo_rec['repo']
     src_key = finfo['key']
     # make an attempt to compute a key in the target repo, this will hopefully

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -68,7 +68,8 @@ class CachedRepo(object):
         """Fall back on the actual repo instance, if we have nothing"""
         return getattr(self._repo, name)
 
-    @lru_cache
+    # more than 20 special remotes may be rare
+    @lru_cache(maxsize=20)
     def get_special_remotes_wo_timestamp(self):
         return {
             k:
@@ -76,7 +77,8 @@ class CachedRepo(object):
             for k, v in self._repo.get_special_remotes().items()
         }
 
-    @lru_cache
+    # there can be many files, and the records per file are smallish
+    @lru_cache(maxsize=10000)
     def get_file_annexinfo(self, fpath):
         rpath = str(fpath.relative_to(self._unresolved_path))
         finfo = self._repo.get_content_annexinfo(
@@ -90,7 +92,8 @@ class CachedRepo(object):
         finfo = finfo.popitem()[1] if finfo else {}
         return finfo
 
-    @lru_cache
+    # n-keys and n-files should have the same order of magnitude
+    @lru_cache(maxsize=10000)
     def get_key_urls_by_specialremote(self, key):
         whereis = self._repo.whereis(key, key=True, output='full')
         urls_by_sr = {
@@ -141,8 +144,8 @@ class StaticRepoCache(dict):
         # `self`
         return id(self)
 
-    # XXX maybe tune cache size
-    @lru_cache
+    # a thousand dirs? should most, certainly not all datasets
+    @lru_cache(maxsize=1000)
     def _dir2reporoot(self, fdir):
         return get_dataset_root(fdir)
 

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -47,7 +47,7 @@ from functools import lru_cache
 lgr = logging.getLogger('datalad.local.copy_file')
 
 
-class CachedRepo(object):
+class _CachedRepo(object):
     """Custom wrapper around a Repo instance
 
     It provides a few customized methods that also cache their return
@@ -132,10 +132,10 @@ class CachedRepo(object):
         return type(self._repo)
 
 
-class StaticRepoCache(dict):
+class _StaticRepoCache(dict):
     """Cache to give a repository instance for any given file path
 
-    Instances of CachedRepo are created and returned based on the
+    Instances of _CachedRepo are created and returned based on the
     determined dataset root path of a given file path.
     """
     def __hash__(self):
@@ -158,7 +158,7 @@ class StaticRepoCache(dict):
 
         Returns
         -------
-        CachedRepo or None
+        _CachedRepo or None
         """
         repo_root = self._dir2reporoot(fpath.parent)
 
@@ -168,7 +168,7 @@ class StaticRepoCache(dict):
         repo = self.get(repo_root)
 
         if repo is None:
-            repo = CachedRepo(repo_root)
+            repo = _CachedRepo(repo_root)
             self[repo_root] = repo
 
         return repo
@@ -380,7 +380,7 @@ class CopyFile(Interface):
 
         # lookup cache for dir to repo mappings, and as a DB for cleaning
         # things up
-        repo_cache = StaticRepoCache()
+        repo_cache = _StaticRepoCache()
         # which paths to pass on to save
         to_save = []
         try:

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -42,8 +42,91 @@ from datalad.distribution.dataset import (
     datasetmethod,
     resolve_path,
 )
+from functools import lru_cache
 
 lgr = logging.getLogger('datalad.local.copy_file')
+
+
+class CachedRepo(object):
+    def __init__(self, path):
+        self.unresolved_path = path
+        self._repo = Dataset(path).repo
+        self._tmpdir = None
+
+    def __getattr__(self, name):
+        """Fall back on the actual repo instance, if we have nothing"""
+        return getattr(self._repo, name)
+
+    @lru_cache
+    def get_special_remotes_wo_timestamp(self):
+        return {
+            k:
+            {pk: pv for pk, pv in v.items() if pk != 'timestamp'}
+            for k, v in self._repo.get_special_remotes().items()
+        }
+
+    def get_tmpdir(self):
+        if not self._tmpdir:
+            tmploc = self._repo.pathobj / '.git' / 'tmp' / 'datalad-copy'
+            tmploc.mkdir(exist_ok=True, parents=True)
+            # put in cache for later clean/lookup
+            self._tmpdir = tmploc
+        return self._tmpdir
+
+    def cleanup_cachedrepo(self):
+        # TODO this could also be the place to stop lingering batch processes
+        if not self._tmpdir:
+            return
+
+        try:
+            self._tmpdir.rmdir()
+        except OSError as e:
+            lgr.warning(
+                'Failed to clean up temporary directory: %s',
+                exc_str(e))
+
+    def get_repotype(self):
+        return type(self._repo)
+
+
+class StaticRepoCache(dict):
+    """Cache to give a repository instance for any given file path
+    """
+    def __hash__(self):
+        # every cache instance is, and should be considered unique
+        # this is only needed for `lru_cache` to be able to handle
+        # `self`
+        return id(self)
+
+    # XXX maybe tune cache size
+    @lru_cache
+    def _dir2reporoot(self, fdir):
+        return get_dataset_root(fdir)
+
+    def __getitem__(self, fpath):
+        """Return a repository instance for a given file path
+
+        Parameters
+        ----------
+        fpath : Path
+        """
+        repo_root = self._dir2reporoot(fpath.parent)
+
+        if repo_root is None:
+            return
+
+        repo = self.get(repo_root)
+
+        if repo is None:
+            repo = CachedRepo(repo_root)
+            self[repo_root] = repo
+
+        return repo
+
+    def clear(self):
+        for repo in self.values():
+            repo.cleanup_cachedrepo()
+        super().clear()
 
 
 @build_doc
@@ -247,7 +330,7 @@ class CopyFile(Interface):
 
         # lookup cache for dir to repo mappings, and as a DB for cleaning
         # things up
-        repo_cache = {}
+        repo_cache = StaticRepoCache()
         # which paths to pass on to save
         to_save = []
         try:
@@ -305,8 +388,7 @@ class CopyFile(Interface):
                             to_save.append(res['destination'])
         finally:
             # cleanup time
-            # TODO this could also be the place to stop lingering batch processes
-            _cleanup_cache(repo_cache)
+            repo_cache.clear()
 
         if not (ds and to_save):
             # nothing left to do
@@ -319,22 +401,6 @@ class CopyFile(Interface):
             message=message,
         )
 
-
-def _cleanup_cache(repo_cache):
-    done = set()
-    for _, repo_rec in repo_cache.items():
-        repo = repo_rec['repo']
-        if not repo or repo.pathobj in done:
-            continue
-        tmp = repo_rec.get('tmp', None)
-        if tmp:
-            try:
-                tmp.rmdir()
-            except OSError as e:
-                lgr.warning(
-                    'Failed to clean up temporary directory: %s',
-                    exc_str(e))
-        done.add(repo.pathobj)
 
 
 def _yield_specs(specs):
@@ -464,11 +530,9 @@ def _copy_file(src, dest, cache):
     # get the source repository, if there is any.
     # `src_repo` will be None, if there is none, and can serve as a flag
     # for further processing
-    src_repo_rec = _get_repo_record(src, cache)
-    src_repo = src_repo_rec['repo']
+    src_repo = cache[src]
     # same for the destination repo
-    dest_repo_rec = _get_repo_record(dest, cache)
-    dest_repo = dest_repo_rec['repo']
+    dest_repo = cache[dest]
     if not dest_repo:
         yield dict(
             path=str_dest,
@@ -478,7 +542,7 @@ def _copy_file(src, dest, cache):
         return
 
     # whenever there is no annex (remember an AnnexRepo is also a GitRepo)
-    if src_repo is None or not isinstance(src_repo, AnnexRepo):
+    if src_repo is None or not issubclass(src_repo.get_repotype(), AnnexRepo):
         # so the best thing we can do is to copy the actual file into the
         # worktree of the destination dataset.
         # we will not care about unlocking or anything like that we just
@@ -499,7 +563,7 @@ def _copy_file(src, dest, cache):
 
     # now we know that we are copying from an AnnexRepo dataset
     # look for URLs on record
-    rpath = str(src.relative_to(src_repo_rec['repo_root']))
+    rpath = str(src.relative_to(src_repo.unresolved_path))
 
     # pull what we know about this file from the source repo
     finfo = src_repo.get_content_annexinfo(
@@ -511,7 +575,7 @@ def _copy_file(src, dest, cache):
         eval_file_type=True,
     )
     finfo = finfo.popitem()[1] if finfo else {}
-    if 'key' not in finfo or not isinstance(dest_repo, AnnexRepo):
+    if 'key' not in finfo or not issubclass(dest_repo.get_repotype(), AnnexRepo):
         lgr.info(
             'Copying non-annexed file or copy into non-annex dataset: %s -> %s',
             src, dest_repo)
@@ -539,10 +603,10 @@ def _copy_file(src, dest, cache):
     # at this point we are copying an annexed file into an annex repo
     if dest_repo.is_managed_branch():
         res = _place_filekey_managed(
-            finfo, str_src, dest, str_dest, dest_repo_rec)
+            finfo, str_src, dest, str_dest, dest_repo)
     else:
         res = _place_filekey(
-            finfo, str_src, dest, str_dest, dest_repo_rec)
+            finfo, str_src, dest, str_dest, dest_repo)
     if isinstance(res, dict):
         yield res
         return
@@ -558,18 +622,11 @@ def _copy_file(src, dest, cache):
     }
     if urls_by_sr:
         # some URLs are on record in the for this file
-        # obtain information on special remotes
-        src_srinfo = src_repo_rec.get('srinfo', None)
-        if src_srinfo is None:
-            src_srinfo = _extract_special_remote_info(src_repo)
-            # put in cache
-            src_repo_rec['srinfo'] = src_srinfo
-
         _register_urls(
             dest_repo,
             dest_key,
             urls_by_sr,
-            src_srinfo,
+            src_repo.get_special_remotes_wo_timestamp(),
         )
 
     # TODO prevent copying .datalad of from other datasets?
@@ -591,9 +648,6 @@ def _register_urls(repo, key, urls_by_sr, src_srinfo):
     urls_by_sr : dict
     src_srinfo : dict
     """
-    # TODO generalize to more than one unique repo
-    dest_srinfo = _extract_special_remote_info(repo)
-
     for src_rid, urls in urls_by_sr.items():
         if not (src_rid == '00000000-0000-0000-0000-000000000001' or
                 src_srinfo.get(src_rid, {}).get('externaltype', None) == 'datalad'):
@@ -603,7 +657,8 @@ def _register_urls(repo, key, urls_by_sr, src_srinfo):
             )
             continue
         if src_rid != '00000000-0000-0000-0000-000000000001' and \
-                src_srinfo[src_rid] not in dest_srinfo.values():
+                src_srinfo[src_rid] \
+                not in repo.get_special_remotes_wo_timestamp().values():
             # this is a special remote that the destination repo doesnt know
             sri = src_srinfo[src_rid]
             lgr.debug('Init additionally required special remote: %s', sri)
@@ -613,7 +668,7 @@ def _register_urls(repo, key, urls_by_sr, src_srinfo):
                 ['{}={}'.format(k, v) for k, v in sri.items() if k != 'name'],
             )
             # must update special remote info for later matching
-            dest_srinfo = _extract_special_remote_info(repo)
+            repo.get_special_remotes_wo_timestamp.cache_clear()
         for url in urls:
             lgr.debug('Register URL for key %s: %s', key, url)
             # TODO OPT: add .register_url(key, batched=False) to AnnexRepo
@@ -622,7 +677,7 @@ def _register_urls(repo, key, urls_by_sr, src_srinfo):
         dest_rid = src_rid \
             if src_rid == '00000000-0000-0000-0000-000000000001' \
             else [
-                k for k, v in dest_srinfo.items()
+                k for k, v in repo.get_special_remotes_wo_timestamp().items()
                 if v['name'] == src_srinfo[src_rid]['name']
             ].pop()
         lgr.debug('Mark key %s as present for special remote: %s',
@@ -638,15 +693,7 @@ def _replace_file(str_src, dest, str_dest, follow_symlinks):
     copyfile(str_src, str_dest, follow_symlinks=follow_symlinks)
 
 
-def _extract_special_remote_info(repo):
-    return {
-        k:
-        {pk: pv for pk, pv in v.items() if pk != 'timestamp'}
-        for k, v in repo.get_special_remotes().items()
-    }
-
-
-def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
+def _place_filekey(finfo, str_src, dest, str_dest, dest_repo):
     """Put a key into a target repository
 
     Parameters
@@ -670,7 +717,6 @@ def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
       If a str, the key was established and the key name is returned.
       If a dict, an error occurred and an error result record is returned.
     """
-    dest_repo = dest_repo_rec['repo']
     src_key = finfo['key']
     # make an attempt to compute a key in the target repo, this will hopefully
     # become more relevant once "salted backends" are possible
@@ -705,14 +751,7 @@ def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
     if 'objloc' in finfo:
         # we have the chance to place the actual content into the target annex
         # put in a tmp location, git-annex will move from there
-        tmploc = dest_repo_rec.get('tmp', None)
-        if not tmploc:
-            tmploc = dest_repo.pathobj / '.git' / 'tmp' / 'datalad-copy'
-            tmploc.mkdir(exist_ok=True, parents=True)
-            # put in cache for later clean/lookup
-            dest_repo_rec['tmp'] = tmploc
-
-        tmploc = tmploc / dest_key
+        tmploc = dest_repo.get_tmpdir() / dest_key
         _replace_file(finfo['objloc'], tmploc, str(tmploc), follow_symlinks=False)
 
         dest_repo.call_annex(['reinject', str(tmploc), str_dest])
@@ -720,10 +759,9 @@ def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
     return dest_key
 
 
-def _place_filekey_managed(finfo, str_src, dest, str_dest, dest_repo_rec):
+def _place_filekey_managed(finfo, str_src, dest, str_dest, dest_repo):
     # TODO put in effect, when salted backends are a thing, until then
     # avoid double-computing the file hash
-    #dest_repo = dest_repo_rec['repo']
     #if finfo.get('has_content', True):
     #    dest_key = dest_repo.call_git_oneline(['annex', 'calckey', str_src])
     dest_key = finfo['key']

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -633,6 +633,15 @@ def _copy_file(src, dest, cache):
     # are there any URLs defined? Get them by special remote
     # query by key to hopefully avoid additional file system interaction
     urls_by_sr = src_repo.get_key_urls_by_specialremote(finfo['key'])
+    if not urls_by_sr:
+        yield dict(
+            path=str_src,
+            destination=str_dest,
+            message='no known location of file content',
+            status='impossible',
+        )
+        return
+
     if urls_by_sr:
         # some URLs are on record in the for this file
         _register_urls(

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -48,10 +48,21 @@ lgr = logging.getLogger('datalad.local.copy_file')
 
 
 class CachedRepo(object):
+    """Custom wrapper around a Repo instance
+
+    It provides a few customized methods that also cache their return
+    values. For all other method access the underlying repo instance
+    is used.
+
+    A repository is assumed to be static. Cache invalidation must
+    be done manually, if that assumption does no longer hold.
+    """
+
     def __init__(self, path):
-        self.unresolved_path = path
+        self._unresolved_path = path
         self._repo = Dataset(path).repo
         self._tmpdir = None
+        self._ismanagedbranch = None
 
     def __getattr__(self, name):
         """Fall back on the actual repo instance, if we have nothing"""
@@ -64,6 +75,35 @@ class CachedRepo(object):
             {pk: pv for pk, pv in v.items() if pk != 'timestamp'}
             for k, v in self._repo.get_special_remotes().items()
         }
+
+    @lru_cache
+    def get_file_annexinfo(self, fpath):
+        rpath = str(fpath.relative_to(self._unresolved_path))
+        finfo = self._repo.get_content_annexinfo(
+            paths=[rpath],
+            # a simple `exists()` will not be enough (pointer files, etc...)
+            eval_availability=True,
+            # if it truely is a symlink, not just an annex pointer, we would not
+            # want to resolve it
+            eval_file_type=True,
+        )
+        finfo = finfo.popitem()[1] if finfo else {}
+        return finfo
+
+    @lru_cache
+    def get_key_urls_by_specialremote(self, key):
+        whereis = self._repo.whereis(key, key=True, output='full')
+        urls_by_sr = {
+            k: v['urls']
+            for k, v in whereis.items()
+            if v.get('urls', None)
+        }
+        return urls_by_sr
+
+    def is_managed_branch(self):
+        if self._ismanagedbranch is None:
+            self._ismanagedbranch = self._repo.is_managed_branch()
+        return self._ismanagedbranch
 
     def get_tmpdir(self):
         if not self._tmpdir:
@@ -91,6 +131,9 @@ class CachedRepo(object):
 
 class StaticRepoCache(dict):
     """Cache to give a repository instance for any given file path
+
+    Instances of CachedRepo are created and returned based on the
+    determined dataset root path of a given file path.
     """
     def __hash__(self):
         # every cache instance is, and should be considered unique
@@ -109,6 +152,10 @@ class StaticRepoCache(dict):
         Parameters
         ----------
         fpath : Path
+
+        Returns
+        -------
+        CachedRepo or None
         """
         repo_root = self._dir2reporoot(fpath.parent)
 
@@ -402,7 +449,6 @@ class CopyFile(Interface):
         )
 
 
-
 def _yield_specs(specs):
     if specs == '-':
         specs_it = sys.stdin
@@ -476,22 +522,6 @@ def _yield_src_dest_filepaths(src, dest, src_base=None, target_dir=None):
     yield src, dest
 
 
-def _get_repo_record(fpath, cache):
-    fdir = fpath.parent
-    # get the repository, if there is any.
-    # `src_repo` will be None, if there is none, and can serve as a flag
-    # for further processing
-    repo_rec = cache.get(fdir, None)
-    if repo_rec is None:
-        repo_root = get_dataset_root(fdir)
-        repo_rec = dict(
-            repo=None if repo_root is None else Dataset(repo_root).repo,
-            # this is different from repo.pathobj which resolves symlinks
-            repo_root=Path(repo_root) if repo_root else None)
-        cache[fdir] = repo_rec
-    return repo_rec
-
-
 def _copy_file(src, dest, cache):
     """Transfer a single file from a source to a target dataset
 
@@ -501,13 +531,7 @@ def _copy_file(src, dest, cache):
       Source file path
     dest : Path or str
       Destination file path
-    cache : dict
-      Repository lookup cache to be provided to _get_repo_record().
-      Each key is a directory, and each value is a dict with a 'repo'
-      key (value `None` if not within a dataset; or a *Repo() instance
-      of the containing repository), and a 'repo_root' key (`None`
-      if not within a dataset; or a `Path` instance with the unresolved
-      repository root path).
+    cache : StaticRepoCache
 
     Yields
     ------
@@ -563,18 +587,9 @@ def _copy_file(src, dest, cache):
 
     # now we know that we are copying from an AnnexRepo dataset
     # look for URLs on record
-    rpath = str(src.relative_to(src_repo.unresolved_path))
 
     # pull what we know about this file from the source repo
-    finfo = src_repo.get_content_annexinfo(
-        paths=[rpath],
-        # a simple `exists()` will not be enough (pointer files, etc...)
-        eval_availability=True,
-        # if it truely is a symlink, not just an annex pointer, we would not
-        # want to resolve it
-        eval_file_type=True,
-    )
-    finfo = finfo.popitem()[1] if finfo else {}
+    finfo = src_repo.get_file_annexinfo(src)
     if 'key' not in finfo or not issubclass(dest_repo.get_repotype(), AnnexRepo):
         lgr.info(
             'Copying non-annexed file or copy into non-annex dataset: %s -> %s',
@@ -614,12 +629,7 @@ def _copy_file(src, dest, cache):
 
     # are there any URLs defined? Get them by special remote
     # query by key to hopefully avoid additional file system interaction
-    whereis = src_repo.whereis(finfo['key'], key=True, output='full')
-    urls_by_sr = {
-        k: v['urls']
-        for k, v in whereis.items()
-        if v.get('urls', None)
-    }
+    urls_by_sr = src_repo.get_key_urls_by_specialremote(finfo['key'])
     if urls_by_sr:
         # some URLs are on record in the for this file
         _register_urls(

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -366,3 +366,28 @@ def test_copy_file_prevent_dotgit_placement(srcpath, destpath):
     badobj = dest.pathobj / '.git' / 'objects' / 'i-do-not-exist'
     dest.copy_file([sub.pathobj / '.git' / 'config', badobj])
     ok_(badobj.exists())
+
+
+@with_tempfile
+@with_tempfile
+@with_tempfile
+def test_copy_file_nourl(serv_path, orig_path, tst_path):
+    """Tests availability transfer to normal git-annex remote"""
+    # prep source dataset that will have the file content
+    srv_ds = Dataset(serv_path).create()
+    (srv_ds.pathobj / 'myfile.dat').write_text('I am content')
+    (srv_ds.pathobj / 'noavail.dat').write_text('null')
+    srv_ds.save()
+    srv_ds.drop('noavail.dat', check=False)
+    # make an empty superdataset, with the test dataset as a subdataset
+    orig_ds = Dataset(orig_path).create()
+    orig_ds.clone(source=serv_path, path='serv')
+    assert_repo_status(orig_ds.path)
+    # now copy the test file into the superdataset
+    no_avail_file = orig_ds.pathobj / 'serv' / 'noavail.dat'
+    assert_in_results(
+        orig_ds.copy_file(no_avail_file, on_failure='ignore'),
+        status='impossible',
+        message='no known location of file content',
+        path=str(no_avail_file),
+    )


### PR DESCRIPTION
This is a first example of an approximation of an idea that I sketched in https://github.com/datalad/datalad/issues/5598

Instead of using a complicated beast made of dicts and more dicts, I RF'ed all relevant Repo method access into an Interface helper that uses `lru_cache` and other means to minimize the actual interaction with the underlying `Repo` instance.

It does that with awareness of what type of access is being made and only works within the context of `copy_file()`.

I mostly did this to see if these task-focused/tailored API classes can make sense, and de-convolute primary command logic from performance aspects.

Happy to get feedback on the approach.