### PR TITLE
RF Exception reporting - part 2

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -133,7 +133,6 @@ def setup_package():
     # own HOME where we pre-setup git for testing (name, email)
     if 'GIT_HOME' in os.environ:
         set_envvar('HOME', os.environ['GIT_HOME'])
-        set_envvar('DATALAD_LOG_EXC', "1")
     else:
         # we setup our own new HOME, the BEST and HUGE one
         from datalad.utils import make_tempfile

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -33,7 +33,7 @@ from ..utils import (
     get_suggestions_msg,
 )
 from ..version import __version__, __full_version__
-from ..dochelpers import exc_str, exc_str_old
+from ..dochelpers import exc_str
 
 from appdirs import AppDirs
 from os.path import join as opj
@@ -440,7 +440,7 @@ def _maybe_get_single_subparser(cmdlineargs, parser, interface_groups,
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
                   __full_version__, parsed_args, unparsed_args)
     except Exception as exc:
-        lgr.debug("Early parsing failed with %s", exc_str_old(exc))
+        lgr.debug("Early parsing failed with %s", exc_str(exc))
         need_single_subparser = False
         unparsed_args = cmdlineargs[1:]  # referenced before assignment otherwise
     # First unparsed could be either unknown option to top level "datalad"
@@ -564,7 +564,7 @@ def add_entrypoints_to_interface_groups(interface_groups):
             interface_groups.append((ep.name, spec[0], spec[1]))
             lgr.debug('Loaded entrypoint %s', ep.name)
         except Exception as e:
-            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str_old(e))
+            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str(e))
             continue
 
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -22,7 +22,6 @@ import os
 
 import datalad
 
-from ..dochelpers import exc_str_old
 from ..support.exceptions import (
     InsufficientArgumentsError,
     IncompleteResultsError,
@@ -216,7 +215,7 @@ def main(args=None):
                 ret = cmdlineargs.func(cmdlineargs)
             except InsufficientArgumentsError as exc:
                 # if the func reports inappropriate usage, give help output
-                lgr.error('%s (%s)', exc_str_old(exc), exc.__class__.__name__)
+                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
                 cmdlineargs.subparser.print_usage(sys.stderr)
                 sys.exit(2)
             except IncompleteResultsError as exc:
@@ -228,7 +227,7 @@ def main(args=None):
                 # in general we do not want to see the error again, but
                 # present in debug output
                 lgr.debug('could not perform all requested actions: %s',
-                          exc_str_old(exc))
+                          exc_str(exc))
                 sys.exit(1)
             except CommandError as exc:
                 # behave as if the command ran directly, importantly pass
@@ -247,7 +246,7 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
-                lgr.error('%s (%s)', exc_str_old(exc), exc.__class__.__name__)
+                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
                 sys.exit(1)
     else:
         # just let argparser spit out its error, since there is smth wrong
@@ -261,7 +260,7 @@ def main(args=None):
         if hasattr(cmdlineargs, 'result_renderer'):
             cmdlineargs.result_renderer(ret, cmdlineargs)
     except Exception as exc:
-        lgr.error("Failed to render results due to %s", exc_str_old(exc))
+        lgr.error("Failed to render results due to %s", exc_str(exc))
         sys.exit(1)
 
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -43,6 +43,7 @@ from .helpers import (
     parser_add_common_opt,
     strip_arg_from_argv,
 )
+from datalad.dochelpers import exc_str
 
 
 # TODO:  OPT look into making setup_parser smarter to become faster

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -43,7 +43,10 @@ from datalad.support.constraints import (
     EnsureStr,
     EnsureKeyChoice,
 )
-from datalad.support.exceptions import DownloadError
+from datalad.support.exceptions import (
+    CapturedException,
+    DownloadError,
+)
 from datalad.support.param import Parameter
 from datalad.support.strings import get_replacement_dict
 from datalad.support.network import (
@@ -293,10 +296,12 @@ class Clone(Interface):
             # spec is determined to be useless
             path.exists()
         except OSError as e:
+            ce = CapturedException(e)
             yield get_status_dict(
                 status='error',
                 path=path,
-                message=('cannot handle target path: %s', exc_str(e)),
+                message=('cannot handle target path: %s', ce),
+                exception=ce,
                 **result_props)
             return
 
@@ -587,11 +592,12 @@ def clone_dataset(
                 create=True)
 
         except CommandError as e:
+            ce = CapturedException(e)
             e_stderr = e.stderr
 
             error_msgs[cand['giturl']] = e
             lgr.debug("Failed to clone from URL: %s (%s)",
-                      cand['giturl'], exc_str(e))
+                      cand['giturl'], ce)
             if dest_path.exists():
                 lgr.debug("Wiping out unsuccessful clone attempt at: %s",
                           dest_path)
