### PR TITLE
Append (not prepend) a newline character(s) to .gitattributes for prettier appearance

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2836,7 +2836,7 @@ class GitRepo(CoreGitRepo):
                         attrline += ' -{}'.format(a)
                     else:
                         attrline += ' {}={}'.format(a, val)
-                f.write('\n{}'.format(attrline))
+                f.write('{}\n'.format(attrline))
 
     def get_content_info(self, paths=None, ref=None, untracked='all',
                          eval_file_type=True):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2819,8 +2819,8 @@ class GitRepo(CoreGitRepo):
         with open(git_attributes_file, mode + '+') as f:
             # for append, fix existing files that do not end with \n
             if mode == 'a' and f.tell():
-                f.seek(f.tell() - 1)
-                if f.read() != '\n':
+                f.seek(max(0, f.tell() - len(os.linesep)))
+                if not f.read().endswith('\n'):
                     f.write('\n')
 
             for pattern, attr in sorted(attrs, key=lambda x: x[0]):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2821,7 +2821,7 @@ class GitRepo(CoreGitRepo):
             if mode == 'a':
                 f.seek(0)
                 s = f.read()
-                if len(s) > 1 and s[-1] != '\n':
+                if s and not s.endswith('\n'):
                     f.write('\n')
 
             for pattern, attr in sorted(attrs, key=lambda x: x[0]):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2818,10 +2818,9 @@ class GitRepo(CoreGitRepo):
 
         with open(git_attributes_file, mode + '+') as f:
             # for append, fix existing files that do not end with \n
-            if mode == 'a':
-                f.seek(0)
-                s = f.read()
-                if s and not s.endswith('\n'):
+            if mode == 'a' and f.tell():
+                f.seek(f.tell() - 1)
+                if f.read() != '\n':
                     f.write('\n')
 
             for pattern, attr in sorted(attrs, key=lambda x: x[0]):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2815,7 +2815,15 @@ class GitRepo(CoreGitRepo):
         attrdir = op.dirname(git_attributes_file)
         if not op.exists(attrdir):
             os.makedirs(attrdir)
-        with open(git_attributes_file, mode) as f:
+
+        with open(git_attributes_file, mode + '+') as f:
+            # for append, fix existing files that do not end with \n
+            if mode == 'a':
+                f.seek(0)
+                s = f.read()
+                if len(s) > 1 and s[-1] != '\n':
+                    f.write('\n')
+
             for pattern, attr in sorted(attrs, key=lambda x: x[0]):
                 # normalize the pattern relative to the target .gitattributes file
                 npath = _normalize_path(

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1395,6 +1395,16 @@ def test_gitattributes(path):
     # mode='w' should replace the entire file:
     gr.set_gitattributes([('**', {'some': 'nonsense'})], mode='w')
     eq_(gr.get_gitattributes('.')['.'], {'some': 'nonsense'})
+    # mode='a' appends additional key/value
+    gr.set_gitattributes([('*', {'king': 'kong'})], mode='a')
+    eq_(gr.get_gitattributes('.')['.'], {'some': 'nonsense', 'king': 'kong'})
+    # handle files without trailing newline
+    with open(op.join(gr.path, '.gitattributes'), 'a+') as f:
+        f.seek(f.tell() - 1)
+        f.truncate()
+    gr.set_gitattributes([('*', {'ding': 'dong'})], mode='a')
+    eq_(gr.get_gitattributes('.')['.'],
+        {'some': 'nonsense', 'king': 'kong', 'ding': 'dong'})
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1399,8 +1399,10 @@ def test_gitattributes(path):
     gr.set_gitattributes([('*', {'king': 'kong'})], mode='a')
     eq_(gr.get_gitattributes('.')['.'], {'some': 'nonsense', 'king': 'kong'})
     # handle files without trailing newline
-    with open(op.join(gr.path, '.gitattributes'), 'a+') as f:
-        f.seek(f.tell() - 1)
+    with open(op.join(gr.path, '.gitattributes'), 'r+') as f:
+        s = f.read()
+        f.seek(0)
+        f.write(s.rstrip())
         f.truncate()
     gr.set_gitattributes([('*', {'ding': 'dong'})], mode='a')
     eq_(gr.get_gitattributes('.')['.'],


### PR DESCRIPTION
Current `.gitattributes` files have this weird structure of an empty line at start and no newline at end. This looks ugly when the files are viewed in terminal.

The solution is very simple and doesn't seem to break anything.