### PR TITLE
BF: Make cmdline interface report exceptions again

### DIFF
--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -36,7 +36,7 @@ from ..utils import (
     on_msys_tainted_paths,
     setup_exceptionhook,
 )
-from ..dochelpers import exc_str
+from ..dochelpers import exc_str_old
 from ..version import __full_version__
 
 
@@ -130,7 +130,7 @@ def setup_parser(
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
                   __full_version__, parsed_args, unparsed_args)
     except Exception as exc:
-        lgr.debug("Early parsing failed with %s", exc_str(exc))
+        lgr.debug("Early parsing failed with %s", exc_str_old(exc))
         need_single_subparser = False
         unparsed_args = cmdlineargs[1:]  # referenced before assignment otherwise
 
@@ -343,7 +343,7 @@ def add_entrypoints_to_interface_groups(interface_groups):
             interface_groups.append((ep.name, spec[0], spec[1]))
             lgr.debug('Loaded entrypoint %s', ep.name)
         except Exception as e:
-            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str(e))
+            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str_old(e))
             continue
 
 def _fix_datalad_ri(s):
@@ -445,7 +445,7 @@ def main(args=None):
                 ret = cmdlineargs.func(cmdlineargs)
             except InsufficientArgumentsError as exc:
                 # if the func reports inappropriate usage, give help output
-                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
+                lgr.error('%s (%s)', exc_str_old(exc), exc.__class__.__name__)
                 cmdlineargs.subparser.print_usage(sys.stderr)
                 sys.exit(2)
             except IncompleteResultsError as exc:
@@ -457,7 +457,7 @@ def main(args=None):
                 # in general we do not want to see the error again, but
                 # present in debug output
                 lgr.debug('could not perform all requested actions: %s',
-                          exc_str(exc))
+                          exc_str_old(exc))
                 sys.exit(1)
             except CommandError as exc:
                 # behave as if the command ran directly, importantly pass
@@ -476,7 +476,7 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
-                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
+                lgr.error('%s (%s)', exc_str_old(exc), exc.__class__.__name__)
                 sys.exit(1)
     else:
         # just let argparser spit out its error, since there is smth wrong
@@ -490,7 +490,7 @@ def main(args=None):
         if hasattr(cmdlineargs, 'result_renderer'):
             cmdlineargs.result_renderer(ret, cmdlineargs)
     except Exception as exc:
-        lgr.error("Failed to render results due to %s", exc_str(exc))
+        lgr.error("Failed to render results due to %s", exc_str_old(exc))
         sys.exit(1)
 
 lgr.log(5, "Done importing cmdline.main")


### PR DESCRIPTION
This partially reverts the behavior change introduced with #5691.
It is universally not desirable to spit out empty error log message
even when exception logging is disabled by default. When this happens
in the outer shell of the cmdline interface, there is no further layer
to perform any kind of introspection. Instead, a user is left clueless
and without any information.

This change switches back to the old implementation for this outer
layer.

Fixes datalad/datalad#5761