### PR TITLE
Better hint when a sibling is provided without --to

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -229,7 +229,6 @@ class Push(Interface):
                     if sr
                     else 'No targets configured in dataset.'))
             return
-
         if since == '^':
             # figure out state of remote branch and set `since`
             since = _get_corresponding_remote_state(ds_repo, to)
@@ -266,6 +265,23 @@ class Push(Interface):
             for i, ds in pbars.items():
                 log_progress(lgr.info, i, 'Finished push of %s', ds)
         if not matched_anything:
+            potential_remote = False
+            if not to and path:
+                # if we get a remote name without --to, provide a hint
+                sr = ds_repo.get_remotes(**get_remote_kwargs)
+                potential_remote = [
+                    p for p in ensure_list(path) if p in sr
+                ]
+            if potential_remote:
+                msg = "It seems like you specified a sibling name {} " \
+                      "as a path. Forgot to use --to?".format(potential_remote)
+                yield dict(
+                    res_kwargs,
+                    status='impossible',
+                    message=msg,
+                    type='dataset',
+                    path=ds.path,
+                )
             yield dict(
                 res_kwargs,
                 status='notneeded',

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -298,6 +298,7 @@ class Push(Interface):
 
     @staticmethod
     def custom_result_summary_renderer(results, action_summary):  # pragma: more cover
+        render_action_summary(action_summary)
         # report on any hints at the end
         # get all unique hints
         hints = set([r.get('hints', None) for r in results])
@@ -306,14 +307,13 @@ class Push(Interface):
             from datalad.ui import ui
             from datalad.support import ansi_colors
             intro = ansi_colors.color_word(
-                "Potential hints to solve encountered errors: ",
+                "Hints: ",
                 ansi_colors.YELLOW)
             ui.message(intro)
             [ui.message("{}: {}".format(
                 ansi_colors.color_word(id + 1, ansi_colors.YELLOW), hint))
                 for id, hint in enumerate(hints)]
 
-        render_action_summary(action_summary)
 
 
 def _datasets_since_(dataset, since, paths, recursive, recursion_limit):

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -273,12 +273,16 @@ class Push(Interface):
                     p for p in ensure_list(path) if p in sr
                 ]
             if potential_remote:
-                msg = "{} matches a sibling name and not a path. " \
+                hint = "{} matches a sibling name and not a path. " \
                       "Forgot --to?".format(potential_remote)
                 yield dict(
                     res_kwargs,
-                    status='impossible',
-                    message=msg,
+                    status='notneeded',
+                    message=hint,
+                    hints=hint,
+                    type='dataset',
+                    path=ds.path,
+                )
                     type='dataset',
                     path=ds.path,
                 )

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -283,9 +283,9 @@ class Push(Interface):
                     type='dataset',
                     path=ds.path,
                 )
-                    type='dataset',
-                    path=ds.path,
-                )
+                # there's no matching path and we have generated a hint on
+                # fixing the call - we can return now
+                return
             yield dict(
                 res_kwargs,
                 status='notneeded',

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -273,8 +273,8 @@ class Push(Interface):
                     p for p in ensure_list(path) if p in sr
                 ]
             if potential_remote:
-                msg = "It seems like you specified a sibling name {} " \
-                      "as a path. Forgot to use --to?".format(potential_remote)
+                msg = "{} matches a sibling name and not a path. " \
+                      "Forgot --to?".format(potential_remote)
                 yield dict(
                     res_kwargs,
                     status='impossible',

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -114,7 +114,7 @@ class Push(Interface):
         path=Parameter(
             args=("path",),
             metavar='PATH',
-            doc="""path to contrain a push to. If given, only
+            doc="""path to constrain a push to. If given, only
             data or changes for those paths are considered for a push.""",
             nargs='*',
             constraints=EnsureStr() | EnsureNone()),

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -987,5 +987,5 @@ def test_push_custom_summary(path):
     ds.config.set("advice.pushFetchFirst", "true", where="local")
     with swallow_outputs() as cmo:
         ds.push(to="sib", result_renderer="default", on_failure="ignore")
-        assert_in("Potential hints to solve", cmo.out)
+        assert_in("Hints:", cmo.out)
         assert_in("action summary:", cmo.out)


### PR DESCRIPTION
This is an attempt to fix #5712. If
- a path is given, 
- but not ``--to``, 
- (a part of) the path matches a known sibling,
- and no matching files are found, 
 
``push`` reports "impossible" instead of "notneeded", and issues a hint to the user.

Before:
![Screenshot from 2021-06-09 16-29-15](https://user-images.githubusercontent.com/29738718/121374058-dfcfeb00-c93f-11eb-9650-0e3fc9191df0.png)

After:
![Screenshot from 2021-06-09 16-28-58](https://user-images.githubusercontent.com/29738718/121374094-e6f6f900-c93f-11eb-9bcd-8a62fa773691.png)
