### PR TITLE
git-credential interfaces (datalad's in Git and vice versa)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,6 +53,9 @@ shallow_clone: false
 
 environment:
   DATALAD_TESTS_SSH: 1
+  # Prevent interactive credential entry (note "true" is the command to run)
+  # See also the core.askPass setting below
+  GIT_ASKPASS: true
 
   # Do not use `image` as a matrix dimension, to have fine-grained control over
   # what tests run on which platform
@@ -220,6 +223,8 @@ init:
   # Identity setup
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"
+  # Companion to the GIT_ASKPASS environment setting above
+  - git config --global core.askPass ""
   # globally setting filter.annex.process (needs git-annex 8.20211117) to reduce git-add runtime
   # https://git-annex.branchable.com/bugs/Windows__58___substantial_per-file_cost_for___96__add__96__/
   - cmd: git config --system filter.annex.process "git-annex filter-process"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,6 +19,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
+        # Prevent interactive credential entry
+        # See also the GIT_ASKPASS env var below
+        git config --global core.askPass ""
+
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -35,6 +39,9 @@ jobs:
       env:
         # fake environment to be able to reuse script for travis
         TRAVIS_PULL_REQUEST: true
+        # Prevent interactive credential entry (note "true" is the command to run)
+        GIT_ASKPASS: true
+
       run: |
         tools/ci/benchmark-travis-pr.sh
     - name: Compare

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -26,6 +26,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
+        # Prevent interactive credential entry
+        # See also the GIT_ASKPASS env var below
+        git config --global core.askPass ""
+
     - uses: actions/checkout@v1
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
@@ -43,6 +47,9 @@ jobs:
       env:
         # forces all test repos/paths into the VFAT FS
         TMPDIR: /crippledfs
+        # Prevent interactive credential entry
+        # (note "true" is the command to run)
+        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -29,6 +29,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
+        # Prevent interactive credential entry
+        # See also the GIT_ASKPASS env var below
+        git config --global core.askPass ""
+
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -57,6 +61,10 @@ jobs:
       run: |
         datalad wtf
     - name: ${{ matrix.extension }} tests
+      env:
+        # Prevent interactive credential entry
+        # (note "true" is the command to run)
+        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -19,6 +19,10 @@ jobs:
         brew install exempi
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
+        # Prevent interactive credential entry
+        # See also the GIT_ASKPASS env var below
+        git config --global core.askPass ""
+
 
     - uses: actions/checkout@v1
 
@@ -45,6 +49,10 @@ jobs:
         datalad wtf
 
     - name: Run tests
+      env:
+        # Prevent interactive credential entry
+        # (note "true" is the command to run)
+        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -28,6 +28,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
+        # Prevent interactive credential entry
+        # See also the GIT_ASKPASS env var below
+        git config --global core.askPass ""
+
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -52,6 +56,10 @@ jobs:
         datalad wtf
         dir
     - name: ${{ matrix.module }} tests
+      env:
+        # Prevent interactive credential entry
+        # (note "true" is the command to run)
+        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ env:
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
     - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20201007 -m conda"
+    # Prevent interactive credential entry (note "true" is the command to run)
+    # See also the core.askPass setting below
+    - GIT_ASKPASS=true
 
 matrix:
   include:
@@ -218,6 +221,13 @@ before_install:
 install:
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
+  # Don't let git ask for credentials in CI runs. Note, that this variable
+  # technically is not a flag, but an executable (which is why name and value
+  # are a bit confusing here - we just want a no-op basically). The environment
+  # variable GIT_ASKPASS overwrites this, but neither env var nor this config
+  # are supported by git-credential on all systems and git versions (most recent
+  # ones should work either way, though). Hence use both across CI builds.
+  - git config --global core.askPass ""
   - cd ..; pip install -q codecov; cd -
   - pip install -r requirements-devel.txt
   # So we could test under sudo -E with PATH pointing to installed location

--- a/datalad/downloaders/__init__.py
+++ b/datalad/downloaders/__init__.py
@@ -10,6 +10,14 @@
 
 """
 
+from datalad.downloaders.credentials import (
+    AWS_S3,
+    LORIS_Token,
+    NDA_S3,
+    Token,
+    UserPassword,
+    GitCredential)
+
 __docformat__ = 'restructuredtext'
 
 from logging import getLogger
@@ -18,3 +26,11 @@ lgr = getLogger('datalad.providers')
 # TODO: we might not need to instantiate it right here
 # lgr.debug("Initializing data providers credentials interface")
 # providers = Providers().from_config_files()
+CREDENTIAL_TYPES = {
+    'user_password': UserPassword,
+    'aws-s3': AWS_S3,
+    'nda-s3': NDA_S3,
+    'token': Token,
+    'loris-token': LORIS_Token,
+    'git': GitCredential,
+}

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -167,6 +167,7 @@ class HTTPBaseAuthenticator(Authenticator):
         # we should use specified URL for this authentication first
         lgr.info("http session: Authenticating into session for %s", url)
         post_url = self.url if self.url else url
+        credential.set_context(auth_url=post_url)
         credentials = credential()
 
         # The whole thing relies on server first spitting out 401
@@ -303,6 +304,10 @@ class HTMLFormAuthenticator(HTTPBaseAuthenticator):
 @auto_repr
 class HTTPRequestsAuthenticator(HTTPBaseAuthenticator):
     """Base class for various authenticators using requests pre-crafted ones
+
+
+    Note, that current implementation assumes REQUESTS_FIELDS to be identical to
+    the keys of a `Credential` object's FIELDS.
     """
 
     REQUESTS_AUTHENTICATOR = None

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -12,7 +12,6 @@
 from glob import glob
 from logging import getLogger
 
-import os
 import re
 from os.path import dirname, abspath, join as pathjoin
 from urllib.parse import urlparse
@@ -32,12 +31,15 @@ from .http import (
 from .s3 import S3Authenticator, S3Downloader
 from .shub import SHubDownloader
 from configparser import ConfigParser as SafeConfigParserWithIncludes
-from ..support.external_versions import external_versions
-from ..support.network import RI
-from ..support import path
-from ..utils import auto_repr
-from ..utils import ensure_list_from_str
-from ..utils import get_dataset_root
+from datalad.support.external_versions import external_versions
+from datalad.support.network import RI
+from datalad.support import path
+from datalad.utils import (
+    auto_repr,
+    ensure_list_from_str,
+    get_dataset_root,
+    Path,
+)
 
 from ..interface.common_cfg import dirs
 
@@ -59,7 +61,7 @@ AUTHENTICATION_TYPES = {
     'none': NoneAuthenticator,
 }
 
-from .credentials import CREDENTIAL_TYPES
+from datalad.downloaders import CREDENTIAL_TYPES
 
 
 @auto_repr
@@ -156,6 +158,23 @@ class Providers(object):
 
     _DEFAULT_PROVIDERS = None
     _DS_ROOT = None
+    _CONFIG_TEMPLATE = """\
+# Provider configuration file created to initially access
+# {url}
+
+[provider:{name}]
+url_re = {url_re}
+authentication_type = {authentication_type}
+# Note that you might need to specify additional fields specific to the
+# authenticator.  Fow now "look into the docs/source" of {authenticator_class}
+# {authentication_type}_
+credential = {credential_name}
+
+[credential:{credential_name}]
+# If known, specify URL or email to how/where to request credentials
+# url = ???
+type = {credential_type}
+"""
 
     def __init__(self, providers=None):
         """
@@ -261,6 +280,8 @@ class Providers(object):
                     raise ValueError("Unknown credential %s. Known are: %s"
                                      % (provider.credential, ", ".join(credentials.keys())))
                 provider.credential = credentials[provider.credential]
+                # TODO: Is this the right place to pass dataset to credential?
+                provider.credential.set_context(dataset=cls._DS_ROOT)
 
         providers = Providers(list(providers.values()))
 
@@ -363,10 +384,74 @@ class Providers(object):
                   scheme, provider)
         return provider
 
