### PR TITLE
Change CapturedException's behavior and intended usage

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -133,7 +133,6 @@ def setup_package():
     # own HOME where we pre-setup git for testing (name, email)
     if 'GIT_HOME' in os.environ:
         set_envvar('HOME', os.environ['GIT_HOME'])
-        set_envvar('DATALAD_LOG_EXC', "1")
     else:
         # we setup our own new HOME, the BEST and HUGE one
         from datalad.utils import make_tempfile

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -33,7 +33,7 @@ from ..utils import (
     get_suggestions_msg,
 )
 from ..version import __version__, __full_version__
-from ..dochelpers import exc_str, exc_str_old
+from ..dochelpers import exc_str
 
 from appdirs import AppDirs
 from os.path import join as opj
@@ -440,7 +440,7 @@ def _maybe_get_single_subparser(cmdlineargs, parser, interface_groups,
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
                   __full_version__, parsed_args, unparsed_args)
     except Exception as exc:
-        lgr.debug("Early parsing failed with %s", exc_str_old(exc))
+        lgr.debug("Early parsing failed with %s", exc_str(exc))
         need_single_subparser = False
         unparsed_args = cmdlineargs[1:]  # referenced before assignment otherwise
     # First unparsed could be either unknown option to top level "datalad"
@@ -564,7 +564,7 @@ def add_entrypoints_to_interface_groups(interface_groups):
             interface_groups.append((ep.name, spec[0], spec[1]))
             lgr.debug('Loaded entrypoint %s', ep.name)
         except Exception as e:
-            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str_old(e))
+            lgr.warning('Failed to load entrypoint %s: %s', ep.name, exc_str(e))
             continue
 
 

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -22,7 +22,6 @@ import os
 
 import datalad
 
-from ..dochelpers import exc_str_old
 from ..support.exceptions import (
     InsufficientArgumentsError,
     IncompleteResultsError,
@@ -44,6 +43,7 @@ from .helpers import (
     parser_add_common_opt,
     strip_arg_from_argv,
 )
+from datalad.dochelpers import exc_str
 
 
 # TODO:  OPT look into making setup_parser smarter to become faster
@@ -216,7 +216,7 @@ def main(args=None):
                 ret = cmdlineargs.func(cmdlineargs)
             except InsufficientArgumentsError as exc:
                 # if the func reports inappropriate usage, give help output
-                lgr.error('%s (%s)', exc_str_old(exc), exc.__class__.__name__)
+                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
                 cmdlineargs.subparser.print_usage(sys.stderr)
                 sys.exit(2)
             except IncompleteResultsError as exc:
@@ -228,7 +228,7 @@ def main(args=None):
                 # in general we do not want to see the error again, but
                 # present in debug output
                 lgr.debug('could not perform all requested actions: %s',
-                          exc_str_old(exc))
+                          exc_str(exc))
                 sys.exit(1)
             except CommandError as exc:
                 # behave as if the command ran directly, importantly pass
@@ -247,7 +247,7 @@ def main(args=None):
                 # had no code defined
                 sys.exit(exc.code if exc.code is not None else 1)
             except Exception as exc:
-                lgr.error('%s (%s)', exc_str_old(exc), exc.__class__.__name__)
+                lgr.error('%s (%s)', exc_str(exc), exc.__class__.__name__)
                 sys.exit(1)
     else:
         # just let argparser spit out its error, since there is smth wrong
@@ -261,7 +261,7 @@ def main(args=None):
         if hasattr(cmdlineargs, 'result_renderer'):
             cmdlineargs.result_renderer(ret, cmdlineargs)
     except Exception as exc:
-        lgr.error("Failed to render results due to %s", exc_str_old(exc))
+        lgr.error("Failed to render results due to %s", exc_str(exc))
         sys.exit(1)
 
 

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -43,7 +43,10 @@ from datalad.support.constraints import (
     EnsureStr,
     EnsureKeyChoice,
 )
