### PR TITLE
BF: Fix reported paths in ORA remote

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1176,7 +1176,7 @@ class RIARemote(SpecialRemote):
                    self.annex.dirhash(key) + "/" + key + "/" + key
 
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
-        return str(key_path) if self._local_io() \
+        return str(dsobj_dir / key_path) if self._local_io() \
             else '{}: {}:{}'.format(
                 self.storage_host,
                 self.remote_git_dir,

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1172,8 +1172,8 @@ class RIARemote(SpecialRemote):
         if isinstance(self.io, HTTPRemoteIO):
             # display the URL for a request
             # TODO: method of HTTPRemoteIO
-            return self.ria_store_url[4:] + "/annex/objects" + \
-                   self.annex.dirhash(key) + "/" + key + "/" + key
+            return self.ria_store_url[4:] + "/annex/objects/" + \
+                   self.annex.dirhash(key) + key + "/" + key
 
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         return str(dsobj_dir / key_path) if self._local_io() \


### PR DESCRIPTION
In a local ORA remote, ``whereis`` only reported the object key:
```
(magma) adina@cpu12 in /data/group/psyinf/processing-workflow-tutorial on git:master
❱ git annex whereis fmriprep/sub-01/anat/sub-01_desc-brain_mask.nii.gz 
whereis fmriprep/sub-01/anat/sub-01_desc-brain_mask.nii.gz (3 copies) 
  	c034a599-5db4-4212-8c2f-5d1bfaa0af5c -- adina@juseless:/data/group/psyinf/processing-workflow-tutorial [here]
   	c564c916-629f-4bb8-8113-01a3b04d7a51 -- gin [gnode]
   	d8807e1f-25ef-4267-a5b9-698eae068b4c -- [output-storage]

  output-storage: Pv/77/MD5E-s422015--f1db473b0ef4bde6cd9bd1b6db9069ff.nii.gz/MD5E-s422015--f1db473b0ef4bde6cd9bd1b6db9069ff.nii.gz
``` 

(reported in https://github.com/datalad/datalad/issues/4979#issuecomment-885170380).
This PR tries to fix this. 

Fixes #4979