@@ -641,7 +647,7 @@ def clone_dataset(
                 error_msg = "Failed to clone from any candidate source URL. " \
                             "Encountered errors per each url were:\n- %s"
                 error_args = '\n- '.join(
-                    '{}\n  {}'.format(url, exc_str(exc))
+                    '{}\n  {}'.format(url, exc.to_str())
                     for url, exc in error_msgs.items()
                 )
         else:

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -42,7 +42,10 @@ import datalad.support.ansi_colors as ac
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureBool
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError
+)
 from datalad.support.globbedpaths import GlobbedPaths
 from datalad.support.param import Parameter
 from datalad.support.json_py import dump2stream
@@ -481,8 +484,10 @@ def _unlock_or_remove(dset_path, paths):
             try:
                 os.unlink(res["path"])
             except OSError as exc:
+                ce = CapturedException(exc)
                 yield dict(res, action="run.remove", status="error",
-                           message=("Removing file failed: %s", exc_str(exc)))
+                           message=("Removing file failed: %s", ce),
+                           exception=ce)
             else:
                 yield dict(res, action="run.remove", status="ok",
                            message="Removed file")

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -234,7 +234,7 @@ def test_interactions(tdir):
             ('VALUE dl+archive://somekey3#path', None),
             ('VALUE',
              re.compile(
-                 'TRANSFER-FAILURE RETRIEVE somekey Failed to fetch any '
+                 'TRANSFER-FAILURE RETRIEVE somekey RuntimeError\(Failed to fetch any '
                  'archive containing somekey. Tried: \[\]')
              )
         ],

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -92,7 +92,7 @@ def test_interactions(tdir):
     fetch_scenarios.append(
         ('VALUE',
          re.compile(
-             'TRANSFER-FAILURE RETRIEVE somekey Failed to download from any')))
+             'TRANSFER-FAILURE RETRIEVE somekey RuntimeError\(Failed to download from any')))
 
     for scenario in BASE_INTERACTION_SCENARIOS + [
         [

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -30,6 +30,7 @@ from ..support.constraints import (
     EnsureNone,
     EnsureStr,
 )
+from datalad.support.exceptions import CapturedException
 from ..utils import (
     ensure_list,
 )
@@ -419,11 +420,13 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
                 status='ok',
             )
         except Exception as e:
+            ce = CapturedException(e)
             yield dict(
                 res_kwargs,
                 # relay all attributes
                 status='error',
-                message=('Failed to create GitLab project: %s', exc_str(e))
+                message=('Failed to create GitLab project: %s', ce),
+                exception=ce
             )
             return
     else:

--- a/datalad/distributed/export_archive_ora.py
+++ b/datalad/distributed/export_archive_ora.py
@@ -34,6 +34,7 @@ from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
 )
+from datalad.support.exceptions import CapturedException
 from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
@@ -188,11 +189,13 @@ class ExportArchiveORA(Interface):
                 status='ok',
                 **res_kwargs)
         except Exception as e:
+            ce = CapturedException(e)
             yield get_status_dict(
                 path=str(archive),
                 type='file',
                 status='error',
-                message=('7z failed: %s', exc_str(e)),
+                message=('7z failed: %s', ce),
+                exception=ce,
                 **res_kwargs)
             return
         finally:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -70,6 +70,7 @@ from datalad.support.constraints import (
     EnsureStr,
 )
 from datalad.support.exceptions import (
+    CapturedException,
     InsufficientArgumentsError,
     MissingExternalDependency,
 )
@@ -813,10 +814,12 @@ class CreateSibling(Interface):
                 try:
                     upload_web_interface(path, shell, shared, ui)
                 except CommandError as e:
+                    ce = CapturedException(e)
                     currentds_ap['status'] = 'error'
                     currentds_ap['message'] = (
                         "failed to push web interface to the remote datalad repository (%s)",
-                        exc_str(e))
+                        ce)
+                    currentds_ap['exception'] = ce
                     yield currentds_ap
                     yielded.add(currentds_ap['path'])
                     continue
@@ -832,10 +835,12 @@ class CreateSibling(Interface):
                       "&& ( [ -x hooks/post-update ] && hooks/post-update || true )"
                       "".format(sh_quote(_path_(path, ".git"))))
             except CommandError as e:
