### PR TITLE
update: Honor --on-failure if fetch fails

### DIFF
--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -823,3 +823,34 @@ def test_update_unborn_master(path):
     assert_status("ok",
                   ds_b.update(merge=True, on_failure="ignore"))
     eq_(ds_a.repo.get_hexsha(), ds_b.repo.get_hexsha())
+
+
+@with_tempfile(mkdir=True)
+def test_update_fetch_failure(path):
+    path = Path(path)
+
+    ds_a = Dataset(path / "ds_a").create()
+    s1 = ds_a.create("s1")
+    ds_a.create("s2")
+
+    ds_b = install(source=ds_a.path, path=str(path / "ds-b"), recursive=True)
+
+    # Rename s1 to make fetch fail.
+    s1.pathobj.rename(s1.pathobj.parent / "s3")
+
+    res = ds_b.update(recursive=True, on_failure="ignore")
+    assert_in_results(
+        res,
+        status="error",
+        path=str(ds_b.pathobj / "s1"),
+        action="update")
+    assert_in_results(
+        res,
+        status="ok",
+        path=str(ds_b.pathobj / "s2"),
+        action="update")
+    assert_in_results(
+        res,
+        status="ok",
+        path=ds_b.path,
+        action="update")

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -221,10 +221,13 @@ class Update(Interface):
                 # test against user-provided value!
                 remote=None if sibling is None else sibling_,
                 all_=sibling is None,
-                # required to not trip over submodules that
-                # were removed in the origin clone
-                recurse_submodules="no",
-                prune=True)  # prune to not accumulate a mess over time
+                git_options=[
+                    # required to not trip over submodules that were removed in
+                    # the origin clone
+                    "--no-recurse-submodules",
+                    # prune to not accumulate a mess over time
+                    "--prune"]
+            )
             repo.fetch(**fetch_kwargs)
             # NOTE reevaluate ds.repo again, as it might have be converted from
             # a GitRepo to an AnnexRepo

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-from os.path import lexists, join as opj
+from os.path import lexists
 import itertools
 
 from datalad.dochelpers import exc_str

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -228,7 +228,13 @@ class Update(Interface):
                     # prune to not accumulate a mess over time
                     "--prune"]
             )
-            repo.fetch(**fetch_kwargs)
+            try:
+                repo.fetch(**fetch_kwargs)
+            except CommandError as exc:
+                yield dict(res, status="error",
+                           message=("Fetch failed: %s", exc_str(exc)))
+                continue
+
             # NOTE reevaluate ds.repo again, as it might have be converted from
             # a GitRepo to an AnnexRepo
             repo = ds.repo


### PR DESCRIPTION
Tweak `update`s `fetch` call to

  * avoid deprecated `kwargs`
  * translate a `CommandError` to a result record

Closes #3278.
Closes #4154.
