### PR TITLE
ENH(UX): state original purpose in NoDatasetFound exception + detail it for get

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -567,10 +567,14 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dspath = get_dataset_root(getpwd())
         if not dspath:
             raise NoDatasetFound(
-                "No dataset found at '{}'.  Specify a dataset to work with "
+                "No dataset found at '{}'{}.  Specify a dataset to work with "
                 "by providing its path via the `dataset` option, "
                 "or change the current working directory to be in a "
-                "dataset.".format(getpwd()))
+                "dataset.".format(
+                    getpwd(),
+                    " for the purpose {!r}".format(purpose) if purpose else ''
+                )
+            )
         dataset = Dataset(dspath)
 
     assert(dataset is not None)

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -68,6 +68,7 @@ from datalad.utils import (
     unique,
     Path,
     get_dataset_root,
+    shortened_repr,
 )
 
 from datalad.local.subdatasets import Subdatasets
@@ -846,7 +847,7 @@ class Get(Interface):
 
         # we have to have a single dataset to operate on
         refds = require_dataset(
-            dataset, check_installed=True, purpose='get content')
+            dataset, check_installed=True, purpose='get content of %s' % shortened_repr(path))
 
         content_by_ds = {}
         # use subdatasets() to discover any relevant content that is not


### PR DESCRIPTION
I have seen those reported by users, and I must confess that some of those stem from the confusing interface of `install` + RFing which lead `install`/`get` to unable to operate on arbitrary paths (#3759).  But I think that such error might come up in other use-cases as well.  So before this PR users might get:

```shell
$> datalad install git://github.com/dl-throwaway/test_gh3 dest                                   
[INFO   ] scanning for unlocked files (this may take some time)                                           
[INFO   ] Remote origin uses a protocol not supported by git-annex; setting annex-ignore                  
install(ok): /home/yoh/.tmp/test_gh3 (dataset)
[ERROR  ] No dataset found at '/home/yoh/.tmp'.  Specify a dataset to work with by providing its path via the `dataset` option, or change the current working directory to be in a dataset. [dataset.py:require_dataset:569] (NoDatasetFound) 
usage: datalad install [-h] [-s SOURCE] [-d DATASET] [-g] [-D DESCRIPTION] [-r] [-R LEVELS]
                       [--reckless [auto|ephemeral|shared-...]] [-J NJOBS]
                       [PATH ...]
```

which leaves them wondering on WTF (error message nohow points to `dest`) and needing to ask/RTFM etc to figure out that they needed `-s`.  With this change it would look like

```shell
$> datalad install git://github.com/dl-throwaway/test_gh3 dest
[ERROR  ] No dataset found at '/home/yoh/.tmp' for the purpose "get content of ['dest']".  Specify a dataset to work with by providing its path via the `dataset` option, or change the current working directory to be in a dataset. [dataset.py:require_dataset:569] (NoDatasetFound) 
usage: datalad install [-h] [-s SOURCE] [-d DATASET] [-g] [-D DESCRIPTION] [-r] [-R LEVELS]
                       [--reckless [auto|ephemeral|shared-...]] [-J NJOBS]
                       [PATH ...]
```
it is still not perfect but it immediately points to the underlying culprit. 