### PR TITLE
Update codecov action to v2

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -52,6 +52,6 @@ jobs:
         python -m nose -s -v --with-cov --cover-package datalad --cover-xml datalad.core datalad.support
 
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: __testhome__/coverage.xml


### PR DESCRIPTION
Version 1 of codecov's GitHub action is [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1) and will start experiencing brownouts soon, and they advise updating to v2.

Note that this PR only updates the action used by the GitHub Actions workflows; separate changes must be made to update Travis and Appveyor to no longer use the Bash uploader.  See [this blog post](https://about.codecov.io/blog/introducing-codecovs-new-uploader/) for more information.