### PR TITLE
BF: start global test_http_server only if not running already

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -217,14 +217,19 @@ def setup_package():
     # the URL will be available from datalad.test_http_server.url
     from datalad.tests.utils import HTTPPath
     import tempfile
+
     global test_http_server
-    serve_path = tempfile.mkdtemp(
-        dir=cfg.get("datalad.tests.temp.dir"),
-        prefix='httpserve',
-    )
-    test_http_server = HTTPPath(serve_path)
-    test_http_server.start()
-    _TEMP_PATHS_GENERATED.append(serve_path)
+    # Start the server only if not running already
+    # Relevant: we have test_misc.py:test_test which runs datalad.test but
+    # not doing teardown, so the original server might never get stopped
+    if test_http_server is None:
+        serve_path = tempfile.mkdtemp(
+            dir=cfg.get("datalad.tests.temp.dir"),
+            prefix='httpserve',
+        )
+        test_http_server = HTTPPath(serve_path)
+        test_http_server.start()
+        _TEMP_PATHS_GENERATED.append(serve_path)
 
     if cfg.obtain('datalad.tests.setup.testrepos'):
         lgr.debug("Pre-populating testrepos")
@@ -258,8 +263,12 @@ def teardown_package():
     if _test_states['loglevel'] is not None:
         lgr.setLevel(_test_states['loglevel'])
 
+    global test_http_server
     if test_http_server:
         test_http_server.stop()
+        test_http_server = None
+    else:
+        lgr.debug("For some reason global http_server was not set/running, thus not stopping")
 
     from datalad.tests import _TEMP_PATHS_GENERATED
     if len(_TEMP_PATHS_GENERATED):


### PR DESCRIPTION
This fix seems to resolve the stall for conda builds in a docker container.

Closes #5992 (~~well -- final verdict is yet to be made, but it seems to resolve on local builds~~ yeap -- that fixed it -- all green in https://github.com/conda-forge/datalad-feedstock/pull/63, merged)