+                ce = CapturedException(e)
                 currentds_ap['status'] = 'error'
                 currentds_ap['message'] = (
                     "failed to run post-update hook under remote path %s (%s)",
-                    path, exc_str(e))
+                    path, ce)
+                currentds_ap['exception'] = ce
                 yield currentds_ap
                 yielded.add(currentds_ap['path'])
                 continue

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -32,7 +32,10 @@ from datalad.support.constraints import (
     EnsureNone,
 )
 from datalad.support.annexrepo import AnnexRepo
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError
+)
 from datalad.support.param import Parameter
 from datalad.interface.common_opts import (
     recursion_flag,
@@ -318,8 +321,11 @@ class Update(Interface):
                 try:
                     repo.fetch(**fetch_kwargs)
                 except CommandError as exc:
-                    yield dict(res, status="error",
-                               message=("Fetch failed: %s", exc_str(exc)))
+                    ce = CapturedException(exc)
+                    yield get_status_dict(status="error",
+                                          message=("Fetch failed: %s", ce),
+                                          exception=ce,
+                                          **res,)
                     continue
 
             # NOTE reevaluate ds.repo again, as it might have be converted from
@@ -334,12 +340,15 @@ class Update(Interface):
                         repo.fetch(remote=sibling_, refspec=revision,
                                    git_options=["--recurse-submodules=no"])
                     except CommandError as exc:
+                        ce = CapturedException(exc)
                         yield dict(
                             res,
                             status="impossible",
                             message=(
                                 "Attempt to fetch %s from %s failed: %s",
-                                revision, sibling_, exc_str(exc)))
+                                revision, sibling_, ce),
+                            exception=ce
+                        )
                         continue
                 else:
                     yield dict(res,
@@ -520,7 +529,8 @@ def _try_command(record, fn, *args, **kwargs):
     try:
         fn(*args, **kwargs)
     except CommandError as exc:
-        return dict(record, status="error", message=exc_str(exc))
+        ce = CapturedException(exc)
+        return dict(record, status="error", message=("%s", ce))
     else:
         return dict(record, status="ok")
 

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -530,7 +530,7 @@ def _try_command(record, fn, *args, **kwargs):
         fn(*args, **kwargs)
     except CommandError as exc:
         ce = CapturedException(exc)
-        return dict(record, status="error", message=("%s", ce))
+        return dict(record, status="error", message=str(ce))
     else:
         return dict(record, status="ok")
 

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -314,73 +314,11 @@ def borrowkwargs(cls=None, methodname=None, exclude=None):
     return _borrowkwargs
 
 
-# TODO: make limit respect config/environment parameter
-def exc_str_old(exc=None, limit=None, include_str=True):
-    """Enhanced str for exceptions.  Should include original location
-
-    Parameters
-    ----------
-    exc: Exception, optional
-      If not provided, information about the last exception caught by except
-      clause (as provided by `sys.exc_info`) will be used.
-    limit: int, optional
-      Number of levels in the traceback stack from the point where exception
-      was raised to include. If `None`, environment variable
-      DATALAD_EXC_STR_TBLIMIT is consulted.
-    include_str: bool, optional
-      Either include str (or `repr` if empty `str`) into representation.
-      If False, just ends up reporting traceback without string representation
-      of exception pre-pended.
-
-    Returns
-    -------
-    str
-      String representation of the exception with traceback information
-      appended.
-    """
-    out = str(exc) if include_str else ""
-    if limit is None:
-        # TODO: config logging.exceptions.traceback_levels = 1
-        limit = int(os.environ.get('DATALAD_EXC_STR_TBLIMIT', '1'))
-    try:
-        exctype, value, tb = sys.exc_info()
-        if not exc:
-            exc = value
-            if include_str:
-                out = str(exc)
-        if include_str and not out:
-            out = repr(exc)
-        # verify that it seems to be the exception we were passed
-        #assert(isinstance(exc, exctype))
-        if exc:
-            assert(exc is value)
-        entries = traceback.extract_tb(tb)
-        if entries:
-            tb_str = "[%s]" % (
-                ','.join(
-                    '%s:%s:%d' % (os.path.basename(x[0]), x[2], x[1])
-                    for x in entries[-limit:]
-                )
-            )
-            if out:
-                out = "%s %s" % (out, tb_str)
-            else:
-                out = tb_str
-    except:  # MIH: TypeError?
-        return out  # To the best of our abilities
-    finally:
-        # As the bible teaches us:
-        # https://docs.python.org/2/library/sys.html#sys.exc_info
-        del tb
-    return out
-
-
 def exc_str(exc=None, limit=None, include_str=True):
-    """Temporary test shim, for finding issues re refactoring for
-    using CapturedException instead.
+    """Temporary adapter
 
-    See gh-5716
+    The CapturedException should be available and be used directly instead.
     """
 
-    return str(CapturedException(exc))
-
+    return CapturedException(exc).format_oneline_tb(limit=limit,
+                                                    include_str=include_str)

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -320,5 +320,4 @@ def exc_str(exc=None, limit=None, include_str=True):
     The CapturedException should be available and be used directly instead.
     """
 
-    return CapturedException(exc).format_oneline_tb(limit=limit,
-                                                    include_str=include_str)
+    return str(CapturedException(exc))

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -309,12 +309,6 @@ definitions = {
         'ui': ('question', {
                'title': 'Runs TraceBack function with collide set to True, if this flag is set to "collide". This replaces any common prefix between current traceback log and previous invocation with "..."'}),
     },
-    'datalad.log.exc': {
-        'ui': ('yesno', {
-               'title': 'Include exceptions and their traceback in log messages. If set, \'datalad.exc.str.tblimit\' applies.'}),
-        'default': False,
-        'type': EnsureBool(),
-    },
     'datalad.ssh.identityfile': {
         'ui': ('question', {
                'title': "If set, pass this file as ssh's -i option."}),

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -34,6 +34,7 @@ from ..support.annexrepo import AnnexRepo
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr, EnsureNone
 from ..support.exceptions import (
+    CapturedException,
     CommandError,
     NoDatasetFound,
 )
@@ -185,12 +186,13 @@ class DownloadURL(Interface):
             try:
                 downloaded_path = downloader.download(url, path=path, overwrite=overwrite)
             except Exception as e:
+                ce = CapturedException(e)
                 yield get_status_dict(
                     status="error",
-                    message=exc_str(e),
+                    message=("%s", ce),
                     type="file",
                     path=path,
-                    exception=e,
+                    exception=ce,
                     **common_report)
             else:
                 if not need_datalad_remote \

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -189,7 +189,7 @@ class DownloadURL(Interface):
                 ce = CapturedException(e)
                 yield get_status_dict(
                     status="error",
-                    message=("%s", ce),
+                    message=str(ce),
                     type="file",
                     path=path,
                     exception=ce,

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -315,7 +315,7 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
         results = _revrange_as_results(dset, revrange)
     except ValueError as exc:
         ce = CapturedException(exc)
-        yield get_status_dict("run", status="error", message=("%s", ce),
+        yield get_status_dict("run", status="error", message=str(ce),
                               exception=ce)
         return
 

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -35,6 +35,7 @@ from datalad.consts import PRE_INIT_COMMIT_SHA
 from datalad.support.constraints import EnsureNone, EnsureStr
 from datalad.support.param import Parameter
 from datalad.support.json_py import load_stream
+from datalad.support.exceptions import CapturedException
 
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
@@ -313,7 +314,9 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
     try:
         results = _revrange_as_results(dset, revrange)
     except ValueError as exc:
-        yield get_status_dict("run", status="error", message=exc_str(exc))
+        ce = CapturedException(exc)
+        yield get_status_dict("run", status="error", message=("%s", ce),
+                              exception=ce)
         return
 
     ds_repo = dset.repo

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -89,7 +89,9 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
     if message is not None:
         d['message'] = message
     if exception is not None:
-        d['exception_traceback'] = exc_str(exception, limit=1000, include_str=False)
+        d['exception'] = exception
+        d['exception_traceback'] = \
+            exception.format_oneline_tb(limit=1000, include_str=False)
     if kwargs:
         d.update(kwargs)
     return d

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -63,18 +63,5 @@ class Test(Interface):
             module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
         module = ensure_list(module)
         lgr.info('Starting test run for module(s): %s', module)
-
-        # Exception (traceback) logging is disabled by default. However, as of
-        # now we do test logging output in (too) great detail. Therefore enable
-        # it here, so `datalad-test` doesn't fail by default.
-        # Can be removed whenever the tests don't require it.
-        from datalad import cfg as dlcfg
-        from datalad.tests.utils import patch
-        try:
-            with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
-                dlcfg.reload()
-                for mod in module:
-                    datalad.test(module=mod, verbose=verbose,
-                                 nocapture=nocapture, pdb=pdb, stop=stop)
-        finally:
-            dlcfg.reload()
+        for mod in module:
+            datalad.test(module=mod, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -833,7 +833,7 @@ def _add_url(row, ds, repo, options=None, drop_after=False):
                               ds=ds,
                               type="file",
                               path=filename_abs,
-                              message=("%s", ce),
+                              message=str(ce),
                               exception=ce,
                               status="error")
         return
@@ -857,7 +857,7 @@ def _add_url(row, ds, repo, options=None, drop_after=False):
             st_kwargs = dict(status="ok")
         except (AssertionError, CommandError) as exc:
             ce = CapturedException(exc)
-            st_kwargs = dict(message=("%s", ce),
+            st_kwargs = dict(message=str(ce),
                              exception=ce,
                              status="error")
         yield get_status_dict(action="drop",
@@ -902,7 +902,7 @@ class RegisterUrl(object):
             fname.write_text(ek_info["objectpointer"])
         except Exception as exc:
             ce = CapturedException(exc)
-            message = ("%s", ce)
+            message = str(ce)
             status = "error"
             exception = ce
         else:
@@ -945,7 +945,7 @@ class RegisterUrl(object):
             ce = CapturedException(exc)
             yield dict(self._err_res,
                        path=row["filename_abs"],
-                       message=("%s", ce),
+                       message=str(ce),
                        exception=ce)
         else:
             yield res
@@ -1359,7 +1359,7 @@ class Addurls(Interface):
                 yield get_status_dict(action="addurls",
                                       ds=ds,
                                       status="error",
-                                      message=("%s", ce),
+                                      message=str(ce),
                                       exception=ce)
                 return
             displayed_source = "'{}'".format(urlfile)
@@ -1378,7 +1378,7 @@ class Addurls(Interface):
                                          missing_value)
             except (ValueError, RequestException) as exc:
                 ce = CapturedException(exc)
-                yield dict(st_dict, status="error", message=("%s", ce),
+                yield dict(st_dict, status="error", message=str(ce),
                            exception=ce)
                 return
 

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -41,7 +41,10 @@ from datalad.interface.common_opts import (
     jobs_opt,
     nosave_opt,
 )
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError,
+)
 from datalad.support.itertools import groupby_sorted
 from datalad.support.network import get_url_filename
 from datalad.support.path import split_ext
@@ -825,11 +828,13 @@ def _add_url(row, ds, repo, options=None, drop_after=False):
         out_json = repo.add_url_to_file(filename, row["url"],
                                         batch=True, options=options)
     except CommandError as exc:
+        ce = CapturedException(exc)
         yield get_status_dict(action="addurls",
                               ds=ds,
                               type="file",
                               path=filename_abs,
-                              message=exc_str(exc),
+                              message=("%s", ce),
+                              exception=ce,
                               status="error")
         return
 
@@ -851,7 +856,9 @@ def _add_url(row, ds, repo, options=None, drop_after=False):
             repo.drop_key(res_addurls['annexkey'], batch=True)
             st_kwargs = dict(status="ok")
         except (AssertionError, CommandError) as exc:
-            st_kwargs = dict(message=exc_str(exc),
+            ce = CapturedException(exc)
+            st_kwargs = dict(message=("%s", ce),
+                             exception=ce,
                              status="error")
         yield get_status_dict(action="drop",
                               ds=ds,
@@ -894,13 +901,17 @@ class RegisterUrl(object):
             fname.parent.mkdir(exist_ok=True, parents=True)
             fname.write_text(ek_info["objectpointer"])
         except Exception as exc:
-            message = exc_str(exc)
+            ce = CapturedException(exc)
+            message = ("%s", ce)
             status = "error"
+            exception = ce
         else:
             message = "registered URL"
             status = "ok"
+            exception = None
         return get_status_dict(action="addurls", ds=self.ds, type="file",
-                               status=status, message=message)
+                               status=status, message=message,
+                               exception=exception)
 
     def __call__(self, row):
         filename = row["ds_filename"]
@@ -931,9 +942,11 @@ class RegisterUrl(object):
                 if not res.get("message"):
                     res["message"] = "registered URL"
         except CommandError as exc:
+            ce = CapturedException(exc)
             yield dict(self._err_res,
                        path=row["filename_abs"],
-                       message=exc_str(exc))
+                       message=("%s", ce),
+                       exception=ce)
         else:
             yield res
 
@@ -1342,10 +1355,12 @@ class Addurls(Interface):
                 records, colidx_to_name = _read_from_file(
                     url_file, input_type)
             except ValueError as exc:
+                ce = CapturedException(exc)
                 yield get_status_dict(action="addurls",
                                       ds=ds,
                                       status="error",
-                                      message=exc_str(exc))
+                                      message=("%s", ce),
+                                      exception=ce)
                 return
             displayed_source = "'{}'".format(urlfile)
         else:
@@ -1362,7 +1377,9 @@ class Addurls(Interface):
                                          dry_run,
                                          missing_value)
             except (ValueError, RequestException) as exc:
-                yield dict(st_dict, status="error", message=exc_str(exc))
+                ce = CapturedException(exc)
+                yield dict(st_dict, status="error", message=("%s", ce),
+                           exception=ce)
                 return
 
         if not rows:

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -93,7 +93,9 @@ class CheckDates(Interface):
             to_render = {k: v for k, v in res.items()
                          if k not in ["status", "message", "logger"]}
         if to_render:
-            ui.message(json.dumps(to_render, sort_keys=True, indent=2))
+            ui.message(json.dumps(to_render, sort_keys=True, indent=2,
+                                  default=str)
+                       )
 
     _params_ = dict(
         paths=Parameter(

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -161,7 +161,7 @@ class CheckDates(Interface):
             ce = CapturedException(exc)
             yield get_status_dict("check_dates",
                                   status="error",
-                                  message=("%s", ce),
+                                  message=str(ce),
                                   exception=ce)
             return
 

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -18,6 +18,7 @@ from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.support.exceptions import (
+    CapturedException,
     InvalidGitRepositoryError,
     MissingExternalDependency,
 )
@@ -157,9 +158,11 @@ class CheckDates(Interface):
             ref_ts = _parse_date(reference_date)
         except ValueError as exc:
             lgr.error("Could not parse '%s' as a date", reference_date)
+            ce = CapturedException(exc)
             yield get_status_dict("check_dates",
                                   status="error",
-                                  message=exc_str(exc))
+                                  message=("%s", ce),
+                                  exception=ce)
             return
 
         lgr.info("Searching for dates %s than %s",

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -25,7 +25,10 @@ from datalad.support.constraints import (
     EnsureNone,
 )
 from datalad.support.param import Parameter
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError
+)
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
@@ -367,12 +370,12 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                     # variable name validity is checked before and Git
                     # replaces the file completely, resolving any permission
                     # issues, if the file could be read (already done above)
+                    ce = CapturedException(e)
                     yield get_status_dict(
                         'subdataset',
                         status='error',
-                        message=(
-                            "Failed to set property '%s': %s",
-                            prop, exc_str(e)),
+                        message=("Failed to set property '%s': %s", prop, ce),
+                        exception=ce,
                         type='dataset',
                         logger=lgr,
                         **sm)

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -37,7 +37,7 @@ def mbasename(s):
     base = basename(s)
     if base.endswith('.py'):
         base = base[:-3]
-    if base in set(['base', '__init__']):
+    if base in set(['base', '__init__', 'utils']):
         base = basename(dirname(s)) + '.' + base
     return base
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -33,6 +33,7 @@ from datalad.utils import quote_cmdlinearg as sh_quote
 # from datalad.support.network import RI, is_ssh
 
 from datalad.support.exceptions import (
+    CapturedException,
     CommandError,
     ConnectionOpenFailedError,
 )
@@ -800,8 +801,9 @@ class MultiplexSSHManager(BaseSSHManager):
                     try:
                         f()
                     except Exception as exc:
+                        ce = CapturedException(exc)
                         lgr.debug("Failed to close a connection: "
-                                  "%s", exc_str(exc))
+                                  "%s", ce.message())
             self._connections = dict()
 
 

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -75,16 +75,6 @@ def test_CapturedException():
     # ...
     assert_equal(full_display[-1].strip(), "RuntimeError: new message")
 
-    # CapturedException.__str__ now independent of log config:
-    try:
-        with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
-            cfg.reload()
-            assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
-                         str(captured_exc))
-
-        with patch.dict('os.environ', {'DATALAD_LOG_EXC': '0'}):
-            cfg.reload()
-            assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
-                         str(captured_exc))
-    finally:
-        cfg.reload()  # make sure we don't have a side effect on other tests
+    # CapturedException.__repr__:
+    assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
+                 captured_exc.__repr__())

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -56,7 +56,8 @@ def test_CapturedException():
     assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr3)
     assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr2)
     assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]", estr1)
