### PR TITLE
ENH+RF+BF:  github - sanitize top level reponame + make hierarchies datasets install/get-able from github

### DIFF
--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -946,7 +946,7 @@ def _create_test_install_recursive_github(path):  # pragma: no cover
 @with_tempfile(mkdir=True)
 def test_install_recursive_github(path):
     # test recursive installation of a hierarchy of datasets created on github
-    # using datalad create-sibling-github.  Following invocation was used to poplate it
+    # using datalad create-sibling-github.  Following invocation was used to populate it
     #
     # out = _create_test_install_recursive_github(path)
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -921,3 +921,41 @@ def test_relpath_semantics(path):
         sub = install(
             dataset='super', source='subsrc', path=op.join('super', 'sub'))
         eq_(sub.path, op.join(super.path, 'sub'))
+
+
+def _create_test_install_recursive_github(path):  # pragma: no cover
+    # to be ran once to populate a hierarchy of test datasets on github
+    # Making it a full round-trip would require github credentials on CI etc
+    ds = create(opj(path, "testrepo  gh"))
+    # making them with spaces and - to ensure that we consistently use the mapping
+    # for create and for get/clone/install
+    ds.create("sub _1")
+    ds.create("sub _1/d/sub_-  1")
+    import datalad.distribution.create_sibling_github  # to bind API
+    ds.create_sibling_github(
+        "testrepo  gh",
+        github_organization='datalad',
+        recursive=True,
+        # yarik forgot to push first, "replace" is not working in non-interactive IIRC
+        # existing='reconfigure'
+    )
+    return ds.push(recursive=True, to='github')
+
+
+@skip_if_no_network
+@with_tempfile(mkdir=True)
+def test_install_recursive_github(path):
+    # test recursive installation of a hierarchy of datasets created on github
+    # using datalad create-sibling-github.  Following invocation was used to poplate it
+    #
+    # out = _create_test_install_recursive_github(path)
+
+    # "testrepo  gh" was mapped by our sanitization in create_sibling_github to testrepo_gh, thus
+    for i, url in enumerate([
+        'https://github.com/datalad/testrepo_gh',
+        # optionally made available to please paranoids, but with all takes too long (22sec)
+        #'https://github.com/datalad/testrepo_gh.git',
+        #'git@github.com:datalad/testrepo_gh.git',
+    ]):
+        ds = install(source=url, path=opj(path, "clone%i" % i), recursive=True)
+        eq_(len(ds.subdatasets(recursive=True, fulfilled=True)), 2)

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -86,9 +86,10 @@ def _get_flexible_source_candidates(src, base_url=None, alternate_suffix=True):
                 # we just urlunquote here and rely on our ad-hoc sanitization for github
                 org_path, reponame = base_path.rsplit('/', 1)
                 ri.path = posixpath.normpath(
-                    opj(org_path,
-                        _get_gh_reponame(reponame, urlunquote(src))  # follow our default preparation
-                        + base_suffix   # github uses .git not /.git as well there
+                    '{}/{}{}'.format(
+                        org_path,
+                        _get_gh_reponame(reponame, urlunquote(src)),  # follow our default preparation
+                        base_suffix   # github uses .git not /.git as well there
                         )
                 )
             else:


### PR DESCRIPTION
Please see the first commit which RFs and IMHO BFs our github repo name sanitization - it should address detected issue of us incorrectly assessing either top level repository is "existing" if its name was sanitized by github (or us) when it was created.

The second commit (details from commit message are pasted below) is the main purpose for this PR. The immediate use-case is to finally deploy https://github.com/con/tinuous/ to collect/archive CI logs for DataLad etc.  I think I will just publish them as hierarchies of the private datasets (one per month) under some dedicated organization (e.g. datalad-logs) so all team members could have access to them. But the `create-sibling-github -r` created hierarchies are not immediately available to `install -r` or `get [-r]` operations, hence this PR to address it.
 
    This change introduces special handling for github URLs.  Since we do
    have `create-sibling-github` I think it is Ok to also provide special
    handling for such dataset hierarchies created on github (by DataLad)
    within DataLad:
    
    - before this change we were using POSIX-style composition for all URL
      + path, even though we know that it would not work for GitHub
    
    - we do our "sanitization" of repository names we provide to GitHub
      upon create-sibling-github.  So we are the "central" place with
      that logic on sanitization (see previous commit -- our logic is
      different from github's)
    
    An alternative solution I considered:
    
    Add an option to `create-sibling-github` to populate full fledged urls
    within .gitmodules.  I've decided against it for a number of reasons:
    
    - per above reasoning -- we are already doing the wrong thing
      by trying POSIX-style composition on github urls, so it should
            go even if for the purpose of not wasting CPU/bandwidth
    
    - GitHub could be one of many remotes, thus it might not be
      desirable to "hard-code" the full url to github within .gitmodules
    
    - already created hierarchies would need fix ups got .gitmodules to
      provide full urls

With this PR I can do full round-trip like

```shell
#!/bin/bash

export PS4='> '
set -x
set -eu
cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"

datalad create "test  gh4"; 
cd "test  gh4"; 
datalad create -d . "sub _1"
datalad create -d . "sub _1/d/sub_sub- 1"

datalad create-sibling-github -s github --github-organization dl-throwaway --existing replace -r "test  gh4"
datalad push --to github -r;

datalad install -r -s git://github.com/dl-throwaway/test_gh4 ../dest
```

<details>
<summary>output of the interesting part</summary> 

```shell
> datalad create-sibling-github -s github --github-organization dl-throwaway --existing replace -r 'test  gh4'
[INFO   ] Successfully obtained information about organization dl-throwaway using token 765... 
.: github(-) [https://github.com/dl-throwaway/test_gh4.git (git)]
.: github(-) [https://github.com/dl-throwaway/test_gh4-sub__1.git (git)]
.: github(-) [https://github.com/dl-throwaway/test_gh4-sub__1-d-sub_sub-_1.git (git)]
'https://github.com/dl-throwaway/test_gh4.git' configured as sibling 'github' for Dataset('/home/yoh/.tmp/dl-g82eogS/test  gh4')
'https://github.com/dl-throwaway/test_gh4-sub__1.git' configured as sibling 'github' for Dataset('/home/yoh/.tmp/dl-g82eogS/test  gh4/sub _1')
'https://github.com/dl-throwaway/test_gh4-sub__1-d-sub_sub-_1.git' configured as sibling 'github' for Dataset('/home/yoh/.tmp/dl-g82eogS/test  gh4/sub _1/d/sub_sub- 1')
> datalad push --to github -r
publish(ok): sub _1/d/sub_sub- 1 (dataset) [refs/heads/master->github:refs/heads/master [new branch]]     
publish(ok): sub _1/d/sub_sub- 1 (dataset) [refs/heads/git-annex->github:refs/heads/git-annex [new branch]]
publish(ok): sub _1 (dataset) [refs/heads/master->github:refs/heads/master [new branch]]                  
publish(ok): sub _1 (dataset) [refs/heads/git-annex->github:refs/heads/git-annex [new branch]]            
publish(ok): . (dataset) [refs/heads/master->github:refs/heads/master [new branch]]                       
publish(ok): . (dataset) [refs/heads/git-annex->github:refs/heads/git-annex [new branch]]                 
> datalad install -r -s git://github.com/dl-throwaway/test_gh4 ../dest                                    
[INFO   ] scanning for unlocked files (this may take some time)                                           
[INFO   ] Remote origin uses a protocol not supported by git-annex; setting annex-ignore                  
install(ok): /home/yoh/.tmp/dl-g82eogS/dest (dataset)
[INFO   ] Installing Dataset(/home/yoh/.tmp/dl-g82eogS/dest) to get /home/yoh/.tmp/dl-g82eogS/dest recursively 
[INFO   ] scanning for unlocked files (this may take some time) 
[INFO   ] Remote origin uses a protocol not supported by git-annex; setting annex-ignore                  
install(ok): /home/yoh/.tmp/dl-g82eogS/dest/sub _1 (dataset)                                              
[INFO   ] scanning for unlocked files (this may take some time)                                           
[INFO   ] Remote origin uses a protocol not supported by git-annex; setting annex-ignore                  
install(ok): /home/yoh/.tmp/dl-g82eogS/dest/sub _1/d/sub_sub- 1 (dataset)                                 
action summary:                                                                                           
  install (ok: 3)
bash gh-recursive  12.14s user 3.39s system 41% cpu 37.848 total

```
</details>

I am also ok to rebase this on  top of master (seems to be not merging cleanly) -- I think we should release `master` quite soon with its new WitlessRunner anyways ;-)