### PR TITLE
clone, install: Support cloning a specified branch or tag

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -9,6 +9,7 @@
 """Plumbing command for dataset installation"""
 
 
+from argparse import REMAINDER
 import logging
 import re
 from os.path import expanduser
@@ -196,6 +197,18 @@ class Clone(Interface):
             doc="""path to clone into.  If no `path` is provided a
             destination path will be derived from a source URL
             similar to :command:`git clone`"""),
+        git_clone_opts=Parameter(
+            args=("git_clone_opts",),
+            metavar='GIT CLONE OPTIONS',
+            nargs=REMAINDER,
+            doc="""[PY: A list of command line arguments PY][CMD: Options CMD]
+            to pass to :command:`git clone`. [CMD: Any argument specified after
+            SOURCE and the optional PATH will be passed to git-clone. CMD] Note
+            that not all options will lead to viable results. For example
+            '--single-branch' will not result in a functional annex repository
+            because both a regular branch and the git-annex branch are
+            required. Note that a version in a RIA URL takes precedence over
+            '--branch'."""),
         description=location_description,
         reckless=reckless_opt,
     )
@@ -208,7 +221,8 @@ class Clone(Interface):
             path=None,
             dataset=None,
             description=None,
-            reckless=None):
+            reckless=None,
+            git_clone_opts=None):
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
         # Otherwise path will be resolved first.
@@ -296,6 +310,7 @@ class Clone(Interface):
             description,
             result_props,
             cfg=None if ds is None else ds.config,
+            clone_opts=git_clone_opts
         )
 
         # TODO handle any 'version' property handling and verification using a
