### PR TITLE
Introduce datalad.log.exc and disable exception logging by default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,6 +51,8 @@ shallow_clone: true
 
 environment:
   DATALAD_TESTS_SSH: 1
+  # The following is currently necessary as we test a lot of logging output in high detail:
+  DATALAD_LOG_EXC: 1
 
   # Do not use `image` as a matrix dimension, to have fine-grained control over
   # what tests run on which platform

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -6,7 +6,9 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    env:
+      # The following is currently necessary as we test a lot of logging output in high detail:
+      DATALAD_LOG_EXC: 1
     steps:
     - name: Set up system
       shell: bash

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    env:
+      # The following is currently necessary as we test a lot of logging output in high detail:
+      DATALAD_LOG_EXC: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -6,6 +6,9 @@ jobs:
   test:
 
     runs-on: windows-2019
+    env:
+      # The following is currently necessary as we test a lot of logging output in high detail:
+      DATALAD_LOG_EXC: 1
 
     strategy:
       fail-fast: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
     - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20201007 -m conda"
+    # The following is currently necessary as we test a lot of logging output in high detail:
+    - DATALAD_LOG_EXC=1
 
 matrix:
   include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -569,8 +569,7 @@ Refer datalad/config.py for information on how to add these environment variable
 - *DATALAD_LOG_VMEM*:
   Reports memory utilization (resident/virtual) at every log line, needs `psutil` module
 - *DATALAD_EXC_STR_TBLIMIT*: 
-  This flag is used by the datalad extract_tb function which extracts and formats stack-traces.
-  It caps the number of lines to DATALAD_EXC_STR_TBLIMIT of pre-processed entries from traceback.
+  This flag is used by datalad to cap the number of traceback steps included in exception logging and result reporting to DATALAD_EXC_STR_TBLIMIT of pre-processed entries from traceback.
 - *DATALAD_SEED*:
   To seed Python's `random` RNG, which will also be used for generation of dataset UUIDs to make
   those random values reproducible.  You might want also to set all the relevant git config variables

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -320,7 +320,7 @@ class AnnexCustomRemote(object):
             try:
                 method(*req_load)
             except Exception as e:
