### PR TITLE
Proposed new message/error default renderer output format

### DIFF
--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -240,7 +240,7 @@ def annexjson2result(d, ds, **kwargs):
                            for k, v in d['fields'].items()
                            if not k.endswith('lastchanged')}
     if d.get('error-messages', None):
-        res['error_message'] = '\n'.join(m.strip() for m in d['error-messages'])
+        res['error_message'] = d['error-messages']
     # avoid meaningless standard messages, and collision with actual error
     # messages
     elif 'note' in d:
@@ -250,7 +250,7 @@ def annexjson2result(d, ds, **kwargs):
         if note:
             messages.append(translate_annex_notes.get(note, note))
     if messages:
-        res['message'] = '\n'.join(m.strip() for m in messages)
+        res['message'] = messages
     return res
 
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -507,16 +507,20 @@ def default_result_renderer(res):
             type=' ({})'.format(
                 ac.color_word(res['type'], ac.MAGENTA)
             ) if 'type' in res else '',
-            msg=' [{}]'.format(
+            msg=' {}{}{}'.format(
+                ac.color_word('[', ac.GREEN),
                 res['message'][0] % res['message'][1:]
-                if isinstance(res['message'], tuple) else res[
-                    'message'])
-            if res.get('message', None) else '',
-            err=ac.color_word(' [{}]'.format(
-                res['error_message'][0] % res['error_message'][1:]
-                if isinstance(res['error_message'], tuple) else res[
-                    'error_message']), ac.RED)
-            if res.get('error_message', None) and res.get('status', None) != 'ok' else ''))
+                if isinstance(res['message'], tuple)
+                else ac.color_word(' | ', ac.GREEN).join(m.strip() for m in res['message']),
+                ac.color_word(']', ac.GREEN))
+            if res.get('message', None)
+            else '',
+            err=' [{}]'.format(
+                ac.color_word(res['error_message'][0] % res['error_message'][1:], ac.RED)
+                if isinstance(res['error_message'], tuple)
+                else ' | '.join(ac.color_word(m.strip(), ac.RED) for m in res['error_message']))
+            if res.get('error_message', None) and res.get('status', None) != 'ok'
+            else ''))
 
 
 def render_action_summary(action_summary):


### PR DESCRIPTION
### Description

I propose a new format for displaying default renderer messages in the console:

1. move concatenation of lines from `results/annexjson2result` to `default_result_renderer`
2. use separator `’ | ’` instead of newline char to join the strings
3. utilise colours to distinguish between message type (normal vs error) & improve readability

This format is a compromise between minimising line use (important for large numbers of messages) & maximising readability.

Example; top is normal message format (white text, green accents), below error message format (red text, white accents): 
![Screenshot from 2021-10-17 22-53-06](https://user-images.githubusercontent.com/49207524/137692230-c0bf3bd9-7d66-4f60-9507-b364482a5f71.png)

