### PR TITLE
UX: Make remove work without -d if the path matches a dataset

### DIFF
--- a/datalad/distribution/remove.py
+++ b/datalad/distribution/remove.py
@@ -120,6 +120,12 @@ class Remove(Interface):
             # act on the whole dataset if nothing else was specified
             # TODO i think that would happen automatically in annotation?
             path = refds_path
+        if path and len(path) == 1 and not os.path.isfile(path[0]) and \
+                not refds_path and GitRepo.is_valid_repo(path[0]):
+            # The path we were given is actually a dataset
+            refds_path = Interface.get_refds_path(path[0])
+            res_kwargs['refds'] = refds_path
+            path = None
 
         to_process = []
 


### PR DESCRIPTION
This is a pretty naive attempt at fixing #4097, and the fact that ``datalad remove someds`` works while ``datalad remove somesuperds`` requires ``-d``/``--dataset``. It adds a basic check whether a single supplied path is a dataset instead of a file to remove, and if it is, it treats the path as the dataset.

Since ``remove`` seems to do this anyway for datasets without subdatasets, I hope this change isn't too controversial. But check if I have overlooked something here, after all, its a quite destructive command. I threw all possible checks into the conditional in hopes to really only catch datasets disguised as paths - let me know if you know a more elegant way to do this.