### PR TITLE
fix a bug in descriptor name rendering

### DIFF
--- a/datalad/cmd_protocols.py
+++ b/datalad/cmd_protocols.py
@@ -83,7 +83,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
         pass
 
     def _log_summary(self, fd, data):
-        fd_name = self.fd_infos[fd]
+        fd_name = self.fd_infos[fd][0]
         lgr.log(5, 'Read %i bytes from %i[%s]%s',
                 len(data), self.process.pid, fd_name, ':' if self._log_outputs else '')
         if self._log_outputs:


### PR DESCRIPTION
This fixes #5774 

Thanks to @mih for catching the bug before the 0.15 release.

Due to a missing array dereferencing the complete hitherto buffered output data of a command execution was written into each log message that logged received data.