-                self.error("Problem processing %r with parameters %r: %r"
+                self.error("Problem processing %r with parameters %r: %s"
                            % (req, req_load, exc_str(e)))
                 from traceback import format_exc
                 lgr.error("Caught exception detail: %s", format_exc())

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -18,7 +18,9 @@ import textwrap
 import os
 import sys
 import traceback
+from pathlib import Path
 
+from datalad.support.exceptions import CapturedException
 
 lgr = logging.getLogger("datalad.docutils")
 
@@ -314,7 +316,7 @@ def borrowkwargs(cls=None, methodname=None, exclude=None):
 
 
 # TODO: make limit respect config/environment parameter
-def exc_str(exc=None, limit=None, include_str=True):
+def exc_str_old(exc=None, limit=None, include_str=True):
     """Enhanced str for exceptions.  Should include original location
 
     Parameters
@@ -372,3 +374,10 @@ def exc_str(exc=None, limit=None, include_str=True):
         # https://docs.python.org/2/library/sys.html#sys.exc_info
         del tb
     return out
+
+
+def exc_str(exc=None, limit=None, include_str=True):
+    """Temporary test shim, for finding issues re refactoring for
+    using CapturedExcpetion instead."""
+
+    return str(CapturedException.capture_exc(exc))

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -378,6 +378,10 @@ def exc_str_old(exc=None, limit=None, include_str=True):
 
 def exc_str(exc=None, limit=None, include_str=True):
     """Temporary test shim, for finding issues re refactoring for
-    using CapturedExcpetion instead."""
+    using CapturedException instead.
 
-    return str(CapturedException.capture_exc(exc))
+    See gh-5716
+    """
+
+    return str(CapturedException(exc))
+

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -101,7 +101,7 @@ definitions = {
     },
     'datalad.exc.str.tblimit': {
         'ui': ('question', {
-               'title': 'This flag is used by the datalad extract_tb function which extracts and formats stack-traces. It caps the number of lines to DATALAD_EXC_STR_TBLIMIT of pre-processed entries from traceback.'}),
+               'title': 'This flag is used by datalad to cap the number of traceback steps included in exception logging and result reporting to DATALAD_EXC_STR_TBLIMIT of pre-processed entries from traceback.'}),
     },
     'datalad.fake-dates': {
         'ui': ('yesno', {

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -255,6 +255,12 @@ definitions = {
         'ui': ('question', {
                'title': 'Runs TraceBack function with collide set to True, if this flag is set to "collide". This replaces any common prefix between current traceback log and previous invocation with "..."'}),
     },
+    'datalad.log.exc': {
+        'ui': ('yesno', {
+               'title': 'Include exceptions and their traceback in log messages. If set, \'datalad.exc.str.tblimit\' applies.'}),
+        'default': False,
+        'type': EnsureBool(),
+    },
     'datalad.ssh.identityfile': {
         'ui': ('question', {
                'title': "If set, pass this file as ssh's -i option."}),

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -63,5 +63,18 @@ class Test(Interface):
             module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
         module = ensure_list(module)
         lgr.info('Starting test run for module(s): %s', module)
-        for mod in module:
-            datalad.test(module=mod, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)
+
+        # Exception (traceback) logging is disabled by default. However, as of
+        # now we do test logging output in (too) great detail. Therefore enable
+        # it here, so `datalad-test` doesn't fail by default.
+        # Can be removed whenever the tests don't require it.
+        from datalad import cfg as dlcfg
+        from datalad.tests.utils import patch
+        try:
+            with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
+                dlcfg.reload()
+                for mod in module:
+                    datalad.test(module=mod, verbose=verbose,
+                                 nocapture=nocapture, pdb=pdb, stop=stop)
+        finally:
+            dlcfg.reload()

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -10,8 +10,152 @@
 """
 
 import re
+import sys
+import traceback
 from os import linesep
+from pathlib import Path
 from pprint import pformat
+
+
+class CapturedException(object):
+    """This class represents information about an occurred exception (including
+    its traceback), while not holding any references to the actual exception
+    object or its traceback, frame references, etc.
+
+    Just keep the textual information for logging or whatever other kind of
+    reporting.
+    """
+
+    @classmethod
+    def capture_exc(cls, exc=None, limit=None, capture_locals=False):
+        """Capture an exception and its traceback for logging.
+
+        Clears the exception's traceback frame references afterwards.
+
+        Parameters
+        ----------
+        exc: Exception or None
+          If None, rely on sys.exc_info() to get the latest.
+        limit: int
+          Note, that this is limiting the capturing of the exception's
+          traceback depth. Formatting for output comes with it's own limit.
+        capture_locals: bool
+          Whether or not to capture the local context of traceback frames.
+
+        Returns
+        -------
+        CapturedException
+        """
+        # Note, that with lookup_lines=False the lookup is deferred,
+        # not disabled. Unclear to me ATM, whether that means to keep frame
+        # references around, but prob. not. TODO: Test that.
+
+        if exc is None:
+            exctype, value, tb = sys.exc_info()
+            tb_exc = traceback.TracebackException(
+                exctype, value, tb,
+                limit=limit,
+                lookup_lines=True,
+                capture_locals=capture_locals
+            )
+            traceback.clear_frames(tb)
+        else:
+            tb_exc = traceback.TracebackException.from_exception(
+                exc,
+                limit=limit,
+                lookup_lines=True,
+                capture_locals=capture_locals
+            )
+            traceback.clear_frames(exc.__traceback__)
+
+        return CapturedException(tb_exc)
+
+    def __init__(self, tb_exc):
+        """
+
+        Parameters
+        ----------
+        tb_exc: traceback.TracebackException
+        """
+
+        self.tb = tb_exc
+
+    def format_oneline_tb(self, limit=None, include_str=True):
+        """Format an exception traceback as a one-line summary
+
+        Returns a string of the form [filename:contextname:linenumber, ...].
+        If include_str is True (default), this is prepended with the string
+        representation of the exception.
+        """
+
+        # Note: No import at module level, since ConfigManager imports
+        # dochelpers -> circular import when creating datalad.cfg instance at
+        # startup.
+        from datalad import cfg
+
+        if include_str:
+            # try exc message
+            leading = str(self.tb)
+            if not leading:
+                # go with type
+                leading = self.tb.exc_type.__qualname__
+            out = "{} ".format(leading)
+        else:
+            out = ""
+
+        if limit is None:
+            # TODO: config logging.exceptions.traceback_levels = 1
+            #       ^ This is taken from exc_str(). What exactly does it mean?
+            #         Controlling the tblimit differently for logging, result
+            #         reporting, whatever else?
+            limit = int(cfg.obtain('datalad.exc.str.tblimit', default=1))
+
+        entries = []
+        entries.extend(self.tb.stack)
+        if self.tb.__cause__:
+            entries.extend(self.tb.__cause__.stack)
+        elif self.tb.__context__ and not self.tb.__suppress_context__:
+            entries.extend(self.tb.__context__.stack)
+
+        if entries:
+            tb_str = "[%s]" % (','.join(
+                "{}:{}:{}".format(
+                    Path(frame_summary.filename).name,
+                    frame_summary.name,
+                    frame_summary.lineno)
+                for frame_summary in entries[-limit:])
+            )
+            out += "{}".format(tb_str)
+
+        return out
+
+    def format_standard(self):
+        """Gives python's standard traceback output"""
+        # TODO: intended for introducing a decent debug mode later;
+        #       for now: a one-liner is free ;-)
+
+        return ''.join(self.tb.format())
+
+    def __str__(self):
+        """String representation
+
+        This is intended to be used via logging Formatters, which is why
+        its behavior is controlled by 'datalad.log.exc'. If that config is false
+        (default), an empty string is returned.
+        """
+        # Note: No import at module level, since ConfigManager imports
+        # dochelpers -> circular import when creating datalad.cfg instance at
+        # startup.
+        from datalad import cfg
+
+        if cfg.obtain('datalad.log.exc'):
+            return self.format_oneline_tb(limit=None, include_str=True)
+        else:
+            return ""
+
+    def __repr__(self):
+        return self.tb.exc_type.__qualname__ + '(' + str(self.tb) + ')'
+
 
 class CommandError(RuntimeError):
     """Thrown if a command call fails.

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -26,8 +26,7 @@ class CapturedException(object):
     reporting.
     """
 
-    @classmethod
-    def capture_exc(cls, exc=None, limit=None, capture_locals=False):
+    def __init__(self, exc=None, limit=None, capture_locals=False):
         """Capture an exception and its traceback for logging.
 
         Clears the exception's traceback frame references afterwards.
@@ -41,18 +40,13 @@ class CapturedException(object):
           traceback depth. Formatting for output comes with it's own limit.
         capture_locals: bool
           Whether or not to capture the local context of traceback frames.
-
-        Returns
-        -------
-        CapturedException
         """
         # Note, that with lookup_lines=False the lookup is deferred,
         # not disabled. Unclear to me ATM, whether that means to keep frame
         # references around, but prob. not. TODO: Test that.
-
         if exc is None:
             exctype, value, tb = sys.exc_info()
-            tb_exc = traceback.TracebackException(
+            self.tb = traceback.TracebackException(
                 exctype, value, tb,
                 limit=limit,
                 lookup_lines=True,
@@ -60,25 +54,13 @@ class CapturedException(object):
             )
             traceback.clear_frames(tb)
         else:
-            tb_exc = traceback.TracebackException.from_exception(
+            self.tb = traceback.TracebackException.from_exception(
                 exc,
                 limit=limit,
                 lookup_lines=True,
                 capture_locals=capture_locals
             )
             traceback.clear_frames(exc.__traceback__)
-
-        return CapturedException(tb_exc)
-
-    def __init__(self, tb_exc):
-        """
-
-        Parameters
-        ----------
-        tb_exc: traceback.TracebackException
-        """
-
-        self.tb = tb_exc
 
     def format_oneline_tb(self, limit=None, include_str=True):
         """Format an exception traceback as a one-line summary

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -11,7 +11,7 @@ def test_CapturedException():
     try:
         raise Exception("BOOM")
     except Exception as e:
-        captured_exc = CapturedException.capture_exc(e)
+        captured_exc = CapturedException(e)
 
     assert_re_in("BOOM \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
     assert_re_in("^\[.*\]", captured_exc.format_oneline_tb(include_str=False))  # only traceback
@@ -19,7 +19,7 @@ def test_CapturedException():
     try:
         raise NotImplementedError
     except Exception as e:
-        captured_exc = CapturedException.capture_exc(e)
+        captured_exc = CapturedException(e)
 
     assert_re_in("NotImplementedError \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
 
@@ -35,7 +35,7 @@ def test_CapturedException():
     try:
         f()
     except Exception as e:
-        captured_exc = CapturedException.capture_exc(e)
+        captured_exc = CapturedException(e)
 
     # default limit: one level:
     estr1 = captured_exc.format_oneline_tb(limit=1)

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -1,0 +1,89 @@
+import os
+from unittest.mock import patch
+from nose.tools import assert_equal, assert_true
+from datalad.support.exceptions import CapturedException
+from datalad.tests.utils import assert_re_in
+from datalad import cfg
+
+
+def test_CapturedException():
+
+    try:
+        raise Exception("BOOM")
+    except Exception as e:
+        captured_exc = CapturedException.capture_exc(e)
+
+    assert_re_in("BOOM \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
+    assert_re_in("^\[.*\]", captured_exc.format_oneline_tb(include_str=False))  # only traceback
+
+    try:
+        raise NotImplementedError
+    except Exception as e:
+        captured_exc = CapturedException.capture_exc(e)
+
+    assert_re_in("NotImplementedError \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
+
+    def f():
+        def f2():
+            raise Exception("my bad again")
+        try:
+            f2()
+        except Exception as e:
+            # exception chain
+            raise RuntimeError("new message") from e
+
+    try:
+        f()
+    except Exception as e:
+        captured_exc = CapturedException.capture_exc(e)
+
+    # default limit: one level:
+    estr1 = captured_exc.format_oneline_tb(limit=1)
+    estr2 = captured_exc.format_oneline_tb(limit=2)
+    # and we can control it via environ/config by default
+    try:
+        with patch.dict('os.environ', {'DATALAD_EXC_STR_TBLIMIT': '3'}):
+            cfg.reload()
+            estr3 = captured_exc.format_oneline_tb()
+        with patch.dict('os.environ', {}, clear=True):
+            cfg.reload()
+            estr_ = captured_exc.format_oneline_tb()
+    finally:
+        cfg.reload()  # make sure we don't have a side effect on other tests
+
+    estr_full = captured_exc.format_oneline_tb(10)
+
+    assert_re_in("new message \[test_captured_exception.py:test_CapturedException:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr_full)
+    assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr3)
+    assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr2)
+    assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]", estr1)
+    assert_equal(estr_, estr1)
+
+    # standard output
+    full_display = captured_exc.format_standard().splitlines()
+
+    assert_equal(full_display[0], "Traceback (most recent call last):")
+    # points in f and f2 for first exception with two lines each
+    # (where is the line and what reads the line):
+    assert_true(full_display[1].lstrip().startswith("File"))
+    assert_equal(full_display[2].strip(), "f2()")
+    assert_true(full_display[3].lstrip().startswith("File"))
+    assert_equal(full_display[4].strip(), "raise Exception(\"my bad again\")")
+    assert_equal(full_display[5].strip(), "Exception: my bad again")
+    assert_equal(full_display[7].strip(), "The above exception was the direct cause of the following exception:")
+    assert_equal(full_display[9], "Traceback (most recent call last):")
+    # ...
+    assert_equal(full_display[-1].strip(), "RuntimeError: new message")
+
+    # now logging / __str__:
+    try:
+        with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
+            cfg.reload()
+            assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]",
+                         str(captured_exc))
+
+        with patch.dict('os.environ', {'DATALAD_LOG_EXC': '0'}):
+            cfg.reload()
+            assert_equal("", str(captured_exc))
+    finally:
+        cfg.reload()  # make sure we don't have a side effect on other tests

--- a/datalad/tests/test_dochelpers.py
+++ b/datalad/tests/test_dochelpers.py
@@ -15,7 +15,7 @@ from ..dochelpers import (
     single_or_plural,
     borrowdoc,
     borrowkwargs,
-    exc_str,
+    exc_str_old,
 )
 
 from datalad.tests.utils import (
@@ -145,13 +145,13 @@ def test_borrow_kwargs():
     assert_true('boguse' in B.met_excludes.__doc__)
 
 
-def test_exc_str():
+def test_exc_str_old():
     try:
         raise Exception("my bad")
     except Exception as e:
-        estr = exc_str(e)
-        estr_tb_only = exc_str(e, include_str=False)
-    assert_re_in("my bad \[test_dochelpers.py:test_exc_str:...\]", estr)
+        estr = exc_str_old(e)
+        estr_tb_only = exc_str_old(e, include_str=False)
+    assert_re_in("my bad \[test_dochelpers.py:test_exc_str_old:...\]", estr)
     assert_re_in("^\[.*\]", estr_tb_only)  # only traceback
 
     def f():
@@ -162,15 +162,15 @@ def test_exc_str():
         f()
     except Exception as e:
         # default one:
-        estr2 = exc_str(e, 2)
-        estr1 = exc_str(e, 1)
+        estr2 = exc_str_old(e, 2)
+        estr1 = exc_str_old(e, 1)
         # and we can control it via environ by default
         with patch.dict('os.environ', {'DATALAD_EXC_STR_TBLIMIT': '3'}):
-            estr3 = exc_str(e)
+            estr3 = exc_str_old(e)
         with patch.dict('os.environ', {}, clear=True):
-            estr_ = exc_str()
+            estr_ = exc_str_old()
 
-    assert_re_in("my bad again \[test_dochelpers.py:test_exc_str:...,test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr3)
+    assert_re_in("my bad again \[test_dochelpers.py:test_exc_str_old:...,test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr3)
     assert_re_in("my bad again \[test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr2)
     assert_re_in("my bad again \[test_dochelpers.py:f2:...\]", estr1)
     assert_equal(estr_, estr1)
@@ -178,4 +178,4 @@ def test_exc_str():
     try:
         raise NotImplementedError
     except Exception as e:
-        assert_re_in("NotImplementedError\(\) \[test_dochelpers.py:test_exc_str:...\]", exc_str(e))
+        assert_re_in("NotImplementedError\(\) \[test_dochelpers.py:test_exc_str_old:...\]", exc_str_old(e))


### PR DESCRIPTION
This is originally motivated by wanting to close #4478. So, there's a config `datalad.log.exc` now, that controls whether exceptions are "rendered" in log messages (and it's off by default).

However, once at it, I took the occasion to somewhat address our exception handling in general. When we catch and report on an exception, we pretty much always would use `exc_str` (or now `CapturedException`), providing an opportunity to let that also do the clean up of stack frame references and thereby somewhat enforcing it. Hence, decided against the proposed approach in the issue to extend the to-be-logged exception and pass it on, but introduced a class that represents the textual information about it (and its traceback) without any stack references. Remember: circular references. Furthermore, since @yarikoptic introduced result reporting on exceptions as well (using `exc_str`, too), there's more to be done with that class - thinking of have a central place to enhance a result record with (possibly several) fields about an exception, so that a renderer can decide what parts to make use of. Also: we can have python's standard output of an exception traceback, too - might be useful for a better "debug mode". But all that should be a follow-up. Here I only address the logging directly and turn `exc_str` into a "dummy". Last remark: In the issue the idea was to have the config be handled by the log formatter. That makes sense, but isn't that straightforward really. There can be different formatters including stdlib ones, that still should be able to deal with an object passed to a log record. That's why it needs a `__str__` anyway. We also use the standard formatter class with `swallow_log` and all the log output testing. So, moving behavior control to `ColorFormatter` (or several formatters?) should be aimed for, I think, but that implies some more reworking of log testing (and we do that a lot with way too precise matches IMO).

Remaining question from my POV: If exception logging is disabled, should it really be an empty string? From a UX standpoint, I think even an exception name can be confusing (see example in original issue - no exc info needed whatsoever), but with most(?) our current messages there's probably a `:` or `()` remaining that way. I'd argue that we should rewrite those messages, so that they make sense either way. If they don't it's probably not yet a good message anyway. WDYT, @datalad/developers?

- Closes #4478