### PR TITLE
Render siblings()'s non-ok results with the default renderer

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -57,6 +57,7 @@ from datalad.interface.common_opts import (
     inherit_opt,
     location_description,
 )
+from datalad.interface.utils import default_result_renderer
 from datalad.downloaders.credentials import UserPassword
 from datalad.distribution.dataset import (
     require_dataset,
@@ -311,7 +312,7 @@ class Siblings(Interface):
             )
             return
         if res['status'] != 'ok' or not res.get('action', '').endswith('-sibling') :
-            # logging complained about this already
+            default_result_renderer(res)
             return
         path = op.relpath(res['path'],
                        res['refds']) if res.get('refds', None) else res['path']


### PR DESCRIPTION
Before this change, siblings() would exclusively rely on result logging to
communicate with a user. While this might have been enough a few years
ago, it is now an outlier behavior.

This change simply calls the default renderer for all results that the
custom renderer cannot handle (and previously silently ignored).

Fixes datalad/datalad#5147