### PR TITLE
Make ORA compatible with URL keys

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -188,6 +188,12 @@ class LocalIO(IOBase):
         )
 
     def get_from_archive(self, archive, src, dst, progress_cb):
+        # Upfront check to avoid cryptic error output
+        # https://github.com/datalad/datalad/issues/4336
+        if not self.exists(archive):
+            raise RIARemoteError("archive {arc} does not exist."
+                                 "".format(arc=archive))
+
         # this requires python 3.5
         with open(dst, 'wb') as target_file:
             subprocess.run([

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1203,6 +1203,9 @@ class RIARemote(SpecialRemote):
     def transfer_store(self, key, filename):
         self._ensure_writeable()
 
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         key_path = dsobj_dir / key_path
 
@@ -1240,6 +1243,8 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def transfer_retrieve(self, key, filename):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
 
         if isinstance(self.io, HTTPRemoteIO):
             self.io.get(PurePosixPath(self.annex.dirhash(key)) / key / key,
@@ -1265,6 +1270,8 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def checkpresent(self, key):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
 
         if isinstance(self.io, HTTPRemoteIO):
             return self.io.checkpresent(
@@ -1284,6 +1291,9 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def remove(self, key):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
         self._ensure_writeable()
 
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
@@ -1310,6 +1320,8 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def whereis(self, key):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
 
         if isinstance(self.io, HTTPRemoteIO):
             # display the URL for a request
@@ -1356,6 +1368,35 @@ class RIARemote(SpecialRemote):
             self._last_keypath[1]
 
     # TODO: implement method 'error'
+
+
+def _sanitize_key(key):
+    """Returns a sanitized key that is a suitable directory/file name
+
+    Documentation from the analog implementation in git-annex
+    Annex/Locations.hs
+
+    Converts a key into a filename fragment without any directory.
+
+    Escape "/" in the key name, to keep a flat tree of files and avoid
+    issues with keys containing "/../" or ending with "/" etc.
+
+    "/" is escaped to "%" because it's short and rarely used, and resembles
+        a slash
+    "%" is escaped to "&s", and "&" to "&a"; this ensures that the mapping
+        is one to one.
+    ":" is escaped to "&c", because it seemed like a good idea at the time.
+
+    Changing what this function escapes and how is not a good idea, as it
+    can cause existing objects to get lost.
+    """
+    esc = {
+        '/': '%',
+        '%': '&s',
+        '&': '&a',
+        ':': '&c',
+    }
+    return ''.join(esc.get(c, c) for c in key)
 
 
 def main():

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -11,6 +11,7 @@ import logging
 from datalad.api import (
     Dataset,
     clone,
+    create_sibling_ria,
 )
 from datalad.utils import Path
 from datalad.tests.utils import (
@@ -624,3 +625,43 @@ def test_push_url(storepath, dspath, blockfile):
     known_sources = ds.repo.whereis('one.txt')
     assert_in(here_uuid, known_sources)
     assert_in(store_uuid, known_sources)
+
+
+@known_failure_windows
+@with_tempfile
+@with_tempfile
+def test_url_keys(dspath, storepath):
+    ds = Dataset(dspath).create()
+    repo = ds.repo
+    filename = 'url_no_size.html'
+    # URL-type key without size
+    repo.call_annex([
+        'addurl', '--relaxed', '--raw', '--file', filename, 'http://example.com',
+    ])
+    ds.save()
+    # copy target
+    ds.create_sibling_ria(
+        name='ria',
+        url='ria+file://{}'.format(storepath),
+        storage_sibling='only',
+    )
+    ds.get(filename)
+    repo.call_annex(['copy', '--to', 'ria', filename])
+    ds.drop(filename)
+    # in the store and on the web
+    assert_equal(len(ds.repo.whereis(filename)), 2)
+    # try download, but needs special permissions to even be attempted
+    ds.config.set('annex.security.allow-unverified-downloads', 'ACKTHPPT', where='local')
+    repo.call_annex(['copy', '--from', 'ria', filename])
+    assert_equal(len(ds.repo.whereis(filename)), 3)
+    # smoke tests that execute the remaining pieces with the URL key
+    repo.call_annex(['fsck', '-f', 'ria'])
+    assert_equal(len(ds.repo.whereis(filename)), 3)
+    # mapped key in whereis output
+    assert_in('%%example', repo.call_annex(['whereis', filename]))
+
+    repo.call_annex(['move', '-f', 'ria', filename])
+    # check that it does not magically reappear, because it actually
+    # did not drop the file
+    repo.call_annex(['fsck', '-f', 'ria'])
+    assert_equal(len(ds.repo.whereis(filename)), 2)

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -36,7 +36,8 @@ from datalad.tests.utils import (
 )
 from datalad.distributed.ora_remote import (
     LocalIO,
-    SSHRemoteIO
+    SSHRemoteIO,
+    _sanitize_key,
 )
 from datalad.support.exceptions import (
     CommandError,
@@ -665,3 +666,11 @@ def test_url_keys(dspath, storepath):
     # did not drop the file
     repo.call_annex(['fsck', '-f', 'ria'])
     assert_equal(len(ds.repo.whereis(filename)), 2)
+
+
+def test_sanitize_key():
+    for i, o in (
+                ('http://example.com/', 'http&c%%example.com%'),
+                ('/%&:', '%&s&a&c'),
+            ):
+        assert_equal(_sanitize_key(i), o)


### PR DESCRIPTION
URL keys contain slashes. POSIX filenames must not. However, the key string was previously used as-is for a file/dirname.

The change introduces a mapping method for problematic keys, that might need to be extended in the future.

The first two commits introduce a test, and fix another issue that was triggered by the broken handling of URL keys.

Fixes #4336
Fixes #5504
Fixes #5822
