### PR TITLE
Ux get result handling broken

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -953,14 +953,7 @@ class Get(Interface):
                     refds.path,
                     source,
                     jobs):
-                if 'path' not in res:
-                    assert res['status'] != 'ok', f'Missing "path"-key in ' \
-                                                  f'result record with ' \
-                                                  f'status {res["status"]}: ' \
-                                                  f'{res}'
+                if 'path' not in res or res['path'] not in content_by_ds:
+                    # we had reports on datasets and subdatasets already
+                    # before the annex stage
                     yield res
-                else:
-                    if res['path'] not in content_by_ds:
-                        # we had reports on datasets and subdatasets already
-                        # before the annex stage
-                        yield res

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -747,10 +747,3 @@ def test_missing_path_handling(path):
 
         # Check for guarded access in error results
         ds.get("foo")
-
-        # Check for for assertion that "path" exists in non-error result dicts
-        get_target_path.return_value = [{
-            "status": "ok"
-        }]
-        assert_raises(Exception, ds.get, "foo")
-


### PR DESCRIPTION
Fixes issue #5940. Adds a guard for "path"-lookups in result dictionaries. Adds regression tests.

[x] adds a guard for "path"-lookups in result dictionary handling in get
[x] asserts that "ok"-results have a "path"-key
[x] adds regression tests