-    assert_equal(estr_, estr1)
+    # default: no limit:
+    assert_equal(estr_, estr_full)
 
     # standard output
     full_display = captured_exc.format_standard().splitlines()
@@ -74,15 +75,16 @@ def test_CapturedException():
     # ...
     assert_equal(full_display[-1].strip(), "RuntimeError: new message")
 
-    # now logging / __str__:
+    # CapturedException.__str__ now independent of log config:
     try:
         with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
             cfg.reload()
-            assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]",
+            assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
                          str(captured_exc))
 
         with patch.dict('os.environ', {'DATALAD_LOG_EXC': '0'}):
             cfg.reload()
-            assert_equal("", str(captured_exc))
+            assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
+                         str(captured_exc))
     finally:
         cfg.reload()  # make sure we don't have a side effect on other tests

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -110,7 +110,7 @@ def test__make_github_repos():
             mock.patch.object(github_, '_make_github_repo', _make_github_repo), \
             swallow_logs(new_level=logging.INFO) as cml:
         res = list(github_._make_github_repos_(*args))
-        assert_in('Failed to create repository while using token 1to...: very bad status', cml.out)
+        assert_in('Failed to create repository while using token 1to...: BadCredentialsException(very bad status', cml.out)
         eq_(res,
             [dict(status='ok', ds='/fakeds1'), dict(status='ok', ds='/fakeds2')])
 

