### PR TITLE
`Path.exist()` no longer raises OSError for non-existing malformed paths p…

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -291,7 +291,8 @@ class Clone(Interface):
             # we are running on -- we don't care if the path actually
             # exists at this point, but we want to abort early if the path
             # spec is determined to be useless
-            path.exists()
+            # we can do strict=False since we are 3.6+
+            path.resolve(strict=False)
         except OSError as e:
             yield get_status_dict(
                 status='error',


### PR DESCRIPTION
Use `Path.resolve(strict=False)` as a more reliable, but also more
expensive test.

Fixes datalad/datalad#5967