### PR TITLE
.travis.yml: use python -m {nose,coverage} invocations, and always show combined report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -275,6 +275,7 @@ after_success:
   - if [ ! ${TRAVIS_EVENT_TYPE} = "cron" ]; then
       cd __testhome__;
       coverage combine -a /tmp/.coverage-entrypoints-*;
+      coverage report;
       codecov;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -262,7 +262,7 @@ script:
   # Run tests
   - http_proxy=
     PATH=$PWD/../tools/coverage-bin:$PATH
-    $NOSE_WRAPPER `which nosetests` "${NOSE_OPTS[@]}"
+    $NOSE_WRAPPER python -m nose "${NOSE_OPTS[@]}"
       -A "$NOSE_SELECTION_OP($NOSE_SELECTION) and not(turtle)"
       --with-doctest
       --with-cov --cover-package datalad
@@ -274,8 +274,8 @@ after_success:
   # cron jobs test more and then PRs will be falling behind since they would not
   # trigger some codepaths.  So submit coverage only from non-cron jobs, but report for all
   - cd __testhome__;
-  - coverage combine -a /tmp/.coverage-entrypoints-*;
-  - coverage report;
+  - python -m coverage combine -a /tmp/.coverage-entrypoints-*;
+  - python -m coverage report;
   - if [ ! ${TRAVIS_EVENT_TYPE} = "cron" ]; then
       codecov;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -271,11 +271,12 @@ script:
   - cd ..
 
 after_success:
-  # submit only what we have covered in the PRs
+  # cron jobs test more and then PRs will be falling behind since they would not
+  # trigger some codepaths.  So submit coverage only from non-cron jobs, but report for all
+  - cd __testhome__;
+  - coverage combine -a /tmp/.coverage-entrypoints-*;
+  - coverage report;
   - if [ ! ${TRAVIS_EVENT_TYPE} = "cron" ]; then
-      cd __testhome__;
-      coverage combine -a /tmp/.coverage-entrypoints-*;
-      coverage report;
       codecov;
     fi
 


### PR DESCRIPTION
Individual commits say more.  I do not expect any effect on coverage.