### PR TITLE
status: Provide special treatment of "this dataset" path

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -355,7 +355,9 @@ class Status(Interface):
                 else:
                     if dataset and root == str(p) and \
                             not (orig_path.endswith(op.sep) or
-                                 orig_path == "."):
+                                 # Note: Compare to Dataset(root).path rather
+                                 # than root to get same path normalization.
+                                 Dataset(root).path == ds_path):
                         # the given path is pointing to a dataset
                         # distinguish rsync-link syntax to identify
                         # the dataset as whole (e.g. 'ds') vs its

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -323,7 +323,7 @@ class Status(Interface):
         # on a manageable level
         ds = require_dataset(
             dataset, check_installed=True, purpose='status reporting')
-
+        ds_path = ds.path
         paths_by_ds = OrderedDict()
         if path:
             # sort any path argument into the respective subdatasets
@@ -347,7 +347,7 @@ class Status(Interface):
                     yield dict(
                         action='status',
                         path=p,
-                        refds=ds.path,
+                        refds=ds_path,
                         status='error',
                         message='path not underneath this dataset',
                         logger=lgr)
@@ -394,7 +394,7 @@ class Status(Interface):
                 # there is only a single refds
                 yield dict(
                     path=str(qdspath),
-                    refds=ds.path,
+                    refds=ds_path,
                     action='status',
                     status='error',
                     message=(
@@ -428,7 +428,7 @@ class Status(Interface):
                     content_info_cache):
                 yield dict(
                     r,
-                    refds=ds.path,
+                    refds=ds_path,
                     action='status',
                     status='ok',
                 )

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -237,9 +237,33 @@ def test_subds_status(path):
         refds=ds.path)
 
     # path="." gets treated as "this dataset's content" without requiring a
-    # trailing "/".
+    # trailing "/"...
     assert_result_count(
         subds.status(path=".", result_renderer=None),
+        1,
+        type="dataset",
+        path=op.join(subds.path, "someotherds"),
+        refds=subds.path)
+
+    # ... and so does path=<path/to/ds>.
+    assert_result_count(
+        subds.status(path=subds.path, result_renderer=None),
+        1,
+        type="dataset",
+        path=op.join(subds.path, "someotherds"),
+        refds=subds.path)
+
+    assert_result_count(
+        subds.status(path=op.join(subds.path, op.pardir, "subds"),
+                     result_renderer=None),
+        1,
+        type="dataset",
+        path=op.join(subds.path, "someotherds"),
+        refds=subds.path)
+
+    assert_result_count(
+        subds.status(path=op.join(subds.path, op.curdir),
+                     result_renderer=None),
         1,
         type="dataset",
         path=op.join(subds.path, "someotherds"),


### PR DESCRIPTION
When called with a path argument that points to a dataset and that
dataset has a parent dataset, status() checks if the original path
ends with "/".  No trailing separate indicates that the dataset as a
whole is of interest, leading to a query in the parent for that
dataset.

The above logic is confusing when `dataset` and `path` point to the
same dataset.  status() with a parent-less dataset works (and behaves
as the path argument ended with "/"), while a nested dataset fails
with

    [ERROR ] dataset containing given paths is not underneath the
    reference dataset [...]

3dea65a9b8 (BF: status: Provide special treatment of "." path,
2019-04-12) avoided the above error for the path="." case.  However,
the same error can be triggered by calling status() with a path
argument other than "." that points to the same location as the
dataset argument.

Adjust the condition from 3dea65a9b8 to handle that too.

Closes #5657.

---

cc: @mih