### PR TITLE
Support username, password and port specification in RIA URLs

### DIFF
--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -79,6 +79,8 @@ def verify_ria_url(url, cfg):
     -------
     tuple
       (host, base-path, rewritten url)
+      `host` is not just a hostname, but may also contain username, password,
+      and port, if specified in a given URL.
     """
     from datalad.config import rewrite_url
     from datalad.support.network import URL
@@ -99,7 +101,16 @@ def verify_ria_url(url, cfg):
                          "Supported: ssh, file, http(s)" %
                          protocol)
 
-    return url_ri.hostname if protocol != 'file' else None, \
+    host = '{user}{pdelim}{passwd}{udelim}{hostname}{portdelim}{port}'.format(
+        user=url_ri.username or '',
+        pdelim=':' if url_ri.password else '',
+        passwd=url_ri.password or '',
+        udelim='@' if url_ri.username else '',
+        hostname=url_ri.hostname or '',
+        portdelim=':' if url_ri.port else '',
+        port=url_ri.port or '',
+    )
+    return host if protocol != 'file' else None, \
         url_ri.path if url_ri.path else '/', \
         url
 

--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -79,8 +79,8 @@ def verify_ria_url(url, cfg):
     -------
     tuple
       (host, base-path, rewritten url)
-      `host` is not just a hostname, but may also contain username, password,
-      and port, if specified in a given URL.
+      `host` is not just a hostname, but is a stub URL that may also contain
+      username, password, and port, if specified in a given URL.
     """
     from datalad.config import rewrite_url
     from datalad.support.network import URL
@@ -101,13 +101,14 @@ def verify_ria_url(url, cfg):
                          "Supported: ssh, file, http(s)" %
                          protocol)
 
-    host = '{user}{pdelim}{passwd}{udelim}{hostname}{portdelim}{port}'.format(
+    host = '{proto}://{user}{pdlm}{passwd}{udlm}{host}{portdlm}{port}'.format(
+        proto=protocol,
         user=url_ri.username or '',
-        pdelim=':' if url_ri.password else '',
+        pdlm=':' if url_ri.password else '',
         passwd=url_ri.password or '',
-        udelim='@' if url_ri.username else '',
-        hostname=url_ri.hostname or '',
-        portdelim=':' if url_ri.port else '',
+        udlm='@' if url_ri.username else '',
+        host=url_ri.hostname or '',
+        portdlm=':' if url_ri.port else '',
         port=url_ri.port or '',
     )
     return host if protocol != 'file' else None, \

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -127,26 +127,32 @@ def test_setup_ds_in_store():
 
 def test_verify_ria_url():
     # unsupported protocol
-    assert_raises(ValueError, verify_ria_url, 'ria+ftp://localhost/tmp/this', {})
+    assert_raises(ValueError,
+                  verify_ria_url, 'ria+ftp://localhost/tmp/this', {})
     # bunch of caes that should work
     cases = {
         'ria+file:///tmp/this': (None, '/tmp/this'),
         # no normalization
         'ria+file:///tmp/this/': (None, '/tmp/this/'),
         # with hosts
-        'ria+ssh://localhost/tmp/this': ('localhost', '/tmp/this'),
-        'ria+http://localhost/tmp/this': ('localhost', '/tmp/this'),
-        'ria+https://localhost/tmp/this': ('localhost', '/tmp/this'),
+        'ria+ssh://localhost/tmp/this': ('ssh://localhost', '/tmp/this'),
+        'ria+http://localhost/tmp/this': ('http://localhost', '/tmp/this'),
+        'ria+https://localhost/tmp/this': ('https://localhost', '/tmp/this'),
         # with username
-        'ria+ssh://humbug@localhost/tmp/this': ('humbug@localhost', '/tmp/this'),
+        'ria+ssh://humbug@localhost/tmp/this':
+            ('ssh://humbug@localhost', '/tmp/this'),
         # with port
-        'ria+ssh://humbug@localhost:2222/tmp/this': ('humbug@localhost:2222', '/tmp/this'),
-        'ria+ssh://localhost:2200/tmp/this': ('localhost:2200', '/tmp/this'),
+        'ria+ssh://humbug@localhost:2222/tmp/this':
+            ('ssh://humbug@localhost:2222', '/tmp/this'),
+        'ria+ssh://localhost:2200/tmp/this':
+            ('ssh://localhost:2200', '/tmp/this'),
         # with password
-        'ria+https://humbug:1234@localhost:8080/tmp/this': ('humbug:1234@localhost:8080', '/tmp/this'),
-        # document a strange (MIH thinks undesirable), but pre-existing behavior
-        # an 'ssh example.com' would end up in the user HOME, not in '/'
-        'ria+ssh://example.com': ('example.com', '/')
+        'ria+https://humbug:1234@localhost:8080/tmp/this':
+            ('https://humbug:1234@localhost:8080', '/tmp/this'),
+        # document a strange (MIH thinks undesirable), but pre-existing
+        # behavior an 'ssh example.com' would end up in the user HOME,
+        # not in '/'
+        'ria+ssh://example.com': ('ssh://example.com', '/')
     }
     for i, o in cases.items():
         # we are not testing the URL rewriting here

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -139,6 +139,14 @@ def test_verify_ria_url():
         'ria+https://localhost/tmp/this': ('localhost', '/tmp/this'),
         # with username
         'ria+ssh://humbug@localhost/tmp/this': ('humbug@localhost', '/tmp/this'),
+        # with port
+        'ria+ssh://humbug@localhost:2222/tmp/this': ('humbug@localhost:2222', '/tmp/this'),
+        'ria+ssh://localhost:2200/tmp/this': ('localhost:2200', '/tmp/this'),
+        # with password
+        'ria+https://humbug:1234@localhost:8080/tmp/this': ('humbug:1234@localhost:8080', '/tmp/this'),
+        # document a strange (MIH thinks undesirable), but pre-existing behavior
+        # an 'ssh example.com' would end up in the user HOME, not in '/'
+        'ria+ssh://example.com': ('example.com', '/')
     }
     for i, o in cases.items():
         # we are not testing the URL rewriting here


### PR DESCRIPTION
Previously only the hostname was retained for performing, e.g. SSH-based
logins, making it required to use an appropriate SSH config.

While not using such properties in RIA URLs is advisable, silently
stripping such information is a bug. Moreover, other mechanisms such
as HTTP (or a future FTP support) may not have equivalent configuration
analogs. Using such a core helper as `verify_ria_url()` to silently
remove information seems inappropriate.

A more comprehensive test is included.

Fixes #5475