### PR TITLE
Cleanups related to new minimum git-annex version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,14 +161,6 @@ matrix:
     # Test under NFS mount  (full, only in master)
     env:
     - _DL_TMPDIR="/tmp/nfsmount"
-#  - if: type = cron
-#    python: 3.6
-#    # test whether known v6 failures still fail
-#    env:
-#    - DATALAD_REPO_VERSION=6
-#    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-#    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-#    - DATALAD_TESTS_SSH=1
 
   allow_failures:
   # Test under NFS mount  (full, only in master)
@@ -176,13 +168,6 @@ matrix:
     python: 3.6
     env:
     - _DL_TMPDIR="/tmp/nfsmount"
-#  # test whether known v6 failures still fail
-#  - if: type = cron
-#    env:
-#    - DATALAD_REPO_VERSION=6
-#    - DATALAD_TESTS_KNOWNFAILURES_SKIP=no
-#    - DATALAD_TESTS_KNOWNFAILURES_PROBE=yes
-#    - DATALAD_TESTS_SSH=1
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -290,7 +290,7 @@ definitions = {
                'title': 'git-annex repository version',
                'text': 'Specifies the repository version for git-annex to be used by default'}),
         'type': EnsureInt(),
-        'default': 5,
+        'default': 8,
     },
     'datalad.metadata.maxfieldsize': {
         'ui': ('question', {

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -80,7 +80,6 @@ def test_dirty(path):
     assert_repo_status(ds.path)
 
 
-@skip_if(cond=on_windows and dl_cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys
@@ -212,7 +211,6 @@ def _check_procedure_properties(ps):
         len(ps))
 
 
-@skip_if(cond=on_windows and dl_cfg.obtain("datalad.repo.version") < 6)
 @with_tree(tree={
     'code': {'datalad_test_proc.py': """\
 import sys

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -126,6 +126,9 @@ class AnnexRepo(GitRepo, RepoInterface):
     # 6.20180913 -- annex fixes all known to us issues for v6
     # 7          -- annex makes v7 mode default on crippled systems. We demand it for consistent operation
     # 7.20190503 -- annex introduced mimeencoding support needed for our text2git
+    #
+    # When bumping this, check whether datalad.repo.version needs to be
+    # adjusted.
     GIT_ANNEX_MIN_VERSION = '8.20200309'
     git_annex_version = None
     supports_direct_mode = None

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -102,7 +102,6 @@ from .utils import (
     eq_,
     has_symlink_capability,
     known_failure,
-    known_failure_v6,
     nok_,
     OBSCURE_FILENAME,
     ok_,
@@ -984,32 +983,6 @@ def test_known_failure():
         failing()
     else:
         # not skipping and not probing results in the original failure:
-        assert_raises(AssertionError, failing)
-
-
-def test_known_failure_v6():
-
-    @known_failure_v6
-    def failing():
-        raise AssertionError("Failed")
-
-    v6 = dl_cfg.obtain("datalad.repo.version") == 6
-    skip = dl_cfg.obtain("datalad.tests.knownfailures.skip")
-    probe = dl_cfg.obtain("datalad.tests.knownfailures.probe")
-
-    if v6:
-        if skip:
-            # skipping takes precedence over probing
-            failing()
-        elif probe:
-            # if we probe a known failure it's okay to fail:
-            failing()
-        else:
-            # not skipping and not probing results in the original failure:
-            assert_raises(AssertionError, failing)
-
-    else:
-        # behaves as if it wasn't decorated at all, no matter what
         assert_raises(AssertionError, failing)
 
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -302,31 +302,6 @@ def skip_nomultiplex_ssh(func):
         return func(*args, **kwargs)
     return  _wrap_skip_nomultiplex_ssh
 
-
-@optional_args
-def skip_v6_or_later(func, method='raise'):
-    """Skip tests if v6 or later will be used as the default repo version.
-
-    The default repository version is controlled by the configured value of
-    DATALAD_REPO_VERSION and whether v5 repositories are supported by the
-    installed git-annex.
-    """
-
-    from datalad.support.annexrepo import AnnexRepo
-
-    version = dl_cfg.obtain("datalad.repo.version")
-    info = AnnexRepo.check_repository_versions()
-
-    @skip_if(version >= 6 or 5 not in info["supported"],
-             msg="Skip test in v6+ test run", method=method)
-    @wraps(func)
-    @attr('skip_v6_or_later')
-    @attr('v6_or_later')
-    def  _wrap_skip_v6_or_later(*args, **kwargs):
-        return func(*args, **kwargs)
-    return  _wrap_skip_v6_or_later
-
-
 #
 # Addition "checkers"
 #
@@ -824,39 +799,6 @@ def known_failure(func):
     def  _wrap_known_failure(*args, **kwargs):
         return func(*args, **kwargs)
     return  _wrap_known_failure
-
-
-def known_failure_v6_or_later(func):
-    """Test decorator marking a test as known to fail in a v6+ test run
-
-    If the default repository version is 6 or later behaves like `known_failure`.
-    Otherwise the original (undecorated) function is returned.
-    The default repository version is controlled by the configured value of
-    DATALAD_REPO_VERSION and whether v5 repositories are supported by the
-    installed git-annex.
-    """
-
-    from datalad.support.annexrepo import AnnexRepo
-
-    version = dl_cfg.obtain("datalad.repo.version")
-    info = AnnexRepo.check_repository_versions()
-
-    if (version and version >= 6) or 5 not in info["supported"]:
-
-        @known_failure
-        @wraps(func)
-        @attr('known_failure_v6_or_later')
-        @attr('v6_or_later')
-        def v6_func(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return v6_func
-
-    return func
-
-
-# TODO: Remove once the released version of datalad-crawler no longer uses it.
-known_failure_v6 = known_failure_v6_or_later
 
 
 def known_failure_direct_mode(func):


### PR DESCRIPTION
This series of cleanups follows up on 315911ca76 (MNT: annexrepo: Bump minimum git-annex version to 8.20200309, 2021-03-18).