### PR TITLE
get_content_{annex,}info: Restrict full report to paths=None

### DIFF
--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -307,12 +307,13 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
             for p, goinside in origpaths.items()
             if ds.pathobj in p.parents or (p == ds.pathobj and goinside)
         )
+    paths_arg = list(paths) if paths else None
     try:
         lgr.debug("Diff %s from '%s' to '%s'", ds, fr, to)
         diff_state = repo.diffstatus(
             fr,
             to,
-            paths=None if not paths else [p for p in paths],
+            paths=paths_arg,
             untracked=untracked,
             eval_file_type=eval_file_type,
             eval_submodule_state='full' if to is None else 'commit',
@@ -328,7 +329,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
     if annexinfo and hasattr(repo, 'get_content_annexinfo'):
         # this will amend `diff_state`
         repo.get_content_annexinfo(
-            paths=paths.keys() if paths is not None else paths,
+            paths=paths_arg,
             init=diff_state,
             eval_availability=annexinfo in ('availability', 'all'),
             ref=to)
@@ -336,7 +337,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
         # a get_content_annexinfo on that state doesn't get us anything new
         if fr and fr != to:
             repo.get_content_annexinfo(
-                paths=paths.keys() if paths is not None else paths,
+                paths=paths_arg,
                 init=diff_state,
                 eval_availability=annexinfo in ('availability', 'all'),
                 ref=fr,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3107,9 +3107,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         Parameters
         ----------
-        paths : list
-          Specific paths to query info for. In none are given, info is
-          reported for all content.
+        paths : list or None
+          Specific paths to query info for. In `None`, info is reported for all
+          content.
         init : 'git' or dict-like or None
           If set to 'git' annex content info will amend the output of
           GitRepo.get_content_info(), otherwise the dict-like object
@@ -3155,6 +3155,10 @@ class AnnexRepo(GitRepo, RepoInterface):
                 paths=paths, ref=ref, **kwargs)
         else:
             info = init
+
+        if not paths and paths is not None:
+            return info
+
         # use this funny-looking option with both find and findref
         # it takes care of git-annex reporting on any known key, regardless
         # of whether or not it actually (did) exist in the local annex

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2860,11 +2860,11 @@ class GitRepo(CoreGitRepo):
 
         Parameters
         ----------
-        paths : list(pathlib.PurePath)
+        paths : list(pathlib.PurePath) or None
           Specific paths, relative to the resolved repository root, to query
           info for. Paths must be normed to match the reporting done by Git,
           i.e. no parent dir components (ala "some/../this").
-          If none are given, info is reported for all content.
+          If `None`, info is reported for all content.
         ref : gitref or None
           If given, content information is retrieved for this Git reference
           (via ls-tree), otherwise content information is produced for the
@@ -2921,6 +2921,8 @@ class GitRepo(CoreGitRepo):
             # any incoming path has to be relative already, so we can simply
             # convert unconditionally
             paths = [ut.PurePosixPath(p) for p in paths]
+        elif paths is not None:
+            return info
 
         path_strs = list(map(str, paths)) if paths else None
         if path_strs and (not ref or external_versions["cmd:git"] >= "2.29.0"):

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -311,4 +311,4 @@ def test_get_content_info_paths_empty_list(path):
 @with_tempfile
 def test_status_paths_empty_list(path):
     ds = Dataset(path).create()
-    assert_false(ds.repo.status(paths=[]))
+    assert_equal(ds.repo.status(paths=[]), {})

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -280,3 +280,35 @@ def test_get_content_info_dotgit(path):
     # Files in .git/ won't be reported, though this takes a kludge on our side
     # before Git 2.25.
     assert_false(ds.repo.get_content_info(paths=[op.join(".git", "config")]))
+
+
+@with_tempfile
+def test_get_content_info_paths_empty_list(path):
+    ds = Dataset(path).create()
+
+    # Unlike None, passing any empty list as paths to get_content_info() does
+    # not report on all content.
+    assert_false(ds.repo.get_content_info(paths=[]))
+    assert_false(ds.repo.get_content_info(paths=[], ref="HEAD"))
+
+    # Add annex content to make sure its not reported.
+    (ds.pathobj / "foo").write_text("foo")
+    ds.save()
+
+    # Same for get_content_annexinfo()...
+    assert_false(ds.repo.get_content_annexinfo(paths=[]))
+    assert_false(ds.repo.get_content_annexinfo(paths=[], init=None))
+    assert_false(ds.repo.get_content_annexinfo(paths=[], ref="HEAD"))
+    assert_false(
+        ds.repo.get_content_annexinfo(paths=[], ref="HEAD", init=None))
+    # ... where whatever was passed for init will be returned as is.
+    assert_equal(
+        ds.repo.get_content_annexinfo(
+            paths=[], ref="HEAD", init={"random": {"entry": "a"}}),
+        {"random": {"entry": "a"}})
+
+
+@with_tempfile
+def test_status_paths_empty_list(path):
+    ds = Dataset(path).create()
+    assert_false(ds.repo.status(paths=[]))


### PR DESCRIPTION
This series makes

    get_content_info(paths=[], ...)

different from

    get_content_info(paths=None, ...)

That, in turn, makes `GitRepo.diff` and `GitRepo.status` match their documented behavior.

See gh-3292 and the second commit message for the details.
