### PR TITLE
UX: Report branch names and states in WTF report

### DIFF
--- a/datalad/local/tests/test_wtf.py
+++ b/datalad/local/tests/test_wtf.py
@@ -36,6 +36,7 @@ from datalad.tests.utils import (
     SkipTest,
     swallow_outputs,
     with_tree,
+    DEFAULT_BRANCH
 )
 
 
@@ -62,6 +63,9 @@ def test_wtf(topdir):
         assert_in('## dataset', cmo.out)
         assert_in(u'path: {}'.format(ds.path),
                   ensure_unicode(cmo.out))
+        assert_in('branches', cmo.out)
+        assert_in(DEFAULT_BRANCH+'@', cmo.out)
+        assert_in('git-annex@', cmo.out)
 
     # and if we run with all sensitive
     for sensitive in ('some', True):

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -241,6 +241,11 @@ def _describe_dataset(ds, sensitive):
             'repo': ds.repo.__class__.__name__ if ds.repo else None,
             'id': ds.id,
         }
+        # describe available branches and their states
+        branches = [
+            '%s@%s' % (b, next(ds.repo.get_branch_commits_(branch=b))[:7])
+            for b in ds.repo.get_branches()]
+        infos['branches'] = branches
         if not sensitive:
             infos['metadata'] = _HIDDEN
         elif ds.id:


### PR DESCRIPTION
This potentially closes #5731. It adds a section "branches" to the dataset report of ``datalad wtf``, and reports all branches using the format ``<branch>[@<commit>]``.
For example:

```
(handbook2) adina@muninn in ~/repos/datalad on git:ux-5731
❱ datalad wtf
# WTF
## configuration <SENSITIVE, report disabled by configuration>
## credentials 
  - keyring: 
    - active_backends: 
      - SecretService Keyring
      - PlaintextKeyring with no encyption v.1.0 at /home/adina/.local/share/python_keyring/keyring_pass.cfg
    - config_file: /home/adina/.config/python_keyring/keyringrc.cfg
    - data_root: /home/adina/.local/share/python_keyring
## datalad 
  - full_version: 0.14.4.dev496-g61bc
  - version: 0.14.4.dev496
## dataset 
  - branches: 
    - appveyor[@618f99e]
    - bf-4359[@b0a4458]
    - bf-flexibleclonecandidates[@73cbe11]
    - bf-git-gc[@9e17649]
    - doc-get[@d91c19e]
    - doc-joss[@5a49c20]
    - enh-addreadme[@96d0a68]
    - enh-addreadme2[@f53c74f]
    - enh-addreadmebackup[@f2deb2a]
    - get-command-annex-error[@8def465]
    - gh-loj[@0b0e7fe]
    - maint[@08f5c58]
    - master[@74f6f81]
    - non-interactive-log-wrap[@60e3edd]
    - rf-auto[@42052d6]
    - rf-callannex[@6c1a736]
    - test-5631[@580537c]
    - test-bf-flexibleclonecandidates[@686f27d]
    - tst-testrepos-appveyor[@dfa5ea5]
    - ux-5547[@8724226]
    - ux-5711[@be4b3c1]
    - ux-5731[@61bcf10]
    - ux-pushtarget[@a46f21e]
  - id: None
  - metadata: <SENSITIVE, report disabled by configuration>
  - path: /home/adina/repos/datalad
  - repo: GitRepo
## dependencies 
[...]
```