### PR TITLE
Remove uses of `__full_version__` and `datalad.version`

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -22,6 +22,7 @@ import warnings
 from tempfile import NamedTemporaryFile
 from textwrap import wrap
 
+from datalad import __version__
 from ..cmd import WitlessRunner as Runner
 from ..interface.common_opts import eval_defaults
 from ..log import is_interactive
@@ -33,7 +34,6 @@ from ..utils import (
     unlink,
     get_suggestions_msg,
 )
-from ..version import __version__, __full_version__
 
 from appdirs import AppDirs
 from os.path import join as opj
@@ -443,7 +443,7 @@ def _maybe_get_single_subparser(cmdlineargs, parser, interface_groups,
                 msg="too few arguments, run with --help or visit https://handbook.datalad.org",
                 exit_code=2)
         lgr.debug("Command line args 1st pass for DataLad %s. Parsed: %s Unparsed: %s",
-                  __full_version__, parsed_args, unparsed_args)
+                  __version__, parsed_args, unparsed_args)
     except Exception as exc:
         ce = CapturedException(exc)
         lgr.debug("Early parsing failed with %s", ce)

--- a/datalad/local/tests/test_wtf.py
+++ b/datalad/local/tests/test_wtf.py
@@ -20,7 +20,7 @@ from datalad.local.wtf import (
     _HIDDEN,
     SECTION_CALLABLES,
 )
-from datalad.version import __version__
+from datalad import __version__
 
 from datalad.utils import ensure_unicode
 from datalad.tests.utils import (

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -31,7 +31,7 @@ from datalad.support.exceptions import (
     CommandError,
     InvalidGitRepositoryError,
 )
-from datalad.version import __version__, __full_version__
+from datalad import __version__
 
 lgr = logging.getLogger('datalad.local.wtf')
 
@@ -84,7 +84,6 @@ def _describe_datalad():
 
     return {
         'version': ensure_unicode(__version__),
-        'full_version': ensure_unicode(__full_version__),
     }
 
 

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -13,7 +13,6 @@ from os import linesep
 
 from datalad import __version__
 from datalad.dochelpers import exc_str
-from datalad.version import __version__
 from ..external_versions import ExternalVersions, LooseVersion
 from datalad.support.exceptions import (
     CommandError,

--- a/datalad/tests/test_version.py
+++ b/datalad/tests/test_version.py
@@ -10,9 +10,7 @@
 import re
 from distutils.version import LooseVersion
 
-from ..version import (
-    __version__,
-)
+from .. import __version__
 from datalad.support import path as op
 from datalad.utils import ensure_unicode
 from datalad.tests.utils import (

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -20,7 +20,7 @@ from ..support.external_versions import external_versions
 from ..utils import swallow_outputs
 from ..utils import swallow_logs
 
-from ..version import __version__
+from .. import __version__
 from . import _TEMP_PATHS_GENERATED
 from .utils import get_tempfile_kwargs
 from datalad.customremotes.base import init_datalad_remote


### PR DESCRIPTION
The import of `__full_version__` in `datalad.local.wtf` was causing a deprecation warning to be emitted from just importing `datalad.api`.  This PR fixes that and also removes all the remaining imports of `datalad.version` I could find.