### PR TITLE
BF: Don't suppress datalad subdatasets output

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -859,7 +859,8 @@ class Get(Interface):
                 recursive=True if path else recursive,
                 recursion_limit=None if path else recursion_limit,
                 return_type='generator',
-                on_failure='ignore'):
+                on_failure='ignore',
+                result_renderer='disabled'):
             if sdsres.get('type', None) != 'dataset':
                 # if it is not about a 'dataset' it is likely content in
                 # the root dataset

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -16,6 +16,7 @@ import re
 import os
 
 from datalad.interface.base import Interface
+from datalad.interface.utils import default_result_renderer
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
@@ -209,6 +210,8 @@ class Subdatasets(Interface):
             option can be given multiple times. CMD]""",
             constraints=EnsureStr() | EnsureNone()))
 
+    result_renderer = "tailored"
+
     @staticmethod
     @datasetmethod(name='subdatasets')
     @eval_results
@@ -284,6 +287,9 @@ class Subdatasets(Interface):
                     #logger=lgr
                 )
 
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        default_result_renderer(res)
 
 
 # internal helper that needs all switches, simply to avoid going through


### PR DESCRIPTION
### Changes

Add `custom_result_renderer()` to `Subdatasets` command class as a wrapper for `default_result_renderer()`.
Now `datalad subdatasets` will actually do what it's supposed to: list all present subdatasets without suppressing the output.

### Related Issues

Fixes #4770
