### PR TITLE
BF: do use OBSCURE_FILENAME instead of hardcoded unicode

### DIFF
--- a/datalad/support/tests/test_globbedpaths.py
+++ b/datalad/support/tests/test_globbedpaths.py
@@ -11,17 +11,21 @@
 
 __docformat__ = 'restructuredtext'
 
-from itertools import product
 import logging
-from unittest.mock import patch
 import os.path as op
+from itertools import product
+from unittest.mock import patch
 
-from datalad.support.globbedpaths import GlobbedPaths
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import eq_
-from datalad.tests.utils import swallow_logs
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils import (
+    OBSCURE_FILENAME,
+    assert_in,
+    eq_,
+    known_failure_windows,
+    swallow_logs,
+    with_tree,
+)
+
+from ..globbedpaths import GlobbedPaths
 
 
 def test_globbedpaths_get_sub_patterns():
@@ -49,11 +53,13 @@ def test_globbedpaths_get_sub_patterns():
         eq_(gp._get_sub_patterns(pat), expected)
 
 
+bOBSCURE_FILENAME = f"b{OBSCURE_FILENAME}.dat"
+
+
 @with_tree(tree={"1.txt": "",
                  "2.dat": "",
                  "3.txt": "",
-                 # Avoid OBSCURE_FILENAME to avoid windows-breakage (gh-2929).
-                 u"bβ.dat": "",
+                 bOBSCURE_FILENAME: "",
                  "subdir": {"1.txt": "", "2.txt": ""}})
 def test_globbedpaths(path):
     dotdir = op.curdir + op.sep
@@ -61,9 +67,9 @@ def test_globbedpaths(path):
     for patterns, expected in [
             (["1.txt", "2.dat"], {"1.txt", "2.dat"}),
             ([dotdir + "1.txt", "2.dat"], {dotdir + "1.txt", "2.dat"}),
-            (["*.txt", "*.dat"], {"1.txt", "2.dat", u"bβ.dat", "3.txt"}),
+            (["*.txt", "*.dat"], {"1.txt", "2.dat", bOBSCURE_FILENAME, "3.txt"}),
             ([dotdir + "*.txt", "*.dat"],
-             {dotdir + "1.txt", "2.dat", u"bβ.dat", dotdir + "3.txt"}),
+             {dotdir + "1.txt", "2.dat", bOBSCURE_FILENAME, dotdir + "3.txt"}),
             ([op.join("subdir", "*.txt")],
              {op.join("subdir", "1.txt"), op.join("subdir", "2.txt")}),
             (["subdir" + op.sep], {"subdir" + op.sep}),
@@ -93,12 +99,12 @@ def test_globbedpaths(path):
 
     # Full patterns still get returned as relative to pwd.
     gp = GlobbedPaths([op.join(path, "*.dat")], pwd=path)
-    eq_(gp.expand(), ["2.dat", u"bβ.dat"])
+    eq_(gp.expand(), ["2.dat", bOBSCURE_FILENAME])
 
     # "." gets special treatment.
     gp = GlobbedPaths([".", "*.dat"], pwd=path)
-    eq_(set(gp.expand()), {"2.dat", u"bβ.dat", "."})
-    eq_(gp.expand(dot=False), ["2.dat", u"bβ.dat"])
+    eq_(set(gp.expand()), {"2.dat", bOBSCURE_FILENAME, "."})
+    eq_(gp.expand(dot=False), ["2.dat", bOBSCURE_FILENAME])
     gp = GlobbedPaths(["."], pwd=path, expand=False)
     eq_(gp.expand(), ["."])
     eq_(gp.paths, ["."])
@@ -111,7 +117,7 @@ def test_globbedpaths(path):
         eq_(gp.expand(), ["z", "b", "d", "x"])
 
     # glob expansion for paths property is determined by expand argument.
-    for expand, expected in [(True, ["2.dat", u"bβ.dat"]),
+    for expand, expected in [(True, ["2.dat", bOBSCURE_FILENAME]),
                              (False, ["*.dat"])]:
         gp = GlobbedPaths(["*.dat"], pwd=path, expand=expand)
         eq_(gp.paths, expected)

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -8,47 +8,20 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
-
 import os
 import sys
-
-from os.path import (
-    join as opj,
-    isabs,
-)
 from collections import OrderedDict
+from os.path import isabs
+from os.path import join as opj
 
 from datalad.distribution.dataset import Dataset
-
-from datalad.utils import (
-    Path,
-    PurePosixPath,
-    on_windows,
-)
-
-from datalad.tests.utils import (
-    eq_,
-    neq_,
-    ok_,
-    nok_,
-    assert_raises,
-    skip_if_on_windows,
-    swallow_logs,
-    assert_in,
-    get_most_obscure_supported_name,
-    SkipTest,
-    known_failure_githubci_win,
-    with_tempfile,
-    assert_status,
-)
-
 from datalad.support.network import (
-    DataLadRI,
-    GitTransportRI,
-    PathRI,
     RI,
     SSHRI,
     URL,
+    DataLadRI,
+    GitTransportRI,
+    PathRI,
     _split_colon,
     dlurljoin,
     get_local_file_url,
@@ -61,6 +34,28 @@ from datalad.support.network import (
     iso8601_to_epoch,
     parse_url_opts,
     same_website,
+    urlquote,
+)
+from datalad.tests.utils import (
+    OBSCURE_FILENAME,
+    SkipTest,
+    assert_in,
+    assert_raises,
+    assert_status,
+    eq_,
+    get_most_obscure_supported_name,
+    known_failure_githubci_win,
+    neq_,
+    nok_,
+    ok_,
+    skip_if_on_windows,
+    swallow_logs,
+    with_tempfile,
+)
+from datalad.utils import (
+    Path,
+    PurePosixPath,
+    on_windows,
 )
 
 
@@ -109,6 +104,8 @@ def test_get_url_straight_filename():
     yield _test_get_url_straight_filename, '?param=1&another=/'
 
 from ..network import rfc2822_to_epoch
+
+
 def test_rfc2822_to_epoch():
     eq_(rfc2822_to_epoch("Thu, 16 Oct 2014 01:16:17 EDT"), 1413436577)
 
@@ -461,10 +458,7 @@ def test_get_local_file_url():
             ) + (
                 ('C:\\Windows\\notepad.exe', 'file://C/Windows/notepad.exe'),
             ) if on_windows else (
-                # static copy of "most_obscore_name"
-                (' "\';a&b&cΔЙקم๗あ `| ',
-                 # and translation by google chrome
-                 "%20%22%27%3Ba%26b%26c%CE%94%D0%99%D7%A7%D9%85%E0%B9%97%E3%81%82%20%60%7C%20"),
+                (OBSCURE_FILENAME, urlquote(OBSCURE_FILENAME)),
                 ('/a', 'file:///a'),
                 ('/a/b/c', 'file:///a/b/c'),
                 ('/a~', 'file:///a~'),


### PR DESCRIPTION
OBSCURE_UNICODE should be used since otherwise tests would
just keep crashing while running on file systems/environment
which do not support those fancy characters.

Initial intention here was to address some Windows fails on Vista and
other elderly systems.  https://github.com/datalad/datalad/issues/2929
If tests pass on current CI I would assume that we are past that
stone age.

Closes a part of #5942.  ~~Wanted first to see if there are side-effects~~