### PR TITLE
New config `datalad.credentials.force-ask` to force interactive credential updates

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -80,6 +80,15 @@ definitions = {
         'destination': 'local',
         'type': bool,
     },
+    # this is actually used in downloaders, but kept cfg name original
+    'datalad.credentials.force-ask': {
+        'ui': ('yesno', {
+               'title': 'Force (re-)entry of credentials',
+               'text': 'Should DataLad prompt for credential (re-)entry? This '
+                       'can be used to update previously stored credentials.'}),
+        'type': bool,
+        'default': False,
+    },
     'datalad.externals.nda.dbserver': {
         'ui': ('question', {
                'title': 'NDA database server',


### PR DESCRIPTION
This change introduces a new configuration setting:

```
 % datalad x-configuration
 ...
 # Force (re-)entry of credentials
 # Should DataLad prompt for credential (re-)entry? This can be used to
 # update previously stored credentials.
 datalad.credentials.force-ask=False
 ...
```

It enables seamless updates of stored credentials. Importantly, users
are no longer required to learn where credentials are stored, and how to
update them in that store. It makes instructions provided in the
handbook on how to learn python `keyring` superfluous. Credential
updates are simply entered at the same place where the original
credentials were provided.

This is not a perfect solution (can get messy when there are a
number of credentials involved in a single datalad operation, and only a
single one needs updating), but it addresses a substantial usability
issue for a broad range of use cases in a straightforward manner.

Besides being compatible with the usual ways of DataLad configuration
handling, this also works for plain git-annex calls that trigger
DataLad's credential handling, e.g.:

```
git -c datalad.credentials.force-ask=no annex get T1w_acpc_dc.nii.gz
```

Fixes datalad/datalad#5775

This is related to #396 by addressing the "update" use case.