### PR TITLE
ENH(UX): warn user if keyring returned a "null" keyring

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -37,7 +37,12 @@ class Keyring(object):
             lgr.debug("Importing keyring")
             import keyring
             self.__keyring = keyring
-
+            the_keyring = keyring.get_keyring()
+            if the_keyring.name.lower().startswith('null '):
+                lgr.warning(
+                    "Keyring module returned '%s', no credentials will be provided",
+                    the_keyring.name
+                )
         return self.__keyring
 
     @classmethod


### PR DESCRIPTION
Happened to me: a number of days ago I had to workaround a pip issue https://github.com/pypa/pip/issues/7883 for which Q&D workaround was just
to export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring .

Then I lived happily ever after (since 1-May?), probably even datalad download-url
was just reusing prior cookies etc.  But while troubleshooting earthdata
data access, I was at WTF stage that datalad kept asking for
credentials, and there were no visual feedback on a reason.

Diff is trivial and IMHO safe, so made it against `maint`