### PR TITLE
Make lock file location configurable

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -800,8 +800,8 @@ class ConfigManager(object):
             lockfile = self._repo_dot_git / 'config.dataladlock'
         else:
             # follow pattern in downloaders for lockfile location
-            lockfile = Path(self.obtain('datalad.locations.cache')) \
-                / 'locks' / 'gitconfig.lck'
+            lockfile = Path(self.obtain('datalad.locations.locks')) \
+                       / 'gitconfig.lck'
 
         with ConfigManager._run_lock, InterProcessLock(lockfile, logger=lgr):
             out = self._runner.run(self._config_cmd + args, **kwargs)

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -114,10 +114,9 @@ class BaseDownloader(object, metaclass=ABCMeta):
         self.authenticator = authenticator
         self._cache = None  # for fetches, not downloads
         self._lock = InterProcessLock(
-            op.join(
-                cfg.obtain('datalad.locations.cache'),
-                'locks',
-                'downloader-auth.lck'))
+            op.join(cfg.obtain('datalad.locations.locks'),
+                    'downloader-auth.lck')
+        )
 
     def access(self, method, url, allow_old_session=True, **kwargs):
         """Generic decorator to manage access to the URL via some method

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -58,6 +58,13 @@ definitions = {
         'destination': 'global',
         'default_fn': lambda: opj(expanduser('~'), 'datalad'),
     },
+    'datalad.locations.locks': {
+        'ui': ('question', {
+               'title': 'Lockfile directory',
+               'text': 'Where should datalad store lock files?'}),
+        'destination': 'global',
+        'default_fn': lambda: opj(dirs.user_cache_dir, 'locks')
+    },
     'datalad.locations.sockets': {
         'ui': ('question', {
                'title': 'Socket directory',


### PR DESCRIPTION
This introduces `datalad.locations.locks` to specify the location to be
used for (global) lock files. Defaults to the currently used
`<user cache dir>/locks`.

Closes #5706
