### PR TITLE
BF+ENH+RF: logic and code support for --jobs='auto', make AnnexRepo. interfaces use 'auto' by default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,6 +51,7 @@ shallow_clone: true
 
 environment:
   DATALAD_TESTS_SSH: 1
+  DATALAD_RUNTIME_MAX__ANNEX__JOBS: 5
 
   # Do not use `image` as a matrix dimension, to have fine-grained control over
   # what tests run on which platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - DATALAD_TESTS_SSH=1
     - DATALAD_LOG_ENV=GIT_SSH_COMMAND
     - TESTS_TO_PERFORM=datalad
+    # To potentially speed up testing, let's do annex jobs in parallel by default
+    - DATALAD_RUNTIME_MAX__ANNEX__JOBS=5
     # Should be an array, travis breaks on it, define/adjust in the "before_install"
     #- NOSE_OPTS=( -v )
     # Note, that there's "turtle" as well, which is always excluded from
@@ -38,6 +40,8 @@ matrix:
     # We cannot have empty -A selector, so the one which always will be fulfilled
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+    # A single run where we do not instruct annex on number of jobs
+    - DATALAD_RUNTIME_MAX__ANNEX__JOBS=0
     # To test https://github.com/datalad/datalad/pull/4342 fix.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LC_ALL=ru_RU.UTF-8
@@ -46,6 +50,8 @@ matrix:
     env:
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+    # A single run where we instruct annex to just have a single job
+    - DATALAD_RUNTIME_MAX__ANNEX__JOBS=1
   - if: type = cron
     python: 3.6
     # Single run for Python 3.6

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -348,9 +348,12 @@ definitions = {
     'datalad.runtime.max-annex-jobs': {
         'ui': ('question', {
                'title': 'Maximum number of git-annex jobs to request when "jobs" option set to "auto" (default)',
-               'text': 'Set this value to enable parallel annex jobs that may speed up certain operations (e.g. get file content). The effective number of jobs will not exceed the number of available CPU cores (or 3 if there is less than 3 cores).'}),
+               'text': 'Set this value to enable parallel annex jobs that may speed up certain operations (e.g. get file content). '
+                       'The effective number of jobs will not exceed the number of available CPU cores (or 3 if there is less than 3 cores). '
+                       'If set to 0, we do not instruct git-annex on number of jobs.'
+        }),
         'type': EnsureInt(),
-        'default': 1,
+        'default': 0,
     },
     'datalad.runtime.max-jobs': {
         'ui': ('question', {

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -13,14 +13,16 @@
 __docformat__ = 'restructuredtext'
 
 from appdirs import AppDirs
+from multiprocessing import cpu_count
 from os import environ
 from os.path import join as opj, expanduser
-from datalad.support.constraints import EnsureBool
-from datalad.support.constraints import EnsureInt
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureChoice
-from datalad.support.constraints import EnsureListOf
-from datalad.support.constraints import EnsureStr
+
+from datalad.support.constraints import (
+    EnsureBool,
+    EnsureChoice,
+    EnsureInt,
+    EnsureStr,
+)
 from datalad.utils import on_windows
 
 dirs = AppDirs("datalad", "datalad.org")
@@ -350,10 +352,11 @@ definitions = {
                'title': 'Maximum number of git-annex jobs to request when "jobs" option set to "auto" (default)',
                'text': 'Set this value to enable parallel annex jobs that may speed up certain operations (e.g. get file content). '
                        'The effective number of jobs will not exceed the number of available CPU cores (or 3 if there is less than 3 cores). '
-                       'If set to 0, we do not instruct git-annex on number of jobs.'
+                       'If set to 0, we do not instruct git-annex on number of jobs. '
+                       'Default value is set to cpu count, but not less than 3 and not greater than 8.'
         }),
         'type': EnsureInt(),
-        'default': 0,
+        'default': min(8, max(3, cpu_count())),
     },
     'datalad.runtime.max-jobs': {
         'ui': ('question', {

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -28,7 +28,6 @@ from os.path import (
     isdir,
     normpath
 )
-from multiprocessing import cpu_count
 from weakref import (
     finalize,
     WeakValueDictionary
@@ -954,14 +953,9 @@ class AnnexRepo(GitRepo, RepoInterface):
             cmd += self._annex_common_options
 
         if jobs == 'auto':
-            # Limit to # of CPUs (but at least 3 to start with)
-            # and also an additional config constraint (by default 1
-            # due to https://github.com/datalad/datalad/issues/4404)
             if self._n_auto_jobs is None:
                 # cache the value
-                self._n_auto_jobs = min(
-                    self.config.obtain('datalad.runtime.max-annex-jobs'),
-                    max(3, cpu_count()))
+                self._n_auto_jobs = self.config.obtain('datalad.runtime.max-annex-jobs')
             jobs = self._n_auto_jobs
         if jobs:
             cmd.append('-J%d' % jobs)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -218,6 +218,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # initialize
         self._uuid = None
+        # will be evaluated lazily
+        self._n_auto_jobs = None
         self._annex_common_options = ["-c", "annex.dotfiles=true"]
 
         if annex_opts or annex_init_opts:
@@ -296,9 +298,6 @@ class AnnexRepo(GitRepo, RepoInterface):
                 ["-c",
                  "annex.retry={}".format(
                      config.obtain("datalad.annex.retry"))])
-
-        # will be evaluated lazily
-        self._n_auto_jobs = None
 
         # Finally, register a finalizer (instead of having a __del__ method).
         # This will be called by garbage collection as well as "atexit". By


### PR DESCRIPTION
The first commit is a true BF which kinda started it all.

And then I think I went a little "too broad" in my changes, even if we decide that it is a good time to return getting annex operations to do some parallelization by default ('auto') it might be a better fit for `master` then.  Alternatively I could kick out that commit which does set default to `auto` for AnnexRepo interfaces, and keep the rest, but then I think it would loose the point of all other RFings... uff...  At least for `maint` we could take the BF and handling for `0` value (as to "do not bother annex") which is now the effect of setting it to `1` (prior default) but then there is no way to overload our or annex config setting (if set > 1) via env var as should be possible.

Please see individual commits  for more reasoning etc.

In any case, I am interested to see if
- [x] we gain run time speed ups for CIs
   - not spotted any gain
- [x] anything fails
   - quite enough -- see below/referenced to this PR
- [ ] decide on how to proceed if at all (besides a tiny bugfix PR)

edit 1: in `maint` we still have 7.20190503 min annex version, and in `master` 8.20200309.  This [annex issue](https://git-annex.branchable.com/bugs/get_-J8_on_OSX_leads_to_git-annex__58___git__58___createProcess__58___runInteractiveProcess__58___pipe__58___resource_exhausted___40__Too_many_open_files__41__/) was fixed before (according to the date of changes, didn't git describe) 20190503 so users should not run into it again even with older annexes. 

edit 2: having thought about it a bit more, I think this PR is a bust and we might just keep as it was (which in effect was "defer to git-annex config" albeit without being able to change it via env var) besides any bug fixes we need to CP or to do.