### PR TITLE
BF: Prefer committed subdataset location info over guesses

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -111,20 +111,20 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     cost is given in parenthesis, higher values indicate higher cost, and
     thus lower priority:
 
-    - URL of any configured superdataset remote that is known to have the
-      desired submodule commit, with the submodule path appended to it.
-      There can be more than one candidate (cost 500).
-
     - A datalad URL recorded in `.gitmodules` (cost 590). This allows for
       datalad URLs that require additional handling/resolution by datalad, like
       ria-schemes (ria+http, ria+ssh, etc.)
 
     - A URL or absolute path recorded for git in `.gitmodules` (cost 600).
 
+    - URL of any configured superdataset remote that is known to have the
+      desired submodule commit, with the submodule path appended to it.
+      There can be more than one candidate (cost 650).
+
     - In case `.gitmodules` contains a relative path instead of a URL,
       the URL of any configured superdataset remote that is known to have the
       desired submodule commit, with this relative path appended to it.
-      There can be more than one candidate (cost 500).
+      There can be more than one candidate (cost 650).
 
     - In case `.gitmodules` contains a relative path as a URL, the absolute
       path of the superdataset, appended with this relative path (cost 900).
@@ -218,7 +218,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                 sm_path_url = sm_path
 
             clone_urls.extend(
-                dict(cost=500, name=remote, url=url)
+                dict(cost=650, name=remote, url=url)
                 for url in _get_flexible_source_candidates(
                     # alternate suffixes are tested by `clone` anyways
                     sm_path_url, remote_url, alternate_suffix=False)

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -104,20 +104,20 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     # own location default remote for current branch
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path)),
-        [dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath)])
+        [dict(cost=650, name=DEFAULT_REMOTE, url=ds_subpath)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=sshurl)),
-        [dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
-         dict(cost=600, name=DEFAULT_REMOTE, url=sshurl)])
+        [dict(cost=600, name=DEFAULT_REMOTE, url=sshurl),
+         dict(cost=650, name=DEFAULT_REMOTE, url=ds_subpath)])
     eq_(f(clone, dict(path=clone_subpath, parentds=clone.path, gitmodule_url=httpurl)),
-        [dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
-         dict(cost=600, name=DEFAULT_REMOTE, url=httpurl)])
+        [dict(cost=600, name=DEFAULT_REMOTE, url=httpurl),
+         dict(cost=650, name=DEFAULT_REMOTE, url=ds_subpath)])
 
     # make sure it does meaningful things in an actual clone with an actual
     # record of a subdataset
     clone_subpath = str(clone.pathobj / 'sub')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+            dict(cost=600, name=DEFAULT_REMOTE, url=ds_subpath),
     ])
 
     # check that a configured remote WITHOUT the desired submodule commit
@@ -126,7 +126,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
                    result_renderer='disabled')
     eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
         [
-            dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+            dict(cost=600, name=DEFAULT_REMOTE, url=ds_subpath),
     ])
     # inject a source URL config, should alter the result accordingly
     with patch.dict(
@@ -134,7 +134,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'youredead'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+                dict(cost=600, name=DEFAULT_REMOTE, url=ds_subpath),
                 dict(cost=700, name='bang', url='youredead', from_config=True),
         ])
     # we can alter the cost by given the name a two-digit prefix
@@ -144,7 +144,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
                 dict(cost=400, name='bang', url='youredead', from_config=True),
-                dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+                dict(cost=600, name=DEFAULT_REMOTE, url=ds_subpath),
         ])
     # verify template instantiation works
     with patch.dict(
@@ -152,7 +152,7 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
             {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'pre-{id}-post'}):
         eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
             [
-                dict(cost=500, name=DEFAULT_REMOTE, url=ds_subpath),
+                dict(cost=600, name=DEFAULT_REMOTE, url=ds_subpath),
                 dict(cost=700, name='bang', url='pre-{}-post'.format(sub.id),
                      from_config=True),
         ])

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -285,6 +285,10 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
     # we will be publishing back to origin, so to not alter testrepo
     # we will first clone it
     origin = install(origin_path, source=pristine_origin, recursive=True)
+    # uncouple subdataset from testrepo sources after recursive install
+    # to make this clone the source of all `get` attempts
+    for sub in origin.subdatasets(result_xfm=lambda x: x['gitmodule_name']):
+        origin.subdatasets(path=sub, set_property=[('url', './{}'.format(sub))])
     # prepare src
     source = install(src_path, source=origin.path, recursive=True)
     # we will be trying to push into this later on, need to give permissions...
@@ -366,14 +370,12 @@ def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub
 
     # still nothing gets pushed, because origin is up to date
     res_ = publish(dataset=source, recursive=True, since='HEAD^')
-    assert_result_count(
-        res_, 3, status='notneeded', type='dataset')
+    assert_status('notneeded', res_)
 
     # and we should not fail if we run it from within the dataset
     with chpwd(source.path):
         res_ = publish(recursive=True, since='HEAD^')
-        assert_result_count(
-            res_, 3, status='notneeded', type='dataset')
+        assert_status('notneeded', res_)
 
     # Let's now update one subm
     with open(opj(sub2.path, "file.txt"), 'w') as f:

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -79,6 +79,10 @@ def test_update_simple(origin, src_path, dst_path):
     # forget we cloned it by removing remote, which should lead to
     # setting tracking branch to target:
     source.repo.remove_remote(DEFAULT_REMOTE)
+    # also forget the declared absolute location of the submodules, and turn them
+    # relative to this/a clone
+    for sub in source.subdatasets(result_xfm=lambda x: x['gitmodule_name']):
+        source.subdatasets(path=sub, set_property=[('url', './{}'.format(sub))])
 
     # dataset without sibling will not need updates
     assert_status('notneeded', source.update())
@@ -190,7 +194,7 @@ def test_update_simple(origin, src_path, dst_path):
         dest.update(merge=True, recursive=True), 2,
         action='update', status='ok', type='dataset')
     # and now we can get new file
-    dest.get('2/load.dat')
+    dest.get(opj('2', 'load.dat'))
     ok_file_has_content(opj(dest.path, '2', 'load.dat'), 'heavy')
 
 


### PR DESCRIPTION
gh-5033 describes a situation where the installation of a sub-subdataset
fails due to the particular condition of the _checkout_ the subdataset
was cloned from. The issues originally expressed the desire for a more
in-depth exploration of possible superdatasets and their subdataset
configurations. However, the undesirable failure can also be avoided by
simply preferring the location information that is committed in each
superdataset, at all clone iterations on the way to a target subdataset.

Effectively, the change reorders the locations priorities from

1. Assumed availability within the assumed existing checkout of the
   superdataset
2. Location info from .gitmodules

to

1. Location info from .gitmodules
2. Other candidates and guesses

Specifically, the following URLs will be tried by default:

1. original URL given to datalad when registering the subdataset
2. `url` from .gitmodules
3. other candidates

Changes to this default order are possible via configuration changes, of
course.

Resolves datalad/datalad#5033