### PR TITLE
Some love and fixes for `siblings`

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -246,18 +246,21 @@ class Siblings(Interface):
         # at the top-level and vice versa
         worker = action_worker_map[action]
 
-        dataset = require_dataset(
-            dataset, check_installed=False, purpose='configure sibling')
-        refds_path = dataset.path
+        ds = require_dataset(
+            dataset,
+            # it makes no sense to use this command without a dataset
+            check_installed=True,
+            purpose='configure sibling')
+        refds_path = ds.path
 
         res_kwargs = dict(refds=refds_path, logger=lgr)
 
-        ds_name = op.basename(dataset.path)
+        ds_name = op.basename(ds.path)
 
         # do not form single list of datasets (with recursion results) to
         # give fastest possible response, for the precise of a long-all
         # function call
-        ds = dataset
+
         # minimize expensive calls to .repo
         ds_repo = ds.repo
 

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -286,8 +286,7 @@ class Siblings(Interface):
             get_annex_info=get_annex_info,
             res_kwargs=res_kwargs,
         )
-        for r in worker(**worker_kwargs):
-            yield r
+        yield from worker(**worker_kwargs)
         if not recursive:
             return
 
@@ -318,8 +317,7 @@ class Siblings(Interface):
                 url=subds_url,
                 pushurl=subds_pushurl,
             )
-            for r in worker(**worker_kwargs):
-                yield r
+            yield from worker(**worker_kwargs)
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -12,71 +12,72 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
-
 import os
 import os.path as op
-
 from urllib.parse import urlparse
 
-from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
-from datalad.interface.results import get_status_dict
-from datalad.support.annexrepo import AnnexRepo
-from datalad.support.constraints import (
-    EnsureStr,
-    EnsureChoice,
-    EnsureNone,
-    EnsureBool,
-)
-from datalad.support.param import Parameter
-from datalad.support.exceptions import (
-    CommandError,
-    InsufficientArgumentsError,
-    AccessDeniedError,
-    AccessFailedError,
-    RemoteNotAvailableError,
-    DownloadError,
-)
-from datalad.support.network import (
-    RI,
-    PathRI,
-    URL,
-)
-from datalad.support.gitrepo import GitRepo
-from datalad.interface.common_opts import (
-    recursion_flag,
-    recursion_limit,
-    as_common_datasrc,
-    publish_depends,
-    publish_by_default,
-    annex_wanted_opt,
-    annex_required_opt,
-    annex_group_opt,
-    annex_groupwanted_opt,
-    inherit_opt,
-    location_description,
-)
-from datalad.interface.utils import default_result_renderer
-from datalad.downloaders.credentials import UserPassword
+import datalad.support.ansi_colors as ac
 from datalad.distribution.dataset import (
-    require_dataset,
     Dataset,
+    require_dataset,
 )
 from datalad.distribution.update import Update
