### PR TITLE
[JOSS review] Change bib classification of BIDS paper

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -174,7 +174,7 @@
     year={2021}
 }
 
-@misc{bids:paper,
+@article{bids:paper,
 	doi = {10.1038/sdata.2016.44},
 	url = {https://doi.org/10.1038/sdata.2016.44},
 	year = 2016,


### PR DESCRIPTION
The current bibliography item that gets rendered into the article is a bit wonky (including the publisher name, for example). I think that reclassifying this explicitly as an article may make the rendered bibliography item more conformant.

