### PR TITLE
RF: just pip install datalad-installer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,8 +79,9 @@ environment:
       # Python version specification is non-standard on windows
       PY: 39-x64
       # TODO: use datalad/git-annex (github release packages) but
-      # it would need setup of a GITHUB_TOKEN to access
-      INSTALL_GITANNEX: git-annex -m datalad/packages
+      # it would need setup of a GITHUB_TOKEN to access.
+      # This one is set in master but kept without change in maint for now
+      # INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
     - ID: MacP38core
       # ~25min

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -228,8 +228,6 @@ init:
   # Temporary keys for localhost access in default place
   - cmd: ssh-keygen -f C:\Users\appveyor\.ssh\id_rsa -N ""
   - sh: ssh-keygen -f ~/.ssh/id_rsa -N ""
-  # deploy the datalad installer
-  - appveyor DownloadFile https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py -FileName datalad_installer.py
 
 
 install:
@@ -250,10 +248,8 @@ install:
   - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
-  - cmd: IF DEFINED INSTALL_GITANNEX python datalad_installer.py --sudo ok %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && python datalad_installer.py --sudo ok ${INSTALL_GITANNEX}"
-  # TODO remove when datalad-installer can handle this
-  - cmd: tools\ci\appveyor_install_git-annex.bat
+  - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
+  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
 
 
 #before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,6 +78,8 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       # Python version specification is non-standard on windows
       PY: 39-x64
+      # TODO: use datalad/git-annex (github release packages) but
+      # it would need setup of a GITHUB_TOKEN to access
       INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
     - ID: MacP38core
@@ -252,7 +254,7 @@ install:
       )
   - sh: python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
   # Missing system software
-  - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
+  - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} ||  { sudo apt-get update -y && sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS}; } ) || true"
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
   - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,6 +78,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       # Python version specification is non-standard on windows
       PY: 39-x64
+      INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
     - ID: MacP38core
       # ~25min
@@ -106,7 +107,6 @@ environment:
       DTS: >
           datalad.downloaders
           datalad.interface
-          datalad.plugin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PY: 39-x64
     - ID: WinP39a3
@@ -135,7 +135,6 @@ environment:
       DTS: >
           datalad.downloaders
           datalad.interface
-          datalad.plugin
       APPVEYOR_BUILD_WORKER_IMAGE: macOS
       PY: 3.8
       INSTALL_GITANNEX: git-annex
@@ -244,9 +243,7 @@ install:
   # use of python/pip executables below
   - sh: "[ \"x$PY\" != x ] && . ${HOME}/venv${PY}/bin/activate || virtualenv -p 3 ${HOME}/dlvenv && . ${HOME}/dlvenv/bin/activate; ln -s \"$VIRTUAL_ENV\" \"${HOME}/VENV\""
   - cmd: "set PATH=C:\\Python%PY%;C:\\Python%PY%\\Scripts;%PATH%"
-  # Missing system software
-  - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
-  # Deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
+  # deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
   - cmd:
       IF DEFINED DATALAD_INSTALLER_VERSION (
       python -m pip install "datalad-installer%DATALAD_INSTALLER_VERSION%"
@@ -254,6 +251,14 @@ install:
       python -m pip install datalad-installer
       )
   - sh: python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
+  # Missing system software
+  - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
+  # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
+  # deploy git-annex, if desired
+  - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
+  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
+  # TODO remove when datalad-installer can handle this
+  - cmd: tools\ci\appveyor_install_git-annex.bat
 
 
 #before_build:
@@ -261,8 +266,8 @@ install:
 
 
 build_script:
-  - pip install ".[tests]"
-  - pip install ".[devel-utils]"
+  - python -m pip install ".[tests]"
+  - python -m pip install ".[devel-utils]"
 
 
 #after_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -246,10 +246,14 @@ install:
   - cmd: "set PATH=C:\\Python%PY%;C:\\Python%PY%\\Scripts;%PATH%"
   # Missing system software
   - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
-  # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
-  # deploy git-annex, if desired
-  - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
+  # Deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
+  - cmd:
+      IF DEFINED DATALAD_INSTALLER_VERSION (
+      python -m pip install "datalad-installer%DATALAD_INSTALLER_VERSION%"
+      ) ELSE (
+      python -m pip install datalad-installer
+      )
+  - sh: python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
 
 
 #before_build:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -24,8 +24,8 @@ jobs:
 
     - name: Install git-annex
       run: |
-        wget -O datalad_installer.py https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py
-        python3 datalad_installer.py --sudo ok -E new.env git-annex -m ${{ matrix.install_scenario }}
+        pip install datalad-installer
+        datalad-installer --sudo ok -E new.env git-annex -m ${{ matrix.install_scenario }}
         . new.env
         echo "PATH=$PATH" >> "$GITHUB_ENV"
 

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -22,6 +22,11 @@ jobs:
 
     - uses: actions/checkout@v1
 
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    
     - name: Install git-annex
       run: |
         pip install datalad-installer
@@ -29,10 +34,6 @@ jobs:
         . new.env
         echo "PATH=$PATH" >> "$GITHUB_ENV"
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.6
 
     - name: Install dependencies
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -230,8 +230,8 @@ before_install:
   - if [ ! -z "${_DL_UPSTREAM_GIT:-}" ]; then source tools/ci/install-upstream-git.sh; fi
   - if [ ! -z "${_DL_MIN_GIT:-}" ]; then tools/ci/install-minimum-git.sh; fi
   # Install git-annex
-  - wget -O datalad_installer.py https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py
-  - eval python3 datalad_installer.py --sudo ok -E new.env ${_DL_ANNEX_INSTALL_SCENARIO}
+  - pip install datalad-installer
+  - eval datalad-installer --sudo ok -E new.env ${_DL_ANNEX_INSTALL_SCENARIO}
   - source new.env && cat new.env >> ~/.bashrc
   - pip install --upgrade pip
 


### PR DESCRIPTION
master branch has its own ideas and binds to some older version
```
$> git grep datalad.installer
.appveyor.yml:  # deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
.appveyor.yml:      python -m pip install "datalad-installer%DATALAD_INSTALLER_VERSION%"
.appveyor.yml:      python -m pip install datalad-installer
.appveyor.yml:  - sh: python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}

```
needs yet to be addressed, decided to just go with maint for now and simplify (not versioned depends etc)