### PR TITLE
RF status to expose its path normalization and sorting functionality

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -112,7 +112,7 @@ def yield_dataset_status(ds, paths, annexinfo, untracked, recursion_limit,
 
     Parameters
     ----------
-    dataset : Dataset
+    ds : Dataset
       Dataset to get the status of.
     path : Path-like, optional
       Paths to constrain the status to (see main status() command).
@@ -150,6 +150,9 @@ def yield_dataset_status(ds, paths, annexinfo, untracked, recursion_limit,
     if reporting_order not in ('depth-first', 'breadth-first'):
         raise ValueError('Unknown reporting order: {}'.format(reporting_order))
 
+    if ds.pathobj in queried:
+        # do not report on a single dataset twice
+        return
     # take the dataset that went in first
     repo = ds.repo
     repo_path = repo.pathobj
@@ -385,101 +388,16 @@ class Status(Interface):
         ds = require_dataset(
             dataset, check_installed=True, purpose='report status')
         ds_path = ds.path
-        paths_by_ds = OrderedDict()
-        if path:
-            # sort any path argument into the respective subdatasets
-            for p in sorted(map(ensure_unicode, ensure_list(path))):
-                # it is important to capture the exact form of the
-                # given path argument, before any normalization happens
-                # for further decision logic below
-                orig_path = str(p)
-                p = resolve_path(p, dataset)
-                # TODO(OPT)? YOH does not spot any optimization for paths under the same
-                # directory: if not isdir(path) - files would all have the same
-                # "root", and we could avoid doing full `get_dataset_root` check for
-                # those. Moreover, if some path points UNDER that path which isdir, and
-                # we have some other path already with the root above - we can just take
-                # the same. Altogether sounds like a logic duplicated with
-                # discover_dataset_trace_to_targets and even get_tree_roots
-                # of save.
-                root = get_dataset_root(str(p))
-                if root is None:
-                    # no root, not possibly underneath the refds
-                    yield dict(
-                        action='status',
-                        path=p,
-                        refds=ds_path,
-                        status='error',
-                        message='path not underneath this dataset',
-                        logger=lgr)
-                    continue
-                else:
-                    if dataset and root == str(p) and \
-                            not (orig_path.endswith(op.sep) or
-                                 # Note: Compare to Dataset(root).path rather
-                                 # than root to get same path normalization.
-                                 Dataset(root).path == ds_path):
-                        # the given path is pointing to a dataset
-                        # distinguish rsync-link syntax to identify
-                        # the dataset as whole (e.g. 'ds') vs its
-                        # content (e.g. 'ds/')
-                        super_root = get_dataset_root(op.dirname(root))
-                        if super_root:
-                            # the dataset identified by the path argument
-                            # is contained in a superdataset, and no
-                            # trailing path separator was found in the
-                            # argument -> user wants to address the dataset
-                            # as a whole (in the superdataset)
-                            root = super_root
-
-                root = ut.Path(root)
-                ps = paths_by_ds.get(root, [])
-                ps.append(p)
-                paths_by_ds[root] = ps
-        else:
-            paths_by_ds[ds.pathobj] = None
-
         queried = set()
         content_info_cache = {}
-        while paths_by_ds:
-            qdspath, qpaths = paths_by_ds.popitem(last=False)
-            if qpaths and qdspath in qpaths:
-                # this is supposed to be a full query, save some
-                # cycles sifting through the actual path arguments
-                qpaths = []
-            # try to recode the dataset path wrt to the reference
-            # dataset
-            # the path that it might have been located by could
-            # have been a resolved path or another funky thing
-            qds_inrefds = path_under_rev_dataset(ds, qdspath)
-            if qds_inrefds is None:
-                # nothing we support handling any further
-                # there is only a single refds
-                yield dict(
-                    path=str(qdspath),
-                    refds=ds_path,
-                    action='status',
-                    status='error',
-                    message=(
-                        "dataset containing given paths is not underneath "
-                        "the reference dataset %s: %s",
-                        ds, qpaths),
-                    logger=lgr,
-                )
+        for res in _yield_paths_by_ds(ds, dataset, ensure_list(path)):
+            if 'status' in res:
+                # this is an error
+                yield res
                 continue
-            elif qds_inrefds != qdspath:
-                # the path this dataset was located by is not how it would
-                # be referenced underneath the refds (possibly resolved
-                # realpath) -> recode all paths to be underneath the refds
-                qpaths = [qds_inrefds / p.relative_to(qdspath) for p in qpaths]
-                qdspath = qds_inrefds
-            if qdspath in queried:
-                # do not report on a single dataset twice
-                continue
-            qds = Dataset(str(qdspath))
             for r in yield_dataset_status(
-                    qds,
-                    qpaths,
+                    res['ds'],
+                    res['paths'],
                     annex,
                     untracked,
                     recursion_limit
@@ -490,11 +408,12 @@ class Status(Interface):
                     None,
                     content_info_cache,
                     reporting_order='depth-first'):
+                if 'status' not in r:
+                    r['status'] = 'ok'
                 yield dict(
                     r,
                     refds=ds_path,
                     action='status',
-                    status='ok',
                 )
 
     @staticmethod
@@ -557,3 +476,144 @@ class Status(Interface):
                for r in results):
             from datalad.ui import ui
             ui.message("nothing to save, working tree clean")
+
+
+def get_paths_by_ds(refds, dataset_arg, paths, subdsroot_mode='rsync'):
+    """Resolve and sort any paths into their containing datasets
+
+    Any path will be associated (sorted into) its nearest containing dataset.
+    It is irrelevant whether or not a path presently exists on the file system.
+    However, only datasets that exist on the file system are used for
+    sorting/association -- known, but non-existent subdatasets are not
+    considered.
+
+    Parameters
+    ----------
+    refds: Dataset
+    dataset_arg: Dataset or str or Path or None
+      Any supported value given to a command's `dataset` argument. Given
+      to `resolve_path()`.
+    paths: list
+      Any number of absolute or relative paths, in str-form or as
+      Path instances, to be sorted into their respective datasets. See also
+      the `subdsroot_mode` parameter.
+    subdsroot_mode: {'rsync', 'super', 'sub'}
+      Switch behavior for paths that are the root of a subdataset. By default
+      ('rsync'), such a path is associated with its parent/superdataset,
+      unless the path ends with a trailing directory separator, in which case
+      it is sorted into the subdataset record (this resembles the path
+      semantics of rsync, hence the label). In 'super' mode, the path is always
+      placed with the superdataset record. Likewise, in 'sub' mode the path
+      is always placed into the subdataset record.
+
+    Returns
+    -------
+    dict, list
+      The first return value is the main result, a dictionary with root
+      directories of all discovered datasets as keys and a list of the
+      associated paths inside these datasets as values.  Keys and values are
+      normalized to be Path instances of absolute paths.
+      The second return value is a list of all paths (again Path instances)
+      that are not located underneath the reference dataset.
+    """
+    ds_path = refds.path
+    paths_by_ds = OrderedDict()
+    errors = []
+
+    if not paths:
+        # that was quick
+        paths_by_ds[refds.pathobj] = None
+        return paths_by_ds, errors
+
+    # in order to guarantee proper path sorting, we first need to resolve all
+    # of them (some may be str, some Path, some relative, some absolute)
+    # step 1: normalize to unicode
+    paths = map(ensure_unicode, paths)
+    # step 2: resolve
+    # for later comparison, we need to preserve the original value too
+    paths = [(resolve_path(p, dataset_arg), str(p)) for p in paths]
+    # sort any path argument into the respective subdatasets
+    # sort by comparing the resolved Path instances, this puts top-level
+    # paths first, leading to their datasets to be injected into the result
+    # dict first
+    for p, orig_path in sorted(paths, key=lambda x: x[0]):
+        # TODO(OPT)? YOH does not spot any optimization for paths under the same
+        # directory: if not isdir(path) - files would all have the same
+        # "root", and we could avoid doing full `get_dataset_root` check for
+        # those. Moreover, if some path points UNDER that path which isdir, and
+        # we have some other path already with the root above - we can just take
+        # the same. Altogether sounds like a logic duplicated with
+        # discover_dataset_trace_to_targets and even get_tree_roots
+        # of save.
+        str_p = str(p)
+        # the dataset root containing the path in question
+        root = get_dataset_root(str_p)
+        # to become the root of the dataset that contains the path in question
+        # in the context of (same basepath) as the reference dataset
+        qds_inrefds = None
+        if root is not None:
+            qds_inrefds = path_under_rev_dataset(refds, root)
+        if root is None or qds_inrefds is None:
+            # no root, not possibly underneath the refds
+            # or root that is not underneath/equal the reference dataset root
+            errors.append(p)
+            continue
+
+        if root != qds_inrefds:
+            # try to recode the dataset path wrt to the reference
+            # dataset
+            # the path that it might have been located by could
+            # have been a resolved path or another funky thing
+            # the path this dataset was located by is not how it would
+            # be referenced underneath the refds (possibly resolved
+            # realpath) -> recode all paths to be underneath the refds
+            p = qds_inrefds / p.relative_to(root)
+            root = qds_inrefds
+
+        # Note: Compare to Dataset(root).path rather
+        # than root to get same path normalization.
+        if root == str_p and not Dataset(root).path == ds_path and (
+                subdsroot_mode == 'super' or (
+                subdsroot_mode == 'rsync' and dataset_arg and
+                not orig_path.endswith(op.sep))):
+            # the given path is pointing to a subdataset
+            # and we are either in 'super' mode, or in 'rsync' and found
+            # rsync-link syntax to identify the dataset as whole
+            # (e.g. 'ds') vs its content (e.g. 'ds/')
+            super_root = get_dataset_root(op.dirname(root))
+            if super_root:
+                # the dataset identified by the path argument
+                # is contained in a superdataset, and no
+                # trailing path separator was found in the
+                # argument -> user wants to address the dataset
+                # as a whole (in the superdataset)
+                root = super_root
+
+        root = ut.Path(root)
+        ps = paths_by_ds.get(root, [])
+        ps.append(p)
+        paths_by_ds[root] = ps
+    return paths_by_ds, errors
+
+
+def _yield_paths_by_ds(refds, dataset_arg, paths):
+    """Status-internal helper to yield get_paths_by_ds() items"""
+    paths_by_ds, errors = get_paths_by_ds(refds, dataset_arg, paths)
+    # communicate all the problems
+    for e in errors:
+        yield dict(
+            path=str(e),
+            action='status',
+            refds=refds.path,
+            status='error',
+            message=('path not underneath the reference dataset %s',
+                     refds.path),
+            logger=lgr)
+
+    while paths_by_ds:
+        qdspath, qpaths = paths_by_ds.popitem(last=False)
+        if qpaths and qdspath in qpaths:
+            # this is supposed to be a full status query, save some
+            # cycles sifting through the actual path arguments
+            qpaths = []
+        yield dict(ds=Dataset(qdspath), paths=qpaths)

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -16,7 +16,9 @@ from datalad.utils import (
     on_windows,
 )
 from datalad.tests.utils import (
+    assert_dict_equal,
     assert_in,
+    assert_in_results,
     assert_raises,
     assert_repo_status,
     assert_result_count,
@@ -38,6 +40,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.api import (
     status,
 )
+from datalad.core.local.status import get_paths_by_ds
 
 
 @with_tempfile(mkdir=True)
@@ -89,18 +92,14 @@ def test_status_nods(path, otherpath):
         ds.status(path=otherpath, on_failure='ignore', result_renderer=None),
         1,
         status='error',
-        message='path not underneath this dataset')
+        message=('path not underneath the reference dataset %s', ds.path))
     otherds = Dataset(otherpath).create()
     assert_result_count(
         ds.status(path=otherpath, on_failure='ignore', result_renderer=None),
         1,
         path=otherds.path,
         status='error',
-        message=(
-            'dataset containing given paths is not underneath the reference '
-            'dataset %s: %s',
-            ds, [])
-        )
+        message=('path not underneath the reference dataset %s', ds.path))
 
 
 @with_tempfile(mkdir=True)
