### PR TITLE
Yield add-archive-content results when called from download-url

### DIFF
--- a/datalad/interface/download_url.py
+++ b/datalad/interface/download_url.py
@@ -285,4 +285,10 @@ URLs:
 
                     if archive:
                         for path in annex_paths:
-                            ds.add_archive_content(path, delete=True)
+                            yield from ds.add_archive_content(
+                                path,
+                                delete=True,
+                                on_failure='ignore',
+                                return_type='generator',
+                                result_renderer='disabled'
+                            )

--- a/datalad/interface/tests/test_download_url.py
+++ b/datalad/interface/tests/test_download_url.py
@@ -31,6 +31,7 @@ from datalad.tests.utils import (
     assert_in,
     assert_message,
     assert_result_count,
+    create_tree,
     eq_,
     ok_,
     ok_exists,
@@ -193,6 +194,16 @@ def test_download_url_archive(toppath, topurl, path):
     ok_(ds.repo.file_has_content(opj("archive", "file1.txt")))
     assert_not_in(opj(ds.path, "archive.tar.gz"),
                   ds.repo.format_commit("%B"))
+    # we should yield an impossible from add archive content when there is
+    # untracked content (gh-#6170)
+    create_tree(ds.path, {'this': 'dirty'})
+    assert_in_results(
+        ds.download_url([topurl + "archive.tar.gz"], archive=True,
+                        on_failure='ignore'),
+        status='impossible',
+        action='add-archive-content',
+        message='clean dataset required. Use `datalad status` to inspect '
+                'unsaved changes')
 
 
 @with_tree(tree={"archive.tar.gz": {'file1.txt': 'abc'}})


### PR DESCRIPTION
This should fix #6170.
In a dirty dataset, the result now looks like this:

```
❱ datalad download-url --archive https://www.fil.ion.ucl.ac.uk/spm/download/data/MoAEpilot/MoAEpilot.bids.zip
[INFO   ] Downloading 'https://www.fil.ion.ucl.ac.uk/spm/download/data/MoAEpilot/MoAEpilot.bids.zip' into '/tmp/testnew/bal/bla/bla/a/c/d/a/a/c/' 
download_url(ok): /tmp/testnew/bal/bla/bla/a/c/d/a/a/c/MoAEpilot.bids.zip (file)            
add(ok): bal/bla/bla/a/c/d/a/a/c/MoAEpilot.bids.zip (file)                                  
save(ok): . (dataset)                                                                       
add-archive-content(impossible): /tmp/testnew (dataset) [clean dataset required. Use `datalad status` to inspect unsaved changes]
action summary:
  add (ok: 1)
  add-archive-content (impossible: 1)
  download_url (ok: 1)
  save (ok: 1)
```