### PR TITLE
ENH(UX,DX): inform user with a warning if version is 0+unknown

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -263,6 +263,17 @@ def teardown_package():
     AnnexRepo._ALLOW_LOCAL_URLS = False  # stay safe!
 
 
-lgr.log(5, "Done importing main __init__")
-
 from .version import __version__
+
+if str(__version__) == '0' or __version__.startswith('0+'):
+    lgr.warning(
+        "DataLad was not installed 'properly' so its version is an uninformative %r.\n"
+        "It can happen e.g. if datalad was installed via\n"
+        "  pip install https://github.com/.../archive/{commitish}.zip\n"
+        "instead of\n"
+        "  pip install git+https://github.com/...@{commitish} .\n"
+        "We advise to re-install datalad or downstream projects might not operate correctly.",
+        __version__
+    )
+
+lgr.log(5, "Done importing main __init__")


### PR DESCRIPTION
A possible to encounter side-effect from using versioneer.  See
https://github.com/datalad/datalad/issues/5785
for more information.  Overall I take it to Closes #5785 

Results in
```shell
$> python -c 'import datalad'                    
[WARNING] DataLad was not installed 'properly' so its version is an uninformative '0+unknown'.
| It can happen e.g. if datalad was installed via
|   pip install https://github.com/.../archive/{commitish}.zip
| instead of
|   pip install git+https://github.com/...@{commitish} .
| We advise to re-install datalad or downstream projects might not operate correctly. 
```

I think that is good enough/better than nothing ;)

edit: fix for datalad/git-annex workflows is coming in https://github.com/datalad/git-annex/pull/72