### PR TITLE
push: render action summary too

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -28,6 +28,7 @@ from datalad.interface.common_opts import (
 )
 from datalad.interface.utils import (
     eval_results,
+    render_action_summary,
 )
 from datalad.interface.results import annexjson2result
 from datalad.log import log_progress
@@ -273,8 +274,10 @@ class Push(Interface):
                 path=ds.path,
             )
 
+    custom_result_summary_renderer_pass_summary = True
+
     @staticmethod
-    def custom_result_summary_renderer(results):  # pragma: more cover
+    def custom_result_summary_renderer(results, action_summary):  # pragma: more cover
         # report on any hints at the end
         # get all unique hints
         hints = set([r.get('hints', None) for r in results])
@@ -289,6 +292,8 @@ class Push(Interface):
             [ui.message("{}: {}".format(
                 ansi_colors.color_word(id + 1, ansi_colors.YELLOW), hint))
                 for id, hint in enumerate(hints)]
+
+        render_action_summary(action_summary)
 
 
 def _datasets_since_(dataset, since, paths, recursive, recursion_limit):

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -988,3 +988,4 @@ def test_push_custom_summary(path):
     with swallow_outputs() as cmo:
         ds.push(to="sib", result_renderer="default", on_failure="ignore")
         assert_in("Potential hints to solve", cmo.out)
+        assert_in("action summary:", cmo.out)

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -50,6 +50,7 @@ from datalad.utils import (
     Path,
     chpwd,
     path_startswith,
+    swallow_outputs,
 )
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
@@ -966,3 +967,24 @@ def test_nested_pushclone_cycle_allplatforms(origpath, storepath, clonepath):
     assert_not_in_results(
         clone_super.status(recursive=True),
         state='modified')
+
+
+@with_tempfile
+def test_push_custom_summary(path):
+    path = Path(path)
+    ds = Dataset(path / "ds").create()
+
+    sib = mk_push_target(ds, "sib", str(path / "sib"), bare=False, annex=False)
+    (sib.pathobj / "f1").write_text("f1")
+    sib.save()
+
+    (ds.pathobj / "f2").write_text("f2")
+    ds.save()
+
+    # These options are true by default and our tests usually run with a
+    # temporary home, but set them to be sure.
+    ds.config.set("advice.pushUpdateRejected", "true", where="local")
+    ds.config.set("advice.pushFetchFirst", "true", where="local")
+    with swallow_outputs() as cmo:
+        ds.push(to="sib", result_renderer="default", on_failure="ignore")
+        assert_in("Potential hints to solve", cmo.out)

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_re_in,
     assert_repo_status,
+    assert_result_count,
     assert_true,
     ok_,
     slow,
@@ -510,3 +511,29 @@ def test_incorrect_msg_interpolation():
 
     # there should be no exception if reported in the record path contains %
     TestUtils2().__call__("%eatthis")
+
+
+class CustomSummary(Interface):
+    result_renderer = "tailored"
+    _params_ = dict(x=Parameter(args=("x",)))
+
+    @staticmethod
+    @eval_results
+    def __call__(x):
+        for action, status in [("test.one", "ok"),
+                               ("test.two", "ok"),
+                               ("test.two", "notneeded"),
+                               ("test.one", "ok")]:
+            yield get_status_dict(action=action, status=status,
+                                  message="message", x=x, logger=lgr)
+
+    @staticmethod
+    def custom_result_summary_renderer(arg):
+        assert_equal(len(arg), 4)
+        assert_result_count(arg, 2, action="test.one", status="ok")
+        assert_result_count(arg, 1, action="test.two", status="ok")
+        assert_result_count(arg, 1, action="test.two", status="notneeded")
+
+
+def test_custom_result_summary_renderer():
+    list(CustomSummary().__call__("arg"))

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -528,12 +528,23 @@ class CustomSummary(Interface):
                                   message="message", x=x, logger=lgr)
 
     @staticmethod
