### PR TITLE
BF: archives upon strip - use rmtree which retries etc instead of rmdir

### DIFF
--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -37,7 +37,6 @@ from datalad.utils import (
     ensure_bytes,
     ensure_unicode,
     unlink,
-    rmdir,
     rmtemp,
     rmtree,
     get_tempfile_kwargs,
@@ -93,7 +92,8 @@ def decompress_file(archive, dir_, leading_directories='strip'):
             subdir, subdirs_, files_ = next(os.walk(opj(dir_, dirs[0])))
             for f in subdirs_ + files_:
                 os.rename(opj(subdir, f), opj(dir_, f))
-            rmdir(widow_dir)
+            # NFS might hold it victim so use rmtree so it tries a few times
+            rmtree(widow_dir)
     elif leading_directories is None:
         pass   # really do nothing
     else:


### PR DESCRIPTION
possible side-effect - if code logic would be flawed and leave some files
behind, rmtree would remove them as well (whenever rmdir would fail).
But since tested and never crashed before for that reason I think it should be
safe.

I have tried to troubleshoot/figure out exact problem with
https://github.com/datalad/datalad/pull/6058
but it did not reproduce, so decided to just make code robust

edit: the hope is that it closes #4496