### PR TITLE
RF(TST): do not test for no EASY and pkg_resources in shims

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -189,12 +189,6 @@ def test_incorrect_options():
 
 def test_script_shims():
     runner = Runner()
-    # The EASY-INSTALL checks below aren't valid for editable installs. Use the
-    # existence of setup.py as an indication that install is _probably_
-    # editable. The file should always exist for editable installs, but it can
-    # also exist for non-editable installs when the tests are being executed
-    # from the top of the source tree.
-    setup_exists = (Path(datalad.__file__).parent.parent / "setup.py").exists()
     for script in [
         'datalad',
         'git-annex-remote-datalad-archives',
@@ -208,10 +202,6 @@ def test_script_shims():
         else:
             from distutils.spawn import find_executable
             content = find_executable(script)
-
-        if not setup_exists:
-            assert_not_in('EASY', content) # NOTHING easy should be there
-            assert_not_in('pkg_resources', content)
 
         # and let's check that it is our script
         out = runner.run([script, '--version'], protocol=StdOutErrCapture)


### PR DESCRIPTION
Awhile back we did switch away from creating our own entry point
scripts, and just succumbed to all the goodness default mechanisms
give us.  We had to skip this test on debian builds, where we have
to run something like   setup.py develop  to produce those entry points
for the tests.  That added up burden etc.  So I decided we should no
longer bother with such tests, also because pkg_resources now used
just as a fall back in those produced by setuptools, so typically there
should be no big penalty in start time.

Closes #5384
