### PR TITLE
Clone URL mapping ability

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -125,22 +125,22 @@ class Clone(Interface):
     URL mapping configuration
 
     'clone' supports the transformation of URLs via (multi-part) substitution
-    specifications. Substitution specification is defined as a configuration
+    specifications. A substitution specification is defined as a configuration
     setting 'datalad.clone.url-substition.<seriesID>' with a string containing
     a match and substitution expression, each following Python's regular
     expression syntax. Both expressions are concatenated to a single string
     with an arbitrary delimiter character. The delimiter is defined by
-    prefixing the string with the delimiter. Prefix and delimiter are
-    stripped from the expressions (Example: ",^http://(.*)$,https://\\1").
-    This setting can be defined multiple times, using the same '<seriesID>'.
-    Substitutions will be applied incrementally, in order of their definition.
+    prefixing the string with the delimiter. Prefix and delimiter are stripped
+    from the expressions (Example: ",^http://(.*)$,https://\\1").  This setting
+    can be defined multiple times, using the same '<seriesID>'.  Substitutions
+    in a series will be applied incrementally, in order of their definition.
     The first substitution in such a series must match, otherwise no further
-    substitutions in a series will be considered. However, following the
-    first match all further substitutions in a series are processed,
-    regardless whether intermediate expressions match or not.
-
-    TODO continue once match preference (longest match?) is decided and
-    implemented.
+    substitutions in a series will be considered. However, following the first
+    match all further substitutions in a series are processed, regardless
+    whether intermediate expressions match or not. Substitution series themselves
+    have no particular order, each matching series will result in a candidate
+    clone URL. Consequently, the initial match specification in a series should
+    be as precise as possible to prevent inflation of candidate URLs.
 
     .. seealso::
 
@@ -379,6 +379,8 @@ def _get_url_mappings(cfg):
     # and in the common config specs
     from datalad.interface.common_cfg import definitions
     subst_keys.update(k for k in definitions if k.startswith(cfg_prefix))
