### PR TITLE
UX: Check argument validity of --as-common-datasrc name

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -379,6 +379,9 @@ def _add_remote(
             message=("sibling is already known: %s, use `configure` instead?", name),
             **res_kwargs)
         return
+    if as_common_datasrc == name:
+        raise ValueError('Sibling name ({}) and common data source name ({}) '
+                         'can not be identical.'.format(name, as_common_datasrc))
     if isinstance(RI(url), PathRI):
         # make sure any path URL is stored in POSIX conventions for consistency
         # with git's behavior (e.g. origin configured by clone)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -242,6 +242,10 @@ def test_siblings(origin, repo_path, local_clone_path):
                          relpath(str(r['path']), source.path))))
         # https://github.com/datalad/datalad/issues/3951
         ok_(not pushurl)  # no pushurl should be defined
+    # 5621: Users shouldn't pass identical names for remote & common data source
+    assert_raises(ValueError, siblings, 'add', dataset=source, name='howdy',
+                  url=httpurl1, as_common_datasrc='howdy')
+
 
 @with_tempfile(mkdir=True)
 def test_here(path):


### PR DESCRIPTION
This PR adds a ValueError that is raised as a validity check when a user supplies identical names for a remote sibling name and the autoenabled as_common_datasrc special remote, as done in #5621.

Fixes #5621