### PR TITLE
BF: ORA incorrectly handled redirects

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -645,7 +645,7 @@ class HTTPRemoteIO(object):
         # to annexremote.dirhash from within IO classes
 
         url = self.base_url + "/annex/objects/" + str(key_path)
-        response = requests.head(url)
+        response = requests.head(url, allow_redirects=True)
         return response.status_code == 200
 
     def get(self, key_path, filename, progress_cb):


### PR DESCRIPTION
The ORA special remote's HEAD request was send w/o
`allow_redirects=True`, which defaults to False. This led CHECKPRESENT
requests to fail.

Closes #5616
