### PR TITLE
Clarify error message re unspecified gitlab project

### DIFF
--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -150,7 +150,7 @@ class CreateSiblingGitlab(Interface):
         project=Parameter(
             args=('--project',),
             metavar='NAME/LOCATION',
-            doc="""project path at the GitLab site. If a subdataset of the
+            doc="""project name/location at the GitLab site. If a subdataset of the
             reference dataset is processed, its project path is automatically
             determined by the `layout` configuration, by default.
             """,
@@ -385,7 +385,7 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
         yield dict(
             res_kwargs,
             status='error',
-            message='No project path specified, and no configuration '
+            message='No project name/location specified, and no configuration '
                     'to derive one',
         )
         return


### PR DESCRIPTION
Issue
```
% datalad create-sibling-gitlab --site gitlab.com
create_sibling_gitlab(error): . (dataset) [No project path specified, and no configuration to derive one]

% datalad create-sibling-gitlab -h
Usage: datalad create-sibling-gitlab [-h] [--site SITENAME] [--project NAME/LOCATION]
                                     [--layout {hierarchy|collection|flat}] [--dataset DATASET] [-r] [-R LEVELS]
                                     [-s NAME] [--existing {skip|error|reconfigure}] [--access {http|ssh|ssh+http}]
                                     [--publish-depends SIBLINGNAME] [--description DESCRIPTION] [--dryrun]
                                     [PATH ...]
```

The error message is hinting at a missing PATH, but --project is
required instead.

This change standardizes on using the terms from the existing metavar
spec, in the docs and the error message to reduce the confusion:

```
create_sibling_gitlab(error): . (dataset) [No project name/location specified, and no configuration to derive one]
```

Fixes datalad/datalad#5764