### PR TITLE
annexrepo: Inform users about repo version auto-upgrades (try 2)

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -96,6 +96,10 @@ from .exceptions import (
 
 lgr = logging.getLogger('datalad.annex')
 
+# This is a map between an auto-upgradeable version and the version that it
+# upgrades to. It should track autoUpgradeableVersions in Annex.Version.
+_AUTO_UPGRADEABLE_VERSIONS = {v: 8 for v in range(3, 8)}
+
 
 class AnnexRepo(GitRepo, RepoInterface):
     """Representation of an git-annex repository.
@@ -1316,6 +1320,10 @@ class AnnexRepo(GitRepo, RepoInterface):
         if description is not None:
             opts += [description]
         if version is not None:
+            upgraded_version = _AUTO_UPGRADEABLE_VERSIONS.get(version)
+            if upgraded_version:
+                lgr.info("Annex repository version %s will be upgraded to %s",
+                         version, upgraded_version)
             opts += ['--version', '{0}'.format(version)]
 
         # TODO: RM DIRECT?  or RF at least ?

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -245,7 +245,19 @@ class AnnexRepo(GitRepo, RepoInterface):
             # '' cannot be converted to int (via Constraint as defined for
             # "datalad.repo.version" in common_cfg
             # => Allow conversion to result in None?
-            if not version:
+            if version:
+                try:
+                    version = int(version)
+                except ValueError:
+                    # Just give a warning if things look off and let
+                    # git-annex-init complain if it can't actually handle it.
+                    lgr.warning(
+                        "Expected an int for datalad.repo.version, got %s",
+                        version)
+            else:
+                # The above comment refers to an empty string case. The commit
+                # (f12eb03f40) seems to deal with direct mode, so perhaps this
+                # isn't reachable anymore.
                 version = None
 
         if do_init:

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1282,13 +1282,16 @@ def test_annex_remove(path):
 @with_tempfile
 @with_tempfile
 def test_repo_version(path1, path2, path3):
-    annex = AnnexRepo(path1, create=True, version=6)
-    assert_repo_status(path1, annex=True)
-    version = int(annex.config.get('annex.version'))
-    # Since git-annex 7.20181031, v6 repos upgrade to v7.
-    supported_versions = AnnexRepo.check_repository_versions()["supported"]
-    v6_lands_on = next(i for i in supported_versions if i >= 6)
-    eq_(version, v6_lands_on)
+    with swallow_logs(new_level=logging.INFO) as cm:
+        annex = AnnexRepo(path1, create=True, version=6)
+        assert_repo_status(path1, annex=True)
+        version = int(annex.config.get('annex.version'))
+        # Since git-annex 7.20181031, v6 repos upgrade to v7.
+        supported_versions = AnnexRepo.check_repository_versions()["supported"]
+        v6_lands_on = next(i for i in supported_versions if i >= 6)
+        eq_(version, v6_lands_on)
+
+        assert_in("will be upgraded to 8", cm.out)
 
     # default from config item (via env var):
     with patch.dict('os.environ', {'DATALAD_REPO_VERSION': '6'}):


### PR DESCRIPTION
This resurrects and updates gh-3027, which was reverted in gh-3044 due to a stalling test.