### PR TITLE
BF(TST): filter away warning from coverage from analysis of stderr of --help

### DIFF
--- a/datalad/tests/test_installed.py
+++ b/datalad/tests/test_installed.py
@@ -9,6 +9,8 @@
 """Test invocation of datalad utilities "as is installed"
 """
 
+import os
+
 from unittest.mock import patch
 from datalad.tests.utils import (
     ok_startswith,
@@ -41,4 +43,6 @@ def check_run_and_get_output(cmd):
 def test_run_datalad_help():
     out, err = check_run_and_get_output("datalad --help")
     ok_startswith(out, "Usage: ")
-    eq_(err, "")
+    # There could be a warning from coverage that no data was collected, should be benign
+    lines = [l for l in err.split(os.linesep) if ('no-data-collected' not in l) and l]
+    eq_(lines, [])


### PR DESCRIPTION
Tests on travis started to fail (today?! see below) with

	======================================================================
	FAIL: datalad.tests.test_installed.test_run_datalad_help
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/tmp/dl-miniconda-hjvqrnh_/lib/python3.9/site-packages/nose/case.py", line 198, in runTest
		self.test(*self.arg)
	  File "/tmp/dl-miniconda-hjvqrnh_/lib/python3.9/site-packages/datalad/tests/utils.py", line 1168, in _wrap_assert_cwd_unchanged
		raise exc_info[1]
	  File "/tmp/dl-miniconda-hjvqrnh_/lib/python3.9/site-packages/datalad/tests/utils.py", line 1140, in _wrap_assert_cwd_unchanged
		ret = func(*args, **kwargs)
	  File "/tmp/dl-miniconda-hjvqrnh_/lib/python3.9/site-packages/datalad/tests/test_installed.py", line 44, in test_run_datalad_help
		eq_(err, "")
	AssertionError: '/tmp/dl-miniconda-hjvqrnh_/lib/python3.9/site-packages/coverage/control.py:761: CoverageWarning: No data was collected. (no-data-collected)\n  self._warn("No data was collected.", slug="no-data-collected")\n' != ''

See e.g. https://app.travis-ci.com/github/datalad/datalad/jobs/540996646

	(git)smaug:/mnt/datasets/datalad/ci/logs/2021/10[master]git
	$> git grep 'FAIL: datalad.tests.test_installed.test_run_datalad_help'
	03/push/maint/6ae9dd8/travis-12567-failed/1.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/maint/6ae9dd8/travis-12567-failed/2.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/maint/6ae9dd8/travis-12567-failed/3.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/maint/6ae9dd8/travis-12567-failed/6.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/maint/6ae9dd8/travis-12567-failed/7.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/maint/6ae9dd8/travis-12567-failed/8.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/master/8203cc1/travis-12568-failed/1.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/master/8203cc1/travis-12568-failed/2.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/master/8203cc1/travis-12568-failed/3.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/master/8203cc1/travis-12568-failed/6.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/master/8203cc1/travis-12568-failed/7.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
	03/push/master/8203cc1/travis-12568-failed/8.txt:FAIL: datalad.tests.test_installed.test_run_datalad_help