--- a/datalad/tests/test_dochelpers.py
+++ b/datalad/tests/test_dochelpers.py
@@ -15,7 +15,6 @@ from ..dochelpers import (
     single_or_plural,
     borrowdoc,
     borrowkwargs,
-    exc_str_old,
 )
 
 from datalad.tests.utils import (
@@ -143,39 +142,3 @@ def test_borrow_kwargs():
     assert_true('Some postamble' in B.met1.__doc__)
     assert_true('B.met_nodockwargs' in B.met_nodockwargs.__doc__)
     assert_true('boguse' in B.met_excludes.__doc__)
-
-
-def test_exc_str_old():
-    try:
-        raise Exception("my bad")
-    except Exception as e:
-        estr = exc_str_old(e)
-        estr_tb_only = exc_str_old(e, include_str=False)
-    assert_re_in("my bad \[test_dochelpers.py:test_exc_str_old:...\]", estr)
-    assert_re_in("^\[.*\]", estr_tb_only)  # only traceback
-
-    def f():
-        def f2():
-            raise Exception("my bad again")
-        f2()
-    try:
-        f()
-    except Exception as e:
-        # default one:
-        estr2 = exc_str_old(e, 2)
-        estr1 = exc_str_old(e, 1)
-        # and we can control it via environ by default
-        with patch.dict('os.environ', {'DATALAD_EXC_STR_TBLIMIT': '3'}):
-            estr3 = exc_str_old(e)
-        with patch.dict('os.environ', {}, clear=True):
-            estr_ = exc_str_old()
-
-    assert_re_in("my bad again \[test_dochelpers.py:test_exc_str_old:...,test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr3)
-    assert_re_in("my bad again \[test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr2)
-    assert_re_in("my bad again \[test_dochelpers.py:f2:...\]", estr1)
-    assert_equal(estr_, estr1)
-
-    try:
-        raise NotImplementedError
-    except Exception as e:
-        assert_re_in("NotImplementedError\(\) \[test_dochelpers.py:test_exc_str_old:...\]", exc_str_old(e))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2223,9 +2223,10 @@ def import_modules(modnames, pkg, msg="Failed to import {module}", log=lgr.debug
                 pkg)
             mods_loaded.append(mod)
         except Exception as exc:
-            from datalad.dochelpers import exc_str
+            from datalad.support.exceptions import CapturedException
+            ce = CapturedException(exc)
             log((msg + ': {exception}').format(
-                module=modname, package=pkg, exception=exc_str(exc)))
+                module=modname, package=pkg, exception=ce.message()))
     return mods_loaded
 
 


### PR DESCRIPTION
Follow-up on #5691.

This PR introduces some enhancements to the new `CapturedException` class and goes through every invocation of `exc_str` and `exc_str_old`, replacing (and deprecating) it and trying to achieve several things with respect to our exception reporting:

1. If we log an exception, do so only where an exception is catched, not where it is (re-)raised!
At some spots we still do log the same thing several times. I think the original idea was to produce some kind of a traceback leaving a log entry wherever an exception passes through. This is unnecessary and almost always just annoying double-(or multi)-reporting. The exception logging captures a full traceback including the `__context__` and `__cause__` if an exception was `raised from` and/or happened within an `except` clause. The latest spot has all the info - we only need to log it where we catch it (if only at the outermost layer) and react to it (if only by failing). That's the meaningful spot.

2. When we log or report on (results, or direct user message) exceptions, we should separate a message that is potentially meaningful for a mortal and the technical info on what exactly the exception was and what its traceback is. If really necessary, the former can still contain part of the latter, but the potentially scary and confusing depiction of the exception is a separate thing.
That's what `CapturedException.log()` is for: You pass a message that's supposed to tell what's going on in datalad and that is meaningful/actionable for users. If `datalad.log.exc` is enabled, that record gets enhanced w/ a message reading "Reason for message above:" and the full exception log. When we ever (and I think this is a step to make that more likely) get to properly iron out user messaging and logging, I think `datalad.log.exc` should then be enabled by default for logging into logfiles and by default be disabled for terminal output.
This separation also is the reason to change the default for the `limit` of the depth of the traceback that is included in the "technical" message from `1` to `None` - now that this is it's own message that needs to be enabled, it can as well be as complete as possible by default.

3. When we reraise with a new message (whether or not same type of exception), that message should NOT include the full exception logging. The meaningful thing is to enhance or change the message. Hence the new message may be based on the old message, but the inclusion of the old type and its traceback is wrong. Instead `NewError raise from OldError` injects a `__cause__` to `NewError` and wherever `NewError` is logged, it will have the traceback including that from `OldError`.

4. For result records the same principle applies: user and "debug" message should be separated. @yarikoptic already introduced a modification to `get_status_dict` that, if `exception` is passed, creates an `exception_traceback` entry. I stuck with that for now, so that `message` is formed the way a default log message would be and pass the `CapturedException` object to `exception`. `get_status_dict` then adds the `exception_traceback` field. I enhanced that to actually keep the `exception` filed (Yarik didn't), so that in python (or result renderers) you have access to the `CapturedException` instance, providing several ways of "stringifying" that exception. Ultimately, this should not live in `get_status_dict` (which isn't used everywhere), but be matter of result renderers. However, I think this is best done with an RF'ing to make renderers actual classes (that custom ones can inherit from).

---------------------------

To ease review/discussion, here come some points to look at.
It does make sense to get an idea of the current state of `CapturedException` first, of course: https://github.com/datalad/datalad/pull/5883/commits/ef6b868909e841d31e05ef91a4862ba2827f3219

There are several kinds of changes throughout all the files:

- Simply separating the "technical" message out. Have what's usually meaningful in the message and let `datalad.log.exc` add details if required. Example: https://github.com/datalad/datalad/pull/5883/commits/511b8be688a1ab388e561f1f387e5ef21e451707#diff-35dad0480a094dee25a5777749e74e0d983b4dc742f3b9834230dba46f3f6619L357

- Use `raise from` when we reraise, instead of including the original exception as text (see point 3). Example: https://github.com/datalad/datalad/pull/5883/commits/6c589c5bcc9f5cbb7b6a6752f6a5f74dc53799f9#diff-94f9b0e4cdbcfe44b244bbf4450719d1034680f27d3a1cef81393694ed7d6e08L520

- For result dicts, have the respective "default message" in `message` and add the `CapturedException` to the `exception` field. `get_status_dict` does then add `exception_traceback`. Example: https://github.com/datalad/datalad/pull/5883/commits/13bf1626c003c1b6c0e934f5591804383e5db70b#diff-e378e274f6a8ae458d174d8e6df74ceca070cc8266670ebd1d94c46ffe9ff17eR189

Change to `get_status_dict`: https://github.com/datalad/datalad/pull/5883/commits/13bf1626c003c1b6c0e934f5591804383e5db70b#diff-092358c734aa136a079bbd581698442c22878877b79687b310cd838a1bc82653L92

- One of the main issues, I think, is us being to broad and unspecific, just dumping shit for the user to deal with, instead of assessing what's going on. This comes mainly in two forms: `except Exception` and `except CommandError`. I didn't change any of that, since this is not what the PR is about really, but those two tend to be similar: We actually can (often) know better, but don't do it. For the `CommandError` dumping that is: Something called a subprocess that failed. The caller knows what was called and can usually make an assessment of possible consequences or tell what kind of thing went wrong how. Ideally, say `fetch` would catch `CommandError` and reraise a `GitFetchError` or something like that and that new Exception can come with a proper message that was parsed from git's output and took into account whatever may be relevant from within the knowledge of the caller. Instead, we tend to just pass on the generic `CommandError` and higher up it may be harder to know what to look for to form a huan-digestable message. Dumping `CommandError`'s message my contain the relevant output of the subprocess, but it also contains a lot of distracting, generic stuff, since it's raised by the runner and that one isn't supposed to know a lot about each and every possible subprocess we may want to call. Anyways - that's just something to take note of and to do better. For now, however, I usually went for generating the message from the output instead of taking the entire "message" of `CommandError`, by `e.stderr or e.stdout or e.to_str()`. This means to look at stderr first (it's almost always git/git-annex - they do report an issue on stderr `fatal: ....`. That's the only part that usually is informative for a user when something is failing - buried under lots of irrelevant things. `or e.to_str()` makes the formerly used `exc_str` or `str` of `CommandError` still the fallback if there was no output. Example: https://github.com/datalad/datalad/pull/5883/commits/511b8be688a1ab388e561f1f387e5ef21e451707#diff-2329d131e6de4ec3957da6b6122869ee6b8e490ac65162461ed767dc0d6cef59L593


- For some spots it's perfectly fine to use the standard `str(e)` in messages. That's another point: At some spots it seems that authors weren't aware what `exc_str` actually adds over just `str`. That is: A questionable magic to decide whether to show the exception's name or its message and the option to put the traceback in that string. The former is questionable, because it very much depends on the exception whether or not the exception's name carries relevant information and whether or not the message can stand on its own. And what is the case is not our under control for any exception coming from third-party code. The latter part was nice, but is something that shouldn't be in a result message for example. It's useful for logging only. So: If it's simply about the exception's message and the exception isn't logged at that spot (in which case one can use the already created `CapturedException`): `str(e)` is perfectly fine!
Example: https://github.com/datalad/datalad/pull/5883/commits/6c589c5bcc9f5cbb7b6a6752f6a5f74dc53799f9#diff-37fba60e98afe87a28f73afa6b5bbc3410bad59901363e26256da5584cec265cL623


- Things are a bit different for special remotes, since their messaging to annex isn't exactly "logging". They are also usually a bit painful to debug. Therefore, I went for always including the full detail for now, like here: https://github.com/datalad/datalad/pull/5883/files#diff-67b52fecf48cc364bc9f19345991f2d3f87c11bdbde3cfc9ea16526b422d08b5L393 This is independent of `datalad.log.exc`! Agree, @yarikoptic ? While at it I stumbled upon something else - @yarikoptic Please have a look at this comment please: https://github.com/datalad/datalad/pull/5883/files#diff-67b52fecf48cc364bc9f19345991f2d3f87c11bdbde3cfc9ea16526b422d08b5R326 If we agree, that should become an issue (or a PR ;-) )

- Finally, https://github.com/datalad/datalad/pull/5883/files#diff-eec184e266c9aa336ee741b532169a76e4e2f52759f03ab4ab2dfa9a4d69ddcaR2057
and https://github.com/datalad/datalad/pull/5883/files#diff-eec184e266c9aa336ee741b532169a76e4e2f52759f03ab4ab2dfa9a4d69ddcaR2235 is the same comment. @yarikoptic : Given that the `logger` parameter of those decorators isn't actually used anywhere, we could as well change to passing the logger, rather than a callable, I think. Objections?

TODO:
- [x] check outermost catch
- [x] ~Remove~ deprecate `exc_str` + `exc_old_str`
- [x]  rebase with proper commit messages
- [x] Ease review by pointing out example cases and linking into the diff. Nobody will go through > 60 files.
- [x] double check for other related issues than the already linked one


Closes #5848
Closes #5716