### PR TITLE
UX: Report GitLab weburl of freshly created projects in the result

### DIFF
--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -412,10 +412,13 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
         try:
             site_project = site_api.create_project(project, description)
             # report success
+            message = "sibling repository '%s' created at %s",\
+                      remotename, site_project.get('web_url', None)
             yield dict(
                 res_kwargs,
                 # relay all attributes
                 project_attributes=site_project,
+                message=message,
                 status='ok',
             )
         except Exception as e:


### PR DESCRIPTION
This harmonizes the reporting of create-sibling-gitlab and the
create-sibling-ghlike-commands slightly more, and fixes #6016.


Here is how it looks with the change:

```
(handbook2) adina@muninn in ~/repos/datalad on git:ux-6016
$ datalad create-sibling-gitlab  -d . --site jugit --project datalad3 --layout flat --access ssh         
create_sibling_gitlab(ok): . (dataset) [sibling repository 'jugit' created at https://jugit.fz-juelich.de/adswa/datalad3]
configure-sibling(ok): . (sibling)
action summary:
  configure-sibling (ok: 1)
  create_sibling_gitlab (ok: 1)
```

which is closer to what I get when using ``create-sibling-github``:

```
$ datalad create-sibling-github new-create-sibling-command-gh4                 
create_sibling_github(ok): [sibling repository 'github' created at https://github.com/adswa/new-create-sibling-command-gh4]
configure-sibling(ok): . (sibling)
action summary:
  configure-sibling (ok: 1)
  create_sibling_github (ok: 1)
```
