### PR TITLE
BF: create-sibling-gitlab: do not skip root dataset when path is given

### DIFF
--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -237,13 +237,16 @@ class CreateSiblingGitlab(Interface):
         siteobjs = dict()
 
         # which datasets to process?
-        if path is None:
+        if path is None or ds.pathobj in path:
             for r in _proc_dataset(
                     ds, ds,
                     site, project, name, layout, existing, access,
                     dryrun, siteobjs, publish_depends, description):
                 yield r
-        if path or recursive:
+        # we need to find a subdataset when recursing, or when there is a path that
+        # could point to one, we have to exclude the parent dataset in this test
+        # to avoid undesired level-1 recursion into subdatasets
+        if any(p != ds.pathobj for p in (path or [])) or recursive:
             # also include any matching subdatasets
             for subds in ds.subdatasets(
                     path=path,

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -77,15 +77,17 @@ def test_dryrun(path):
         site='dummy', sibling='dummy',
     )
     # now a working, fully manual call
-    res = ctlg['root'].create_sibling_gitlab(
-        dryrun=True, on_failure='ignore',
-        site='dummy', project='here',
-    )
-    assert_result_count(res, 1)
-    assert_result_count(
-        res, 1, path=ctlg['root'].path, type='dataset', status='ok',
-        site='dummy', sibling='dummy', project='here',
-    )
+    for p in (None, ctlg['root'].path):
+        res = ctlg['root'].create_sibling_gitlab(
+            dryrun=True, on_failure='ignore',
+            site='dummy', project='here',
+            path=p,
+        )
+        assert_result_count(res, 1)
+        assert_result_count(
+            res, 1, path=ctlg['root'].path, type='dataset', status='ok',
+            site='dummy', sibling='dummy', project='here',
+        )
 
     # now configure a default gitlab site
     ctlg['root'].config.set('datalad.gitlab-default-site', 'theone')
@@ -324,7 +326,7 @@ def test_fake_gitlab(path):
 
     # try recreation, the sibling is already configured, same setup, no error
     with patch("datalad.distributed.create_sibling_gitlab.GitLabSite", _ExistingProjectGitLab):
-        res = ds.create_sibling_gitlab(site='dummy', project='here')
+        res = ds.create_sibling_gitlab(path=ds.path, site='dummy', project='here')
         assert_result_count(res, 2)
         assert_result_count(
             res, 1, action='create_sibling_gitlab', path=path,


### PR DESCRIPTION
Before `datalad create-sibling-gitlab .` would just do nothing.
Now the root dataset is processed if a given path matches it.

Fixes datalad/datalad#5763