### PR TITLE
ENH: CLI - allow for no value for options with None available but not default

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -33,8 +33,10 @@ from ..dochelpers import exc_str
 from datalad.interface.common_opts import eval_params
 from datalad.interface.common_opts import eval_defaults
 from datalad.support.constraints import (
-    EnsureKeyChoice,
+    AltConstraints,
     EnsureChoice,
+    EnsureKeyChoice,
+    EnsureNone,
 )
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import resolve_path
@@ -711,6 +713,13 @@ class Interface(object):
                 help = help.rstrip() + '.'
             if param.constraints is not None:
                 parser_kwargs['type'] = param.constraints
+                # if we have an option which does not default to None
+                # but has None as possible value, allow for empty value
+                if (isinstance(param.constraints, AltConstraints)
+                     and any(isinstance(c, EnsureNone) for c in param.constraints.constraints)
+                     and parser_kwargs.get('default', None) is not None
+                    ):
+                    parser_kwargs['nargs'] = '?'
                 # include value constraint description and default
                 # into the help string
                 cdoc = alter_interface_docs_for_cmdline(


### PR DESCRIPTION
E.g. so we could have `--fulfilled --` (to assign None) for `foreach` (#749) while having it to default to True

Interestingly comparing the difference between manpages produced without/with this change we already detect a few cases where we have non-None default and `None` is still allowed to be a value:

```shell
$> diff -Naur build/man build/man-optional-none | grep -e '\+\\fBdatalad ' -e '^\+\\fB-' | sed -e 's,\(^\+\\fB-\),  \1,g'
+\fBdatalad addurls\fR [-h] [-d\~DATASET] [-t\~TYPE] [-x\~REGEXP] [-m\~FORMAT] [--key\~FORMAT] [--message\~MESSAGE] [-n] [--fast] [--ifexists\~{overwrite|skip}] [--missing-value\~VALUE] [--nosave] [--version-urls] [-c\~PROC] [-J [NJOBS]] [--drop-after] URL-FILE URL-FORMAT FILENAME-FORMAT
  +\fB-J\fR [NJOBS], \fB--jobs\fR [NJOBS]
+\fBdatalad annotate\-paths\fR [-h] [-d\~DATASET] [-r] [-R\~LEVELS] [--action\~LABEL] [--unavailable-path-status [LABEL]] [--unavailable-path-msg\~message] [--nondataset-path-status [LABEL]] [--no-parentds-discovery] [--no-subds-discovery] [--revision-change-discovery] [--no-untracked-discovery] [--modified [MODIFIED]] [PATH ...]
  +\fB--unavailable-path-status\fR [LABEL]
  +\fB--nondataset-path-status\fR [LABEL]
+\fBdatalad create\-sibling\-ria\fR [-h] -s NAME [-d\~DATASET] [--storage-name\~NAME] [--post-update-hook] [--shared\~{false|true|umask|group|all|world|everybody|0xxx}] [--group\~GROUP] [--storage-sibling [MODE]] [--existing [MODE]] [--trust-level TRUST-LEVEL] [-r] [-R\~LEVELS] [--no-storage-sibling] ria+<ssh|file>://<host>[/path]
  +\fB--storage-sibling\fR [MODE]
  +\fB--existing\fR [MODE]
+\fBdatalad get\fR [-h] [-s\~LABEL] [-d\~PATH] [-r] [-R\~LEVELS] [-n] [-D\~DESCRIPTION] [--reckless [auto|ephemeral|shared-...]] [-J [NJOBS]] [PATH ...]
  +\fB-J\fR [NJOBS], \fB--jobs\fR [NJOBS]
+\fBdatalad install\fR [-h] [-s\~SOURCE] [-d\~DATASET] [-g] [-D\~DESCRIPTION] [-r] [-R\~LEVELS] [--reckless [auto|ephemeral|shared-...]] [-J [NJOBS]] [PATH ...]
  +\fB-J\fR [NJOBS], \fB--jobs\fR [NJOBS]
+\fBdatalad publish\fR [-h] [-d\~DATASET] [--to\~LABEL] [--since\~SINCE] [--missing\~MODE] [-f] [--transfer-data\~{auto|none|all}] [-r] [-R\~LEVELS] [--git-opts\~STRING] [--annex-opts\~STRING] [--annex-copy-opts\~STRING] [-J [NJOBS]] [PATH ...]
  +\fB-J\fR [NJOBS], \fB--jobs\fR [NJOBS]
+\fBdatalad push\fR [-h] [-d\~DATASET] [--to\~SIBLING] [--since\~SINCE] [--data {anything|nothing|auto|auto-if-wanted}] [-f\~{all|gitpush|checkdatapresent}] [-r] [-R\~LEVELS] [-J [NJOBS]] [PATH ...]
  +\fB-J\fR [NJOBS], \fB--jobs\fR [NJOBS]
+\fBdatalad save\fR [-h] [-m\~MESSAGE] [-d\~DATASET] [-t\~ID] [-r] [-R\~LEVELS] [-u] [-F\~MESSAGE_FILE] [--to-git] [-J [NJOBS]] [PATH ...]
  +\fB-J\fR [NJOBS], \fB--jobs\fR [NJOBS]
```

I think this would increase consistency between Python and CLI interfaces, and partially (I think there is more to it there) address #4751 at least for the case of `None`.  

I positioned it against `maint` since in principle it addresses the inconsistency but I would be ok to just go against `master` since its ramifications are not entirely known and it effects only CLI which is IMHO is undertested in direct invocations.

WDYT?

TODOs (if decided to proceed):
- [ ] tests
  - Q to @mih and @adswa: datalad-handbook is the primary tester for CLI AFAIK.  Is there a way to add its examples to be ran under CI here?