### PR TITLE
BF(UX): do not keep logging ERROR possibly present in progress records

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3503,11 +3503,14 @@ class AnnexJsonProtocol(WitlessProtocol):
         pbar_id = self._get_pbar_id(j)
         known_pbar = pbar_id in self._pbars
         action = j.get('action')
-        if action:
+
+        is_progress = action and 'byte-progress' in j
+        # ignore errors repeatedly reported in progress messages. Final message
+        # will contain them
+        if action and not is_progress:
             for err_msg in action.pop('error-messages', []):
                 lgr.error(err_msg)
 
-        is_progress = action and 'byte-progress' in j
         if known_pbar and (not is_progress or
                            j.get('byte-progress') == j.get('total-size')):
             # take a known pbar down, completion or broken report


### PR DESCRIPTION
Initially observed while giving a live demo (kheh kheh -- always the best time
to find bugs) on DANDI datasets such as
http://github.com/dandisets/000029, e.g.:

	(git-annex)lena:/tmp/000029[tags/0.210806.2112^0]git
	$> datalad get sub-anm36996*
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	[ERROR  ]   download failed: Not Found
	Total:   0%|                                                             | 0.00/20.7M [00:12<?, ? Bytes/s]
	Get sub-anm369964/sub-anm .. 9964_behavior+ecephys.nwb:  41%|█▋  | 3.11M/7.66M [00:10<00:15, 295k Bytes/s]

which is due to the fact that the first URL in git-annex for the files is
no longer available, so annex falls to the second available URL, but it keeps
repeating the same list error-messages in its --json-error-messages:

	$> 'git' 'annex' 'get' '--json' '--json-error-messages' '--json-progress' '-c' 'annex.dotfiles=true' '--' 'sub-anm369962/sub-anm369962_behavior+ecephys.nwb'
	{"byte-progress":4989429,"action":{"command":"get","note":"from web...","input":["sub-anm369962/sub-anm369962_behavior+ecephys.nwb"],"key":"SHA256E-s6644036--d01c43576e3aeceed53a052defa8bbbf15b885146f518acf63d228cee44576ac.nwb","error-messages":["  download failed: Not Found"],"file":"sub-anm369962/sub-anm369962_behavior+ecephys.nwb"},"total-size":6644036,"percent-progress":"75.1%"}
	{"byte-progress":5546485,"action":{"command":"get","note":"from web...","input":["sub-anm369962/sub-anm369962_behavior+ecephys.nwb"],"key":"SHA256E-s6644036--d01c43576e3aeceed53a052defa8bbbf15b885146f518acf63d228cee44576ac.nwb","error-messages":["  download failed: Not Found"],"file":"sub-anm369962/sub-anm369962_behavior+ecephys.nwb"},"total-size":6644036,"percent-progress":"83.48%"}
    ...
	{"byte-progress":6451701,"action":{"command":"get","note":"from web...","input":["sub-anm369962/sub-anm369962_behavior+ecephys.nwb"],"key":"SHA256E-s6644036--d01c43576e3aeceed53a052defa8bbbf15b885146f518acf63d228cee44576ac.nwb","error-messages":["  download failed: Not Found"],"file":"sub-anm369962/sub-anm369962_behavior+ecephys.nwb"},"total-size":6644036,"percent-progress":"97.11%"}
	{"command":"get","note":"from web...\nchecksum...","success":true,"input":["sub-anm369962/sub-anm369962_behavior+ecephys.nwb"],"key":"SHA256E-s6644036--d01c43576e3aeceed53a052defa8bbbf15b885146f518acf63d228cee44576ac.nwb","error-messages":["  download failed: Not Found"],"file":"sub-anm369962/sub-anm369962_behavior+ecephys.nwb"}

Not sure yet if there could be a json record from annex which would have
"action" but without byte-progress reporting, so decided to just condition on
it being not a progress report for logging an error (work @mih is doing might
eventually remove all those ERROR logs anyways).  With this patch we would just
get the cleaner

	$> datalad get sub-anm369962/sub-anm369962_behavior+ecephys.nwb
	get(ok): sub-anm369962/sub-anm369962_behavior+ecephys.nwb (file) [download failed: Not Found]

where this non-consequential/non-informative and possibly confusing to the user
error is reported, but how could we address that (e.g. not report any errors if
command eventually succedeed?) is a separate question.

PS. relevant issues in dandisets, which whenever addressed would eliminate this
problem, and thus would cause this issue to not reproduce using aforementioned
commands:

- https://github.com/dandi/dandisets/issues/78
- https://github.com/dandi/dandisets/issues/79

