### PR TITLE
Dry run option for clean command

### DIFF
--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -32,6 +32,7 @@ from ..utils import ensure_bytes
 from ..utils import unlink
 from .base import AnnexCustomRemote
 from .main import main as super_main
+from datalad.consts import ARCHIVES_SPECIAL_REMOTE
 
 
 # ####
@@ -393,8 +394,16 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 # so
                 pwd = getpwd()
                 lgr.debug(u"Getting file {afile} from {akey_path} while PWD={pwd}".format(**locals()))
+                was_extracted = self.cache[akey_path].is_extracted
                 apath = self.cache[akey_path].get_extracted_file(afile)
                 link_file_load(apath, path)
+                if not was_extracted and self.cache[akey_path].is_extracted:
+                    self.info("%s special remote is using an extraction cache "
+                              "under %s. Remove it with DataLad's 'clean' "
+                              "command to save disk space." %
+                              (ARCHIVES_SPECIAL_REMOTE,
+                               self.cache[akey_path].path)
+                              )
                 self.send('TRANSFER-SUCCESS', cmd, key)
                 return
             except Exception as exc:

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -122,7 +122,12 @@ def test_basic_scenario(d, d2):
     in_('[%s]' % ARCHIVES_SPECIAL_REMOTE, list_of_remotes)
 
     assert_false(annex.file_has_content(fn_extracted))
-    annex.get(fn_extracted)
+
+    with swallow_logs(new_level=logging.INFO) as cml:
+        annex.get(fn_extracted)
+        # Hint users to the extraction cache (and to datalad clean)
+        cml.assert_logged(msg="datalad-archives special remote is using an "
+                              "extraction", level="INFO", regex=False)
     assert_true(annex.file_has_content(fn_extracted))
 
     annex.rm_url(fn_extracted, file_url)


### PR DESCRIPTION
There are several places where temporary files could be left by datalad operations. `datalad clean` now comes with a `--dry-run` option to just report on what could be cleaned.
Furthermore, the `datalad-archives` special remote now issues an INFO message to annex when it's actually extracting an archive in order to let a user know they may want to call `datalad clean` afterwards. This should make the presence of an extraction cache less surprising to users and make them aware of the `clean` command.

The issue leading to this PR and the discussion therein is #5519, although this is not actually solving it. However, at least this is an improvement of the UX aspect of the issue.

Closes #5834