### PR TITLE
Use platform-appropriate "echo" calls in tests

### DIFF
--- a/datalad/tests/test_nonasyncrunner.py
+++ b/datalad/tests/test_nonasyncrunner.py
@@ -15,11 +15,26 @@ import signal
 import subprocess
 from time import sleep
 
-from datalad.tests.utils import assert_false, assert_true, eq_, \
-    known_failure_windows, known_failure_osx, with_tempfile
+from datalad.tests.utils import (
+    assert_false,
+    assert_true,
+    eq_,
+    known_failure_windows,
+    known_failure_osx,
+    with_tempfile,
+)
 
-from ..cmd import WitlessProtocol, WitlessRunner, StdOutCapture
-from ..nonasyncrunner import _ReaderThread, run_command
+from datalad.cmd import (
+    StdOutCapture,
+    WitlessProtocol,
+    WitlessRunner,
+)
+from datalad.nonasyncrunner import (
+    _ReaderThread,
+    run_command,
+)
+
+from datalad.utils import on_windows
 
 
 @known_failure_windows  # Windows uses different signals and commands
@@ -135,11 +150,13 @@ def test_thread_exit():
 def test_inside_async():
     async def main():
         runner = WitlessRunner()
-        return runner.run(["echo", "abc"], StdOutCapture)
+        return runner.run(
+            (["cmd.exe", "/c"] if on_windows else []) + ["echo", "abc"],
+            StdOutCapture)
 
     loop = asyncio.get_event_loop()
     result = loop.run_until_complete(main())
-    eq_(result["stdout"], "abc\n")
+    eq_(result["stdout"], "abc" + os.linesep)
 
 
 @known_failure_osx

--- a/datalad/tests/test_witless_runner.py
+++ b/datalad/tests/test_witless_runner.py
@@ -168,7 +168,7 @@ def test_runner_no_stdin_no_capture():
     # Ensure a runner without stdin data and output capture progresses
     runner = Runner()
     runner.run(
-        ["echo", "a", "b", "c"],
+        (["cmd.exe", "/c"] if on_windows else []) + ["echo", "a", "b", "c"],
         stdin=None,
         protocol=None
     )


### PR DESCRIPTION
This implements the suggestion made by @adswa in #5870. 'echo' is a
shell built-in, so call it with a shell.

Fixes #5870

Plus some minor changes to make other test code for the runner run on windows.