### PR TITLE
BF(TST): Boost version of git-annex to 8.20201129 to test an error message

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -329,5 +329,5 @@ def test_commanderror_jsonmsgs(src, exp):
         Runner(cwd=ds.path).run(
             ['datalad', 'push', '--to', 'expdir'],
             protocol=StdOutErrCapture)
-    if ds.repo.git_annex_version >= "8.20200309":
+    if ds.repo.git_annex_version >= "8.20201129":
         in_('use `git-annex export`', cme.exception.stderr)


### PR DESCRIPTION
By no means I did thorough investigation but

- test currently fails on cron (and locally) if I do have 8.20200309 installed

- last change to that line/logic is from later -- so I decided to go with that one

	$> git blame Remote/Helper/ExportImport.hs | grep 'use .git-annex export'
	9a2c8757f3 Remote/Helper/ExportImport.hs (Joey Hess 2020-12-18 14:52:57 -0400 153) 					then giveup "remote is configured with exporttree=yes; use `git-annex export` to store content on it"
	$> git describe --contains 9a2c8757f3
	8.20201129~30^2~22

  someone else is welcome to bisect closer if that is not the version

refs:
- prior discussion https://github.com/datalad/datalad/pull/5809#issuecomment-885585730
- Closes #5879
