### PR TITLE
ENH/BF: Safeguard get against missing submodule property

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -334,7 +334,8 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
                 res.get('path', None) == dest_path:
             _fixup_submodule_dotgit_setup(ds, sm_path)
 
-            section_name = 'submodule.{}'.format(sm['gitmodule_name'])
+            section_name = 'submodule.{}'.format(
+                sm.get('gitmodule_name', None))
             # register the submodule as "active" in the superdataset
             ds.config.set(
                 '{}.active'.format(section_name),

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -334,7 +334,8 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                     repo.call_git(
                         ['config', '--file', '.gitmodules',
                          '--unset-all',
-                         'submodule.{}.{}'.format(sm['gitmodule_name'], dprop),
+                         'submodule.{}.{}'.format(
+                             sm.get('gitmodule_name', None), dprop),
                         ]
                     )
                 except CommandError:
@@ -345,7 +346,7 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                             "Deleting subdataset property '%s' failed for "
                             "subdataset '%s', possibly did "
                             "not exist",
-                            dprop, sm['gitmodule_name']),
+                            dprop, sm.get('gitmodule_name', None)),
                         logger=lgr,
                         **sm)
                 # also kick from the info we just read above
@@ -366,7 +367,8 @@ def _get_submodules(ds, paths, fulfilled, recursive, recursion_limit,
                     repo.call_git(
                         ['config', '--file', '.gitmodules',
                          '--replace-all',
-                         'submodule.{}.{}'.format(sm['gitmodule_name'], prop),
+                         'submodule.{}.{}'.format(
+                             sm.get('gitmodule_name', None), prop),
                          str(val),
                         ]
                     )


### PR DESCRIPTION
I hope this is a fix/safeguard for #6025, in which a seemingly non existent ``gitmodule_name`` submodule property resulted in a ``KeyError``.
