### PR TITLE
tributors: annotate commit and PR with [skip ci]

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -68,13 +68,15 @@ jobs:
           else
              export OPEN_PULL_REQUEST=1
              printf "Changes\n"
-             git commit -a -m "Automated deployment to update contributors $(date '+%Y-%m-%d')"
+             git commit -a -m "Automated deployment to update contributors $(date '+%Y-%m-%d')
+
+             [skip ci]"
              git push origin "${BRANCH_FROM}"
           fi
           echo "OPEN_PULL_REQUEST=${OPEN_PULL_REQUEST}" >> $GITHUB_ENV
           echo "PULL_REQUEST_FROM_BRANCH=${BRANCH_FROM}" >> $GITHUB_ENV
           echo "PULL_REQUEST_TITLE=[tributors] ${BRANCH_FROM}" >> $GITHUB_ENV
-          echo "PULL_REQUEST_BODY=Tributors update automated pull request." >> $GITHUB_ENV
+          echo -e "PULL_REQUEST_BODY='Tributors update automated pull request.\n\n[skip ci]'" >> $GITHUB_ENV
 
       - name: Open Pull Request
         uses: vsoch/pull-request-action@1.0.17


### PR DESCRIPTION
It seems that now even github should support it if marker is in the commit
message: https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

[skip ci]

not sure if my changes do not break it, I guess we will discover whenever it is merged. Meanwhile will see if [skip ci] works here