@@ -310,3 +309,114 @@ def test_status_symlinked_dir_within_repo(path):
         # TODO: Consider providing better error handling in this case.
         with assert_raises(CommandError):
             call()
+
+
+@with_tempfile
+@with_tempfile
+def test_get_paths_by_ds(path, otherdspath):
+    otherds = Dataset(otherdspath).create()
+    ds = get_deeply_nested_structure(path)
+
+    # for testing below, a shortcut
+    subds_modified = Dataset(ds.pathobj / 'subds_modified')
+
+    # check docstrong of get_deeply_nested_structure() to understand
+    # what is being tested here
+    testcases = (
+        # (
+        #   (<dataset_arg>, <path arg>),
+        #   {<path by ds dict>}
+        #   [<error list>]
+        # ),
+
+        # find main dataset, pass-through arbitrary arguments, if no paths
+        # go in, also no paths come out
+        ((path, None), {ds.pathobj: None}, []),
+        # a simple path in the rootds, stays just that, not traversal
+        # into files underneaths
+        ((ds, ['subdir']), {ds.pathobj: [ds.pathobj / 'subdir']}, []),
+        # same for files, any number,
+        # one record per dataset with multiple files
+        ((ds, [op.join('subdir', 'git_file.txt'), 'directory_untracked']),
+         {ds.pathobj: [ds.pathobj / 'directory_untracked',
+                       ds.pathobj / 'subdir' / 'git_file.txt']},
+         []),
+        # same for a subdataset root -- still reported as part of
+        # the superdataset!
+        ((ds, ['subds_modified']),
+         {ds.pathobj: [subds_modified.pathobj]},
+         []),
+        # but not with a trailing slash, then it is the subdataset root
+        # itself that becomes the record!!!
+        ((ds, ['subds_modified' + op.sep]),
+         {subds_modified.pathobj: [subds_modified.pathobj]},
+         []),
+        # however, regardless of the path syntax, each behavior can be forced
+        ((ds, ['subds_modified'], 'sub'),
+         {subds_modified.pathobj: [subds_modified.pathobj]},
+         []),
+        ((ds, ['subds_modified' + op.sep], 'super'),
+         {ds.pathobj: [subds_modified.pathobj]},
+         []),
+        # subdataset content is sorted into a subdataset record
+        ((ds, [op.join('subds_modified', 'subdir')]),
+         {subds_modified.pathobj: [ds.pathobj / 'subds_modified' / 'subdir']},
+         []),
+        # content from different datasets ends up in different records
+        ((ds, [op.join('subdir', 'git_file.txt'),
+               op.join('subds_modified', 'subdir'),
+               op.join('subds_modified', 'subds_lvl1_modified')]),
+         {ds.pathobj: [ds.pathobj / 'subdir' / 'git_file.txt'],
+          subds_modified.pathobj: [
+              subds_modified.pathobj / 'subdir',
+              subds_modified.pathobj / 'subds_lvl1_modified']},
+         []),
+        # paths not matching existing content are no problem
+        ((ds, ['doesnotexist',
+               op.join('subdir', 'nothere'),
+               op.join('subds_modified', 'subdir', 'gone')]),
+         {ds.pathobj: [ds.pathobj / 'doesnotexist',
+                       ds.pathobj / 'subdir' / 'nothere'],
+          subds_modified.pathobj: [
+              subds_modified.pathobj / 'subdir' / 'gone']},
+         []),
+        #
+        # now error case
+        #
+        # a path that does sort under the root dataset
+        ((path, [otherds.pathobj / 'totally' / 'different']),
+         {},
+         [otherds.pathobj / 'totally' / 'different']),
+    )
+    # evaluate the test cases
+    for inp, pbd_target, error_target in testcases:
+        print('TTT', inp)
+        paths_by_ds, errors = get_paths_by_ds(ds, *inp)
+        assert_dict_equal(pbd_target, paths_by_ds)
+        eq_(error_target, errors)
+
+    # lastly, some more specialized test
+    # paths get collapsed into dataset records, even when the path
+    # order is not presorted to match individual datasets sequentially
+    paths_by_ds, errors = get_paths_by_ds(
+        ds, ds, [
+            op.join('subdir', 'git_file.txt'),
+            op.join('subds_modified', 'subdir'),
+            op.join('subdir', 'annexed_file.txt'),
+        ])
+    eq_(
+        list(paths_by_ds.keys()),
+        [ds.pathobj, subds_modified.pathobj]
+    )
+    # result order (top-level first) is stable, even when a path comes first
+    # that sorts later. Also mixed types are not a problem
+    paths_by_ds, errors = get_paths_by_ds(
+        ds, ds, [
+            ds.pathobj / 'subds_modified' / 'subdir',
+            op.join('subdir', 'git_file.txt'),
+            op.join('subds_modified', 'subdir', 'annexed_file.txt'),
+        ])
+    eq_(
+        list(paths_by_ds.keys()),
+        [ds.pathobj, subds_modified.pathobj]
+    )

