### PR TITLE
ENH (UX): add python-gitlab dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ requires = {
     'publish': [
         'jsmin',             # nice to have, and actually also involved in `install`
         'PyGithub',          # nice to have
+        'python-gitlab',     # required for create-sibling-gitlab
     ],
     'misc': [
         'pyperclip',         # clipboard manipulations


### PR DESCRIPTION
Fixes #4344

Adds `python-gitlab` to setup.py so that it does not have to be installed manually when users want to run `create-sibling-gitlab`