### PR TITLE
addurls: Improve reporting and handling of file name collisions

### DIFF
--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -692,7 +692,7 @@ def extract(rows, colidx_to_name=None,
 
     rows_with_url = []
     infos = []
-    for row in rows:
+    for idx, row in enumerate(rows):
         try:
             url = format_url(row)
         except KeyError as exc:
@@ -701,7 +701,7 @@ def extract(rows, colidx_to_name=None,
         if not url or url == missing_value:
             continue  # pragma: no cover, peephole optimization
         rows_with_url.append(row)
-        info = {"url": url}
+        info = {"url": url, "input_idx": idx}
         for fn in info_fns:
             fn(info, row)
         infos.append(info)

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -576,6 +576,28 @@ def add_extra_filename_values(filename_format, rows, urls, dry_run):
                          "Finished requesting file names")
 
 
+def _find_collisions(rows):
+    """Find file name collisions.
+
+    Parameters
+    ----------
+    rows : list of dict
+
+    Returns
+    -------
+    Dict where each key is a file name with a collision and values are the rows
+    (list of ints) that have the given file name.
+    """
+    fname_idxs = defaultdict(list)
+    collisions = set()
+    for idx, row in enumerate(rows):
+        fname = row["filename"]
+        if fname in fname_idxs:
+            collisions.add(fname)
+        fname_idxs[fname].append(idx)
+    return {fname: fname_idxs[fname] for fname in collisions}
+
+
 def _handle_collisions(rows):
     """Handle file name collisions in `rows`.
 
@@ -588,7 +610,8 @@ def _handle_collisions(rows):
     Error message (str) or None
     """
     err_msg = None
-    if len(rows) != len(set(row["filename"] for row in rows)):
+    collisions = _find_collisions(rows)
+    if collisions:
         err_msg = ("There are file name collisions; "
                    "consider using {_repindex}")
     return err_msg

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -25,7 +25,10 @@ from urllib.parse import urlparse
 from datalad.support.external_versions import external_versions
 import datalad.support.path as op
 from datalad.distribution.dataset import resolve_path
-from datalad.dochelpers import exc_str
+from datalad.dochelpers import (
+    exc_str,
+    single_or_plural,
+)
 from datalad.log import log_progress, with_result_progress
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
@@ -693,9 +696,11 @@ def _handle_collisions(records, rows, on_collision):
                         [records[i]
                          for i in remapped[next(iter(remapped))][:2]],
                         sort_keys=True, indent=2, default=str))
-            err_msg = ("There are file name collisions; "
+            err_msg = ("%s collided across rows; "
                        "troubleshoot by logging at debug level or "
-                       "consider using {_repindex}")
+                       "consider using {_repindex}",
+                       single_or_plural("file name", "file names",
+                                        len(to_report), include_count=True))
         else:
             _ignore_collisions(rows, collisions,
                                last_wins=on_collision == "take-last")

--- a/datalad/local/tests/test_addurls.py
+++ b/datalad/local/tests/test_addurls.py
@@ -614,7 +614,7 @@ class TestAddurls(object):
 
         with assert_raises(IncompleteResultsError) as raised:
             ds.addurls(self.json_file, "{url}", "{subdir}")
-        assert_in("There are file name collisions", str(raised.exception))
+        assert_in("collided", str(raised.exception))
 
         ds.addurls(self.json_file, "{url}", "{subdir}-{_repindex}")
 


### PR DESCRIPTION
As mentioned in gh-4840, `addurls` doesn't provide the caller any help in troubleshooting file name collisions.  This series improves the error message and debugging output.  It also implements an option like the one suggested in gh-4840 that allows the caller to either 1) ignore collisions if the end result is the same or 2) specify that the first/last row should be used.

Closes #4840.

---

The tests in this series require the fix from PR gh-5674, which is against maint.  That PR is merged into this one.

- [x] Drop temporary merge.
