### PR TITLE
UX: When two or more clone URL templates are found, error out more gracefully

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -243,6 +243,13 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                         ds_repo.config[c])
                        for c in ds_repo.config.keys()
                        if c.startswith(candcfg_prefix)]:
+        # ensure that there is only one template of the same name
+        if type(tmpl) == tuple and len(tmpl) > 1:
+            raise ValueError(
+                f"There are multiple URL templates for submodule clone "
+                f"candidate '{name}', but only one is allowed. "
+                f"Check your configuration!"
+            )
         url = tmpl.format(**sm_candidate_props)
         # we don't want "flexible_source_candidates" here, this is
         # configuration that can be made arbitrarily precise from the

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -248,7 +248,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
             raise ValueError(
                 f"There are multiple URL templates for submodule clone "
                 f"candidate '{name}', but only one is allowed. "
-                f"Check your configuration!"
+                f"Check datalad.get.subdataset-source-candidate-* configuration!"
             )
         url = tmpl.format(**sm_candidate_props)
         # we don't want "flexible_source_candidates" here, this is

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -173,6 +173,17 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
          for i in f(clone3, clone3.subdatasets(return_type='item-or-list'))]
     )
 
+    # check #5839: two source configs with the same name should raise an error
+    clone3.config.add(
+        f"datalad.get.subdataset-source-candidate-{DEFAULT_REMOTE}",
+        "should-not-work"
+    )
+    clone3.config.add(
+        f"datalad.get.subdataset-source-candidate-{DEFAULT_REMOTE}",
+        "should-really-not-work"
+    )
+    assert_raises(ValueError, clone3.get, 'sub')
+
     # TODO: check that http:// urls for the dataset itself get resolved
     # TODO: many more!!
 


### PR DESCRIPTION
This is cherry-picked from #5644 because it fixes an issue unrelated to that PR. If someone ends up with two configurations for source candidates with identical names, one would see
```
❱ datalad get HCP1200/100206                                                1 !
[ERROR  ] 'tuple' object has no attribute 'format' [get.py:_get_flexible_source_candidates_for_submodule:240] (AttributeError) 
```

With this change, a user gets a more helpful error message:
```
❱ datalad get HCP1200/100206                                                2 !
[ERROR  ] There are multiple URL templates for submodule clone candidate 'origin', but only one is allowed. Check your configuration! [get.py:_get_flexible_source_candidates_for_submodule:245] (ValueError) 
```