### PR TITLE
BF: account for annex now "scanning for annexed" instead of "unlocked" files

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3609,9 +3609,9 @@ class AnnexInitOutput(WitlessProtocol):
     def pipe_data_received(self, fd, byts):
         line = byts.decode(self.encoding)
         if fd == 1:
-            if "scanning for unlocked files" in line:
-                lgr.info("Scanning for unlocked files "
-                         "(this may take some time)")
+            res = re.search("(scanning for .* files)", line, flags=re.IGNORECASE)
+            if res:
+                lgr.info("%s (this may take some time)", res.groups()[0])
         elif fd == 2:
             lgr.info(line.strip())
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1309,7 +1309,8 @@ def test_init_scanning_message(path):
         # somewhere around 8.20210428-186-g428c91606 git annex changed
         # handling of scanning for unlocked files upon init and started to report
         # "scanning for annexed" instead of "scanning for unlocked".
-        assert_re_in(".*scanning for .* files", cml.out, flags=re.IGNORECASE)
+        # Could be a line among many (as on Windows) so match=False so we search
+        assert_re_in(".*scanning for .* files", cml.out, flags=re.IGNORECASE, match=False)
 
 
 @with_tempfile

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1306,7 +1306,11 @@ def test_init_scanning_message(path):
     # | end kludge
     with swallow_logs(new_level=logging.INFO) as cml:
         AnnexRepo(path, create=True, version=7)
-        assert_in("for unlocked", cml.out)
+        # somewhere around 8.20210428-186-g428c91606 git annex changed
+        # handling of scanning for unlocked files upon init . It was optimized etc
+        # and that message is no longer appears. yoh is not yet sure when it would
+        if external_versions['cmd:annex'] <= '8.20210428':
+            assert_in("for unlocked", cml.out)
 
 
 @with_tempfile

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1307,10 +1307,9 @@ def test_init_scanning_message(path):
     with swallow_logs(new_level=logging.INFO) as cml:
         AnnexRepo(path, create=True, version=7)
         # somewhere around 8.20210428-186-g428c91606 git annex changed
-        # handling of scanning for unlocked files upon init . It was optimized etc
-        # and that message is no longer appears. yoh is not yet sure when it would
-        if external_versions['cmd:annex'] <= '8.20210428':
-            assert_in("for unlocked", cml.out)
+        # handling of scanning for unlocked files upon init and started to report
+        # "scanning for annexed" instead of "scanning for unlocked".
+        assert_re_in(".*scanning for .* files", cml.out, flags=re.IGNORECASE)
 
 
 @with_tempfile


### PR DESCRIPTION
Closes #5702

Recently, somewhere around [8.20210428-186-g428c91606](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=428c91606b434512d1986622e751c795edf4df44)
git-annex changed its logic for doing initial scanning for
unlocked (and now locked?) files.  Now I do not observe that message
to be printed out and our tests started to fail in daily testing of
datalad/git-annex
https://github.com/datalad/git-annex/actions/runs/877176725 might be
the first one and version reported is 8.20210428+git228-g13a6bfff4
when previous green one was 8.20210428+git202-g9a5981a15

It seems that `annex init` might have got notably slower :-/ (attn
@joeyh), e.g.  our test tuned here here

    python -m nose -s -v datalad/support/tests/test_annexrepo.py:test_init_scanning_message

runs for 1.3s with 8.20210223-1~ndall+1 and then 3.238s with 8.20210429-g66355b99a
although a proper analysis should be done on closer builds.

The same goes for `datalad install ///openneuro/ds000001` which went
from 2.1sec (with a message about "Scanning for unlocked") to 6 sec
without any notification on "Scanning..."

So, overall, I feel that there is a need for a better timing comparison and possibly a report to @joeyh on substantial slow down :-/

Not sure if we should merge this workaround or see it resolved in git-annex somehow before its release (ATM it is still at 8.20210428-241-g66355b99a)