### PR TITLE
OPT: do not deduce the ds path over and over again for files in a dir

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -589,7 +589,11 @@ def get_paths_by_ds(refds, dataset_arg, paths, subdsroot_mode='rsync'):
             # and we are either in 'super' mode, or in 'rsync' and found
             # rsync-link syntax to identify the dataset as whole
             # (e.g. 'ds') vs its content (e.g. 'ds/')
-            super_root = get_dataset_root(op.dirname(root))
+            root_dir = op.dirname(root)
+            try:
+                super_root = roots_cache[root_dir]
+            except KeyError:
+                super_root = roots_cache[root_dir] = get_dataset_root(root_dir)
             if super_root:
                 # the dataset identified by the path argument
                 # is contained in a superdataset, and no


### PR DESCRIPTION
I had some concerns due about symlinks but it seems that get_dataset_root doesn't bother much about them, so I think it should be kosher -- let's see what CI says ;-)

edit: may be I should just add a locally decorated `lru_cache(get_dataset_root)` instead of "manual" try/excepts?

edit: on a trial attempt benefit seems to be minor but present:

```shell
(git-annex)lena:~/datalad/dandi/dandisets/000026[draft]rawdata/sub-I46/ses-SPIM
$> multitime -n 5 datalad status *  # has 1100 files in that directory
```

this branch first line, master - 2nd (both are warm runs)
```
            Mean        Std.Dev.    Min         Median      Max
real        0.825       0.018       0.792       0.834       0.842   
real        0.848       0.031       0.816       0.830       0.897
```