### PR TITLE
Enable exception logging in test fixture

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,8 +51,6 @@ shallow_clone: true
 
 environment:
   DATALAD_TESTS_SSH: 1
-  # The following is currently necessary as we test a lot of logging output in high detail:
-  DATALAD_LOG_EXC: 1
 
   # Do not use `image` as a matrix dimension, to have fine-grained control over
   # what tests run on which platform

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -6,9 +6,6 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-    env:
-      # The following is currently necessary as we test a lot of logging output in high detail:
-      DATALAD_LOG_EXC: 1
     steps:
     - name: Set up system
       shell: bash

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   test:
     runs-on: macos-latest
-    env:
-      # The following is currently necessary as we test a lot of logging output in high detail:
-      DATALAD_LOG_EXC: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -6,9 +6,6 @@ jobs:
   test:
 
     runs-on: windows-2019
-    env:
-      # The following is currently necessary as we test a lot of logging output in high detail:
-      DATALAD_LOG_EXC: 1
 
     strategy:
       fail-fast: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ env:
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
     - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20201007 -m conda"
-    # The following is currently necessary as we test a lot of logging output in high detail:
-    - DATALAD_LOG_EXC=1
 
 matrix:
   include:

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -135,6 +135,7 @@ def setup_package():
     # own HOME where we pre-setup git for testing (name, email)
     if 'GIT_HOME' in os.environ:
         set_envvar('HOME', os.environ['GIT_HOME'])
+        set_envvar('DATALAD_LOG_EXC', "1")
     else:
         # we setup our own new HOME, the BEST and HUGE one
         from datalad.utils import make_tempfile

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -149,6 +149,8 @@ def setup_package():
 [user]
 	name = DataLad Tester
 	email = test@example.com
+[datalad "log"]
+	exc = 1
 """)
         _TEMP_PATHS_GENERATED.append(new_home)
 

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -103,6 +103,8 @@ test_http_server = None
 def setup_package():
     import os
     from datalad.utils import on_osx
+    from datalad.tests import _TEMP_PATHS_GENERATED
+
     if on_osx:
         # enforce honoring TMPDIR (see gh-5307)
         import tempfile
@@ -136,7 +138,6 @@ def setup_package():
     else:
         # we setup our own new HOME, the BEST and HUGE one
         from datalad.utils import make_tempfile
-        from datalad.tests import _TEMP_PATHS_GENERATED
         # TODO: split into a function + context manager
         with make_tempfile(mkdir=True) as new_home:
             pass


### PR DESCRIPTION
Exception logging is now disabled by default in datalad, but tests are
still making detailed assertions about what is logged how. Running them
currently requires that config to be set.

However, eventually tests need to be adjusted and enable the config
themselves, if they are making assertions about logged exceptions.

Closes #5758