-from datalad.support.exceptions import DownloadError
+from datalad.support.exceptions import (
+    CapturedException,
+    DownloadError,
+)
 from datalad.support.param import Parameter
 from datalad.support.strings import get_replacement_dict
 from datalad.support.network import (
@@ -293,10 +296,12 @@ class Clone(Interface):
             # spec is determined to be useless
             path.exists()
         except OSError as e:
+            ce = CapturedException(e)
             yield get_status_dict(
                 status='error',
                 path=path,
-                message=('cannot handle target path: %s', exc_str(e)),
+                message=('cannot handle target path: %s', ce),
+                exception=ce,
                 **result_props)
             return
 
@@ -587,11 +592,12 @@ def clone_dataset(
                 create=True)
 
         except CommandError as e:
+            ce = CapturedException(e)
             e_stderr = e.stderr
 
             error_msgs[cand['giturl']] = e
             lgr.debug("Failed to clone from URL: %s (%s)",
-                      cand['giturl'], exc_str(e))
+                      cand['giturl'], ce)
             if dest_path.exists():
                 lgr.debug("Wiping out unsuccessful clone attempt at: %s",
                           dest_path)
@@ -641,7 +647,7 @@ def clone_dataset(
                 error_msg = "Failed to clone from any candidate source URL. " \
                             "Encountered errors per each url were:\n- %s"
                 error_args = '\n- '.join(
-                    '{}\n  {}'.format(url, exc_str(exc))
+                    '{}\n  {}'.format(url, exc.to_str())
                     for url, exc in error_msgs.items()
                 )
         else:

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -42,7 +42,10 @@ import datalad.support.ansi_colors as ac
 from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureBool
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError
+)
 from datalad.support.globbedpaths import GlobbedPaths
 from datalad.support.param import Parameter
 from datalad.support.json_py import dump2stream
@@ -481,8 +484,10 @@ def _unlock_or_remove(dset_path, paths):
             try:
                 os.unlink(res["path"])
             except OSError as exc:
+                ce = CapturedException(exc)
                 yield dict(res, action="run.remove", status="error",
-                           message=("Removing file failed: %s", exc_str(exc)))
+                           message=("Removing file failed: %s", ce),
+                           exception=ce)
             else:
                 yield dict(res, action="run.remove", status="ok",
                            message="Removed file")

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -234,7 +234,7 @@ def test_interactions(tdir):
             ('VALUE dl+archive://somekey3#path', None),
             ('VALUE',
              re.compile(
-                 'TRANSFER-FAILURE RETRIEVE somekey Failed to fetch any '
+                 'TRANSFER-FAILURE RETRIEVE somekey RuntimeError\(Failed to fetch any '
                  'archive containing somekey. Tried: \[\]')
              )
         ],

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -92,7 +92,7 @@ def test_interactions(tdir):
     fetch_scenarios.append(
         ('VALUE',
          re.compile(
-             'TRANSFER-FAILURE RETRIEVE somekey Failed to download from any')))
+             'TRANSFER-FAILURE RETRIEVE somekey RuntimeError\(Failed to download from any')))
 
     for scenario in BASE_INTERACTION_SCENARIOS + [
         [

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -30,6 +30,7 @@ from ..support.constraints import (
     EnsureNone,
     EnsureStr,
 )
+from datalad.support.exceptions import CapturedException
 from ..utils import (
     ensure_list,
 )
@@ -419,11 +420,13 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
                 status='ok',
             )
         except Exception as e:
+            ce = CapturedException(e)
             yield dict(
                 res_kwargs,
                 # relay all attributes
                 status='error',
-                message=('Failed to create GitLab project: %s', exc_str(e))
+                message=('Failed to create GitLab project: %s', ce),
+                exception=ce
             )
             return
     else:

--- a/datalad/distributed/export_archive_ora.py
+++ b/datalad/distributed/export_archive_ora.py
@@ -34,6 +34,7 @@ from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
 )
+from datalad.support.exceptions import CapturedException
 from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
@@ -188,11 +189,13 @@ class ExportArchiveORA(Interface):
                 status='ok',
                 **res_kwargs)
         except Exception as e:
+            ce = CapturedException(e)
             yield get_status_dict(
                 path=str(archive),
                 type='file',
                 status='error',
-                message=('7z failed: %s', exc_str(e)),
+                message=('7z failed: %s', ce),
+                exception=ce,
                 **res_kwargs)
             return
         finally:

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -70,6 +70,7 @@ from datalad.support.constraints import (
     EnsureStr,
 )
 from datalad.support.exceptions import (
+    CapturedException,
     InsufficientArgumentsError,
     MissingExternalDependency,
 )
@@ -813,10 +814,12 @@ class CreateSibling(Interface):
                 try:
                     upload_web_interface(path, shell, shared, ui)
                 except CommandError as e:
+                    ce = CapturedException(e)
                     currentds_ap['status'] = 'error'
                     currentds_ap['message'] = (
                         "failed to push web interface to the remote datalad repository (%s)",
-                        exc_str(e))
+                        ce)
+                    currentds_ap['exception'] = ce
                     yield currentds_ap
                     yielded.add(currentds_ap['path'])
                     continue
@@ -832,10 +835,12 @@ class CreateSibling(Interface):
                       "&& ( [ -x hooks/post-update ] && hooks/post-update || true )"
                       "".format(sh_quote(_path_(path, ".git"))))
             except CommandError as e:
+                ce = CapturedException(e)
                 currentds_ap['status'] = 'error'
                 currentds_ap['message'] = (
                     "failed to run post-update hook under remote path %s (%s)",
-                    path, exc_str(e))
+                    path, ce)
+                currentds_ap['exception'] = ce
                 yield currentds_ap
                 yielded.add(currentds_ap['path'])
                 continue

--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -314,73 +314,10 @@ def borrowkwargs(cls=None, methodname=None, exclude=None):
     return _borrowkwargs
 
 
-# TODO: make limit respect config/environment parameter
-def exc_str_old(exc=None, limit=None, include_str=True):
-    """Enhanced str for exceptions.  Should include original location
-
-    Parameters
-    ----------
-    exc: Exception, optional
-      If not provided, information about the last exception caught by except
-      clause (as provided by `sys.exc_info`) will be used.
-    limit: int, optional
-      Number of levels in the traceback stack from the point where exception
-      was raised to include. If `None`, environment variable
-      DATALAD_EXC_STR_TBLIMIT is consulted.
-    include_str: bool, optional
-      Either include str (or `repr` if empty `str`) into representation.
-      If False, just ends up reporting traceback without string representation
-      of exception pre-pended.
-
-    Returns
-    -------
-    str
-      String representation of the exception with traceback information
-      appended.
-    """
-    out = str(exc) if include_str else ""
-    if limit is None:
-        # TODO: config logging.exceptions.traceback_levels = 1
-        limit = int(os.environ.get('DATALAD_EXC_STR_TBLIMIT', '1'))
-    try:
-        exctype, value, tb = sys.exc_info()
-        if not exc:
-            exc = value
-            if include_str:
-                out = str(exc)
-        if include_str and not out:
-            out = repr(exc)
-        # verify that it seems to be the exception we were passed
-        #assert(isinstance(exc, exctype))
-        if exc:
-            assert(exc is value)
-        entries = traceback.extract_tb(tb)
-        if entries:
-            tb_str = "[%s]" % (
-                ','.join(
-                    '%s:%s:%d' % (os.path.basename(x[0]), x[2], x[1])
-                    for x in entries[-limit:]
-                )
-            )
-            if out:
-                out = "%s %s" % (out, tb_str)
-            else:
-                out = tb_str
-    except:  # MIH: TypeError?
-        return out  # To the best of our abilities
-    finally:
-        # As the bible teaches us:
-        # https://docs.python.org/2/library/sys.html#sys.exc_info
-        del tb
-    return out
-
-
 def exc_str(exc=None, limit=None, include_str=True):
-    """Temporary test shim, for finding issues re refactoring for
-    using CapturedException instead.
+    """Temporary adapter
 
