### PR TITLE
BF produce an error in create and run_procedure if procedure does not exist

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -121,6 +121,11 @@
             "name": "Gau, Rémi",
             "affiliation": "Université catholique de Louvain, Louvain la neuve, Belgium",
             "orcid": "0000-0002-1535-9767"
+        },
+	{
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Szczepanik, Michał",
+            "orcid": "0000-0002-4028-2087"
         }
     ],
     "grants": [

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -339,18 +339,22 @@ class Create(Interface):
             yield res
             return
 
-        # Check if specified cfg_proc(s) can be discovered. If not,
-        # raise an error to prevent creating the dataset.
+        # Check if specified cfg_proc(s) can be discovered, storing
+        # the results so they can be used when the time comes to run
+        # the procedure. If a procedure cannot be found, raise an
+        # error to prevent creating the dataset.
+        cfg_proc_specs = []
         for cfg_proc_ in cfg_proc:
             for discovered_proc in tbds.run_procedure(
                     discover=True,
                     result_renderer='disabled',
                     return_type='generator'):
                 if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
+                    cfg_proc_specs.append(discovered_proc)
                     break
             else:
-                raise ValueError("Cannot find procedure with name"
-                                 "'%s'" % cfg_proc)
+                raise ValueError("Cannot find procedure with name "
+                                 "'%s'" % cfg_proc_)
 
         if initopts is not None and isinstance(initopts, list):
             initopts = {'_from_cmdline_': initopts}
@@ -424,8 +428,8 @@ class Create(Interface):
             _status=add_to_git,
         )
 
-        for cfg_proc_ in cfg_proc:
-            for r in tbds.run_procedure('cfg_' + cfg_proc_):
+        for cfg_proc_spec in cfg_proc_specs:
+            for r in tbds.run_procedure(cfg_proc_spec):
                 yield r
 
         # the next only makes sense if we saved the created dataset,

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -344,17 +344,17 @@ class Create(Interface):
         # the procedure. If a procedure cannot be found, raise an
         # error to prevent creating the dataset.
         cfg_proc_specs = []
-        for cfg_proc_ in cfg_proc:
-            for discovered_proc in tbds.run_procedure(
-                    discover=True,
-                    result_renderer='disabled',
-                    return_type='generator'):
-                if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
-                    cfg_proc_specs.append(discovered_proc)
-                    break
-            else:
-                raise ValueError("Cannot find procedure with name "
-                                 "'%s'" % cfg_proc_)
+        if cfg_proc:
+            discovered_procs = tbds.run_procedure(
+                discover=True, result_renderer='disabled')
+            for cfg_proc_ in cfg_proc:
+                for discovered_proc in discovered_procs:
+                    if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
+                        cfg_proc_specs.append(discovered_proc)
+                        break
+                else:
+                    raise ValueError("Cannot find procedure with name "
+                                     "'%s'" % cfg_proc_)
 
         if initopts is not None and isinstance(initopts, list):
             initopts = {'_from_cmdline_': initopts}

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -339,6 +339,19 @@ class Create(Interface):
             yield res
             return
 
+        # Check if specified cfg_proc(s) can be discovered. If not,
+        # raise an error to prevent creating the dataset.
+        for cfg_proc_ in cfg_proc:
+            for discovered_proc in tbds.run_procedure(
+                    discover=True,
+                    result_renderer='disabled',
+                    return_type='generator'):
+                if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
+                    break
+            else:
+                raise ValueError("Cannot find procedure with name"
+                                 "'%s'" % cfg_proc)
+
         if initopts is not None and isinstance(initopts, list):
             initopts = {'_from_cmdline_': initopts}
 

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -531,3 +531,12 @@ def check_create_initopts_form(form, path):
 def test_create_initopts_form():
     yield check_create_initopts_form, "dict"
     yield check_create_initopts_form, "list"
