### PR TITLE
Ensure there's a blank line between the class `__doc__` and "Parameters" in `build_doc` docstrings

### DIFF
--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -349,6 +349,8 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     doc = prefix if prefix else u''
     if len(args) > 1:
         if len(doc):
+            if not doc.endswith('\n'):
+                doc += '\n'
             doc += '\n'
         doc += "Parameters\n----------\n"
         for i, arg in enumerate(args):

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -216,6 +216,21 @@ def test_update_docstring_with_parameters_no_kwds():
     assert_in("3", fn.__doc__)
 
 
+def test_update_docstring_with_parameters_single_line_prefix():
+    from datalad.support.param import Parameter
+
+    def fn(pos0, pos1):
+        pass
+
+    update_docstring_with_parameters(
+        fn,
+        dict(pos0=Parameter(doc="pos0 param doc"),
+             pos1=Parameter(doc="pos1 param doc")),
+        prefix="This is a single line.",
+    )
+    assert_in("This is a single line.\n\nParameters\n", fn.__doc__)
+
+
 def check_call_from_parser_pos_arg_underscore(how):
     from datalad.cmdline.helpers import parser_add_common_options
     from datalad.support.param import Parameter


### PR DESCRIPTION
Without this change, applying `@build_doc` to a class whose docstring doesn't end in a newline, like so:

```python
@build_doc
class Foo(Interface):
     """Foo all the bars"""

    @staticmethod
    @eval_results
    def __call__():
        pass
```

will result in `__call__` getting a docstring that starts out with:

```
Foo all the bars
Parameters
----------
```

and the lack of a newline between the class docstring and "Parameters" will result in Sphinx producing a warning when trying to build the documentation for the class.  This PR fixes this behavior by ensuring that, if the class docstring doesn't already end with a newline, one is added, so that there are always at least two newlines (i.e., one blank line) before the "Parameters" header.