### PR TITLE
add --on-failure default value and document it

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -104,6 +104,11 @@
             "affiliation": "Maze Therapeutics, South San Francisco, CA, United States",
             "name": "Nichols, B. Nolan",
             "orcid": "0000-0003-1099-3328"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Mönch, Christian",
+            "orcid": "0000-0002-3092-0612"
         }
     ],
     "grants": [

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -20,7 +20,7 @@ from tempfile import NamedTemporaryFile
 from textwrap import wrap
 
 from ..cmd import WitlessRunner as Runner
-from ..interface.common_opts import on_failure_default
+from ..interface.common_opts import eval_defaults
 from ..log import is_interactive
 from ..utils import (
     ensure_unicode,
@@ -164,6 +164,9 @@ def parser_add_common_options(parser, version):
         help="""configuration variable setting. Overrides any configuration
         read from a file, but is potentially overridden itself by configuration
         variables in the process environment.""")
+    # CLI analog of eval_params.result_renderer but with `<template>` handling
+    # and a different default: in Python API we have None as default and do not render
+    # the results but return them.  In CLI we default to "default" renderer
     parser.add_argument(
         '-f', '--output-format', dest='common_output_format',
         default='default',
@@ -181,7 +184,7 @@ def parser_add_common_options(parser, version):
         "format() language". It is possible to report individual
         dictionary values, e.g. '{metadata[name]}'. If a 2nd-level key contains
         a colon, e.g. 'music:Genre', ':' must be substituted by '#' in the template,
-        like so: '{metadata[music#Genre]}'. [Default: 'default']""")
+        like so: '{metadata[music#Genre]}'. [Default: '%(default)s']""")
     parser.add_argument(
         '--report-status', dest='common_report_status',
         choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],
@@ -194,16 +197,17 @@ def parser_add_common_options(parser, version):
         action='append',
         help="""constrain command result report to records matching the given
         type. Can be given more than once to match multiple types.""")
+    # CLI analog of eval_params.on_failure. TODO: dedup
     parser.add_argument(
         '--on-failure', dest='common_on_failure',
-        default=on_failure_default,
+        default=eval_defaults['on_failure'],
         choices=['ignore', 'continue', 'stop'],
-        help=f"""when an operation fails: 'ignore' and continue with remaining
+        help="""when an operation fails: 'ignore' and continue with remaining
         operations, the error is logged but does not lead to a non-zero exit code
         of the command; 'continue' works like 'ignore', but an error causes a
         non-zero exit code; 'stop' halts on first failure and yields non-zero exit
         code. A failure is any result with status 'impossible' or 'error'.
-        [Default: '{on_failure_default}']""")
+        [Default: '%(default)s']""")
     parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -20,6 +20,7 @@ from tempfile import NamedTemporaryFile
 from textwrap import wrap
 
 from ..cmd import WitlessRunner as Runner
+from ..interface.common_opts import on_failure_default
 from ..log import is_interactive
 from ..utils import (
     ensure_unicode,
@@ -180,7 +181,7 @@ def parser_add_common_options(parser, version):
         "format() language". It is possible to report individual
         dictionary values, e.g. '{metadata[name]}'. If a 2nd-level key contains
         a colon, e.g. 'music:Genre', ':' must be substituted by '#' in the template,
-        like so: '{metadata[music#Genre]}'.""")
+        like so: '{metadata[music#Genre]}'. [Default: 'default']""")
     parser.add_argument(
         '--report-status', dest='common_report_status',
         choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],
@@ -195,13 +196,14 @@ def parser_add_common_options(parser, version):
         type. Can be given more than once to match multiple types.""")
     parser.add_argument(
         '--on-failure', dest='common_on_failure',
+        default=on_failure_default,
         choices=['ignore', 'continue', 'stop'],
-        # no default: better be configure per-command
-        help="""when an operation fails: 'ignore' and continue with remaining
+        help=f"""when an operation fails: 'ignore' and continue with remaining
         operations, the error is logged but does not lead to a non-zero exit code
         of the command; 'continue' works like 'ignore', but an error causes a
         non-zero exit code; 'stop' halts on first failure and yields non-zero exit
-        code. A failure is any result with status 'impossible' or 'error'.""")
+        code. A failure is any result with status 'impossible' or 'error'.
+        [Default: '{on_failure_default}']""")
     parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -23,11 +23,6 @@ from datalad.support.constraints import (
     EnsureStrPrefix,
 )
 
-
-return_type_default = 'list'
-on_failure_default = 'continue'
-
-
 location_description = Parameter(
     args=("-D", "--description",),
     constraints=EnsureStr() | EnsureNone(),
@@ -241,6 +236,7 @@ annex_groupwanted_opt = Parameter(
     See https://git-annex.branchable.com/git-annex-groupwanted/ for more information""",
     constraints=EnsureStr() | EnsureNone())
 