-    See gh-5716
+    The CapturedException should be available and be used directly instead.
     """
 
     return str(CapturedException(exc))
-

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -309,12 +309,6 @@ definitions = {
         'ui': ('question', {
                'title': 'Runs TraceBack function with collide set to True, if this flag is set to "collide". This replaces any common prefix between current traceback log and previous invocation with "..."'}),
     },
-    'datalad.log.exc': {
-        'ui': ('yesno', {
-               'title': 'Include exceptions and their traceback in log messages. If set, \'datalad.exc.str.tblimit\' applies.'}),
-        'default': False,
-        'type': EnsureBool(),
-    },
     'datalad.ssh.identityfile': {
         'ui': ('question', {
                'title': "If set, pass this file as ssh's -i option."}),

--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -34,6 +34,7 @@ from ..support.annexrepo import AnnexRepo
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr, EnsureNone
 from ..support.exceptions import (
+    CapturedException,
     CommandError,
     NoDatasetFound,
 )
@@ -185,12 +186,13 @@ class DownloadURL(Interface):
             try:
                 downloaded_path = downloader.download(url, path=path, overwrite=overwrite)
             except Exception as e:
+                ce = CapturedException(e)
                 yield get_status_dict(
                     status="error",
-                    message=exc_str(e),
+                    message=str(ce),
                     type="file",
                     path=path,
-                    exception=e,
+                    exception=ce,
                     **common_report)
             else:
                 if not need_datalad_remote \

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -35,6 +35,7 @@ from datalad.consts import PRE_INIT_COMMIT_SHA
 from datalad.support.constraints import EnsureNone, EnsureStr
 from datalad.support.param import Parameter
 from datalad.support.json_py import load_stream
+from datalad.support.exceptions import CapturedException
 
 from datalad.distribution.dataset import require_dataset
 from datalad.distribution.dataset import EnsureDataset
@@ -313,7 +314,9 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
     try:
         results = _revrange_as_results(dset, revrange)
     except ValueError as exc:
-        yield get_status_dict("run", status="error", message=exc_str(exc))
+        ce = CapturedException(exc)
+        yield get_status_dict("run", status="error", message=str(ce),
+                              exception=ce)
         return
 
     ds_repo = dset.repo

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -89,7 +89,9 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
     if message is not None:
         d['message'] = message
     if exception is not None:
-        d['exception_traceback'] = exc_str(exception, limit=1000, include_str=False)
+        d['exception'] = exception
+        d['exception_traceback'] = \
+            exception.format_oneline_tb(limit=1000, include_str=False)
     if kwargs:
         d.update(kwargs)
     return d

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -63,18 +63,5 @@ class Test(Interface):
             module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
         module = ensure_list(module)
         lgr.info('Starting test run for module(s): %s', module)
-
-        # Exception (traceback) logging is disabled by default. However, as of
-        # now we do test logging output in (too) great detail. Therefore enable
-        # it here, so `datalad-test` doesn't fail by default.
-        # Can be removed whenever the tests don't require it.
-        from datalad import cfg as dlcfg
-        from datalad.tests.utils import patch
-        try:
-            with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
-                dlcfg.reload()
-                for mod in module:
-                    datalad.test(module=mod, verbose=verbose,
-                                 nocapture=nocapture, pdb=pdb, stop=stop)
-        finally:
-            dlcfg.reload()
+        for mod in module:
+            datalad.test(module=mod, verbose=verbose, nocapture=nocapture, pdb=pdb, stop=stop)

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -93,7 +93,9 @@ class CheckDates(Interface):
             to_render = {k: v for k, v in res.items()
                          if k not in ["status", "message", "logger"]}
         if to_render:
-            ui.message(json.dumps(to_render, sort_keys=True, indent=2))
+            ui.message(json.dumps(to_render, sort_keys=True, indent=2,
+                                  default=str)
+                       )
 
     _params_ = dict(
         paths=Parameter(

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -18,6 +18,7 @@ from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
 from datalad.support.exceptions import (
+    CapturedException,
     InvalidGitRepositoryError,
     MissingExternalDependency,
 )
@@ -157,9 +158,11 @@ class CheckDates(Interface):
             ref_ts = _parse_date(reference_date)
         except ValueError as exc:
             lgr.error("Could not parse '%s' as a date", reference_date)
+            ce = CapturedException(exc)
             yield get_status_dict("check_dates",
                                   status="error",
-                                  message=exc_str(exc))
+                                  message=str(ce),
+                                  exception=ce)
             return
 
         lgr.info("Searching for dates %s than %s",

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -25,7 +25,10 @@ from datalad.support.constraints import (
     EnsureNone,
 )
 from datalad.support.param import Parameter
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError
+)
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
@@ -367,12 +370,12 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                     # variable name validity is checked before and Git
                     # replaces the file completely, resolving any permission
                     # issues, if the file could be read (already done above)
+                    ce = CapturedException(e)
                     yield get_status_dict(
                         'subdataset',
                         status='error',
-                        message=(
-                            "Failed to set property '%s': %s",
-                            prop, exc_str(e)),
+                        message=("Failed to set property '%s': %s", prop, ce),
+                        exception=ce,
                         type='dataset',
                         logger=lgr,
                         **sm)

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -267,7 +267,7 @@ def _describe_dataset(ds, sensitive):
         return infos
     except InvalidGitRepositoryError as e:
         ce = CapturedException(e)
-        return {"invalid": ce.message()}
+        return {"invalid": ce.message}
 
 
 def _describe_location(res):

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -37,7 +37,7 @@ def mbasename(s):
     base = basename(s)
     if base.endswith('.py'):
         base = base[:-3]
-    if base in set(['base', '__init__']):
+    if base in set(['base', '__init__', 'utils']):
         base = basename(dirname(s)) + '.' + base
     return base
 

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -30,7 +30,7 @@ class CapturedException(object):
     reporting.
     """
 
