### PR TITLE
BF(TST): skip testing for showing "Scanning for ..." since not shown if too quick

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1293,6 +1293,7 @@ def test_repo_version(path1, path2, path3):
             eq_(version, 5)
 
 
+@skip_if(external_versions['cmd:annex'] > '8.20210428', "Stopped showing if too quick")
 @with_tempfile
 def test_init_scanning_message(path):
     # | begin kludge


### PR DESCRIPTION
probably happened at  [8.20210428-329-g7b6deb110](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=7b6deb1109d315fffb2e8a856340f022ed3db249)
