### PR TITLE
MNT: setup.py: Temporarily avoid Sphinx 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ requires.update({
         # used for converting README.md -> .rst for long_description
         'pypandoc',
         # Documentation
-        'sphinx>=1.7.8',
+        'sphinx>=1.7.8, <4',
         'sphinx-rtd-theme',
     ],
     'devel-utils': [


### PR DESCRIPTION
With Sphinx 4.0.0 (released yesterday), the docs builds for maint and
master are failing (with different errors):

  https://github.com/datalad/datalad/actions/runs/828244083
  https://github.com/datalad/datalad/actions/runs/828227680

Hold off upgrading until the issues are resolved.
