### PR TITLE
BF: take path from SSHRI, test URLs not only on Windows

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -48,13 +48,14 @@ from datalad.support.constraints import (
 from datalad.support.exceptions import DownloadError
 from datalad.support.param import Parameter
 from datalad.support.network import (
-    get_local_file_url,
-    download_url,
-    is_url,
-    URL,
-    RI,
     DataLadRI,
     PathRI,
+    RI,
+    SSHRI,
+    URL,
+    download_url,
+    get_local_file_url,
+    is_url,
 )
 from datalad.dochelpers import (
     exc_str,
@@ -1206,7 +1207,7 @@ def _get_installationpath_from_url(url):
     from a URL, analog to what `git clone` does.
     """
     ri = RI(url)
-    if isinstance(ri, (URL, DataLadRI)):  # decode only if URL
+    if isinstance(ri, (URL, DataLadRI, SSHRI)):  # decode only if URL
         path = ri.path.rstrip('/')
         path = urlunquote(path) if path else ri.hostname
         if '/' in path:

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -532,24 +532,41 @@ def test_clone_autoenable_msg_handles_sameas(repo, clone_path):
 
 
 def test_installationpath_from_url():
-    cases = (
+    # cases for all OSes
+    cases = [
         'http://example.com/lastbit',
         'http://example.com/lastbit.git',
         'http://lastbit:8000',
-    ) + (
+        # SSH
+        'hostname:lastbit',
+        'hostname:lastbit/',
+        'hostname:subd/lastbit',
+        'hostname:/full/path/lastbit',
+        'hostname:lastbit/.git',
+        'hostname:lastbit/.git/',
+        'hostname:/full/path/lastbit/.git',
+        'full.hostname.com:lastbit/.git',
+        'user@full.hostname.com:lastbit/.git',
+        'ssh://user:passw@full.hostname.com/full/path/lastbit',
+        'ssh://user:passw@full.hostname.com/full/path/lastbit/',
+        'ssh://user:passw@full.hostname.com/full/path/lastbit/.git',
+    ]
+    # OS specific cases
+    cases += [
         'C:\\Users\\mih\\AppData\\Local\\Temp\\lastbit',
         'C:\\Users\\mih\\AppData\\Local\\Temp\\lastbit\\',
         'Temp\\lastbit',
         'Temp\\lastbit\\',
         'lastbit.git',
         'lastbit.git\\',
-    ) if on_windows else (
+    ] if on_windows else [
         'lastbit',
         'lastbit/',
         '/lastbit',
         'lastbit.git',
         'lastbit.git/',
-    )
+    ]
+
     for p in cases:
         eq_(_get_installationpath_from_url(p), 'lastbit')
     # we need to deal with quoted urls


### PR DESCRIPTION
While extending test with SSH RIs I realized that

`(a + b if False else d) == d`, so in effect those example URLs
were tested only on Windows.  I have made it a bit more explicit so
we do not fall into this trap again.

Closes #5880

- I am really not sure yet how we haven't ran into this bug before, since cloning over ssh while resorting to a default name should be a common task.
- I think that we could further improve `_get_installationpath_from_url` to avoid any class checks.  Logic should not rely on the class, but rather on either `path` is provided IMHO.  I might submit a follow up PR against master, wanted to keep this PR to the point