### PR TITLE
Address #5995

### DIFF
--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -350,21 +350,24 @@ class HTTPAuthAuthenticator(HTTPRequestsAuthenticator):
         authenticator = self.REQUESTS_AUTHENTICATOR(
             *[credentials[f] for f in self.REQUESTS_FIELDS])
         session.auth = authenticator
-        response = session.post(post_url, data={},
-                                auth=authenticator)
-        auth_request = response.headers.get('www-authenticate')
-        if response.status_code == 401 and auth_request:
-            if auth_request.lower().split(' ', 1)[0] == 'basic':
-                if response.url != post_url:
-                    # was instructed to authenticate elsewhere
-                    # TODO: do we need to loop may be??
-                    response2 = session.get(response.url, auth=authenticator)
-                    return response2
-            else:
-                lgr.warning(
-                    f"{self} received response with www-authenticate={auth_request!r} "
-                    "which is not Basic, and thus it cannot handle ATM.")
-        return response
+
+        # response = session.post(post_url, data={},
+        #                         auth=authenticator)
+        #
+        # auth_request = response.headers.get('www-authenticate')
+        # if response.status_code == 401 and auth_request:
+        #     if auth_request.lower().split(' ', 1)[0] == 'basic':
+        #         if response.url != post_url:
+        #             # was instructed to authenticate elsewhere
+        #             # TODO: do we need to loop may be??
+        #             response2 = session.get(response.url,
+        #                                     auth=authenticator)
+        #             return response2
+        #     else:
+        #         lgr.warning(
+        #             f"{self} received response with www-authenticate={auth_request!r} "
+        #             "which is not Basic, and thus it cannot handle ATM.")
+        # return response
 
 
 @auto_repr


### PR DESCRIPTION
For now just looking for failures in the entire test battery.

Locally there's `datalad.downloaders.tests.test_http.test_access_denied` failing with its last assertion. However, that one is a convoluted mess. The reason it's passing to begin with (in `master` that is) is a bit absurd. The POST request I ripped out, does fail with `Unsupported request` by the http server used in the test, leading to a different call path that ultimately makes the assertion pass. So, sending an unsupported POST is required to correctly fail with `AccessDeniedError`. W/O that POST request, there still is an `AccessDeniedError`, but it ends up being handled by trying to ask for credentials which then somehow fails with an `AssertionError` instead.
I think that test is simply wrong. Not yet clear how it should look like, though.