### PR TITLE
BF: http_auth - follow redirect (just 1) to re-authenticate after initial attempt

### DIFF
--- a/datalad/downloaders/configs/nsidc.cfg
+++ b/datalad/downloaders/configs/nsidc.cfg
@@ -1,0 +1,12 @@
+[provider:NSIDC]
+# might be a little too wide, in particular if some data is public
+url_re = https://.*\.nsidc.org/.*
+authentication_type = http_auth
+credential = NSIDC
+# NSIDC ATM does not return a 403 for non-auth access
+# with our DataLad User-Agent string.  This might help to
+# detect fetching content which is just a login page
+http_auth_failure_re = input\s*type=.password
+
+[credential:NSIDC]
+type = user_password

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -87,10 +87,16 @@ __docformat__ = 'restructuredtext'
 def process_www_authenticate(v):
     if not v:
         return []
+    # TODO: provide proper parsing/handling of this custom format and wider support:
+    #   <type> realm=<realm>[, charset="UTF-8"]
+    # More notes: https://github.com/datalad/datalad/issues/5846#issuecomment-890221053
+    # The most complete solution is from 2018 on https://stackoverflow.com/a/52462292/1265472
+    # relying on parsing it using pyparsing.
     supported_type = v.split(' ')[0].lower()
     our_type = {
         'basic': 'http_basic_auth',
         'digest': 'http_digest_auth',
+        # TODO: bearer_token_anon ?
     }.get(supported_type)
     return [our_type] if our_type else []
 
@@ -346,6 +352,18 @@ class HTTPAuthAuthenticator(HTTPRequestsAuthenticator):
         session.auth = authenticator
         response = session.post(post_url, data={},
                                 auth=authenticator)
+        auth_request = response.headers.get('www-authenticate')
+        if response.status_code == 401 and auth_request:
+            if auth_request.lower().split(' ', 1)[0] == 'basic':
+                if response.url != post_url:
+                    # was instructed to authenticate elsewhere
+                    # TODO: do we need to loop may be??
+                    response2 = session.get(response.url, auth=authenticator)
+                    return response2
+            else:
+                lgr.warning(
+                    f"{self} received response with www-authenticate={auth_request!r} "
+                    "which is not Basic, and thus it cannot handle ATM.")
         return response
 
 
@@ -396,6 +414,9 @@ class HTTPAnonBearerTokenAuthenticator(HTTPBearerTokenAuthenticator):
                 .format(status, url))
 
         lgr.debug("Requesting authorization token for %s", url)
+        # TODO: it is not RFC 2068 Section 2 format, but a custom
+        # <type> realm=<realm>[, charset="UTF-8"]
+        # see TODO/harmonize with  process_www_authenticate
         auth_parts = parse_dict_header(response.headers["www-authenticate"])
         auth_url = ("{}?service={}&scope={}"
                     .format(auth_parts["Bearer realm"],


### PR DESCRIPTION
Closes #5846

needs provider config like

```
[provider:NSIDC]
url_re = https://.*\.nsidc.org/.*
authentication_type = http_auth
credential = NSIDC

[credential:NSIDC]
type = user_password
```

attn @mankoff - might like to try. Note that since our "User-Agent" is still discriminated, you must create that provider file first since datalad will not receive 401 and thus will not prompt you to setup a provider

TODOs

- [x] run the other downloaders needing credentials access through testing locally to ensure no immediate side-effect (we even have it in that `test_authenticate_external_portals` so tested on HCP db one -- seems to work)
- [x] I think I will add aforementioned provider config to our little collection and add a test on a sample url
- not yet sure about a more proper/long-term RF on handling various auth schemes better and automatically selecting one, see original issue for more thoughts/info