+
+
+@with_tempfile
+def test_bad_cfg_proc(path):
+    ds = Dataset(path)
+    # check if error is raised for incorrect cfg_proc
+    assert_raises(ValueError, ds.create, path=path, cfg_proc='unknown')
+    # verify that no directory got created prior to the error
+    assert not op.isdir(path)

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -387,17 +387,7 @@ class RunProcedure(Interface):
             procedure_file, cmd_name, cmd_tmpl, cmd_help = \
                 next(_get_procedure_implementation(name, ds=ds))
         except StopIteration:
-            res = get_status_dict(
-                    action='run_procedure',
-                    # TODO: Default renderer requires a key "path" to exist.
-                    # Doesn't make a lot of sense in this case
-                    path=name,
-                    logger=lgr,
-                    refds=ds.path if ds else None,
-                    status='impossible',
-                    message="Cannot find procedure with name '%s'" % name)
-            yield res
-            return
+            raise ValueError("Cannot find procedure with name '%s'" % name)
 
         ex = _guess_exec(procedure_file)
         # configured template (call-format string) takes precedence:

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -282,7 +282,7 @@ class RunProcedure(Interface):
             nargs=REMAINDER,
             doc="""Name and possibly additional arguments of the to-be-executed
             procedure. [PY: Can also be a dictionary coming from
-            run-procedure(discover=True).] [CMD: Note, that all options
+            run-procedure(discover=True).][CMD: Note, that all options
             to run-procedure need to be put before NAME, since all
             ARGS get assigned to NAME CMD]"""),
         dataset=Parameter(

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -427,3 +427,15 @@ def test_call_fmt_from_env_requires_reload(path):
                      f"{sys.executable} {{script}}"}):
         # This will fail if the above environment variable isn't in effect.
         ds.run_procedure("p")
+
+
+@with_tempfile
+def test_run_proc_with_dict(path):
+    # Test whether a result from run_procedure(discover=True) will be accepted
+    ds = Dataset(path).create()
+    g = ds.run_procedure(discover=True, result_renderer='disabled',
+                         return_type='generator')
+    for proc in g:
+        if proc['procedure_name'] == 'cfg_text2git':
+            break
+    ds.run_procedure(spec=proc)

--- a/datalad/interface/tests/test_run_procedure.py
+++ b/datalad/interface/tests/test_run_procedure.py
@@ -60,9 +60,8 @@ def test_invalid_call(path):
 
         # needs spec or discover
         assert_raises(InsufficientArgumentsError, run_procedure)
-        res = run_procedure('unknown', on_failure='ignore')
-        assert_true(len(res) == 1)
-        assert_in_results(res, status="impossible")
+        # an unknown procedure should cause an error
+        assert_raises(ValueError, run_procedure, 'unknown')
 
 
 @with_tree(tree={'README.md': 'dirty'})


### PR DESCRIPTION
This PR changes the behaviour of `create` and `run_procedure` so that using an incorrect (unavailable) procedure name results in an error. Closes #6129 

Specifically, the following changes were made:

1. The `run_procedure` on its own was changed to raise a `ValueError` instead of reporting a result with `status='impossible'`
2. A call to `run_procedure(discover=True)` was introduced in `datalad create` before any creation takes place to check whether the requested `cfg_proc(s)` are available.
3. To avoid going through a discovery process again when the procedure is applied to a newly created dataset, results of the call described above are reused. To make it possible, a new behaviour was introduced to `run_procedure(spec, ...)` when `spec` is a dictionary.

The third change seems the most "invasive" to me so I'd be happy to have your opinions on whether this is the correct way.

Resulting behaviour:
```
datalad create -c unknown my-dataset                                                             `129` !
[ERROR  ] ValueError(Cannot find procedure with name 'unknown') (ValueError)
```

Remaining TODO items:
- [x] Add a test for `create` asserting that `ValueError` is raised and the dataset is not created
- [x] Add a test for `run_procedure` asserting that it can be done with a (proper) dictionary input.
