### PR TITLE
BF: Don't make create-sibling recursive by default

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -598,7 +598,8 @@ class CreateSibling(Interface):
         #
         # all checks that are possible before we start parsing the dataset
         #
-
+        if since and not recursive:
+            raise ValueError("The use of 'since' requires 'recursive'")
         # possibly use sshurl to get the name in case if not specified
         if not sshurl:
             if not inherit:
@@ -658,39 +659,44 @@ class CreateSibling(Interface):
             active_branch = ds.repo.get_active_branch()
             since = '%s/%s' % (name, active_branch)
 
-        #
-        # parse the base dataset to find all subdatasets that need processing
-        #
         to_process = []
-        cand_ds = [
-            Dataset(r['path'])
-            for r in diff_dataset(
-                ds,
-                fr=since,
-                to=None,
-                # make explicit, but doesn't matter, no recursion in diff()
-                constant_refs=True,
-                # contrain to the paths of all locally existing subdatasets
-                path=[
-                    sds['path']
-                    for sds in ds.subdatasets(
-                        recursive=recursive,
-                        recursion_limit=recursion_limit,
-                        fulfilled=True,
-                        result_renderer=None)
-                ],
-                # save cycles, we are only looking for datasets
-                annex=None,
-                untracked='no',
-                # recursion was done faster by subdatasets()
-                recursive=False,
-                # save cycles, we are only looking for datasets
-                eval_file_type=False,
-            )
-            if r.get('type') == 'dataset' and r.get('state', None) != 'clean'
-        ]
+        if recursive:
+            #
+            # parse the base dataset to find all subdatasets that need processing
+            #
+            cand_ds = [
+                Dataset(r['path'])
+                for r in diff_dataset(
+                    ds,
+                    fr=since,
+                    to=None,
+                    # make explicit, but doesn't matter, no recursion in diff()
+                    constant_refs=True,
+                    # contrain to the paths of all locally existing subdatasets
+                    path=[
+                        sds['path']
+                        for sds in ds.subdatasets(
+                            recursive=recursive,
+                            recursion_limit=recursion_limit,
+                            fulfilled=True,
+                            result_renderer=None)
+                    ],
+                    # save cycles, we are only looking for datasets
+                    annex=None,
+                    untracked='no',
+                    # recursion was done faster by subdatasets()
+                    recursive=False,
+                    # save cycles, we are only looking for datasets
+                    eval_file_type=False,
+                )
+                if r.get('type') == 'dataset' and r.get('state', None) != 'clean'
+            ]
+            cand_ds = [ds] + cand_ds
+        else:
+            # only the current ds
+            cand_ds = [ds]
         # check remotes setup
-        for d in cand_ds if since else ([ds] + cand_ds):
+        for d in cand_ds:
             d_repo = d.repo
             if d_repo is None:
                 continue

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -548,9 +548,9 @@ class CreateSibling(Interface):
         since=Parameter(
             args=("--since",),
             constraints=EnsureStr() | EnsureNone(),
-            doc="""limit processing to datasets that have been changed since a given
-            state (by tag, branch, commit, etc). This can be used to create siblings
-            for recently added subdatasets."""),
+            doc="""limit processing to subdatasets that have been changed since
+            a given state (by tag, branch, commit, etc). This can be used to
+            create siblings for recently added subdatasets."""),
     )
 
     @staticmethod
@@ -691,11 +691,13 @@ class CreateSibling(Interface):
                 )
                 if r.get('type') == 'dataset' and r.get('state', None) != 'clean'
             ]
-            cand_ds = [ds] + cand_ds
+            if not since:
+                # not only subdatasets
+                cand_ds = [ds] + cand_ds
         else:
             # only the current ds
             cand_ds = [ds]
-        # check remotes setup
+        # check remotes setup()
         for d in cand_ds:
             d_repo = d.repo
             if d_repo is None:

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -869,3 +869,20 @@ def test_preserve_attrs(src, dest):
     assert s.st_mtime == 1234567890
     with open(opj(dest, "src", "foo", "bar")) as fp:
         assert fp.read() == "This is test text."
+
+
+@with_tempfile(mkdir=True)
+def test_only_one_level_without_recursion(path):
+    # this tests for https://github.com/datalad/datalad/issues/5614: accidental
+    # recursion of one level by default
+    path = Path(path)
+    ds_main = Dataset(path / "main").create()
+    ds_main.create('sub1')
+
+    ds_main.create_sibling(
+        name="dummy",
+        sshurl=str(path / "toplevelsibling"))
+    # this should exist
+    ok_((path / 'toplevelsibling').exists())
+    # this shouldn't
+    assert_false(Path(path / 'toplevelsibling' / 'sub1').exists())


### PR DESCRIPTION
This fixes #5614: I prevents an accidental recursion of one level by not evaluating subdataset states - which should not play any role for the sibling creation of the toplevel ds - only when the recursive flag is set. 
It also adds a check for concurrent occurrence of ``--since`` with ``--recursive`` - Given the description of ``--since``, I believe that it requires recursion and is thus useless if used without ``--recursive``.