### PR TITLE
TST: test_partial_unlocked: Document and avoid recent git-annex failure

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -651,7 +651,21 @@ def test_partial_unlocked(path):
     ds.repo.set_gitattributes([
         ('*', {'annex.largefiles': 'nothing'})])
     ds.save()
-    assert_repo_status(ds.path)
+    try:
+        assert_repo_status(ds.path)
+    except AssertionError:
+        if ds.repo.git_annex_version > "8.20210428":
+            # Before git-annex's 424bef6b6 (smudge: check for known annexed
+            # inodes before checking annex.largefiles, 2021-05-03), the above
+            # leads to the last commit including the switch of culprit.txt to
+            # being tracked in git. With 424bef6b6, the switch is (racily) left
+            # staged, where the commit captures the symbolic link to pointer
+            # change.
+            #
+            # https://git-annex.branchable.com/bugs/case_where_using_pathspec_with_git-commit_leaves_s/
+            assert_repo_status(ds.path, modified=["culprit.txt"])
+        else:
+            raise
 
 
 @with_tree({'.gitattributes': "* annex.largefiles=(largerthan=4b)",


### PR DESCRIPTION
git-annex's 424bef6b6 (smudge: check for known annexed inodes before
checking annex.largefiles, 2021-05-03) fixed a case where an unchanged
unlocked annexed file that does not match annex.largefiles gets sent
to git.

That change leads to a racy failure of test_partial_unlocked.  The
test unlocks a file and then configures .gitattributes so that the
file doesn't match annex.largefiles.  Before 424bef6b6, providing that
file as a pathspec to `git commit` (as `datalad save` does) results in
a commit where the file changes to being tracked by git.  With
424bef6b6, the above sometimes doesn't happen; instead the commit
includes the link to a pointer file change, and the change to being
tracked by git remains in the index.

This issue has been reported upstream.  For now, document it, and
adjust the test to avoid the intermittent failure.

Closes #5637

[1] https://git-annex.branchable.com/bugs/case_where_using_pathspec_with_git-commit_leaves_s/
