### PR TITLE
MNT: github: Add compatibility wrapper for GithubException

### DIFF
--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -79,6 +79,17 @@ def _get_tokens_for_login(login, tokens):
     return selected_tokens
 
 
+def _gh_exception(exc_cls, status, data):
+    """Compatibility wrapper for instantiating a GithubException.
+    """
+    try:
+        exc = exc_cls(status, data, None)
+    except TypeError:
+        # Before PyGithub 1.5, GithubException had only two required arguments.
+        exc = exc_cls(status, data)
+    return exc
+
+
 def _gen_github_ses(github_login):
     """Generate viable Github sessions
 
@@ -96,7 +107,8 @@ def _gen_github_ses(github_login):
 
     """
     if github_login == 'disabledloginfortesting':
-        raise gh.BadCredentialsException(403, 'no login specified')
+        raise _gh_exception(gh.BadCredentialsException,
+                            403, 'no login specified')
 
     # see if we have tokens - might be many. Doesn't cost us much so get at once
     tokens = unique(

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -33,6 +33,7 @@ from .. import github_
 from ..github_ import (
     _gen_github_entity,
     _get_github_cred,
+    _gh_exception,
     _token_str,
     get_repo_url,
 )
@@ -105,7 +106,8 @@ def test__make_github_repos():
 
     def _make_github_repo(github_login, entity, reponame, *args):
         if entity == 'entity1':
-            raise gh.BadCredentialsException("very bad status", "some data")
+            raise _gh_exception(gh.BadCredentialsException,
+                                "very bad status", "some data")
         return reponame
 
     with mock.patch.object(github_, '_gen_github_entity', _gen_github_entity), \
@@ -117,7 +119,8 @@ def test__make_github_repos():
 
     def _make_github_repo(github_login, entity, reponame, *args):
         # Always throw an exception
-        raise gh.BadCredentialsException("very bad status", "some data")
+        raise _gh_exception(gh.BadCredentialsException,
+                            "very bad status", "some data")
 
     with mock.patch.object(github_, '_gen_github_entity', _gen_github_entity), \
             mock.patch.object(github_, '_make_github_repo', _make_github_repo):


### PR DESCRIPTION
A few spots in the code base instantiate GithubException with two
arguments, but in PyGithub v1.55 (released today) GithubException and
its subclasses require an additional argument (`headers`).

Add a helper that tries to create an exception with three arguments,
falling back to two arguments for compatibility.  Note that using None
for the headers follows what was done in the upstream commit,
ddd437a7c (Export headers in GithubException).

Closes #5602.