### PR TITLE
Limit use of default annex.retry=3 to `get` and `copy` operations

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -866,6 +866,11 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
     # and go
     res = ds_repo._call_annex_records(
         cmd,
+        git_options=[
+            "-c",
+            "annex.retry={}".format(
+                ds_repo.config.obtain("datalad.annex.retry"))]
+            if ds_repo.config.get("annex.retry") else None,
         stdin=file_list,
         progress=True,
         # tailor the progress protocol with the total number of files

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -301,12 +301,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         if self._ALLOW_LOCAL_URLS:
             self._allow_local_urls()
 
-        if config.get("annex.retry") is None:
-            self._annex_common_options.extend(
-                ["-c",
-                 "annex.retry={}".format(
-                     config.obtain("datalad.annex.retry"))])
-
         # will be evaluated lazily
         self._n_auto_jobs = None
 
@@ -1381,6 +1375,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         files : list of dict
         """
         options = options[:] if options else []
+
+        if self.config.get("annex.retry") is None:
+            options.extend(
+                ["-c",
+                 "annex.retry={}".format(
+                     self.config.obtain("datalad.annex.retry"))])
 
         if remote:
             if remote not in self.get_remotes():


### PR DESCRIPTION
As discussed in gh-5808 the unconditional use can lead to problematic
error reporting. @yarikoptic's verdict was to maintain the behavior, but
limit it to data transfer commands.

This change implements this move and enables this datalad-specific
default only for `get` and `copy` operations. The latter is not
implemented in `AnnexRepo.copy_to()` because this method is only used
internally in tests, partially broken (gh-5903), and was deprecated in
Apr 2021. Instead, the change is implemented directly in `push`.

Fixes datalad/datalad#5808
