### PR TITLE
BF: import importlib.metadata not importlib_metadata whenever available

### DIFF
--- a/_datalad_build_support/setup.py
+++ b/_datalad_build_support/setup.py
@@ -40,7 +40,11 @@ def get_version(name):
       Name of the folder (package) where from to read version.py
     """
     # delay import so we do not require it for a simple setup stage
-    from importlib_metadata import version as importlib_version
+    try:
+        from importlib.metadata import version as importlib_version
+    except ImportError:
+        # TODO - remove whenever python >= 3.8
+        from importlib_metadata import version as importlib_version
     return importlib_version(name)
 
 


### PR DESCRIPTION
Bug introduced by myself in https://github.com/datalad/datalad/pull/5669 ,
which forbids building debian package on systems with python3 >= 3.8
where we do not (as should not) require importlib_metadata backport.
