### PR TITLE
Add config datalad.remote.archives.autoclean

### DIFF
--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -21,6 +21,7 @@ from ..cmdline import helpers
 
 from ..utils import setup_exceptionhook
 from ..ui import ui
+from datalad import cfg
 
 backends = ['archive']
 
@@ -77,7 +78,10 @@ def _main(args, backend=None):
     assert(backend is not None)
     if backend == 'archive':
         from .archives import ArchiveAnnexCustomRemote
-        remote = ArchiveAnnexCustomRemote()
+        autoclean = cfg.obtain("datalad.remote.archives.autoclean")
+        remote = ArchiveAnnexCustomRemote(
+            persistent_cache=not autoclean
+        )
     elif backend == 'datalad':
         from .datalad import DataladAnnexCustomRemote
         remote = DataladAnnexCustomRemote()

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -440,6 +440,14 @@ definitions = {
         'default': True,
         'type': EnsureBool(),
     },
+    'datalad.remote.archives.autoclean': {
+        'ui': ('yesno', {
+               'title': "datalad-archives special remote extraction cache",
+               'text': "Set this flag to autoremove temporary, extracted files"
+                       " instead of keeping them as a cache."}),
+        'type': EnsureBool(),
+        'default': True,
+    },
 }
 
 


### PR DESCRIPTION
This flag determines whether or not the datalad-archives
special remote keeps extracted files under .git as an
extraction cache. Default set to False, since this can
be expensive to keep around, it's not obvious for users
that it's there and how to remove it, and generally the
defaults should scale. True doesn't scale here.

Closes #5519

There's a little more TODO - see https://github.com/datalad/datalad/issues/5519#issuecomment-802883995


@yarikoptic : What do you think of this approach?