### PR TITLE
BF: ProgressHandler - close the other handler if was specified

### DIFF
--- a/datalad/log.py
+++ b/datalad/log.py
@@ -210,6 +210,11 @@ class ProgressHandler(logging.Handler):
         self._other_handler = other_handler
         self.pbars = {}
 
+    def close(self):
+        if self._other_handler:
+            self._other_handler.close()
+        super().close()
+
     def emit(self, record):
         from datalad.ui import ui
         if not hasattr(record, 'dlm_progress'):

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -32,6 +32,7 @@ from datalad.support import ansi_colors as colors
 from datalad.tests.utils import (
     assert_equal,
     assert_in,
+    assert_no_open_files,
     assert_not_in,
     assert_re_in,
     known_failure_githubci_win,
@@ -86,6 +87,7 @@ def test_logging_to_a_file(dst):
     # Close all handlers so windows is happy -- apparently not closed fast enough
     for handler in lgr.handlers:
         handler.close()
+    assert_no_open_files(dst)
 
 
 @with_tempfile

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -538,7 +538,7 @@ if _assert_no_open_files_cfg:
     def assert_no_open_files(path):
         files = get_open_files(path, log_open=40)
         if _assert_no_open_files_cfg == 'assert':
-            assert not files
+            assert not files, "Got following files still open: %s" % ','.join(files)
         elif files:
             if _assert_no_open_files_cfg == 'pdb':
                 import pdb


### PR DESCRIPTION
First commit actually enhances the test to optionally (if env var set) ensure that and reporting about open files for `DATALAD_ASSERT_NO_OPEN_FILES=assert` runs. 2nd commit then fixes the underlying issue of ProgressHandler not closing the "other" handler upon close.