### PR TITLE
ENH: addreadme: improve default template

### DIFF
--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -128,8 +128,75 @@ class AddReadme(Interface):
 
 This is a DataLad dataset{id}.
 
-For more information on DataLad and on how to work with its datasets,
-see the DataLad documentation at: http://handbook.datalad.org
+## DataLad datasets and how to use them
+
+This repository is a [DataLad](https://www.datalad.org/) dataset. It provides
+fine-grained data access down to the level of individual files, and allows for
+tracking future updates. In order to use this repository for data retrieval,
+[DataLad](https://www.datalad.org/) is required. It is a free and open source
+command line tool, available for all major operating systems, and builds up on
+Git and [git-annex](https://git-annex.branchable.com/) to allow sharing,
+synchronizing, and version controlling collections of large files.
+
+More information on how to install DataLad and [how to install](http://handbook.datalad.org/en/latest/intro/installation.html)
+it can be found in the [DataLad Handbook](https://handbook.datalad.org/en/latest/index.html).
+
+### Get the dataset
+
+A DataLad dataset can be `cloned` by running
+
+```
+datalad clone <url>
+```
+
+Once a dataset is cloned, it is a light-weight directory on your local machine.
+At this point, it contains only small metadata and information on the identity
+of the files in the dataset, but not actual *content* of the (sometimes large)
+data files.
+
+### Retrieve dataset content
+
+After cloning a dataset, you can retrieve file contents by running
+
+```
+datalad get <path/to/directory/or/file>
+```
+
+This command will trigger a download of the files, directories, or subdatasets
+you have specified.
+
+DataLad datasets can contain other datasets, so called *subdatasets*.  If you
+clone the top-level dataset, subdatasets do not yet contain metadata and
+information on the identity of files, but appear to be empty directories. In
+order to retrieve file availability metadata in subdatasets, run
+
+```
+datalad get -n <path/to/subdataset>
+```
+
+Afterwards, you can browse the retrieved metadata to find out about subdataset
+contents, and retrieve individual files with `datalad get`.  If you use
+`datalad get <path/to/subdataset>`, all contents of the subdataset will be
+downloaded at once.
+
+### Stay up-to-date
+
+DataLad datasets can be updated. The command `datalad update` will *fetch*
+updates and store them on a different branch (by default
+`remotes/origin/master`). Running
+
+```
+datalad update --merge
+```
+
+will *pull* available updates and integrate them in one go.
+
+### Find out what has been done
+
+DataLad datasets contain their history in the ``git log``.  By running ``git
+log`` (or a tool that displays Git history) in the dataset or on specific
+files, you can find out what has been done to the dataset or to individual
+files by whom, and when.
 """.format(
             title='Dataset "{}"'.format(meta['title']) if 'title' in meta else 'About this dataset',
             metainfo=metainfo,

--- a/datalad/local/tests/test_add_readme.py
+++ b/datalad/local/tests/test_add_readme.py
@@ -16,7 +16,8 @@ from datalad.distribution.dataset import Dataset
 from datalad.tests.utils import (
     assert_repo_status,
     assert_status,
-    eq_,
+    assert_in,
+    ok_startswith,
     known_failure_githubci_win,
     with_tree,
 )
@@ -49,8 +50,9 @@ def test_add_readme(path):
     assert_repo_status(ds.path)
     assert_status('ok', ds.add_readme())
     # should use default name
-    eq_(
-        open(opj(path, 'README.md')).read(),
+    content = open(opj(path, 'README.md')).read()
+    ok_startswith(
+        content,
         """\
 # Dataset "demo_ds"
 
@@ -68,11 +70,17 @@ PDDL
 ## General information
 
 This is a DataLad dataset (id: {id}).
-
-For more information on DataLad and on how to work with its datasets,
-see the DataLad documentation at: http://handbook.datalad.org
 """.format(
     id=ds.id))
+    # make sure that central README references are present
+    assert_in(
+        """More information on how to install DataLad and [how to install](http://handbook.datalad.org/en/latest/intro/installation.html)
+it can be found in the [DataLad Handbook](https://handbook.datalad.org/en/latest/index.html).
+""",
+        content
+    )
+    # no unexpectedly long lines
+    assert all([len(l) < 160 for l in content.splitlines()])
 
     # should skip on re-run
     assert_status('notneeded', ds.add_readme())


### PR DESCRIPTION
This improves the default template for `add-readme` using the content that @adswa created for the [DataLad Handbook](http://handbook.datalad.org/en/latest/basics/101-180-FAQ.html#how-can-i-help-others-get-started-with-a-shared-dataset).

Closes #5714
