### PR TITLE
Support credential query via config manager

### DIFF
--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -31,6 +31,8 @@ from ..ui import ui
 from ..utils import auto_repr
 from ..support.network import iso8601_to_epoch
 
+from datalad import cfg as dlcfg
+
 from logging import getLogger
 lgr = getLogger('datalad.downloaders.credentials')
 
@@ -94,7 +96,10 @@ class Credential(object):
             return False
 
     def _get_field_value(self, field):
-        return self._keyring.get(self.name, field)
+        return dlcfg.get('datalad.credential.{name}.{field}'.format(
+            name=self.name,
+            field=field.replace('_', '-')
+        )) or self._keyring.get(self.name, field)
 
     def _ask_field_value(self, f, instructions=None):
         msg = instructions if instructions else \


### PR DESCRIPTION
Analysis and background in #5677

- [x] Switch to ConfigManager instead of direct `os.environ` query
- [x] Consult `ConfigManager` in `Credential` not `Keyring`
- [x] Support `datalad.credential.<name>.<field>` config settings (map field names via `_` -> `-`;, do not map `name` in any way, other than what `ConfigManager` does for all variables)
- [x] Extended test to query via new setup
- [x] Maintain compatibility with previous setup, but only as a fallback

Closes #5677