### PR TITLE
BF: Retain git-annex error messages & don't show them if operation successful

### DIFF
--- a/datalad/core/local/tests/test_results.py
+++ b/datalad/core/local/tests/test_results.py
@@ -35,8 +35,8 @@ def test_default_result_renderer():
         (dict(type='funky'),
          ['<action-unspecified>(<status-unspecified>): (funky)']),
         # plain message makes it through
-        (dict(message='funky'),
-         ['<action-unspecified>(<status-unspecified>): [funky]']),
+        (dict(message='funky', error_message='extra-funky'),
+         ['<action-unspecified>(<status-unspecified>): [funky] [extra-funky]']),
     ]
     if on_windows:
         testcases.extend([

--- a/datalad/distributed/tests/test_ria_git_remote.py
+++ b/datalad/distributed/tests/test_ria_git_remote.py
@@ -125,15 +125,15 @@ def _test_bare_git_version_1(host, dspath, store):
     assert_result_count(fsck_res,
                         1,
                         status='error',
-                        message='** Based on the location log, one.txt\n'
-                                '** was expected to be present, '
-                                'but its content is missing.')
+                        error_message='** Based on the location log, one.txt\n'
+                                      '** was expected to be present, '
+                                      'but its content is missing.')
     assert_result_count(fsck_res,
                         1,
                         status='error',
-                        message='** Based on the location log, subdir/two\n'
-                                '** was expected to be present, '
-                                'but its content is missing.')
+                        error_message='** Based on the location log, subdir/two\n'
+                                      '** was expected to be present, '
+                                      'but its content is missing.')
     eq_(len(ds.repo.whereis('one.txt')), 1)
     # and the other way around: upload via ora-remote and have it available via
     # git-remote:
@@ -226,9 +226,9 @@ def _test_bare_git_version_2(host, dspath, store):
     assert_result_count(fsck_res,
                         1,
                         status='error',
-                        message='** Based on the location log, one.txt\n'
-                                '** was expected to be present, '
-                                'but its content is missing.')
+                        error_message='** Based on the location log, one.txt\n'
+                                      '** was expected to be present, '
+                                      'but its content is missing.')
     assert_result_count(fsck_res, 1, status='ok')
     eq_(len(fsck_res), 2)
     eq_(len(ds.repo.whereis('one.txt')), 1)

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -9,7 +9,6 @@
 
 __docformat__ = 'restructuredtext'
 
-
 import itertools
 from .base import Interface
 from ..utils import (
@@ -40,6 +39,7 @@ from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from logging import getLogger
+
 lgr = getLogger('datalad.api.clean')
 
 # needed API commands
@@ -90,7 +90,7 @@ class Clean(Interface):
             args=("--dry-run",),
             doc="""Report on cleanable locations - not actually cleaning up
             anything.""",
-            action="store_true",),
+            action="store_true", ),
         # TODO: Python only???
         what=Parameter(
             args=("--what",),
@@ -207,7 +207,7 @@ class Clean(Interface):
 
             refds = res.get('refds', None)
             refds = refds if kwargs.get('dataset', None) is not None \
-                or refds == getcwd() else None
+                             or refds == getcwd() else None
             path = res['path'] if refds is None \
                 else str(Path(res['path']).relative_to(refds))
 
@@ -216,8 +216,8 @@ class Clean(Interface):
                 message=(res['message'][0] % res['message'][1:]
                          if isinstance(res['message'], tuple)
                          else res['message'])
-                        if res.get('message', None) else ''
-                )
+                if res.get('message', None) else ''
+            )
             )
 
         else:

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -47,7 +47,7 @@ success_status_map = {
 
 def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
                     refds=None, status=None, message=None, exception=None,
-                    **kwargs):
+                    error_message=None, **kwargs):
     # `type` is intentionally not `type_` or something else, as a mismatch
     # with the dict key 'type' causes too much pain all over the place
     # just for not shadowing the builtin `type` in this function
@@ -88,6 +88,8 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
         d['status'] = status
     if message is not None:
         d['message'] = message
+    if error_message is not None:
+        d['error_message'] = error_message
     if exception is not None:
         d['exception'] = exception
         d['exception_traceback'] = \
@@ -238,7 +240,7 @@ def annexjson2result(d, ds, **kwargs):
                            for k, v in d['fields'].items()
                            if not k.endswith('lastchanged')}
     if d.get('error-messages', None):
-        messages.extend(d['error-messages'])
+        res['error_message'] = '\n'.join(m.strip() for m in d['error-messages'])
     # avoid meaningless standard messages, and collision with actual error
     # messages
     elif 'note' in d:

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 
 import inspect
 import logging
+import os
 import wrapt
 import sys
 import re
