### PR TITLE
BF(DOC)+RF: report "present" for the state of a present/installed/fulfilled (sub)dataset

### DIFF
--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -108,8 +108,7 @@ class Subdatasets(Interface):
         SHA1 of the subdataset commit recorded in the parent dataset
 
     "state"
-        Condition of the subdataset: 'clean', 'modified', 'absent', 'conflict'
-        as reported by `git submodule`
+        Condition of the subdataset: 'absent', 'present'
 
     "gitmodule_url"
         URL of the subdataset recorded in the parent
@@ -312,6 +311,9 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
         # not matching `contains`
         if not sm_path.exists() or not GitRepo.is_valid_repo(sm_path):
             sm['state'] = 'absent'
+        else:
+            assert 'state' not in sm
+            sm['state'] = 'present'
         # do we just need this to recurse into subdatasets, or is this a
         # real results?
         to_report = paths is None \

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -286,10 +286,8 @@ def test_get_subdatasets(origpath, path):
 def test_state(path):
     ds = Dataset.create(path)
     sub = ds.create('sub')
-    res = ds.subdatasets()
-    assert_result_count(res, 1, path=sub.path)
-    # by default we are not reporting any state info
-    assert_not_in('state', res[0])
+    assert_result_count(
+        ds.subdatasets(), 1, path=sub.path, state='present')
     # uninstall the subdataset
     ds.uninstall('sub')
     # normal 'gone' is "absent"


### PR DESCRIPTION
I think that docstring was left from old(er) times whenever `git submodule` was
used to report the "state" of the subdatasets.  After it was replaced with
ad-hoc parsing of .gitmodules as far as I see it "state" no longer corresponds
to any of those values besides "absent", and we simply do not report any state
(as changed unittest shows) for "present" (a clear antonym to "absent")
datasets.  All those states are reported by "status" command though.  E.g.
compare:

	$> datalad -f '{type} {path}: {state} {status}' --report-type dataset status -d . | grep dataset
	dataset /tmp/testds3/mod-inited: clean ok
	dataset /tmp/testds3/not-committed: added ok
	dataset /tmp/testds3/not-mod-inited: clean ok
	dataset /tmp/testds3/openneuro: clean ok
	dataset /tmp/testds3/uninstalled: clean ok

to (with these changes, without -- would say NA instead of "present" since
there would be no "state")

	$> datalad -f '{type} {path}: {state} {status}' --report-type dataset subdatasets -d . | grep dataset
	dataset /tmp/testds3/mod-inited: present ok
	dataset /tmp/testds3/not-committed: present ok
	dataset /tmp/testds3/not-mod-inited: present ok
	dataset /tmp/testds3/openneuro: present ok
	dataset /tmp/testds3/uninstalled: absent ok

to see that "status" does not care about "subdataset state" and reports it as
"clean" if absent.

To mitigate it, I have established "present" as a possible value for the
subdataset's "state", thus overall making it a "bool" value as just a field
with two possible states.  ATM I do not see any other possible value we might
want to report which would be complimentary (not a sub-category) to those two.

This might establish a precedent for RFing of --fulfilled into
--state={any,present,absent} for selection of subdatasets according to their
state, making interface more coherent IMHO.  But with that in mind I would
still have consideration of the fact that "state" means different things
depending on the command (subdatasets vs status) which might cause
confusion/conflict here.  But I think it is status="ok" (pun intended) as long
as we document that it is "subdatasets state" and possibly use "--status-state"
or just "--status" whenever we decide to harmonize options for that.

WDYT?  if we decide to proceed with this one, then for `foreach` (#749) I would add `--state={present,absent,any}` and possibly suggest a PR for `--fulfilled` -> `--state={any,present,absent}` RFing/deprecation of fulfilled

