### PR TITLE
Report correct HTTP URL for RIA store content

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1345,13 +1345,14 @@ class RIARemote(SpecialRemote):
         # we need a file-system compatible name for the key
         key = _sanitize_key(key)
 
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         if isinstance(self.io, HTTPRemoteIO):
             # display the URL for a request
             # TODO: method of HTTPRemoteIO
-            return self.ria_store_url[4:] + "/annex/objects/" + \
-                   self.annex.dirhash(key) + key + "/" + key
+            # in case of a HTTP remote (unchecked for others), storage_host
+            # is not just a host, but a full URL without a path
+            return f'{self.storage_host}{dsobj_dir}/{key_path}'
 
-        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         return str(dsobj_dir / key_path) if self._local_io() \
             else '{}: {}:{}'.format(
                 self.storage_host,

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -10,6 +10,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_repo_status,
     assert_result_count,
+    assert_status,
     known_failure_windows,
     serve_path_via_http,
     skip_if_adjusted_branch,
@@ -144,4 +145,9 @@ def test_read_access(store_path, store_url, ds_path):
     assert_equal(len(res), 2)
     assert_result_count(res, 2, status='ok', type='file', action='get',
                         message="from ora-remote...")
+
+    # try whether the reported access URL is correct
+    one_url = ds.repo.whereis('one.txt', output='full'
+        )[store_uuid]['urls'].pop()
+    assert_status('ok', ds.download_url(urls=[one_url], path=str(ds.pathobj / 'dummy')))
 

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -117,9 +117,11 @@ def test_read_access(store_path, store_url, ds_path):
     ds.repo.init_remote('ora-remote', options=init_opts)
     ds.repo.fsck(remote='ora-remote', fast=True)
     store_uuid = ds.siblings(name='ora-remote',
-                             return_type='item-or-list')['annex-uuid']
+                             return_type='item-or-list',
+                             result_renderer='disabled')['annex-uuid']
     here_uuid = ds.siblings(name='here',
-                            return_type='item-or-list')['annex-uuid']
+                            return_type='item-or-list',
+                            result_renderer='disabled')['annex-uuid']
 
     # nothing in store yet:
     for f in files:


### PR DESCRIPTION
These URL do not only have annecdotal value. In efforts like #828 incorrect URLs invalidate the result.

The fix is not pretty (due to #6089 and similar issues), but it comes with a test that hopefully indicates breakage when these are fixed.