+
 inherit_opt = Parameter(
     args=("--inherit",),
     action="store_true",
@@ -307,7 +303,7 @@ eval_params = dict(
         value is returned instead of a one-item return value list, or a
         list in case of multiple return values. `None` is return in case
         of an empty list.""",
-        default=return_type_default,
+        default='list',
         constraints=EnsureChoice('generator', 'list', 'item-or-list')),
     result_filter=Parameter(
         doc="""if given, each to-be-returned
@@ -329,7 +325,6 @@ eval_params = dict(
         constraints=EnsureChoice(*list(known_result_xfms.keys())) | EnsureCallable() | EnsureNone()),
     result_renderer=Parameter(
         doc="""format of return value rendering on stdout""",
-        default='default',
         constraints=EnsureChoice('default', 'json', 'json_pp', 'tailored') | EnsureNone()),
     on_failure=Parameter(
         doc="""behavior to perform on failure: 'ignore' any failure is reported,
@@ -340,14 +335,11 @@ eval_params = dict(
         'impossible' or 'error'. Raised exception is an IncompleteResultsError
         that carries the result dictionaries of the failures in its `failed`
         attribute.""",
-        default=on_failure_default,
+        default='continue',
         constraints=EnsureChoice('ignore', 'continue', 'stop')),
 )
 
-eval_defaults = dict(
-    return_type=return_type_default,
-    result_filter=None,
-    result_renderer=None,
-    result_xfm=None,
-    on_failure=on_failure_default,
-)
+eval_defaults = {
+    k: p.cmd_kwargs.get('default', None)
+    for k, p in eval_params.items()
+}

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -23,6 +23,11 @@ from datalad.support.constraints import (
     EnsureStrPrefix,
 )
 
+
+return_type_default = 'list'
+on_failure_default = 'continue'
+
+
 location_description = Parameter(
     args=("-D", "--description",),
     constraints=EnsureStr() | EnsureNone(),
@@ -236,7 +241,6 @@ annex_groupwanted_opt = Parameter(
     See https://git-annex.branchable.com/git-annex-groupwanted/ for more information""",
     constraints=EnsureStr() | EnsureNone())
 
-
 inherit_opt = Parameter(
     args=("--inherit",),
     action="store_true",
@@ -303,6 +307,7 @@ eval_params = dict(
         value is returned instead of a one-item return value list, or a
         list in case of multiple return values. `None` is return in case
         of an empty list.""",
+        default=return_type_default,
         constraints=EnsureChoice('generator', 'list', 'item-or-list')),
     result_filter=Parameter(
         doc="""if given, each to-be-returned
@@ -324,6 +329,7 @@ eval_params = dict(
         constraints=EnsureChoice(*list(known_result_xfms.keys())) | EnsureCallable() | EnsureNone()),
     result_renderer=Parameter(
         doc="""format of return value rendering on stdout""",
+        default='default',
         constraints=EnsureChoice('default', 'json', 'json_pp', 'tailored') | EnsureNone()),
     on_failure=Parameter(
         doc="""behavior to perform on failure: 'ignore' any failure is reported,
@@ -334,13 +340,14 @@ eval_params = dict(
         'impossible' or 'error'. Raised exception is an IncompleteResultsError
         that carries the result dictionaries of the failures in its `failed`
         attribute.""",
+        default=on_failure_default,
         constraints=EnsureChoice('ignore', 'continue', 'stop')),
 )
 
 eval_defaults = dict(
-    return_type='list',
+    return_type=return_type_default,
     result_filter=None,
     result_renderer=None,
     result_xfm=None,
-    on_failure='continue',
+    on_failure=on_failure_default,
 )


### PR DESCRIPTION
Set and document default value "continue" for common argument --on-failure, and "default" for common argument --output-format

There was a comment that misleadingly stated for --on-failure: "no default: better be configure per-command". If this was true, we could not set or document a general default-value for --on-failure. I did not find per-command configurations, therefore I added the default value to the doc-string and as keyword argument

Fixes #4334 
