### PR TITLE
RF: Normalize logging (levels) for process execution

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -145,7 +145,7 @@ class WitlessRunner(object):
             cwd=cwd,
         )
 
-        lgr.debug('run:\n cwd=%s\n cmd=%s', cwd, cmd)
+        lgr.debug('Run %r (cwd=%s)', cmd, cwd)
         results = run_command(
             cmd,
             protocol,
@@ -156,7 +156,7 @@ class WitlessRunner(object):
         )
 
         # log before any exception is raised
-        lgr.log(8, "Finished running %r with status %s", cmd, results['code'])
+        lgr.debug("Finished %r with status %s", cmd, results['code'])
 
         # make it such that we always blow if a protocol did not report
         # a return code at all

--- a/datalad/cmd_protocols.py
+++ b/datalad/cmd_protocols.py
@@ -95,7 +95,7 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
 
     def connection_made(self, process):
         self.process = process
-        lgr.debug('Process %i started', self.process.pid)
+        lgr.log(8, 'Process %i started', self.process.pid)
 
     def pipe_data_received(self, fd, data):
         self._log(fd, data)
@@ -119,7 +119,8 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
             raise CommandError(
                 "Got None as a return_code for the process %i",
                 self.process.pid)
-        lgr.debug(
+        lgr.log(
+            8,
             'Process %i exited with return code %i',
             self.process.pid, return_code)
         # give captured process output back to the runner as string(s)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -638,8 +638,7 @@ def test_cfg_originorigin(path):
     with chpwd(path), swallow_logs(new_level=logging.DEBUG) as cml:
         clone_lev3 = clone('clone_lev2', 'clone_lev3')
         # we called git-annex-init; see gh-4367:
-        cml.assert_logged(msg=r"[^[]*run:\n cwd=.*\n"
-                              r" cmd=\[('git',.*'annex'|'git-annex'), 'init'",
+        cml.assert_logged(msg=r"[^[]*Run \[('git',.*'annex'|'git-annex'), 'init'",
                           match=False,
                           level='DEBUG')
     assert_result_count(

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -70,13 +70,13 @@ class _ReaderThread(threading.Thread):
         self.quit = True
 
     def run(self):
-        logger.debug("%s started", self)
+        logger.log(5, "%s started", self)
 
         while not self.quit:
 
             data = os.read(self.file.fileno(), 1024)
             if data == b"":
-                logger.debug("%s exiting (stream end)", self)
+                logger.log(5, "%s exiting (stream end)", self)
                 self.queue.put((self.file.fileno(), None, time.time()))
                 return
 
@@ -113,13 +113,13 @@ class _StdinWriterThread(threading.Thread):
             f"{self.process}, {self.stdin_fileno}, {self.command})")
 
     def run(self):
-        logger.debug("%s started", self)
+        logger.log(5, "%s started", self)
 
         # (ab)use internal helper that takes care of a bunch of corner cases
         # and closes stdin at the end
         self.process._stdin_write(self.stdin_data)
 
-        logger.debug("%s exiting (write completed or interrupted)", self)
+        logger.log(5, "%s exiting (write completed or interrupted)", self)
         self.queue.put((self.stdin_fileno, None, time.time()))
 
 

--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, IO, List, Type, Union, Optional
 from .cmd_protocols import WitlessProtocol
 
 
-logger = logging.getLogger("datalad.runner")
+lgr = logging.getLogger("datalad.runner")
 
 STDIN_FILENO = 0
 STDOUT_FILENO = 1
@@ -70,13 +70,13 @@ class _ReaderThread(threading.Thread):
         self.quit = True
 
     def run(self):
-        logger.log(5, "%s started", self)
+        lgr.log(5, "%s started", self)
 
         while not self.quit:
 
             data = os.read(self.file.fileno(), 1024)
             if data == b"":
-                logger.log(5, "%s exiting (stream end)", self)
+                lgr.log(5, "%s exiting (stream end)", self)
                 self.queue.put((self.file.fileno(), None, time.time()))
                 return
 
@@ -113,13 +113,13 @@ class _StdinWriterThread(threading.Thread):
             f"{self.process}, {self.stdin_fileno}, {self.command})")
 
     def run(self):
-        logger.log(5, "%s started", self)
+        lgr.log(5, "%s started", self)
 
         # (ab)use internal helper that takes care of a bunch of corner cases
         # and closes stdin at the end
         self.process._stdin_write(self.stdin_data)
 
-        logger.log(5, "%s exiting (write completed or interrupted)", self)
+        lgr.log(5, "%s exiting (write completed or interrupted)", self)
         self.queue.put((self.stdin_fileno, None, time.time()))
 
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1685,7 +1685,7 @@ def test_gitrepo_push_default_first_kludge(path):
                                            DEFAULT_BRANCH + ":a-oneshot",
                                            DEFAULT_BRANCH + ":c-oneshot"])
     cmds_oneshot = [ln for ln in cml.out.splitlines()
-                    if "cmd" in ln and "push" in ln and DEFAULT_BRANCH in ln]
+                    if "Run" in ln and "push" in ln and DEFAULT_BRANCH in ln]
     eq_(len(cmds_oneshot), 1)
     assert_in(":a-oneshot", cmds_oneshot[0])
     assert_in(":b-oneshot", cmds_oneshot[0])
@@ -1701,7 +1701,7 @@ def test_gitrepo_push_default_first_kludge(path):
                                            DEFAULT_BRANCH + ":a-twoshot",
                                            DEFAULT_BRANCH + ":c-twoshot"])
     cmds_twoshot = [ln for ln in cml.out.splitlines()
-                    if "cmd" in ln and "push" in ln and DEFAULT_BRANCH in ln]
+                    if "Run" in ln and "push" in ln and DEFAULT_BRANCH in ln]
     # ... there are instead two git-push calls.
     eq_(len(cmds_twoshot), 2)
     # The first is for the first item of the refspec.


### PR DESCRIPTION
For the non-async Runner and its protocols.

Log levels:

- Matching log levels for start and end of an event
- High-level execution -> debug
- Process start/finish -> 8
- Threading and IO -> 5

Exemplary output at log-level 1:

```
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config'] (cwd=/tmp/some) 
[Level 8] Process 110667 started 
[Level 5] ReaderThread(<_io.FileIO name=22 mode='rb' closefd=True>, <queue.Queue object at 0x7faa7f55ed00>, ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config']) started 
[Level 5] ReaderThread(<_io.FileIO name=22 mode='rb' closefd=True>, <queue.Queue object at 0x7faa7f55ed00>, ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config']) exiting (stream end) 
[Level 5] ReaderThread(<_io.FileIO name=19 mode='rb' closefd=True>, <queue.Queue object at 0x7faa7f55ed00>, ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config']) started 
[Level 5] ReaderThread(<_io.FileIO name=19 mode='rb' closefd=True>, <queue.Queue object at 0x7faa7f55ed00>, ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config']) exiting (stream end) 
[Level 5] Read 87 bytes from 110667[stdout] 
[Level 8] Process 110667 exited with return code 0 
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config'] with status 0 
```

At `debug` level (arguably the default one, if "something is wrong") the output is reduced to

```
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config'] (cwd=/tmp/some) 
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/some/.datalad/config'] with status 0 
```

which is compact, but still verbose enough to show everything without diving "into" a command execution.

Fixes datalad/datalad#5772