--- a/datalad/interface/tests/test_unlock.py
+++ b/datalad/interface/tests/test_unlock.py
@@ -82,7 +82,7 @@ def test_unlock_raises(path, path2, path3):
     assert_in_results(
         ds.unlock(path=path2, on_failure="ignore"),
         status="error",
-        message="path not underneath this dataset")
+        message=("path not underneath the reference dataset %s", ds.path))
 
     chpwd(_cwd)
 


### PR DESCRIPTION
This is a precondition for the proposed reimplementation of `drop`. A function to sort path arguments to locally existing datasets for further processing.

Having a dedicated helper outside `status()` enables earlier parallelization of processing, and avoid expensive status queries, when they are not needed. A side-effect of only `status` doing this reliably across platforms was that further processing was file-by-file, or required resorting file records into subdatasets. Now there is a dedicated helper that operates on the granularity of the provided paths.

Unlike before, the path handling is now verified exhaustively in a dedicated test, and comes with documentation, and the ability to chose particular behavior via a mode switch.

While the diff looks extensive, most is explained by an indentation change alone. 

`git diff ... --color-moved --color-moved-ws=allow-indentation-change`

Essentially, the trailing end of `Status.__call__()` became its own function.

### Assessment re behavior change of core command

`status` behavior remains identical, except for the particular wording of the error message when a path is resolved that belongs to a dataset that does not belong to the reference dataset. This used to be a different message form the case of a path that belongs to no dataset whatsoever (and thereby also not to the reference dataset). These two cases are no standardized to the same message:

```
message=("path not underneath the reference dataset %s", ds.path))
```