### PR TITLE
Download session/credentials locking -- inform user if locking is "failing" to be obtained, fail upon ~5min timeout

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -159,7 +159,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
             try:
                 # Try to lock since it might desire to ask for credentials, but still allow to time out at 5 minutes
                 # while providing informative message on what other process might be holding it.
-                with try_lock_informatively(self._lock, purpose="establish download session", proceed_unlocked=True):
+                with try_lock_informatively(self._lock, purpose="establish download session", proceed_unlocked=False):
                     used_old_session = self._establish_session(url, allow_old=allow_old_session)
                 if not allow_old_session:
                     assert(not used_old_session)

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -45,6 +45,7 @@ from ..support.exceptions import (
 from ..support.locking import (
     InterProcessLock,
     try_lock,
+    try_lock_informatively,
 )
 
 from ..support.network import RI
@@ -156,12 +157,9 @@ class BaseDownloader(object, metaclass=ABCMeta):
             supported_auth_types = []
             used_old_session = False
             try:
-                lgr.debug("Acquiring a currently %s lock to establish download session. "
-                          "If stalls - check which process holds %s",
-                          "existing" if self._lock.exists() else "absent",
-                          self._lock.path)
-                with self._lock:
-                    # Locking since it might desire to ask for credentials
+                # Try to lock since it might desire to ask for credentials, but still allow to time out at 5 minutes
+                # while providing informative message on what other process might be holding it.
+                with try_lock_informatively(self._lock, purpose="establish download session", proceed_unlocked=True):
                     used_old_session = self._establish_session(url, allow_old=allow_old_session)
                 if not allow_old_session:
                     assert(not used_old_session)

--- a/datalad/support/tests/test_locking.py
+++ b/datalad/support/tests/test_locking.py
@@ -147,6 +147,9 @@ with try_lock_informatively(lock, timeouts=[0.05, 0.15], proceed_unlocked={{proc
         assert_in(f'Failed to acquire lock at {lock_path} in 0.15', res['stderr'])
         assert_in('proceed without locking', res['stderr'])
         assert_greater(time() - t0, 0.19999)  # should wait for at least 0.2
+        # PID does not correspond
+        assert_in('Check following process: PID=', res['stderr'])
+        assert_in(f'CWD={os.getcwd()} CMDLINE=', res['stderr'])
 
         # in 2nd case, lets try without proceeding unlocked
         script1.write_text(script1_fmt.format(proceed_unlocked=False))
@@ -164,3 +167,4 @@ with try_lock_informatively(lock, timeouts=[0.05, 0.15], proceed_unlocked={{proc
     res = runner.run([sys.executable, str(script1)], protocol=StdOutErrCapture)
     assert_in('Lock acquired=True', res['stdout'])
     assert_not_in(f'Failed to acquire lock', res['stderr'])
+    assert_not_in('PID', res['stderr'])


### PR DESCRIPTION
I think it could be considered to resolve #5099 - user will be given INFO level log messages (just now realized -- may be the last one at least should be a warning??? or should we have a progress bar? ;-)) with all possible information we can provide, even which processes have that lock ATM (well -- might not universally work... windows - I am talking to you).

I also decided that "heck with that locking" if we fail to get the lock within 5 minutes!  at least this way may be some processes would complete (but possibly hide the problem).

Please see individual commits for more information.  It seems to come out to be again yet another "one time use locking helper", but since we have not come up with a better way to address this locking "issue", I think it is a small price to pay ;)

- [-] I have positioned against `maint` but it grew a bit too big.  I will be fine to reposition it against `master` -- we should get one out of the door soon.
- [-] I wonder if I should add some randomization so that not all parallel processes which fail to acquire lock start asking for credentials at the same time ... ;-)