### PR TITLE
BF(TST): parallel - take longer for producer to produce

### DIFF
--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -179,7 +179,7 @@ def test_gracefull_death():
 
     def producer():
         for i in range(10):
-            sleep(0.0001)
+            sleep(0.0003)
             yield i
         raise ValueError()
     # by default we do not stop upon producer failing
@@ -196,10 +196,10 @@ def test_gracefull_death():
     assert_equal(results, list(range(len(results))))
     assert_greater_equal(len(results), 2)
     if info_log_level and not (on_windows or on_osx):
-        # windows does not behave according to the initial performance
-        # expectations gh-5296 (~9), and neither does a macosx cloud instance
-        # (~7)
-        assert_greater_equal(6, len(results))
+        # consumers should not be able to consume all produced items.
+        # production of 10 should take 3 unites, while consumers 10/2 (jobs)
+        # 5 units, so some should not have a chance.
+        assert_greater_equal(8, len(results))
 
     # Simulate situation close to what we have when outside code consumes
     # some yielded results and then "looses interest" (on_failure="error").

--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -195,11 +195,18 @@ def test_gracefull_death():
     # we will get some results, seems around 4 and they should be "sequential"
     assert_equal(results, list(range(len(results))))
     assert_greater_equal(len(results), 2)
-    if info_log_level and not (on_windows or on_osx):
-        # consumers should not be able to consume all produced items.
-        # production of 10 should take 3 unites, while consumers 10/2 (jobs)
-        # 5 units, so some should not have a chance.
-        assert_greater_equal(8, len(results))
+
+    # This test relies too much on threads scheduling to not hog up on handling
+    # consumers, but if it happens so - they might actually consume all results
+    # before producer decides to finally raise an exception.  As such it remains
+    # flaky and thus not ran, but could be useful to test locally while
+    # changing that logic.
+    #
+    # if info_log_level and not (on_windows or on_osx):
+    #     # consumers should not be able to consume all produced items.
+    #     # production of 10 should take 3 unites, while consumers 10/2 (jobs)
+    #     # 5 units, so some should not have a chance.
+    #     assert_greater_equal(8, len(results))
 
     # Simulate situation close to what we have when outside code consumes
     # some yielded results and then "looses interest" (on_failure="error").


### PR DESCRIPTION
so that consumers have a better chance to finish up at least some
jobs (we got assert_greater_equal(len(results), 2) failing), before
the whole thing fails and we raise right away (that is what this
portion of the test tests).

If this does not show to be a reliable workaround, since we do not
use  reraise_immediately=True  mode yet anywhere, I gues we could just
disable this portion of the test.

Closes #5746