-    def custom_result_summary_renderer(arg):
-        assert_equal(len(arg), 4)
-        assert_result_count(arg, 2, action="test.one", status="ok")
-        assert_result_count(arg, 1, action="test.two", status="ok")
-        assert_result_count(arg, 1, action="test.two", status="notneeded")
+    def custom_result_summary_renderer(*args):
+        if getattr(CustomSummary, "custom_result_summary_renderer_pass_summary",
+                   False):
+            action_summary = args[1]
+            assert_equal(action_summary["test.one"], {"ok": 2})
+            assert_equal(action_summary["test.two"], {"ok": 1, "notneeded": 1})
+        results = args[0]
+        assert_equal(len(results), 4)
+        assert_result_count(results, 2, action="test.one", status="ok")
+        assert_result_count(results, 1, action="test.two", status="ok")
+        assert_result_count(results, 1, action="test.two", status="notneeded")
 
 
 def test_custom_result_summary_renderer():
     list(CustomSummary().__call__("arg"))
+    try:
+        CustomSummary.custom_result_summary_renderer_pass_summary = True
+        list(CustomSummary().__call__("arg"))
+    finally:
+        del CustomSummary.custom_result_summary_renderer_pass_summary

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -388,6 +388,9 @@ def eval_results(func):
             results = []
             do_custom_result_summary = result_renderer in ('tailored', 'default') \
                 and hasattr(wrapped_class, 'custom_result_summary_renderer')
+            pass_summary = do_custom_result_summary and \
+                getattr(wrapped_class,
+                        'custom_result_summary_renderer_pass_summary', None)
 
             # process main results
             for r in _process_results(
@@ -443,7 +446,11 @@ def eval_results(func):
             # result summary before a potential exception
             # custom first
             if do_custom_result_summary:
-                wrapped_class.custom_result_summary_renderer(results)
+                if pass_summary:
+                    summary_args = (results, action_summary)
+                else:
+                    summary_args = (results,)
+                wrapped_class.custom_result_summary_renderer(*summary_args)
             elif result_renderer == 'default' and action_summary and \
                     sum(sum(s.values()) for s in action_summary.values()) > 1:
                 # give a summary in default mode, when there was more than one

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -455,12 +455,7 @@ def eval_results(func):
                     sum(sum(s.values()) for s in action_summary.values()) > 1:
                 # give a summary in default mode, when there was more than one
                 # action performed
-                ui.message("action summary:\n  {}".format(
-                    '\n  '.join('{} ({})'.format(
-                        act,
-                        ', '.join('{}: {}'.format(status, action_summary[act][status])
-                                  for status in sorted(action_summary[act])))
-                                for act in sorted(action_summary))))
+                render_action_summary(action_summary)
 
             if incomplete_results:
                 raise IncompleteResultsError(
@@ -516,6 +511,16 @@ def default_result_renderer(res):
                 if isinstance(res['message'], tuple) else res[
                     'message'])
             if res.get('message', None) else ''))
+
+
+def render_action_summary(action_summary):
+    ui.message("action summary:\n  {}".format(
+        '\n  '.join('{} ({})'.format(
+            act,
+            ', '.join('{}: {}'.format(status, action_summary[act][status])
+                      for status in sorted(action_summary[act])))
+                    for act in sorted(action_summary))))
+
 
 
 def _display_suppressed_message(nsimilar, ndisplayed, last_ts, final=False):


### PR DESCRIPTION
gh-5660 mentions that it'd be good to see an action summary for `push` in addition to the custom summary.   The first three commits in gh-5689 _almost_ make that possible.  This draft series reworks those to show how it'd look for `push`.

---

<details>
<summary>script</summary>

```sh
set -eu

cd "$(mktemp -d "${TMPDIR:-/tmp}"/dl-XXXXXXX)"
datalad create a
(
    cd a
    datalad create-sibling -s b ../b
    echo one >one
    datalad save
    datalad push --to b
)
```

</details>

```
[...]
copy(ok): one (file) [to b...]                                                                                                                                                                                      
publish(ok): . (dataset) [refs/heads/git-annex->b:refs/heads/git-annex e1a64a0..aec5b08]                                                                                                                            
publish(ok): . (dataset) [refs/heads/master->b:refs/heads/master [new branch]]                                                                                                                                      
action summary:                                                                                                                                                                                                     
  copy (ok: 1)
  publish (ok: 2)
```

