### PR TITLE
Fix log flooding during witless-runner tests

### DIFF
--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -157,7 +157,7 @@ def test_runner_stdin_no_capture():
     # Ensure that stdin writing alone progresses
     runner = Runner()
     runner.run(
-        py2cmd('import sys; print(sys.stdin.read())'),
+        py2cmd('import sys; _ = sys.stdin.read()'),
         stdin=('ABCDEFGHIJKLMNOPQRSTUVWXYZ-' * 10000).encode('utf-8'),
         protocol=None
     )

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -157,7 +157,7 @@ def test_runner_stdin_no_capture():
     # Ensure that stdin writing alone progresses
     runner = Runner()
     runner.run(
-        py2cmd('import sys; _ = sys.stdin.read()'),
+        py2cmd('import sys; print(sys.stdin.read()[-10:])'),
         stdin=('ABCDEFGHIJKLMNOPQRSTUVWXYZ-' * 10000).encode('utf-8'),
         protocol=None
     )


### PR DESCRIPTION
Stops printing of 240000 characters during witless-runner tests.