### PR TITLE
Use fromkey to create unlocked files when supported

### DIFF
--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -708,6 +708,8 @@ class RegisterUrl(object):
         self._err_res = get_status_dict(action="addurls", ds=self.ds,
                                         type="file", status="error")
         self.use_pointer = repo.is_managed_branch()
+        self._avoid_fromkey = self.use_pointer and \
+            not repo._check_version_kludges("fromkey-supports-unlocked")
 
     def examinekey(self, parsed_key, filename, migrate=False):
         opts = []
@@ -742,9 +744,9 @@ class RegisterUrl(object):
         try:
             parsed_key = row["key"]
             migrate = "target_backend" in parsed_key
-            use_pointer = self.use_pointer
+            avoid_fromkey = self._avoid_fromkey
             ek_info = None
-            if use_pointer or migrate:
+            if avoid_fromkey or migrate:
                 ek_info = self.examinekey(parsed_key, filename,
                                           migrate=migrate)
                 if not ek_info:
@@ -758,7 +760,7 @@ class RegisterUrl(object):
                 key = parsed_key["key"]
 
             self.registerurl(key, row["url"])
-            if use_pointer:
+            if avoid_fromkey:
                 res = self._write_pointer(row, ek_info)
             else:
                 res = annexjson2result(self.fromkey(key, filename),

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -516,7 +516,8 @@ def _copy_file(src, dest, cache):
         return
 
     # at this point we are copying an annexed file into an annex repo
-    if dest_repo.is_managed_branch():
+    if not dest_repo._check_version_kludges("fromkey-supports-unlocked") \
+       and dest_repo.is_managed_branch():
         res = _place_filekey_managed(
             finfo, str_src, dest, str_dest, dest_repo_rec)
     else:

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -55,9 +55,11 @@ def test_copy_file(workdir, webdir, weburl):
     ok_file_has_content(src_ds.pathobj / 'myfile1.txt', '123')
     # now create a fresh dataset
     dest_ds = Dataset(workdir / 'dest').create()
-    if not dest_ds.repo.is_managed_branch():
+    if dest_ds.repo._check_version_kludges("fromkey-supports-unlocked") or \
+       not dest_ds.repo.is_managed_branch():
         # unless we have a target ds on a cripples FS (where `annex fromkey`
-        # doesn't work), we can even drop the file content in the source repo
+        # doesn't work until after 8.20210428), we can even drop the file
+        # content in the source repo
         src_ds.drop('myfile1.txt', check=False)
         nok_(src_ds.repo.file_has_content('myfile1.txt'))
     # copy the file from the source dataset into it.

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -552,9 +552,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         if cls.git_annex_version is None:
             cls._check_git_annex_version()
 
-        # NOTE: All the kludges that were here have been removed with the
-        # latest GIT_ANNEX_MIN_VERSION increase. This method is being kept
-        # around for future kludges, but it's safe to drop.
+        ver = cls.git_annex_version
+        kludges["fromkey-supports-unlocked"] = ver > "8.20210428"
         cls._version_kludges = kludges
         return kludges[key]
 


### PR DESCRIPTION
`addurls` and `copy-file` avoid `fromkey` on adjusted branches because `fromkey` unconditionally creates a symbolic link, but that's no longer needed as of git-annex's 4588668a1 (fromkey unlocked files support, 2021-05-03).

The main behavioral change/improvement here is that `copy-file` no longer yields an error result when the copied file doesn't have content and the destination repo is on an adjusted branch.

I've tested this locally with git-annex's e811a50e2 (2021-05-03).
