### PR TITLE
DOC: Refine --reckless docstring on usage and wording

### DIFF
--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -152,9 +152,10 @@ reckless_opt = Parameter(
     w/o git-annex being aware of it. In case of a change in origin you need to
     update the clone before you're able to save new content on your end.
     Alternative to 'auto' when hardlinks are not an option, or number of consumed
-    inodes needs to be minimized. Note that this is meant to be used
-    with either non-bare repositories or a RIA store as origin, since otherwise the organization of the annex object
-    trees of the clone and its symlinked origin may conflict (dirhashmixed vs dirhashlower).
+    inodes needs to be minimized. Note that this mode can only be used with clones from
+    non-bare repositories or a RIA store! Otherwise two different annex object tree
+    structures (dirhashmixed vs dirhashlower) will be used simultaneously, and annex keys
+    using the respective other structure will be inaccessible.
     ['shared-<mode>']: set up repository and annex permission to enable multi-user
     access. This disables the standard write protection of annex'ed files.
     <mode> can be any value support by 'git init --shared=', such as 'group', or


### PR DESCRIPTION
This is an attempt to fix #6039, in which a user's confusion over the
``--reckless`` parameter could be traced to a lack of clarity
about the fact that this parameter is meant to be used at cloning.
Therefore, this change adds concrete examples and more refined wording
to the parameter docstring.
This change also removes a rather patronizing statement completely.
