### PR TITLE
DOC: Add supported URL types to download-url's docstring

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -38,7 +38,7 @@ from ..support.exceptions import (
     CommandError,
     NoDatasetFound,
 )
-
+from datalad.downloaders.providers import Provider
 from logging import getLogger
 lgr = getLogger('datalad.api.download-url')
 
@@ -48,14 +48,14 @@ class DownloadURL(Interface):
     """Download content
 
     It allows for a uniform download interface to various supported URL
-    schemes ('http', 'https', 'shub', 'ftp', 's3'), re-using or asking for
+    schemes (see command help for details), re-using or asking for
     authentication details maintained by datalad.
     """
 
     _params_ = dict(
         urls=Parameter(
-            doc="""URL(s) to be downloaded. Supported protocols: 'http',
-            'https', 'shub', 'ftp', and 's3'""",
+            doc="""URL(s) to be downloaded. Supported protocols: {}""".format(
+                ", ".join(map(repr, sorted(Provider.DOWNLOADERS)))),
             constraints=EnsureStr(),  # TODO: EnsureURL
             metavar='url',
             nargs='+'),


### PR DESCRIPTION
When I looked through old issues I found https://github.com/datalad/datalad/issues/2369. While the feature request for ssh or sftp urls is not supported by git-annex still, I realized that it is quite difficult to find out what kind of URLs actually work with ``download-url``. One either needs to read the source code, or trigger a ValueError with an unsupported URL type. This small change adds a list of supported protocols to the docstring of the command. 