### PR TITLE
Close file descriptors after process exit

### DIFF
--- a/datalad/nonasyncrunner.py
+++ b/datalad/nonasyncrunner.py
@@ -246,5 +246,8 @@ def run_command(cmd: Union[str, List],
     result = protocol._prepare_result()
     protocol.process_exited()
     protocol.connection_lost(None)  # TODO: check exception
+    for fd in (process.stdin, process.stdout, process.stderr):
+        if fd is not None:
+            fd.close()
 
     return result


### PR DESCRIPTION
Even a `datalad --version` leave open file descriptors around. This
change closes all FDs after a process has exited and any
protocol-based post-processing has completed.

I am not at all confident that this should be done unconditionally,
though.

Run `PYTHONDEVMODE=1 datalad --version` to see the pre/post effect.

Closes #5965