### PR TITLE
BF(TST): use sys.executable and not hardcoded "python"

### DIFF
--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -405,7 +405,7 @@ def test_name_with_underscore(path):
     # environment variable.
     with patch.dict("os.environ",
                     {"DATALAD_PROCEDURES_PRINT_ARGS_CALL__FORMAT":
-                     'python {script}'}):
+                     '%s {script}' % sys.executable}):
         with assert_raises(ValueError):
             ds.run_procedure(spec=["print_args"])
 
@@ -413,7 +413,7 @@ def test_name_with_underscore(path):
     with patch.dict("os.environ",
                     {"DATALAD_CONFIG_OVERRIDES_JSON":
                      '{"datalad.procedures.print_args.call-format": '
-                     '"python {script}"}'}):
+                     '"%s {script}"}' % sys.executable}):
         ds.config.reload()
         ds.run_procedure(spec=["print_args"])
 

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import json
 import os.path as op
 import sys
 from unittest.mock import patch
@@ -412,8 +413,10 @@ def test_name_with_underscore(path):
     # But it can be set via DATALAD_CONFIG_OVERRIDES_JSON.
     with patch.dict("os.environ",
                     {"DATALAD_CONFIG_OVERRIDES_JSON":
-                     '{"datalad.procedures.print_args.call-format": '
-                     '"%s {script}"}' % sys.executable}):
+                     json.dumps({
+                         "datalad.procedures.print_args.call-format":
+                         "%s {script}" % sys.executable
+                    })}):
         ds.config.reload()
         ds.run_procedure(spec=["print_args"])
 


### PR DESCRIPTION
Detected while trying to build 0.14.2 for Debian

Lead to

	======================================================================
	ERROR: datalad.interface.tests.test_run_procedure.test_name_with_underscore
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
		self.test(*self.arg)
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/tests/utils.py", line 578, in _wrap_with_tree
		return t(*(arg + (d,)), **kw)
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/tests/test_run_procedure.py", line 418, in test_name_with_underscore
		ds.run_procedure(spec=["print_args"])
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/distribution/dataset.py", line 503, in apply_func
		return f(**kwargs)
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/utils.py", line 482, in eval_func
		return return_func(generator_func)(*args, **kwargs)
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/utils.py", line 470, in return_func
		results = list(results)
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/utils.py", line 389, in generator_func
		for r in _process_results(
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/utils.py", line 557, in _process_results
		for res in results:
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/run_procedure.py", line 448, in __call__
		for r in Run.__call__(
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/utils.py", line 389, in generator_func
		for r in _process_results(
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/interface/utils.py", line 557, in _process_results
		for res in results:
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/core/local/run.py", line 237, in __call__
		for r in run_command(cmd, dataset=dataset,
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/core/local/run.py", line 685, in run_command
		raise exc
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/core/local/run.py", line 464, in _execute_command
		runner.run(
	  File "/build/datalad-0.14.2/.pybuild/cpython3_3.9_datalad/build/datalad/cmd.py", line 408, in run
		raise CommandError(
	datalad.support.exceptions.CommandError: CommandError: 'python /tmp/datalad_temp_tree_test_name_with_underscoreydwd49na/.datalad/procedures/print_args' failed with exitcode 127 under /tmp/datalad_temp_tree_test_name_with_underscoreydwd49na

	----------------------------------------------------------------------
	Ran 1227 tests in 1944.566s

	FAILED (SKIP=142, errors=1)
	D: /a
	D: /a/b/c
	D: /a~
	D: /a b/name
	testing 0
	testing 1
	/tmp/datalad_temp_tree_test_paths_with_forward_slashest42h83pf
	' |;&%b5{}\'" .datc '
