### PR TITLE
RF a first RIA test to run across platforms

### DIFF
--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -42,6 +42,7 @@ from datalad.tests.utils import (
     assert_true,
     has_symlink_capability,
     known_failure_windows,
+    serve_path_via_http,
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_ssh,
@@ -56,11 +57,10 @@ from datalad.utils import Path
 # Note, that exceptions to test for are generally CommandError since we are
 # talking to the special remote via annex.
 
-@known_failure_windows  # see gh-4469
+
 @with_tempfile
 @with_tempfile
-@with_tempfile
-def _test_initremote_basic(host, ds_path, store, link):
+def _test_initremote_basic(url, io, store, ds_path, link):
 
     ds_path = Path(ds_path)
     store = Path(store)
@@ -69,11 +69,6 @@ def _test_initremote_basic(host, ds_path, store, link):
     populate_dataset(ds)
     ds.save()
 
-    if host:
-        url = "ria+ssh://{host}{path}".format(host=host,
-                                              path=store)
-    else:
-        url = "ria+{}".format(store.as_uri())
     init_opts = common_init_opts + ['url={}'.format(url)]
 
     # fails on non-existing storage location
@@ -96,7 +91,6 @@ def _test_initremote_basic(host, ds_path, store, link):
                   )
 
     # set up store:
-    io = SSHRemoteIO(host) if host else LocalIO()
     create_store(io, store, '1')
     # still fails, since ds isn't setup in the store
     assert_raises(CommandError,
@@ -159,17 +153,50 @@ def _test_initremote_basic(host, ds_path, store, link):
             # annex too old - doesn't know --sameas
             pass
         else:
-            raise 
+            raise
     # TODO: - check output of failures to verify it's failing the right way
     #       - might require to run initremote directly to get the output
 
 
-def test_initremote_basic():
+# TODO: Skipped due to gh-4436
+@known_failure_windows
+@skip_ssh
+@with_tempfile
+def test_initremote_basic_sshurl(storepath):
+    _test_initremote_basic(
+        'ria+ssh://datalad-test{}'.format(Path(storepath).as_posix()), \
+        SSHRemoteIO('datalad-test'), \
+        storepath,
+    )
 
-    # TODO: Skipped due to gh-4436
-    yield known_failure_windows(skip_ssh(_test_initremote_basic)), \
-          'datalad-test'
-    yield _test_initremote_basic, None
+
+@with_tempfile
+def test_initremote_basic_fileurl(storepath):
+    _test_initremote_basic(
+        "ria+{}".format(Path(storepath).as_uri()),
+        LocalIO(),
+        storepath,
+    )
+
+
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+def test_initremote_basic_httpurl(storepath, storeurl):
+    _test_initremote_basic(
+        f"ria+{storeurl}",
+        LocalIO(),
+        storepath,
+    )
+
+
+@with_tempfile(mkdir=True)
+@serve_path_via_http(use_ssl=True)
+def test_initremote_basic_httpsurl(storepath, storeurl):
+    _test_initremote_basic(
+        f"ria+{storeurl}",
+        LocalIO(),
+        storepath,
+    )
 
 
 @skip_wo_symlink_capability


### PR DESCRIPTION
The previous strict linkage between access protocols and IO
implementation to generate test stores was pointless.
This is a general pattern that needs to be altered throughout the
codebase.
