### PR TITLE
enable metalad tests again

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -13,6 +13,7 @@ jobs:
         extension: [
             datalad-neuroimaging,
             datalad-container,
+            datalad-metalad,
             datalad-crawler,
             datalad-deprecated,
         ]


### PR DESCRIPTION
Fixes #6053 

Brings testing of metalad back into core since datalad-metadata-model enters
a more stable state.

- [X] move metadata-model repository under datalad
- [X] release metadata-model on pypi to suport datalad-metalad installation with `pip -e .`
   