### PR TITLE
nf: export-archive-ora add options to filter files exported to the 7z archive

### DIFF
--- a/datalad/distributed/export_archive_ora.py
+++ b/datalad/distributed/export_archive_ora.py
@@ -137,6 +137,9 @@ class ExportArchiveORA(Interface):
         else:
             archive.parent.mkdir(exist_ok=True, parents=True)
 
+        if isinstance(froms, str):
+            froms = [froms]
+
         if not opts:
             # uncompressed by default
             opts = ['-mx0']

--- a/datalad/distributed/tests/ria_utils.py
+++ b/datalad/distributed/tests/ria_utils.py
@@ -32,6 +32,14 @@ example_payload = {
 }
 
 
+example_payload2 = {
+    'three.txt': 'content3',
+    'subdir': {
+        'four': 'content4',
+    },
+}
+
+
 def get_all_files(path):
     return sorted([
         Path(p).relative_to(path)
@@ -70,7 +78,10 @@ def setup_archive_remote(repo, archive_path):
 
 
 def populate_dataset(ds):
-    create_tree(ds.path, example_payload)
+    # create 2 commits
+    for pl in [example_payload, example_payload2]:
+        create_tree(ds.path, pl)
+        ds.save()
 
 
 def check_not_generatorfunction(func):

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -103,7 +103,6 @@ def test_read_access(store_path, store_url, ds_path):
 
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
-    ds.save()
 
     files = [Path('one.txt'), Path('subdir') / 'two']
     store_path = Path(store_path)
@@ -141,7 +140,6 @@ def test_read_access(store_path, store_url, ds_path):
 
     ds.drop('.')
     res = ds.get('.')
-    assert_equal(len(res), 2)
-    assert_result_count(res, 2, status='ok', type='file', action='get',
+    assert_equal(len(res), 4)
+    assert_result_count(res, 4, status='ok', type='file', action='get',
                         message="from ora-remote...")
-

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -159,7 +159,7 @@ def _test_initremote_basic(host, ds_path, store, link):
             # annex too old - doesn't know --sameas
             pass
         else:
-            raise 
+            raise
     # TODO: - check output of failures to verify it's failing the right way
     #       - might require to run initremote directly to get the output
 
@@ -345,6 +345,11 @@ def _test_remote_layout(host, dspath, store, archiv_store):
         # now fsck the new remote to get the new special remote indexed
         ds.repo.fsck(remote='archive', fast=True)
         assert_equal(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
+        # test creating an archive with filters on files
+        ds.export_archive_ora(archive_dir / 'archive2.7z', annex_wanted='include=*.txt')
+        # test with wanted expression of a specific remote
+        ds.repo.set_preferred_content("wanted", "include=subdir/*", remote="store")
+        ds.export_archive_ora(archive_dir / 'archive3.7z', remote="store")
 
 
 @slow  # 12sec + ? on travis

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -67,7 +67,6 @@ def _test_initremote_basic(host, ds_path, store, link):
     link = Path(link)
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
-    ds.save()
 
     if host:
         url = "ria+ssh://{host}{path}".format(host=host,
@@ -182,7 +181,6 @@ def _test_initremote_alias(host, ds_path, store):
     store = Path(store)
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
-    ds.save()
 
     if host:
         url = "ria+ssh://{host}{path}".format(host=host,
@@ -228,7 +226,6 @@ def _test_initremote_rewrite(host, ds_path, store):
     store = Path(store)
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
-    ds.save()
     assert_repo_status(ds.path)
 
     url = "mystore:"
@@ -282,7 +279,6 @@ def _test_remote_layout(host, dspath, store, archiv_store):
     archiv_store = Path(archiv_store)
     ds = Dataset(dspath).create()
     populate_dataset(ds)
-    ds.save()
     assert_repo_status(ds.path)
 
     # set up store:
@@ -314,7 +310,7 @@ def _test_remote_layout(host, dspath, store, archiv_store):
         get_layout_locations(1, store, ds.id)
     store_objects = get_all_files(dsobj_dir)
     local_objects = get_all_files(ds.pathobj / '.git' / 'annex' / 'objects')
-    assert_equal(len(store_objects), 2)
+    assert_equal(len(store_objects), 4)
 
     if not ds.repo.is_managed_branch():
         # with managed branches the local repo uses hashdirlower instead
@@ -346,10 +342,15 @@ def _test_remote_layout(host, dspath, store, archiv_store):
         ds.repo.fsck(remote='archive', fast=True)
         assert_equal(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
         # test creating an archive with filters on files
-        ds.export_archive_ora(archive_dir / 'archive2.7z', annex_wanted='include=*.txt')
+        ds.export_archive_ora(archive_dir / 'archive2.7z', annex_wanted='(include=*.txt)')
         # test with wanted expression of a specific remote
         ds.repo.set_preferred_content("wanted", "include=subdir/*", remote="store")
         ds.export_archive_ora(archive_dir / 'archive3.7z', remote="store")
+        # test with the current sha
+        ds.export_archive_ora(
+            archive_dir / 'archive4.7z',
+            froms=ds.repo.get_revisions()[1],
+            )
 
 
 @slow  # 12sec + ? on travis
@@ -369,7 +370,6 @@ def _test_version_check(host, dspath, store):
 
     ds = Dataset(dspath).create()
     populate_dataset(ds)
-    ds.save()
     assert_repo_status(ds.path)
 
     # set up store:
@@ -467,7 +467,6 @@ def _test_gitannex(host, store, dspath):
     ds = Dataset(dspath).create()
 
     populate_dataset(ds)
-    ds.save()
     assert_repo_status(ds.path)
 
     # set up store:
@@ -585,7 +584,6 @@ def test_push_url(storepath, dspath, blockfile):
 
     ds = Dataset(dspath).create()
     populate_dataset(ds)
-    ds.save()
     assert_repo_status(ds.path)
 
     # set up store:

--- a/datalad/distributed/tests/test_ria_git_remote.py
+++ b/datalad/distributed/tests/test_ria_git_remote.py
@@ -62,7 +62,6 @@ def _test_bare_git_version_1(host, dspath, store):
     store = Path(store)
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
-    ds.save()
 
     bare_repo_path, _, objdir = get_layout_locations(1, store, ds.id)
     # Use git to make sure the remote end is what git thinks a bare clone of it
@@ -170,7 +169,6 @@ def _test_bare_git_version_2(host, dspath, store):
     store = Path(store)
     ds = Dataset(ds_path).create()
     populate_dataset(ds)
-    ds.save()
 
     bare_repo_path, _, objdir = get_layout_locations(1, store, ds.id)
     # Use git to make sure the remote end is what git thinks a bare clone of it
@@ -229,8 +227,8 @@ def _test_bare_git_version_2(host, dspath, store):
                         error_message='** Based on the location log, one.txt\n'
                                       '** was expected to be present, '
                                       'but its content is missing.')
-    assert_result_count(fsck_res, 1, status='ok')
-    eq_(len(fsck_res), 2)
+    assert_result_count(fsck_res, 3, status='ok')
+    eq_(len(fsck_res), 4)
     eq_(len(ds.repo.whereis('one.txt')), 1)
 
 
@@ -268,7 +266,6 @@ def test_bare_git_version_2():
 #
 #     ds = create(origin)
 #     populate_dataset(ds)
-#     ds.save()
 #     assert_repo_status(ds.path)
 #
 #     # add the ria remote:


### PR DESCRIPTION
changes to command export-archive-ora:

- adds `--for <remote>` which will apply the remote `wanted` expression to select files to archive
- adds `--filters <git-annex-preferred-content>` to provide additional filters to select files to archive
- adds `--branch=<tree-ish>` to select files based on a specific repo state.

Closes #5845 

TODO:

- [x] Add tests
- [x] Handle missing files in current repo (raise or ignore). 
