### PR TITLE
UX: Report the sibling name in create-sibling-github's results record

### DIFF
--- a/datalad/distribution/create_sibling_github.py
+++ b/datalad/distribution/create_sibling_github.py
@@ -241,7 +241,7 @@ class CreateSiblingGithub(Interface):
                 res,
                 **res_kwargs)
             if 'message' not in res:
-                res['message'] = ("project at %s", res['url'])
+                res['message'] = ("Dataset sibling '%s', project at %s", name, res['url'])
             # report to caller
             yield get_status_dict(**res)
             if res['status'] not in ('ok', 'notneeded'):


### PR DESCRIPTION
Here's my attempt at reporting a sibling name when a GitHub sibling is created, as desired in #5711. Its not a separate key in the result, but merely added into the message, but I found that it looked quite crowded when I rendered several messages.
Here is the current look:
![Screenshot from 2021-06-14 15-37-24](https://user-images.githubusercontent.com/29738718/121901240-82181600-cd26-11eb-97ae-161061161fd6.png)

