### PR TITLE
TST: test_whereis_batch_eqv: Don't hard code remote name

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2544,7 +2544,7 @@ def test_whereis_batch_eqv(path):
     repo_b = repo_a.clone(repo_a.path, str(path / "b"))
     repo_b.drop(["bar"])
     repo_b.drop(["baz"])
-    repo_b.drop(["baz"], options=["--from=origin", "--force"])
+    repo_b.drop(["baz"], options=["--from=" + DEFAULT_REMOTE, "--force"])
 
     files = ["foo", "bar", "baz"]
     for output in "full", "uuids", "descriptions":


### PR DESCRIPTION
The recently merged gh-5572 adjusted our tests and code on maint to
avoid assuming "origin" is the default remote name in a clone, but the
master-specific 417f292be7 (ENH: annexrepo.whereis: Implement
batch=True, 2021-03-25) added a test that hard codes "origin".  Update
it to use DEFAULT_REMOTE.