+    # TODO a potential sorting of substitution series could be implemented
+    # here
     return [
         # decode the rule specifications
         get_replacement_dict(

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -11,7 +11,6 @@
 
 import logging
 import re
-import requests
 from os.path import expanduser
 from collections import OrderedDict
 from urllib.parse import unquote as urlunquote
@@ -32,7 +31,6 @@ from datalad.cmd import (
     CommandError,
     GitWitlessRunner,
     StdOutCapture,
-    StdOutErrCapture,
 )
 from datalad.distributed.ora_remote import (
     LocalIO,

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1604,14 +1604,6 @@ def test_clone_url_mapping(src_path, dest_path):
     eq_(submod_rec['gitmodule_url'], src_path)
 
 
-_github_map = {
-    'datalad.clone.url-substitute.github': (
-        r',https://github.com/([^/]+)/(.*)$,\1###\2',
-        r',[/\\]+,-',
-        r',\s+,_',
-        r',([^#]+)###(.*),https://github.com/\1/\2',
-    )
-}
 _nomatch_map = {
     'datalad.clone.url-substitute.nomatch': (
         ',nomatch,NULL',
@@ -1632,17 +1624,17 @@ def test_url_mapping_specs():
             (_windows_map,
              r'C:\Users\datalad\from',
              r'D:\to'),
-            # test standard github mapping
-            (_github_map,
+            # test standard github mapping, no pathc needed
+            ({},
              'https://github.com/datalad/testrepo_gh/sub _1',
              'https://github.com/datalad/testrepo_gh-sub__1'),
             # and on deep subdataset too
-            (_github_map,
+            ({},
              'https://github.com/datalad/testrepo_gh/sub _1/d/sub_-  1',
              'https://github.com/datalad/testrepo_gh-sub__1-d-sub_-_1'),
             # test that the presence of another mapping spec doesn't ruin
             # the outcome
-            (dict(_nomatch_map, **_github_map),
+            (_nomatch_map,
              'https://github.com/datalad/testrepo_gh/sub _1',
              'https://github.com/datalad/testrepo_gh-sub__1'),
             ):

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1564,3 +1564,87 @@ def test_clone_recorded_subds_reset(path):
     eq_(ds_b.subdatasets()[0]["gitshasum"],
         sub_repo.get_hexsha(
             sub_repo.get_corresponding_branch(branch) or branch))
+
+
+@with_tempfile
+@with_tempfile
+def test_clone_url_mapping(src_path, dest_path):
+    src = create(src_path)
+    dest = Dataset(dest_path)
+    # check that the impossible doesn't work
+    assert_raises(IncompleteResultsError, clone, 'rambo', dest_path)
+    # rather than adding test URL mapping here, consider
+    # test_url_mapping_specs(), it is cheaper there
+  
+    # anticipate windows test paths and escape them
+    escaped_subst = (r',rambo,%s' % src_path).replace('\\', '\\\\')
+    for specs in (
+            # we can clone with a simple substitution
+            {'datalad.clone.url-substitute.mike': escaped_subst},
+            # a prior match to a dysfunctional URL doesn't impact success
+            {
+                'datalad.clone.url-substitute.no': ',rambo,picknick',
+                'datalad.clone.url-substitute.mike': escaped_subst,
+            }):
+        try:
+            with patch.dict(dest.config._merged_store, specs):
+                clone('rambo', dest_path)
+        finally:
+            dest.remove(check=False)
+
+    # check submodule config impact
+    dest.create()
+    with patch.dict(dest.config._merged_store,
+                    {'datalad.clone.url-substitute.mike': escaped_subst}):
+        dest.clone('rambo', 'subds')
+    submod_rec = dest.repo.get_submodules()[0]
+    # we record the original-original URL
+    eq_(submod_rec['gitmodule_datalad-url'], 'rambo')
+    # and put the effective one as the primary URL
+    eq_(submod_rec['gitmodule_url'], src_path)
+
+
+_github_map = {
+    'datalad.clone.url-substitute.github': (
+        r',https://github.com/([^/]+)/(.*)$,\1###\2',
+        r',[/\\]+,-',
+        r',\s+,_',
+        r',([^#]+)###(.*),https://github.com/\1/\2',
+    )
+}
+_nomatch_map = {
+    'datalad.clone.url-substitute.nomatch': (
+        ',nomatch,NULL',
+    )
+}
+_windows_map = {
+    'datalad.clone.url-substitute.win': (
+        r',C:\\Users\\datalad\\from,D:\\to',
+    )
+}
+
+
+def test_url_mapping_specs():
+    from datalad.core.distributed.clone import _map_urls
+    cfg = ConfigManager()
+    for m, i, o in (
+            # path redirect on windows
+            (_windows_map,
+             r'C:\Users\datalad\from',
+             r'D:\to'),
+            # test standard github mapping
+            (_github_map,
+             'https://github.com/datalad/testrepo_gh/sub _1',
+             'https://github.com/datalad/testrepo_gh-sub__1'),
+            # and on deep subdataset too
+            (_github_map,
+             'https://github.com/datalad/testrepo_gh/sub _1/d/sub_-  1',
+             'https://github.com/datalad/testrepo_gh-sub__1-d-sub_-_1'),
+            # test that the presence of another mapping spec doesn't ruin
+            # the outcome
+            (dict(_nomatch_map, **_github_map),
+             'https://github.com/datalad/testrepo_gh/sub _1',
+             'https://github.com/datalad/testrepo_gh-sub__1'),
+            ):
+        with patch.dict(cfg._merged_store, m):
+            eq_(_map_urls(cfg, [i]), [o])

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1637,6 +1637,12 @@ def test_url_mapping_specs():
             (_nomatch_map,
              'https://github.com/datalad/testrepo_gh/sub _1',
              'https://github.com/datalad/testrepo_gh-sub__1'),
+            # verify OSF mapping, but see
+            # https://github.com/datalad/datalad/issues/5769 for future
+            # implications
+            ({},
+             'https://osf.io/q8xnk/',
+             'osf://q8xnk'),
             ):
         with patch.dict(cfg._merged_store, m):
             eq_(_map_urls(cfg, [i]), [o])

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -27,6 +27,39 @@ dirs = AppDirs("datalad", "datalad.org")
 
 
 definitions = {
+    'datalad.clone.url-substitute.github': {
+        'ui': ('question', {
+               'title': 'GitHub URL substitution rule',
+               'text': 'Substitution specification defined as a string with a '
+                       'match and substitution expression, each following '
+                       "Python's regular expression syntax. Both expressions "
+                       'are concatenated to a single string with an arbitrary '
+                       'delimiter character. The delimiter is defined by '
+                       'prefixing the string with the delimiter. Prefix and '
+                       'delimiter are stripped from the expressions '
+                       '(Example: ",^http://(.*)$,https://\\1"). '
+                       'This setting can be defined multiple times. '
+                       'Substitutions will be applied incrementally, in order '
+                       'of their definition. The first substitution in such '
+                       'a series must match, otherwise no further substitutions '
+                       'in a series will be considered. However, following the '
+                       'first match all further substitutions in a series are '
+                       'processed, regardless whether intermediate expressions '
+                       'match or not.'
+        }),
+        'destination': 'global',
+        'default': (
+            # take any github project URL apart into <org>###<identifier>
+            r',https?://github.com/([^/]+)/(.*)$,\1###\2',
+            # replace any (back)slashes with a single dash
+            r',[/\\]+,-',
+            # replace any whitespace (include urlquoted variant)
+            # with a single underscore
+            r',\s+|(%2520)+|(%20)+,_',
+            # rebuild functional project URL
+            r',([^#]+)###(.*),https://github.com/\1/\2',
+        )
+    },
     # this is actually used in downloaders, but kept cfg name original
     'datalad.crawl.cache': {
         'ui': ('yesno', {

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -25,27 +25,24 @@ from datalad.utils import on_windows
 
 dirs = AppDirs("datalad", "datalad.org")
 
+subst_rule_docs = """\
+A substitution specification is a string with a match and substitution
+expression, each following Python's regular expression syntax. Both expressions
+are concatenated to a single string with an arbitrary delimiter character. The
+delimiter is defined by prefixing the string with the delimiter. Prefix and
+delimiter are stripped from the expressions (Example:
+",^http://(.*)$,https://\\1").  This setting can be defined multiple times.
+Substitutions will be applied incrementally, in order of their definition. The
+first substitution in such a series must match, otherwise no further
+substitutions in a series will be considered. However, following the first
+match all further substitutions in a series are processed, regardless whether
+intermediate expressions match or not."""
 
 definitions = {
     'datalad.clone.url-substitute.github': {
         'ui': ('question', {
                'title': 'GitHub URL substitution rule',
-               'text': 'Substitution specification defined as a string with a '
-                       'match and substitution expression, each following '
-                       "Python's regular expression syntax. Both expressions "
-                       'are concatenated to a single string with an arbitrary '
-                       'delimiter character. The delimiter is defined by '
-                       'prefixing the string with the delimiter. Prefix and '
-                       'delimiter are stripped from the expressions '
-                       '(Example: ",^http://(.*)$,https://\\1"). '
-                       'This setting can be defined multiple times. '
-                       'Substitutions will be applied incrementally, in order '
-                       'of their definition. The first substitution in such '
-                       'a series must match, otherwise no further substitutions '
-                       'in a series will be considered. However, following the '
-                       'first match all further substitutions in a series are '
-                       'processed, regardless whether intermediate expressions '
-                       'match or not.'
+               'text': 'Mangling for GitHub-related URL. ' + subst_rule_docs
         }),
         'destination': 'global',
         'default': (
@@ -58,6 +55,21 @@ definitions = {
             r',\s+|(%2520)+|(%20)+,_',
             # rebuild functional project URL
             r',([^#]+)###(.*),https://github.com/\1/\2',
+        )
+    },
+    # TODO this one should migrate to the datalad-osf extension. however, right
+    # now extensions cannot provide default configuration
+    # https://github.com/datalad/datalad/issues/5769
+    'datalad.clone.url-substitute.osf': {
+        'ui': ('question', {
+               'title': 'Open Science Framework URL substitution rule',
+               'text': 'Mangling for OSF-related URLs. ' + subst_rule_docs
+        }),
+        'destination': 'global',
+        'default': (
+            # accept browser-provided URL and convert to those accepted by
+            # the datalad-osf extension
+            r',^https://osf.io/([^/]+)[/]*$,osf://\1',
         )
     },
     # this is actually used in downloaders, but kept cfg name original


### PR DESCRIPTION
This implements a simple feature and fix for #4822. It allows for configuring an arbitrary number of URL mapping specification. With this change one can configure datalad to transfer URLs like `https://osf.io/q8xnk/` (copied from a browser window), which do not work, but can be reliably mapped into working URLs (`osf://q8xnk` in this case) via a regular expression specification.

In the example above, this would do the trick:

```
datalad -c 'datalad.url.substitute.osf=,^https://osf.io/([^/]+)[/]*$,osf://\1' clone https://osf.io/q8xnk/
```

as usual, configuration is read from all supported places. Here is an example of a mapping rule
for GitHub

```
% datalad x-configuration
...
# GitHub URL substitution rule
# Substitution specification defined as a string with a match and
# substitution expression, each following Python's regular expression
# syntax. Both expressions are concatenated to a single string with an
# arbitrary delimiter character. The delimiter is defined by prefixing
# the string with the delimiter. Prefix and delimiter are stripped
# from the expressions (Example: ",^http://(.*)$,https://\1"). This
# setting can be defined multiple times. Substitutions will be applied
# incrementally, in order of their definition. The first substitution
# in such a series must match, otherwise no further substitutions in a
# series will be considered. However, following the first match all
# further substitutions in a series are processed, regardless whether
# intermediate expressions match or not.
datalad.clone.url-substitute.github=(',https?://github.com/([^/]+)/(.*)$,\\1###\\2', ',[/\\\\]+,-', ',\\s+|(%2520)+|(%20)+,_', ',([^#]+)###(.*),https://github.com/\\1/\\2')
...
```

It would be possible to implement a mechanism to read additional specifications from an entrypoint that can be provided by extensions. However, it would make also sense to finally support extension-provided (default) configuration and use that mechanism.

TODO:

- [x] Implement sketch for discussion
- [x] Documentation
- [x] Test
- [x] should it rather be `datalad.clone.url-substitute`? (to limit the scope)
- [x] Institutionalize OSF-related mapping from example above?

Closes #4822 