### PR TITLE
BF: do not leave test in a tmp dir destined for removal

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -369,8 +369,8 @@ def test_getpwd_basic():
         assert_false(oschdir.called)
 
 
-@assert_cwd_unchanged(ok_to_chdir=True)
 @with_tempfile(mkdir=True)
+@assert_cwd_unchanged(ok_to_chdir=True)
 def test_getpwd_change_mode(tdir):
     from datalad import utils
     if utils._pwd_mode != 'PWD':


### PR DESCRIPTION
Othervice it does trigger assert_no_open_files since if it is wrapping around
`@with_tempfile` -- that one cannot rmdir it since it is open (we have it as a CWD)