### PR TITLE
ENH(TST): populate heavy tree with 100 unique keys (not just 1) among 10,000

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2358,7 +2358,12 @@ def test_files_split_exc():
 _HEAVY_TREE = {
     # might already run into 'filename too long' on windows probably
     "d" * 98 + '%03d' % d: {
-        'f' * 98 + '%03d' % f: ''
+        # populate with not entirely unique but still not all identical (empty) keys.
+        # With content unique to that filename we would still get 100 identical
+        # files for each key, thus possibly hitting regressions in annex like
+        # https://git-annex.branchable.com/bugs/significant_performance_regression_impacting_datal/
+        # but also would not hit filesystem as hard as if we had all the keys unique.
+        'f' * 98 + '%03d' % f: str(f)
         for f in range(100)
     }
     for d in range(100)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -52,6 +52,7 @@ from datalad.support.sshconnector import get_connection_hash
 from datalad.utils import (
     chpwd,
     get_linux_distribution,
+    on_windows,
     rmtree,
     unlink,
     Path,
@@ -2354,19 +2355,24 @@ def test_files_split_exc():
     for cls in GitRepo, AnnexRepo:
         yield check_files_split_exc, cls
 
+# with 204  (/ + (98+3)*2 + /) chars guaranteed, we hit "filename too long" quickly on windows
+# so we are doomed to shorten the filepath for testing on windows. Since the limits are smaller
+# on windows (16k vs e.g. 1m on linux in CMD_MAX_ARG), it would already be a "struggle" for it,
+# we also reduce number of dirs/files
+_ht_len, _ht_n = (48, 20) if on_windows else (98, 100)
 
 _HEAVY_TREE = {
     # might already run into 'filename too long' on windows probably
-    "d" * 98 + '%03d' % d: {
+    "d" * _ht_len + '%03d' % d: {
         # populate with not entirely unique but still not all identical (empty) keys.
         # With content unique to that filename we would still get 100 identical
         # files for each key, thus possibly hitting regressions in annex like
         # https://git-annex.branchable.com/bugs/significant_performance_regression_impacting_datal/
         # but also would not hit filesystem as hard as if we had all the keys unique.
-        'f' * 98 + '%03d' % f: str(f)
-        for f in range(100)
+        'f' * _ht_len + '%03d' % f: str(f)
+        for f in range(_ht_n)
     }
-    for d in range(100)
+    for d in range(_ht_n)
 }
 
 
@@ -2390,7 +2396,7 @@ def check_files_split(cls, topdir):
     dl.save(dataset=r.path, path=dirs)
 
 
-@known_failure_windows  # does not find files to add (too long paths?)
+# @known_failure_windows  # might fail with some older annex `cp` failing to set permissions
 @slow  # 313s  well -- if errors out - only 3 sec
 def test_files_split():
     for cls in GitRepo, AnnexRepo:


### PR DESCRIPTION
I think it would still fit the purpose of the test (long lists of files) while possibly avoid annex taking too long to deal with 10,000 copies of the same file (unrealistic scenario IMHO).  We would still have 100 unique keys (not 10,000) so file system would not get tortured that heavily to populate all the `.git/annex/objects`.

Ref: https://git-annex.branchable.com/bugs/significant_performance_regression_impacting_datal/