### PR TITLE
Add dedicated HTTP500 error handler

### DIFF
--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -510,7 +510,7 @@ class _GitHubLike(object):
         elif r.status_code == requests.codes.internal_server_error:
             return dict(
                 status='error',
-                message=response.get('message', '').strip() or None,
+                message=response.get('message', '').strip() or 'Server returned error code %d without any further information' % requests.codes.internal_server_error,
             )
         # make sure any error-like situation causes noise
         r.raise_for_status()

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -507,6 +507,11 @@ class _GitHubLike(object):
                 status='error',
                 message=('unauthorized: %s', response.get('message')),
             )
+        elif r.status_code == requests.codes.internal_server_error:
+            return dict(
+                status='error',
+                message=response.get('message', '').strip() or None,
+            )
         # make sure any error-like situation causes noise
         r.raise_for_status()
         # catch-all


### PR DESCRIPTION
Simply relay the error message, if there is any.

```
datalad create-sibling-gogs --credential gogs --api https://try.gogs.io mike1
create_sibling_gogs(error): [initRepository: init repository: exit status 128 - fatal: cannot copy '/usr/share/git-core/templates/hooks/pre-applypatch.sample' to '/mnt/volume_nyc1_01/gogs-repositories/dataladtester/mike1.git/hooks/pre-applypatch.sample': No space left on device]
```

Fixes datalad/datalad#6018