### PR TITLE
Remove deprecated --pbs-runner cmdline option

### DIFF
--- a/datalad/cmdline/common_args.py
+++ b/datalad/cmdline/common_args.py
@@ -46,13 +46,6 @@ log_level = (
               % ', '.join(_log_level_names))
 )
 
-pbs_runner = (
-    'pbs-runner', ('--pbs-runner',),
-    dict(choices=['condor'],
-         default=None,
-         help="""DEPRECATED, will be removed in a future release.""")
-)
-
 change_path = (
     'change-path', ('-C',),
     dict(action='append',

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -216,7 +216,6 @@ def parser_add_common_opt(parser, opt, names=None, **kwargs):
 
 def parser_add_common_options(parser, version=None):
     parser_add_common_opt(parser, 'log_level')
-    parser_add_common_opt(parser, 'pbs_runner')
     parser_add_common_opt(parser, 'change_path')
     if version is not None:
         warnings.warn("Passing 'version' to parser_add_common_options "
@@ -296,7 +295,7 @@ def strip_arg_from_argv(args, value, opt_names):
     # Yarik doesn't know better
     if args is None:
         args = sys.argv
-    # remove present pbs-runner option
+    # remove present opt_names
     args_clean = []
     skip = 0
     for i, arg in enumerate(args):
@@ -310,39 +309,6 @@ def strip_arg_from_argv(args, value, opt_names):
             # we need to skip this one and next one
             skip = 1
     return args_clean
-
-
-def run_via_pbs(args, pbs):
-    warnings.warn("Job submission via --pbs-runner is deprecated."
-                  "Use something like condor_run",
-                  DeprecationWarning)
-
-    assert(pbs in ('condor',))  # for now
-
-    # TODO: RF to support multiple backends, parameters, etc, for now -- just condor, no options
-    f = NamedTemporaryFile('w', prefix='datalad-%s-' % pbs, suffix='.submit', delete=False)
-    try:
-        pwd = getpwd()
-        logs = f.name.replace('.submit', '.log')
-        exe = args[0]
-        # TODO: we might need better way to join them, escaping spaces etc.  There must be a stock helper
-        #exe_args = ' '.join(map(repr, args[1:])) if len(args) > 1 else ''
-        exe_args = ' '.join(args[1:]) if len(args) > 1 else ''
-        f.write("""\
-Executable = %(exe)s
-Initialdir = %(pwd)s
-Output = %(logs)s
-Error = %(logs)s
-getenv = True
-
-arguments = %(exe_args)s
-queue
-""" % locals())
-        f.close()
-        Runner().run(['condor_submit', f.name])
-        lgr.info("Scheduled execution via %s.  Logs will be stored under %s", pbs, logs)
-    finally:
-        unlink(f.name)
 
 
 def get_repo_instance(path=os.curdir, class_=None):

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -196,13 +196,7 @@ def main(args=None):
             args_ = strip_arg_from_argv(args_, path, change_path_opt[1])
 
     ret = None
-    if cmdlineargs.pbs_runner:
-        from .helpers import run_via_pbs
-        from .common_args import pbs_runner as pbs_runner_opt
-        args_ = strip_arg_from_argv(args_, cmdlineargs.pbs_runner, pbs_runner_opt[1])
-        # run the function associated with the selected command
-        run_via_pbs(args_, cmdlineargs.pbs_runner)
-    elif has_func:
+    if has_func:
         if cmdlineargs.common_debug or cmdlineargs.common_idebug:
             # so we could see/stop clearly at the point of failure
             setup_exceptionhook(ipython=cmdlineargs.common_idebug)

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -741,7 +741,7 @@ class Interface(object):
             # common options
             # XXX define or better get from elsewhere
             common_opts = ('change_path', 'common_debug', 'common_idebug', 'func',
-                           'help', 'log_level', 'logger', 'pbs_runner',
+                           'help', 'log_level', 'logger',
                            'result_renderer', 'subparser')
             argnames = [name for name in dir(args)
                         if not (name.startswith('_') or name in common_opts)]

--- a/docs/source/basics_cmdline.rst.in
+++ b/docs/source/basics_cmdline.rst.in
@@ -14,7 +14,7 @@ of basic options, and a list of available sub-commands.
 .. code-block:: ansi-color
 
    [1;36m~[0m % datalad
-   usage: datalad [-h] [-l LEVEL] [--pbs-runner {condor}] [-C PATH] [--version]
+   usage: datalad [-h] [-l LEVEL] [-C PATH] [--version]
                   [--dbg] [--idbg] [-c KEY=VALUE]
                   [-f {default,json,json_pp,tailored,'<template>'}]
                   [--report-status {success,failure,ok,notneeded,impossible,error}]


### PR DESCRIPTION
Was deprecated with the 0.15.0 release, see gh-5956.

Fixes datalad/datalad#5962