+from datalad.dochelpers import exc_str
+from datalad.downloaders.credentials import UserPassword
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.common_opts import (
+    annex_group_opt,
+    annex_groupwanted_opt,
+    annex_required_opt,
+    annex_wanted_opt,
+    as_common_datasrc,
+    inherit_opt,
+    location_description,
+    publish_by_default,
+    publish_depends,
+    recursion_flag,
+    recursion_limit,
+)
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import (
+    default_result_renderer,
+    eval_results,
+)
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import (
+    EnsureBool,
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import (
+    AccessDeniedError,
+    AccessFailedError,
+    CommandError,
+    DownloadError,
+    InsufficientArgumentsError,
+    RemoteNotAvailableError,
+)
+from datalad.support.gitrepo import GitRepo
+from datalad.support.network import (
+    RI,
+    URL,
+    PathRI,
+)
+from datalad.support.param import Parameter
 from datalad.utils import (
+    Path,
     ensure_list,
     slash_join,
-    Path,
 )
-from datalad.dochelpers import exc_str
 
 from .dataset import (
     EnsureDataset,
     datasetmethod,
 )
-import datalad.support.ansi_colors as ac
-
 
 lgr = logging.getLogger('datalad.distribution.siblings')
 
@@ -314,6 +315,7 @@ class Siblings(Interface):
     @staticmethod
     def custom_result_renderer(res, **kwargs):
         from datalad.ui import ui
+
         # should we attempt to remove an unknown sibling, complain like Git does
         if res['status'] == 'notneeded' and res['action'] == 'remove-sibling':
             ui.message(

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -353,6 +353,11 @@ def _add_remote(ds, name, known_remotes, url, pushurl, as_common_datasrc,
         raise InsufficientArgumentsError(
             """insufficient information to add a sibling
             (needs at least a dataset, and any URL).""")
+
+    # a pushurl should always be able to fill in for a not
+    # specified url, however, only when adding new remotes,
+    # not when configuring existing remotes (to avoid undesired
+    # overwriting of configurations), hence done here only
     if url is None:
         url = pushurl
 

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -262,7 +262,7 @@ class Siblings(Interface):
                 as_common_datasrc, publish_depends, publish_by_default,
                 annex_wanted, annex_required, annex_group, annex_groupwanted,
                 inherit, get_annex_info,
-                **res_kwargs):
+                res_kwargs):
             yield r
         if not recursive:
             return
@@ -297,7 +297,7 @@ class Siblings(Interface):
                     as_common_datasrc, publish_depends, publish_by_default,
                     annex_wanted, annex_required, annex_group, annex_groupwanted,
                     inherit, get_annex_info,
-                    **res_kwargs):
+                    res_kwargs):
                 yield r
 
     @staticmethod
@@ -338,7 +338,7 @@ def _add_remote(
         as_common_datasrc, publish_depends, publish_by_default,
         annex_wanted, annex_required, annex_group, annex_groupwanted,
         inherit, get_annex_info,
-        **res_kwargs):
+        res_kwargs):
     # TODO: allow for no url if 'inherit' and deduce from the super ds
     #       create-sibling already does it -- generalize/use
     #  Actually we could even inherit/deduce name from the super by checking
@@ -396,7 +396,7 @@ def _add_remote(
             as_common_datasrc, publish_depends, publish_by_default,
             annex_wanted, annex_required, annex_group, annex_groupwanted,
             inherit, get_annex_info,
-            **res_kwargs):
+            res_kwargs):
         if r['action'] == 'configure-sibling':
             r['action'] = 'add-sibling'
         yield r
@@ -408,7 +408,7 @@ def _configure_remote(
         as_common_datasrc, publish_depends, publish_by_default,
         annex_wanted, annex_required, annex_group, annex_groupwanted,
         inherit, get_annex_info,
-        **res_kwargs):
+        res_kwargs):
     result_props = dict(
         action='configure-sibling',
         path=ds.path,
@@ -612,7 +612,8 @@ def _query_remotes(
         as_common_datasrc=None, publish_depends=None, publish_by_default=None,
         annex_wanted=None, annex_required=None, annex_group=None, annex_groupwanted=None,
         inherit=None, get_annex_info=True,
-        **res_kwargs):
+        res_kwargs=None):
+    res_kwargs = res_kwargs or {}
     annex_info = {}
     available_space = None
     if get_annex_info and isinstance(ds.repo, AnnexRepo):
@@ -710,7 +711,7 @@ def _remove_remote(
         as_common_datasrc, publish_depends, publish_by_default,
         annex_wanted, annex_required, annex_group, annex_groupwanted,
         inherit, get_annex_info,
-        **res_kwargs):
+        res_kwargs):
     if not name:
         # TODO we could do ALL instead, but that sounds dangerous
         raise InsufficientArgumentsError("no sibling name given")
