### PR TITLE
http downloaders: Provide custom informative User-Agent, do not claim to be "Authenticated access"

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -171,10 +171,10 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 break
             except AccessDeniedError as e:
                 if isinstance(e, AnonymousAccessDeniedError):
-                    access_denied = "Anonymous"
+                    access_denied = "Anonymous access"
                 else:
-                    access_denied = "Authenticated"
-                lgr.debug("%s access was denied: %s", access_denied, exc_str(e))
+                    access_denied = "Access"
+                lgr.debug("%s was denied: %s", access_denied, exc_str(e))
                 supported_auth_types = e.supported_types
                 exc_info = sys.exc_info()
 
@@ -305,8 +305,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
         DownloadError
           If no known credentials type or user refuses to update
         """
-        title = "{msg} access to {url} has failed.".format(
-            msg=denied_msg, url=url)
+        title = f"{denied_msg} to {url} has failed."
 
         if new_provider:
             # No credential was known, we need to create an

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -21,6 +21,7 @@ from requests.utils import parse_dict_header
 import io
 from time import sleep
 
+from .. import __version__
 from ..utils import (
     ensure_list_from_str,
     ensure_dict_from_str,
@@ -49,6 +50,13 @@ from .base import BaseDownloader, DownloaderSession
 from logging import getLogger
 from ..log import LoggerHelper
 lgr = getLogger('datalad.http')
+
+# Following https://meta.wikimedia.org/wiki/User-Agent_policy to provide
+# extended and informative User-Agent string
+DEFAULT_USER_AGENT = \
+    f'DataLad/{__version__} ' \
+    '(https://datalad.org; team@datalad.org) ' \
+    f'python-requests/{requests.__version__}'
 
 try:
     import requests_ftp
@@ -543,6 +551,9 @@ class HTTPDownloader(BaseDownloader):
             headers = {}
         if 'Accept-Encoding' not in headers:
             headers['Accept-Encoding'] = ''
+        if 'user-agent' not in map(str.lower, headers):
+            headers['User-Agent'] = DEFAULT_USER_AGENT
+
         # TODO: our tests ATM aren't ready for retries, thus altogether disabled for now
         nretries = 1
         for retry in range(1, nretries+1):


### PR DESCRIPTION
Closes #5801  although I believe it is no longer an issue -- wikipedia seems to no longer mind any bad User-Agent (at least for me locally as of a few minutes back). But I think it would be nice/proper to provide detailed user-agent string.

See individual commits for more information

