### PR TITLE
ENH: get_status_dict - add exit_code if CommandError

### DIFF
--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -27,6 +27,7 @@ from datalad.utils import (
     path_is_subpath,
     PurePosixPath,
 )
+from datalad.support.exceptions import CommandError
 from datalad.support.path import robust_abspath
 from datalad.support.exceptions import (
     format_oneline_tb,
@@ -106,6 +107,8 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
             if isinstance(exception, CapturedException) \
             else format_oneline_tb(
                 exception, include_str=False)
+        if isinstance(exception, CommandError):
+            d['exit_code'] = exception.code
     if kwargs:
         d.update(kwargs)
     return d

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -99,7 +99,7 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
     if exception is not None:
         d['exception'] = exception
         d['exception_traceback'] = \
-            exception.format_oneline_tb(limit=1000, include_str=False)
+            exception.format_oneline_tb(limit=None, include_str=False)
     if kwargs:
         d.update(kwargs)
     return d

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -28,7 +28,10 @@ from datalad.utils import (
     PurePosixPath,
 )
 from datalad.support.path import robust_abspath
-
+from datalad.support.exceptions import (
+    format_oneline_tb,
+    CapturedException,
+)
 from datalad.distribution.dataset import Dataset
 
 
@@ -62,12 +65,12 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
       If given, the `path` and `type` values are populated with the path of the
       datasets and 'dataset' as the type. Giving additional values for both
       keys will overwrite these pre-populated values.
-    exception : CapturedException
+    exception : Exception
       Exceptions that occurred while generating a result should be captured
       by immediately instantiating a CapturedException. This instance can
       be passed here to yield more comprehensive error reporting, including
       an auto-generated traceback (added to the result record under an
-      'exception_traceback' key).
+      'exception_traceback' key). Exceptions of other types are also supported.
 
     Returns
     -------
@@ -98,8 +101,11 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
         d['error_message'] = error_message
     if exception is not None:
         d['exception'] = exception
-        d['exception_traceback'] = \
-            exception.format_oneline_tb(limit=None, include_str=False)
+        d['exception_traceback'] = exception.format_oneline_tb(
+            include_str=False) \
+            if isinstance(exception, CapturedException) \
+            else format_oneline_tb(
+                exception, include_str=False)
     if kwargs:
         d.update(kwargs)
     return d

--- a/datalad/interface/tests/test_results.py
+++ b/datalad/interface/tests/test_results.py
@@ -12,9 +12,10 @@
 
 from datalad.interface.results import (
     annexjson2result,
+    get_status_dict,
 )
 from datalad.distribution.dataset import Dataset
-
+from datalad.runner import CommandError
 from datalad.tests.utils import (
     eq_,
     with_tempfile,
@@ -44,3 +45,8 @@ def test_annexjson2result(dspath):
     eq_(annexjson2result(dict(file='dir1/file1'), ds),
         dict(status='error',
              path=str(ds.pathobj / 'dir1' / 'file1')))
+
+
+def tests_status_dict_exit_code():
+    d = get_status_dict(exception=CommandError(code=105))
+    eq_(d['exit_code'], 105)


### PR DESCRIPTION
Immediate use-case is foreach since it feels worthwhile channeling
upstairs the details of the failed execution, but I can imagine
it being useful for other cases too.

WDYT?

TODO:
- [x] test