### PR TITLE
BF ensure lists in AnnexRepo and GitRepo

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3130,7 +3130,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         Parameters
         ----------
-        paths : list or None
+        paths : str, list of str, or None
           Specific paths to query info for. In `None`, info is reported for all
           content.
         init : 'git' or dict-like or None
@@ -3171,6 +3171,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             pathlib.Path of the content object in the local annex, if one
             is available (with `eval_availability`)
         """
+        paths = ensure_list(paths)
+
         if init is None:
             info = OrderedDict()
         elif init == 'git':

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3087,7 +3087,7 @@ class GitRepo(CoreGitRepo):
 
         Parameters
         ----------
-        paths : list or None
+        paths : str, list of str, or None
           If given, limits the query to the specified paths. To query all
           paths specify `None`, not an empty list. If a query path points
           into a subdataset, a report is made on the subdataset record
@@ -3118,6 +3118,8 @@ class GitRepo(CoreGitRepo):
           `state`
             Can be 'added', 'untracked', 'clean', 'deleted', 'modified'.
         """
+        paths = ensure_list(paths)
+
         lgr.debug('Query status of %r for %s paths',
                   self, len(paths) if paths else 'all')
         return self.diffstatus(


### PR DESCRIPTION
This PR ensures that paths that are converted into lists if list parameters are expected.
This prevents some status()-functions from yielding information about a complete repo when information about just a single file is requested.
