### PR TITLE
copy-file: Work around two pointer file issues

### DIFF
--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -629,6 +629,14 @@ def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
         # failing next on 'fromkey', due to a key mismatch.
         # this is more compatible with the nature of 'cp'
         dest.unlink()
+    # Make sure the destination exists because fromkey doesn't do this when
+    # writing a pointer file:
+    # https://git-annex.branchable.com/bugs/fromkey__58___create_directories_for_pointer_files__63__/
+    #
+    # TODO: Remove this mkdir() call if the patch at the above link (or
+    # something like it) is applied on git-annex's end before there is another
+    # release (current version is 8.20210428).
+    dest.parent.mkdir(exist_ok=True, parents=True)
     res = dest_repo._call_annex_records(
         # we use force, because in all likelihood there is no content for this key
         # yet

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -662,7 +662,12 @@ def _place_filekey(finfo, str_src, dest, str_dest, dest_repo_rec):
         tmploc = tmploc / dest_key
         _replace_file(finfo['objloc'], tmploc, str(tmploc), follow_symlinks=False)
 
-        dest_repo.call_annex(['reinject', str(tmploc), str_dest])
+        # Note: A relative path for the destination is needed for pointer
+        # files.
+        #
+        # https://git-annex.branchable.com/bugs/reinject__58___silent_failure_with_absolute_path_to_poi/
+        dest_repo.call_annex(['reinject', str(tmploc),
+                              str(dest.relative_to(dest_repo.pathobj))])
 
     return dest_key
 


### PR DESCRIPTION
Following ee2c014602 (ENH: copy-file: Use 'annex fromkey' on adjusted branch if supported, 2021-05-03), the Windows run with git-annex's master is failing (gh-5645).  This is a combination of two issues with pointer files:

  * https://git-annex.branchable.com/bugs/fromkey__58___create_directories_for_pointer_files__63__/
  * https://git-annex.branchable.com/bugs/reinject__58___silent_failure_with_absolute_path_to_poi/

Add workarounds for both of those.

In gh-5630, I mistakenly executed only a subset of `test_copy_file` tests that happended to not be affected by the above issues.  Now all the tests in that file pass under `tools/eval_under_testloopfs`:

```
$ stack exec -- ~/src/python/datalad/tools/eval_under_testloopfs python -m nose datalad.local.tests.test_copy_file
I: vfat of 10:  /tmp/datalad-fs-Chv6b
10+0 records in
10+0 records out
10321920 bytes (10 MB, 9.8 MiB) copied, 0.00376414 s, 2.7 GB/s
mkfs.fat 4.1 (2017-01-24)
I: running python -m nose datalad.local.tests.test_copy_file
........
----------------------------------------------------------------------
Ran 8 tests in 31.824s

OK
I: done, unmounting
$ stack exec -- git annex version
git-annex version: 8.20210429-g06e996efa
[...]
```

Closes #5645.

---

- [ ] Drop first commit.  Patch has been applied upstream in 4450fe362 (fromkey: create directory for pointer files too, 2021-05-06).