### PR TITLE
mimic new logic of git-annex to split_ext

### DIFF
--- a/datalad/support/path.py
+++ b/datalad/support/path.py
@@ -104,10 +104,21 @@ def split_ext(filename):
     >>> split_ext("filename.above4chars.ext")
     ('filename.above4chars', '.ext')
     """
+    # needs to be delayed due to circular
+    # . > config -> cmd -> path -> exernal_version -> log -> ansi_colors -> .
+    from .external_versions import external_versions
+
     parts = filename.split(".")
     if len(parts) == 1:
         return filename, ""
-
+    # stay in sync with annex'es treatment of .dot files to not consider them
+    # having only an extension, and thus including in the key name for E backends
+    # Change in behavior introduced in 8.20210803-2-g899983058
+    if (
+        external_versions['cmd:annex'] > '8.20210803' and
+        len(parts) == 2 and not parts[0]
+    ):
+        return filename, ""
     tail = list(dropwhile(lambda x: len(x) < 5,
                           reversed(parts[1:])))
 

--- a/datalad/support/tests/test_path.py
+++ b/datalad/support/tests/test_path.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import os
+from ..external_versions import external_versions
 from ..path import (
     abspath,
     curdir,
@@ -57,6 +58,13 @@ def test_split_ext():
     eq_(split_ext("file.a.b.ccccc.d"), ("file.a.b.ccccc", ".d"))
 
     eq_(split_ext("file.a.b..c"), ("file", ".a.b..c"))
+    if external_versions['cmd:annex'] > '8.20210803':
+        eq_(split_ext(".dot"), (".dot", ""))
+        eq_(split_ext(".dot.ext"), (".dot", ".ext"))
+    else:
+        eq_(split_ext(".dot"), ("", ".dot"))
+        eq_(split_ext(".dot.ext"), ("", ".dot.ext"))
+
 
 
 def test_get_parent_paths():


### PR DESCRIPTION
The change was introduced in git-annex today
in

[8.20210803-2-g899983058](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=899983058f77fbeb67a2ac04016ea26fec5468fa)

in response to my report

https://git-annex.branchable.com/bugs/should_not_assume_entire_name_to_be_an_extension__63__/

I have decided to make it git-annex version specific since most likely use is
"along side with annex operation" although I could be wrong. ATM we use this
one in only few spots:

	(git)lena:~datalad/datalad-maint[rf-annex-dotfile-extension]git-annex
	$> git grep split_ext | grep -v 'test_'
	datalad/metadata/aggregate.py:from datalad.support.path import split_ext
	datalad/metadata/aggregate.py:        split_ext(key).split('--', 1)[1] if key else key
	datalad/plugin/addurls.py:from datalad.support.path import split_ext
	datalad/plugin/addurls.py:    root, ext = split_ext(filename)
	datalad/support/path.py:def split_ext(filename):
	datalad/support/path.py:    >>> from datalad.plugin.addurls import split_ext
	datalad/support/path.py:    >>> split_ext("filename.py")
	datalad/support/path.py:    >>> split_ext("filename.tar.gz")
	datalad/support/path.py:    >>> split_ext("filename.above4chars.ext")

Yet to see with a fresh datalad/git-annex build of tomorrow if anything
got broken, before we introduce this "fix".

Dear @jwodder, please read the haskell diff of [8.20210803-2-g899983058](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=899983058f77fbeb67a2ac04016ea26fec5468fa) and let me know if the logic I added in Python corresponds (I with there were more tests in annex, which I could have read ;-))