### PR TITLE
BF: Report info from annex JSON error message in CommandError

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -339,4 +339,5 @@ def test_commanderror_jsonmsgs(src, exp):
         Runner(cwd=ds.path).run(
             ['datalad', 'push', '--to', 'expdir'],
             protocol=StdOutErrCapture)
-    in_('use `git-annex export`', cme.exception.stderr)
+    if ds.repo.git_annex_version >= "8.20200309":
+        in_('use `git-annex export`', cme.exception.stderr)

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -13,6 +13,36 @@ import re
 from os import linesep
 from pprint import pformat
 
+
+def _format_json_error_messages(recs):
+    # there could be many, condense
+    msgs = {}
+    for r in recs:
+        if r.get('success'):
+            continue
+        msg = '{}{}'.format(
+            ' {}\n'.format(r['note']) if r.get('note') else '',
+            '\n'.join(r.get('error-messages', [])),
+        )
+        if 'file' in r or 'key' in r:
+            occur = msgs.get(msg, 0)
+            occur += 1
+            msgs[msg] = occur
+
+    if not msgs:
+        return ''
+
+    return '\n>{}'.format(
+        '\n> '.join(
+            '{}{}'.format(
+                m,
+                ' [{} times]'.format(n) if n > 1 else '',
+            )
+            for m, n in msgs.items()
+        )
+    )
+
+
 class CommandError(RuntimeError):
     """Thrown if a command call fails.
 
@@ -52,6 +82,15 @@ class CommandError(RuntimeError):
         if self.msg:
             # typically a command error has no specific idea
             to_str += " [{}]".format(ensure_unicode(self.msg))
+
+        if self.kwargs:
+            to_str += " [info keys: {}]".format(
+                ', '.join(self.kwargs.keys()))
+
+            if 'stdout_json' in self.kwargs:
+                to_str += _format_json_error_messages(
+                    self.kwargs['stdout_json'])
+
         if not include_output:
             return to_str
 
@@ -59,19 +98,7 @@ class CommandError(RuntimeError):
             to_str += " [out: '{}']".format(ensure_unicode(self.stdout).strip())
         if self.stderr:
             to_str += " [err: '{}']".format(ensure_unicode(self.stderr).strip())
-        if self.kwargs:
-            if 'stdout_json' in self.kwargs:
-                src_keys = ('note', 'error-messages')
-                from datalad.utils import unique
-                json_errors = unique(
-                    '; '.join(str(m[key]) for key in src_keys if m.get(key))
-                    for m in self.kwargs['stdout_json']
-                    if any(m.get(k) for k in src_keys)
-                )
-                if json_errors:
-                    to_str += " [errors from JSON records: {}]".format(json_errors)
-            to_str += " [info keys: {}]".format(
-                ', '.join(self.kwargs.keys()))
+
         return to_str
 
     def __str__(self):


### PR DESCRIPTION
When a `CommandError` bubbles up to the main entrypoint it is rendered
differently than anywhere else (calls `to_str()` with
`include_output=False`. This is done to be able to write the
`stdout|err` output of a failed command to the proper channels. However,
this also caused all information extraction from JSON records to be
disabled.

This change, makes sure that JSON records are processed even in this
case. It also RFs the exception rendering code to make it less
repr()-like.

From:

```
CommandError: 'git -c diff.ignoreSubmodules=none annex copy --batch -z --to expdir --fast --json --json-error-messages --json-progress -c annex.dotfiles=true' failed with exitcode 1 under /tmp/testds
git-annex: copy: 2 failed
```

To:

```
CommandError: 'git -c diff.ignoreSubmodules=none annex copy --batch -z --to expdir --fast --json --json-error-messages --json-progress -c annex.dotfiles=true' failed with exitcode 1 under /tmp/testds [info keys: stdout_json]
> to expdir...
  remote is configured with exporttree=yes; use `git-annex export` to store content on it
  This could have failed because --fast is enabled. [2 times]
git-annex: copy: 2 failed
```

Fixes datalad/datalad#5807