-    def enter_new(self, url=None, auth_types=[]):
+    def _store_new(self, url=None, authentication_type=None,
+                   authenticator_class=None, url_re=None, name=None,
+                   credential_name=None, credential_type=None, level='user'):
+        """Stores a provider and credential config and reloads afterwards.
+
+        Note
+        ----
+        non-interactive version of `enter_new`.
+        For now non-public, pending further refactoring
+
+        Parameters
+        ----------
+        level: str
+          Where to store the config. Choices: 'user' (default), 'ds', 'site'
+
+        Returns
+        -------
+        Provider
+          The stored `Provider` as reported by reload
+        """
+
+        # We don't ask user for confirmation, so for this non-interactive
+        # routine require everything to be explicitly specified.
+        if any(not a for a in [url, authentication_type, authenticator_class,
+                               url_re, name, credential_name, credential_type]):
+            raise ValueError("All arguments must be specified")
+
+        if level not in ['user', 'ds', 'site']:
+            raise ValueError("'level' must be one of 'user', 'ds', 'site'")
+
+        providers_dir = Path(self._get_providers_dirs()[level])
+        if not providers_dir.exists():
+            providers_dir.mkdir(parents=True, exist_ok=True)
+        filepath = providers_dir / f"{name}.cfg"
+        cfg = self._CONFIG_TEMPLATE.format(**locals())
+        filepath.write_bytes(cfg.encode('utf-8'))
+        self.reload()
+        return self.get_provider(url)
+
+    def enter_new(self, url=None, auth_types=[], url_re=None, name=None,
+                  credential_name=None, credential_type=None):
+        # TODO: level/location!
+        """Create new provider and credential config
+
+        If interactive, this will ask the user to enter the details (or confirm
+        default choices). A dedicated config file is written at
+        <user_config_dir>/providers/<name>.cfg
+
+        Parameters:
+        -----------
+        url: str or RI
+          URL this config is created for
+        auth_types: list
+          List of authentication types to choose from. First entry becomes
+          default. See datalad.downloaders.providers.AUTHENTICATION_TYPES
+        url_re: str
+          regular expression; Once created, this config will be used for any
+          matching URL; defaults to `url`
+        name: str
+          name for the provider; needs to be unique per user
+        credential_name: str
+          name for the credential; defaults to the provider's name
+        credential_type: str
+          credential type to use (key for datalad.downloaders.CREDENTIAL_TYPES)
+        """
+
         from datalad.ui import ui
-        name = None
-        if url:
+        if url and not name:
             ri = RI(url)
             for f in ('hostname', 'name'):
                 try:
@@ -398,7 +483,10 @@ class Providers(object):
             else:
                 break
 
-        url_re = re.escape(url) if url else None
+        if not credential_name:
+            credential_name = name
+        if not url_re:
+            url_re = re.escape(url) if url else None
         while True:
             url_re = ui.question(
                 title="New provider regular expression",
@@ -439,42 +527,30 @@ class Providers(object):
             title="Credential",
             text="What type of credential should be used?",
             choices=sorted(CREDENTIAL_TYPES),
-            default=getattr(authenticator_class, 'DEFAULT_CREDENTIAL_TYPE')
+            default=credential_type or getattr(authenticator_class,
+                                               'DEFAULT_CREDENTIAL_TYPE')
         )
 
-        # Just create a configuration file and reload the thing
-        if not path.lexists(providers_user_dir):
-            os.makedirs(providers_user_dir)
-        cfg = """\
-# Provider configuration file created to initially access
-# {url}
-
-[provider:{name}]
-url_re = {url_re}
-authentication_type = {authentication_type}
-# Note that you might need to specify additional fields specific to the
-# authenticator.  Fow now "look into the docs/source" of {authenticator_class}
-# {authentication_type}_
-credential = {name}
-
-[credential:{name}]
-# If known, specify URL or email to how/where to request credentials
-# url = ???
-type = {credential_type}
-""".format(**locals())
+        cfg = self._CONFIG_TEMPLATE.format(**locals())
         if ui.yesno(
             title="Save provider configuration file",
             text="Following configuration will be written to %s:\n%s"
                 % (filename, cfg),
             default='yes'
         ):
-            with open(filename, 'wb') as f:
-                f.write(cfg.encode('utf-8'))
+            # Just create a configuration file and reload the thing
+            return self._store_new(url=url,
+                                   authentication_type=authentication_type,
+                                   authenticator_class=authenticator_class,
+                                   url_re=url_re,
+                                   name=name,
+                                   credential_name=credential_name,
+                                   credential_type=credential_type,
+                                   level='user'
+                                   )
         else:
             return None
-        self.reload()
-        # XXX see above note about possibly multiple matches etc
-        return self.get_provider(url)
+
 
     # TODO: avoid duplication somehow ;)
     # Sugarings to get easier access to downloaders

--- a/datalad/downloaders/tests/test_credentials.py
+++ b/datalad/downloaders/tests/test_credentials.py
@@ -22,6 +22,7 @@ from datalad.tests.utils import (
     with_testsui,
 )
 from datalad.support.external_versions import external_versions