-    def __init__(self, exc=None, limit=None, capture_locals=False,
+    def __init__(self, exc, limit=None, capture_locals=False,
                  level=8, logger=None):
         """Capture an exception and its traceback for logging.
 
@@ -38,8 +38,7 @@ class CapturedException(object):
 
         Parameters
         ----------
-        exc: Exception or None
-          If None, rely on sys.exc_info() to get the latest.
+        exc: Exception
         limit: int
           Note, that this is limiting the capturing of the exception's
           traceback depth. Formatting for output comes with it's own limit.
@@ -49,23 +48,13 @@ class CapturedException(object):
         # Note, that with lookup_lines=False the lookup is deferred,
         # not disabled. Unclear to me ATM, whether that means to keep frame
         # references around, but prob. not. TODO: Test that.
-        if exc is None:
-            exctype, value, tb = sys.exc_info()
-            self.tb = traceback.TracebackException(
-                exctype, value, tb,
-                limit=limit,
-                lookup_lines=True,
-                capture_locals=capture_locals
-            )
-            traceback.clear_frames(tb)
-        else:
-            self.tb = traceback.TracebackException.from_exception(
-                exc,
-                limit=limit,
-                lookup_lines=True,
-                capture_locals=capture_locals
-            )
-            traceback.clear_frames(exc.__traceback__)
+        self.tb = traceback.TracebackException.from_exception(
+            exc,
+            limit=limit,
+            lookup_lines=True,
+            capture_locals=capture_locals
+        )
+        traceback.clear_frames(exc.__traceback__)
 
         # log the captured exception
         logger = logger or lgr
@@ -86,7 +75,7 @@ class CapturedException(object):
 
         if include_str:
             # try exc message else exception type
-            leading = self.message() or self.name()
+            leading = self.message or self.name
             out = "{} ".format(leading)
         else:
             out = ""
@@ -134,8 +123,9 @@ class CapturedException(object):
         -------
         str
         """
-        return self.name() + '(' + self.message() + ')'
+        return self.name + '(' + self.message + ')'
 
+    @property
     def message(self):
         """Returns only the message of the original exception
 
@@ -145,6 +135,7 @@ class CapturedException(object):
         """
         return str(self.tb)
 
+    @property
     def name(self):
         """Returns the class name of the original exception
 

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -431,7 +431,7 @@ class ProducerConsumer:
                             lgr.warning("Interrupted via Ctrl-C.  Forcing the exit")
                             self.shutdown(force=True, exception=exc)
                         else:
-                            lgr.warning("One more exception was received while trying to finish gracefully: %s", exc_str())
+                            lgr.warning("One more exception was received while trying to finish gracefully: %s", exc_str(exc))
                             # and we go back into the loop until we finish or there is Ctrl-C
                     else:
                         interrupted_by_exception = exc

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -33,6 +33,7 @@ from datalad.utils import quote_cmdlinearg as sh_quote
 # from datalad.support.network import RI, is_ssh
 
 from datalad.support.exceptions import (
+    CapturedException,
     CommandError,
     ConnectionOpenFailedError,
 )
@@ -800,8 +801,9 @@ class MultiplexSSHManager(BaseSSHManager):
                     try:
                         f()
                     except Exception as exc:
+                        ce = CapturedException(exc)
                         lgr.debug("Failed to close a connection: "
-                                  "%s", exc_str(exc))
+                                  "%s", ce.message())
             self._connections = dict()
 
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -803,7 +803,7 @@ class MultiplexSSHManager(BaseSSHManager):
                     except Exception as exc:
                         ce = CapturedException(exc)
                         lgr.debug("Failed to close a connection: "
-                                  "%s", ce.message())
+                                  "%s", ce.message)
             self._connections = dict()
 
 

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -56,7 +56,8 @@ def test_CapturedException():
     assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr3)
     assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr2)
     assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]", estr1)
-    assert_equal(estr_, estr1)
+    # default: no limit:
+    assert_equal(estr_, estr_full)
 
     # standard output
     full_display = captured_exc.format_standard().splitlines()
@@ -74,15 +75,6 @@ def test_CapturedException():
     # ...
     assert_equal(full_display[-1].strip(), "RuntimeError: new message")
 
-    # now logging / __str__:
-    try:
-        with patch.dict('os.environ', {'DATALAD_LOG_EXC': '1'}):
-            cfg.reload()
-            assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]",
-                         str(captured_exc))
-
-        with patch.dict('os.environ', {'DATALAD_LOG_EXC': '0'}):
-            cfg.reload()
-            assert_equal("", str(captured_exc))
-    finally:
-        cfg.reload()  # make sure we don't have a side effect on other tests
+    # CapturedException.__repr__:
+    assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
+                 captured_exc.__repr__())

--- a/datalad/support/tests/test_github_.py
+++ b/datalad/support/tests/test_github_.py
@@ -110,7 +110,7 @@ def test__make_github_repos():
             mock.patch.object(github_, '_make_github_repo', _make_github_repo), \
             swallow_logs(new_level=logging.INFO) as cml:
         res = list(github_._make_github_repos_(*args))
-        assert_in('Failed to create repository while using token 1to...: very bad status', cml.out)
+        assert_in('Failed to create repository while using token 1to...: BadCredentialsException(very bad status', cml.out)
         eq_(res,
             [dict(status='ok', ds='/fakeds1'), dict(status='ok', ds='/fakeds2')])
 

--- a/datalad/tests/test_dochelpers.py
+++ b/datalad/tests/test_dochelpers.py
@@ -15,7 +15,6 @@ from ..dochelpers import (
     single_or_plural,
     borrowdoc,
     borrowkwargs,
-    exc_str_old,
 )
 
 from datalad.tests.utils import (
@@ -143,39 +142,3 @@ def test_borrow_kwargs():
     assert_true('Some postamble' in B.met1.__doc__)
     assert_true('B.met_nodockwargs' in B.met_nodockwargs.__doc__)
     assert_true('boguse' in B.met_excludes.__doc__)
-
-
-def test_exc_str_old():
-    try:
-        raise Exception("my bad")
-    except Exception as e:
-        estr = exc_str_old(e)
-        estr_tb_only = exc_str_old(e, include_str=False)
-    assert_re_in("my bad \[test_dochelpers.py:test_exc_str_old:...\]", estr)
-    assert_re_in("^\[.*\]", estr_tb_only)  # only traceback
-
-    def f():
-        def f2():
-            raise Exception("my bad again")
-        f2()
-    try:
-        f()
-    except Exception as e:
-        # default one:
-        estr2 = exc_str_old(e, 2)
-        estr1 = exc_str_old(e, 1)
-        # and we can control it via environ by default
-        with patch.dict('os.environ', {'DATALAD_EXC_STR_TBLIMIT': '3'}):
-            estr3 = exc_str_old(e)
-        with patch.dict('os.environ', {}, clear=True):
-            estr_ = exc_str_old()
-
-    assert_re_in("my bad again \[test_dochelpers.py:test_exc_str_old:...,test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr3)
-    assert_re_in("my bad again \[test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr2)
-    assert_re_in("my bad again \[test_dochelpers.py:f2:...\]", estr1)
-    assert_equal(estr_, estr1)
-
-    try:
-        raise NotImplementedError
-    except Exception as e:
-        assert_re_in("NotImplementedError\(\) \[test_dochelpers.py:test_exc_str_old:...\]", exc_str_old(e))

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2226,7 +2226,7 @@ def import_modules(modnames, pkg, msg="Failed to import {module}", log=lgr.debug
             from datalad.support.exceptions import CapturedException
             ce = CapturedException(exc)
             log((msg + ': {exception}').format(
-                module=modname, package=pkg, exception=ce.message()))
+                module=modname, package=pkg, exception=ce.message))
     return mods_loaded
 
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2223,9 +2223,10 @@ def import_modules(modnames, pkg, msg="Failed to import {module}", log=lgr.debug
                 pkg)
             mods_loaded.append(mod)
         except Exception as exc:
-            from datalad.dochelpers import exc_str
+            from datalad.support.exceptions import CapturedException
+            ce = CapturedException(exc)
             log((msg + ': {exception}').format(
-                module=modname, package=pkg, exception=exc_str(exc)))
+                module=modname, package=pkg, exception=ce.message()))
     return mods_loaded
 
 

--- a/docs/source/design/exception_handling.rst
+++ b/docs/source/design/exception_handling.rst
@@ -25,14 +25,17 @@ apply:
           ce = CapturedException(e)
 
   First, this ensures a low-level (8) log entry including the traceback of that
-  exception. Second, it deletes the frame stack references of the exception and
-  keeps textual information only, in order to avoid circular references, where
-  an object (whose method raised the exception) isn't going to be picked by the
-  generational garbage collection. This can be particularly troublesome if that
-  object holds a reference to a subprocess for example. However, it's not easy
-  to see in what situation this would really be needed and we never need
-  anything other than the textual information about what happened. Making the
-  reference cleaning a general rule is easiest to write, maintain and review.
+  exception. The depth of the included traceback can be limited by setting the
+  ``datalad.exc.str.tb_limit`` config accordingly.
+
+  Second, it deletes the frame stack references of the exception and keeps
+  textual information only, in order to avoid circular references, where an
+  object (whose method raised the exception) isn't going to be picked by the
+  garbage collection. This can be particularly troublesome if that object holds
+  a reference to a subprocess for example. However, it's not easy to see in what
+  situation this would really be needed and we never need anything other than
+  the textual information about what happened. Making the reference cleaning a
+  general rule is easiest to write, maintain and review.
 
 - if we raise, neither a log entry nor such a
   :class:`~datalad.support.exceptions.CapturedException` instance is to be

--- a/docs/source/design/exception_handling.rst
+++ b/docs/source/design/exception_handling.rst
@@ -1,0 +1,83 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_exception_handling:
+
+******************
+Exception handling
+******************
+
+.. topic:: Specification scope and status
+
+   This specification describes the current implementation target.
+
+
+Catching exceptions
+===================
+
+Whenever we catch an exception in an ``except`` clause, the following rules
+apply:
+
+- unless we (re-)raise, the first line instantiates a
+  :class:`~datalad.support.exceptions.CapturedException`::
+
+      except Exception as e:
+          ce = CapturedException(e)
+
+  First, this ensures a low-level (8) log entry including the traceback of that
+  exception. Second, it deletes the frame stack references of the exception and
+  keeps textual information only, in order to avoid circular references, where
+  an object (whose method raised the exception) isn't going to be picked by the
+  generational garbage collection. This can be particularly troublesome if that
+  object holds a reference to a subprocess for example. However, it's not easy
+  to see in what situation this would really be needed and we never need
+  anything other than the textual information about what happened. Making the
+  reference cleaning a general rule is easiest to write, maintain and review.
+
+- if we raise, neither a log entry nor such a
+  :class:`~datalad.support.exceptions.CapturedException` instance is to be
+  created.
+  Eventually, there will be a spot where that (re-)raised exception is caught.
+  This then is the right place to log it. That log entry will have the
+  traceback, there's no need to leave a trace by means of log messages!
+
+- if we raise, but do not simply reraise that exact same exception, in order to
+  change the exception class and/or its message, ``raise from`` must be used!::
+
+      except SomeError as e:
+          raise NewError("new message") from e
+
+  This ensures that the original exception is properly registered as the cause
+  for the exception via its ``__cause__`` attribute. Hence, the original
+  exception's traceback will be part of the later on logged traceback of the new
+  exception.
+
+
+Messaging about an exception
+============================
+
+In addition to the auto-generated low-level log entry there might be a need to
+create a higher-level log, a user message or a (result) dictionary that includes
+information from that exception. While such messaging may use anything the
+(captured) exception provides, please consider that "technical" details about an
+exception are already auto-logged and generally not incredibly meaningful for
+users.
+
+For message creation :class:`~datalad.support.exceptions.CapturedException`
+comes with a couple of ``format_*`` helper methods, its ``__str__`` provides a
+short representation of the form ``ExceptionClass(message)`` and its
+``__repr__`` the log form with a traceback tht is used for the auto-generated
+log.
+
+For result dictionaries :class:`~datalad.support.exceptions.CapturedException`
+can be assigned to the field ``exception``. Currently, ``get_status_dict`` will
+consider this field and create an additional field with a traceback string.
+Hence, whether putting a captured exception into that field actually has an
+effect depends on whether ``get_status_dict`` is subsequently used with that
+dictionary. In the future such functionality may move into result renderers
+instead, leaving the decision of what to do with the passed
+:class:`~datalad.support.exceptions.CapturedException` to them. Therefore, even
+if of no immediate effect, enhancing the result dicts accordingly makes sense
+already, since it may be useful when using datalad via its python interface
+already and provide instant benefits whenever the result rendering gets such an
+upgrade.

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -18,3 +18,4 @@ subsystems in DataLad.
    drop
    python_imports
    miscpatterns
+   exception_handling


### PR DESCRIPTION
Replaces PR #5883 as discussed and summarized in https://github.com/datalad/datalad/pull/5883#issuecomment-900348975

The linked comment suggests how to use that. Except from places where `exc_str` was used to create a `message` in a (result) dict, this PR only provides the means - it does NOT fully implement the usage pattern. This would again be a huge diff and (I think) should involve similar changes to the higher level log messages as its predecessor. From my POV it's better to get this merged as is and I can then provide those changes in reviewable and discussable batches against `maint` - no need to include them in a particular release. Therefore `exc_str` still exists (but doesn't return empty) and is still used. However, there's no need for `exc_str_old` anymore, hence removed.

Also removed config `datalad.log.exc` again. Since the detailed logging is at low level, I think there's no need to additionally enable/disable it.

Closes #5848 

UPDATE: Please consider the included design document.