### PR TITLE
ENH: Supply stdin to process without a tmp file

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -59,12 +59,6 @@ class WitlessRunner(object):
     """
     __slots__ = ['cwd', 'env']
 
-    # To workaround issues where parent process does not take care about proper
-    # new loop instantiation in a child process
-    # https://bugs.python.org/issue21998
-    _loop_pid = None
-    _loop_need_new = None
-
     def __init__(self, cwd=None, env=None):
         """
         Parameters
@@ -180,6 +174,7 @@ class WitlessRunner(object):
         # denoise, must be zero at this point
         results.pop('code', None)
         return results
+
 
 class GitRunnerBase(object):
     """

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -109,8 +109,8 @@ class WitlessRunner(object):
           (e.g. output capture). A number of pre-crafted classes are
           provided (e.g `KillOutput`, `NoCapture`, `GitProgress`).
         stdin : byte stream, optional
-          File descriptor like, used as stdin for the process. Passed
-          verbatim to subprocess.Popen().
+          File descriptor like, or bytes objects used as stdin for the process.
+          Passed verbatim to run_command().
         cwd : path-like, optional
           If given, commands are executed with this path as PWD,
           the PWD of the parent process is used otherwise. Overrides

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -11,7 +11,6 @@
 """
 
 import re
-import time
 import os
 import os.path as op
 
@@ -33,12 +32,7 @@ from os.path import (
 )
 
 import posixpath
-import threading
 from functools import wraps
-from weakref import (
-    finalize,
-    WeakValueDictionary
-)
 import warnings
 
 from datalad.log import log_progress
@@ -53,7 +47,6 @@ from datalad.cmd import (
     StdOutErrCapture,
 )
 from datalad.config import (
-    ConfigManager,
     parse_gitconfig_dump,
     write_config_section,
 )
@@ -79,11 +72,9 @@ from .external_versions import external_versions
 from .exceptions import (
     CommandError,
     FileNotInRepositoryError,
-    GitIgnoreError,
     InvalidGitReferenceError,
     InvalidGitRepositoryError,
     NoSuchPathError,
-    PathKnownToRepositoryError,
 )
 from .network import (
     RI,

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -174,6 +174,17 @@ def test_runner_no_stdin_no_capture():
     )
 
 
+@timed(3)
+def test_runner_empty_stdin():
+    # Ensure a runner without stdin data and output capture progresses
+    runner = Runner()
+    runner.run(
+        ["cat"],
+        stdin=b"",
+        protocol=None
+    )
+
+
 def test_runner_parametrized_protocol():
     runner = Runner()
 

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -141,6 +141,14 @@ def test_runner_stdin(path):
     )
     assert_in(OBSCURE_FILENAME, res['stdout'])
 
+    # we can do the same without a tempfile, too
+    res = runner.run(
+        py2cmd('import fileinput; print(fileinput.input().readline())'),
+        stdin=OBSCURE_FILENAME.encode('utf-8'),
+        protocol=StdOutCapture,
+    )
+    assert_in(OBSCURE_FILENAME, res['stdout'])
+
 
 def test_runner_parametrized_protocol():
     runner = Runner()

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -18,6 +18,8 @@ from time import (
     sleep,
     time,
 )
+from nose.tools import timed
+
 
 from datalad.tests.utils import (
     assert_cwd_unchanged,
@@ -148,6 +150,28 @@ def test_runner_stdin(path):
         protocol=StdOutCapture,
     )
     assert_in(OBSCURE_FILENAME, res['stdout'])
+
+
+@timed(3)
+def test_runner_stdin_no_capture():
+    # Ensure that stdin writing alone progresses
+    runner = Runner()
+    runner.run(
+        py2cmd('import sys; print(sys.stdin.read())'),
+        stdin=('ABCDEFGHIJKLMNOPQRSTUVWXYZ-' * 10000).encode('utf-8'),
+        protocol=None
+    )
+
+
+@timed(3)
+def test_runner_no_stdin_no_capture():
+    # Ensure a runner without stdin data and output capture progresses
+    runner = Runner()
+    runner.run(
+        ["echo", "a", "b", "c"],
+        stdin=None,
+        protocol=None
+    )
 
 
 def test_runner_parametrized_protocol():


### PR DESCRIPTION
So far, a temporary file was necessary to pass input to a process's `stdin`
in `WitlessRunner` (need for `.fileno` in `subprocess.Popen`). This
enhancement adopts the subprocess `input=` implementation, and allows
for feeding input from a `str|bytes`, by writing its content to a stdin
pipe.

This enables a simplifications of the `push` implementation and reduces
the overall technical complexity of passing `stdin`.

As `WitlessRunner` presently operates the pipes in binary mode, input
must be given as bytes. However, the underlying implementation in
`run_command()` could handle strings as well, should `Popen` be
parametrized accordingly using custom arguments.

This PR include two cleanup commits that are essentially unrelated.