### PR TITLE
RF+BF: use skip_if_no_module helper instead of try/except for libxmp and boto

### DIFF
--- a/datalad/downloaders/tests/test_s3.py
+++ b/datalad/downloaders/tests/test_s3.py
@@ -20,6 +20,7 @@ from ...tests.utils import (
     assert_raises,
     integration,
     skip_if_no_network,
+    skip_if_no_module,
     SkipTest,
     swallow_outputs,
     turtle,
@@ -35,15 +36,10 @@ from ...utils import (
 )
 
 from ...support import path as op
-
-try:
-    import boto
-except Exception as e:
-    raise SkipTest("boto module is not available") from e
-
 from .utils import get_test_providers
 from .test_http import check_download_external_url
 
+skip_if_no_module('boto')
 skip_if_no_network()  # TODO: provide persistent vcr fixtures for the tests
 
 url_2versions_nonversioned1 = 's3://datalad-test0-versioned/2versions-nonversioned1.txt'

--- a/datalad/metadata/extractors/tests/test_xmp.py
+++ b/datalad/metadata/extractors/tests/test_xmp.py
@@ -14,13 +14,11 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     eq_,
-    SkipTest,
+    skip_if_no_module,
     with_tempfile,
 )
-try:
-    import libxmp
-except Exception as exc:
-    raise SkipTest("libxmp cannot be imported") from exc
+
+skip_if_no_module('libxmp')
 
 from shutil import copy
 from os.path import (

--- a/datalad/metadata/tests/test_extract_metadata.py
+++ b/datalad/metadata/tests/test_extract_metadata.py
@@ -26,6 +26,7 @@ from datalad.tests.utils import (
     assert_repo_status,
     assert_result_count,
     known_failure_githubci_win,
+    skip_if_no_module,
     with_tempfile,
 )
 
@@ -43,11 +44,7 @@ def test_error(path):
 @known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_ds_extraction(path):
-    from datalad.tests.utils import SkipTest
-    try:
-        import libxmp
-    except ImportError:
-        raise SkipTest
+    skip_if_no_module('libxmp')
 
     ds = Dataset(path).create()
     copy(testpath, path)
@@ -83,11 +80,7 @@ def test_ds_extraction(path):
 @known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_file_extraction(path):
-    from datalad.tests.utils import SkipTest
-    try:
-        import libxmp
-    except ImportError:
-        raise SkipTest
+    skip_if_no_module('libxmp')
 
     # go into virgin dir to avoid detection of any dataset
     with chpwd(path):


### PR DESCRIPTION
Closes #6141 ("maint" specific, "master" was catching all exceptions, conflicts will need to be resolved in favor of the helper)
