### PR TITLE
RF: get_content_annexinfo: Mark content availability just once

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3199,10 +3199,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                     # of None/NaN etc.
                     del rec['bytesize']
             info[path] = rec
-            # TODO make annex availability checks optional and move in here
-            if not eval_availability:
-                # not desired, or not annexed
-                continue
+        # TODO make annex availability checks optional and move in here
+        if eval_availability:
             self._mark_content_availability(info)
         return info
 


### PR DESCRIPTION
get_content_annexinfo() calls _mark_content_availability() for each
file received from `git annex find{,ref}`.  This is unnecessary work
because _mark_content_availability() operates on the entire dictionary
of paths.  Delay the call until after get_content_annexinfo() has
constructed the entire dictionary from the `git annex find{,ref}`
information.