### PR TITLE
Revert "TST: test_partial_unlocked: Document and avoid recent git-annex failure"

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -651,21 +651,7 @@ def test_partial_unlocked(path):
     ds.repo.set_gitattributes([
         ('*', {'annex.largefiles': 'nothing'})])
     ds.save()
-    try:
-        assert_repo_status(ds.path)
-    except AssertionError:
-        if ds.repo.git_annex_version > "8.20210428":
-            # Before git-annex's 424bef6b6 (smudge: check for known annexed
-            # inodes before checking annex.largefiles, 2021-05-03), the above
-            # leads to the last commit including the switch of culprit.txt to
-            # being tracked in git. With 424bef6b6, the switch is (racily) left
-            # staged, where the commit captures the symbolic link to pointer
-            # change.
-            #
-            # https://git-annex.branchable.com/bugs/case_where_using_pathspec_with_git-commit_leaves_s/
-            assert_repo_status(ds.path, modified=["culprit.txt"])
-        else:
-            raise
+    assert_repo_status(ds.path)
 
 
 @with_tree({'.gitattributes': "* annex.largefiles=(largerthan=4b)",


### PR DESCRIPTION
This reverts commit 501c9d0b655b6c26d49f273a81ebaab6f0a0db97.

The above commit worked around a racy test_partial_unlocked() failure
triggered by git-annex's 424bef6b6 (smudge: check for known annexed -
inodes before checking annex.largefiles, 2021-05-03).  Due to this
issue, 424bef6b6 has now been reverted and replaced by [8.20210428-95-g675556fd9](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=675556fd9)
(smudge: check for known annexed inodes before checking
annex.largefiles, 2021-05-10).
