### PR TITLE
BF: Catch key error when a submodule lacks a required property

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -1355,15 +1355,12 @@ def _add_hint_on_misbuilt_urls(urls, error_msgs):
     error_msgs : OrderedDict
       encountered cloning errors
     """
-    # import pdb; pdb.set_trace()
-    from datalad.ui import ui
-    from datalad.support import ansi_colors
-    intro = ansi_colors.color_word(
-        "Hint: A configuration for custom subdataset clone candidates exists, "
-        "but some key(s) used in the template were missing: ",
-        ansi_colors.YELLOW)
-    hint = ansi_colors.color_word('\n- '.join(
-        '{} {}'.format(subds, tmpl)
-        for subds, tmpl in urls.items()),
-        ansi_colors.YELLOW)
-    error_msgs[intro] = hint
+    for remote in urls.keys():
+        from datalad.support import ansi_colors
+        formatted_msg = ansi_colors.color_word(
+                             urls[remote]['msg'],
+                             ansi_colors.YELLOW)
+        msg = '{} {}'.format(
+                 formatted_msg,
+                 urls[remote]['error'])
+        error_msgs[remote] = msg

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -247,6 +247,16 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                         ds_repo.config[c])
                        for c in ds_repo.config.keys()
                        if c.startswith(candcfg_prefix)]:
+        # ensure that there is only one template of the same name
+        if type(tmpl) == tuple and len(tmpl) > 1:
+            lgr.debug('Found %i URL templates for the submodule clone '
+                      'candidate %s, but only one is allowed. Check your '
+                      'dataset configuration!', len(tmpl), name)
+            raise ValueError(
+                "There are multiple URL templates for submodule clone "
+                "candidate '{}', but only one is allowed. "
+                "Check your configuration!".format(name)
+            )
         try:
             url = tmpl.format(**sm_candidate_props)
         except KeyError as e:

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -255,7 +255,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
             # for a dataset id, for example.
             lgr.debug('Caught a key error in the generation of a submodule '
                       'URL using the template %s (%s)', tmpl, exc_str(e))
-            misbuilt_url[name] = tmpl
+            misbuilt_url[name] = (tmpl, e)
             continue
         # we don't want "flexible_source_candidates" here, this is
         # configuration that can be made arbitrarily precise from the

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -264,8 +264,12 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
             # template - this can happen if a pure Git repository is queried
             # for a dataset id, for example.
             lgr.debug('Caught a key error in the generation of a submodule '
-                      'URL using the template %s (%s)', tmpl, exc_str(e))
-            misbuilt_url[name] = (tmpl, e)
+                      'URL using the template %s (%s). The URL will not be '
+                      'constructed.', tmpl, exc_str(e))
+            msg = 'Hint! A custom clone candidate configuration exists, ' \
+                'but some key(s) in this template were missing:'
+            misbuilt_url[name] = {'msg': msg,
+                                  'error': tmpl}
             continue
         # we don't want "flexible_source_candidates" here, this is
         # configuration that can be made arbitrarily precise from the

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -172,7 +172,12 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
         [i['url']
          for i in f(clone3, clone3.subdatasets(return_type='item-or-list'))]
     )
-
+    # smoke test to check for #5631: We shouldn't crash with a KeyError when a
+    # template can not be matched.
+    with patch.dict(
+            'os.environ',
+            {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'pre-{not-a-key}-post'}):
+        f(clone, clone.subdatasets(return_type='item-or-list'))
     # TODO: check that http:// urls for the dataset itself get resolved
     # TODO: many more!!
 


### PR DESCRIPTION
During flexible clone candidate generation, it can happen that a submodule does not contain
a property that the url template requires. One example for this arises in #5631 where a
superdataset that is cloned from a RIA store passes its subdataset-source-candidate configuration
to its subdatasets, and one of the subdatasets is a pure Git repository that lacks the dataset
id property required for the url template from the superds' configuration.
In these cases, we run into a key error and crash.

This change catches any key error (but logs it at the debug level)

@bpoldrack , do you think that this is sufficient?

- [x] add a test