### PR TITLE
Fix syntax of update-contributors workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -9,7 +9,7 @@ jobs:
   Update:
     name: Generate
     runs-on: ubuntu-latest
-    if: contains(github.repository, "datalad/datalad")
+    if: contains(github.repository, 'datalad/datalad')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The `update-contributors.yml` workflow has been broken since December, as strings in workflow context expressions such as "`if:`" keys must use single quotes, not double-quotes.