### PR TITLE
NF: implement a non asyncio-based runner

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -535,6 +535,9 @@ class GitWitlessRunner(WitlessRunner, GitRunnerBase):
 
 
 def readline_rstripped(stdout):
+    warnings.warn("the function `readline_rstripped()` is deprecated "
+                  "and will be removed in a future release",
+                  DeprecationWarning)
     return stdout.readline().rstrip()
 
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -15,19 +15,13 @@ import subprocess
 import sys
 import logging
 import os
-import functools
 import tempfile
 from locale import getpreferredencoding
 import asyncio
-from collections import (
-    namedtuple,
-)
+import warnings
 
 from .consts import GIT_SSH_COMMAND
-from .dochelpers import (
-    borrowdoc,
-    exc_str,
-)
+from .dochelpers import borrowdoc
 from .support import path as op
 from .support.exceptions import CommandError
 from .utils import (

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -22,7 +22,6 @@ import warnings
 
 from .consts import GIT_SSH_COMMAND
 from .dochelpers import borrowdoc
-from .nonasyncrunner import run_command
 from .support import path as op
 from .support.exceptions import CommandError
 from .utils import (
@@ -290,6 +289,10 @@ class WitlessRunner(object):
         FileNotFoundError
           When a given executable does not exist.
         """
+
+        # imported here to avoid recursive importing
+        from .nonasyncrunner import run_command
+
         if protocol is None:
             # by default let all subprocess stream pass through
             protocol = NoCapture

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -144,11 +144,11 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
             self.process.pid, return_code)
         # give captured process output back to the runner as string(s)
         results = {
-            self.fd_infos[fileno][0]: (
-                bytes(self.fd_infos[fileno][1]).decode(self.encoding)
-                if self.fd_infos[fileno][1] is not None
+            name: (
+                bytes(byt).decode(self.encoding)
+                if byt is not None
                 else '')
-            for fileno in (self.stdout_fileno, self.stderr_fileno)
+            for name, byt in self.fd_infos.items()
         }
         results['code'] = return_code
         return results

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -137,7 +137,8 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         'cmd' and 'cwd' on error, if they are present in the result.
         """
         return_code = self.process.poll()
-        assert return_code is not None
+        if return_code is None:
+            raise CommandError("Got None as a return_code for the process %i", self.process.pid)
         lgr.debug(
             'Process %i exited with return code %i',
             self.process.pid, return_code)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -22,6 +22,7 @@ import warnings
 
 from .consts import GIT_SSH_COMMAND
 from .dochelpers import borrowdoc
+from .nonasyncrunner import run_command
 from .support import path as op
 from .support.exceptions import CommandError
 from .utils import (
@@ -138,7 +139,9 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         """
         return_code = self.process.poll()
         if return_code is None:
-            raise CommandError("Got None as a return_code for the process %i", self.process.pid)
+            raise CommandError(
+                "Got None as a return_code for the process %i",
+                self.process.pid)
         lgr.debug(
             'Process %i exited with return code %i',
             self.process.pid, return_code)
@@ -296,8 +299,6 @@ class WitlessRunner(object):
             env or self.env,
             cwd=cwd,
         )
-
-        from .nonasyncrunner import run_command
 
         lgr.debug('run:\n cwd=%s\n cmd=%s', cwd, cmd)
         results = run_command(

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -67,14 +67,21 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
     proc_out = None
     proc_err = None
 
-    def __init__(self, encoding=None):
+    def __init__(self, done_future=None, encoding=None):
         """
         Parameters
         ----------
+        done_future: Any
+          Ignored parameter, kept for backward compatibility (DEPRECATED)
         encoding : str
           Encoding to be used for process output bytes decoding. By default,
           the preferred system encoding is guessed.
         """
+
+        if done_future is not None:
+            warnings.warn("`done_future` argument is ignored "
+                          "and will be removed in a future release",
+                          DeprecationWarning)
 
         self.fd_infos = {}
 
@@ -532,7 +539,6 @@ class GitWitlessRunner(WitlessRunner, GitRunnerBase):
 
 
 def readline_rstripped(stdout):
-    #return iter(stdout.readline, b'').next().rstrip()
     return stdout.readline().rstrip()
 
 

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -333,36 +333,6 @@ class WitlessRunner(object):
         results.pop('code', None)
         return results
 
-    @classmethod
-    def _check_if_new_proc(cls):
-        """Check if WitlessRunner is used under a new PID
-
-        Note that this is a function that is meant to be called from within a
-        particular context only. The RuntimeError is expected to be caught by
-        the caller and is meant to be more like a response message than an
-        exception.
-
-        Returns
-        -------
-        bool
-
-        Raises
-        ------
-        RuntimeError
-          If it is not a new proc and we already know that we need a new loop
-          in this pid
-        """
-        pid = os.getpid()
-        is_new_proc = cls._loop_pid is None or cls._loop_pid != pid
-        if is_new_proc:
-            # We need to check if we can run any command smoothly
-            cls._loop_pid = pid
-            cls._loop_need_new = None
-        elif cls._loop_need_new:
-            raise RuntimeError("we know we need a new loop")
-        return is_new_proc
-
-
 class GitRunnerBase(object):
     """
     Mix-in class for Runners to be used to run git and git annex commands

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -11,17 +11,24 @@ Wrapper for command and function calls, allowing for dry runs and output handlin
 
 """
 
-import subprocess
-import sys
 import logging
 import os
+import subprocess
+import sys
 import tempfile
-from locale import getpreferredencoding
-import asyncio
 import warnings
 
+from .cmd_protocols import (
+    KillOutput,
+    NoCapture,
+    StdErrCapture,
+    StdOutCapture,
+    StdOutErrCapture,
+    WitlessProtocol,
+)
 from .consts import GIT_SSH_COMMAND
 from .dochelpers import borrowdoc
+from .nonasyncrunner import run_command
 from .support import path as op
 from .support.exceptions import CommandError
 from .utils import (
@@ -42,161 +49,6 @@ _TEMP_std = sys.stdout, sys.stderr
 # in Runner so we take care about their removal, in contrast to those
 # which might be created outside and passed into Runner
 _MAGICAL_OUTPUT_MARKER = "_runneroutput_"
-
-
-class WitlessProtocol(asyncio.SubprocessProtocol):
-    """Subprocess communication protocol base class for `run_async_cmd`
-
-    This class implements basic subprocess output handling. Derived classes
-    like `StdOutCapture` should be used for subprocess communication that need
-    to capture and return output. In particular, the `pipe_data_received()`
-    method can be overwritten to implement "online" processing of process
-    output.
-
-    This class defines a default return value setup that causes
-    `run_async_cmd()` to return a 2-tuple with the subprocess's exit code
-    and a list with bytestrings of all captured output streams.
-    """
-
-    proc_out = None
-    proc_err = None
-
-    def __init__(self, done_future=None, encoding=None):
-        """
-        Parameters
-        ----------
-        done_future: Any
-          Ignored parameter, kept for backward compatibility (DEPRECATED)
-        encoding : str
-          Encoding to be used for process output bytes decoding. By default,
-          the preferred system encoding is guessed.
-        """
-
-        if done_future is not None:
-            warnings.warn("`done_future` argument is ignored "
-                          "and will be removed in a future release",
-                          DeprecationWarning)
-
-        self.fd_infos = {}
-
-        self.process = None
-        self.stdout_fileno = 1
-        self.stderr_fileno = 2
-
-        # capture output in bytearrays while the process is running
-        self.fd_infos[self.stdout_fileno] = ("stdout", bytearray()) if self.proc_out else ("stdout", None)
-        self.fd_infos[self.stderr_fileno] = ("stderr", bytearray()) if self.proc_err else ("stderr", None)
-
-        super().__init__()
-        self.encoding = encoding or getpreferredencoding(do_setlocale=False)
-
-        self._log_outputs = False
-        if lgr.isEnabledFor(5):
-            try:
-                from . import cfg
-                self._log_outputs = cfg.getbool('datalad.log', 'outputs', default=False)
-            except ImportError:
-                pass
-            self._log = self._log_summary
-        else:
-            self._log = self._log_nolog
-
-    def _log_nolog(self, *args):
-        pass
-
-    def _log_summary(self, fd, data):
-        fd_name = self.fd_infos[fd]
-        lgr.log(5, 'Read %i bytes from %i[%s]%s',
-                len(data), self.process.pid, fd_name, ':' if self._log_outputs else '')
-        if self._log_outputs:
-            log_data = ensure_unicode(data)
-            # The way we log is to stay consistent with Runner.
-            # TODO: later we might just log in a single entry, without
-            # fd_name prefix
-            lgr.log(5, "%s| %s ", fd_name, log_data)
-
-    def connection_made(self, process):
-        self.process = process
-        lgr.debug('Process %i started', self.process.pid)
-
-    def pipe_data_received(self, fd, data):
-        self._log(fd, data)
-        # store received output if stream was to be captured
-        fd_name, buffer = self.fd_infos[fd]
-        if buffer is not None:
-            buffer.extend(data)
-
-    def _prepare_result(self):
-        """Prepares the final result to be returned to the runner
-
-        Note for derived classes overwriting this method:
-
-        The result must be a dict with keys that do not unintentionally
-        conflict with the API of CommandError, as the result dict is passed to
-        this exception class as kwargs on error. The Runner will overwrite
-        'cmd' and 'cwd' on error, if they are present in the result.
-        """
-        return_code = self.process.poll()
-        if return_code is None:
-            raise CommandError(
-                "Got None as a return_code for the process %i",
-                self.process.pid)
-        lgr.debug(
-            'Process %i exited with return code %i',
-            self.process.pid, return_code)
-        # give captured process output back to the runner as string(s)
-        results = {
-            name: (
-                bytes(byt).decode(self.encoding)
-                if byt is not None
-                else '')
-            for name, byt in self.fd_infos.values()
-        }
-        results['code'] = return_code
-        return results
-
-    def process_exited(self):
-        pass
-
-
-class NoCapture(WitlessProtocol):
-    """WitlessProtocol that captures no subprocess output
-
-    As this is identical with the behavior of the WitlessProtocol base class,
-    this class is merely a more readable convenience alias.
-    """
-    pass
-
-
-class StdOutCapture(WitlessProtocol):
-    """WitlessProtocol that only captures and returns stdout of a subprocess"""
-    proc_out = True
-
-
-class StdErrCapture(WitlessProtocol):
-    """WitlessProtocol that only captures and returns stderr of a subprocess"""
-    proc_err = True
-
-
-class StdOutErrCapture(WitlessProtocol):
-    """WitlessProtocol that captures and returns stdout/stderr of a subprocess
-    """
-    proc_out = True
-    proc_err = True
-
-
-class KillOutput(WitlessProtocol):
-    """WitlessProtocol that swallows stdout/stderr of a subprocess
-    """
-    proc_out = True
-    proc_err = True
-
-    def pipe_data_received(self, fd, data):
-        if lgr.isEnabledFor(5):
-            lgr.log(
-                5,
-                'Discarded %i bytes from %i[%s]',
-                len(data), self.process.pid, self.fd_infos[fd][0])
 
 
 class WitlessRunner(object):
@@ -289,10 +141,6 @@ class WitlessRunner(object):
         FileNotFoundError
           When a given executable does not exist.
         """
-
-        # imported here to avoid recursive importing
-        from .nonasyncrunner import run_command
-
         if protocol is None:
             # by default let all subprocess stream pass through
             protocol = NoCapture

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -148,7 +148,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
                 bytes(byt).decode(self.encoding)
                 if byt is not None
                 else '')
-            for name, byt in self.fd_infos.items()
+            for name, byt in self.fd_infos.values()
         }
         results['code'] = return_code
         return results
@@ -299,7 +299,7 @@ class WitlessRunner(object):
 
         from .nonasyncrunner import run_command
 
-        lgr.debug('Async run:\n cwd=%s\n cmd=%s', cwd, cmd)
+        lgr.debug('run:\n cwd=%s\n cmd=%s', cwd, cmd)
         results = run_command(
             cmd,
             protocol,

--- a/datalad/cmd_protocols.py
+++ b/datalad/cmd_protocols.py
@@ -1,0 +1,177 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+Protocols used by WitlessRunner
+"""
+
+import asyncio
+import logging
+import warnings
+from locale import getpreferredencoding
+
+from .support.exceptions import CommandError
+from .utils import ensure_unicode
+
+
+lgr = logging.getLogger('datalad.cmd')
+
+
+class WitlessProtocol(asyncio.SubprocessProtocol):
+    """Subprocess communication protocol base class for `run_async_cmd`
+
+    This class implements basic subprocess output handling. Derived classes
+    like `StdOutCapture` should be used for subprocess communication that need
+    to capture and return output. In particular, the `pipe_data_received()`
+    method can be overwritten to implement "online" processing of process
+    output.
+
+    This class defines a default return value setup that causes
+    `run_async_cmd()` to return a 2-tuple with the subprocess's exit code
+    and a list with bytestrings of all captured output streams.
+    """
+
+    proc_out = None
+    proc_err = None
+
+    def __init__(self, done_future=None, encoding=None):
+        """
+        Parameters
+        ----------
+        done_future: Any
+          Ignored parameter, kept for backward compatibility (DEPRECATED)
+        encoding : str
+          Encoding to be used for process output bytes decoding. By default,
+          the preferred system encoding is guessed.
+        """
+
+        if done_future is not None:
+            warnings.warn("`done_future` argument is ignored "
+                          "and will be removed in a future release",
+                          DeprecationWarning)
+
+        self.fd_infos = {}
+
+        self.process = None
+        self.stdout_fileno = 1
+        self.stderr_fileno = 2
+
+        # capture output in bytearrays while the process is running
+        self.fd_infos[self.stdout_fileno] = ("stdout", bytearray()) if self.proc_out else ("stdout", None)
+        self.fd_infos[self.stderr_fileno] = ("stderr", bytearray()) if self.proc_err else ("stderr", None)
+
+        super().__init__()
+        self.encoding = encoding or getpreferredencoding(do_setlocale=False)
+
+        self._log_outputs = False
+        if lgr.isEnabledFor(5):
+            try:
+                from . import cfg
+                self._log_outputs = cfg.getbool('datalad.log', 'outputs', default=False)
+            except ImportError:
+                pass
+            self._log = self._log_summary
+        else:
+            self._log = self._log_nolog
+
+    def _log_nolog(self, *args):
+        pass
+
+    def _log_summary(self, fd, data):
+        fd_name = self.fd_infos[fd]
+        lgr.log(5, 'Read %i bytes from %i[%s]%s',
+                len(data), self.process.pid, fd_name, ':' if self._log_outputs else '')
+        if self._log_outputs:
+            log_data = ensure_unicode(data)
+            # The way we log is to stay consistent with Runner.
+            # TODO: later we might just log in a single entry, without
+            # fd_name prefix
+            lgr.log(5, "%s| %s ", fd_name, log_data)
+
+    def connection_made(self, process):
+        self.process = process
+        lgr.debug('Process %i started', self.process.pid)
+
+    def pipe_data_received(self, fd, data):
+        self._log(fd, data)
+        # store received output if stream was to be captured
+        fd_name, buffer = self.fd_infos[fd]
+        if buffer is not None:
+            buffer.extend(data)
+
+    def _prepare_result(self):
+        """Prepares the final result to be returned to the runner
+
+        Note for derived classes overwriting this method:
+
+        The result must be a dict with keys that do not unintentionally
+        conflict with the API of CommandError, as the result dict is passed to
+        this exception class as kwargs on error. The Runner will overwrite
+        'cmd' and 'cwd' on error, if they are present in the result.
+        """
+        return_code = self.process.poll()
+        if return_code is None:
+            raise CommandError(
+                "Got None as a return_code for the process %i",
+                self.process.pid)
+        lgr.debug(
+            'Process %i exited with return code %i',
+            self.process.pid, return_code)
+        # give captured process output back to the runner as string(s)
+        results = {
+            name: (
+                bytes(byt).decode(self.encoding)
+                if byt is not None
+                else '')
+            for name, byt in self.fd_infos.values()
+        }
+        results['code'] = return_code
+        return results
+
+    def process_exited(self):
+        pass
+
+
+class NoCapture(WitlessProtocol):
+    """WitlessProtocol that captures no subprocess output
+
+    As this is identical with the behavior of the WitlessProtocol base class,
+    this class is merely a more readable convenience alias.
+    """
+    pass
+
+
+class StdOutCapture(WitlessProtocol):
+    """WitlessProtocol that only captures and returns stdout of a subprocess"""
+    proc_out = True
+
+
+class StdErrCapture(WitlessProtocol):
+    """WitlessProtocol that only captures and returns stderr of a subprocess"""
+    proc_err = True
+
+
+class StdOutErrCapture(WitlessProtocol):
+    """WitlessProtocol that captures and returns stdout/stderr of a subprocess
+    """
+    proc_out = True
+    proc_err = True
+
+
+class KillOutput(WitlessProtocol):
+    """WitlessProtocol that swallows stdout/stderr of a subprocess
+    """
+    proc_out = True
+    proc_err = True
+
+    def pipe_data_received(self, fd, data):
+        if lgr.isEnabledFor(5):
+            lgr.log(
+                5,
+                'Discarded %i bytes from %i[%s]',
+                len(data), self.process.pid, self.fd_infos[fd][0])

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -629,7 +629,7 @@ def test_cfg_originorigin(path):
     with chpwd(path), swallow_logs(new_level=logging.DEBUG) as cml:
         clone_lev3 = clone('clone_lev2', 'clone_lev3')
         # we called git-annex-init; see gh-4367:
-        cml.assert_logged(msg=r"[^[]*Async run:\n cwd=.*\n"
+        cml.assert_logged(msg=r"[^[]*run:\n cwd=.*\n"
                               r" cmd=\[('git',.*'annex'|'git-annex'), 'init'",
                           match=False,
                           level='DEBUG')

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -53,7 +53,7 @@ class ReaderThread(threading.Thread):
             try:
                 data = os.read(self.file.fileno(), 1024)
             except BrokenPipeError as exc:
-                logger.debug(f"{self} exiting (broken pipe)")
+                logger.debug("%s exiting (broken pipe)", self)
                 self.queue.put((self.file.fileno(), exc, time.time()))
                 return
 

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -48,7 +48,7 @@ class ReaderThread(threading.Thread):
         self.file.close()
 
     def run(self):
-        logger.debug(f"ReaderThread({self.file}, {self.queue}) started")
+        logger.debug("ReaderThread(%s, %s) started", self.file, self.queue)
         while not self.quit:
             try:
                 data = os.read(self.file.fileno(), 1024)

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -62,7 +62,6 @@ class ReaderThread(threading.Thread):
                 self.queue.put((self.file.fileno(), None, time.time()))
                 return
 
-            logger.debug(f"{self} got data: {data}")
             self.queue.put((self.file.fileno(), data, time.time()))
 
 

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -58,7 +58,7 @@ class ReaderThread(threading.Thread):
                 return
 
             if data == b"":
-                logger.debug(f"{self} exiting (stream end)")
+                logger.debug("%s exiting (stream end)", self)
                 self.queue.put((self.file.fileno(), None, time.time()))
                 return
 

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -18,7 +18,8 @@ import threading
 import time
 from typing import Any, Dict, IO, List, Type, Union, Optional
 
-from .cmd import WitlessProtocol
+from .cmd_protocols import WitlessProtocol
+
 
 logger = logging.getLogger("datalad.runner")
 
@@ -82,7 +83,7 @@ class _ReaderThread(threading.Thread):
 
 
 def run_command(cmd: Union[str, List],
-                protocol_class: Type[WitlessProtocol],
+                protocol: Type[WitlessProtocol],
                 stdin: Any,
                 protocol_kwargs: Optional[Dict] = None,
                 **kwargs) -> Any:
@@ -100,7 +101,7 @@ def run_command(cmd: Union[str, List],
     cmd : list or str
       Command to be executed, passed to `subprocess.Popen`. If cmd
       is a str, `subprocess.Popen will be called with `shell=True`.
-    protocol_class : WitlessProtocol
+    protocol : WitlessProtocol class or subclass
       Protocol class to be instantiated for managing communication
       with the subprocess.
     stdin : file-like, subprocess.PIPE or None
@@ -121,8 +122,8 @@ def run_command(cmd: Union[str, List],
 
     protocol_kwargs = {} if protocol_kwargs is None else protocol_kwargs
 
-    catch_stdout = protocol_class.proc_out is not None
-    catch_stderr = protocol_class.proc_err is not None
+    catch_stdout = protocol.proc_out is not None
+    catch_stderr = protocol.proc_err is not None
 
     kwargs = {
         **kwargs,
@@ -135,7 +136,7 @@ def run_command(cmd: Union[str, List],
         )
     }
 
-    protocol = protocol_class(**protocol_kwargs)
+    protocol = protocol(**protocol_kwargs)
 
     process = subprocess.Popen(cmd, **kwargs)
     process_stdout_fileno = process.stdout.fileno() if catch_stdout else None

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -17,7 +17,7 @@ import queue
 import subprocess
 import threading
 import time
-from typing import Any
+from typing import Any, IO, List, Union
 
 
 logger = logging.getLogger("datalad.runner")
@@ -27,10 +27,14 @@ STDERR_FILENO = 2
 
 
 class ReaderThread(threading.Thread):
-    def __init__(self, file, a_queue, command):
+    def __init__(self,
+                 file: IO,
+                 queue_: queue.Queue,
+                 command: Union[str, List]):
+
         super().__init__(daemon=True)
         self.file = file
-        self.queue = a_queue
+        self.queue = queue_
         self.command = command
         self.quit = False
 
@@ -78,7 +82,7 @@ def run_command(cmd,
     cmd : list or str
       Command to be executed, passed to `subprocess.Popen`. If cmd
       is a str, `subprocess.Popen will be called with `shell=True`.
-    protocol : WitlessProtocol
+    protocol_class : WitlessProtocol
       Protocol class to be instantiated for managing communication
       with the subprocess.
     stdin : file-like, subprocess.PIPE or None

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -1,0 +1,138 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+Wrapper for command and function calls, allowing for dry runs and output handling
+
+"""
+
+import logging
+import os
+import queue
+import subprocess
+import threading
+import time
+from typing import Any
+
+
+logger = logging.getLogger("datalad.runner")
+
+STDOUT_FILENO = 1
+STDERR_FILENO = 2
+
+
+class ReaderThread(threading.Thread):
+    def __init__(self, file, q):
+        super().__init__(daemon=True)
+        self.file = file
+        self.queue = q
+        self.quit = False
+
+    def __str__(self):
+        return f"ReaderThread({self.file}, {self.queue})"
+
+    def request_exit(self):
+        """
+        Request the thread to exit. This is not guaranteed to
+        have any effect, because the thread might be waiting in
+        os.read() or queue.put(). We are closing the file that read
+        is reading from here, but the queue has to be emptied in
+        another thread in order to ensure thread-exiting.
+        """
+        self.quit = True
+        self.file.close()
+
+    def run(self):
+        logger.debug(f"ReaderThread({self.file}, {self.queue}) started")
+        while not self.quit:
+            try:
+                data = os.read(self.file.fileno(), 1024)
+            except BrokenPipeError as exc:
+                logger.debug(f"{self} exiting (broken pipe)")
+                self.queue.put((self.file.fileno(), exc, time.time()))
+                return
+
+            if data == b"":
+                logger.debug(f"{self} exiting (stream end)")
+                self.queue.put((self.file.fileno(), None, time.time()))
+                return
+
+            logger.debug(f"{self} got data: {data}")
+            self.queue.put((self.file.fileno(), data, time.time()))
+
+
+def run_command(cmd,
+                protocol_class,
+                stdin,
+                protocol_kwargs=None,
+                **kwargs) -> Any:
+
+    catch_stdout = protocol_class.proc_out is not None
+    catch_stderr = protocol_class.proc_err is not None
+
+    kwargs = {
+        **kwargs,
+        **dict(
+            bufsize=0,
+            stdin=stdin,
+            stdout=subprocess.PIPE if catch_stdout else None,
+            stderr=subprocess.PIPE if catch_stderr else None,
+            shell=True if isinstance(cmd, str) else False
+        )
+    }
+
+    process = subprocess.Popen(cmd, **kwargs)
+    process_stdout_fileno = process.stdout.fileno() if catch_stdout else None
+    process_stderr_fileno = process.stderr.fileno() if catch_stderr else None
+    protocol = protocol_class(**protocol_kwargs)
+
+    # We pass process as transport-argument. It does not have the same
+    # semantics as the asyncio-signature, but since it is only used in
+    # WitlessProtocol, we can change it there.
+    protocol.connection_made(process)
+
+    # Map the pipe file numbers to stdout and stderr file number, because
+    # the latter are hardcoded in the protocol code
+    # TODO: the fixed file numbers seem to be a side-effect of using
+    #  SubprocessProtocol. Some datalad-code relies on this. Shall
+    #  we replace hard coded stdout, stderr-file numbers with parameters?
+
+    fileno_mapping = {
+        process_stdout_fileno: STDOUT_FILENO,
+        process_stderr_fileno: STDERR_FILENO
+    }
+
+    if catch_stdout or catch_stderr:
+
+        output_queue = queue.Queue()
+        active_file_numbers = set()
+        if catch_stderr:
+            stderr_reader_thread = ReaderThread(process.stderr, output_queue)
+            stderr_reader_thread.start()
+            active_file_numbers.add(process.stderr.fileno())
+        if catch_stdout:
+            stdout_reader_thread = ReaderThread(process.stdout, output_queue)
+            stdout_reader_thread.start()
+            active_file_numbers.add(process.stdout.fileno())
+
+        while True:
+            file_number, data, time_stamp = output_queue.get()
+            if isinstance(data, bytes):
+                protocol.pipe_data_received(fileno_mapping[file_number], data)
+            else:
+                protocol.pipe_connection_lost(fileno_mapping[file_number], data)
+                active_file_numbers.remove(file_number)
+                if not active_file_numbers:
+                    break
+
+    process.wait()
+    result = protocol._prepare_result()
+    protocol.process_exited()
+    protocol.connection_lost(None)  # TODO: check exception
+
+    return result

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -89,7 +89,7 @@ def run_command(cmd,
        Passed to the Protocol class constructor.
     kwargs : Pass to `subprocess.Popen`, will typically be parameters
        supported by `subprocess.Popen`. Note that `bufsize`, `stdin`,
-       `stdout`, `stderr`, and `shell` will be overwriten by
+       `stdout`, `stderr`, and `shell` will be overwritten by
        `run_command`.
 
     Returns

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3408,7 +3408,11 @@ class AnnexJsonProtocol(WitlessProtocol):
     proc_out = True
     proc_err = True
 
-    def __init__(self, total_nbytes=None):
+    def __init__(self, done_future=None, total_nbytes=None):
+        if done_future is not None:
+            warnings.warn("`done_future` argument is ignored "
+                          "and will be removed in a future release",
+                          DeprecationWarning)
         super().__init__()
         # to collect parsed JSON command output
         self.json_out = []

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3408,10 +3408,10 @@ class AnnexJsonProtocol(WitlessProtocol):
     proc_out = True
     proc_err = True
 
-    def __init__(self, done_future, total_nbytes=None):
+    def __init__(self, total_nbytes=None):
+        super().__init__()
         # to collect parsed JSON command output
         self.json_out = []
-        super().__init__(done_future)
         self._global_pbar_id = 'annexprogress-{}'.format(id(self))
         self.total_nbytes = total_nbytes
         self._unprocessed = None

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import sys
+import unittest.mock
 
 from functools import partial
 from glob import glob
@@ -2554,3 +2555,13 @@ def test_whereis_batch_eqv(path):
     # --key= and --batch are incompatible.
     with assert_raises(ValueError):
         repo_b.whereis(files=files, batch=True, key=True)
+
+
+def test_done_deprecation():
+    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+        _ = AnnexJsonProtocol("done")
+        warn_mock.assert_called_once()
+
+    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+        _ = AnnexJsonProtocol()
+        warn_mock.assert_not_called()

--- a/datalad/tests/test_nonasyncrunner.py
+++ b/datalad/tests/test_nonasyncrunner.py
@@ -1,0 +1,125 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test the thread based runner (aka. non asyncio based runner).
+"""
+import logging
+import os
+import queue
+import subprocess
+import sys
+
+from datalad.tests.utils import assert_true, eq_
+
+from ..cmd import WitlessProtocol
+from ..nonasyncrunner import ReaderThread, run_command
+
+
+def test_subprocess_return_code_capture():
+
+    class KillProtocol(WitlessProtocol):
+
+        proc_out = True
+        proc_err = True
+
+        def __init__(self, signal_to_send: int, result_pool: dict):
+            super().__init__()
+            self.signal_to_send = signal_to_send
+            self.result_pool = result_pool
+
+        def connection_made(self, process):
+            super().connection_made(process)
+            process.send_signal(self.signal_to_send)
+
+        def connection_lost(self, exc):
+            self.result_pool["connection_lost_called"] = (True, exc)
+
+        def process_exited(self):
+            self.result_pool["process_exited_called"] = True
+
+    signal_to_send = 13
+    result_pool = dict()
+    result = run_command(["sleep", "10000"],
+                         KillProtocol,
+                         None,
+                         {
+                             "signal_to_send": signal_to_send,
+                             "result_pool": result_pool
+                         })
+    eq_(result["code"], -signal_to_send)
+    assert_true(result_pool["connection_lost_called"][0])
+    assert_true(result_pool["process_exited_called"])
+
+
+def test_interactive_communication():
+
+    class BidirectionalProtocol(WitlessProtocol):
+
+        proc_out = True
+        proc_err = True
+
+        def __init__(self, result_pool: dict):
+            super().__init__()
+            self.state = 0
+            self.result_pool = result_pool
+
+        def connection_made(self, process):
+            super().connection_made(process)
+            os.write(self.process.stdin.fileno(), b"1 + 1\n")
+
+        def connection_lost(self, exc):
+            self.result_pool["connection_lost_called"] = True
+
+        def process_exited(self):
+            self.result_pool["process_exited_called"] = True
+
+        def pipe_data_received(self, fd, data):
+            super().pipe_data_received(fd, data)
+            if self.state == 0:
+                self.state += 1
+                os.write(self.process.stdin.fileno(), b"2 ** 3\n")
+            if self.state == 1:
+                self.state += 1
+                os.write(self.process.stdin.fileno(), b"exit(0)\n")
+
+    result_pool = dict()
+    result = run_command(["python3", "-i"],
+                         BidirectionalProtocol,
+                         stdin=subprocess.PIPE,
+                         protocol_kwargs={
+                            "result_pool": result_pool
+                         })
+
+    eq_(result["stdout"], "2\n8\n")
+    assert_true(result_pool["connection_lost_called"], True)
+    assert_true(result_pool["process_exited_called"], True)
+
+
+def test_thread_exit():
+    logger = logging.getLogger("datalad.runner")
+    logger.setLevel(logging.DEBUG)
+
+    (read_descriptor, write_descriptor) = os.pipe()
+    read_file = os.fdopen(read_descriptor, "r")
+    read_queue = queue.Queue()
+
+    reader_thread = ReaderThread(read_file, read_queue, "test")
+    reader_thread.start()
+
+    os.write(write_descriptor, b"some data")
+    assert_true(reader_thread.is_alive())
+    data = read_queue.get()
+    eq_(data[1], b"some data")
+
+    reader_thread.request_exit()
+
+    os.write(write_descriptor, b"more data")
+    reader_thread.join()
+    data = read_queue.get()
+    eq_(data[1], b"more data")
+    assert_true(read_queue.empty())

--- a/datalad/tests/test_nonasyncrunner.py
+++ b/datalad/tests/test_nonasyncrunner.py
@@ -22,6 +22,7 @@ from ..cmd import WitlessProtocol, WitlessRunner, StdOutCapture
 from ..nonasyncrunner import ReaderThread, run_command
 
 
+@known_failure_windows
 def test_subprocess_return_code_capture():
 
     class KillProtocol(WitlessProtocol):
@@ -97,7 +98,8 @@ def test_interactive_communication():
                             "result_pool": result_pool
                          })
 
-    eq_(result["stdout"], "2\n8\n")
+    lines = [line.strip() for line in result["stdout"].splitlines()]
+    eq_(lines, ["2", "8"])
     assert_true(result_pool["connection_lost_called"], True)
     assert_true(result_pool["process_exited_called"], True)
 

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -248,3 +248,16 @@ def test_readline_rstripped_deprecation():
                 return "abc\n"
         readline_rstripped(StdoutMock())
         warn_mock.assert_called_once()
+
+
+def test_faulty_poll_detection():
+
+    class PopenMock:
+        pid = 666
+
+        def poll(self):
+            return None
+
+    protocol = WitlessProtocol()
+    protocol.process = PopenMock()
+    assert_raises(CommandError, protocol._prepare_result)

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -9,7 +9,6 @@
 """Test WitlessRunner
 """
 
-import logging
 import os
 import signal
 import sys
@@ -30,7 +29,6 @@ from datalad.tests.utils import (
     ok_,
     ok_file_has_content,
     SkipTest,
-    swallow_logs,
     with_tempfile,
 )
 from datalad.cmd import (

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -9,11 +9,12 @@
 """Test WitlessRunner
 """
 
+import logging
 import os
 import signal
 import sys
+import unittest.mock
 
-from pathlib import Path
 from time import (
     sleep,
     time,
@@ -29,12 +30,14 @@ from datalad.tests.utils import (
     ok_,
     ok_file_has_content,
     SkipTest,
+    swallow_logs,
     with_tempfile,
 )
 from datalad.cmd import (
-    StdOutErrCapture,
-    WitlessRunner as Runner,
     StdOutCapture,
+    StdOutErrCapture,
+    WitlessProtocol,
+    WitlessRunner as Runner,
 )
 from datalad.utils import (
     on_windows,
@@ -227,3 +230,13 @@ def test_asyncio_forked(temp):
     else:
        # sleep enough so parent just kills me the kid before I continue doing bad deeds
        sleep(10)
+
+
+def test_done_deprecation():
+    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+        _ = WitlessProtocol("done")
+        warn_mock.assert_called_once()
+
+    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+        _ = WitlessProtocol()
+        warn_mock.assert_not_called()

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -145,9 +145,9 @@ def test_runner_parametrized_protocol():
 
     # protocol returns a given value whatever it receives
     class ProtocolInt(StdOutCapture):
-        def __init__(self, done_future, value):
+        def __init__(self, value):
             self.value = value
-            super().__init__(done_future)
+            super().__init__()
 
         def pipe_data_received(self, fd, data):
             super().pipe_data_received(fd, self.value)

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -32,6 +32,7 @@ from datalad.tests.utils import (
     with_tempfile,
 )
 from datalad.cmd import (
+    readline_rstripped,
     StdOutCapture,
     StdOutErrCapture,
     WitlessProtocol,
@@ -238,3 +239,12 @@ def test_done_deprecation():
     with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
         _ = WitlessProtocol()
         warn_mock.assert_not_called()
+
+
+def test_readline_rstripped_deprecation():
+    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+        class StdoutMock:
+            def readline(self):
+                return "abc\n"
+        readline_rstripped(StdoutMock())
+        warn_mock.assert_called_once()


### PR DESCRIPTION
PR for an non asyncio-based runner.

This patch implements a thread-based runner, that uses the asyncio protocol interface to communicate
process output to protocol instances. 

This change was done to support running datalad commands from processes within a concurrent.futures.ProcessPoolExecutor. This did not work reliably if the datalad command invoked subprocesses, and if asyncio-based subprocess were used. In the asyncio-based implementation processes would randomly wait forever on some synchronization primitive.

Motivation: I am creating a *pipeline*/*orchestration* command for metalad that allows a user to specify an information source element, e.g. a dataset-traverser, and a number of processing elements, e.g. a metadata-extractor and a metadata-adder, which would be run on the output of the previous element. So the pipeline would look something like this:

   [dataset-traverser->metadata-extractor->metadata-adder]

And I would like to use concurrent.futures (or some other process-based parallelization) to distribute pipeline element processing to multiple cores.


This PR is marked as draft-pull request, since it changes a central piece of datalad, and since I did not yet test it on Windows or MacOS

Closes #5422, #5409, #5100

TODOs:
- [x] docstrings for added functions
- [x] add a `test_popen_invocation` from https://github.com/datalad/datalad/pull/5369/files#diff-4aa1a9688db72f7a475890e0ee6a343ea98af70ccc3bfa66f17da82c819dfa8dR230
- [x] add an explicit test to verify its operation within an asyncio event_loop (ref  #5100)