### PR TITLE
BF: test_addurls: Avoid modifying shared test data

### DIFF
--- a/datalad/plugin/tests/test_addurls.py
+++ b/datalad/plugin/tests/test_addurls.py
@@ -9,6 +9,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test addurls plugin"""
 
+from copy import deepcopy
 import json
 import logging
 import os
@@ -847,7 +848,7 @@ class TestAddurls(object):
         if OLD_EXAMINEKEY and ds.repo.is_managed_branch():
             raise SkipTest("Adjusted branch functionality requires "
                            "more recent `git annex examinekey`")
-        data = self.data.copy()
+        data = deepcopy(self.data)
         for row in data:
             if row["name"] == "b":
                 del row["md5sum"]


### PR DESCRIPTION
test_addurls_row_missing_key_fields() makes a shallow copy of the
`data` attribute (list of dictionaries) exposed to all TestAddurls
tests and then modifies one of the dictionaries to remove a key, which
of course modifies the row in TestAddurls.data.

Make a deep copy to avoid interfering with other tests.

---

As far as I know, this doesn't trigger any failures right now, but it will in an upcoming PR (against master).

