### PR TITLE
MNT: Reduce unused imports and harmonize existing imports for a subset of the code base

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -15,7 +15,6 @@ __docformat__ = 'restructuredtext'
 from collections import OrderedDict
 import logging
 import re
-from tempfile import TemporaryFile
 
 from datalad.interface.base import (
     Interface,
@@ -33,7 +32,6 @@ from datalad.interface.utils import (
 from datalad.interface.results import annexjson2result
 from datalad.log import log_progress
 from datalad.support.annexrepo import (
-    AnnexJsonProtocol,
     AnnexRepo,
 )
 from datalad.support.gitrepo import GitRepo

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1103,7 +1103,6 @@ def test_ria_postclonecfg():
         raise SkipTest("Can't create symlinks")
 
     from datalad.utils import make_tempfile
-    from datalad.tests.utils import HTTPPath
 
     with make_tempfile(mkdir=True) as lcl, make_tempfile(mkdir=True) as store, \
             make_tempfile(mkdir=True) as store2:

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -27,7 +27,6 @@ from datalad.cmd import (
 )
 from datalad.utils import (
     Path,
-    on_windows,
 )
 from datalad.tests.utils import (
     assert_in,

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -25,7 +25,6 @@ import sys
 
 from unittest.mock import patch
 
-from datalad import __version__
 from datalad.utils import (
     chpwd,
     ensure_unicode,

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -14,7 +14,6 @@ import os.path as op
 from datalad.utils import (
     ensure_list,
     Path,
-    on_windows,
     rmtree,
 )
 from datalad.tests.utils import (

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -12,14 +12,16 @@ from __future__ import absolute_import
 
 __docformat__ = 'restructuredtext'
 
-import inspect
 import errno
 import os
 import sys
 
 from collections import Counter
 
-from ..support.path import exists, join as opj, dirname, lexists
+from ..support.path import (
+    join as opj,
+    lexists,
+)
 
 from urllib.parse import urlparse
 
@@ -32,9 +34,7 @@ from ..support.cache import DictCache
 from ..cmdline.helpers import get_repo_instance
 from ..dochelpers import exc_str
 from datalad.utils import (
-    ensure_unicode,
     getargspec,
-    Path,
 )
 
 URI_PREFIX = "dl"

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -13,7 +13,6 @@ __docformat__ = 'restructuredtext'
 import logging
 lgr = logging.getLogger('datalad.customremotes.datalad')
 
-from ..utils import disable_logger
 from .base import AnnexCustomRemote
 from ..dochelpers import exc_str
 

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 import argparse
 import os
 
-from .. import __doc__ as m__doc__, __version__ as m__version__
+from .. import __doc__ as m__doc__
 from ..log import lgr
 
 from ..cmdline import helpers

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -31,7 +31,6 @@ from ...tests.utils import (
     abspath,
     assert_equal,
     assert_false,
-    assert_is_instance,
     assert_not_equal,
     assert_not_in,
     assert_raises,
@@ -41,7 +40,6 @@ from ...tests.utils import (
     in_,
     known_failure_githubci_win,
     ok_,
-    ok_file_has_content,
     serve_path_via_http,
     swallow_logs,
     with_tempfile,
@@ -55,7 +53,6 @@ from datalad.cmd import (
 )
 from datalad.support.exceptions import CommandError
 from ...utils import (
-    _path_,
     unlink,
 )
 

--- a/datalad/dataset/repo.py
+++ b/datalad/dataset/repo.py
@@ -11,10 +11,8 @@
 """
 
 import logging
-import weakref
 
 from datalad.support.exceptions import InvalidInstanceRequestError
-from datalad.support import path as op
 from datalad.support.network import RI
 from datalad import utils as ut
 

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -12,7 +12,6 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-import subprocess
 
 from datalad.cmd import WitlessRunner as Runner
 from datalad.interface.common_opts import (

--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -251,7 +251,6 @@ class ExportToFigshare(Interface):
                  # TODO: support working with projects and articles within them
                  # project_id=None,
                  article_id=None):
-        import os
         import logging
         lgr = logging.getLogger('datalad.plugin.export_to_figshare')
 

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -25,7 +25,6 @@ from datalad.tests.utils import (
     assert_raises,
     eq_,
     with_tempfile,
-    known_failure_githubci_win,
 )
 
 
@@ -305,7 +304,6 @@ class _CreateFailureGitLab(_FakeGitLab):
 @with_tempfile
 def test_fake_gitlab(path):
     from unittest.mock import patch
-    import datalad.distributed.create_sibling_gitlab
     ds = Dataset(path).create()
     with patch("datalad.distributed.create_sibling_gitlab.GitLabSite", _NewProjectGitLab):
         res = ds.create_sibling_gitlab(site='dummy', project='here', description='thisisit')

--- a/datalad/distributed/tests/test_export_to_figshare.py
+++ b/datalad/distributed/tests/test_export_to_figshare.py
@@ -10,23 +10,15 @@
 """Test export_to_figshare"""
 
 from datalad.api import export_archive
-from datalad.utils import chpwd
-from datalad.utils import md5sum
 from datalad.support import path as op
 
 from datalad.tests.utils import with_tree, eq_
-from datalad.tests.utils import ok_startswith
-from datalad.tests.utils import assert_true, assert_not_equal, assert_raises, \
-    assert_false, assert_equal
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_result_count
 
 from datalad.support.gitrepo import GitRepo
 from datalad.api import Dataset
 
 from ..export_to_figshare import (
     _get_default_title,
-    _enter_title,
 )
 
 

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -39,7 +39,6 @@ from datalad.distributed.ora_remote import (
 )
 from datalad.support.exceptions import (
     CommandError,
-    IncompleteResultsError
 )
 from datalad.distributed.tests.ria_utils import (
     get_all_files,

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -51,7 +51,6 @@ from datalad.utils import (
     Path,
     PurePath,
     ensure_list,
-    quote_cmdlinearg,
 )
 
 
@@ -405,7 +404,6 @@ class Dataset(object, metaclass=PathBasedFlyweight):
         -------
         Dataset or None
         """
-        from datalad.coreapi import subdatasets
         path = self.path
         sds_path = path if topmost else None
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -15,8 +15,6 @@ import re
 
 import os.path as op
 
-from functools import partial
-
 from datalad.config import ConfigManager
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
@@ -25,7 +23,6 @@ from datalad.interface.results import (
     get_status_dict,
     results_from_paths,
     annexjson2result,
-    count_results,
     success_status_map,
     results_from_annex_noinfo,
 )
@@ -60,9 +57,6 @@ from datalad.support.network import (
 )
 from datalad.support.parallel import (
     ProducerConsumerProgressLog,
-)
-from datalad.dochelpers import (
-    single_or_plural,
 )
 from datalad.utils import (
     unique,

--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -16,28 +16,37 @@ from collections import OrderedDict
 from os.path import join as opj
 
 from datalad import ssh_manager
-from datalad.interface.annotate_paths import AnnotatePaths
-from datalad.interface.annotate_paths import annotated2content_by_ds
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
+from datalad.interface.annotate_paths import (
+    AnnotatePaths,
+    annotated2content_by_ds
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
 from datalad.interface.utils import eval_results
 from datalad.interface.results import get_status_dict
 from datalad.interface.common_opts import annex_copy_opts, recursion_flag, \
     recursion_limit, git_opts, annex_opts, jobs_opt
 from datalad.interface.common_opts import missing_sibling_opt
 from datalad.support.param import Parameter
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureChoice
-from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureChoice,
+    EnsureNone,
+)
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.sshconnector import sh_quote
 from datalad.support.exceptions import (
     InsufficientArgumentsError,
 )
-from datalad.support.network import URL, RI, SSHRI, is_ssh
+from datalad.support.network import (
+    is_ssh,
+    RI,
+    URL,
+)
 
 from datalad.utils import ensure_list
-from datalad.dochelpers import exc_str
 
 from .dataset import EnsureDataset
 from .dataset import Dataset

--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -12,13 +12,14 @@
 
 __docformat__ = 'restructuredtext'
 
-import os
 import logging
 
-from os.path import exists
-from os.path import relpath
-from os.path import pardir
-from os.path import join as opj
+from os.path import (
+    exists,
+    join as opj,
+    pardir,
+    relpath,
+)
 from datalad.utils import rmdir
 from datalad.support.param import Parameter
 from datalad.support.constraints import EnsureStr, EnsureNone
@@ -29,20 +30,28 @@ from datalad.distribution.dataset import Dataset, \
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.annotate_paths import annotated2content_by_ds
 from datalad.interface.base import Interface
-from datalad.interface.common_opts import if_dirty_opt
-from datalad.interface.common_opts import recursion_flag
-from datalad.interface.common_opts import nosave_opt
-from datalad.interface.common_opts import save_message_opt
-from datalad.interface.utils import path_is_under
-from datalad.interface.utils import eval_results
+from datalad.interface.common_opts import (
+    if_dirty_opt,
+    nosave_opt,
+    recursion_flag,
+    save_message_opt,
+)
+from datalad.interface.utils import (
+    path_is_under,
+    eval_results,
+)
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.core.local.save import Save
-from datalad.distribution.drop import _drop_files
-from datalad.distribution.drop import dataset_argument
-from datalad.distribution.drop import check_argument
-from datalad.distribution.uninstall import _uninstall_dataset
-from datalad.distribution.uninstall import Uninstall
+from datalad.distribution.drop import (
+    check_argument,
+    dataset_argument,
+    _drop_files,
+)
+from datalad.distribution.uninstall import (
+    _uninstall_dataset,
+    Uninstall,
+)
 
 
 lgr = logging.getLogger('datalad.distribution.remove')

--- a/datalad/distribution/tests/test_create_github.py
+++ b/datalad/distribution/tests/test_create_github.py
@@ -18,14 +18,12 @@ from datalad.utils import (
     ensure_list,
 )
 from datalad.tests.utils import (
-    assert_equal,
     assert_false,
     assert_in,
     assert_in_results,
     assert_not_in,
     assert_raises,
     assert_true,
-    eq_,
     skip_if_no_network,
     SkipTest,
     use_cassette as use_cassette_,

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -12,7 +12,6 @@
 import os
 from os import chmod
 import stat
-import re
 import sys
 
 from os.path import join as opj, exists, basename
@@ -52,7 +51,6 @@ from datalad.tests.utils import (
     known_failure_windows,
     ok_,
     ok_endswith,
-    ok_exists,
     ok_file_has_content,
     ok_file_under_git,
     skip_if_on_windows,

--- a/datalad/distribution/tests/test_publish.py
+++ b/datalad/distribution/tests/test_publish.py
@@ -103,7 +103,6 @@ def test_invalid_call(origin, tdir):
 @with_tempfile
 def test_since_empty_and_unsupported(p1, p2):
     source = Dataset(p1).create()
-    from datalad.support.network import PathRI
     source.create_sibling(p2, name='target1')
     # see https://github.com/datalad/datalad/pull/4448#issuecomment-620847327
     # Test that it doesn't fail without a prior push

--- a/datalad/distribution/tests/test_uninstall.py
+++ b/datalad/distribution/tests/test_uninstall.py
@@ -31,7 +31,6 @@ from datalad.tests.utils import (
     ok_,
     eq_,
     with_testrepos,
-    SkipTest,
     assert_raises,
     assert_status,
     assert_in,

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -12,15 +12,18 @@
 
 import logging
 
-from os.path import join as opj
-from os.path import isabs
-from os.path import normpath
+from os.path import (
+    isabs,
+    join as opj,
+    normpath,
+)
 import posixpath
 
-from datalad.support.network import DataLadRI
-from datalad.support.network import URL
-from datalad.support.network import RI
-from datalad.support.network import PathRI
+from datalad.support.network import (
+    PathRI,
+    RI,
+    URL,
+)
 
 
 lgr = logging.getLogger('datalad.distribution.utils')

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -18,7 +18,6 @@ import textwrap
 import os
 import sys
 import traceback
-from pathlib import Path
 
 from datalad.support.exceptions import CapturedException
 

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -42,8 +42,6 @@ from datalad.tests.utils import (
     ok_archives_caches,
     ok_file_under_git,
     serve_path_via_http,
-    slow,
-    swallow_logs,
     swallow_outputs,
     with_tempfile,
     with_tree,

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -40,7 +40,6 @@ from datalad.tests.utils import (
     ok_file_has_content,
     on_windows,
     patch_config,
-    skip_if,
     with_tempfile,
     with_tree,
 )
@@ -50,7 +49,6 @@ from datalad.support.exceptions import (
     InsufficientArgumentsError,
 )
 from datalad.api import run_procedure
-from datalad import cfg as dl_cfg
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-import os
 from os.path import join as opj
 
 
@@ -38,8 +37,6 @@ from datalad.tests.utils import (
     assert_cwd_unchanged,
     with_testrepos,
     with_tree,
-    on_windows,
-    skip_if,
     skip_if_root,
     slow,
     assert_in_results,

--- a/datalad/local/export_archive.py
+++ b/datalad/local/export_archive.py
@@ -83,7 +83,6 @@ class ExportArchive(Interface):
         from datalad.distribution.dataset import require_dataset
         from datalad.utils import file_basename
         from datalad.support.annexrepo import AnnexRepo
-        from datalad.dochelpers import exc_str
 
         import logging
         lgr = logging.getLogger('datalad.local.export_archive')

--- a/datalad/local/tests/test_subdataset.py
+++ b/datalad/local/tests/test_subdataset.py
@@ -23,7 +23,6 @@ from datalad.api import (
 )
 from datalad.utils import (
     chpwd,
-    on_windows,
     Path,
     PurePosixPath,
 )

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -14,7 +14,6 @@ import logging
 import os
 import os.path as op
 from functools import partial
-from itertools import chain
 from collections import OrderedDict
 
 

--- a/datalad/support/archive_utils_patool.py
+++ b/datalad/support/archive_utils_patool.py
@@ -18,13 +18,11 @@ from .exceptions import MissingExternalDependency
 from .path import (
     basename,
     join as opj,
-    exists,
 )
 
 from datalad.utils import (
     ensure_bytes,
     chpwd,
-    rmdir,
 )
 
 import logging

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -13,7 +13,6 @@
 import hashlib
 import os
 import tempfile
-from urllib.parse import unquote as urlunquote
 import string
 import random
 import logging

--- a/datalad/support/cookies.py
+++ b/datalad/support/cookies.py
@@ -10,7 +10,6 @@
 
 import atexit
 import shelve
-import pickle
 import appdirs
 import os.path
 

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -5,7 +5,7 @@ Support functionality for using DueCredit
 """
 
 # Note Text was added/exposed only since DueCredit 0.6.5
-from .due import due, Doi, Url, Text
+from .due import due, Doi, Text
 from ..utils import never_fail, swallow_logs
 from ..dochelpers import exc_str
 

--- a/datalad/support/github_.py
+++ b/datalad/support/github_.py
@@ -16,8 +16,10 @@ from ..consts import (
 from ..dochelpers import exc_str
 from ..downloaders.credentials import Token
 from ..ui import ui
-from ..utils import unique, ensure_list, ensure_tuple_or_list
-
+from ..utils import (
+    ensure_list,
+    unique,
+)
 from .exceptions import (
     AccessDeniedError,
     MissingExternalDependency,

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -22,17 +22,23 @@ import iso8601
 
 from hashlib import md5
 from collections import OrderedDict
-from os.path import abspath, isabs
-from os.path import join as opj
-from os.path import dirname
+from os.path import (
+    dirname,
+    join as opj,
+)
 from ntpath import splitdrive as win_splitdrive
 
-from urllib.parse import urlsplit
 from urllib.request import Request
-from urllib.parse import unquote as urlunquote
-from urllib.parse import urljoin, urlparse, urlsplit, urlunparse, ParseResult
-from urllib.parse import parse_qsl
-from urllib.parse import urlencode
+from urllib.parse import (
+    parse_qsl,
+    ParseResult,
+    unquote as urlunquote,
+    urlencode,
+    urljoin,
+    urlparse,
+    urlsplit,
+    urlunparse,
+)
 from urllib.error import URLError
 
 from datalad.dochelpers import exc_str

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 from nose.tools import assert_equal, assert_true
 from datalad.support.exceptions import CapturedException

--- a/datalad/support/tests/test_due_utils.py
+++ b/datalad/support/tests/test_due_utils.py
@@ -1,6 +1,5 @@
 from ...distribution import dataset as dataset_mod
 from ...distribution.dataset import Dataset
-from .. import due_utils
 from ..due_utils import duecredit_dataset
 
 from ..due import (
@@ -12,12 +11,6 @@ from ..due import (
 from ..external_versions import external_versions
 
 from ...tests.utils import (
-    assert_raises,
-    eq_,
-    integration,
-    ok_,
-    SkipTest,
-    skip_if_no_module,
     swallow_logs,
     with_tempfile,
 )

--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -17,11 +17,12 @@ from unittest.mock import patch
 import os.path as op
 
 from datalad.support.globbedpaths import GlobbedPaths
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import eq_
-from datalad.tests.utils import swallow_logs
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils import (
+    assert_in,
+    eq_,
+    swallow_logs,
+    with_tree,
+)
 
 
 def test_globbedpaths_get_sub_patterns():

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -14,7 +14,6 @@ from datalad.tests.utils import (
     create_tree,
     with_tempfile,
     eq_,
-    known_failure_githubci_win,
     known_failure_windows,
 )
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -10,15 +10,17 @@
 """
 
 import logging
-import os
 import os.path as op
-from os.path import exists, isdir, getmtime, join as opj
-from unittest.mock import patch
+from os.path import (
+    exists,
+    getmtime,
+    isdir,
+    join as opj,
+)
 
 from datalad.tests.utils import SkipTest
 
 
-from datalad.support.external_versions import external_versions
 from datalad.utils import Path
 
 from datalad.tests.utils import (
@@ -38,7 +40,6 @@ from datalad.tests.utils import (
     with_tempfile,
     with_tree,
 )
-from datalad import cfg as dl_cfg
 from ..sshconnector import (
     SSHConnection,
     SSHManager,

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -9,13 +9,14 @@
 import sys
 import json
 
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.request import (
+    Request,
+    urlopen,
+)
 from urllib.error import HTTPError
 
 from datalad.support.exceptions import (
     AccessDeniedError,
-    AccessFailedError,
 )
 from datalad.utils import ensure_unicode
 

--- a/datalad/support/third/noseclasses.py
+++ b/datalad/support/third/noseclasses.py
@@ -12,7 +12,6 @@ import inspect
 
 import nose
 from nose.plugins import doctests as npd
-from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
 from nose.plugins.base import Plugin
 from nose.util import src
 from .nosetester import get_package_name

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -398,7 +398,7 @@ def _prep_file_under_git(path, filename):
     # do absolute() in addition to always get an absolute path
     # even with non-existing paths on windows
     path = str(Path(path).resolve().absolute())  # intentional realpath to match GitRepo behavior
-    file_repo_dir = op.relpath(path, repo.path)
+    file_repo_dir = relpath(path, repo.path)
     file_repo_path = filename if file_repo_dir == curdir else opj(file_repo_dir, filename)
     return annex, file_repo_path, filename, path, repo
 
@@ -1679,26 +1679,26 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
         ds.save(to_git=True)
         ds.drop([
             'file_dropped_clean',
-            op.join('subdir', 'file_dropped_clean')],
+            opj('subdir', 'file_dropped_clean')],
             check=False)
     # clean and proper subdatasets
     ds.create('subds_clean')
-    ds.create(op.join('subdir', 'subds_clean'))
+    ds.create(opj('subdir', 'subds_clean'))
     ds.create('subds_unavailable_clean')
-    ds.create(op.join('subdir', 'subds_unavailable_clean'))
+    ds.create(opj('subdir', 'subds_unavailable_clean'))
     # uninstall some subdatasets (still clean)
     ds.uninstall([
         'subds_unavailable_clean',
-        op.join('subdir', 'subds_unavailable_clean')],
+        opj('subdir', 'subds_unavailable_clean')],
         check=False)
     assert_repo_status(ds.path)
     # make a dirty subdataset
     ds.create('subds_modified')
-    ds.create(op.join('subds_modified', 'someds'))
-    ds.create(op.join('subds_modified', 'someds', 'dirtyds'))
+    ds.create(opj('subds_modified', 'someds'))
+    ds.create(opj('subds_modified', 'someds', 'dirtyds'))
     # make a subdataset with additional commits
-    ds.create(op.join('subdir', 'subds_modified'))
-    pdspath = op.join(ds.path, 'subdir', 'subds_modified', 'progressedds')
+    ds.create(opj('subdir', 'subds_modified'))
+    pdspath = opj(ds.path, 'subdir', 'subds_modified', 'progressedds')
     ds.create(pdspath)
     create_tree(
         pdspath,
@@ -1707,10 +1707,10 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
     Dataset(pdspath).save()
     assert_repo_status(pdspath)
     # staged subds, and files
-    create(op.join(ds.path, 'subds_added'))
+    create(opj(ds.path, 'subds_added'))
     ds.repo.add_submodule('subds_added')
-    create(op.join(ds.path, 'subdir', 'subds_added'))
-    ds.repo.add_submodule(op.join('subdir', 'subds_added'))
+    create(opj(ds.path, 'subdir', 'subds_added'))
+    ds.repo.add_submodule(opj('subdir', 'subds_added'))
     # some more untracked files
     create_tree(
         ds.path,
@@ -1733,18 +1733,18 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
             },
         }
     )
-    ds.repo.add(['file_added', op.join('subdir', 'file_added')])
+    ds.repo.add(['file_added', opj('subdir', 'file_added')])
     # untracked subdatasets
-    create(op.join(ds.path, 'subds_untracked'))
-    create(op.join(ds.path, 'subdir', 'subds_untracked'))
+    create(opj(ds.path, 'subds_untracked'))
+    create(opj(ds.path, 'subdir', 'subds_untracked'))
     # deleted files
-    os.remove(op.join(ds.path, 'file_deleted'))
-    os.remove(op.join(ds.path, 'subdir', 'file_deleted'))
+    os.remove(opj(ds.path, 'file_deleted'))
+    os.remove(opj(ds.path, 'subdir', 'file_deleted'))
     # staged deletion
     ds.repo.remove('file_staged_deleted')
     # modified files
     if isinstance(ds.repo, AnnexRepo):
-        ds.repo.unlock(['file_modified', op.join('subdir', 'file_modified')])
+        ds.repo.unlock(['file_modified', opj('subdir', 'file_modified')])
         create_tree(
             ds.path,
             {
@@ -1800,7 +1800,7 @@ def get_deeply_nested_structure(path):
     # a subtree of datasets
     subds = ds.create('subds_modified')
     # another dataset, plus an additional dir in it
-    ds.create(op.join('subds_modified', 'subds_lvl1_modified'))
+    ds.create(opj('subds_modified', 'subds_lvl1_modified'))
     create_tree(
         ds.path,
         {
@@ -1830,15 +1830,15 @@ def get_deeply_nested_structure(path):
     (ds.pathobj / 'link2dir').symlink_to('subdir')
     # upwards pointing symlink to directory within the same dataset
     (ds.pathobj / 'directory_untracked' / 'link2dir').symlink_to(
-        op.join('..', 'subdir'))
+        opj('..', 'subdir'))
     # symlink pointing to a subdataset mount in the same dataset
     (ds.pathobj / 'link2subdsroot').symlink_to('subds_modified')
     # symlink to a dir in a subdataset (across dataset boundaries)
     (ds.pathobj / 'link2subdsdir').symlink_to(
-        op.join('subds_modified', 'subdir'))
+        opj('subds_modified', 'subdir'))
     # symlink to a dir in a superdataset (across dataset boundaries)
     (ut.Path(subds.path) / 'link2superdsdir').symlink_to(
-        op.join('..', 'subdir'))
+        opj('..', 'subdir'))
     return ds
 
 

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -320,7 +320,6 @@ class IPythonUI(DialogUI):
         """
         backend = kwargs.pop('backend', None)
         if self._tqdm_frontend == "unknown":
-            from .progressbars import tqdmProgressBar
             try:
                 from tqdm import tqdm_notebook  # check if available etc
                 self.__class__._tqdm_frontend = 'ipython'

--- a/datalad/ui/tests/test_base.py
+++ b/datalad/ui/tests/test_base.py
@@ -20,7 +20,6 @@ from ...tests.utils import (
     assert_equal, assert_not_equal,
     assert_raises,
     assert_false,
-    ok_,
     with_testsui,
 )
 

--- a/datalad/version.py
+++ b/datalad/version.py
@@ -9,7 +9,6 @@
 """Defines version to be imported in the module and obtained from setup.py
 """
 
-import sys
 from os.path import lexists, dirname, join as opj, curdir
 
 # Hard coded version, to be done by release process,


### PR DESCRIPTION
I went through the list of unused imports in #5812, and found plenty of unused imports in the code base. This PR removes them. I hope I didn't kill relevant imports - the tests will tell. 
Whenever I found inconsistent import formats, I tried to harmonize them into the current import statement standard, i.e.
```
from xy import (
   A,
   C, 
   Q,
   Z,
)
```

Within datalad/tests/utils.py  I stumbled about a mix between ``opj`` and ``op.join`` and I tried to unify this to ``opj``.

(There is still much to clean up, but this is all I got so far.)