### PR TITLE
BF(TST): remove reuse of the same tape across unrelated tests

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -124,7 +124,6 @@ def test_invalid_args(path, otherpath, alienpath):
 
 @integration
 @skip_if_no_network
-@use_cassette('test_install_crcns')
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 def test_clone_crcns(tdir, ds_path):
@@ -143,7 +142,6 @@ def test_clone_crcns(tdir, ds_path):
 
 @integration
 @skip_if_no_network
-@use_cassette('test_install_crcns')
 @with_tree(tree={'sub': {}})
 def test_clone_datasets_root(tdir):
     tdir = Path(tdir)

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -175,7 +175,6 @@ def test_invalid_args(path):
 
 
 @skip_if_no_network
-@use_cassette('test_install_crcns')
 @with_tree(tree={'sub': {}})
 def test_install_datasets_root(tdir):
     with chpwd(tdir):
@@ -443,7 +442,6 @@ def test_install_into_dataset(source, top_path):
 @known_failure_windows  #FIXME
 @usecase  # 39.3074s
 @skip_if_no_network
-@use_cassette('test_install_crcns')
 @with_tempfile
 def test_failed_install_multiple(top_path):
     ds = create(top_path)


### PR DESCRIPTION
originally that tape was added for test_install_crcns (hence the name of the tape)
which later was commented out in 941e51ffc8c506b51678e2fe3b2bf334ff3299ab and never
brought back.  Somehow that decorator was copy/pasted into other tests.

I guess because we no longer use GitPython, no online interactions through
python http modules were made, so tape was not really used, and it did not
lead to any failures.

My attention to that was brought by failures on Windows, such as
https://github.com/datalad/git-annex/runs/4042500337?check_suite_focus=true
which also should be unrelated, thus probably would not provide any
remedy, but there remains no reason to keep those "uses" of the same vcr
tape around.