### PR TITLE
Tests: Allow for version to contain + as a separator and provide more information for version related comparisons

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -218,7 +218,7 @@ def test_script_shims():
         version = (out['stdout'] + out['stderr']).splitlines()[0].split(' ', 1)[1]
         # we can get git and non git .dev version... so for now
         # relax
-        get_numeric_portion = lambda v: [x for x in v.split('.') if x.isdigit()]
+        get_numeric_portion = lambda v: [x for x in re.split('[+.]', v) if x.isdigit()]
         # extract numeric portion
         assert get_numeric_portion(version) # that my lambda is correctish
         assert_equal(get_numeric_portion(__version__),

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -220,7 +220,7 @@ def test_script_shims():
         # relax
         get_numeric_portion = lambda v: [x for x in re.split('[+.]', v) if x.isdigit()]
         # extract numeric portion
-        assert get_numeric_portion(version) # that my lambda is correctish
+        assert get_numeric_portion(version), f"Got no numeric portion from {version}"
         assert_equal(get_numeric_portion(__version__),
                      get_numeric_portion(version))
 

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -54,6 +54,11 @@ def test_external_versions_basic():
     assert_equal(ev[our_module], __version__)
     # and it could be compared
     assert_greater_equal(ev[our_module], __version__)
+    # We got some odd failure in this test not long are after switching to versionner
+    # https://github.com/datalad/datalad/issues/5785.  Verify that we do get expected
+    # data types
+    our_version = ev[our_module].version
+    assert isinstance(our_version, (str, list)), f"Got {our_version!r} of type {type(our_version)}"
     assert_greater(ev[our_module], '0.1')
     assert_equal(list(ev.keys()), [our_module])
     assert_true(our_module in ev)


### PR DESCRIPTION
To partially address and provide more information to figure out details of https://github.com/datalad/datalad/issues/5785