### PR TITLE
BF: obtain information about annex special remotes also from annex journal

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -782,33 +782,51 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         argspec = re.compile(r'^([^=]*)=(.*)$')
         srs = {}
+
+        # We provide custom implementation to access this metadata since ATM
+        # no git-annex command exposes it on CLI.
+        #
+        # Information will potentially be obtained from remote.log within
+        # git-annex branch, and git-annex's journal, which might exist e.g.
+        # due to alwayscommit=false operations
+        sources = []
         try:
-            for line in self.call_git_items_(
-                    ['cat-file', 'blob', 'git-annex:remote.log'],
-                    read_only=True):
-                # be precise and split by spaces
-                fields = line.split(' ')
-                # special remote UUID
-                sr_id = fields[0]
-                # the rest are config args for enableremote
-                sr_info = dict(argspec.match(arg).groups()[:2] for arg in fields[1:])
-                if "name" not in sr_info:
-                    name = sr_info.get("sameas-name")
-                    if name is None:
-                        lgr.warning(
-                            "Encountered git-annex remote without a name or "
-                            "sameas-name value: %s",
-                            sr_info)
-                    else:
-                        sr_info["name"] = name
-                srs[sr_id] = sr_info
+            sources.append(
+                list(
+                    self.call_git_items_(
+                        ['cat-file', 'blob', 'git-annex:remote.log'],
+                        read_only=True)
+                )
+            )
         except CommandError as e:
             if 'Not a valid object name git-annex:remote.log' in e.stderr:
-                # no special remotes configures
-                return {}
+                # no special remotes configures - might still be in the journal
+                pass
             else:
                 # some unforeseen error
                 raise e
+
+        journal_path = self.dot_git / "annex" / "journal" / "remote.log"
+        if journal_path.exists():
+            sources.append(journal_path.read_text().splitlines())
+
+        for line in chain(*sources):
+            # be precise and split by spaces
+            fields = line.split(' ')
+            # special remote UUID
+            sr_id = fields[0]
+            # the rest are config args for enableremote
+            sr_info = dict(argspec.match(arg).groups()[:2] for arg in fields[1:])
+            if "name" not in sr_info:
+                name = sr_info.get("sameas-name")
+                if name is None:
+                    lgr.warning(
+                        "Encountered git-annex remote without a name or "
+                        "sameas-name value: %s",
+                        sr_info)
+                else:
+                    sr_info["name"] = name
+            srs[sr_id] = sr_info
         return srs
 
     def _call_annex(self, args, files=None, jobs=None, protocol=StdOutErrCapture,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -764,6 +764,10 @@ class AnnexRepo(GitRepo, RepoInterface):
     def get_special_remotes(self):
         """Get info about all known (not just enabled) special remotes.
 
+        The present implementation is not able to report on special remotes
+        that have only been configured in a private annex repo
+        (annex.private=true).
+
         Returns
         -------
         dict


### PR DESCRIPTION
An alternative to https://github.com/datalad/datalad/pull/6133 implementation
which first forces git-annex to commit.

The use case was detected while working on https://github.com/datalad/datalad-crawler/pull/112
to accompany https://github.com/datalad/datalad/pull/6105 .

Although we could have easily "fixed" the test in datalad-crawler, I consider
the approach of going around git-annex commands to interrogate git-annex
metadata to be fragile, in particular for such a case as here: some other
command could have been ran in alwayscommit=false mode, and information in
git-annex branch might not yet reflect actual state of git-annex.  Ideally we
should avoid doing such "going around git-annex", but ATM there is no git-annex
command which would "expose" all this information.