### PR TITLE
BF: do not use .acquired - just get state from acquire()

### DIFF
--- a/datalad/support/locking.py
+++ b/datalad/support/locking.py
@@ -30,7 +30,7 @@ def lock_if_check_fails(
     lock_path,
     operation=None,
     blocking=True,
-    return_acquired=False,
+    _return_acquired=False,
     **kwargs
 ):
     """A context manager to establish a lock conditionally on result of a check
@@ -66,8 +66,9 @@ def lock_if_check_fails(
     blocking: bool, optional
       If blocking, process would be blocked until acquired and verified that it
       was acquired after it gets the lock
-    return_acquired: bool, optional
-      Return also if lock was acquired
+    _return_acquired: bool, optional
+      Return also if lock was acquired.  For "private" use within DataLad (tests),
+      do not rely on it in 3rd party solutions.
     **kwargs
       Passed to `.acquire` of the fasteners.InterProcessLock
 
@@ -97,7 +98,7 @@ def lock_if_check_fails(
             assert acquired
         check2 = _get(check)
         ret_lock = None if check2 else lock
-        if return_acquired:
+        if _return_acquired:
             yield check2, ret_lock, acquired
         else:
             yield check2, ret_lock

--- a/datalad/support/locking.py
+++ b/datalad/support/locking.py
@@ -30,6 +30,7 @@ def lock_if_check_fails(
     lock_path,
     operation=None,
     blocking=True,
+    return_acquired=False,
     **kwargs
 ):
     """A context manager to establish a lock conditionally on result of a check
@@ -65,12 +66,14 @@ def lock_if_check_fails(
     blocking: bool, optional
       If blocking, process would be blocked until acquired and verified that it
       was acquired after it gets the lock
+    return_acquired: bool, optional
+      Return also if lock was acquired
     **kwargs
       Passed to `.acquire` of the fasteners.InterProcessLock
 
     Returns
     -------
-    result of check, lock
+    result of check, lock[, acquired]
     """
     check1 = _get(check)
     if check1:  # we are done - nothing to do
@@ -85,19 +88,21 @@ def lock_if_check_fails(
     lock_filename += 'lck'
 
     lock = InterProcessLock(lock_filename)
+    acquired = False
     try:
         lgr.debug("Acquiring a lock %s", lock_filename)
-        lock.acquire(blocking=blocking, **kwargs)
-        lgr.debug("Acquired? lock %s: %s", lock_filename, lock.acquired)
+        acquired = lock.acquire(blocking=blocking, **kwargs)
+        lgr.debug("Acquired? lock %s: %s", lock_filename, acquired)
         if blocking:
-            assert lock.acquired
+            assert acquired
         check2 = _get(check)
-        if check2:
-            yield check2, None
+        ret_lock = None if check2 else lock
+        if return_acquired:
+            yield check2, ret_lock, acquired
         else:
-            yield check2, lock
+            yield check2, ret_lock
     finally:
-        if lock.acquired:
+        if acquired:
             lgr.debug("Releasing lock %s", lock_filename)
             lock.release()
             if exists(lock_filename):

--- a/datalad/support/tests/test_locking.py
+++ b/datalad/support/tests/test_locking.py
@@ -40,8 +40,11 @@ class Subproc:
         self.tempfile = tempfile
 
     def __call__(self, q):
-        with lock_if_check_fails(False, self.tempfile, blocking=False) as (_, lock2):
-            q.put(lock2.acquired)
+        with lock_if_check_fails(False, self.tempfile, blocking=False, return_acquired=True)\
+                as (_, lock2, acquired):
+            # we used to check for .acquired here but it was removed from
+            # fasteners API: https://github.com/harlowja/fasteners/issues/71
+            q.put(acquired)
 
 
 @known_failure_windows
@@ -52,7 +55,6 @@ def test_lock_if_check_fails(tempfile):
         assert check is True
         assert lock is None
     assert check  # still available outside
-
     # and with a callable
     with lock_if_check_fails(lambda: "valuable", None) as (check, lock):
         eq_(check, "valuable")
@@ -61,14 +63,14 @@ def test_lock_if_check_fails(tempfile):
 
     # basic test, should never try to lock so filename is not important
     with lock_if_check_fails(False, tempfile) as (check, lock):
-        ok_(lock.acquired)
+        ok_(lock)
         ok_exists(tempfile + '.lck')
     assert not op.exists(tempfile + '.lck')  # and it gets removed after
 
     # the same with providing operation
     # basic test, should never try to lock so filename is not important
     with lock_if_check_fails(False, tempfile, operation='get') as (check, lock):
-        ok_(lock.acquired)
+        ok_(lock)
         ok_exists(tempfile + '.get-lck')
     assert not op.exists(tempfile + '.get-lck')  # and it gets removed after
 
@@ -77,9 +79,10 @@ def test_lock_if_check_fails(tempfile):
     p = Process(target=Subproc(tempfile), args=(q,))
 
     # now we need somehow to actually check the bloody lock functioning
-    with lock_if_check_fails((op.exists, (tempfile,)), tempfile) as (check, lock):
+    with lock_if_check_fails((op.exists, (tempfile,)), tempfile, return_acquired=True) as (check, lock, acquired):
         eq_(check, False)
-        ok_(lock.acquired)
+        ok_(lock)
+        ok_(acquired)
         # but now we will try to lock again, but we need to do it in another
         # process
         p.start()

--- a/datalad/support/tests/test_locking.py
+++ b/datalad/support/tests/test_locking.py
@@ -40,7 +40,7 @@ class Subproc:
         self.tempfile = tempfile
 
     def __call__(self, q):
-        with lock_if_check_fails(False, self.tempfile, blocking=False, return_acquired=True)\
+        with lock_if_check_fails(False, self.tempfile, blocking=False, _return_acquired=True)\
                 as (_, lock2, acquired):
             # we used to check for .acquired here but it was removed from
             # fasteners API: https://github.com/harlowja/fasteners/issues/71
@@ -79,7 +79,7 @@ def test_lock_if_check_fails(tempfile):
     p = Process(target=Subproc(tempfile), args=(q,))
 
     # now we need somehow to actually check the bloody lock functioning
-    with lock_if_check_fails((op.exists, (tempfile,)), tempfile, return_acquired=True) as (check, lock, acquired):
+    with lock_if_check_fails((op.exists, (tempfile,)), tempfile, _return_acquired=True) as (check, lock, acquired):
         eq_(check, False)
         ok_(lock)
         ok_(acquired)


### PR DESCRIPTION
Somewhat ad-hoc and makes an already confusing lock_if_check_fails even more so
by optionally changing its return signature. So eventually we might want
to RF this whole piece of code.  But I think it should work ok for now.
Anyways -- fasteners 0.16.x series might re-gain .acquired (see
https://github.com/harlowja/fasteners/issues/71) and we might want to see to RF
this PR properly if so instead of merging/releasing it right away.  But FWIW
Closes #5717
