### PR TITLE
DOC: Reference plugins via datalad.api

### DIFF
--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -30,7 +30,7 @@ operate on a particular dataset, but also general functionality that can be
 used outside the context of a specific dataset. The following table provides an
 overview of plugins included in this DataLad release.
 
-.. currentmodule:: datalad.plugin
+.. currentmodule:: datalad.api
 .. autosummary::
    :toctree: generated
 

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -99,7 +99,7 @@ Plugins
 DataLad can be customized by plugins. The following plugins are shipped
 with DataLad.
 
-.. currentmodule:: datalad.plugin
+.. currentmodule:: datalad.api
 .. autosummary::
    :toctree: generated
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ requires.update({
         # used for converting README.md -> .rst for long_description
         'pypandoc',
         # Documentation
-        'sphinx>=1.7.8, <4',
+        'sphinx>=1.7.8, !=4.0.0',
         'sphinx-rtd-theme',
     ],
     'devel-utils': [


### PR DESCRIPTION
With the recent release of Sphinx v4, the doc build on master and
maint started to fail.  The failure on master was due to a bug in
Sphinx and fixed by v4.0.1.  The failure on maint is due to a warning:

    docstring of datalad.support.constraints.EnsureChoice:1:duplicate
    object description of datalad.support.constraints.EnsureChoice,
    other instance in generated/datalad.plugin.add_readme, use
    :noindex: for one of them

One our end, this is triggered by the combination of two things:

  * many of the plugin modules have imports at the class level

  * the documentation refers to these plugin commands via
    datalad.plugin.NAME rather than datalad.api.NAME

The end result is that the plugin commands are not rendered like other
commands (e.g., no command parameters) and instead have a lot of noise
about unrelated class attributes (e.g., AddReadme.EnsureChoice).

We could remove the warning by moving these imports to the module
level, but these pages still wouldn't be rendered in the same way that
other commands are.  Remove the warnings and fix the rendering by
pointing to datalad.api rather than datalad.plugin.

Note that master doesn't have this issue because all plugins have been
converted to regular commands and are referenced as datalad.api.NAME.

Fixes #5650.

---

Example of the problem:

https://docs.datalad.org/en/stable/generated/datalad.plugin.add_readme.html#datalad.plugin.add_readme.AddReadme.EnsureChoice
