### PR TITLE
NF: Hint the user if lots of content was committed directly to git (WIP)

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -470,8 +470,12 @@ def with_gitsize_investigation(saver):
                                             "files are",
                                             num_files, False),
                            '\n'.join(("{} ({})".format(file, ut.bytes2human(size))
-                                      for file, size in files.items()[:num_files
-                                                                      if 10 > num_files else 10])),
+                                      for file, size in
+                                      sorted(files.items(), key=lambda x: x[1],
+                                             reverse=True)[:num_files
+                                                           if 10 > num_files else 10]
+                                      )
+                                     )
                            )
                    )
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -480,8 +480,8 @@ definitions = {
         'ui': ('question', {
             'title': 'Show notification on possibly excessive git commit',
             'text': "If enabled, a notification listing the number of files, "
-                    "total file size & biggest file committed will be displayed "
-                    "if a commit saved to git exceeds the size set by "
+                    "total file size & biggest files committed will be displayed "
+                    "if files saved to git exceed the size set by "
                     "datalad.ui.git-commit-notification-threshold."}),
         'default': True,
         'type': EnsureBool(),
@@ -489,8 +489,8 @@ definitions = {
     'datalad.ui.git-commit-notification-threshold': {
         'ui': ('question', {
             'title': 'Threshold for notification on possibly excessive git commit',
-            'text': "Maximum acceptable size (in bytes) of a git commit, "
-                    "before a notification is displayed. "
+            'text': "Maximum acceptable total size (in bytes) of files to be "
+                    "committed directly to git, before a notification is displayed. "
                     "See 'datalad.ui.git-commit-notification' for more "
                     "information."}),
         'default': 104857600,  # 100 MiB

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -482,7 +482,7 @@ definitions = {
             'text': "If enabled, a notification listing the number of files, "
                     "total file size & biggest file committed will be displayed "
                     "if a commit saved to git exceeds the size set by "
-                    "datalad.ui.git-commit-notification-threshold. "}),
+                    "datalad.ui.git-commit-notification-threshold."}),
         'default': True,
         'type': EnsureBool(),
     },
@@ -490,7 +490,7 @@ definitions = {
         'ui': ('question', {
             'title': 'Threshold for notification on possibly excessive git commit',
             'text': "Maximum acceptable size (in bytes) of a git commit, "
-                    "before a notifiaction is displayed. "
+                    "before a notification is displayed. "
                     "See 'datalad.ui.git-commit-notification' for more "
                     "information."}),
         'default': 104857600,  # 100 MiB

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -476,6 +476,26 @@ definitions = {
         'default': 10,
         'type': EnsureInt(),
     },
+    'datalad.ui.git-commit-notification': {
+        'ui': ('question', {
+            'title': 'Show notification on possibly excessive git commit',
+            'text': "If enabled, a notification listing the number of files, "
+                    "total file size & biggest file committed will be displayed "
+                    "if a commit saved to git exceeds the size set by "
+                    "datalad.ui.git-commit-notification-threshold. "}),
+        'default': True,
+        'type': EnsureBool(),
+    },
+    'datalad.ui.git-commit-notification-threshold': {
+        'ui': ('question', {
+            'title': 'Threshold for notification on possibly excessive git commit',
+            'text': "Maximum acceptable size (in bytes) of a git commit, "
+                    "before a notifiaction is displayed. "
+                    "See 'datalad.ui.git-commit-notification' for more "
+                    "information."}),
+        'default': 104857600,  # 100 MiB
+        'type': EnsureInt(),
+    },
     'datalad.save.no-message': {
         'ui': ('question', {
             'title': 'Commit message handling',


### PR DESCRIPTION
### Description

As suggested by #5919, this implements a notification triggered by a large amount of data being saved directly to git (current default threshold 100 MiB). The note currently displays the total number and size of files saved to git as well as the largest file(s) and their (individual) size. It can be disabled via `datalad.ui.git-commit-notification` and the threshold can be adjusted via `datalad.ui.git-commit-notification-threshold`.

Any comments and suggestions are very welcome.

### TODO

- [ ] check if dataset is pure git repo
- [x] inform the user to adjust .gitattributes
- [ ] point to ways to mitigate
- [ ] add unit test(s)  (item added by @yarikoptic)