### PR TITLE
RF/NF: Overhaul ORA's config business

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -995,9 +995,10 @@ def postclonecfg_ria(ds, props, remote="origin"):
                 # we only need the store:
                 new_url = props['source'].split('#')[0]
                 try:
-                    repo.enable_remote(srs[org_uuid]['name'],
-                                       options=['url={}'.format(new_url)]
-                                       )
+                    # local config to overwrite committed URL
+                    repo.config.set(f"remote.{srs[org_uuid]['name']}.ora-url",
+                                    new_url, where='local')
+                    repo.enable_remote(srs[org_uuid]['name'])
                     lgr.info("Reconfigured %s for %s",
                              srs[org_uuid]['name'], new_url)
                     # update ora_remotes for considering publication dependency
@@ -1010,6 +1011,8 @@ def postclonecfg_ria(ds, props, remote="origin"):
                 except CommandError as e:
                     lgr.debug("Failed to reconfigure ORA special remote: %s",
                               exc_str(e))
+                    repo.config.unset(f"remote.{srs[org_uuid]['name']}.ora-url",
+                                      where='local')
             else:
                 lgr.debug("Unknown ORA special remote uuid at '%s': %s",
                           remote, org_uuid)

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -586,6 +586,7 @@ def test_push_url(storepath, dspath, blockfile):
     populate_dataset(ds)
     ds.save()
     assert_repo_status(ds.path)
+    repo = ds.repo
 
     # set up store:
     io = LocalIO()
@@ -604,25 +605,37 @@ def test_push_url(storepath, dspath, blockfile):
     block_url = "ria+" + blockfile.as_uri()
     init_opts = common_init_opts + ['url={}'.format(store_url),
                                     'push-url={}'.format(block_url)]
-    ds.repo.init_remote('store', options=init_opts)
-
-    # but a push will fail:
-    assert_raises(CommandError, ds.repo.call_annex,
-                  ['copy', 'one.txt', '--to', 'store'])
-
-    # reconfigure with correct push-url:
-    init_opts = common_init_opts + ['url={}'.format(store_url),
-                                    'push-url={}'.format(store_url)]
-    ds.repo.enable_remote('store', options=init_opts)
-
-    # push works now:
-    ds.repo.call_annex(['copy', 'one.txt', '--to', 'store'])
+    repo.init_remote('store', options=init_opts)
 
     store_uuid = ds.siblings(name='store',
                              return_type='item-or-list')['annex-uuid']
     here_uuid = ds.siblings(name='here',
                             return_type='item-or-list')['annex-uuid']
 
+    # but a push will fail:
+    assert_raises(CommandError, ds.repo.call_annex,
+                  ['copy', 'one.txt', '--to', 'store'])
+
+    # reconfigure w/ local overwrite:
+    repo.config.add("remote.store.ora-push-url", store_url, where='local')
+    # push works now:
+    repo.call_annex(['copy', 'one.txt', '--to', 'store'])
+
+    # remove again (config and file from store)
+    repo.call_annex(['move', 'one.txt', '--from', 'store'])
+    repo.config.unset("remote.store.ora-push-url", where='local')
+    repo.call_annex(['fsck', '-f', 'store'])
+    known_sources = repo.whereis('one.txt')
+    assert_in(here_uuid, known_sources)
+    assert_not_in(store_uuid, known_sources)
+
+    # reconfigure (this time committed)
+    init_opts = common_init_opts + ['url={}'.format(store_url),
+                                    'push-url={}'.format(store_url)]
+    ds.repo.enable_remote('store', options=init_opts)
+
+    # push works now:
+    ds.repo.call_annex(['copy', 'one.txt', '--to', 'store'])
     known_sources = ds.repo.whereis('one.txt')
     assert_in(here_uuid, known_sources)
     assert_in(store_uuid, known_sources)


### PR DESCRIPTION
Clean up the entire config consideration code and introduce consistent local configs to overrule what is committed in the `git-annex` branch. This will then be used by auto-reconfiguration in `clone` to not commit reconfigs.


Not ready yet. Want to see tests (as insufficient as they are) in more environments than my laptop.