### PR TITLE
Fix argument-spec for `siblings` and improve usage synopsis

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -148,9 +148,8 @@ class Siblings(Interface):
         action=Parameter(
             args=('action',),
             nargs='?',
-            metavar='ACTION',
             doc="""command action selection (see general documentation)""",
-            constraints=EnsureChoice('query', 'add', 'remove', 'configure', 'enable') | EnsureNone()),
+            constraints=EnsureChoice('query', 'add', 'remove', 'configure', 'enable')),
         url=Parameter(
             args=('--url',),
             doc="""the URL of or path to the dataset sibling named by


### PR DESCRIPTION
`None` was declared as supported `action`, but if given, would cause a crash.

Synopsis went from

```
Usage: datalad siblings [-h] [-d DATASET] [-s NAME] [--url [URL]] [--pushurl PUSHURL] [-D DESCRIPTION] [--fetch]
                        [--as-common-datasrc NAME] [--publish-depends SIBLINGNAME] [--publish-by-default REFSPEC]
                        [--annex-wanted EXPR] [--annex-required EXPR] [--annex-group EXPR] [--annex-groupwanted EXPR]
                        [--inherit] [--no-annex-info] [-r] [-R LEVELS] [--version]
                        [ACTION]
```

to

```
Usage: datalad siblings [-h] [-d DATASET] [-s NAME] [--url [URL]] [--pushurl PUSHURL] [-D DESCRIPTION] [--fetch]
                        [--as-common-datasrc NAME] [--publish-depends SIBLINGNAME] [--publish-by-default REFSPEC]
                        [--annex-wanted EXPR] [--annex-required EXPR] [--annex-group EXPR] [--annex-groupwanted EXPR]
                        [--inherit] [--no-annex-info] [-r] [-R LEVELS] [--version]
                        [{query|add|remove|configure|enable}]
```

Fixes datalad/datalad#5912
