### PR TITLE
BF: do not crash, just skip whenever trying to delete non existing field in the underlying keyring

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -19,13 +19,22 @@ class Keyring(object):
 
     It also delays import of keyring which takes 300ms I guess due to all plugins etc
     """
-    def __init__(self):
-        self.__keyring = None
+    def __init__(self, keyring_backend=None):
+        """
+
+        Parameters
+        ----------
+        keyring_backend: keyring.backend.KeyringBackend, optional
+          Specific keyring to use.  If not provided, the one returned by
+          `keyring.get_keyring()` is used
+        """
+        self.__keyring = keyring_backend
+        self.__keyring_mod = None
 
     @property
     def _keyring(self):
-        if self.__keyring is None:
-            # Setup logging for keyring if we are debugging, althought keyring's logging
+        if self.__keyring_mod is None:
+            # Setup logging for keyring if we are debugging, although keyring's logging
             # is quite scarce ATM
             from datalad.log import lgr
             import logging
@@ -36,8 +45,14 @@ class Keyring(object):
                 keyring_lgr.handlers = lgr.handlers
             lgr.debug("Importing keyring")
             import keyring
-            self.__keyring = keyring
-            the_keyring = keyring.get_keyring()
+            self.__keyring_mod = keyring
+
+        if self.__keyring is None:
+            from datalad.log import lgr
+            # we use module bound interfaces whenever we were not provided a dedicated
+            # backend
+            self.__keyring = self.__keyring_mod
+            the_keyring = self.__keyring_mod.get_keyring()
             if the_keyring.name.lower().startswith('null '):
                 lgr.warning(
                     "Keyring module returned '%s', no credentials will be provided",
@@ -64,7 +79,12 @@ class Keyring(object):
     def delete(self, name, field=None):
         if field is None:
             raise NotImplementedError("Deletion of all fields associated with a name")
-        return self._keyring.delete_password(self._get_service_name(name), field)
+        try:
+            return self.__keyring.delete_password(self._get_service_name(name), field)
+        except self.__keyring_mod.errors.PasswordDeleteError as exc:
+            if 'not found' in str(exc):
+                return
+            raise
 
 
 class MemoryKeyring(object):


### PR DESCRIPTION
Fixing bug leading to a crash: We have pairs or more in composite
credentials. If user saved some but not all of them, then upon renew whenever
we try to delete them all we would crash here since keyring cannot delete the
ones it does not yet know.  So the easiest (although adhoc due to need to match
msg) is to handle such an exception.

To get it tested, I had to use a "real" keyring's backend (so they are called),
and for that I had to RF our Keyring helper class to be capable of being
provided a keyring backend instance (or in other words -- a "keyring").  An odd
logic abit I left behind is that even though we are now explicitly asking for
what keyring will be used, so we could store/use that instance if no explicit
backend is provided, but for consistency with current behavior (since to go
against maint), decided to keep it as is and keep using module level bound
interfaces of keyring module in case if no backend instance was provided.

So now ._keyring  could be either keyring module (no backend instance provided,
or actual keyring backend if it was provided (used only in the tests).

Added test also tests basic assumption that keyring is storing the name
somewhere, and deletes entire section whenever we delete entire credential.
Relies on "ad-hoc" way to specify the filename. Somewhat inquired in
https://github.com/jaraco/keyrings.alt/issues/45 on a better way.

Closes #5889