### PR TITLE
TST: Enable more Windows tests

### DIFF
--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -40,7 +40,6 @@ from ...tests.utils import (
     DEFAULT_REMOTE,
     assert_in_results,
     assert_not_in,
-    known_failure_windows,
     serve_path_via_http,
     skip_if_no_network,
     slow,
@@ -83,7 +82,6 @@ def test_download_url_existing_dir_no_slash_exception(path):
                        res)
 
 
-@known_failure_windows
 @assert_cwd_unchanged
 @with_tree(tree=[
     ('file1.txt', 'abc'),

--- a/datalad/interface/tests/test_rerun.py
+++ b/datalad/interface/tests/test_rerun.py
@@ -447,7 +447,6 @@ def test_rerun_invalid_merge_run_commit(path):
     eq_(len(ds.repo.get_revisions(hexsha_orig + ".." + DEFAULT_BRANCH)), 1)
 
 
-@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_outofdate_tree(path):
     ds = Dataset(path).create()
@@ -477,7 +476,6 @@ def test_rerun_ambiguous_revision_file(path):
         len(ds.repo.get_revisions("ambig")))
 
 
-@known_failure_windows
 @with_tree(tree={"subdir": {}})
 def test_rerun_subdir(path):
     # Note: Using with_tree rather than with_tempfile is matters. The latter
@@ -568,7 +566,6 @@ def test_new_or_modified(path):
         {"to_modify", op.join("d", "to_modify")})
 
 
-@known_failure_windows
 @with_tempfile(mkdir=True)
 def test_rerun_script(path):
     ds = Dataset(path).create()
@@ -765,7 +762,6 @@ def test_run_inputs_outputs(src, path):
                         strip=True)
 
 
-@known_failure_windows
 @with_tree({"foo": "foo"})
 def test_run_inputs_no_annex_repo(path):
     ds = Dataset(path).create(annex=False, force=True)

--- a/datalad/support/tests/test_locking.py
+++ b/datalad/support/tests/test_locking.py
@@ -36,7 +36,6 @@ from datalad.tests.utils import (
     ok_exists,
     on_osx,
     with_tempfile,
-    known_failure_windows,
 )
 
 
@@ -55,7 +54,6 @@ class Subproc:
             q.put(acquired)
 
 
-@known_failure_windows
 @with_tempfile
 def test_lock_if_check_fails(tempfile):
     # basic test, should never try to lock so filename is not important

--- a/datalad/tests/test_utils_cached_dataset.py
+++ b/datalad/tests/test_utils_cached_dataset.py
@@ -26,7 +26,6 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_true,
     DEFAULT_REMOTE,
-    known_failure_windows,
     skip_if_no_network,
     with_tempfile
 )
@@ -154,7 +153,6 @@ def test_get_cached_dataset(cache_dir):
             assert_is(ds, ds2)
 
 
-@known_failure_windows
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_cached_dataset(cache_dir):
@@ -256,7 +254,6 @@ def test_cached_dataset(cache_dir):
         assert_not_equal(first_repopath, second_repopath)
 
 
-@known_failure_windows
 @skip_if_no_network
 @with_tempfile(mkdir=True)
 def test_cached_url(cache_dir):


### PR DESCRIPTION
A mix of newly enabled tests because they passed on an actual Windows box, and a few adjusted tests that pass after they got a Window equivalent to a Unix command. Let's see if the CIs agree.