+from datalad.api import Dataset
 from datalad.support.keyring_ import (
     Keyring,
     MemoryKeyring,
@@ -29,6 +30,7 @@ from datalad.support.keyring_ import (
 from ..credentials import (
     AWS_S3,
     CompositeCredential,
+    GitCredential,
     UserPassword,
 )
 from datalad import cfg as dlcfg
@@ -194,3 +196,112 @@ def test_delete_not_crashing(path):
         raise AssertionError("keyring still has our key")
     except AssertionError:
         pass
+
+
+@with_tempfile
+def test_gitcredential_read(path):
+
+    matching_url = "https://example.datalad.org"
+    non_matching_url = "http://some.other.org"
+    ds = Dataset(path).create()
+
+    # Set configs so git-credential does provide something,
+    # using an inline helper:
+
+    # Simple inline credential helper to provide a password to read.
+    # Strangely seems to pass on windows. Probably depends on what git is
+    # passing this definition to (git-bash).
+    cred_helper = \
+        "!f() { test \"$1\" = get && echo \"password=apassword\"; }; f"
+
+    ds.config.add(f"credential.{matching_url}.username", "auser",
+                  where="local")
+    ds.config.add(f"credential.{matching_url}.helper", cred_helper,
+                  where="local")
+
+    # we can get those credentials when the context is right:
+    cred = GitCredential("some", auth_url=matching_url,
+                         dataset=ds)
+
+    assert_true(cred.is_known)
+    assert_equal(cred.get('user'), 'auser')
+    assert_equal(cred.get('password'), 'apassword')
+
+    # env var overrules
+    import datalad
+    try:
+        with patch.dict('os.environ', {'DATALAD_CREDENTIAL_some_user': 'new'}):
+            datalad.cfg.reload()
+            assert_true(cred.is_known)
+            assert_equal(cred.get('user'), 'new')
+            assert_equal(cred.get('password'), 'apassword')
+            with patch.dict('os.environ',
+                            {'DATALAD_CREDENTIAL_some_password': 'pwd'}):
+                datalad.cfg.reload()
+                assert_true(cred.is_known)
+                assert_equal(cred.get('user'), 'new')
+                assert_equal(cred.get('password'), 'pwd')
+    finally:
+        datalad.cfg.reload()
+
+    # different context
+    cred = GitCredential("some", auth_url=non_matching_url,
+                         dataset=ds)
+    # unknown since git-credential config doesn't match
+    assert_false(cred.is_known)
+
+    # however, w/ env vars still works:
+    try:
+        with patch.dict('os.environ',
+                        {'DATALAD_CREDENTIAL_some_user': 'user3'}):
+            datalad.cfg.reload()
+            assert_false(cred.is_known)  # no pwd yet
+            assert_equal(cred.get('user'), 'user3')
+            assert_equal(cred.get('password'), None)
+            with patch.dict('os.environ',
+                            {'DATALAD_CREDENTIAL_some_password': 'pass3'}):
+                datalad.cfg.reload()
+                assert_true(cred.is_known)
+                assert_equal(cred.get('user'), 'user3')
+                assert_equal(cred.get('password'), 'pass3')
+        # without the env vars unknown yet again:
+        assert_false(cred.is_known)
+    finally:
+        datalad.cfg.reload()
+
+
+@with_tempfile
+def test_gitcredential(path):
+
+    # Note, that credential labels are irrelevant in context of the to be tested
+    # Object here.
+
+    matching_url = "https://example.datalad.org"
+    non_matching_url = "http://some.other.org"
+    ds = Dataset(path).create()
+    # use git native credential store
+    ds.config.add("credential.helper", "store", where='local')
+
+    # store credentials
+    cred = GitCredential("cred_label", auth_url=matching_url, dataset=ds)
+    cred.set(user="dl-user", password="dl-pwd")
+
+    # read it again
+    cred2 = GitCredential("whatever", auth_url=matching_url, dataset=ds)
+    assert_equal(cred2.get("user"), "dl-user")
+    assert_equal(cred2.get("password"), "dl-pwd")
+    # but doesn't deliver w/o matching url
+    cred3 = GitCredential("whatever", auth_url=non_matching_url, dataset=ds)
+    assert_equal(cred3.get("user"), None)
+    assert_equal(cred3.get("password"), None)
+
+    # delete it
+    cred2.delete()
+
+    # not there anymore
+    cred4 = GitCredential("yet_another", auth_url=matching_url, dataset=ds)
+    assert_equal(cred4.get("user"), None)
+    assert_equal(cred4.get("password"), None)
+
+    # delete non-existing
+    cred2.delete()

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -94,6 +94,16 @@ definitions = {
         'type': bool,
         'default': False,
     },
+    'datalad.credentials.githelper.noninteractive':{
+        'ui': ('yesno', {
+               'title': 'Non-interactive mode for git-credential helper',
+               'text': 'Should git-credential-datalad operate in '
+                       'non-interactive mode? This would mean to not ask for '
+                       'user confirmation when storing new '
+                       'credentials/provider configs.'}),
+        'type': bool,
+        'default': False,
+    },
     'datalad.externals.nda.dbserver': {
         'ui': ('question', {
                'title': 'NDA database server',

--- a/datalad/local/gitcredential.py
+++ b/datalad/local/gitcredential.py
@@ -1,0 +1,158 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+
+"""
+
+from io import StringIO
+
+from datalad.cmd import (
+    GitWitlessRunner,
+    StdOutErrCapture,
+)
+
+from logging import getLogger
+lgr = getLogger('datalad.local.gitcredentials')
+
+
+def _credspec2dict(spec):
+    """Parser for git-credential input/output format
+
+    See `man 1 git-credential` (INPUT/OUTPUT FORMAT)
+
+    Parameters
+    ----------
+    spec : file-like or IO stream
+
+    Returns
+    -------
+    dict
+    """
+    attrs = {}
+    for line in spec:
+        if not line:
+            # empty line ends specification
+            break
+        # protocol violations?
+        assert('=' in line)
+        assert(line[-1] == '\n')
+        k, v = line[:-1].split('=', maxsplit=1)
+        # w/o conversion to str this might be a _io.TextWrapper crashing further
+        # down the road (for example when passed to re.match):
+        attrs[k] = str(v)
+    return attrs
+
+
+class GitCredentialInterface(object):
+    """Frontend to `git credential`
+    """
+
+    def __init__(self, protocol=None, host=None, path=None, username=None,
+                 password=None, url=None, repo=None):
+        """
+        protocol: str, optional
+          The protocol over which the credential will be used (e.g., https).
+        host: str, optional
+          The remote hostname for a network credential. This includes the port
+          number if one was specified (e.g., "example.com:8088").
+        path: str, optional
+          The path with which the credential will be used. E.g., for accessing
+          a remote https repository, this will be the repository’s path on the
+          server.
+        username: str, optional
+          The credential’s username, if we already have one (e.g., from a URL,
+          the configuration, the user, or from a previously run helper).
+        password: str, optional
+          The credential’s password, if we are asking it to be stored.
+        url: str, optional
+          When this special attribute is read by git credential as 'url', the
+          value is parsed as a URL and treated as if its constituent parts were
+          read (e.g., url=https://example.com would behave as if
+          protocol=https and host=example.com had been provided).
+          This can help callers avoid parsing URLs themselves.
+
+          Note that specifying a protocol is mandatory and if the URL doesn’t
+          specify a hostname (e.g., "cert:///path/to/file") the credential will
+          contain a hostname attribute whose value is an empty string.
+
+          Components which are missing from the URL (e.g., there is no username
+          in the example above) will be left unset.
+        repo : GitRepo, optional
+            Specify to process credentials in the context of a particular
+            repository (e.g. to consider a repository-local credential helper
+            configuration).
+        """
+        self._runner = None
+        self._repo = repo
+        self._credential_props = {}
+        for name, var in (('url', url),
+                          ('protocol', protocol),
+                          ('host', host),
+                          ('path', path),
+                          ('username', username),
+                          ('password', password)):
+            if var is None:
+                continue
+            self._credential_props[name] = var
+
+    def _get_runner(self):
+        runner = self._runner or GitWitlessRunner(
+            cwd=self._repo.path if self._repo else None)
+        self._runner = runner
+        return runner
+
+    def _format_props(self):
+        props = ''
+        for p in self._credential_props:
+            val = self._credential_props.get(p)
+            if self._credential_props.get(p) is None:
+                continue
+            props += '{}={}\n'.format(p, val)
+
+        props = props.encode('utf-8')
+        if not props:
+            props = b'\n'
+        return props
+
+    def __getitem__(self, key):
+        return self._credential_props.__getitem__(key)
+
+    def __contains__(self, key):
+        return self._credential_props.__contains__(key)
+
+    def __repr__(self):
+        return repr(self._credential_props)
+
+    def fill(self):
+        # TODO we could prevent prompting by setting GIT_ASKPASS=true
+        # unclear how to achieve the same on windows
+        # would be better to use a special return value for no-prompt
+        # with GIT_ASKPASS=true would just be an empty string
+        out = self._get_runner().run(
+            ['git', 'credential', 'fill'],
+            protocol=StdOutErrCapture,
+            stdin=self._format_props()
+        )
+        attrs = _credspec2dict(StringIO(out['stdout']))
+        self._credential_props = attrs
+        return self
+
+    def approve(self):
+        self._get_runner().run(
+            ['git', 'credential', 'approve'],
+            stdin=self._format_props()
+        )
+
+    def reject(self):
+        self._get_runner().run(
+            ['git', 'credential', 'reject'],
+            stdin=self._format_props()
+        )
+
+

--- a/datalad/local/gitcredential_datalad.py
+++ b/datalad/local/gitcredential_datalad.py
@@ -1,0 +1,168 @@
+import sys
+
+from datalad.downloaders import UserPassword
+from datalad.downloaders.providers import (
+    AUTHENTICATION_TYPES,
+    Providers,
+)
+from datalad.local.gitcredential import _credspec2dict
+from datalad.utils import Path
+
+git_credential_datalad_help = """\
+Git credential interface to DataLad's credential management system.
+
+Only DataLad's UserPassword-type credentials are supported. This helper
+passes standard 'get', 'store' actions on to the respective interfaces in
+DataLad.
+The 'erase' action is not supported, since this is called by Git, when the
+credentials didn't work for a URL. However, DataLad's providers store a regex
+for matching URLs. That regex-credential combo may still be valid and simply
+too broad. We wouldn't want to auto-delete in that case. Another case is a
+somewhat circular setup: Another credential-helper provided the credentials and
+is also used by DataLad. The provider config connecting it to DataLad could be
+intentionally broad. Deleting credentials from keyring but keeping the provider
+config pointing to them, on the other hand,  would be even worse, as it would
+invalidate the provider config and also means rejecting credentials w/o context.
+Hence, this helper doesn't do anything on 'erase' at the moment.
+
+usage: git credential-datalad [option] <action>
+
+options:
+    -h                   Show this help.
+    --non-interactive    Don't ask for user confirmation when storing to
+                         DataLad's credential system. This may fail if default
+                         names result in a conflict with existing ones.
+                         This mode is used for DataLad's CI tests.
+"""
+
+
+def git_credential_datalad():
+    """Entrypoint to query DataLad's credentials via git-credential
+    """
+
+    if not 2 <= len(sys.argv) <= 3 \
+            or sys.argv[1] == "-h" \
+            or sys.argv[1] != "--non-interactive" \
+            or sys.argv[-1] not in ['get', 'store', 'erase']:
+        help_explicit = sys.argv[1] == "-h"
+        print(git_credential_datalad_help,
+              file=sys.stdout if help_explicit else sys.stderr)
+        sys.exit(0 if help_explicit else 1)
+
+    interactive = False if sys.argv[1] == "--non-interactive" else True
+    action = sys.argv[-1]
+    attrs = _credspec2dict(sys.stdin)
+
+    # This helper is intended to be called by git. While git-credential takes a
+    # `url` property of the description, what it passes on is `protocol`, `host`
+    # and potentially `path` (if instructed to useHttpPath by config).
+    # For communication with datalad's credential system, we need to reconstruct
+    # the url, though.
+    assert 'protocol' in attrs.keys()
+    assert 'host' in attrs.keys()
+    if 'url' not in attrs:
+        attrs['url'] = "{protocol}://{host}{path}".format(
+            protocol=attrs.get('protocol'),
+            host=attrs.get('host'),
+            path="/{}".format(attrs.get('path')) if 'path' in attrs else ""
+        )
+
+    # Get datalad's provider configs.
+    providers = Providers.from_config_files()
+
+    if action == 'get':
+        _action_get(attrs, providers)
+    elif action == 'store':
+        _action_store(attrs, interactive, providers)
+
+
+def _action_store(attrs, interactive, providers):
+    # Determine the defaults to use for storing. In non-interactive mode,
+    # this is what's going to be stored, in interactive mode user is
+    # presented with them as default choice.
+    # We don't really know what authentication type makes sense to store in
+    # the provider config (this would be relevant for datalad using those
+    # credentials w/o git).
+    # However, pick 'http_basic_auth' in case of HTTP(S) URL and 'none'
+    # otherwise as the default to pass into store routine.
+    if attrs.get('protocol') in ['http', 'https']:
+        authentication_type = 'http_basic_auth'
+    else:
+        authentication_type = 'none'
+    # If we got a `path` component from git, usehttppath is set and thereby
+    # git was instructed to include it when matching. Hence, do the same.
+    url_re = "{pr}://{h}{p}.*".format(pr=attrs.get('protocol'),
+                                      h=attrs.get('host'),
+                                      p="/" + attrs.get('path')
+                                      if "path" in attrs.keys() else "")
+    name = attrs.get('host')
+    credential_name = name
+    credential_type = "user_password"
+    if not interactive:
+
+        # TODO: What about credential labels? This could already exist as
+        #       well. However, it's unlikely since the respective
+        #       "service name" for keyring is prepended with "datalad-".
+        #       For the same reason of how the keyring system is used by
+        #       datalad it's not very transparently accessible what labels
+        #       we'd need to check for. Rather than encoding knowledge about
+        #       datalad's internal handling here, let's address that in
+        #       datalad's provider and credential classes and have an easy
+        #       check to be called from here.
+        if any(p.name == name for p in providers):
+            print(f"Provider name '{name}' already exists. This can't be "
+                  "resolved in non-interactive mode.",
+                  file=sys.stderr)
+
+        authenticator_class = AUTHENTICATION_TYPES[authentication_type]
+        saved_provider = providers._store_new(
+            url=attrs.get('url'),
+            authentication_type=authentication_type,
+            authenticator_class=authenticator_class,
+            url_re=url_re,
+            name=name,
+            credential_name=credential_name,
+            credential_type=credential_type,
+            level='user'
+        )
+    else:
+        # use backend made for annex special remotes for interaction from a
+        # subprocess whose stdin/stdout are in use for communication with
+        # its parent
+        from datalad.ui import ui
+        ui.set_backend('annex')
+
+        # ensure default is first in list (that's how `enter_new` determines
+        # it's the default)
+        auth_list = AUTHENTICATION_TYPES.copy()
+        auth_list.pop(authentication_type, None)
+        auth_list = [authentication_type] + list(auth_list.keys())
+
+        saved_provider = providers.enter_new(
+            url=attrs.get('url'),
+            auth_types=auth_list,
+            url_re=url_re,
+            name=name,
+            credential_name=credential_name,
+            credential_type=credential_type)
+    saved_provider.credential.set(user=attrs['username'],
+                                  password=attrs['password'])
+
+
+def _action_get(attrs, providers):
+    # query datalad and report if it knows anything, or be silent
+    # git handles the rest
+    provider = providers.get_provider(attrs['url'],
+                                      only_nondefault=True)
+    if provider is None \
+            or provider.credential is None \
+            or not isinstance(provider.credential, UserPassword):
+        # datalad doesn't know or only has a non UserPassword credential for
+        # this URL - create empty entry
+        dlcred = UserPassword()
+    else:
+        dlcred = provider.credential
+    for dlk, gitk in (('user', 'username'), ('password', 'password')):
+        val = dlcred.get(dlk)
+        if val is not None:
+            print('{}={}'.format(gitk, val))

--- a/datalad/local/gitcredential_datalad.py
+++ b/datalad/local/gitcredential_datalad.py
@@ -11,6 +11,12 @@ from datalad.utils import Path
 git_credential_datalad_help = """\
 Git credential interface to DataLad's credential management system.
 
+In order to use this, one needs to configure git to use the credential helper
+'datalad'. In the simplest case this can be achieved by 'git config --add
+--global credential.helper datalad'. This can be restricted to apply to
+certain URLs only. See 'man gitcredentials' and
+http://docs.datalad.org/credentials.html for details.
+
 Only DataLad's UserPassword-type credentials are supported. This helper
 passes standard 'get', 'store' actions on to the respective interfaces in
 DataLad.

--- a/datalad/local/gitcredential_datalad.py
+++ b/datalad/local/gitcredential_datalad.py
@@ -42,7 +42,10 @@ options:
 If DataLad's config variable 'datalad.credentials.githelper.noninteractive' is
 set: Don't ask for user confirmation when storing to DataLad's credential
 system. This may fail if default names result in a conflict with existing ones.
-This mode is used for DataLad's CI tests.
+This mode is used for DataLad's CI tests. Note, that this config can not
+reliably be read from local configs (a repository's .git/config or
+.datalad/config) as this credential helper when called by Git doesn't get to
+know what repository it is operating on.
 """
 
 

--- a/datalad/local/tests/test_gitcredential.py
+++ b/datalad/local/tests/test_gitcredential.py
@@ -1,0 +1,151 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test git-credential wrapper and helper"""
+
+from datalad.api import Dataset
+from datalad.downloaders.credentials import UserPassword
+from datalad.local.gitcredential import GitCredentialInterface
+from datalad.tests.utils import (
+    assert_false,
+    assert_is_instance,
+    assert_not_in,
+    assert_true,
+    eq_,
+    with_tempfile,
+)
+from datalad.utils import (
+    chpwd,
+    Path,
+)
+
+
+@with_tempfile
+def test_gitcredential_interface(path):
+    # use a dataset as a local configuration vehicle
+    ds = Dataset(path).create()
+
+    # preserve credentials between git processes for a brief time
+    # credential-cache is not supported on windows (needs UNIX sockets)
+    # ds.config.set('credential.helper', 'cache', where='local')
+    # However, first set an empty helper in order to disable already set helpers
+    ds.config.set('credential.helper', '', where='local')
+    ds.config.set('credential.helper', 'store', where='local')
+
+    # git manages credentials by target URL
+    credurl = 'https://example.datalad.org/somepath'
+    credurl_justhost = 'https://example.datalad.org'
+    # define a credential
+    cred = GitCredentialInterface(url=credurl, username='mike',
+                                  password='s3cr3t', repo=ds)
+    # put it in the manager (a cache in this case, but could invoke any number
+    # of helpers
+    cred.approve()
+    # new instance, no knowledge of login
+    cred = GitCredentialInterface(url=credurl, repo=ds)
+    assert_not_in('username', cred)
+    # query store
+    cred.fill()
+    eq_(cred['username'], 'mike')
+    eq_(cred['password'], 's3cr3t')
+    # git does host-only identification by default (see credential.useHttpPath)
+    cred = GitCredentialInterface(url=credurl_justhost, repo=ds)
+    cred.fill()
+    eq_(cred['username'], 'mike')
+    eq_(cred['password'], 's3cr3t')
+
+    # the URL is enough to remove ("reject") a credential
+    GitCredentialInterface(url=credurl, repo=ds).reject()
+
+    cred = GitCredentialInterface(url=credurl, repo=ds)
+    # this will yield empty passwords, not the most precise test
+    # whether it actually removed the credentials, but some test
+    # at least
+    cred.fill()
+    assert_false(cred['username'])
+    assert_false(cred['password'])
+
+
+@with_tempfile
+def test_datalad_credential_helper(path):
+
+    ds = Dataset(path).create()
+
+    # tell git to use git-credential-datalad
+    ds.config.add('credential.helper', 'datalad --non-interactive', where='local')
+
+    from datalad.downloaders.providers import Providers
+
+    url1 = "https://datalad-test.org/some"
+    url2 = "https://datalad-test.org/other"
+    provider_name = "datalad-test.org"
+
+    # `Providers` code is old and only considers a dataset root based on PWD
+    # for config lookup. contextmanager below can be removed once the
+    # provider/credential system is redesigned.
+    with chpwd(ds.path):
+
+        gitcred = GitCredentialInterface(url=url1, repo=ds)
+
+        # There's nothing set up yet, helper should return empty
+        gitcred.fill()
+        eq_(gitcred['username'], '')
+        eq_(gitcred['password'], '')
+
+        # store new credentials
+        # Note, that `Providers.enter_new()` currently uses user-level config
+        # files for storage only. TODO: make that an option!
+        # To not mess with existing ones, fail if it already exists:
+
+        cfg_file = Path(Providers._get_providers_dirs()['user']) \
+                   / f"{provider_name}.cfg"
+        assert_false(cfg_file.exists())
+
+        # Make sure we clean up
+        from datalad.tests import _TEMP_PATHS_GENERATED
+        _TEMP_PATHS_GENERATED.append(str(cfg_file))
+
+        # Give credentials to git and ask it to store them:
+        gitcred = GitCredentialInterface(url=url1, username="dl-user",
+                                         password="dl-pwd", repo=ds)
+        gitcred.approve()
+
+        assert_true(cfg_file.exists())
+        providers = Providers.from_config_files()
+        p1 = providers.get_provider(url=url1, only_nondefault=True)
+        assert_is_instance(p1.credential, UserPassword)
+        eq_(p1.credential.get('user'), 'dl-user')
+        eq_(p1.credential.get('password'), 'dl-pwd')
+
+        # default regex should be host only, so matching url2, too
+        p2 = providers.get_provider(url=url2, only_nondefault=True)
+        assert_is_instance(p1.credential, UserPassword)
+        eq_(p1.credential.get('user'), 'dl-user')
+        eq_(p1.credential.get('password'), 'dl-pwd')
+
+        # git, too, should now find it for both URLs
+        gitcred = GitCredentialInterface(url=url1, repo=ds)
+        gitcred.fill()
+        eq_(gitcred['username'], 'dl-user')
+        eq_(gitcred['password'], 'dl-pwd')
+
+        gitcred = GitCredentialInterface(url=url2, repo=ds)
+        gitcred.fill()
+        eq_(gitcred['username'], 'dl-user')
+        eq_(gitcred['password'], 'dl-pwd')
+
+        # Rejection must not currently lead to deleting anything, since we would
+        # delete too broadly.
+        gitcred.reject()
+        assert_true(cfg_file.exists())
+        gitcred = GitCredentialInterface(url=url1, repo=ds)
+        gitcred.fill()
+        eq_(gitcred['username'], 'dl-user')
+        eq_(gitcred['password'], 'dl-pwd')
+        dlcred = UserPassword(name=provider_name)
+        eq_(dlcred.get('user'), 'dl-user')
+        eq_(dlcred.get('password'), 'dl-pwd')

--- a/datalad/local/tests/test_gitcredential.py
+++ b/datalad/local/tests/test_gitcredential.py
@@ -76,7 +76,9 @@ def test_datalad_credential_helper(path):
     ds = Dataset(path).create()
 
     # tell git to use git-credential-datalad
-    ds.config.add('credential.helper', 'datalad --non-interactive', where='local')
+    ds.config.add('credential.helper', 'datalad', where='local')
+    ds.config.add('datalad.credentials.githelper.noninteractive', 'true',
+                  where='global')
 
     from datalad.downloaders.providers import Providers
 

--- a/docs/source/credentials.rst
+++ b/docs/source/credentials.rst
@@ -33,3 +33,7 @@ Valid locations for these files are listed in :ref:`chap_design_credentials`.
 In opposition to Git's approach, `url_re` is a regular expression that matches the entire URL including the scheme.
 The name of the provider section (`data_example_provider`)needs to match the file name.
 The name of the credential section (`data_example_cred`) needs to match the `credential` entry in the provider section.
+
+DataLad will create a provider configuration interactively, whenever it first encounters an URL that requires authentication and no credentials can be matched yet.
+This behavior extends to the git credential helper and can therefore even be triggered by a `git clone`.
+However, `git-credential-datalad` will not do this, if the config variable `datalad.credentials.githelper.noninteractive` is set.

--- a/docs/source/credentials.rst
+++ b/docs/source/credentials.rst
@@ -1,0 +1,35 @@
+Credentials
+***********
+
+Integration with Git
+====================
+
+Git and DataLad can use each other's credential system.
+In order to allow Git to query credentials from DataLad, the git credential helper delivered with DataLad needs to be configured.
+That is, a section like this needs to be part of one's git config file::
+
+  [credential "https://*.data.example.com"]
+    helper = "datalad"
+
+Note:
+
+- This most likely only makes sense at the user or system level (options `--global`|`--system` with `git config`), since cloning of a repository needs the credentials before there is a local repository.
+- The name of that section is a URL matching expression - see `man gitcredentials`.
+- The URL matching does NOT include the scheme! Hence, if you need to match `http` as well as `https`, you need two such entries.
+- Multiple different git credential helpers can be configured - Git will ask them one after another. For example on OSX, Git comes with a helper to use the OSX keychain which is configured at system level. This does not conflict with setting up DataLad's credential helper.
+
+The other way around, DataLad can ask Git for credentials it knows by other means (other git credential helpers).
+For that a datalad provider config needs to be set up in similar fashion::
+
+  [provider:data_example_provider]
+    url_re = http.*://.*data\.example\.com
+    authentication_type = http_basic_auth
+    credential = data_example_cred
+  [credential:data_example_cred]
+    type = git
+
+Such a config lives in a dedicated file named after the provider name (:file:`data_example_provider.cfg` in this case).
+Valid locations for these files are listed in :ref:`chap_design_credentials`.
+In opposition to Git's approach, `url_re` is a regular expression that matches the entire URL including the scheme.
+The name of the provider section (`data_example_provider`)needs to match the file name.
+The name of the credential section (`data_example_cred`) needs to match the `credential` entry in the provider section.

--- a/docs/source/credentials.rst
+++ b/docs/source/credentials.rst
@@ -5,7 +5,14 @@ Integration with Git
 ====================
 
 Git and DataLad can use each other's credential system.
-In order to allow Git to query credentials from DataLad, the git credential helper delivered with DataLad needs to be configured.
+Both directions are independent of each other and none is necessarily required.
+Either direction can be configured based on URL matching patterns.
+In addition, Git can be configured to always query DataLad for credentials without any URL matching.
+
+Let Git query Datalad
+=====================
+
+In order to allow Git to query credentials from DataLad, Git needs to be configured to use the git credential helper delivered with DataLad (an executable called `git-credential-datalad`).
 That is, a section like this needs to be part of one's git config file::
 
   [credential "https://*.data.example.com"]
@@ -16,24 +23,34 @@ Note:
 - This most likely only makes sense at the user or system level (options `--global`|`--system` with `git config`), since cloning of a repository needs the credentials before there is a local repository.
 - The name of that section is a URL matching expression - see `man gitcredentials`.
 - The URL matching does NOT include the scheme! Hence, if you need to match `http` as well as `https`, you need two such entries.
-- Multiple different git credential helpers can be configured - Git will ask them one after another. For example on OSX, Git comes with a helper to use the OSX keychain which is configured at system level. This does not conflict with setting up DataLad's credential helper.
+- Multiple git credential helpers can be configured - Git will ask them one after another until it got a username and a password for the URL in question. For example on macOS, Git comes with a helper to use the system's keychain and Git is configured system-wide to query `git-credential-osxkeychain`. This does not conflict with setting up DataLad's credential helper.
+- The example configuration requires `git-credential-datalad` to be in the path in order for Git to find it. Alternatively, the value of the `helper` entry needs to be the absolute path of `git-credential-datalad`.
+- In order to make Git always consider DataLad as a credential source, one can simply not specify any URL pattern (so it's `[credential]` instead of `[credential "SOME-PATTERN"]`)
 
-The other way around, DataLad can ask Git for credentials it knows by other means (other git credential helpers).
-For that a datalad provider config needs to be set up in similar fashion::
+Let DataLad query Git
+=====================
+
+The other way around, DataLad can ask Git for credentials (which it will acquire via other git credential helpers).
+To do so, a DataLad provider config needs to be set up::
 
   [provider:data_example_provider]
-    url_re = http.*://.*data\.example\.com
+    url_re = https://.*data\.example\.com
     authentication_type = http_basic_auth
     credential = data_example_cred
   [credential:data_example_cred]
     type = git
 
-Such a config lives in a dedicated file named after the provider name (:file:`data_example_provider.cfg` in this case).
-Valid locations for these files are listed in :ref:`chap_design_credentials`.
-In opposition to Git's approach, `url_re` is a regular expression that matches the entire URL including the scheme.
-The name of the provider section (`data_example_provider`)needs to match the file name.
-The name of the credential section (`data_example_cred`) needs to match the `credential` entry in the provider section.
+Note:
 
-DataLad will create a provider configuration interactively, whenever it first encounters an URL that requires authentication and no credentials can be matched yet.
-This behavior extends to the git credential helper and can therefore even be triggered by a `git clone`.
-However, `git-credential-datalad` will not do this, if the config variable `datalad.credentials.githelper.noninteractive` is set.
+- Such a config lives in a dedicated file named after the provider name (e.g. all of the above example would be the content of :file:`data_example_provider.cfg`, matching `[provider:data_example_provider]`).
+- Valid locations for these files are listed in :ref:`chap_design_credentials`.
+- In opposition to Git's approach, `url_re` is a regular expression that matches the entire URL including the scheme.
+- The above is particularly important in case of redirects, as DataLad currently matches the URL it was given instead of the one it ultimately uses the credentials with.
+- The name of the credential section must match the credential entry in the provider section (e.g. `[credential:data_example_cred]` and `credential = data_example_cred` in the above example).
+
+DataLad will prompt the user to create a provider configuration and respective credentials when it first encounters a URL that requires authentication but no matching credentials are found.
+This behavior extends to the credential helper and may therefore be triggered by a `git clone` if Git is configured to use `git-credential-datalad`.
+However, interactivity of `git-credential-datalad` can be turned off (see `git-credential-datalad -h`)
+
+It is possible to end up in a situation where Git would query DataLad and vice versa for the same URL, especially if Git is configured to query DataLad unconditionally.
+`git-credential-datalad` will discover this circular setup and stop it by simply ignoring DataLad's provider configuration that points back to Git.

--- a/docs/source/design/credentials.rst
+++ b/docs/source/design/credentials.rst
@@ -12,13 +12,18 @@ Credential management
    This specification describes the current implementation.
 
 Various components of DataLad need to be passed credentials to interact with services that require authentication. 
-This includes downloading files, but also things like REST API usage.
+This includes downloading files, but also things like REST API usage or authenticated cloning.
+Key components of Datalad's credential management are credentials types, providers, authenticators and downloaders.
+
+Credentials
+===========
 
 Supported credential types include basic user/password combinations, access tokens, and a range of tailored solutions for particular services.
 All credential type implementations are derived from a common :class:`Credential` base class.
+A mapping from string labels to credential classes is defined in ``datalad.downloaders.CREDENTIAL_TYPES``.
 
 Importantly, credentials must be identified by a name.
-This name is a label that is often hard-coded in the program code of DataLad, any of its extensions, or specified in a dataset.
+This name is a label that is often hard-coded in the program code of DataLad, any of its extensions, or specified in a dataset or in provider configurations (see below).
 
 Given a credential ``name``, one or more credential ``component``\(s) (e.g., ``token``, ``username``, or ``password``) can be looked up by DataLad in at least two different locations.
 These locations are tried in the following order, and the first successful lookup yields the final value.
@@ -28,11 +33,60 @@ These locations are tried in the following order, and the first successful looku
    As with any other specification of configuration items, environment variables can be used to set or override credentials.
    Variable names take the form of ``DATALAD_CREDENTIAL_<NAME>_<COMPONENT>``, and standard replacement rules into configuration variable names apply.
 
-2. DataLad uses the `keyring` package https://pypi.org/project/keyring to connect to any of its supported back-ends for setting or getting credentials.
+2. DataLad uses the `keyring` package https://pypi.org/project/keyring to connect to any of its supported back-ends for setting or getting credentials,
+   via a wrapper in :mod:`~datalad.support.keyring_`.
    This provides support for credential storage on all major platforms, but also extensibility, providing 3rd-parties to implement and use specialized solutions.
 
 When a credential is required for operation, but could not be obtained via any of the above approaches, DataLad can prompt for credentials in interactive terminal sessions.
 Interactively entered credentials will be stored in the active credential store available via the ``keyring`` package.
+Note, however, that the keyring approach is somewhat abused by datalad.
+The wrapper only uses ``get_/set_password`` of ``keyring`` with the credential's ``FIELDS`` as the name to query (essentially turning the keyring into a plain key-value store) and "datalad-<CREDENTIAL-LABEL>" as the "service name".
+With this approach it's not possible to use credentials in a system's keyring that were defined by other, datalad unaware software (or users).
 
 When a credential value is known but invalid, the invalid value must be removed or replaced in the active credential store.
 By setting the configuration flag ``datalad.credentials.force-ask``, DataLad can be instructed to force interactive credential re-entry to effectively override any store credential with a new value.
+
+Providers
+=========
+
+Providers are associating credentials with a context for using them and are defined by configuration files.
+A single provider is represented by :class:`Provider` object and the list of available providers is represented by the :class:`Providers` class.
+A provider is identified by a label and stored in a dedicated config file per provider named `LABEL.cfg`.
+Such a file can reside in a dataset (under `.datalad/providers/`), at the user level (under `{user_config_dir}/providers`), at the system level (under `{site_config_dir}/providers`) or come packaged with the datalad distribution (in directory `configs` next to `providers.py`).
+Such a provider specifies a regular expression to match URLs against and assigns authenticator abd credentials to be used for a match.
+Credentials are referenced by their label, which in turn is the name of another section in such a file specifying the type of the credential.
+References to credential and authenticator types are strings that are mapped to classes by the following dict definitions:
+
+- ``datalad.downloaders.AUTHENTICATION_TYPES``
+- ``datalad.downloaders.CREDENTIAL_TYPES``
+
+Available providers can be loaded by ``Providers.from_config_files`` and ``Providers.get_provider(url)`` will match a given URL against them and return the appropriate `Provider` instance.
+A :class:`Provider` object will determine a downloader to use (derived from :class:`BaseDownloader`), based on the URL's protocol.
+
+Note, that the provider config files are not currently following datalad's general config approach.
+Instead they are special config files, read by :class:`configparser.ConfigParser` that are not compatible with `git-config` and hence the :class:`ConfigManager`.
+
+There are currently two ways of storing a provider and thus creating its config file: ``Providers.enter_new`` and ``Providers._store_new``.
+The former will only work interactively and provide the user with options to choose from, while the latter is non-interactive and can therefore only be used, when all properties of the provider config are known and passed to it.
+There's no way at the moment to store an existing :class:`Provider` object directly.
+
+Integration with Git
+====================
+
+In addition, there's a special case for interfacing `git-credential`: A dedicated :class:`GitCredential` class is used to talk to Git's ``git-credential`` command instead of the keyring wrapper.
+This class has identical fields to the :class:`UserPassword` class and thus can be used by the same authenticators.
+Since Git's way to deal with credentials doesn't involve labels but only matching URLs, it is - in some sense - the equivalent of datalad's provider layer.
+However, providers don't talk to a backend, credentials do.
+Hence, a more seemless integration requires some changes in the design of datalad's credential system as a whole.
+
+In the opposite direction - making Git aware of datalad's credentials, there's no special casing, though.
+Datalad comes with a `git-credential-datalad` executable.
+Whenever Git is configured to use it by setting `credential.helper=datalad`, it will be able to query datalad's credential system for a provider matching the URL in question and retrieve the referenced by this provider credentials.
+This helper can also store a new provider+credentials when asked to do so by Git.
+It can do this interactively, asking a user to confirm/change that config or - if `credential.helper='datalad --non-interactive'` - try to non-interactively store with its defaults.
+
+Authenticators
+==============
+
+Authenticators are used by downloaders to issue authenticated requests.
+They are not easily available to directly be applied to requests being made outside of the downloaders.

--- a/docs/source/design/credentials.rst
+++ b/docs/source/design/credentials.rst
@@ -77,7 +77,7 @@ In addition, there's a special case for interfacing `git-credential`: A dedicate
 This class has identical fields to the :class:`UserPassword` class and thus can be used by the same authenticators.
 Since Git's way to deal with credentials doesn't involve labels but only matching URLs, it is - in some sense - the equivalent of datalad's provider layer.
 However, providers don't talk to a backend, credentials do.
-Hence, a more seemless integration requires some changes in the design of datalad's credential system as a whole.
+Hence, a more seamless integration requires some changes in the design of datalad's credential system as a whole.
 
 In the opposite direction - making Git aware of datalad's credentials, there's no special casing, though.
 Datalad comes with a `git-credential-datalad` executable.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Concepts and technologies
    background
    related
    basics
+   credentials
    metadata
    customization
    design/index

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ entry_points = {
         'git-annex-remote-datalad-archives=datalad.customremotes.archives:main',
         'git-annex-remote-datalad=datalad.customremotes.datalad:main',
         'git-annex-remote-ora=datalad.distributed.ora_remote:main',
+        'git-credential-datalad=datalad.local.gitcredential_datalad:git_credential_datalad',
     ],
     'datalad.metadata.extractors': [
         'annex=datalad.metadata.extractors.annex:MetadataExtractor',


### PR DESCRIPTION
Towards #5028

This description is updated by me (@bpoldrack), since I took over.

This implements an integration with `git-credential` in both directions:
1. A `git-credential-datalad` script that allows git to query (and store to)
   Datalad's credential system, by adding it as potential backend by setting 
   `credential.helper=datalad`. This credential helper will query datalad for a 
   provider matching the URL in question and retrieve the linked credentials.
   The other way around, storing will create such a provider config file and the 
   respective credential entries via `keyring`.
2. `Gitcredential` class, that can be referred to by provider configs as the 
   `type` of credential ('git'). This allows datalad to use `git-credential` 
   instead of `keyring`. Credentials provided via datalad config (or environment 
   variables) are still taking precedence over what is stored in that backend 
   (same as with keyring: no change).
   This class uses the same internal `FIELDS` as the `UserPassword` class and 
   hence should be useable with any authenticator that works with `UserPassword`.

Tests for the credential helper in `datalad/local/tests/test_gitcredential.py`
and for the new `Credential` object in
`datalad/downloaders/tests/test_credentials.py:test_gitcredential_read` and
`datalad/downloaders/tests/test_credentials.py:test_gitcredential`

While 1.) is a rather seemless integration in my view, 2.) isn't ideal yet, as 
it's sort of a special case, where the provider config would need to state it
wants to query `git-credential` rather than `keyring` by setting `type=git` for
the credential (rather than `type=userpassword`). However, I think this is good
enough to enable these usecases but should be developed further and make
`git-credential` just an additional backend to query (in addition rather than
instead of keyring). This requires some more overhauling of our credential
system as a whole, though. This view may raise concerns WRT introducing a value
for such - possibly committed - configs, that may be deprecated in the
foreseeable future again. In my view, this would only concern those 
configuration files and I think they should be replaced in the process of
overhauling the credential system. They are an unnecessary exception to how
configurations are dealt with by datalad everywhere else. Those files should
become a legacy format, that we keep support for reading. But the to-be default
approach should be regular, datalad configuration variables (probably in
standard config file locations). The switch will then not be "Hey use credential 
type git" to "Just kidding, use credential type userpassword", but instead from
"This is how you do it with provider config files" to "You can still do it that
way, but better do it like everywhere else. The new datalad config variables for
this are: ...". Hence, that anticipated deprecation doesn't really matter, I think.


### Changelog

#### 💫 Enhancements and new features

- DataLad's credential system is now able to query `git-credential` by specifying credential type `git` in the respective provider configuration [#5796](https://github.com/datalad/datalad/pull/5796) (by @bpoldrack)
- DataLad now comes with a git credential helper `git-credential-datalad` allowing Git to query DataLad's credential system [#5796](https://github.com/datalad/datalad/pull/5796) (by @bpoldrack and @mih)

#### 📝 Documentation

- A new [document](http://docs.datalad.org/credentials.html) describes the credential system from a user's perspective [#5796](https://github.com/datalad/datalad/pull/5796) (by @bpoldrack)
- Enhance the [design document](http://docs.datalad.org/design/credentials.html) on DataLad's credential system [#5796](https://github.com/datalad/datalad/pull/5796) (by @bpoldrack)

#### 🏠 Internal

- Add internal method for non-interactive provider/credential storing [#5796](https://github.com/datalad/datalad/pull/5796) (by @bpoldrack)
- Allow credential classes to have a context set, consisting of a URL they are to be used with and a dataset DataLad is operating on, allowing to consider "local" and "dataset" config locations [#5796](https://github.com/datalad/datalad/pull/5796) (by @bpoldrack)
