### PR TITLE
BF: use `==` not `is`

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -595,7 +595,7 @@ def _process_results(
                 res_lgr = getattr(
                     res_lgr,
                     default_logchannels[res['status']]
-                    if result_log_level is 'match-status'
+                    if result_log_level == 'match-status'
                     else result_log_level)
             msg = res['message']
             msgargs = None


### PR DESCRIPTION
Introduced by an incomplete replacement in 3a8fd827a8bb21bee91815fe133422356aedf777

Fixes datalad/datalad#5959