### PR TITLE
Revert "TST: Disable tests against metalad"

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -13,6 +13,7 @@ jobs:
         extension: [
             datalad-neuroimaging,
             datalad-container,
+            datalad-metalad,
             datalad-crawler,
             datalad-deprecated,
         ]


### PR DESCRIPTION
This reverts commit 96014ecc9ccfca3ddddba2e04c2a9d1520f5ae1d.

metalad is under active development but starts to be tested/used in
use cases, so would be useful to have datalad cocompatible with it
(might need a release).  Relevant issues

https://github.com/datalad/datalad-metalad/issues/124
https://github.com/datalad/datalad-metalad/issues/66
