### PR TITLE
BF: left-over subprocess call didn't use env

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 import logging
 import subprocess
 
+from datalad.cmd import WitlessRunner as Runner
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit
@@ -679,8 +680,10 @@ def _create_sibling_ria(
         if post_update_hook:
             disabled_hook.rename(enabled_hook)
         if group:
-            # TODO; do we need a cwd here?
-            subprocess.run(chgrp_cmd, cwd=ds.path)
+            # No CWD needed here, since `chgrp` is expected to be found via PATH
+            # and the path it's operating on is absolute (repo_path). No
+            # repository operation involved.
+            Runner().run(chgrp_cmd)
         # finally update server
         if post_update_hook:
             # Conditional on post_update_hook, since one w/o the other doesn't


### PR DESCRIPTION
#5679 showed, that the last remaining call to `subprocess.run` in
`create-sibling-ria` would fail w/o using `shell=True`. The issue is, that
there's nothing to ensure we run from within a sane environment.
Switch to use `WitlessRunner` in order to get the environment to run from
the same way as in every other place.

(Closes #5679)


Note: I'm aware we don't really test everything related to users/groups here. With current approach on testing RIA-related stuff (or anything happening on remote ends really), it's quite complicated and effortful to meaningfully test such aspects. I plan to look into a different setup, probably using a docker as the remote end, next week and will then care for rewriting/adding tests accordingly. For now, this change should not be objectionable even w/o a test from my POV.
