### PR TITLE
create, gitrepo: Restore handling of initopts list

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -462,7 +462,7 @@ def _setup_git_repo(path, initopts=None, fake_dates=False):
     ----------
     path: str or Path
       Path of the repository
-    initopts: list, optional
+    initopts: dict, optional
       Git options to be passed to the GitRepo constructor
     fake_dates: bool, optional
       Passed to the GitRepo constructor
@@ -502,7 +502,7 @@ def _setup_annex_repo(path, initopts=None, fake_dates=False,
     ----------
     path: str or Path
       Path of the repository
-    initopts: list, optional
+    initopts: dict, optional
       Git options to be passed to the AnnexRepo constructor
     fake_dates: bool, optional
       Passed to the AnnexRepo constructor

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -30,7 +30,6 @@ from datalad.interface.base import build_doc
 from datalad.interface.common_opts import (
     location_description,
 )
-from datalad.interface.results import ResultXFM
 from datalad.support.constraints import (
     EnsureStr,
     EnsureNone,

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -26,7 +26,6 @@ from datalad.utils import (
 )
 from datalad.cmd import (
     WitlessRunner as Runner,
-    StdOutErrCapture,
 )
 
 from datalad.tests.utils import (

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -39,6 +39,7 @@ from datalad.tests.utils import (
     has_symlink_capability,
     OBSCURE_FILENAME,
     ok_,
+    ok_exists,
     swallow_outputs,
     with_tempfile,
     with_tree,
@@ -509,3 +510,24 @@ def test_gh2927(path, linkpath):
     ds.create('subds_clean')
     assert_status('ok', ds.create(op.join('subds_clean', 'subds_lvl1_clean'),
                                   result_xfm=None, return_type='list'))
+
+
+@with_tempfile(mkdir=True)
+def check_create_initopts_form(form, path):
+    path = Path(path)
+
+    template_dir = path / "templates"
+    template_dir.mkdir()
+    (template_dir / "foo").write_text("")
+
+    forms = {"list": [f"--template={template_dir}"],
+             "dict": {"template": str(template_dir)}}
+
+    ds = Dataset(path / "ds")
+    ds.create(initopts=forms[form])
+    ok_exists(ds.repo.dot_git / "foo")
+
+
+def test_create_initopts_form():
+    yield check_create_initopts_form, "dict"
+    yield check_create_initopts_form, "list"

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -898,9 +898,10 @@ class GitRepo(CoreGitRepo):
         self._cfg = None
 
         if do_create:  # we figured it out earlier
+            from_cmdline = git_opts.pop('_from_cmdline_', [])
             self.init(
                 sanity_checks=create_sanity_checks,
-                init_options=to_options(**git_opts),
+                init_options=from_cmdline + to_options(**git_opts),
             )
 
         # with DryRunProtocol path might still not exist


### PR DESCRIPTION
On the master branch, passing `git init` options to `create` no longer works:

```
$ datalad create . --template=/dev/null
[...]
error: unknown option `-from-cmdline-=--template=/dev/null'
```

That's fixed by the second commit.  The other two commits are minor cleanups in the area.
