### PR TITLE
BF(TST): account for git-annex starting to "singularize" copy in drop

### DIFF
--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -345,7 +345,7 @@ def test_uninstall_recursive(path):
     assert_result_values_cond(
         res, 'message',
         lambda x: "configured minimum number of copies not found" in x or
-        "Could only verify the existence of 0 out of 1 necessary copies" in x
+        "Could only verify the existence of 0 out of 1 necessary cop" in x
     )
 
     # this should do it
@@ -428,7 +428,7 @@ def test_kill(path):
     assert_result_values_cond(
         [err_result], 'message',
         lambda x: "configured minimum number of copies not found" in x or
-        "Could only verify the existence of 0 out of 1 necessary copies" in x
+        "Could only verify the existence of 0 out of 1 necessary cop" in x
     )
     eq_(ds.remove(recursive=True, check=False, result_xfm='datasets'),
         [subds, ds])

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1449,7 +1449,7 @@ def test_annex_drop(src, dst):
     with assert_raises(CommandError) as e:
         ar.drop('somefile.txt')
     # CommandError has to pull the errors from the JSON record 'note'
-    assert_in('necessary copies', str(e.exception))
+    assert_in('necessary cop', str(e.exception))
 
     with assert_raises(CommandError) as e:
         ar._call_annex_records(['fsck', '-N', '3'])


### PR DESCRIPTION
test runs of datalad/git-annex started to fail, so I spotted it.

Introduced in
[8.20210330-245-g4edde9870](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=4edde987092a3fcf8f359b14c5223ec7d458ddba)

I do not think it is worth tracking copy vs copies as only used in
the tests.
