### PR TITLE
Provide a few more hints whenever user just runs `datalad`

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -433,7 +433,7 @@ def _maybe_get_single_subparser(cmdlineargs, parser, interface_groups,
         if not unparsed_args and getattr(parsed_args, 'version', None):
             parsed_args.version()  # will exit with 0
         if not (completing or unparsed_args):
-            fail_handler(parser, msg="too few arguments", exit_code=2)
+            fail_handler(parser, msg="too few arguments, run with --help to get more information.", exit_code=2)
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
                   __full_version__, parsed_args, unparsed_args)
     except Exception as exc:

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -433,7 +433,10 @@ def _maybe_get_single_subparser(cmdlineargs, parser, interface_groups,
         if not unparsed_args and getattr(parsed_args, 'version', None):
             parsed_args.version()  # will exit with 0
         if not (completing or unparsed_args):
-            fail_handler(parser, msg="too few arguments, run with --help to get more information.", exit_code=2)
+            fail_handler(
+                parser,
+                msg="too few arguments, run with --help or visit https://handbook.datalad.org",
+                exit_code=2)
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
                   __full_version__, parsed_args, unparsed_args)
     except Exception as exc:

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -591,6 +591,7 @@ def fail_with_short_help(parser=None,
         out.write("error: %s\n" % msg)
     if not known:
         if parser:
+            parser_add_common_opt(parser, 'help')
             # just to appear in print_usage also consistent with --help output
             parser.add_argument("command [command-opts]")
             parser.print_usage(file=out)


### PR DESCRIPTION
Instead of 
```
$> datalad
error: too few arguments
usage: datalad [-l LEVEL] [--pbs-runner {condor}] [-C PATH] [--version] [--dbg] [--idbg] [-c KEY=VALUE]
               [-f {default,json,json_pp,tailored,'<template>'}]
               [--report-status {success,failure,ok,notneeded,impossible,error}]
               [--report-type {dataset,file}] [--on-failure {ignore,continue,stop}] [--cmd]
               command [command-opts]
```

and being puzzled on "what next" until they realize they need to run apparently non-listed above`--help`:

```
$> datalad
error: too few arguments, run with --help to get more information.
visit: https://www.datalad.org https://docs.datalad.org https://handbook.datalad.org
usage: datalad [-l LEVEL] [--pbs-runner {condor}] [-C PATH] [--version] [--dbg] [--idbg] [-c KEY=VALUE]
               [-f {default,json,json_pp,tailored,'<template>'}]
               [--report-status {success,failure,ok,notneeded,impossible,error}]
               [--report-type {dataset,file}] [--on-failure {ignore,continue,stop}] [--cmd] [-h]
               command [command-opts]
```