### PR TITLE
UX/ENH: Disable reporting, and don't do superfluous internal subdatasets calls

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -436,7 +436,9 @@ def _install_necessary_subdatasets(
                 else:
                     # report unconditionally to caller
                     yield res
-
+        if sd.pathobj == path:
+            # we've just got the target subdataset, we're done
+            return
         # now check whether the just installed subds brought us any closer to
         # the target path
         subds_trail = sd.subdatasets(contains=path, recursive=False,


### PR DESCRIPTION
This fixes #6093 UX component by disabling the rendering of internal ``datalad subdataset`` calls that would be reported to the user. 
It also fixes its performance component by not running an additional ``subdatasets`` query when the target dataset has already been installed.

Before, a simple ``get`` of a subdataset looked like this:

```
❱ datalad  get -n HCP1200/102513 
subdataset(ok): HCP1200/102513 (dataset)
[INFO   ] Fetching 'http://store.datalad.org/2e2/5d898-2c0f-11ea-961a-002590496000/config'                              
install(ok): /tmp/hcp/HCP1200/102513 (dataset) [Installed subdataset in order to get /tmp/hcp/HCP1200/102513]
subdataset(impossible): /tmp/hcp/HCP1200/102513 [path not contained in any matching subdataset]
```

Now, it looks like this:
```
datalad get -n HCP1200/104012 
[INFO   ] Fetching 'http://store.datalad.org/9c8/9f1c8-2be9-11ea-bf9f-002590496000/config'                              
install(ok): /tmp/hcp/HCP1200/104012 (dataset) [Installed subdataset in order to get /tmp/hcp/HCP1200/104012]
```
