### PR TITLE
infra: Provide custom prefix to auto-related labels

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -12,5 +12,15 @@
                 "afterRelease": "python -m build && twine upload dist/*"
             }
         ]
-    ]
+    ],
+  "labels": [
+    { "releaseType": "major", "name": "semver-major" },
+    { "releaseType": "minor", "name": "semver-minor" },
+    { "releaseType": "patch", "name": "semver-patch" },
+    { "releaseType": "dependencies", "name": "semver-dependencies" },
+    { "releaseType": "documentation", "name": "semver-documentation" },
+    { "releaseType": "internal", "name": "semver-internal" },
+    { "releaseType": "performance", "name": "semver-performance" },
+    { "releaseType": "tests", "name": "semver-tests" }
+  ]
 }

--- a/.github/workflows/test-label.yml
+++ b/.github/workflows/test-label.yml
@@ -14,26 +14,26 @@ jobs:
           # This should evaluate to either `true` or `false`, which runs the
           # command of the same name.
           ${{
-            !contains(github.event.pull_request.labels.*.name, 'major')
+            !contains(github.event.pull_request.labels.*.name, 'semver-major')
           }}
       - name: Check that PR against "maint" branch does not have "minor"
         if: github.event.pull_request.base.label == 'datalad:maint'
         run: |
           ${{
-            !contains(github.event.pull_request.labels.*.name, 'minor')
+            !contains(github.event.pull_request.labels.*.name, 'semver-minor')
           }}
       - name: Check that PR uses one of the standard "auto" labels
         run: |
           # major is included to stay optimistic, and to not forget later
           ${{
-            contains(github.event.pull_request.labels.*.name, 'major')
-            || contains(github.event.pull_request.labels.*.name, 'minor')
-            || contains(github.event.pull_request.labels.*.name, 'patch')
-            || contains(github.event.pull_request.labels.*.name, 'dependencies')
-            || contains(github.event.pull_request.labels.*.name, 'documentation')
-            || contains(github.event.pull_request.labels.*.name, 'internal')
-            || contains(github.event.pull_request.labels.*.name, 'performance')
-            || contains(github.event.pull_request.labels.*.name, 'tests')
+            contains(github.event.pull_request.labels.*.name, 'semver-major')
+            || contains(github.event.pull_request.labels.*.name, 'semver-minor')
+            || contains(github.event.pull_request.labels.*.name, 'semver-patch')
+            || contains(github.event.pull_request.labels.*.name, 'semver-dependencies')
+            || contains(github.event.pull_request.labels.*.name, 'semver-documentation')
+            || contains(github.event.pull_request.labels.*.name, 'semver-internal')
+            || contains(github.event.pull_request.labels.*.name, 'semver-performance')
+            || contains(github.event.pull_request.labels.*.name, 'semver-tests')
           }}
 
 # vim:set sts=2:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -666,15 +666,15 @@ The section that `auto` adds to the changelog on a new release consists of the
 titles of all pull requests merged into master since the previous release,
 organized by label.  `auto` recognizes the following PR labels:
 
-- `minor` — for changes corresponding to an increase in the minor version
+- `semver-minor` — for changes corresponding to an increase in the minor version
   component
-- `patch` — for changes corresponding to an increase in the patch/micro version
+- `semver-patch` — for changes corresponding to an increase in the patch/micro version
   component; this is the default label for unlabelled PRs
-- `internal` — for changes only affecting the internal API
-- `documentation` — for changes only affecting the documentation
-- `tests` — for changes to tests
-- `dependencies` — for updates to dependency versions
-- `performance` — for performance improvements
+- `semver-internal` — for changes only affecting the internal API
+- `semver-documentation` — for changes only affecting the documentation
+- `semver-tests` — for changes to tests
+- `semver-dependencies` — for updates to dependency versions
+- `semver-performance` — for performance improvements
 
 [link_zenodo]: https://github.com/datalad/datalad/blob/master/.zenodo.json
 [contrib_emoji]: https://allcontributors.org/docs/en/emoji-key


### PR DESCRIPTION
In looking through the issues closed over the weekend, I felt compelled to act on the suggestion in #5833 to prefix a common, versioning-related identifier to the PR labels for the auto-workflow.
I think there was some general agreement in the original issue, but not enough momentum to implement the change. I personally keep forgetting which labels exist, and would be in favor of having them in one group to ease discoverability. 
I'm suggesting ``semver`` as a prefix, because the corresponding test is called "Test for semver label". I'm happy to change this into anything else, though.

- [x] if this change is accepted, the label names need to be changed