### PR TITLE
DOC: Design document for the `dataset` argument

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -162,31 +162,6 @@ Finally, DataLad supports SSH login style resource identifiers, such as ``me@loc
 
 ``datalad install me@localhost:/path``
 
-`--dataset` argument
---------------------
-
-All commands which operate with/on datasets (practically all commands) have a
-``dataset`` argument (``-d`` or ``--dataset`` for the command line API) which takes a
-path to the dataset that the command should operate on. If a dataset is
-identified this way then any relative path that is provided as an argument to
-the command will be interpreted as being relative to the topmost directory of that
-dataset.  If no dataset argument is provided, relative paths are considered to be
-relative to the current directory.
-
-There are also some useful pre-defined "shortcut" values for dataset arguments:
-
-``///``
-   refers to the "default" dataset located under `$HOME/datalad/`.
-   So running ``datalad install -d/// crcns`` will install the ``crcns`` subdataset
-   under ``$HOME/datalad/crcns``.  This is the same as running
-   ``datalad install $HOME/datalad/crcns``.
-``^``
-   topmost superdataset containing the dataset the current directory is part of.
-   For example, if you are in ``$HOME/datalad/openfmri/ds000001/sub-01`` and want
-   to search metadata of the entire superdataset you are under (in this case
-   ``///``), run ``datalad search -d^ [something to search]``.
-``^.``
-   the dataset the current directory is part of.
 
 Commands `install` vs `get`
 ---------------------------

--- a/docs/source/design/dataset_argument.rst
+++ b/docs/source/design/dataset_argument.rst
@@ -12,8 +12,9 @@
    This specification describes the current implementation.
 
 All commands which operate on datasets have a ``dataset`` argument (``-d`` or
-``--dataset`` for the command line API) to identify a single dataset as the
-context of an operation.
+``--dataset`` for the :term:`CLI`) to identify a single dataset as the
+If ``--dataset`` argument is not provided, the context of an operation is operation-specific (e.g., for `clone` command -- the dataset which is being cloned), but typically - a dataset which current working directory belongs to.
+In the latter case, if operation (e.g., `get`) does not find a dataset in current working directory, operation fails with an ``NoDatasetFound`` error.
 
 
 Impact on relative path resolution

--- a/docs/source/design/dataset_argument.rst
+++ b/docs/source/design/dataset_argument.rst
@@ -7,6 +7,10 @@
 ``dataset`` argument
 ********************
 
+.. topic:: Specification scope and status
+
+   This specification describes the current implementation.
+
 All commands which operate on datasets have a ``dataset`` argument (``-d`` or
 ``--dataset`` for the command line API) to identify a single dataset as the
 context of an operation.

--- a/docs/source/design/dataset_argument.rst
+++ b/docs/source/design/dataset_argument.rst
@@ -13,7 +13,10 @@
 
 All commands which operate on datasets have a ``dataset`` argument (``-d`` or
 ``--dataset`` for the :term:`CLI`) to identify a single dataset as the
-If ``--dataset`` argument is not provided, the context of an operation is operation-specific (e.g., for `clone` command -- the dataset which is being cloned), but typically - a dataset which current working directory belongs to.
+context of an operation.
+If ``--dataset`` argument is not provided, the context of an operation is command-specific.
+For example, `clone` command will consider the :term:`dataset` which is being cloned to be the context.
+But typically, a dataset which current working directory belongs to is the context of an operation.
 In the latter case, if operation (e.g., `get`) does not find a dataset in current working directory, operation fails with an ``NoDatasetFound`` error.
 
 

--- a/docs/source/design/dataset_argument.rst
+++ b/docs/source/design/dataset_argument.rst
@@ -1,0 +1,58 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_dataset_argument:
+
+********************
+``dataset`` argument
+********************
+
+All commands which operate on datasets have a ``dataset`` argument (``-d`` or
+``--dataset`` for the command line API) to identify a single dataset as the
+context of an operation.
+
+
+Impact on relative path resolution
+==================================
+
+With one exception, the nature of a provided ``dataset`` argument does **not**
+impact the interpretation of relative paths. Relative paths are always considered
+to be relative to the process working directory.
+
+The one exception to this rule is passing a ``Dataset`` object instance as
+``dataset`` argument value in the Python API. In this, and only this, case, a
+relative path is interpreted as relative to the root of the respective dataset.
+
+
+Special values
+==============
+
+There are some pre-defined "shortcut" values for dataset arguments:
+
+``^``
+   Represents to the topmost superdataset that contains the dataset the current
+   directory is part of.
+``^.``
+   Represents the root directory of the dataset the current directory is part of.
+``///``
+   Represents the "default" dataset located under `$HOME/datalad/`.
+
+
+Use cases
+=========
+
+Save modification in superdataset hierarchy
+-------------------------------------------
+
+Sometimes it is convenient to work only in the context of a subdataset.
+Executing a ``datalad save <subdataset content>`` will record changes to the
+subdataset, but will leave existing superdatasets dirty, as the subdataset
+state change will not be saved there. Using the ``dataset`` argument it is
+possible to redefine the scope of the save operation. For example::
+
+  datalad save -d^ <subdataset content>
+
+will perform the exact same save operation in the subdataset, but additionally
+save all subdataset state changes in all superdatasets until the root of a
+dataset hierarchy. Except for the specification of the dataset scope there is
+no need to adjust path arguments or change the working directory.

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -13,4 +13,5 @@ subsystems in DataLad.
 .. toctree::
    :maxdepth: 2
 
+   dataset_argument
    miscpatterns

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,6 +44,10 @@ them to the corresponding Git_/git-annex_ concepts.
     operations significantly and impair handling of such repositories in
     general).
 
+  CLI
+    A `Command Line Interface`_. Could be used interactively by executing
+    commands in a `shell`_, or as a programmable API for shell scripts.
+
   DataLad extension
     A Python package, developed outside of the core DataLad codebase, which
     (when installed) typically either provides additional top level `datalad`
@@ -54,3 +58,5 @@ them to the corresponding Git_/git-annex_ concepts.
 
 .. _Git: https://git-scm.com
 .. _Git-annex: http://git-annex.branchable.com
+.. _`Command Line Interface`: https://en.wikipedia.org/wiki/Command-line_interface
+.. _shell: https://en.wikipedia.org/wiki/Shell_(computing)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ DataLad |---| data management and publication multitool
 *******************************************************
 
 Welcome to DataLad's **technical documentation**. Information here is targeting
-software developers and is focused on the Python and command line APIs, as well
+software developers and is focused on the Python API and :term:`CLI`, as well
 as software design, employed technologies, and key features.  Comprehensive
 **user documentation** with information on installation, basic operation,
 support, and (advanced) use case descriptions is available in the `DataLad


### PR DESCRIPTION
This is no revolutionary re-design. It merely moves existing information
into a standalone document -- and strips incorrect information.

This also works towards datalad/datalad#5862