### PR TITLE
Log result record message at DEBUG level by default

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -270,13 +270,13 @@ definitions = {
     'datalad.log.result-level': {
         'ui': ('question', {
                'title': 'Log level for command result messages',
-               'text': "Overrides the default behavior of logging 'impossible' "
+               'text': "If 'match-status', it will log 'impossible' "
                        "results as a warning, 'error' results as errors, and "
-                       "everything else as 'debug' with a single alternative "
-                       "log level"}),
-        'type': EnsureChoice('debug', 'info', 'warning', 'error'),
-        # None keeps the default behavior
-        'default': 'None',
+                       "everything else as 'debug'. Otherwise the indicated "
+                       "log-level will be used for all such messages"}),
+        'type': EnsureChoice('debug', 'info', 'warning', 'error',
+                             'match-status'),
+        'default': 'debug',
     },
     'datalad.log.name': {
         'ui': ('question', {

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -362,7 +362,7 @@ def eval_results(func):
         if not result_renderer:
             result_renderer = dlcfg.get('datalad.api.result-renderer', None)
         # look for potential override of logging behavior
-        result_log_level = dlcfg.get('datalad.log.result-level', None)
+        result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
 
         # query cfg for defaults
         # .is_installed and .config can be costly, so ensure we do
@@ -595,7 +595,7 @@ def _process_results(
                 res_lgr = getattr(
                     res_lgr,
                     default_logchannels[res['status']]
-                    if result_log_level is None
+                    if result_log_level is 'match-status'
                     else result_log_level)
             msg = res['message']
             msgargs = None


### PR DESCRIPTION
Previously, messages with 'impossible' and 'error' status were logged
at WARNING and ERROR level respectively (by default). gh-3754 introduced
the config switch `datalad.log.result-level` to change this behavior,
but kept the default behavior.

This change makes DEBUG-level logging the default, and keeps the
previous default accessible as a 'match-status' mode.

Rational: Logging behavior can be configured in many ways, including
making it disappear from a user's point of view. Therefore it cannot be
relied on for critical messaging of _results_. Consequently, result
renderers perform their own messaging, ultimately leading to
double-reporting of errors and warnings in many default setups (see
gh-3752). Moreover, higher-level commands may later act on non-OK
results with recovery or mitigation actions. In such cases an
unconditional (prominent) logging of results emitted by a lower-level
command can be undesirable, but it is presently impossible to disable
from a calling command.

This change alters the requirements for result renderers to assume the
sole responsibility for visualizing (or not) any and all results that are
passed to them, without being able to rely on a particular logging
behavior.

It is unknown in how many edge cases critical messages will disappear
with this change. However, @mih has been running with
`datalad.log.result-level=debug` since Oct 2019, and has not noticed
undesirable behavior (or fixed it).

Fixes datalad/datalad#5910