### PR TITLE
download-url: Set up datalad special remote if needed

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -217,7 +217,8 @@ URLs:
                             on_failure="ignore"):
                 yield r
 
-            if isinstance(ds.repo, AnnexRepo):
+            ds_repo = ds.repo
+            if isinstance(ds_repo, AnnexRepo):
                 if got_ds_instance:
                     # Paths in `downloaded_paths` are already relative to the
                     # dataset.
@@ -238,7 +239,7 @@ URLs:
                                         orig_path, ds)
                 annex_paths = [p for p, annexed in
                                zip(rpaths,
-                                   ds.repo.is_under_annex(list(rpaths.keys())))
+                                   ds_repo.is_under_annex(list(rpaths.keys())))
                                if annexed]
                 if annex_paths:
                     for path in annex_paths:
@@ -246,7 +247,7 @@ URLs:
                         try:
                             # The file is already present. This is just to
                             # register the URL.
-                            ds.repo.add_url_to_file(
+                            ds_repo.add_url_to_file(
                                 path,
                                 url,
                                 # avoid batch mode for single files
@@ -261,4 +262,4 @@ URLs:
                     if archive:
                         from datalad.api import add_archive_content
                         for path in annex_paths:
-                            add_archive_content(path, annex=ds.repo, delete=True)
+                            add_archive_content(path, annex=ds_repo, delete=True)

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -25,16 +25,27 @@ from ...utils import (
     Path,
 )
 from ...downloaders.tests.utils import get_test_providers
-from ...tests.utils import ok_, ok_exists, eq_, assert_cwd_unchanged, \
-    assert_in, assert_false, assert_message, assert_result_count, \
-    with_tempfile
-from ...tests.utils import assert_not_in
-from ...tests.utils import assert_in_results
-from ...tests.utils import DEFAULT_REMOTE
-from ...tests.utils import with_tree
-from ...tests.utils import serve_path_via_http
-from ...tests.utils import skip_if_no_network
-from ...tests.utils import known_failure_windows
+from ...tests.utils import (
+    assert_cwd_unchanged,
+    assert_false,
+    assert_in,
+    assert_message,
+    assert_result_count,
+    eq_,
+    ok_,
+    ok_exists,
+    with_tempfile,
+)
+from ...tests.utils import (
+    DEFAULT_REMOTE,
+    assert_in_results,
+    assert_not_in,
+    known_failure_windows,
+    serve_path_via_http,
+    skip_if_no_network,
+    slow,
+    with_tree,
+)
 
 
 def test_download_url_exceptions():
@@ -217,11 +228,12 @@ def test_download_url_archive_trailing_separator(toppath, topurl, path):
     ok_(ds.repo.file_has_content(opj("a1", "f1.txt")))
 
 
+@slow  # 12-14 sec
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_download_url_need_datalad_remote(path):
-    url = "s3://datalad-test0-versioned/2versions-nonversioned1.txt"
-    get_test_providers(url)  # Skips if provider isn't setup.
+    # publicly available (requires anonymous s3 access, so still needs our special remote)
+    url = "s3://dandiarchive/ros3test.hdf5"
     path = Path(path)
     ds_a = Dataset(path / "a").create()
     ds_a.download_url([url], path="foo")


### PR DESCRIPTION
As suggested in gh-5510, `download-url` should set up the datalad special remote if needed to avoid non-functional URLs.

- [x] ~The added code should be covered by existing tests, but~ an explicit test of the new behavior would be good.

  It seems tricky to test this in `test_download_url`, though, assuming we don't want to hit a real endpoint.  For example, if we were to use `shub://`, patching for the initial download to point to the `serve_path_via_http` works, but then anything that involves the special remote (registering the URL, downloading it from another clone) wouldn't because that is of course in a separate process.