### PR TITLE
BF: Don't overwrite subdataset source candidates

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -369,13 +369,15 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
         for rec in cand_cfg:
             # check whether any of this configuration originated from the
             # superdataset. if so, inherit the config in the new subdataset
-            # clone. if not, keep things clean in order to be able to move with
-            # any outside configuration change
+            # clone unless that config is already specified in the new
+            # subdataset which can happen during postclone_cfg routines.
+            # if not, keep things clean in order to be able to move with any
+            # outside configuration change
             for c in ('datalad.get.subdataset-source-candidate-{}{}'.format(
                           rec['cost'], rec['name']),
                       'datalad.get.subdataset-source-candidate-{}'.format(
                           rec['name'])):
-                if c in super_cfg.keys():
+                if c in super_cfg.keys() and c not in subds.config.keys():
                     subds.config.set(c, super_cfg.get(c), where='local',
                                      reload=False)
                     need_reload = True

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -28,6 +28,7 @@ from datalad.support.exceptions import (
     InsufficientArgumentsError,
     RemoteNotAvailableError,
 )
+from datalad.support.network import get_local_file_url
 from datalad.tests.utils import (
     ok_,
     eq_,
@@ -747,3 +748,39 @@ def test_missing_path_handling(path):
 
         # Check for guarded access in error results
         ds.get("foo")
+
+
+@known_failure_windows  # create-sibling-ria + ORA not fit for windows
+@with_tempfile
+@with_tempfile
+@with_tree(tree={'sub1': {'file1.txt': 'content 1'},
+                 'sub2': {'file2.txt': 'content 2'}})
+@with_tempfile
+@with_tempfile
+def test_source_candidate_subdataset(store1, store2, intermediate,
+                                     super, clone):
+
+    # This tests the scenario of gh-6159.
+    # However, the actual point is to test that `get` does not overwrite a
+    # source candidate config in subdatasets, if they already have such a
+    # config. This could come from any postclone_cfg routine, but the only one
+    # actually doing this ATM is postclone_cfg_ria.
+
+    ds = Dataset(intermediate).create(force=True)
+    ds.create("sub1", force=True)
+    ds.create("sub2", force=True)
+    ds.save(recursive=True)
+    ria_url_1 = "ria+" + get_local_file_url(store1, compatibility='git')
+    ds.create_sibling_ria(ria_url_1, "firststore", recursive=True)
+    ds.push(".", to="firststore", recursive=True)
+    superds = Dataset(super).create()
+    superds.clone(source=ria_url_1 + "#" + ds.id, path="intermediate")
+    ria_url_2 = "ria+" + get_local_file_url(store2, compatibility='git')
+    superds.create_sibling_ria(ria_url_2, "secondstore")
+    superds.push(".", to="secondstore")
+
+    cloneds = install(clone, source=ria_url_2 + "#" + superds.id)
+
+    # This would fail if source candidates weren't right, since cloneds only
+    # knows the second store so far (which doesn't have the subdatasets).
+    cloneds.get("intermediate", recursive=True)


### PR DESCRIPTION
datalad-get used to overwrite possibly existing source candidate configs
in newly cloned subdatasets. While inheriting is generally fine, it
didn't take into account that postclone_cfg routines may already have
had a better idea.

"Better idea" in that I think the principle of looking up subdatasets in the same RIA store their super came from should apply at all levels recursively. Hence, when `super` came from storeA, storeA is also considered for `sub`. If it, however, turns out that `sub` ultimately came from storeB, then `subsub` should be looked for in storeB. And that's the situation where that overwrite matters AFAICT.

Closes #6159

