### PR TITLE
test_no_annex: Update for git-annex-smudge fix

### DIFF
--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -202,7 +202,8 @@ def test_no_annex(path):
     # add inannex and README post configuration
     ds.save([opj('code', 'notinannex'), 'README'])
 
-    if ds.repo.is_managed_branch():
+    repo = ds.repo
+    if repo.is_managed_branch():
         # For unlocked files, if .gitattributes is configured so that a file
         # should go to git, an annexed file will switch to be tracked by git
         # the next time the clean filter runs on it.
@@ -214,7 +215,7 @@ def test_no_annex(path):
         # one is annex'ed, the other is not, despite no change in add call
         # importantly, also .gitattribute is not annexed
         eq_([opj('code', 'inannex')],
-            [str(Path(p)) for p in ds.repo.get_annexed_files()])
+            [str(Path(p)) for p in repo.get_annexed_files()])
 
 
 _ds_template = {

--- a/datalad/plugin/tests/test_plugins.py
+++ b/datalad/plugin/tests/test_plugins.py
@@ -193,29 +193,30 @@ def test_no_annex(path):
     no_annex(pattern=['code/**', 'README'], dataset=ds.path)
 
     inannex = (ds.pathobj / 'code' / 'inannex')
-    # Ensure that notinannex's mtime is as recent or newer than .git/index's so
-    # that, on an adjusted branch, the clean filter runs on the next save. This
-    # avoids a racy failure of the managed-branch assert_repo_status check
-    # below.
-    inannex.touch()
 
     # add inannex and README post configuration
     ds.save([opj('code', 'notinannex'), 'README'])
 
     repo = ds.repo
-    if repo.is_managed_branch():
-        # For unlocked files, if .gitattributes is configured so that a file
-        # should go to git, an annexed file will switch to be tracked by git
-        # the next time the clean filter runs on it.
+    try:
+        assert_repo_status(ds.path)
+    except AssertionError:
+        # If on an adjusted branch and notinannex's mtime is as recent or newer
+        # than .git/index's, the clean filter runs on it when save() is called.
+        # This leads to a racy failure until after git-annex's 424bef6b6
+        # (smudge: check for known annexed inodes before checking
+        # annex.largefiles, 2021-05-03).
         #
         # https://git-annex.branchable.com/forum/one-off_unlocked_annex_files_that_go_against_large/
-        assert_repo_status(ds.path, modified=[inannex])
-    else:
-        assert_repo_status(ds.path)
-        # one is annex'ed, the other is not, despite no change in add call
-        # importantly, also .gitattribute is not annexed
-        eq_([opj('code', 'inannex')],
-            [str(Path(p)) for p in repo.get_annexed_files()])
+        if repo.is_managed_branch() and repo.git_annex_version <= "8.20210428":
+            assert_repo_status(ds.path, modified=[inannex])
+            raise SkipTest("Known bug fixed in git-annex")
+        raise
+
+    # one is annex'ed, the other is not, despite no change in add call
+    # importantly, also .gitattribute is not annexed
+    eq_([opj('code', 'inannex')],
+        [str(Path(p)) for p in repo.get_annexed_files()])
 
 
 _ds_template = {


### PR DESCRIPTION
This follows up on gh-5579.  There is now a fix on git-annex's end that addresses the original intermittent failure of `test_no_annex` (gh-5300).