### PR TITLE
BF: undeprecate readline_rstripped + adjust mock to mock actual warnings library

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -16,7 +16,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import warnings
 
 # start of legacy import block
 # to avoid breakage of code written before datalad.runner
@@ -62,9 +61,6 @@ _MAGICAL_OUTPUT_MARKER = "_runneroutput_"
 
 
 def readline_rstripped(stdout):
-    warnings.warn("the function `readline_rstripped()` is deprecated "
-                  "and will be removed in a future release",
-                  DeprecationWarning)
     return stdout.readline().rstrip()
 
 

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -13,6 +13,8 @@ import os
 import signal
 import sys
 import unittest.mock
+import warnings
+
 from time import (
     sleep,
     time,
@@ -274,11 +276,11 @@ def test_asyncio_forked(temp):
 
 
 def test_done_deprecation():
-    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+    with unittest.mock.patch("warnings.warn") as warn_mock:
         _ = Protocol("done")
         warn_mock.assert_called_once()
 
-    with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
+    with unittest.mock.patch("warnings.warn") as warn_mock:
         _ = Protocol()
         warn_mock.assert_not_called()
 


### PR DESCRIPTION
I was wrong in my statement that this function is no longer used, it is used in the Batched*
classes.  It is a trivial function and could be moved I guess to not appear in the interface
but since we do not really sanitize those, I decided that undeprecating would be the easiest
way forward.  Closes #6030.

Upon removal of "warnings" import test_done_deprecation started to fail since it patches
the local import of warnings. IMHO it should mock patch the actual warnings library, so I have
fixed that test accordingly
