### PR TITLE
[INFRA] change issue template into a github form

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -1,0 +1,37 @@
+name: Generic issue
+
+# For documentation concerning the Github form schema see
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+description: Generic issue
+
+body:
+  - type: textarea
+    attributes:
+      label: What is the problem?
+
+  - type: textarea
+    attributes:
+      label: What steps will reproduce the problem?
+
+  - type: textarea
+    attributes:
+      label: Datalad information
+      description: |
+        What version of DataLad and git-annex do you use (run `datalad --version`)? 
+
+        On what operating system (consider running `datalad wtf`)?
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description:
+        Is there anything else that would be useful to know in this context?
+
+  - type: textarea
+    attributes:
+      label: Have you had any success using DataLad before?
+      description: |
+        This is to assess your expertise/prior luck.
+
+        We would welcome your testimonial additions [here](https://github.com/datalad/datalad/wiki/Testimonials).

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,0 @@
-#### What is the problem?
-#### What steps will reproduce the problem?
-#### What version of DataLad are you using (run `datalad --version`)? On what operating system (consider running `datalad wtf`)?
-#### Is there anything else that would be useful to know in this context?
-#### Have you had any success using DataLad before? (to assess your expertise/prior luck.  We would welcome your testimonial additions to https://github.com/datalad/datalad/wiki/Testimonials as well)


### PR DESCRIPTION
Suggested in an issue on the datalad handbook repo: https://github.com/datalad-handbook/book/pull/768#issuecomment-936633703

This transforms the markdown based issue template into a yml that will render as a github issue form that are both more user friendly and may prevent users having to delete placeholders...

The result can be previewed here: https://github.com/Remi-Gau/datalad/issues/new?assignees=&labels=&template=issue_template.yml

- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.



