### PR TITLE
Make result suppression configurable

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -391,6 +391,20 @@ definitions = {
         'default': 'auto',
         'type': EnsureChoice('on', 'off', 'auto'),
     },
+    'datalad.ui.suppress-similar-results': {
+        'ui': ('question', {
+            'title': 'Suppress rendering of similar repetitive results',
+            'text': "If enabled, after a certain number of subsequent "
+                    "results that are identical regarding key properties, "
+                    "such as 'status', 'action', and 'type', additional "
+                    "similar results are not rendered by the common result "
+                    "renderer anymore. Instead, a count "
+                    "of suppressed results is displayed. If disabled, or "
+                    "when not running in an interactive terminal, all results "
+                    "are rendered."}),
+        'default': True,
+        'type': EnsureBool(),
+    },
     'datalad.save.no-message': {
         'ui': ('question', {
             'title': 'Commit message handling',

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -405,6 +405,16 @@ definitions = {
         'default': True,
         'type': EnsureBool(),
     },
+    'datalad.ui.suppress-similar-results-threshold': {
+        'ui': ('question', {
+            'title': 'Threshold for suppressing similar repetitive results',
+            'text': "Minimum number of similar results to occur before "
+                    "suppression is considered. "
+                    "See 'datalad.ui.suppress-similar-results' for more "
+                    "information."}),
+        'default': 10,
+        'type': EnsureInt(),
+    },
     'datalad.save.no-message': {
         'ui': ('question', {
             'title': 'Commit message handling',

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -558,7 +558,10 @@ def _process_results(
     # counter for detected repetitions
     result_repetitions = 0
     # how many repetitions to show, before suppression kicks in
-    render_n_repetitions = 10 if sys.stdout.isatty() else float("inf")
+    render_n_repetitions = 10 \
+        if sys.stdout.isatty() \
+        and dlcfg.obtain('datalad.ui.suppress-similar-results') \
+        else float("inf")
 
     for res in results:
         if not res or 'action' not in res:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -558,7 +558,8 @@ def _process_results(
     # counter for detected repetitions
     result_repetitions = 0
     # how many repetitions to show, before suppression kicks in
-    render_n_repetitions = 10 \
+    render_n_repetitions = \
+        dlcfg.obtain('datalad.ui.suppress-similar-results-threshold') \
         if sys.stdout.isatty() \
         and dlcfg.obtain('datalad.ui.suppress-similar-results') \
         else float("inf")

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -526,7 +526,7 @@ def _display_suppressed_message(nsimilar, ndisplayed, last_ts, final=False):
         # CPU load than the actual processing
         # arbitrarily go for a 2Hz update frequency -- it "feels" good
         if last_ts is None or final or (ts - last_ts > 0.5):
-            ui.message('  [{} similar {} been suppressed]'
+            ui.message('  [{} similar {} been suppressed; disable with datalad.ui.suppress-similar-results=off]'
                        .format(n_suppressed,
                                single_or_plural("message has",
                                                 "messages have",


### PR DESCRIPTION
```
% datalad x-configuration
...
# Suppress rendering of similar repetitive results
# If enabled, after a certain number of subsequent results that are
# identical regarding key properties, such as 'status', 'action', and
# 'type', additional similar results are not rendered by the common
# result renderer anymore. Instead, a count of suppressed results is
# displayed. If disabled, or when not running in an interactive
# terminal, all results are rendered.
datalad.ui.suppress-similar-results=True
# Threshold for suppressing similar repetitive results
# Minimum number of similar results to occur before suppression is
# considered. See 'datalad.ui.suppress-similar-results' for more
# information.
datalad.ui.suppress-similar-results-threshold=10
...
```

```
% datalad -c datalad.ui.suppress-similar-results=off subdatasets 
...
subdataset(ok): HCP1200/993675 (dataset)
subdataset(ok): HCP1200/994273 (dataset)
subdataset(ok): HCP1200/995174 (dataset)
subdataset(ok): HCP1200/996782 (dataset)
action summary:
  subdataset (ok: 1113)

% datalad -c datalad.ui.suppress-similar-results=on subdatasets
subdataset(ok): HCP1200/100206 (dataset)
subdataset(ok): HCP1200/100307 (dataset)
subdataset(ok): HCP1200/100408 (dataset)
subdataset(ok): HCP1200/100610 (dataset)
subdataset(ok): HCP1200/101006 (dataset)
subdataset(ok): HCP1200/101107 (dataset)
subdataset(ok): HCP1200/101309 (dataset)
subdataset(ok): HCP1200/101410 (dataset)
subdataset(ok): HCP1200/101915 (dataset)
subdataset(ok): HCP1200/102008 (dataset)
  [1103 similar messages have been suppressed; disable with datalad.ui.suppress-similar-results=off]
action summary:
  subdataset (ok: 1113)

```
This does not change the present behavior, but enables the modifications requested in https://github.com/datalad/datalad/issues/4417

Closes #4417