### PR TITLE
run: Provide result record for command execution

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -176,6 +176,7 @@ class Run(Interface):
     ]
 
     result_renderer = "tailored"
+    on_failure = "stop"
 
     _params_ = dict(
         cmd=Parameter(

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -559,8 +559,6 @@ def _execute_command(command, pwd, expected_exit=None):
             command
         )
     except CommandError as e:
-        # strip our own info from the exception. The original command output
-        # went to stdout/err -- we just have to exitcode in the same way
         exc = e
         cmd_exitcode = e.code
 

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -100,15 +100,17 @@ def test_basics(path, nodspath):
     with chpwd(path), \
             swallow_outputs():
         # provoke command failure
-        with assert_raises(CommandError) as cme:
-            ds.run('7i3amhmuch9invalid')
+        res = ds.run('7i3amhmuch9invalid', on_failure="ignore",
+                     result_renderer=None)
+        assert_result_count(res, 1, action="run", status="error")
+        run_res = [r for r in res if r["action"] == "run"][0]
         # let's not speculate that the exit code is always 127
-        ok_(cme.exception.code > 0)
+        ok_(run_res["run_info"]["exit"] > 0)
         eq_(last_state, ds.repo.get_hexsha())
         # now one that must work
         res = ds.run('cd .> empty', message='TEST')
         assert_repo_status(ds.path)
-        assert_result_count(res, 2)
+        assert_result_count(res, 3)
         # TODO 'state' is still untracked!!!
         assert_result_count(res, 1, action='add',
                             path=op.join(ds.path, 'empty'), type='file')
@@ -176,8 +178,9 @@ def test_py2_unicode_command(path):
         assert_repo_status(ds.path)
         ok_exists(op.join(path, u" β1 "))
 
-    with assert_raises(CommandError), swallow_outputs():
-        ds.run(u"bβ2.dat")
+    assert_in_results(
+        ds.run(u"bβ2.dat", result_renderer=None, on_failure="ignore"),
+        status="error", action="run")
 
 
 @with_tempfile(mkdir=True)
@@ -296,8 +299,10 @@ def test_run_assume_ready(path):
     ds.drop("f1", check=False)
     if not adjusted:
         # If the input is not actually ready, the command will fail.
-        with assert_raises(CommandError):
-            ds.run(cat_cmd("f1"), inputs=["f1"], assume_ready="inputs")
+        assert_in_results(
+            ds.run(cat_cmd("f1"), inputs=["f1"], assume_ready="inputs",
+                   on_failure="ignore", result_renderer=None),
+            action="run", status="error")
 
     # --assume-ready=outputs
 
@@ -462,7 +467,7 @@ def test_run_cmdline_disambiguation(path):
                 main(["datalad", "run", "--", "--message"])
             exec_cmd.assert_called_once_with(
                 '"--message"' if on_windows else "--message",
-                path, expected_exit=None)
+                path)
 
         # Our parser used to mishandle --version (gh-3067),
         # treating 'datalad run CMD --version' as 'datalad --version'.
@@ -474,7 +479,7 @@ def test_run_cmdline_disambiguation(path):
                     main(["datalad", "run"] + sep + ["echo", "--version"])
                 exec_cmd.assert_called_once_with(
                     '"echo" "--version"' if on_windows else "echo --version",
-                    path, expected_exit=None)
+                    path)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -827,7 +827,7 @@ def get_allargs_as_kwargs(call, args, kwargs):
     """Generate a kwargs dict from a call signature and *args, **kwargs
 
     Basically resolving the argnames for all positional arguments, and
-    resolvin the defaults for all kwargs that are not given in a kwargs
+    resolving the defaults for all kwargs that are not given in a kwargs
     dict
     """
     from datalad.utils import getargspec

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -72,7 +72,10 @@ def test_invalid_call(path):
 def test_dirty(path):
     ds = Dataset(path).create(force=True)
     # must fail, because README.md is to be modified, but already dirty
-    assert_raises(CommandError, ds.run_procedure, 'cfg_yoda')
+    assert_in_results(
+        ds.run_procedure('cfg_yoda',
+                         on_failure="ignore", result_renderer=None),
+        action="run", status="error")
     # make sure that was the issue
     # save to git explicitly to keep the test simple and avoid unlocking...
     ds.save('README.md', to_git=True)
@@ -334,8 +337,10 @@ def test_quoting(path):
                   where="dataset")
     with swallow_outputs():
         ds.run_procedure(spec=["just2args", "with ' sing", 'with " doub'])
-        with assert_raises(CommandError):
-            ds.run_procedure(spec=["just2args", "still-one arg"])
+        assert_in_results(
+            ds.run_procedure(spec=["just2args", "still-one arg"],
+                             on_failure="ignore", result_renderer=None),
+            action="run", status="error")
 
         runner = WitlessRunner(cwd=ds.path)
         runner.run(

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -510,3 +510,27 @@ def test_incorrect_msg_interpolation():
 
     # there should be no exception if reported in the record path contains %
     TestUtils2().__call__("%eatthis")
+
+
+class CustomResultRenderer(Interface):
+    result_renderer = "tailored"
+    _params_ = dict(x=Parameter(args=("x",)))
+
+    @staticmethod
+    @eval_results
+    def __call__(x):
+        yield get_status_dict(action="foo", status="ok", message="message",
+                              x=x, logger=lgr)
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        # This custom result renderer gets the command's keyword arguments and
+        # all of the common ones too, even those not explicitly specified.
+        assert_in("x", kwargs)
+        assert_in("on_failure", kwargs)
+        assert_in("result_filter", kwargs)
+        assert_in("result_renderer", kwargs)
+
+
+def test_custom_result_renderer():
+    list(CustomResultRenderer().__call__("arg"))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -325,11 +325,6 @@ def eval_results(func):
     @wrapt.decorator
     def eval_func(wrapped, instance, args, kwargs):
         lgr.log(2, "Entered eval_func for %s", func)
-        # for result filters
-        # we need to produce a dict with argname/argvalue pairs for all args
-        # incl. defaults and args given as positionals
-        allkwargs = get_allargs_as_kwargs(wrapped, args, kwargs)
-
         # determine the command class associated with `wrapped`
         wrapped_class = get_wrapped_class(wrapped)
 
@@ -348,6 +343,12 @@ def eval_results(func):
                     # or the common default
                     eval_defaults[p_name]))
             for p_name in eval_params}
+
+        # for result filters
+        # we need to produce a dict with argname/argvalue pairs for all args
+        # incl. defaults and args given as positionals
+        allkwargs = get_allargs_as_kwargs(wrapped, args,
+                                          {**kwargs, **common_params})
 
         # short cuts and configured setup for common options
         return_type = common_params['return_type']


### PR DESCRIPTION
This draft series is an attempt to implement @mih's suggestion from <https://github.com/datalad/datalad/issues/3071#issuecomment-847844162>.

I'll post more on that issue.
