### PR TITLE
BF: Do not overwrite existing sibling configurations with create-sibling-gitlab

### DIFF
--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -319,17 +319,14 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
             recursive=False,
             result_renderer='disabled')
     }
-    if existing == 'skip' and remotename in dremotes:
-        # we have a conflict of target remote and the
-        # set of existing remotes
+    if remotename in dremotes and existing not in ['replace', 'reconfigure']:
+        # we already know a sibling with this name
         yield dict(
             res_kwargs,
-            status='notneeded',
-        )
+            status='error' if existing == 'error' else 'notneeded',
+            message=('already has a configured sibling "%s"', remotename),
+            )
         return
-    # TODO for existing == error, check against would be gitlab URL
-    # cannot be done in, needs an idea of the project path config
-    # and an API call to gitlab
 
     if layout is None:
         # figure out the layout of projects on the site


### PR DESCRIPTION
This tries to be a fix for #6014. It adds a safe-guard to check whether a sibling-name to-be already exists, and errors out instead of overwriting it. I believe that this should be non-controversial, as it mirrors the way the other ``create-sibling-``s work. However, the comments seem to indicate that there is something special going on with GitLab, and the tests required some larger changes. I would therefore be very grateful if @mih (who has written code I have now changed) could check my changes carefully.
