### PR TITLE
Replace AnnotatePaths in metadata commands

### DIFF
--- a/datalad/interface/annotate_paths.py
+++ b/datalad/interface/annotate_paths.py
@@ -10,7 +10,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from collections import defaultdict
+from pathlib import Path
 
 import logging
 import textwrap
@@ -795,3 +795,76 @@ class AnnotatePaths(Interface):
                     reported_paths[res['path']] = res
                     yield res
         return
+
+
+def _minimal_annotate_paths(paths_by_ds, errors, action="annotate_path",
+                            recursive=None, recursion_limit=None, refds=None):
+    """This is an internal helper to replace AnnotatePaths
+
+    DO NOT USE IN ANY NEW CODE!!
+
+    It supports only a fraction of the functionality, but enough to keep the
+    metadata commands working. The goal is to remove it together with these
+    metadata commands, when they are replaced by metalad
+    """
+    for e in errors:
+        yield dict(
+            action=action,
+            path=str(e),
+            status='error',
+            message="path not associated with any dataset",
+        )
+    for dpath, paths in paths_by_ds.items():
+        if paths is None:
+            yield dict(
+                action=action,
+                path=str(dpath),
+                status='',
+                state='present',
+                type='dataset',
+                refds=refds,
+                parentds=Dataset(dpath).get_superdataset(),
+            )
+            continue
+
+        subdatasets = Dataset(dpath).subdatasets(
+            path=paths,
+            fulfilled=None,
+            recursive=recursive,
+            recursion_limit=recursion_limit,
+            result_renderer='disabled',
+            result_xfm=None)
+        subdataset_paths = [Path(r['path']) for r in subdatasets]
+
+        for p in paths:
+            ptype = 'dataset' \
+                if p == dpath or p in subdataset_paths \
+                else 'directory' \
+                if p.is_dir() \
+                else 'file'
+            if ptype == 'dataset':
+                pstate = 'present' if p == dpath \
+                    else [r.get('state') for r in subdatasets
+                          if Path(r['path']) == p][0]
+            else:
+                pstate = 'present' if lexists(p) else 'absent'
+            yield dict(
+                action=action,
+                path=str(p),
+                status='',
+                type=ptype,
+                state=pstate,
+                refds=refds,
+                parentds=str(dpath),
+            )
+        if recursive:
+            for sd in subdatasets:
+                yield dict(
+                    action=action,
+                    path=sd['path'],
+                    status='',
+                    state=sd['state'],
+                    type='dataset',
+                    refds=refds,
+                    parentds=sd.get('parentds'),
+                )

--- a/datalad/metadata/tests/test_aggregation.py
+++ b/datalad/metadata/tests/test_aggregation.py
@@ -138,13 +138,6 @@ def test_aggregate_query(path):
     res = ds.metadata(opj('sub', 'deep', 'some'), reporton='datasets')
     assert_result_count(res, 1)
     eq_({'homepage': 'http://top.example.com'}, res[0]['metadata'])
-    # when no reference dataset is given the command will report the
-    # aggregated metadata as it is recorded in the dataset that is the
-    # closest parent on disk
-    ds.create('sub', force=True)
-    res = metadata(opj(path, 'sub', 'deep', 'some'), reporton='datasets')
-    assert_result_count(res, 1)
-    eq_({'homepage': 'http://sub.example.com'}, res[0]['metadata'])
     # when a reference dataset is given, it will be used as the metadata
     # provider
     res = ds.metadata(opj('sub', 'deep', 'some'), reporton='datasets')


### PR DESCRIPTION
This is the second-to-last stop to finally resolve #3368

There is only a minimal behavior change: A rather peculiar reporting
behavior, where metadata of the "nearest" available dataset is chosen
when no explicit dataset is given.

This has no practical value and would complicate this temporary fix
substantially. This whole stuff only needs to last until metalad is
fully functional.