### PR TITLE
Use the noreply account for Vanessa 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,8 +18,9 @@ Neuroimaging Community <committer@example.com> <test@example.com>
 Neuroimaging Community <committer@example.com> unknown <test@nowhere.com> 
 Taylor Olson <to.overlake@gmail.com> Taylor Olson <taylor.m.olson.21@dartmouth.edu>
 Torsten Stoeter <torsten.stoeter@lin-magdeburg.de>
-Vanessa Sochat <vsochat@gmail.com> Vanessasaurus <vsochat@gmail.com>
-Vanessa Sochat <vsochat@gmail.com> <vsochat@stanford.edu> 
+Vanessa Sochat <vsoch@github.noreply.users.com> Vanessasaurus <vsochat@gmail.com>
+Vanessa Sochat <vsoch@github.noreply.users.com> Vanessasaurus <814322+vsoch@users.noreply.github.com>
+Vanessa Sochat <vsoch@github.noreply.users.com> <vsochat@stanford.edu>
 Yaroslav Halchenko <debian@onerussian.com> 
 Yaroslav Halchenko <debian@onerussian.com> <site-github-private@onerussian.com>
 Yaroslav Halchenko <debian@onerussian.com> <yoh@smaug.cns.dartmouth.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -18,7 +18,8 @@ Neuroimaging Community <committer@example.com> <test@example.com>
 Neuroimaging Community <committer@example.com> unknown <test@nowhere.com> 
 Taylor Olson <to.overlake@gmail.com> Taylor Olson <taylor.m.olson.21@dartmouth.edu>
 Torsten Stoeter <torsten.stoeter@lin-magdeburg.de>
-Vanessa Sochat <vsoch@users.noreply.github.com> 
+Vanessa Sochat <vsochat@gmail.com> Vanessasaurus <vsochat@gmail.com>
+Vanessa Sochat <vsochat@gmail.com> <vsochat@stanford.edu> 
 Yaroslav Halchenko <debian@onerussian.com> 
 Yaroslav Halchenko <debian@onerussian.com> <site-github-private@onerussian.com>
 Yaroslav Halchenko <debian@onerussian.com> <yoh@smaug.cns.dartmouth.edu>


### PR DESCRIPTION
Still all previous emails used in git commits history are doomed to be
listed AFAIK to have git shortlog -sn  working

Attn @vsoch

A "redo" for #5595

With this we get
```
$> git shortlog -sn | grep Van                       
    17	Vanessa Sochat
```
so the one and only Vanessa