### PR TITLE
BF?: add-archive-content on .xz and other non-.gz stream compressed files

### DIFF
--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -14,40 +14,55 @@ from __future__ import print_function
 __docformat__ = 'restructuredtext'
 
 
-import re
 import os
+import re
 import tempfile
-
-from os.path import join as opj, curdir, exists, lexists, relpath, basename
-from os.path import commonprefix
+from os.path import (
+    basename,
+    commonprefix,
+    curdir,
+    dirname,
+    exists,
+    isabs,
+    islink,
+)
+from os.path import join as opj
+from os.path import (
+    lexists,
+    normpath,
+    relpath,
+    splitext,
+)
 from os.path import sep as opsep
-from os.path import islink
-from os.path import isabs
-from os.path import dirname
-from os.path import normpath
+
+from datalad.cmdline.helpers import get_repo_instance
+from datalad.consts import ARCHIVES_SPECIAL_REMOTE
+from datalad.customremotes.base import init_datalad_remote
+from datalad.interface.base import build_doc
+from datalad.log import logging
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import FileNotInRepositoryError
+from datalad.support.param import Parameter
+from datalad.support.stats import ActivityStats
+from datalad.support.strings import apply_replacement_rules
+from datalad.utils import (
+    Path,
+    ensure_tuple_or_list,
+    file_basename,
+    get_dataset_root,
+    getpwd,
+    md5sum,
+    rmtree,
+    split_cmdline,
+)
 
 from .base import Interface
-from datalad.interface.base import build_doc
 from .common_opts import allow_dirty
-from ..consts import ARCHIVES_SPECIAL_REMOTE
-from ..support.param import Parameter
-from ..support.constraints import EnsureStr, EnsureNone
 
-from ..support.annexrepo import AnnexRepo
-from datalad.support.exceptions import FileNotInRepositoryError
-from ..support.strings import apply_replacement_rules
-from ..support.stats import ActivityStats
-from ..cmdline.helpers import get_repo_instance
-from ..utils import getpwd, rmtree, file_basename
-from ..utils import md5sum
-from ..utils import Path
-from ..utils import ensure_tuple_or_list
-from ..utils import get_dataset_root
-from ..utils import split_cmdline
-
-from datalad.customremotes.base import init_datalad_remote
-
-from ..log import logging
 lgr = logging.getLogger('datalad.interfaces.add_archive_content')
 
 
@@ -336,7 +351,8 @@ class AddArchiveContent(Interface):
             outside_stats = stats
             stats = ActivityStats()
 
-            for extracted_file in earchive.get_extracted_files():
+            extracted_files = list(earchive.get_extracted_files())
+            for extracted_file in extracted_files:
                 stats.files += 1
                 extracted_path = opj(earchive.path, extracted_file)
 
@@ -350,6 +366,16 @@ class AddArchiveContent(Interface):
 
                 # preliminary target name which might get modified by renames
                 target_file_orig = target_file = extracted_file