@@ -325,7 +340,8 @@ def clone_dataset(
         description=None,
         result_props=None,
         cfg=None,
-        checkout_gitsha=None):
+        checkout_gitsha=None,
+        clone_opts=None):
     """Internal helper to perform cloning without sanity checks (assumed done)
 
     This helper does not handle any saving of subdataset modification or adding
@@ -354,6 +370,10 @@ def clone_dataset(
       did not obtain the commit object. Should the checkout of the target commit
       cause a detached HEAD, the previously active branch will be reset to the
       target commit.
+    clone_opts : list of str, optional
+      Options passed to git-clone. Note that for RIA URLs, the version is
+      translated to a --branch argument, and that will take precedence over a
+      --branch argument included in this value.
 
     Yields
     ------
@@ -437,6 +457,7 @@ def clone_dataset(
         label='Clone attempt',
         unit=' Candidate locations',
     )
+    clone_opts = clone_opts or []
     error_msgs = OrderedDict()  # accumulate all error messages formatted per each url
     for cand in candidate_sources:
         log_progress(
@@ -446,17 +467,18 @@ def clone_dataset(
             update=1,
             increment=True)
 
-        clone_opts = {}
-
         if cand.get('version', None):
-            clone_opts['branch'] = cand['version']
+            opts = clone_opts + ["--branch=" + cand['version']]
+        else:
+            opts = clone_opts
+
         try:
             # TODO for now GitRepo.clone() cannot handle Path instances, and PY35
             # doesn't make it happen seamlessly
             GitRepo.clone(
                 path=str(dest_path),
                 url=cand['giturl'],
-                clone_options=clone_opts,
+                clone_options=opts,
                 create=True)
 
         except CommandError as e:

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -188,7 +188,7 @@ class Clone(Interface):
             metavar='SOURCE',
             doc="""URL, DataLad resource identifier, local path or instance of
             dataset to be cloned""",
-            constraints=EnsureStr() | EnsureNone()),
+            constraints=EnsureStr()),
         path=Parameter(
             args=("path",),
             metavar='PATH',

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -11,7 +11,6 @@
 
 import logging
 import re
-import requests
 from os.path import expanduser
 from collections import OrderedDict
 from urllib.parse import unquote as urlunquote
@@ -32,7 +31,6 @@ from datalad.cmd import (
     CommandError,
     GitWitlessRunner,
     StdOutCapture,
-    StdOutErrCapture,
 )
 from datalad.distributed.ora_remote import (
     LocalIO,

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -150,6 +150,13 @@ class Install(Interface):
             metavar='SOURCE',
             doc="URL or local path of the installation source",
             constraints=EnsureStr() | EnsureNone()),
+        branch=Parameter(
+            args=("--branch",),
+            doc="""Clone source at this branch or tag. This option applies only
+            to the top-level dataset not any subdatasets that may be cloned
+            when installing recursively. Note that if the source is a RIA URL
+            with a version, it takes precedence over this option.""",
+            constraints=EnsureStr() | EnsureNone()),
         get_data=Parameter(
             args=("-g", "--get-data",),
             doc="""if given, obtain all data content too""",
@@ -173,7 +180,8 @@ class Install(Interface):
             recursive=False,
             recursion_limit=None,
             reckless=None,
-            jobs="auto"):
+            jobs="auto",
+            branch=None):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`
@@ -352,6 +360,7 @@ class Install(Interface):
         res = Clone.__call__(
             source, path, dataset=ds, description=description,
             reckless=reckless,
+            git_clone_opts=["--branch=" + branch] if branch else None,
             # we need to disable error handling in order to have it done at
             # the very top, otherwise we are not able to order a global
             # "ignore-and-keep-going"

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -19,6 +19,9 @@ import logging
 from collections import (
     OrderedDict,
 )
+from collections.abc import (
+    Mapping,
+)
 from os import linesep
 from os.path import (
     join as opj,
@@ -937,9 +940,10 @@ class GitRepo(CoreGitRepo):
         ----------
         url : str
         path : str
-        clone_options : dict
-          Key/value pairs of arbitrary options that will be passed on to the
-          underlying call to `git-clone`.
+        clone_options : dict or list
+          Arbitrary options that will be passed on to the underlying call to
+          `git-clone`. This may be a list of plain options or key-value pairs
+          that will be converted to a list of plain options with `to_options`.
         expect_fail : bool
           Whether expect that command might fail, so error should be logged then
           at DEBUG level instead of ERROR
@@ -995,7 +999,9 @@ class GitRepo(CoreGitRepo):
 
         cmd = cls._git_cmd_prefix + ['clone', '--progress']
         if clone_options:
-            cmd.extend(to_options(**clone_options))
+            if isinstance(clone_options, Mapping):
+                clone_options = to_options(**clone_options)
+            cmd.extend(clone_options)
         cmd.extend([url, path])
 
         fix_annex = None

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -993,19 +993,18 @@ class GitRepo(CoreGitRepo):
                     lgr.info("Expanded source path to %s from %s", new_url, url)
                     url = new_url
 
-        cmd_base = cls._git_cmd_prefix + ['clone', '--progress']
+        cmd = cls._git_cmd_prefix + ['clone', '--progress']
+        if clone_options:
+            cmd.extend(to_options(**clone_options))
+        cmd.extend([url, path])
+
         fix_annex = None
         ntries = 5  # 3 is not enough for robust workaround
         for trial in range(ntries):
             try:
                 lgr.debug("Git clone from {0} to {1}".format(url, path))
 
-                res = GitWitlessRunner().run(
-                        cmd_base + [url, path] \
-                        + (to_options(**clone_options)
-                           if clone_options else []),
-                        protocol=GitProgress,
-                )
+                res = GitWitlessRunner().run(cmd, protocol=GitProgress)
                 # fish out non-critical warnings by git-clone
                 # (empty repo clone, etc.), all other content is logged
                 # by the progress helper to 'debug'

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -50,10 +50,14 @@ def _test_consistent_order_of_args(intf, spec_posargs):
     elif intf.__name__ in (
             'AddReadme',
             'Addurls',
+            # Clone gained a git_clone_opts REMAINDER option. This is
+            # positional on the command line, but positioning it at the front
+            # of the signature could break existing python callers.
+            'Clone',
             'ExportArchive',
             'ExportToFigshare',
             'ExtractMetadata'):
-        if intf.__name__ != 'ExtractMetadata':
+        if intf.__name__ not in ['Clone', 'ExtractMetadata']:
             # ex-plugins had 'dataset' as the first positional argument
             # and ExtractMetadata has 'types' as the first positional arg
             eq_(args[0], 'dataset')


### PR DESCRIPTION
Note: This is marked as a draft because, based on past discussion, I expect there to be a good amount of disagreement about how to expose this.

---

Per @yarikoptic's request, this PR is a continuation of the discussion in gh-2109 about installing a specific version of a dataset.  gh-4036 added a RIA-specific URL scheme to support cloning a specific branch or tag: `ria+...#<dataset uuid>[@<tag/branch>]`.

I see two main routes to extend that support to URLs in general:

  * come up with a scheme for non-RIA URLs

    Forms mentioned in gh-2109 include `...#version=X` (in fragment) and `...@X` (in path).

  * add an argument to `clone` and `install` that allows specifying `X`.


I'm in favor of the second due to the combination of the following reasons:

  * It avoids all of the discussion in gh-2109 about how to represent the version in the URL.

  * Allowing arbitrary `git clone` options to be passed to `datalad clone` seems like a good idea to me.  This has been brought up before (e.g., gh-4035 and gh-5286), and I think it will likely come up more as sparse checkouts and partial clones become more mature and widely used.

Going the command-argument route leaves the question of what to do with `datalad install`.  We could allow arbitrary `git clone` options there too.  However, given that `install` also wraps `get`, it's not clear that clone options should take precedence over arbitrary `git annex get` options.  So, in the case of `install`, a dedicated `--branch` argument could be added.  This doesn't block switching to arbitrary clone options later, aside from introducing the requirement that `--branch` (like other arbitrary options) comes at the end.

Here are the main points against using command arguments instead of an URL-embedded version that come to mind:

  * RIA already uses an embedded version.

  * `--branch` is tied to git-clone's tag/branch implementation, and, even though RIA versions currently use `--branch`, it'd be possible to switch away from that behind the scenes so that arbitrary commits are supported.

However, if `datalad clone` is going to accept arbitrary `git clone` options anyway, `--branch` falls out of that, so neither of those points carry much weight in my view.  `--branch` can be used until there's a clear need for arbitrary revisions (which, as far as I'm aware, hasn't been brought up for RIA URLs yet) and then an embedded URL scheme can be implemented.  At that point, it's still good for `datalad clone` to support arbitrary options, and the only extra cost is the `--branch` argument of `install`.

Thoughts?

cc: @mih @yarikoptic @bpoldrack @dorianps
