### PR TITLE
Let `siblings()` report on annex special remote configuration

### DIFF
--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -565,3 +565,18 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
     eq_('likemagic', (testbed.pathobj / 'testfile').read_text())
     # and the other one
     assert_status('ok', testbed.get('testfile2'))
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_specialremote(dspath, remotepath):
+    ds = Dataset(dspath).create()
+    ds.repo.call_annex(
+        ['initremote', 'myremote', 'type=directory',
+         f'directory={remotepath}', 'encryption=none'])
+    res = ds.siblings('query', result_renderer=None)
+    assert_in_results(
+        res,
+        **{'name': 'myremote',
+           'annex-type': 'directory',
+           'annex-directory': remotepath})


### PR DESCRIPTION
These new properties in the result record are prefixed with `annex-`, as
are all other such annex-related properties that where reported so far.

Example

```
{
  "action": "query-sibling",
  "annex-archive-id": "2bc339c2-153e-4f0e-8765-0743921ca6de",
  "annex-autoenable": "true",
  "annex-availability": "GloballyAvailable",
  "annex-cost": "200.0",
  "annex-description": "[pmacs-ria-storage]",
  "annex-encryption": "none",
  "annex-externaltype": "ora",
  "annex-name": "pmacs-ria-storage",
  "annex-timestamp": "1629126840.298837171s",
  "annex-type": "external",
  "annex-url": "ria+ssh://humbug@juseless.inm7.de/tmp/store2",
  "annex-uuid": "386e24bd-ad4f-4638-8c17-2cb94a560b56",
  "name": "pmacs-ria-storage",
  "path": "/tmp/some",
  "refds": "/tmp/some",
  "skipfetchall": "true",
  "status": "ok",
  "type": "sibling"
}
```

Fixes datalad/datalad#2883
