### PR TITLE
BF: downloader - fail to download even on non-crippled FS if symlink exists

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -436,9 +436,9 @@ class BaseDownloader(object, metaclass=ABCMeta):
         else:
             filepath = downloader_session.filename
 
-        existed = exists(filepath)
+        existed = op.lexists(filepath)
         if existed and not overwrite:
-            raise DownloadError("File %s already exists" % filepath)
+            raise DownloadError("Path %s already exists" % filepath)
 
         # FETCH CONTENT
         # TODO: pbar = ui.get_progressbar(size=response.headers['size'])


### PR DESCRIPTION
Observed initially by @jwodder on
https://github.com/datalad/datalad-fuse/pull/3#issuecomment-921934544
since datalad-extensions-template default workflow runs on a crippled FS.

I think it makes sense to fail regardless either it is existing file or a
(broken) symlink since the idea is not to override a (possibly annexed) file
