### PR TITLE
TST: set --allow-unrelated-histories in the mk_push_target setup for Windows

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -120,7 +120,10 @@ def mk_push_target(ds, name, path, annex=True, bare=True):
         # commit for the managed branch.
         # the only sane approach is to let git-annex establish a shared
         # history
-        ds.repo.call_annex(['sync'])
+        if AnnexRepo.git_annex_version > "8.20210631":
+            ds.repo.call_annex(['sync', '--allow-unrelated-histories'])
+        else:
+            ds.repo.call_annex(['sync'])
         ds.repo.call_annex(['sync', '--cleanup'])
     return target
 


### PR DESCRIPTION
The test helper mk_push_target creates a sibling dataset by
creating an unrelated dataset and adding it as a sibling. On
Windows, this was not straightforward, as the datasets had
unrelated histories due to the initial adjusted branch commit
in the target dataset. Until git-annex version 20210720, a git
annex sync would establish a shared history - more recent versions
of git-annex will fail to sync unrelated histories unless
--allow-unrelated-histories is set.

With this patch, the tests that started to fail on Windows in #5811 pass again.

Fixes #5811.

