### PR TITLE
Fixes for RIA when using different push/pull URLs

### DIFF
--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+from pathlib import Path
 
 
 lgr = logging.getLogger('datalad.customremotes.ria_utils')
@@ -215,7 +216,11 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=No
         alias_dir = base_path / "alias"
         io.mkdir(alias_dir)
         try:
-            io.symlink(dsgit_dir, alias_dir / alias)
+            # go for a relative path to keep the alias links valid
+            # when moving a store
+            io.symlink(
+                Path('..') / dsgit_dir.relative_to(base_path),
+                alias_dir / alias)
         except FileExistsError:
             lgr.warning("Alias %r already exists in the RIA store, not adding an "
                         "alias.", alias)

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1206,7 +1206,7 @@ class RIARemote(SpecialRemote):
         self.push_io.mkdir(transfer_dir)
         tmp_path = transfer_dir / key
 
-        if tmp_path.exists():
+        if self.push_io.exists(tmp_path):
             # Just in case - some parallel job could already be writing to it at
             # least tell the conclusion, not just some obscure permission error
             raise RIARemoteError('{}: upload already in progress'


### PR DESCRIPTION
Sister PR of #5607 against master

Additionally alters the behavior of the new alias feature introduced with #5592 to use a relative path for the alias. This keep the symlinks valid when moving an entire store.