### PR TITLE
WiP Q&D AnnexRepo.add_ batched (by default) if more than a single file passed

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2384,7 +2384,7 @@ def check_files_split(cls, topdir):
 @known_failure_windows  # does not find files to add (too long paths?)
 @slow  # 313s  well -- if errors out - only 3 sec
 def test_files_split():
-    for cls in GitRepo, AnnexRepo:
+    for cls in AnnexRepo, :
         yield check_files_split, cls
 
 


### PR DESCRIPTION
If ever finished, Closes #5721 

If to proceed
- ideally some hero of the Runners, like @christian-monch  , would just RF/fold that BatchedAnnexes deep into the guts of `_call_annex*` so reduce duplication etc, but it shouldn't be the goal of this PR
- [x] see if any positive effect on OSX with bleeding edge annex in relation to [recent regression on our tests on OSX](https://git-annex.branchable.com/bugs/significant_performance_regression_impacting_datal/#comment-4df4242f85746baef8afd32e0632c37c)
   - yeap, seems to mitigate it well, see the git-annex issue above for fresh comments on that.
- [x] no effect on benchmarks... if anything only `0.92  plugins.addurls.addurls1.time_addurls('*')` is happier 
- [ ] see what fails and either it could be addressed here or there is some roadblock
- [ ] I think added `batch=None` logic handling is sound (taken from `get_file_key`), so I would just keep it but could be improved to just reuse a batched `add` if already one running.
- [ ] interface that `total_nbytes` (I did not even look into what it is about)