### PR TITLE
UX: If a clean repo is dirty after a failed run, give clean-up hints

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -807,8 +807,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             if repo.dirty and not explicit:
                 # Give clean-up hints if a formerly clean repo is left dirty
                 lgr.info(
-                    "The commands 'git reset --hard' and/or 'git clean -df' "
-                    "could be used to get to a clean dataset state again."
+                    "The commands 'git clean -di' and/or 'git reset' "
+                    "could be used to get to a clean dataset state again. "
+                    "Consult their man pages for more information."
                 )
         raise exc
     elif do_save:

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -804,6 +804,12 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                      "If this is expected, you can save the changes with "
                      "'datalad save -d . -r -F %s'",
                      msg_path)
+            if repo.dirty and not explicit:
+                # Give clean-up hints if a formerly clean repo is left dirty
+                lgr.info(
+                    "The commands 'git reset --hard' and/or 'git clean -df' "
+                    "could be used to get to a clean dataset state again."
+                )
         raise exc
     elif do_save:
         with chpwd(pwd):


### PR DESCRIPTION
This is an implementation of #2924.
In case where a run command failed in a formerly clean repo, and the repo is
left in a dirty state, log general hints to use 'git clean' and 'git reset'
at INFO level.
Closes #2924.