+
+                # stream archives would not have had the original filename information
+                # in them, so would be extracted under a name derived from their annex key.
+                # Provide ad-hoc handling for such cases
+                if (len(extracted_files) == 1 and
+                        splitext(archive)[-1] in ('.xz', '.gz', '.lzma') and
+                        basename(key_rpath).startswith(basename(extracted_file))):
+                    # take archive's name (without extension) for the filename and place
+                    # where it was originally extracted
+                    target_file = opj(dirname(extracted_file), basename(splitext(archive)[0]))
 
                 # strip leading dirs
                 target_file = target_file[leading_dir_len:]

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -40,6 +40,7 @@ from datalad.tests.utils import (
     known_failure_windows,
     ok_,
     ok_archives_caches,
+    ok_file_has_content,
     ok_file_under_git,
     serve_path_via_http,
     slow,
@@ -412,6 +413,27 @@ def test_add_archive_use_archive_dir(repo_path):
         add_archive_content(opj('4u', 'sub.tar.gz'))
         ok_file_under_git(repo.path, opj('4u', 'sub', '2 f.txt'), annexed=True)
         ok_archives_caches(repo.path, 0)
+
+
+@with_tree(
+    tree={
+        '1.gz': '1',
+        '2.xz': '2',
+        '3.lzma': '3',
+        # TODO: add any other stream compression we might be supporting via 7zip or patool?
+    }
+)
+def test_add_archive_single_file(repo_path):
+    repo = AnnexRepo(repo_path, create=True)
+    with chpwd(repo_path):
+        archives = glob('*')
+        repo.add(archives)
+        repo.commit('Added archives')
+
+        for archive in archives:
+            archive_name = os.path.splitext(archive)[0]
+            add_archive_content(archive)
+            ok_file_has_content(archive_name, archive_name)
 
 
 class TestAddArchiveOptions():

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -417,23 +417,26 @@ def test_add_archive_use_archive_dir(repo_path):
 
 @with_tree(
     tree={
-        '1.gz': '1',
-        '2.xz': '2',
-        '3.lzma': '3',
-        # TODO: add any other stream compression we might be supporting via 7zip or patool?
+        'archives': {
+            '1.gz': '1',
+            '2.xz': '2',
+            '3.lzma': '3',
+            # TODO: add any other stream compression we might be supporting via 7zip or patool?
+        },
     }
 )
 def test_add_archive_single_file(repo_path):
     repo = AnnexRepo(repo_path, create=True)
     with chpwd(repo_path):
-        archives = glob('*')
+        archives = glob('archives/*')
         repo.add(archives)
         repo.commit('Added archives')
 
         for archive in archives:
             archive_name = os.path.splitext(archive)[0]
+            archive_content = os.path.basename(archive_name)
             add_archive_content(archive)
-            ok_file_has_content(archive_name, archive_name)
+            ok_file_has_content(archive_name, archive_content)
 
 
 class TestAddArchiveOptions():

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -1263,12 +1263,16 @@ def test_create_tree(path):
             # right away an obscure case where we have both 1 and 1.gz
                 ('1', content*2),
                 ('1.gz', content*3),
+                ('1.xz', content*4),
+                ('1.lzma', content*5),
             ]
         )),
     ]))
     ok_file_has_content(op.join(path, '1'), content)
     ok_file_has_content(op.join(path, 'sd', '1'), content*2)
     ok_file_has_content(op.join(path, 'sd', '1.gz'), content*3, decompress=True)
+    ok_file_has_content(op.join(path, 'sd', '1.xz'), content*4, decompress=True)
+    ok_file_has_content(op.join(path, 'sd', '1.lzma'), content*5, decompress=True)
 
 
 def test_never_fail():

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -11,6 +11,7 @@
 import glob
 import gzip
 import inspect
+import lzma
 import shutil
 import stat
 from json import dumps
@@ -538,6 +539,8 @@ def ok_file_has_content(path, content, strip=False, re_=False,
     if decompress:
         if path.suffix == '.gz':
             open_func = gzip.open
+        elif path.suffix in ('.xz', '.lzma'):
+            open_func = lzma.open
         else:
             raise NotImplementedError("Don't know how to decompress %s" % path)
     else:

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2417,6 +2417,9 @@ def create_tree(path, tree, archives_leading_dir=True, remove_existing=False):
             open_func = open
             if full_name.endswith('.gz'):
                 open_func = gzip.open
+            elif full_name.split('.')[-1] in ('xz', 'lzma'):
+                import lzma
+                open_func = lzma.open
             with open_func(full_name, "wb") as f:
                 f.write(ensure_bytes(load, 'utf-8'))
         if executable:


### PR DESCRIPTION
If ever to be finished, closes #5929 .  For now just establishes a test to demonstrate the failure (in future - test the fix).

May be it is not worth even attempting in `maint` but rather RF add-archive-content (it is one of the oldest, doesn't have `--dataset` argument etc) in `master` and likely drop going through the datalad-archives support code (and its caching mechanism), which only sees annex'ed keys at that level.