### PR TITLE
interface: Don't repeat custom summary for non-generator results

### DIFF
--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -183,18 +183,12 @@ def test_status_custom_summary_no_repeats(path):
     # command for this test, but it's at least a necessary condition.
     ok_(hasattr(Status, "custom_result_summary_renderer"))
 
-    # Note: This test was added on a branch without a60bf7274a (BF: Don't be
-    # silent in default renderer when everything is clean, 2020-01-30), but
-    # once merged into a branch with that commit, the block below and --annex
-    # could be dropped.
-    ds = Dataset(path).create()
-    (ds.pathobj / "foo").write_text("foo content")
-    ds.save()
-
+    Dataset(path).create()
     out = WitlessRunner(cwd=path).run(
-        ["datalad", "--output-format=tailored", "status", "--annex"],
+        ["datalad", "--output-format=tailored", "status"],
         protocol=StdOutCapture)
     out_lines = out['stdout'].splitlines()
+    ok_(out_lines)
     eq_(len(out_lines), len(set(out_lines)))
 
 

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -18,6 +18,7 @@ from datalad.tests.utils import (
     eq_,
     ok_,
     patch_config,
+    swallow_outputs,
     with_tempfile,
 )
 from datalad.utils import (
@@ -183,13 +184,17 @@ def test_status_custom_summary_no_repeats(path):
     # command for this test, but it's at least a necessary condition.
     ok_(hasattr(Status, "custom_result_summary_renderer"))
 
-    Dataset(path).create()
+    ds = Dataset(path).create()
     out = WitlessRunner(cwd=path).run(
         ["datalad", "--output-format=tailored", "status"],
         protocol=StdOutCapture)
     out_lines = out['stdout'].splitlines()
     ok_(out_lines)
     eq_(len(out_lines), len(set(out_lines)))
+
+    with swallow_outputs() as cmo:
+        ds.status(return_type="list", result_renderer="tailored")
+        eq_(out_lines, cmo.out.splitlines())
 
 
 def test_update_docstring_with_parameters_no_kwds():

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -472,11 +472,6 @@ def eval_results(func):
                     # unwind generator if there is one, this actually runs
                     # any processing
                     results = list(results)
-                # render summaries
-                if not result_xfm and result_renderer in ('tailored', 'default'):
-                    # cannot render transformed results
-                    if hasattr(wrapped_class, 'custom_result_summary_renderer'):
-                        wrapped_class.custom_result_summary_renderer(results)
                 if return_type == 'item-or-list' and \
                         len(results) < 2:
                     return results[0] if results else None


### PR DESCRIPTION
This series fixes (another) case where custom summary output was repeated.  The last commit contains the details, while the first one is just cleanup in the area.

---

Demo of the issue:

```python
import tempfile
import datalad.api as dl

ds = dl.Dataset(tempfile.mkdtemp(prefix="dl-")).create()
ds.status()
```

```
[INFO   ] Creating a new annex repo at /tmp/dl-w3q0odkp 
[INFO   ] Scanning for unlocked files (this may take some time) 
nothing to save, working tree clean
nothing to save, working tree clean
```