### PR TITLE
UX: Log clone-candidate number and URLs

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -285,6 +285,8 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     # take out any duplicate source candidates
     # unique() takes out the duplicated at the tail end
     clone_urls = unique(clone_urls, lambda x: x['url'])
+    lgr.debug('Assembled %i clone candidates for %s: %s',
+              len(clone_urls), sm_path, [cand['url'] for cand in clone_urls])
 
     return clone_urls
 


### PR DESCRIPTION
Previously, it was not obvious from which URL a subdataset clone
was attempted, leading to confusion in #6080.
This change adds a one-time log message at the debug level to
report the number of assembled clone candidates and their URLs.

fixes #6080.

PS: can I use % string interpolation with a list like I have done here?