@@ -741,7 +742,7 @@ def _enable_remote(
         as_common_datasrc, publish_depends, publish_by_default,
         annex_wanted, annex_required, annex_group, annex_groupwanted,
         inherit, get_annex_info,
-        **res_kwargs):
+        res_kwargs):
     result_props = dict(
         action='enable-sibling',
         path=ds.path,

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -45,7 +45,10 @@ from datalad.tests.utils import (
     DEFAULT_REMOTE,
 )
 
-from datalad.utils import Path
+from datalad.utils import (
+    on_windows,
+    Path,
+)
 
 
 # work on cloned repos to be safer
@@ -364,12 +367,17 @@ def test_arg_missing(path, path2):
     # trigger some name guessing functionality that will still not
     # being able to end up using a hostnames-spec despite being
     # given a URL
-    assert_raises(
-        InsufficientArgumentsError,
-        ds.siblings,
-        'add',
-        url=f'file://{path2}',
-    )
+    if not on_windows:
+        # the trick with the file:// URL creation only works on POSIX
+        # the underlying tested code here is not about paths, though,
+        # so it is good enough to run this on POSIX system to be
+        # reasonably sure that things work
+        assert_raises(
+            InsufficientArgumentsError,
+            ds.siblings,
+            'add',
+            url=f'file://{path2}',
+        )
 
     # there is no name guessing with 'configure'
     assert_in_results(

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -112,6 +112,11 @@ def test_siblings(origin, repo_path, local_clone_path):
                    result_renderer=None)
     assert_status('ok', res)
     assert_not_in("test-remote", source.repo.get_remotes())
+    # remove again (with result renderer to smoke-test a renderer
+    # special case for this too)
+    res = siblings('remove', dataset=source, name="test-remote")
+    assert_status('notneeded', res)
+
     res = siblings('add', dataset=source, name="test-remote",
                    url=httpurl1, on_failure='ignore',
                    result_renderer=None)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1825,7 +1825,7 @@ class GitRepo(CoreGitRepo):
         try:
             self.call_git(['remote', 'remove', name])
         except CommandError as e:
-            if 'fatal: No such remote' in e.stderr:
+            if 'No such remote' in e.stderr:
                 raise RemoteNotAvailableError(name,
                                               cmd="git remote remove",
                                               msg="No such remote",


### PR DESCRIPTION
The diff looks massive, but looking at individual commits should tell a simpler story.

Key changes:

- coverage boost from 77% to 90% (see below)
- `--as-common-datasrc` working again, and tested from now (fixes: #4697)
- fixed `GitRepo.remove_remote()` to issue the expected exception when trying to remove a non-existing remote (also covered by a test now)
- fix crash with invalid `dataset` argument (fixes #5626)

Individual fixes could have been PR'ed against `master`. However, this whole thing sparks no joy and I am happy to have come to this point. I do not plan on further improvements. There is more to do, even after #5913 and #5915. Importantly #5914. The changes included here should make incremental improvements simpler. But I have to detach for now.

```
DATALAD_TESTS_SSH=1 python -m nose -s -v --with-coverage --cover-erase --cover-package datalad.distribution.siblings datalad.distribution.tests.test_siblings
...
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
datalad/distribution/siblings.py     341     78    77%   225, 308-313, 351, 355, 371, 419-422, 508, 513-522, 525-532, 561-577, 593, 597-600, 623-624, 645-648, 661, 685, 700, 716, 726-731, 753-757, 760-764, 771-775, 781-807, 815-827, 834, 847, 865, 874
----------------------------------------------------------------
TOTAL                                341     78    77%
----------------------------------------------------------------------
Ran 8 tests in 24.917s
```

```
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
datalad/distribution/siblings.py     345     35    90%   520, 608, 634-635, 672, 696, 711, 722, 781-807, 815-827, 834, 847, 865, 874
----------------------------------------------------------------
TOTAL                                345     35    90%
----------------------------------------------------------------------
Ran 10 tests in 26.504s
```