@@ -61,7 +62,6 @@ from datalad.core.local.resulthooks import (
     match_jsonhook2result,
     run_jsonhook,
 )
-
 
 lgr = logging.getLogger('datalad.interface.utils')
 
@@ -171,7 +171,7 @@ def path_is_under(values, path=None):
         # need to protect against unsupported use of relpath() with
         # abspaths on windows from different drives (gh-3724)
         if path_drive != p_drive:
-        # different drives, enough evidence for "not under"
+            # different drives, enough evidence for "not under"
             continue
         rpath = relpath(p, start=path)
         if rpath == curdir \
@@ -230,7 +230,7 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
         current_trace = current_trace + [basepath]
     # this edge is not done, we need to try to reach any downstream
     # dataset
-    undiscovered_ds = set(t for t in targetpaths) # if t != basepath)
+    undiscovered_ds = set(t for t in targetpaths)  # if t != basepath)
     # whether anything in this directory matched a targetpath
     filematch = False
     if isdir(basepath):
@@ -258,8 +258,8 @@ def discover_dataset_trace_to_targets(basepath, targetpaths, current_trace,
                     downward_targets))
     undiscovered_ds = [t for t in undiscovered_ds
                        if includeds and
-                          path_is_subpath(t, current_trace[-1]) and
-                          t in includeds]
+                       path_is_subpath(t, current_trace[-1]) and
+                       t in includeds]
     if filematch or basepath in targetpaths or undiscovered_ds:
         for i, p in enumerate(current_trace[:-1]):
             # TODO RF prepare proper annotated path dicts
@@ -387,10 +387,10 @@ def eval_results(func):
             # of the command execution
             results = []
             do_custom_result_summary = result_renderer in ('tailored', 'default') \
-                and hasattr(wrapped_class, 'custom_result_summary_renderer')
+                                       and hasattr(wrapped_class, 'custom_result_summary_renderer')
             pass_summary = do_custom_result_summary and \
-                getattr(wrapped_class,
-                        'custom_result_summary_renderer_pass_summary', None)
+                           getattr(wrapped_class,
+                                   'custom_result_summary_renderer_pass_summary', None)
 
             # process main results
             for r in _process_results(
@@ -479,6 +479,7 @@ def eval_results(func):
                     return results[0] if results else None
                 else:
                     return results
+
             lgr.log(2, "Returning return_func from eval_func for %s", wrapped_class)
             return return_func(generator_func)(*args, **kwargs)
 
@@ -497,7 +498,7 @@ def default_result_renderer(res):
                 # can happen, e.g., on windows with paths from different
                 # drives. just go with the original path in this case
                 pass
-        ui.message('{action}({status}):{path}{type}{msg}'.format(
+        ui.message('{action}({status}):{path}{type}{msg}{err}'.format(
             action=ac.color_word(
                 res.get('action', '<action-unspecified>'),
                 ac.BOLD),
@@ -510,7 +511,12 @@ def default_result_renderer(res):
                 res['message'][0] % res['message'][1:]
                 if isinstance(res['message'], tuple) else res[
                     'message'])
-            if res.get('message', None) else ''))
+            if res.get('message', None) else '',
+            err=ac.color_word(' [{}]'.format(
+                res['error_message'][0] % res['error_message'][1:]
+                if isinstance(res['error_message'], tuple) else res[
+                    'error_message']), ac.RED)
+            if res.get('error_message', None) and res.get('status', None) != 'ok' else ''))
 
 
 def render_action_summary(action_summary):
@@ -520,7 +526,6 @@ def render_action_summary(action_summary):
             ', '.join('{}: {}'.format(status, action_summary[act][status])
                       for status in sorted(action_summary[act])))
                     for act in sorted(action_summary))))
-
 
 
 def _display_suppressed_message(nsimilar, ndisplayed, last_ts, final=False):
@@ -567,9 +572,9 @@ def _process_results(
     # how many repetitions to show, before suppression kicks in
     render_n_repetitions = \
         dlcfg.obtain('datalad.ui.suppress-similar-results-threshold') \
-        if sys.stdout.isatty() \
-        and dlcfg.obtain('datalad.ui.suppress-similar-results') \
-        else float("inf")
+            if sys.stdout.isatty() \
+               and dlcfg.obtain('datalad.ui.suppress-similar-results') \
+            else float("inf")
 
     for res in results:
         if not res or 'action' not in res:


### PR DESCRIPTION
### Description

Instead of being mashed into a 'normal' message, git-annex reported error messages will now be retained in a separate dict entry.
This allows for more differentiated handling of them. Examples implemented in this PR:

1. To avoid confusion, git-annex error messages will only be rendered if they are meaningful, i.e. when the operation actually failed.
2. Error messages are now grouped separately from notes & coloured red.

### Related Issues

1. #5617 
2. #3939